### PR TITLE
Don't include script directory in sys.path if it's started via python -m

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2067,7 +2067,7 @@ def connect(
         # are the same.
         # When using an interactive shell, there is no script directory.
         if not interactive_mode:
-            script_directory = os.path.abspath(os.path.dirname(sys.argv[0]))
+            script_directory = os.path.realpath(os.path.dirname(sys.argv[0]))
             # If driver's sys.path doesn't include the script directory
             # (e.g driver is started via `python -m`,
             # see https://peps.python.org/pep-0338/),

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2068,9 +2068,14 @@ def connect(
         # When using an interactive shell, there is no script directory.
         if not interactive_mode:
             script_directory = os.path.abspath(os.path.dirname(sys.argv[0]))
-            worker.run_function_on_all_workers(
-                lambda worker_info: sys.path.insert(1, script_directory)
-            )
+            # If driver's sys.path doesn't include the script directory
+            # (e.g driver is started via `python -m`,
+            # see https://peps.python.org/pep-0338/),
+            # then we shouldn't add it to the workers.
+            if script_directory in sys.path:
+                worker.run_function_on_all_workers(
+                    lambda worker_info: sys.path.insert(1, script_directory)
+                )
         # In client mode, if we use runtime envs with "working_dir", then
         # it'll be handled automatically.  Otherwise, add the current dir.
         if not job_config.client_job and not job_config.runtime_env_has_working_dir():

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -12,6 +12,7 @@ import ray.cluster_utils
 from ray._private.test_utils import (
     run_string_as_driver,
     wait_for_pid_to_exit,
+    check_call_subprocess,
 )
 
 logger = logging.getLogger(__name__)
@@ -178,6 +179,48 @@ ray.get(ready.remote())
     run_string_as_driver(driver_script)
     run_string_as_driver(driver_script)
     run_string_as_driver(driver_script)
+
+
+def test_worker_sys_path_contains_driver_script_directory(tmp_path, monkeypatch):
+    package_folder = tmp_path / "package"
+    package_folder.mkdir()
+    init_file = tmp_path / "package" / "__init__.py"
+    init_file.write_text("")
+
+    module1_file = tmp_path / "package" / "module1.py"
+    module1_file.write_text(
+        f"""
+import sys
+import ray
+ray.init()
+
+@ray.remote
+def sys_path():
+    return sys.path
+
+assert '{str(tmp_path / "package")}' in ray.get(sys_path.remote())
+"""
+    )
+    check_call_subprocess(["python", str(module1_file)])
+
+    # If the driver script is run via `python -m`,
+    # the script directory is not included in sys.path.
+    module2_file = tmp_path / "package" / "module2.py"
+    module2_file.write_text(
+        f"""
+import sys
+import ray
+ray.init()
+
+@ray.remote
+def sys_path():
+    return sys.path
+
+assert '{str(tmp_path / "package")}' not in ray.get(sys_path.remote())
+"""
+    )
+    monkeypatch.chdir(str(tmp_path))
+    check_call_subprocess(["python", "-m", "package.module2"])
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 import time
+import subprocess
 
 import pytest
 
@@ -12,7 +13,6 @@ import ray.cluster_utils
 from ray._private.test_utils import (
     run_string_as_driver,
     wait_for_pid_to_exit,
-    check_call_subprocess,
 )
 
 logger = logging.getLogger(__name__)
@@ -201,7 +201,7 @@ def sys_path():
 assert '{str(tmp_path / "package")}' in ray.get(sys_path.remote())
 """
     )
-    check_call_subprocess(["python", str(module1_file)])
+    subprocess.check_call(["python", str(module1_file)])
 
     # If the driver script is run via `python -m`,
     # the script directory is not included in sys.path.
@@ -220,7 +220,7 @@ assert '{str(tmp_path / "package")}' not in ray.get(sys_path.remote())
 """
     )
     monkeypatch.chdir(str(tmp_path))
-    check_call_subprocess(["python", "-m", "package.module2"])
+    subprocess.check_call(["python", "-m", "package.module2"])
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -198,7 +198,7 @@ ray.init()
 def sys_path():
     return sys.path
 
-assert '{str(tmp_path / "package")}' in ray.get(sys_path.remote())
+assert r'{str(tmp_path / "package")}' in ray.get(sys_path.remote())
 """
     )
     subprocess.check_call(["python", str(module1_file)])
@@ -216,7 +216,7 @@ ray.init()
 def sys_path():
     return sys.path
 
-assert '{str(tmp_path / "package")}' not in ray.get(sys_path.remote())
+assert r'{str(tmp_path / "package")}' not in ray.get(sys_path.remote())
 """
     )
     monkeypatch.chdir(str(tmp_path))


### PR DESCRIPTION
Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
According to https://peps.python.org/pep-0338/
> The -m switch provides a benefit here, as it inserts the current directory into sys.path, instead of the directory contain the main module.

We should follow this and don't add the driver script directory to worker's sys.path. I couldn't find a way to detect that the driver is run via `python -m` but instead we don't add the script directory to worker's sys.path if it doesn't exist in driver's sys.path.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/PrefectHQ/prefect-ray/issues/33
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
