### PR TITLE
[Java] Fix statical define concurrency groups.

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/util/ConcurrencyGroupUtils.java
+++ b/java/runtime/src/main/java/io/ray/runtime/util/ConcurrencyGroupUtils.java
@@ -24,30 +24,28 @@ public final class ConcurrencyGroupUtils {
     Class<?> actorClz =
         MethodUtils.getReturnTypeFromSignature(serializedLambda.getInstantiatedMethodType());
 
+    /// Extract the concurrency groups definition.
     ArrayList<ConcurrencyGroup> ret = new ArrayList<ConcurrencyGroup>();
-    DefConcurrencyGroups concurrencyGroupsDefinitionAnnotation =
-        actorClz.getAnnotation(DefConcurrencyGroups.class);
-    if (concurrencyGroupsDefinitionAnnotation == null) {
-      /// This actor is not annotated with concurrency groups definition.
-      return ret;
+    Map<String, ConcurrencyGroupImpl> allConcurrencyGroupsMap =
+      extractConcurrencyGroupsFromClassAnnotation(actorClz);
+    Class<?>[] interfaces = actorClz.getInterfaces();
+    for (Class<?> interfaceClz : interfaces) {
+      Preconditions.checkState(interfaceClz != null);
+      Map<String, ConcurrencyGroupImpl> currConcurrencyGroups =
+        extractConcurrencyGroupsFromClassAnnotation(interfaceClz);
+      allConcurrencyGroupsMap.putAll(currConcurrencyGroups);
+
     }
 
-    Map<String, ConcurrencyGroupImpl> concurrencyGroupsMap = new HashMap<>();
-    DefConcurrencyGroup[] defAnnotations = concurrencyGroupsDefinitionAnnotation.value();
-    Preconditions.checkState(defAnnotations.length != 0);
-    for (DefConcurrencyGroup def : defAnnotations) {
-      concurrencyGroupsMap.put(
-          def.name(), new ConcurrencyGroupImpl(def.name(), def.maxConcurrency()));
-    }
-
+    /// Extract the using of concurrency groups which annotated on the actor methods.
     Method[] methods = actorClz.getMethods();
     for (Method method : methods) {
       UseConcurrencyGroup useConcurrencyGroupAnnotation =
           method.getAnnotation(UseConcurrencyGroup.class);
       if (useConcurrencyGroupAnnotation != null) {
         String concurrencyGroupName = useConcurrencyGroupAnnotation.name();
-        Preconditions.checkState(concurrencyGroupsMap.containsKey(concurrencyGroupName));
-        concurrencyGroupsMap
+        Preconditions.checkState(allConcurrencyGroupsMap.containsKey(concurrencyGroupName));
+        allConcurrencyGroupsMap
             .get(concurrencyGroupName)
             .addJavaFunctionDescriptor(
                 new JavaFunctionDescriptor(
@@ -57,10 +55,41 @@ public final class ConcurrencyGroupUtils {
       }
     }
 
-    concurrencyGroupsMap.forEach(
+    allConcurrencyGroupsMap.forEach(
         (key, value) -> {
           ret.add(value);
         });
+    return ret;
+  }
+
+  /// Extract the concurrency groups from the class annotation.
+  /// Both work for class and interface.
+  private static Map<String, ConcurrencyGroupImpl> extractConcurrencyGroupsFromClassAnnotation(
+    Class<?> clz) {
+    Map<String, ConcurrencyGroupImpl> ret = new HashMap<>();
+    DefConcurrencyGroups concurrencyGroupsDefinitionAnnotation =
+      clz.getAnnotation(DefConcurrencyGroups.class);
+    if (concurrencyGroupsDefinitionAnnotation != null) {
+      DefConcurrencyGroup[] defAnnotations = concurrencyGroupsDefinitionAnnotation.value();
+      if (defAnnotations.length == 0) {
+        throw new IllegalArgumentException("TODO");
+      }
+      for (DefConcurrencyGroup def : defAnnotations) {
+        ret.put(def.name(), new ConcurrencyGroupImpl(def.name(), def.maxConcurrency()));
+      }
+    } else {
+      /// Code path of that no annotation or 1 annotation definition.
+      DefConcurrencyGroup defConcurrencyGroup = clz.getAnnotation(DefConcurrencyGroup.class);
+      if (defConcurrencyGroup != null) {
+        ret.put(
+          defConcurrencyGroup.name(),
+          new ConcurrencyGroupImpl(
+            defConcurrencyGroup.name(), defConcurrencyGroup.maxConcurrency()));
+      } else {
+        /// This actor is not defined with concurrency groups annotation.
+        return ret;
+      }
+    }
     return ret;
   }
 }

--- a/java/runtime/src/main/java/io/ray/runtime/util/ConcurrencyGroupUtils.java
+++ b/java/runtime/src/main/java/io/ray/runtime/util/ConcurrencyGroupUtils.java
@@ -27,14 +27,13 @@ public final class ConcurrencyGroupUtils {
     /// Extract the concurrency groups definition.
     ArrayList<ConcurrencyGroup> ret = new ArrayList<ConcurrencyGroup>();
     Map<String, ConcurrencyGroupImpl> allConcurrencyGroupsMap =
-      extractConcurrencyGroupsFromClassAnnotation(actorClz);
+        extractConcurrencyGroupsFromClassAnnotation(actorClz);
     Class<?>[] interfaces = actorClz.getInterfaces();
     for (Class<?> interfaceClz : interfaces) {
       Preconditions.checkState(interfaceClz != null);
       Map<String, ConcurrencyGroupImpl> currConcurrencyGroups =
-        extractConcurrencyGroupsFromClassAnnotation(interfaceClz);
+          extractConcurrencyGroupsFromClassAnnotation(interfaceClz);
       allConcurrencyGroupsMap.putAll(currConcurrencyGroups);
-
     }
 
     /// Extract the using of concurrency groups which annotated on the actor methods.
@@ -65,10 +64,10 @@ public final class ConcurrencyGroupUtils {
   /// Extract the concurrency groups from the class annotation.
   /// Both work for class and interface.
   private static Map<String, ConcurrencyGroupImpl> extractConcurrencyGroupsFromClassAnnotation(
-    Class<?> clz) {
+      Class<?> clz) {
     Map<String, ConcurrencyGroupImpl> ret = new HashMap<>();
     DefConcurrencyGroups concurrencyGroupsDefinitionAnnotation =
-      clz.getAnnotation(DefConcurrencyGroups.class);
+        clz.getAnnotation(DefConcurrencyGroups.class);
     if (concurrencyGroupsDefinitionAnnotation != null) {
       DefConcurrencyGroup[] defAnnotations = concurrencyGroupsDefinitionAnnotation.value();
       if (defAnnotations.length == 0) {
@@ -82,9 +81,9 @@ public final class ConcurrencyGroupUtils {
       DefConcurrencyGroup defConcurrencyGroup = clz.getAnnotation(DefConcurrencyGroup.class);
       if (defConcurrencyGroup != null) {
         ret.put(
-          defConcurrencyGroup.name(),
-          new ConcurrencyGroupImpl(
-            defConcurrencyGroup.name(), defConcurrencyGroup.maxConcurrency()));
+            defConcurrencyGroup.name(),
+            new ConcurrencyGroupImpl(
+                defConcurrencyGroup.name(), defConcurrencyGroup.maxConcurrency()));
       } else {
         /// This actor is not defined with concurrency groups annotation.
         return ret;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fix 2 issues about Java ConcurrencyGroup:
 - Fix concurrency actor annotated with only 1 concurrency group doesn't work issue, see `testSingleConcurrencyActor` case.
 - Fix concurrency group annotations couldn't be inherited, see `testLimitMethodsInOneGroupOfStaticDefinitionForInterface` case.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
