### PR TITLE
[WIP] [Serve] [Docs] Use `seealso` block in Ray Serve documentation

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -267,9 +267,21 @@ div.topic{
   border-left-color: var(--border-color-gray);
 }
 
-/* custom css for up and down arrows in colllapsable cards */
+/* custom css for up and down arrows in collapsible cards */
 details.dropdown .summary-up, details.dropdown .summary-down {
   top: 1em;
+}
+
+/* remove focus border up and down arrows in collapsible admonitions
+
+   Arrow class names found here: (
+    https://github.com/executablebooks/sphinx-design/blob/
+    ed533277df25c172e80e8a4c3ccbbc04efe88cd0/sphinx_design/
+    dropdown.py#L152-L163
+   )
+*/
+.sd-summary-up:focus, .sd-summary-down:focus {
+  outline: none;
 }
 
 /* custom css for shadow class */

--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -272,15 +272,8 @@ details.dropdown .summary-up, details.dropdown .summary-down {
   top: 1em;
 }
 
-/* remove focus border up and down arrows in collapsible admonitions
-
-   Arrow class names found here: (
-    https://github.com/executablebooks/sphinx-design/blob/
-    ed533277df25c172e80e8a4c3ccbbc04efe88cd0/sphinx_design/
-    dropdown.py#L152-L163
-   )
-*/
-.sd-summary-up:focus, .sd-summary-down:focus {
+/* remove focus border in collapsible admonition buttons */
+.toggle.admonition button.toggle-button:focus {
   outline: none;
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -63,6 +63,10 @@ myst_enable_extensions = [
     "replacements",
 ]
 
+# Turn off hint in toggle buttons
+togglebutton_hint = ""
+togglebutton_hint_hide = ""
+
 # Thebe configuration for launching notebook cells within the docs.
 thebe_config = {
     "selector": "div.highlight",

--- a/doc/source/serve/getting_started.md
+++ b/doc/source/serve/getting_started.md
@@ -61,10 +61,11 @@ Bonjour Monde!
 
 Keep in mind that the `TranslationPipeline` is an example ML model for this
 tutorial. You can follow along using arbitrary models from any
-Python framework. Check out our tutorials on scikit-learn,
-PyTorch, and Tensorflow for more info and examples:
+Python framework.
 
-- {ref}`serve-ml-models-tutorial`
+:::{seealso}
+Check our our [tutorials](serve-ml-models-tutorial) on scikit-learn, PyTorch, and Tensorflow for more info and examples!
+:::
 
 (converting-to-ray-serve-deployment)=
 ## Converting to a Ray Serve Deployment

--- a/doc/source/serve/getting_started.md
+++ b/doc/source/serve/getting_started.md
@@ -264,9 +264,6 @@ See the [Model Composition guide](serve-model-composition) for more details on d
 - Learn more about how to deploy your Ray Serve application to production: {ref}`serve-in-production`.
 - Check more in-depth tutorials for popular machine learning frameworks: {doc}`tutorials/index`.
 
-```{rubric} Footnotes
-```
-
 [^f1]: [Starlette](https://www.starlette.io/) is a web server framework
     used by Ray Serve. Its [Request](https://www.starlette.io/requests/) class
     provides a nice interface for incoming HTTP requests.

--- a/doc/source/serve/getting_started.md
+++ b/doc/source/serve/getting_started.md
@@ -60,11 +60,10 @@ Bonjour Monde!
 ```
 
 Keep in mind that the `TranslationPipeline` is an example ML model for this
-tutorial. You can follow along using arbitrary models from any
-Python framework.
+tutorial. You can follow along with models from any Python framework.
 
 :::{seealso}
-Check our our [tutorials](serve-ml-models-tutorial) on scikit-learn, PyTorch, and Tensorflow for more info and examples!
+Check out the [tutorials](serve-ml-models-tutorial) on scikit-learn, PyTorch, and Tensorflow for Ray Serve examples using popular Python ML frameworks!
 :::
 
 (converting-to-ray-serve-deployment)=
@@ -253,7 +252,11 @@ $ python graph_client.py
 c'était le meilleur des temps, c'était le pire des temps .
 ```
 
-Deployment graphs are useful since they let you deploy each part of your machine learning pipeline, such as inference and business logic steps, in separate deployments. Each of these deployments can be individually configured and scaled, ensuring you get maximal performance from your resources. See the guide on [model composition](serve-model-composition) to learn more.
+Deployment graphs are useful since they let you deploy each part of your machine learning pipeline, such as inference and business logic steps, in separate deployments. Each of these deployments can be individually configured and scaled, ensuring you get maximal performance from your resources.
+
+:::{seealso}
+See the [Model Composition guide](serve-model-composition) for more details on deployment graphs.
+:::
 
 ## Next Steps
 

--- a/doc/source/serve/model_composition.md
+++ b/doc/source/serve/model_composition.md
@@ -131,7 +131,7 @@ In both types of `ServeHandle`, you can call a specific method by using the `.me
 (serve-model-composition-deployment-graph)=
 ## Deployment Graph API
 
-:::{admonition} This API is in **alpha**, so it's subject to change.
+:::{admonition} This API is in `alpha`, so it's subject to change.
 :class: attention, dropdown
 If you notice any issues or have suggestions on how to improve this API,
 please [let us know](https://github.com/ray-project/ray/issues/new/choose)!

--- a/doc/source/serve/model_composition.md
+++ b/doc/source/serve/model_composition.md
@@ -132,7 +132,9 @@ In both types of `ServeHandle`, you can call a specific method by using the `.me
 ## Deployment Graph API
 
 :::{admonition} This API is in **alpha**, so it's subject to change.
-:class: versionadded
+:class: versionadded, dropdown
+If you notice any issues or have suggestions on how to improve this API,
+please [let us know](https://github.com/ray-project/ray/issues/new/choose)!
 :::
 
 For more advanced composition patterns, it can be useful to surface the relationships between deployments, instead of hiding them inside individual deployment definitions.

--- a/doc/source/serve/model_composition.md
+++ b/doc/source/serve/model_composition.md
@@ -132,7 +132,7 @@ In both types of `ServeHandle`, you can call a specific method by using the `.me
 ## Deployment Graph API
 
 :::{admonition} This API is in **alpha**, so it's subject to change.
-:class: versionadded, dropdown
+:class: attention, dropdown
 If you notice any issues or have suggestions on how to improve this API,
 please [let us know](https://github.com/ray-project/ray/issues/new/choose)!
 :::

--- a/doc/source/serve/model_composition.md
+++ b/doc/source/serve/model_composition.md
@@ -131,8 +131,8 @@ In both types of `ServeHandle`, you can call a specific method by using the `.me
 (serve-model-composition-deployment-graph)=
 ## Deployment Graph API
 
-:::{note}
-The call graph is in **alpha**, so its APIs are subject to change.
+:::{admonition} This API is in **alpha**, so it's subject to change.
+:class: versionadded
 :::
 
 For more advanced composition patterns, it can be useful to surface the relationships between deployments, instead of hiding them inside individual deployment definitions.


### PR DESCRIPTION
Signed-off-by: Shreyas Krishnaswamy <shrekris@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Some pages in Ray Serve's documentation includes references to other pages in the docs. This change encloses these references in `seealso` blocks for smoother reading.

For example:
<img width="763" alt="Screen Shot 2022-08-19 at 4 51 06 PM" src="https://user-images.githubusercontent.com/92341594/185720540-3424875c-e9f7-446b-966a-e52903be43c1.png">

Doc links:
* [Getting Started](https://ray--28024.org.readthedocs.build/en/28024/serve/getting_started.html)
* [Deployment Graph API](https://ray--28024.org.readthedocs.build/en/28024/serve/model_composition.html#deployment-graph-api)

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change only affects doc formatting.
