### PR TITLE
[Docs] Omit terminal prompt when using copy button

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -80,6 +80,10 @@ external_toc_path = "_toc.yml"
 
 html_extra_path = ["robots.txt"]
 
+# Omit prompt when using copy button
+copybutton_prompt_text = r"\$ "
+copybutton_prompt_is_regexp = True
+
 
 # There's a flaky autodoc import for "TensorFlowVariables" that fails depending on the doc structure / order
 # of imports.


### PR DESCRIPTION
Signed-off-by: Shreyas Krishnaswamy <shrekris@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When users copy documentation text with the copy button, they copy all the text in the code block. This change omits the terminal prompt `$` when copying CLI examples.

Example doc link: https://ray--28028.org.readthedocs.build/en/28028/serve/production-guide/rest-api.html#using-a-remote-cluster

* Copy-pasting the CLI command omits the `$` prompt:

<img width="766" alt="Screen Shot 2022-08-20 at 3 43 22 PM" src="https://user-images.githubusercontent.com/92341594/185768494-b39254df-7d21-47d2-a68c-92613c0481c9.png">

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change only affects doc formatting.
