### PR TITLE
[Doc] [runtime env] Clarify zip requirements for remote URIs

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -510,7 +510,7 @@ Your ``runtime_env`` dictionary should contain:
   You can inspect a zip file's contents by running the ``zipinfo -1 zip_file_name.zip`` command in the Terminal.
   Some zipping methods can cause hidden files or metadata directories to appear in the zip file at the top level.
   This will cause Ray to throw an error because the structure of the zip file is invalid since there is more than a single directory at the top level.
-  You can avoid this by using the ``zip -r`` command directly on the directory you want to compress and being sure to run the command from the parent directory.
+  You can avoid this by using the ``zip -r`` command directly on the directory you want to compress. Make sure to run the command from that directory's parent.
 
 Currently, three types of remote URIs are supported for hosting ``working_dir`` and ``py_modules`` packages:
 

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -475,22 +475,28 @@ If you want to specify this directory as a local path, your ``runtime_env`` dict
 
 Suppose instead you want to host your files in your ``/some_path/example_dir`` directory remotely and provide a remote URI.
 You would need to first compress the ``example_dir`` directory into a zip file.
-You can use the following command in the Terminal to do so:
-
-.. code-block:: bash
-
-    zip -r example.zip /some_path/example_dir
-
-In general, to compress a directory called ``directory_to_zip`` into a zip file called ``zip_file_name.zip``, the command is:
-
-.. code-block:: bash
-
-    # General command
-    zip -r zip_file_name.zip directory_to_zip
 
 There should be no other files or directories at the top level of the zip file, other than ``example_dir``.
+You can use the following command in the Terminal to do this:
+
+.. code-block:: bash
+
+    cd /some_path
+    zip -r zip_file_name.zip example_dir
+
+Note that this command must be run from the *parent directory* of the desired ``working_dir`` to ensure that the resulting zip file contains a single top-level directory.
 In general, the zip file's name and the top-level directory's name can be anything.
 The top-level directory's contents will be used as the ``working_dir`` (or ``py_module``).
+
+You can check that the zip file contains a single top-level directory by running the following command in the Terminal:
+
+.. code-block:: bash
+
+  zipinfo -1 zip_file_name.zip
+  # example_dir/
+  # example_dir/my_file_1.txt
+  # example_dir/subdir/my_file_2.txt
+
 Suppose you upload the compressed ``example_dir`` directory to AWS S3 at the S3 URI ``s3://example_bucket/example.zip``.
 Your ``runtime_env`` dictionary should contain:
 
@@ -504,7 +510,7 @@ Your ``runtime_env`` dictionary should contain:
   You can inspect a zip file's contents by running the ``zipinfo -1 zip_file_name.zip`` command in the Terminal.
   Some zipping methods can cause hidden files or metadata directories to appear in the zip file at the top level.
   This will cause Ray to throw an error because the structure of the zip file is invalid since there is more than a single directory at the top level.
-  You can avoid this by using the ``zip -r`` command directly on the directory you want to compress.
+  You can avoid this by using the ``zip -r`` command directly on the directory you want to compress and being sure to run the command from the parent directory.
 
 Currently, three types of remote URIs are supported for hosting ``working_dir`` and ``py_modules`` packages:
 

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -800,10 +800,13 @@ def unzip_package(
         top_level_directory = get_top_level_dir_from_compressed_package(package_path)
         if top_level_directory is None:
             raise ValueError(
-                "The package at package_path must contain "
+                f"The zip package at {package_path} must contain "
                 "a single top level directory. Make sure there "
                 "are no hidden files at the same level as the "
-                "top level directory."
+                "top level directory. You can ensure this by running "
+                "`zip -r example.zip example_dir` from the parent "
+                "directory of example_dir when creating the zip file. "
+                "You can check the contents with `zipinfo -1 example.zip`."
             )
 
         remove_dir_from_filepaths(target_dir, top_level_directory)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The requirements that a remote URI have a top-level directory are specified fully in the documentation; this PR makes the instructions more foolproof. This PR 
- specifies that the `zip` command must be run from the parent directory
- gives an example of the correct `zipinfo` output
- Adds instructions to the error message when there's no top-level directory

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
