### PR TITLE
[docs/tune] Fix loguniform range in tune tutorial

### DIFF
--- a/python/ray/tune/tests/tutorial.py
+++ b/python/ray/tune/tests/tutorial.py
@@ -166,7 +166,7 @@ from hyperopt import hp
 from ray.tune.search.hyperopt import HyperOptSearch
 
 space = {
-    "lr": hp.loguniform("lr", 1e-10, 0.1),
+    "lr": hp.loguniform("lr", -10, -1),
     "momentum": hp.uniform("momentum", 0.1, 0.9),
 }
 


### PR DESCRIPTION
hp.loguniform takes low/high exponent, not the result

Signed-off-by: Kilian Lieret <kilian.lieret@posteo.de>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The parameter space of the `hyperopt` example is wrong (doesn't match previous example and produces terrible results).

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
