### PR TITLE
[runtime env][java] Support runtime env config in Java

### DIFF
--- a/java/api/src/main/java/io/ray/api/exception/RuntimeEnvException.java
+++ b/java/api/src/main/java/io/ray/api/exception/RuntimeEnvException.java
@@ -5,4 +5,8 @@ public class RuntimeEnvException extends RayException {
   public RuntimeEnvException(String message) {
     super(message);
   }
+
+  public RuntimeEnvException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/java/api/src/main/java/io/ray/api/runtimecontext/RuntimeContext.java
+++ b/java/api/src/main/java/io/ray/api/runtimecontext/RuntimeContext.java
@@ -5,6 +5,7 @@ import io.ray.api.id.ActorId;
 import io.ray.api.id.JobId;
 import io.ray.api.id.TaskId;
 import io.ray.api.id.UniqueId;
+import io.ray.api.runtimeenv.RuntimeEnv;
 import java.util.List;
 
 /** A class used for getting information of Ray runtime. */
@@ -45,4 +46,9 @@ public interface RuntimeContext {
 
   /** Get the node id of this worker. */
   UniqueId getCurrentNodeId();
+
+  /**
+   * Get the runtime env of this worker. If it is a driver, job level runtime env will be returned.
+   */
+  RuntimeEnv getCurrentRuntimeEnv();
 }

--- a/java/api/src/main/java/io/ray/api/runtimeenv/RuntimeEnv.java
+++ b/java/api/src/main/java/io/ray/api/runtimeenv/RuntimeEnv.java
@@ -77,7 +77,7 @@ public interface RuntimeEnv {
    *
    * @return
    */
-  boolean empty();
+  boolean isEmpty();
 
   /**
    * Serialize the runtime env to string of RuntimeEnvInfo.
@@ -108,7 +108,7 @@ public interface RuntimeEnv {
   /**
    * Get runtime env config.
    *
-   * @return
+   * @return The runtime env config.
    */
   public RuntimeEnvConfig getConfig();
 

--- a/java/api/src/main/java/io/ray/api/runtimeenv/RuntimeEnv.java
+++ b/java/api/src/main/java/io/ray/api/runtimeenv/RuntimeEnv.java
@@ -48,6 +48,14 @@ public interface RuntimeEnv {
   public String getJsonStr(String name) throws RuntimeEnvException;
 
   /**
+   * Whether a field is contained.
+   *
+   * @param name The runtime env plugin name.
+   * @return
+   */
+  boolean contains(String name);
+
+  /**
    * Remove a runtime env field by name.
    *
    * @param name The build-in names or a runtime env plugin name.
@@ -63,6 +71,13 @@ public interface RuntimeEnv {
    * @throws RuntimeEnvException
    */
   public String serialize() throws RuntimeEnvException;
+
+  /**
+   * Whether the runtime env is empty.
+   *
+   * @return
+   */
+  boolean empty();
 
   /**
    * Serialize the runtime env to string of RuntimeEnvInfo.
@@ -82,6 +97,20 @@ public interface RuntimeEnv {
   public static RuntimeEnv deserialize(String serializedRuntimeEnv) throws RuntimeEnvException {
     return Ray.internal().deserializeRuntimeEnv(serializedRuntimeEnv);
   }
+
+  /**
+   * Set runtime env config.
+   *
+   * @param runtimeEnvConfig
+   */
+  public void setConfig(RuntimeEnvConfig runtimeEnvConfig);
+
+  /**
+   * Get runtime env config.
+   *
+   * @return
+   */
+  public RuntimeEnvConfig getConfig();
 
   /** The builder which is used to generate a RuntimeEnv instance. */
   public static class Builder {

--- a/java/api/src/main/java/io/ray/api/runtimeenv/RuntimeEnvConfig.java
+++ b/java/api/src/main/java/io/ray/api/runtimeenv/RuntimeEnvConfig.java
@@ -1,0 +1,39 @@
+package io.ray.api.runtimeenv;
+
+/** A POJO class used to specify configuration options for a runtime environment. */
+public class RuntimeEnvConfig {
+  /**
+   * The timeout of runtime environment creation, timeout is in seconds. The value `-1` means
+   * disable timeout logic, except `-1`, `setup_timeout_seconds` cannot be less than or equal to 0.
+   * The default value of `setup_timeout_seconds` is 600 seconds.
+   */
+  private Integer setupTimeoutSeconds = 600;
+  /**
+   * Indicates whether to install the runtime environment on the cluster at `ray.init()` time,
+   * before the workers are leased. This flag is set to `True` by default.
+   */
+  private Boolean eagerInstall = true;
+
+  public RuntimeEnvConfig() {}
+
+  public RuntimeEnvConfig(int setupTimeoutSeconds, boolean eagerInstall) {
+    this.setupTimeoutSeconds = setupTimeoutSeconds;
+    this.eagerInstall = eagerInstall;
+  }
+
+  public void setSetupTimeoutSeconds(int setupTimeoutSeconds) {
+    this.setupTimeoutSeconds = setupTimeoutSeconds;
+  }
+
+  public Integer getSetupTimeoutSeconds() {
+    return this.setupTimeoutSeconds;
+  }
+
+  public void setEagerInstall(boolean eagerInstall) {
+    this.eagerInstall = eagerInstall;
+  }
+
+  public Boolean getEagerInstall() {
+    return eagerInstall;
+  }
+}

--- a/java/runtime/src/main/java/io/ray/runtime/config/RayConfig.java
+++ b/java/runtime/src/main/java/io/ray/runtime/config/RayConfig.java
@@ -8,6 +8,7 @@ import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
 import io.ray.api.id.JobId;
 import io.ray.api.options.ActorLifetime;
+import io.ray.api.runtimeenv.RuntimeEnvConfig;
 import io.ray.api.runtimeenv.types.RuntimeEnvName;
 import io.ray.runtime.generated.Common.WorkerType;
 import io.ray.runtime.runtimeenv.RuntimeEnvImpl;
@@ -216,12 +217,31 @@ public class RayConfig {
       if (config.hasPath(jarsPath)) {
         jarUrls = config.getStringList(jarsPath);
       }
+
+      /// Runtime env config
+      RuntimeEnvConfig runtimeEnvConfig = null;
+      final String timeoutPath = "ray.job.runtime-env.config.setup-timeout-seconds";
+      if (config.hasPath(timeoutPath)) {
+        runtimeEnvConfig = new RuntimeEnvConfig();
+        runtimeEnvConfig.setSetupTimeoutSeconds(config.getInt(timeoutPath));
+      }
+      final String eagerInstallPath = "ray.job.runtime-env.config.eager-install";
+      if (config.hasPath(eagerInstallPath)) {
+        if (runtimeEnvConfig == null) {
+          runtimeEnvConfig = new RuntimeEnvConfig();
+        }
+        runtimeEnvConfig.setEagerInstall(config.getBoolean(eagerInstallPath));
+      }
+
       runtimeEnvImpl = new RuntimeEnvImpl();
       if (!envVars.isEmpty()) {
         runtimeEnvImpl.set(RuntimeEnvName.ENV_VARS, envVars);
       }
       if (!jarUrls.isEmpty()) {
         runtimeEnvImpl.set(RuntimeEnvName.JARS, jarUrls);
+      }
+      if (runtimeEnvConfig != null) {
+        runtimeEnvImpl.setConfig(runtimeEnvConfig);
       }
     }
 

--- a/java/runtime/src/main/java/io/ray/runtime/context/LocalModeWorkerContext.java
+++ b/java/runtime/src/main/java/io/ray/runtime/context/LocalModeWorkerContext.java
@@ -6,6 +6,7 @@ import io.ray.api.id.ActorId;
 import io.ray.api.id.JobId;
 import io.ray.api.id.TaskId;
 import io.ray.api.id.UniqueId;
+import io.ray.api.runtimeenv.RuntimeEnv;
 import io.ray.runtime.generated.Common.Address;
 import io.ray.runtime.generated.Common.TaskSpec;
 import io.ray.runtime.generated.Common.TaskType;
@@ -69,6 +70,11 @@ public class LocalModeWorkerContext implements WorkerContext {
   @Override
   public Address getRpcAddress() {
     return Address.getDefaultInstance();
+  }
+
+  @Override
+  public RuntimeEnv getCurrentRuntimeEnv() {
+    throw new RuntimeException("Not implemented.");
   }
 
   public void setCurrentTask(TaskSpec taskSpec) {

--- a/java/runtime/src/main/java/io/ray/runtime/context/NativeWorkerContext.java
+++ b/java/runtime/src/main/java/io/ray/runtime/context/NativeWorkerContext.java
@@ -5,6 +5,7 @@ import io.ray.api.id.ActorId;
 import io.ray.api.id.JobId;
 import io.ray.api.id.TaskId;
 import io.ray.api.id.UniqueId;
+import io.ray.api.runtimeenv.RuntimeEnv;
 import io.ray.runtime.generated.Common.Address;
 import io.ray.runtime.generated.Common.TaskType;
 import java.nio.ByteBuffer;
@@ -48,6 +49,15 @@ public class NativeWorkerContext implements WorkerContext {
     }
   }
 
+  @Override
+  public RuntimeEnv getCurrentRuntimeEnv() {
+    String serialized_runtime_env = nativeGetSerializedRuntimeEnv();
+    if (serialized_runtime_env == null) {
+      return null;
+    }
+    return RuntimeEnv.deserialize(serialized_runtime_env);
+  }
+
   private static native int nativeGetCurrentTaskType();
 
   private static native ByteBuffer nativeGetCurrentTaskId();
@@ -59,4 +69,6 @@ public class NativeWorkerContext implements WorkerContext {
   private static native ByteBuffer nativeGetCurrentActorId();
 
   private static native byte[] nativeGetRpcAddress();
+
+  private static native String nativeGetSerializedRuntimeEnv();
 }

--- a/java/runtime/src/main/java/io/ray/runtime/context/RuntimeContextImpl.java
+++ b/java/runtime/src/main/java/io/ray/runtime/context/RuntimeContextImpl.java
@@ -9,6 +9,7 @@ import io.ray.api.id.UniqueId;
 import io.ray.api.runtimecontext.NodeInfo;
 import io.ray.api.runtimecontext.ResourceValue;
 import io.ray.api.runtimecontext.RuntimeContext;
+import io.ray.api.runtimeenv.RuntimeEnv;
 import io.ray.runtime.AbstractRayRuntime;
 import io.ray.runtime.config.RunMode;
 import io.ray.runtime.util.ResourceUtil;
@@ -101,5 +102,10 @@ public class RuntimeContextImpl implements RuntimeContext {
   @Override
   public UniqueId getCurrentNodeId() {
     return runtime.getCurrentNodeId();
+  }
+
+  @Override
+  public RuntimeEnv getCurrentRuntimeEnv() {
+    return runtime.getWorkerContext().getCurrentRuntimeEnv();
   }
 }

--- a/java/runtime/src/main/java/io/ray/runtime/context/WorkerContext.java
+++ b/java/runtime/src/main/java/io/ray/runtime/context/WorkerContext.java
@@ -4,6 +4,7 @@ import io.ray.api.id.ActorId;
 import io.ray.api.id.JobId;
 import io.ray.api.id.TaskId;
 import io.ray.api.id.UniqueId;
+import io.ray.api.runtimeenv.RuntimeEnv;
 import io.ray.runtime.generated.Common.Address;
 import io.ray.runtime.generated.Common.TaskType;
 
@@ -26,4 +27,7 @@ public interface WorkerContext {
   TaskId getCurrentTaskId();
 
   Address getRpcAddress();
+
+  /** RuntimeEnv of the current worker or job(for driver). */
+  RuntimeEnv getCurrentRuntimeEnv();
 }

--- a/java/runtime/src/main/java/io/ray/runtime/runtimeenv/RuntimeEnvImpl.java
+++ b/java/runtime/src/main/java/io/ray/runtime/runtimeenv/RuntimeEnvImpl.java
@@ -32,7 +32,7 @@ public class RuntimeEnvImpl implements RuntimeEnv {
     try {
       node = MAPPER.valueToTree(value);
     } catch (IllegalArgumentException e) {
-      throw new RuntimeEnvException("Setting field error", e);
+      throw new RuntimeEnvException("Failed to set field.", e);
     }
     runtimeEnvs.set(name, node);
   }
@@ -43,7 +43,7 @@ public class RuntimeEnvImpl implements RuntimeEnv {
     try {
       node = JsonLoader.fromString(jsonStr);
     } catch (IOException e) {
-      throw new RuntimeEnvException("Setting json field error", e);
+      throw new RuntimeEnvException("Failed to set json field.", e);
     }
     runtimeEnvs.set(name, node);
   }
@@ -57,7 +57,7 @@ public class RuntimeEnvImpl implements RuntimeEnv {
     try {
       return MAPPER.treeToValue(jsonNode, classOfT);
     } catch (JsonProcessingException e) {
-      throw new RuntimeEnvException("Getting field error", e);
+      throw new RuntimeEnvException("Failed to get field.", e);
     }
   }
 
@@ -66,7 +66,7 @@ public class RuntimeEnvImpl implements RuntimeEnv {
     try {
       return MAPPER.writeValueAsString(runtimeEnvs.get(name));
     } catch (JsonProcessingException e) {
-      throw new RuntimeEnvException("Getting json field error", e);
+      throw new RuntimeEnvException("Failed to get json field.", e);
     }
   }
 
@@ -89,12 +89,12 @@ public class RuntimeEnvImpl implements RuntimeEnv {
     try {
       return MAPPER.writeValueAsString(runtimeEnvs);
     } catch (JsonProcessingException e) {
-      throw new RuntimeEnvException("Serializing error", e);
+      throw new RuntimeEnvException("Failed to serialize.", e);
     }
   }
 
   @Override
-  public boolean empty() {
+  public boolean isEmpty() {
     return runtimeEnvs.isEmpty();
   }
 
@@ -106,7 +106,7 @@ public class RuntimeEnvImpl implements RuntimeEnv {
     try {
       return printer.print(protoRuntimeEnvInfo);
     } catch (InvalidProtocolBufferException e) {
-      throw new RuntimeEnvException("Serializing to runtime env info error", e);
+      throw new RuntimeEnvException("Failed to serialize to runtime env info.", e);
     }
   }
 

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -44,6 +44,19 @@ ray {
             // "https://my_host/a.jar",
             // "https://my_host/b.jar"
          ]
+
+         // The config of runtime env.
+         "config": {
+             // The timeout of runtime environment creation, timeout is in seconds.
+             // The value `-1` means disable timeout logic, except `-1`, `setup_timeout_seconds`
+             // cannot be less than or equal to 0. The default value of `setup_timeout_seconds`
+             // is 600 seconds.
+             // setup-timeout-seconds: 600
+             // Indicates whether to install the runtime environment on the cluster at `ray.init()`
+             // time, before the workers are leased. This flag is set to `True` by default.
+             // eager-install: true
+         }
+
     }
 
     /// The namespace of this job. It's used for isolation between jobs.

--- a/java/test/src/main/java/io/ray/test/RuntimeEnvTest.java
+++ b/java/test/src/main/java/io/ray/test/RuntimeEnvTest.java
@@ -57,6 +57,8 @@ public class RuntimeEnvTest {
       val = actor.task(A::getEnv, "KEY2").remote().get();
       Assert.assertEquals(val, "B");
     } finally {
+      System.clearProperty("ray.job.runtime-env.env-vars.KEY1");
+      System.clearProperty("ray.job.runtime-env.env-vars.KEY2");
       Ray.shutdown();
     }
   }
@@ -111,6 +113,8 @@ public class RuntimeEnvTest {
       val = Ray.task(RuntimeEnvTest::getEnvVar, "KEY2").setRuntimeEnv(runtimeEnv).remote().get();
       Assert.assertEquals(val, "B");
     } finally {
+      System.clearProperty("ray.job.runtime-env.env-vars.KEY1");
+      System.clearProperty("ray.job.runtime-env.env-vars.KEY2");
       Ray.shutdown();
     }
   }
@@ -194,6 +198,8 @@ public class RuntimeEnvTest {
               .get();
       Assert.assertTrue(ret);
     } finally {
+      System.clearProperty("ray.job.runtime-env.jars.0");
+      System.clearProperty("ray.job.runtime-env.jars.1");
       Ray.shutdown();
     }
   }
@@ -268,7 +274,7 @@ public class RuntimeEnvTest {
     }
   }
 
-  public void testRuntimeEnvContextJobLevel() {
+  public void testRuntimeEnvContextForJob() {
     System.setProperty("ray.job.runtime-env.jars.0", FOO_JAR_URL);
     System.setProperty("ray.job.runtime-env.jars.1", BAR_JAR_URL);
     System.setProperty("ray.job.runtime-env.config.setup-timeout-seconds", "1");
@@ -286,6 +292,9 @@ public class RuntimeEnvTest {
       Assert.assertEquals((int) runtimeEnvConfig.getSetupTimeoutSeconds(), 1);
 
     } finally {
+      System.clearProperty("ray.job.runtime-env.jars.0");
+      System.clearProperty("ray.job.runtime-env.jars.1");
+      System.clearProperty("ray.job.runtime-env.config.setup-timeout-seconds");
       Ray.shutdown();
     }
   }
@@ -298,11 +307,11 @@ public class RuntimeEnvTest {
     return null;
   }
 
-  public void testRuntimeEnvContextTaskLevel() {
+  public void testRuntimeEnvContextForTask() {
     try {
       Ray.init();
       RuntimeEnv currentRuntimeEnv = Ray.getRuntimeContext().getCurrentRuntimeEnv();
-      Assert.assertTrue(currentRuntimeEnv.empty());
+      Assert.assertTrue(currentRuntimeEnv.isEmpty());
       RuntimeEnv runtimeEnv = new RuntimeEnv.Builder().build();
       RuntimeEnvConfig runtimeEnvConfig = new RuntimeEnvConfig(1, false);
       runtimeEnv.setConfig(runtimeEnvConfig);

--- a/src/ray/core_worker/lib/java/io_ray_runtime_context_NativeWorkerContext.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_context_NativeWorkerContext.cc
@@ -71,6 +71,23 @@ Java_io_ray_runtime_context_NativeWorkerContext_nativeGetRpcAddress(JNIEnv *env,
   return NativeStringToJavaByteArray(env, rpc_address.SerializeAsString());
 }
 
+JNIEXPORT jstring JNICALL
+Java_io_ray_runtime_context_NativeWorkerContext_nativeGetSerializedRuntimeEnv(JNIEnv *env,
+                                                                              jclass) {
+  std::string serialized_runtime_env;
+  if (CoreWorkerProcess::GetCoreWorker().GetWorkerType() == WorkerType::DRIVER) {
+    serialized_runtime_env = CoreWorkerProcess::GetCoreWorker()
+                                 .GetJobConfig()
+                                 .runtime_env_info()
+                                 .serialized_runtime_env();
+  } else {
+    serialized_runtime_env = CoreWorkerProcess::GetCoreWorker()
+                                 .GetWorkerContext()
+                                 .GetCurrentSerializedRuntimeEnv();
+  }
+  return env->NewStringUTF(serialized_runtime_env.c_str());
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ray/core_worker/lib/java/io_ray_runtime_context_NativeWorkerContext.h
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_context_NativeWorkerContext.h
@@ -74,10 +74,10 @@ Java_io_ray_runtime_context_NativeWorkerContext_nativeGetRpcAddress(JNIEnv *, jc
 /*
  * Class:     io_ray_runtime_context_NativeWorkerContext
  * Method:    nativeGetSerializedRuntimeEnv
- * Signature: ()[B
+ * Signature: ()Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL
-Java_io_ray_runtime_context_NativeWorkerContext_nativeGetSerializedRuntimeEnv(JNIEnv *env,
+Java_io_ray_runtime_context_NativeWorkerContext_nativeGetSerializedRuntimeEnv(JNIEnv *,
                                                                               jclass);
 
 #ifdef __cplusplus

--- a/src/ray/core_worker/lib/java/io_ray_runtime_context_NativeWorkerContext.h
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_context_NativeWorkerContext.h
@@ -71,6 +71,15 @@ Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentActorId(JNIEnv *
 JNIEXPORT jbyteArray JNICALL
 Java_io_ray_runtime_context_NativeWorkerContext_nativeGetRpcAddress(JNIEnv *, jclass);
 
+/*
+ * Class:     io_ray_runtime_context_NativeWorkerContext
+ * Method:    nativeGetSerializedRuntimeEnv
+ * Signature: ()[B
+ */
+JNIEXPORT jstring JNICALL
+Java_io_ray_runtime_context_NativeWorkerContext_nativeGetSerializedRuntimeEnv(JNIEnv *env,
+                                                                              jclass);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Signed-off-by: 久龙 <guyang.sgy@antfin.com>

## Why are these changes needed?

Support job level and task/actor level runtime env config eg. `setupTimeoutSeconds` and `eagerInstall`.