### PR TITLE
[tests] Remove unnecessary sleep time from pipelined ingest tests

### DIFF
--- a/release/nightly_tests/dataset/pipelined_training.py
+++ b/release/nightly_tests/dataset/pipelined_training.py
@@ -44,7 +44,6 @@ parser.add_argument(
     help=("how many batches to wait before logging training " "status"),
 )
 parser.add_argument("--num-workers", type=int, default=16)
-parser.add_argument("--mock-train-step-time", type=float, default=1.0)
 parser.add_argument("--num-files", type=int, default=30)
 parser.add_argument("--num-windows", type=int, default=1)
 parser.add_argument("--manual-windows", type=bool, default=False)
@@ -137,7 +136,6 @@ def train_main(args, splits):
                     f"Processing batch {batch_idx} in epoch {epoch} on worker "
                     f"{rank}."
                 )
-            time.sleep(args.mock_train_step_time)
             loss = loss_function(batch_pred, target, delta=60)
             loss.mean().backward()
             for opt in optimizers:


### PR DESCRIPTION
Signed-off-by: Stephanie Wang <swang@cs.berkeley.edu>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Removes the mock sleep time from pipelined ingest tests to hopefully make them run faster.