### PR TITLE
[RLlib] quick fix for learning rate schedule for APPO algorithm.

### DIFF
--- a/rllib/algorithms/appo/appo_tf_policy.py
+++ b/rllib/algorithms/appo/appo_tf_policy.py
@@ -122,7 +122,6 @@ def get_appo_tf_policy(name: str, base: type) -> type:
             # that base.__init__ will use the make_model() call.
             VTraceClipGradients.__init__(self)
             VTraceOptimizer.__init__(self)
-            LearningRateSchedule.__init__(self, config["lr"], config["lr_schedule"])
 
             # Initialize base class.
             base.__init__(
@@ -134,6 +133,9 @@ def get_appo_tf_policy(name: str, base: type) -> type:
                 existing_model=existing_model,
             )
 
+            # TF LearningRateSchedule depends on self.framework, so initialize
+            # after base.__init__() is called.
+            LearningRateSchedule.__init__(self, config["lr"], config["lr_schedule"])
             EntropyCoeffSchedule.__init__(
                 self, config["entropy_coeff"], config["entropy_coeff_schedule"]
             )

--- a/rllib/algorithms/appo/tests/test_appo.py
+++ b/rllib/algorithms/appo/tests/test_appo.py
@@ -106,13 +106,13 @@ class TestAPPO(unittest.TestCase):
                     [500, 0.0001],
                 ],
             )
-            .reporting(min_train_timesteps_per_iteration=20)
+            .reporting(
+                min_train_timesteps_per_iteration=20,
+                # 0 metrics reporting delay, this makes sure timestep,
+                # which entropy coeff depends on, is updated after each worker rollout.
+                min_time_s_per_iteration=0,
+            )
         )
-
-        config.min_sample_timesteps_per_iteration = 20
-        # 0 metrics reporting delay, this makes sure timestep,
-        # which entropy coeff depends on, is updated after each worker rollout.
-        config.min_time_s_per_iteration = 0
 
         def _step_n_times(algo, n: int):
             """Step Algorithm n times.
@@ -141,6 +141,54 @@ class TestAPPO(unittest.TestCase):
             self.assertLessEqual(coeff, 0.001)
 
             algo.stop()
+
+    def test_appo_learning_rate_schedule(self):
+        config = (
+            appo.APPOConfig()
+            .rollouts(
+                num_rollout_workers=1,
+                batch_mode="truncate_episodes",
+                rollout_fragment_length=10,
+            )
+            .resources(num_gpus=0)
+            .training(
+                train_batch_size=20,
+                entropy_coeff=0.01,
+                # Setup lr schedule for testing.
+                lr_schedule=[[0, 5e-2], [500, 0.0]],
+            )
+            .reporting(
+                min_train_timesteps_per_iteration=20,
+                # 0 metrics reporting delay, this makes sure timestep,
+                # which entropy coeff depends on, is updated after each worker rollout.
+                min_time_s_per_iteration=0,
+            )
+        )
+
+        def _step_n_times(algo, n: int):
+            """Step Algorithm n times.
+
+            Returns:
+                learning rate at the end of the execution.
+            """
+            for _ in range(n):
+                results = algo.train()
+                print(algo.workers.local_worker().global_vars)
+                print(results)
+            return results["info"][LEARNER_INFO][DEFAULT_POLICY_ID][LEARNER_STATS_KEY][
+                "cur_lr"
+            ]
+
+        for _ in framework_iterator(config):
+            algo = config.build(env="CartPole-v0")
+
+            lr1 = _step_n_times(algo, 10)  # 200 timesteps
+            lr2 = _step_n_times(algo, 10)  # 200 timesteps
+
+            self.assertGreater(lr1, lr2)
+
+            algo.stop()
+
 
     def test_appo_model_variables(self):
         config = (

--- a/rllib/algorithms/appo/tests/test_appo.py
+++ b/rllib/algorithms/appo/tests/test_appo.py
@@ -189,7 +189,6 @@ class TestAPPO(unittest.TestCase):
 
             algo.stop()
 
-
     def test_appo_model_variables(self):
         config = (
             appo.APPOConfig()


### PR DESCRIPTION
## Why are these changes needed?

LearningRateSchedule must be initialized after base.__init__() call.
Longer term, base classes should rely as little as possible on class member variables.
E.g., all these base modules could have simply taken config as input when necessary.

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
