### PR TITLE
Log histograms in wandb

### DIFF
--- a/python/ray/air/callbacks/wandb.py
+++ b/python/ray/air/callbacks/wandb.py
@@ -35,8 +35,17 @@ WANDB_SETUP_API_KEY_HOOK = "WANDB_SETUP_API_KEY_HOOK"
 # It takes in a W&B run object and doesn't return anything.
 # Example: "your.module.wandb_process_run_info_hook".
 WANDB_PROCESS_RUN_INFO_HOOK = "WANDB_PROCESS_RUN_INFO_HOOK"
-_VALID_TYPES = (Number, wandb.data_types.Video, wandb.data_types.Image)
-_VALID_ITERABLE_TYPES = (wandb.data_types.Video, wandb.data_types.Image)
+_VALID_TYPES = (
+    Number,
+    wandb.data_types.Video,
+    wandb.data_types.Image,
+    wandb.data_types.Histogram,
+)
+_VALID_ITERABLE_TYPES = (
+    wandb.data_types.Video,
+    wandb.data_types.Image,
+    wandb.data_types.Histogram,
+)
 
 
 def _is_allowed_type(obj):


### PR DESCRIPTION
## Why are these changes needed?

We should be able to log wandb histograms from ray. This commit enables this. I'm using this edited code in my own version of ray for a while now, and figure it is worth upstreaming.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] On my local setup 
