### PR TITLE
[Docs] Remove topbar overlap on left table of contents

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -1,5 +1,11 @@
-/* For Algolia search box to flow-over horizontally into main content*/
-#site-navigation { overflow-y: visible; }
+/* For Algolia search box
+    * overflow-y: to flow-over horizontally into main content
+    * height: to prevent topbar overlap
+*/
+#site-navigation {
+  overflow-y: visible;
+  height: 100% !important;
+}
 
 /* Center the algolia search bar*/
 #search-input {


### PR DESCRIPTION
Signed-off-by: Shreyas Krishnaswamy <shrekris@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The topbar shadow overlaps the left table of contents before the user scrolls completely past them:

<img width="1440" alt="Screen Shot 2022-08-20 at 12 35 56 AM" src="https://user-images.githubusercontent.com/92341594/185734505-ed8dfea2-121c-4170-9d54-a2f98c1fdee6.png">

This change expands the left table of contents' height, so the topbar shadow doesn't expand until the user scrolls completely past the table.

Doc link: https://ray--28031.org.readthedocs.build/en/28031/

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change only affects doc formatting.
