### PR TITLE
Add readme for K8s test.

### DIFF
--- a/python/ray/tests/kuberay/README.md
+++ b/python/ray/tests/kuberay/README.md
@@ -1,6 +1,6 @@
 # How to run the KubeRay autoscaling test
 
-We provide some notes on how to run the test `test_autoscaling_e2e` in this directory locally.
+This page provides suggestions on running the test `test_autoscaling_e2e` locally.
 You might want to do this if your PR is breaking this test in CI and you want to debug why.
 
 ## Build a docker image with your code changes.

--- a/python/ray/tests/kuberay/README.md
+++ b/python/ray/tests/kuberay/README.md
@@ -1,0 +1,54 @@
+# How to run the KubeRay autoscaling test
+
+We provide some notes on how to run the test `test_autoscaling_e2e` in this directory locally.
+You might want to do this if your PR is breaking this test in CI and you want to debug why.
+
+## Build a docker image with your code changes.
+First, push your code changes to your git fork.
+The Dockerfile below will work if you've only made Python changes.
+```dockerfile
+# Use the latest Ray master as base.
+FROM rayproject/ray:nightly
+# Invalidate the cache so that fresh code is pulled in the next step.
+ARG BUILD_DATE
+# Retrieve your development code.
+RUN git clone -b <my-dev-branch> https://github.com/<my-git-handle>/ray
+# Install symlinks to your modified Python code.
+RUN python ray/python/ray/setup-dev.py -y
+```
+
+Build the image and push it to your docker account or registry. Assuming your Dockerfile is named "Dockerfile":
+```shell
+docker build --build-arg BUILD_DATE=$(date +%Y-%m-%d:%H:%M:%S) -t <registry>/<repo>:<tag> - < Dockerfile
+docker push <registry>/<repo>:<tag>
+```
+
+## Setup Access to a Kubernetes cluster.
+Gain access to a Kubernetes cluster.
+The easiest thing to do is to use KinD.
+```shell
+brew install kind
+kind create cluster
+```
+
+## Install master Ray
+The test uses Ray client, so you should either
+- install nightly Ray in your environment
+- install Ray from source in your environment (`pip install -e`)
+
+## Run the test.
+
+```shell
+# Set up the operator.
+python setup/setup_kuberay.py
+# Run the test.
+RAY_IMAGE=<your-image> python test_autoscaling_e2e.py
+# Tear RayClusters and operator down.
+python setup/teardown_kuberay.py
+```
+
+The test itself does not tear down resources on failure; you can
+- examine a Ray cluster from a failed test (`kubectl get pod`, `kubectl get raycluster`)
+- delete the Ray cluster (`kubectl delete raycluster -A`)
+- rerun the test without tearing the operator down (`RAY_IMAGE=<your-image> python test_autoscaling_e2e.py`)
+- tear down the operator when you're done `python setup/teardown_kuberay.py`

--- a/python/ray/tests/kuberay/README.md
+++ b/python/ray/tests/kuberay/README.md
@@ -8,7 +8,7 @@ First, push your code changes to your git fork.
 The Dockerfile below will work if you've only made Python changes.
 ```dockerfile
 # Use the latest Ray master as base.
-FROM rayproject/ray:nightly
+FROM rayproject/ray:nightly-py37
 # Invalidate the cache so that fresh code is pulled in the next step.
 ARG BUILD_DATE
 # Retrieve your development code.
@@ -35,6 +35,7 @@ kind create cluster
 The test uses Ray client, so you should either
 - install nightly Ray in your environment
 - install Ray from source in your environment (`pip install -e`)
+Match your environment's Python version with the Ray image you are using.
 
 ## Run the test.
 

--- a/python/ray/tests/kuberay/README.md
+++ b/python/ray/tests/kuberay/README.md
@@ -35,6 +35,7 @@ kind create cluster
 The test uses Ray client, so you should either
 - install nightly Ray in your environment
 - install Ray from source in your environment (`pip install -e`)
+
 Match your environment's Python version with the Ray image you are using.
 
 ## Run the test.


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

It's come to my attention that it can be a pain for anyone who is not me to debug the KubeRay autoscaling test when it breaks in a non-PR branch.

This PR adds a README explaining how to run the test locally.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
