### PR TITLE
Slurm: Set load_env to empty string if not specified

### DIFF
--- a/doc/source/cluster/doc_code/slurm-launch.py
+++ b/doc/source/cluster/doc_code/slurm-launch.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
         "--load-env",
         type=str,
         help="The script to load your environment ('module load cuda/10.1')",
+        default="",
     )
     parser.add_argument(
         "--command",


### PR DESCRIPTION
Signed-off-by: Kilian Lieret <kilian.lieret@posteo.de>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If `load-env` is not specified from the command line `"None"` is inserted in the shell script. This causes an error (but the shell script is in non-stop mode, so it doesn't care -- still not nice though)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
