### PR TITLE
[RLlib] Cast `TensorShape` dimensions to `int` before creating `gym.spaces.Box`

### DIFF
--- a/rllib/policy/dynamic_tf_policy_v2.py
+++ b/rllib/policy/dynamic_tf_policy_v2.py
@@ -709,11 +709,15 @@ class DynamicTFPolicyV2(TFPolicy):
             self._input_dict[key] = get_placeholder(value=value, name=key)
             if key not in self.view_requirements:
                 logger.info("Adding extra-action-fetch `{}` to view-reqs.".format(key))
+
+                # Some models specify parameter space shape with
+                # TensorShape[Dimension(...)], which are not compatible with gym.
+                # Reformat the shape here into a sequence of ints.
                 self.view_requirements[key] = ViewRequirement(
                     space=gym.spaces.Box(
                         -1.0,
                         1.0,
-                        shape=value.shape.as_list()[1:],
+                        shape=[int(dim) for dim in value.shape[1:]],
                         dtype=value.dtype.name,
                     ),
                     used_for_compute_actions=False,


### PR DESCRIPTION
## Why are these changes needed?

With `gym>0.23.1`, RLlib incorrectly initializes `gym.spaces.Box` with a `shape=TensorShape([Dimension(...)])` kwarg, when `gym.spaces.Box` expects a `Optional[Sequence[int]]` for the `shape` kwarg, raising an exception. This PR simply passes in a list of `int` which are obtained from the shape instead.

Currently `gym` is pinned to be `0.21.0<=gym<0.24.0` in `python/requirements.txt`, but the AIR examples say to `pip install -U gym` so users end up getting a version that raises errors. This PR aims to address the compatibility issues with `gym>0.23.1` to allow us to bump or unpin the dependency version.

Feedback is welcome here - someone more familiar with this area of the code might have a way of preventing the parameter space given by `TensorShape` from being initialized with a sequence of `Dimension` rather than `int` in the first place. For now, this solves the issues seen by the `rl_online_example`, `rl_offline_example`, and `rl_serving_example` at the point where the exceptions occur.

## Related issue number

Partially addresses #27851.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
