### PR TITLE
[Serve] [Docs] Fix link in Serve Config Files documentation on `master` branch

### DIFF
--- a/doc/source/serve/production-guide/config.md
+++ b/doc/source/serve/production-guide/config.md
@@ -7,7 +7,7 @@ This section should help you:
 - understand the Serve config file format.
 - understand how to generate and update a config file for a Serve application.
 
-This config file can be used with the [serve deploy](serve-in-production-deploying) command CLI or embedded in a [RayService] custom resource in Kubernetes to deploy and update your application in production.
+This config file can be used with the [serve deploy](serve-in-production-deploying) command CLI or embedded in a [RayService](serve-in-production-kubernetes) custom resource in Kubernetes to deploy and update your application in production.
 The file is written in YAML and has the following format:
 
 ```yaml


### PR DESCRIPTION
Signed-off-by: Shreyas Krishnaswamy <shrekris@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The "Serve Config Files" documentation is missing a link:

<img width="763" alt="Screen Shot 2022-08-18 at 9 41 42 AM" src="https://user-images.githubusercontent.com/92341594/185449318-331c4a97-02e5-40c9-add9-cd6470d6a939.png">

This changes adds the link.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This will be tested by link check.
