### PR TITLE
Revert "Don't include script directory in sys.path if it's started via python -m (#28043)"

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2067,15 +2067,10 @@ def connect(
         # are the same.
         # When using an interactive shell, there is no script directory.
         if not interactive_mode:
-            script_directory = os.path.realpath(os.path.dirname(sys.argv[0]))
-            # If driver's sys.path doesn't include the script directory
-            # (e.g driver is started via `python -m`,
-            # see https://peps.python.org/pep-0338/),
-            # then we shouldn't add it to the workers.
-            if script_directory in sys.path:
-                worker.run_function_on_all_workers(
-                    lambda worker_info: sys.path.insert(1, script_directory)
-                )
+            script_directory = os.path.abspath(os.path.dirname(sys.argv[0]))
+            worker.run_function_on_all_workers(
+                lambda worker_info: sys.path.insert(1, script_directory)
+            )
         # In client mode, if we use runtime envs with "working_dir", then
         # it'll be handled automatically.  Otherwise, add the current dir.
         if not job_config.client_job and not job_config.runtime_env_has_working_dir():

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -4,7 +4,6 @@ import logging
 import os
 import sys
 import time
-import subprocess
 
 import pytest
 
@@ -179,48 +178,6 @@ ray.get(ready.remote())
     run_string_as_driver(driver_script)
     run_string_as_driver(driver_script)
     run_string_as_driver(driver_script)
-
-
-def test_worker_sys_path_contains_driver_script_directory(tmp_path, monkeypatch):
-    package_folder = tmp_path / "package"
-    package_folder.mkdir()
-    init_file = tmp_path / "package" / "__init__.py"
-    init_file.write_text("")
-
-    module1_file = tmp_path / "package" / "module1.py"
-    module1_file.write_text(
-        f"""
-import sys
-import ray
-ray.init()
-
-@ray.remote
-def sys_path():
-    return sys.path
-
-assert r'{str(tmp_path / "package")}' in ray.get(sys_path.remote())
-"""
-    )
-    subprocess.check_call(["python", str(module1_file)])
-
-    # If the driver script is run via `python -m`,
-    # the script directory is not included in sys.path.
-    module2_file = tmp_path / "package" / "module2.py"
-    module2_file.write_text(
-        f"""
-import sys
-import ray
-ray.init()
-
-@ray.remote
-def sys_path():
-    return sys.path
-
-assert r'{str(tmp_path / "package")}' not in ray.get(sys_path.remote())
-"""
-    )
-    monkeypatch.chdir(str(tmp_path))
-    subprocess.check_call(["python", "-m", "package.module2"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

This reverts commit b41ee37c3a8298b34f23c5c5ee7a91d2af77cd5e.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This failed `linux://python/ray/train:tune_linear_example`
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
