### PR TITLE
[Docs] [Tune] `ResultGrid` Docs and API reference

### DIFF
--- a/doc/source/tune/api_docs/result_grid.rst
+++ b/doc/source/tune/api_docs/result_grid.rst
@@ -1,41 +1,12 @@
 .. _tune-analysis-docs:
 
+.. _result-grid-docstring:
+
 ResultGrid (tune.ResultGrid)
 ========================================
 
-You can use the ``ResultGrid`` object for interacting with tune results.
-It is returned by ``Tuner.fit()``.
-
-.. code-block:: python
-
-    from ray import air, tune
-
-    tuner = tune.Tuner(
-        trainable,
-        run_config=air.RunConfig(name="example-experiment"),
-        tune_config=tune.TuneConfig(num_samples=10),
-    )
-    results = tuner.fit()
-
-Here are some example operations for obtaining a summary of your experiment:
-
-.. code-block:: python
-
-    # Get a dataframe for the last reported results of all of the trials
-    df = results.get_dataframe()
-
-    # Get a dataframe for the max accuracy seen for each trial
-    df = results.get_dataframe()(metric="mean_accuracy", mode="max")
-
-
-One may wonder how is ResultGrid different than ExperimentAnalysis. ResultGrid is supposed
-to succeed ExperimentAnalysis. However, it has not reached the same feature parity yet.
-For interacting with an existing experiment, located at ``local_dir``, one may do the following:
-
-.. code-block:: python
-
-    from ray.tune import ExperimentAnalysis
-    analysis = ExperimentAnalysis("~/ray_results/example-experiment")
+.. autoclass:: ray.tune.ResultGrid
+    :members:
 
 .. _exp-analysis-docstring:
 

--- a/python/ray/tune/result_grid.py
+++ b/python/ray/tune/result_grid.py
@@ -22,7 +22,7 @@ class ResultGrid:
      The constructor is a private API. This object can only be created as a result of
      ``Tuner.fit()``.
 
-     Usage pattern:
+     Example:
 
      .. code-block:: python
 

--- a/python/ray/tune/result_grid.py
+++ b/python/ray/tune/result_grid.py
@@ -64,7 +64,7 @@ class ResultGrid:
         df = result_grid.get_dataframe()
 
         # Get a dataframe for the minimum loss seen for each trial
-        df = result_grid.get_dataframe()(metric="loss", mode="min")
+        df = result_grid.get_dataframe(metric="loss", mode="min")
 
     Note that trials of all statuses are included in the final result grid.
     If a trial is not in terminated state, its latest result and checkpoint as

