### PR TITLE
[air/docs] Add example to fetch results dataframe for trainer/tuner

### DIFF
--- a/doc/source/ray-air/doc_code/tuner.py
+++ b/doc/source/ray-air/doc_code/tuner.py
@@ -176,7 +176,6 @@ config = TuneConfig(
 # __tune_optimization_end__
 
 # __result_grid_inspection_start__
-from ray.air.config import RunConfig
 from ray.tune import Tuner, TuneConfig
 
 tuner = Tuner(
@@ -201,7 +200,11 @@ best_checkpoint = best_result.checkpoint
 # And the best metrics
 best_metric = best_result.metrics
 
-# Inspect all results
+# Or a dataframe for further analysis
+results_df = best_result.metrics_dataframe
+print("Shortest training time:", results_df["time_total_s"].min())
+
+# Iterate over results
 for result in result_grid:
     if result.error:
         print("The trial had an error:", result.error)

--- a/doc/source/ray-air/doc_code/tuner.py
+++ b/doc/source/ray-air/doc_code/tuner.py
@@ -201,7 +201,7 @@ best_checkpoint = best_result.checkpoint
 best_metric = best_result.metrics
 
 # Or a dataframe for further analysis
-results_df = best_result.metrics_dataframe
+results_df = results.get_dataframe()
 print("Shortest training time:", results_df["time_total_s"].min())
 
 # Iterate over results

--- a/doc/source/ray-air/doc_code/tuner.py
+++ b/doc/source/ray-air/doc_code/tuner.py
@@ -201,7 +201,7 @@ best_checkpoint = best_result.checkpoint
 best_metric = best_result.metrics
 
 # Or a dataframe for further analysis
-results_df = results.get_dataframe()
+results_df = result_grid.get_dataframe()
 print("Shortest training time:", results_df["time_total_s"].min())
 
 # Iterate over results

--- a/doc/source/ray-air/trainer.rst
+++ b/doc/source/ray-air/trainer.rst
@@ -212,8 +212,11 @@ You can interact with a `Result` object as follows:
     # returns the final metrics as reported
     result.metrics
 
-    # returns the contain an Exception if training failed.
+    # returns the Exception if training failed.
     result.error
+
+    # Returns a pandas dataframe of all reported results
+    results.metrics_dataframe
 
 
 See :class:`the Result docstring <ray.air.result.Result>` for more details.

--- a/doc/source/ray-air/trainer.rst
+++ b/doc/source/ray-air/trainer.rst
@@ -216,7 +216,7 @@ You can interact with a `Result` object as follows:
     result.error
 
     # Returns a pandas dataframe of all reported results
-    results.metrics_dataframe
+    result.metrics_dataframe
 
 
 See :class:`the Result docstring <ray.air.result.Result>` for more details.


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Our docs examples should contain example code to fetch dataframes from result/result grid objects

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
