### PR TITLE
[Train] Change `_move_to_device` log line to debug instead of info

### DIFF
--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -604,7 +604,7 @@ class _WrappedDataLoader(DataLoader):
             elif isinstance(item, torch.Tensor):
                 item_on_device = try_move_device(item)
             else:
-                logger.info(
+                logger.debug(
                     f"Data type {type(item)} doesn't support being moved to device."
                 )
                 item_on_device = item


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

@amogkam

## Why are these changes needed?

The loglines from `_move_to_device` have become too numerous. Setting this to debug would help. Should we consider completely removing it? Since it's a valid use case, I feel like there isn't much benefit to this logline.

![image](https://user-images.githubusercontent.com/19661538/185791277-c0e9130c-331d-4da5-afe7-362a9ca1bbbf.png)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