--- a/python/ray/tune/result_grid.py
+++ b/python/ray/tune/result_grid.py
@@ -17,67 +17,67 @@ from ray.util import PublicAPI
 class ResultGrid:
     """A set of ``Result`` objects for interacting with Ray Tune results.
 
-    You can use it to inspect the trials run as well as obtaining the best result.
+     You can use it to inspect the trials and obtain the best result.
 
-    The constructor is a private API. This object can only be created as a result of
-    ``Tuner.fit()``.
+     The constructor is a private API. This object can only be created as a result of
+     ``Tuner.fit()``.
 
-    Usage pattern:
+     Usage pattern:
 
-    .. code-block:: python
+     .. code-block:: python
 
-        import random
-        from ray import air, tune
+         import random
+         from ray import air, tune
 
-        def random_error_trainable(config):
-            if random.random() < 0.5:
-                return {"loss": 0.0}
-            else:
-                raise ValueError("This is an error")
+         def random_error_trainable(config):
+             if random.random() < 0.5:
+                 return {"loss": 0.0}
+             else:
+                 raise ValueError("This is an error")
 
-        tuner = tune.Tuner(
-            random_error_trainable,
-            run_config=air.RunConfig(name="example-experiment"),
-            tune_config=tune.TuneConfig(num_samples=10),
-        )
-        result_grid = tuner.fit()
+         tuner = tune.Tuner(
+             random_error_trainable,
+             run_config=air.RunConfig(name="example-experiment"),
+             tune_config=tune.TuneConfig(num_samples=10),
+         )
+         result_grid = tuner.fit()
 
-        for i in range(len(result_grid)):
-            result = result_grid[i]
-            if not result.error:
-                print(f"Trial finishes successfully with metric {result.metric}.")
-            else:
-                print(f"Trial failed with error {result.error}.")
+         for i in range(len(result_grid)):
+             result = result_grid[i]
+             if not result.error:
+                 print(f"Trial finishes successfully with metric {result.metric}.")
+             else:
+                 print(f"Trial failed with error {result.error}.")
 
 
-    You can also use `result_grid` for more advanced analysis.
+     You can also use ``result_grid`` for more advanced analysis.
 
-    .. code-block:: python
+     .. code-block:: python
 
-        # Get the best result based on a particular metric.
-        best_result = result_grid.get_best_result(metric="loss", mode="min")
+         # Get the best result based on a particular metric.
+         best_result = result_grid.get_best_result(metric="loss", mode="min")
 
-        # Get the best checkpoint corresponding to the best result.
-        best_checkpoint = best_result.checkpoint
+         # Get the best checkpoint corresponding to the best result.
+         best_checkpoint = best_result.checkpoint
 
-        # Get a dataframe for the last reported results of all of the trials
-        df = result_grid.get_dataframe()
+         # Get a dataframe for the last reported results of all of the trials
+         df = result_grid.get_dataframe()
 
-        # Get a dataframe for the minimum loss seen for each trial
-        df = result_grid.get_dataframe(metric="loss", mode="min")
+         # Get a dataframe for the minimum loss seen for each trial
+         df = result_grid.get_dataframe(metric="loss", mode="min")
 
-    Note that trials of all statuses are included in the final result grid.
-    If a trial is not in terminated state, its latest result and checkpoint as
-    seen by Tune will be provided.
+     Note that trials of all statuses are included in the final result grid.
+     If a trial is not in terminated state, its latest result and checkpoint as
+     seen by Tune will be provided.
 
-   ResultGrid will be the successor of the ExperimentAnalysis object
-   but is not yet at feature parity. For interacting with an existing experiment, located at
-    ``local_dir``, do the following:
+    ``ResultGrid`` will be the successor of the ``ExperimentAnalysis`` object
+    but is not yet at feature parity. For interacting with an existing experiment,
+    located at ``local_dir``, do the following:
 
-    .. code-block:: python
+     .. code-block:: python
 
-        from ray.tune import ExperimentAnalysis
-        analysis = ExperimentAnalysis("~/ray_results/example-experiment")
+         from ray.tune import ExperimentAnalysis
+         analysis = ExperimentAnalysis("~/ray_results/example-experiment")
     """
 
     def __init__(

--- a/python/ray/tune/result_grid.py
+++ b/python/ray/tune/result_grid.py
@@ -70,10 +70,9 @@ class ResultGrid:
     If a trial is not in terminated state, its latest result and checkpoint as
     seen by Tune will be provided.
 
-    One may wonder how is ResultGrid different than ExperimentAnalysis. ResultGrid is
-    supposed to succeed ExperimentAnalysis. However, it has not reached the same
-    feature parity yet. For interacting with an existing experiment, located at
-    ``local_dir``, one may do the following:
+   ResultGrid will be the successor of the ExperimentAnalysis object
+   but is not yet at feature parity. For interacting with an existing experiment, located at
+    ``local_dir``, do the following:
 
     .. code-block:: python
 

--- a/python/ray/tune/result_grid.py
+++ b/python/ray/tune/result_grid.py
@@ -15,30 +15,70 @@ from ray.util import PublicAPI
 
 @PublicAPI(stability="beta")
 class ResultGrid:
-    """A set of ``Result`` objects returned from a call to ``tuner.fit()``.
+    """A set of ``Result`` objects for interacting with Ray Tune results.
 
     You can use it to inspect the trials run as well as obtaining the best result.
 
-    The constructor is a private API.
+    The constructor is a private API. This object can only be created as a result of
+    ``Tuner.fit()``.
 
     Usage pattern:
 
     .. code-block:: python
 
+        import random
+        from ray import air, tune
+
+        def random_error_trainable(config):
+            if random.random() < 0.5:
+                return {"loss": 0.0}
+            else:
+                raise ValueError("This is an error")
+
+        tuner = tune.Tuner(
+            random_error_trainable,
+            run_config=air.RunConfig(name="example-experiment"),
+            tune_config=tune.TuneConfig(num_samples=10),
+        )
         result_grid = tuner.fit()
+
         for i in range(len(result_grid)):
             result = result_grid[i]
             if not result.error:
                 print(f"Trial finishes successfully with metric {result.metric}.")
             else:
-                print(f"Trial errors out with {result.error}.")
-        best_result = result_grid.get_best_result()
+                print(f"Trial failed with error {result.error}.")
+
+
+    You can also use `result_grid` for more advanced analysis.
+
+    .. code-block:: python
+
+        # Get the best result based on a particular metric.
+        best_result = result_grid.get_best_result(metric="loss", mode="min")
+
+        # Get the best checkpoint corresponding to the best result.
         best_checkpoint = best_result.checkpoint
-        best_metric = best_result.metric
+
+        # Get a dataframe for the last reported results of all of the trials
+        df = result_grid.get_dataframe()
+
+        # Get a dataframe for the minimum loss seen for each trial
+        df = result_grid.get_dataframe()(metric="loss", mode="min")
 
     Note that trials of all statuses are included in the final result grid.
     If a trial is not in terminated state, its latest result and checkpoint as
     seen by Tune will be provided.
+
+    One may wonder how is ResultGrid different than ExperimentAnalysis. ResultGrid is
+    supposed to succeed ExperimentAnalysis. However, it has not reached the same
+    feature parity yet. For interacting with an existing experiment, located at
+    ``local_dir``, one may do the following:
+
+    .. code-block:: python
+
+        from ray.tune import ExperimentAnalysis
+        analysis = ExperimentAnalysis("~/ray_results/example-experiment")
     """
 
     def __init__(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Improve docstring for `ResultGrid` and show API reference and docstring in Tune API section.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
