### PR TITLE
[Serve] [CI] Deflake `test_standalone.py` by replacing `list_named_actors` with new State API

### DIFF
--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -41,6 +41,7 @@ from ray.serve._private.utils import (
 from ray.serve.schema import ServeApplicationSchema
 
 from ray.experimental.state.api import list_actors
+
 # Explicitly importing it here because it is a ray core tests utility (
 # not in the tree)
 from ray.tests.conftest import maybe_external_redis  # noqa: F401

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -40,6 +40,7 @@ from ray.serve._private.utils import (
 )
 from ray.serve.schema import ServeApplicationSchema
 
+from ray.experimental.state.api import list_actors
 # Explicitly importing it here because it is a ray core tests utility (
 # not in the tree)
 from ray.tests.conftest import maybe_external_redis  # noqa: F401
@@ -658,17 +659,17 @@ def test_recovering_controller_no_redeploy():
 
     serve.run(f.bind())
 
-    num_actors = len(ray.util.list_named_actors(all_namespaces=True))
+    num_actors = len(list_actors())
     pid = ray.get(client._controller.get_pid.remote())
 
     ray.kill(client._controller, no_restart=False)
 
     wait_for_condition(lambda: ray.get(client._controller.get_pid.remote()) != pid)
 
-    # Confirm that no new deployment is deployed over the next 10 seconds
+    # Confirm that no new deployment is deployed over the next 5 seconds
     with pytest.raises(RuntimeError):
         wait_for_condition(
-            lambda: len(ray.util.list_named_actors(all_namespaces=True)) > num_actors,
+            lambda: len(list_actors()) > num_actors,
             timeout=5,
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The flaky test `test_standalone.py` was hanging at `list_named_actors()` in 5 out of the 5 failed cases I checked:

```
*** SIGTERM received at time=1660084080 on cpu 5 ***
--
  | PC: @     0x7f6e3dfae73d  (unknown)  syscall
  | @     0x7f6e3e09c420  (unknown)  (unknown)
  | @     0x7f6e3b026f02        336  ray::gcs::ActorInfoAccessor::SyncListNamedActors()
  | @     0x7f6e3aeee539        592  _ZN3ray4core10CoreWorker15ListNamedActorsB5cxx11Eb
  | @     0x7f6e3adef38e        320  __pyx_pw_3ray_7_raylet_10CoreWorker_79list_named_actors()
  | @     0x55c088ea2e95  (unknown)  _PyCFunction_FastCallDict
```
<!-- Please give a short summary of the change and the problem this solves. -->

This PR works around this by updating the test to use the new API `list_actors` from the State API.  

Ideally we should fix the hanging in `list_named_actors`. Since it only seems to hang in this edge case where we're killing an actor, and since it's being replaced by `list_actors`, it's probably not high priority.
## Related issue number
Closes https://github.com/ray-project/ray/issues/27957
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
