### PR TITLE
[autoscaler] SNS Event Publisher plugin for Event Callbacks

### DIFF
--- a/python/ray/autoscaler/_private/aws/events.py
+++ b/python/ray/autoscaler/_private/aws/events.py
@@ -1,0 +1,147 @@
+import copy
+import json
+import logging
+import time
+from typing import Any, Dict, List
+
+from botocore.exceptions import ClientError
+
+from ray.autoscaler._private.aws.sns.sns_helper import SnsHelper
+from ray.autoscaler._private.cli_logger import cli_logger
+from ray.autoscaler._private.event_system import (
+    EventCallbackHandler,
+    EventPublisher,
+    RayEvent,
+)
+from ray.autoscaler._private.updater import NodeContext
+
+logger = logging.getLogger(__name__)
+
+
+class AwsEventPublisher(EventPublisher):
+    """AWS implementation of Event Publisher that allows notifications to be
+    published to AWS managed services (i.e. Amazon SNS, Cloudwatch, Lambda).
+    """
+
+    def __init__(self, events_config: Dict[str, Any]):
+        """Constructor for event publisher using AWS managed services.
+        Args:
+            events_config: A dict loaded from the autoscaler config.
+        """
+        super().__init__(events_config)
+
+    def validate_config(self, events_config: Dict[str, Any]):
+        notification_uri = events_config["notification_uri"]
+        assert (
+            notification_uri is not None
+        ), "`notification_uri` is a required field in `events`"
+        assert notification_uri.startswith(
+            "arn:aws"
+        ), f"Invalid ARN specified: {notification_uri}"
+
+    def validate_event_base_params(self, params_config: Dict[str, Any]):
+        assert params_config is not None
+
+    def get_callback_handlers(self) -> List[EventCallbackHandler]:
+        """Get callback handlers based on the provided AWS ARN.
+        TODO: Add support for multiple URI?
+
+        Returns: A list of callback handlers with their corresponding Callable
+        arguments and keyword arguments
+        """
+        handlers = []
+        if self.uri.startswith("arn:aws:sns"):
+            handlers.append(
+                EventCallbackHandler(
+                    self._sns_callback,
+                    SnsHelper(self._get_region()),
+                    **self.event_base_params,
+                )
+            )
+        elif self.uri.startswith("arn:aws:lambda"):
+            handlers.append(
+                EventCallbackHandler(
+                    self._lambda_callback, None, **self.event_base_params
+                )
+            )
+        elif self.uri.startswith("arn:aws:logs"):
+            handlers.append(
+                EventCallbackHandler(
+                    self._cloudwatch_callback, None, **self.event_base_params
+                )
+            )
+        elif self.uri.startswith("arn:aws:apigateway"):
+            handlers.append(
+                EventCallbackHandler(
+                    self._api_gateway_callback, None, **self.event_base_params
+                )
+            )
+
+        return handlers
+
+    def _construct_sns_message(
+        self, event_data: Dict[str, Any], **kwargs
+    ) -> Dict[str, Any]:
+        """Builds a message for Amazon SNS notifications.
+        Args:
+            event_data: Contains event specific data to be inserted into message
+                payload.
+            **kwargs: Additional parameters to insert into message payload.
+        Returns: A dict representing the SNS message payload.
+        """
+        # create a copy of the event data to modify
+        event_dict = copy.deepcopy(event_data)
+        event = event_dict.pop("event_name")
+        message = {
+            **kwargs,
+            **event_dict,
+            "state": event.state,
+            "stateSequence": event.value - 1,  # zero-index sequencing
+            "timestamp": round(time.time() * 1000),
+        }
+
+        node_context: NodeContext = event_dict.get("node_context", {})
+        if node_context:
+            message["rayNodeId"] = node_context["node_id"]
+            message["rayNodeType"] = (
+                "HEAD" if node_context["is_head_node"] else "WORKER"
+            )
+
+        return message
+
+    def _sns_callback(
+        self, sns_client: SnsHelper, event_data: Dict[str, Any], **kwargs
+    ):
+        """SNS callback for sending Ray cluster event data to an SNS topic.
+        Args:
+            sns_client: Amazon SNS client for publishing to an SNS topic
+            event_data: Ray event data which contains the event name, enum ID,
+                and additional metadata (i.e. the initialization or
+                setup command used during this setup step).
+            **kwargs: Keyword arguments injected into the callback handler.
+        """
+        event: RayEvent = event_data.get("event_name")
+        message = self._construct_sns_message(event_data, **kwargs)
+        try:
+            json_payload = json.dumps(message)
+            sns_client.publish(self.uri, json_payload)
+            logger.info("Published SNS event {} to {}".format(event.name, self.uri))
+            logger.debug("Published SNS event payload: {}".format(json_payload))
+        except ClientError as exc:
+            cli_logger.abort(
+                "{} Error caught when publishing {} create cluster events to SNS",
+                exc.response["Error"],
+                event.name,
+            )
+
+    def _lambda_callback(self):
+        raise NotImplementedError("AWS Lambda callback is not implemented")
+
+    def _cloudwatch_callback(self):
+        raise NotImplementedError("AWS Cloudwatch callback is not implemented")
+
+    def _api_gateway_callback(self):
+        raise NotImplementedError("AWS API Gateway callback is not implemented")
+
+    def _get_region(self) -> str:
+        return self.uri.split(":")[3]

--- a/python/ray/autoscaler/_private/aws/sns/sns_helper.py
+++ b/python/ray/autoscaler/_private/aws/sns/sns_helper.py
@@ -1,0 +1,40 @@
+import logging
+from typing import Any, Dict
+
+from ray.autoscaler._private.aws.utils import client_cache
+
+logger = logging.getLogger(__name__)
+
+
+class SnsHelper:
+    def __init__(self, region: str, **kwargs):
+        """Constructor for SNS helper class. Re-uses the SNS client from
+        the resource cache, if present.
+
+        Args:
+            region: The AWS Region used in instantiating the client.
+            **kwargs: Additional keyword arguments specified when loading the
+                SNS client from the resource cache.
+        """
+        self.sns = client_cache("sns", region, **kwargs)
+
+    def subscribe(self, topic_arn: str) -> str:
+        """Subscribe to an SNS topic.
+
+        Args:
+            topic_arn: SNS topic ARN.
+        Returns: A string representing the subscription ARN.
+        """
+        response = self.sns.subscribe(TopicArn=topic_arn, Protocol="https")
+        return response["SubscriptionArn"]
+
+    def publish(self, topic_arn: str, message: str) -> Dict[str, Any]:
+        """Publish a message to an SNS topic.
+
+        Args:
+            topic_arn: SNS topic ARN.
+            message: SNS message payload.
+        Returns: A deserialized JSON response object from SNS.
+        """
+        response = self.sns.publish(TopicArn=topic_arn, Message=message)
+        return response

--- a/python/ray/autoscaler/_private/event_system.py
+++ b/python/ray/autoscaler/_private/event_system.py
@@ -1,10 +1,39 @@
+import functools
+from abc import ABC, abstractmethod
 from enum import Enum, auto
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from ray.autoscaler._private.cli_logger import cli_logger
 
 
-class CreateClusterEvent(Enum):
+class EventSequence:
+    """Extensible class for building custom events."""
+
+    @property
+    @abstractmethod
+    def state(self) -> str:
+        raise NotImplementedError("State must be implemented by a sub-class")
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        raise NotImplementedError("Event name must be implemented by a sub-class")
+
+    @property
+    @abstractmethod
+    def value(self) -> int:
+        raise NotImplementedError("Sequence value must be implemented by a sub-class")
+
+
+class StateEvent(Enum):
+    """Events to track with an associated state identifier."""
+
+    @property
+    def state(self) -> str:
+        raise NotImplementedError("State must be implemented by a sub-class")
+
+
+class CreateClusterEvent(StateEvent):
     """Events to track in ray.autoscaler.sdk.create_or_update_cluster.
 
     Attributes:
@@ -25,6 +54,10 @@ class CreateClusterEvent(Enum):
             is completed.
     """
 
+    @property
+    def state(self) -> str:
+        return "DISPATCHED"
+
     up_started = auto()
     ssh_keypair_downloaded = auto()
     cluster_booting_started = auto()
@@ -36,6 +69,9 @@ class CreateClusterEvent(Enum):
     start_ray_runtime = auto()
     start_ray_runtime_completed = auto()
     cluster_booting_completed = auto()
+
+
+RayEvent = Union[EventSequence, StateEvent]
 
 
 class _EventSystem:
@@ -51,8 +87,10 @@ class _EventSystem:
 
     def add_callback_handler(
         self,
-        event: str,
+        event: RayEvent,
         callback: Union[Callable[[Dict], None], List[Callable[[Dict], None]]],
+        *args,
+        **kwargs,
     ):
         """Stores callback handler for event.
 
@@ -63,18 +101,14 @@ class _EventSystem:
             callback (Callable[[Dict], None]): Callable object that is invoked
                 when specified event occurs.
         """
-        if event not in CreateClusterEvent.__members__.values():
-            cli_logger.warning(
-                f"{event} is not currently tracked, and this"
-                " callback will not be invoked."
-            )
+        callback = functools.partial(callback, *args, **kwargs)
 
         self.callback_map.setdefault(event, []).extend(
             [callback] if type(callback) is not list else callback
         )
 
     def execute_callback(
-        self, event: CreateClusterEvent, event_data: Optional[Dict[str, Any]] = None
+        self, event: RayEvent, event_data: Optional[Dict[str, Any]] = None
     ):
         """Executes all callbacks for event.
 
@@ -101,6 +135,105 @@ class _EventSystem:
         """
         if event in self.callback_map:
             del self.callback_map[event]
+
+
+class EventCallbackHandler:
+    def __init__(self, handler: Callable, *args, **kwargs):
+        """A helper class containing a callable object with its associated args and kwargs.
+        Args:
+            handler: A callable object.
+            *args: Arguments to be passed into the callable.
+            **kwargs: Keyword arguments to be passed into the callable.
+        """
+        self._handler = handler
+        self._args = args
+        self._kwargs = kwargs
+
+    @property
+    def handler(self):
+        return self._handler
+
+    @property
+    def args(self):
+        return self._args
+
+    @property
+    def kwargs(self):
+        return self._kwargs
+
+
+class EventPublisher(ABC):
+    """Event publisher abstract class for publishing event notifications."""
+
+    def __init__(self, events_config: Dict[str, Any]):
+        """Constructor for event publisher.
+        Args:
+            events_config: A dict loaded from the autoscaler YAML config.
+        """
+        self.validate_config(events_config)
+        self._config = events_config
+        self._event_base_params = _event_base_params = events_config.get(
+            "parameters", {}
+        )
+        self.validate_event_base_params(_event_base_params)
+        self._uri = events_config["notification_uri"]
+
+    def add_callback(self, event: RayEvent):
+        """Adds a callback handler for a given event.
+        Args:
+            event: The event to invoke the callback handler for
+        """
+        callback_handlers: List[EventCallbackHandler] = self.get_callback_handlers()
+        for cb in callback_handlers:
+            global_event_system.add_callback_handler(
+                event, cb.handler, *cb.args, **cb.kwargs
+            )
+            cli_logger.info(
+                f"Added callback handler {cb.handler.__name__} for event {event.name}"
+            )
+
+    def get_callback_handlers(self) -> List[EventCallbackHandler]:
+        raise NotImplementedError(
+            "Event publisher sub-classes must provide their own callback handlers."
+        )
+
+    @staticmethod
+    def publish(event: RayEvent, event_data: Optional[Dict[str, Any]] = None):
+        global_event_system.execute_callback(event, event_data)
+
+    @abstractmethod
+    def validate_config(self, events_config: Dict[str, Any]):
+        raise NotImplementedError("Method is not implemented")
+
+    @abstractmethod
+    def validate_event_base_params(self, params_config: Dict[str, Any]):
+        raise NotImplementedError("Method is not implemented")
+
+    @property
+    def config(self) -> Dict[str, Any]:
+        """Configuration for event notifications.
+        Holds outgoing event base parameters, the notification URI,
+            and other additional metadata.
+
+        Returns: configuration dict
+        """
+        return self._config
+
+    @property
+    def event_base_params(self) -> Dict[str, Any]:
+        """Base parameters injected into every outgoing event notification.
+
+        Returns: parameters dict
+        """
+        return self._event_base_params
+
+    @property
+    def uri(self) -> str:
+        """URI endpoint for outgoing event notifications.
+
+        Returns: uri string
+        """
+        return self._uri
 
 
 global_event_system = _EventSystem()

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -38,6 +38,21 @@
             "type": "number",
             "minimum": 0
         },
+        "events": {
+          "type": "object",
+          "description": "Event callback configuration",
+          "additionalProperties": true,
+          "properties": {
+            "notification_uri": {
+              "type": "string",
+              "description": "cloud provider resource identifier to send events to"
+            },
+            "parameters": {
+              "type": "object",
+              "description": "additional parameters injected into each outgoing event notification"
+            }
+          }
+        },
         "provider": {
             "type": "object",
             "description": "Cloud-provider specific configuration.",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When a Ray cluster launches, the global event system in the autoscaler code executes an event callback at certain steps of the setup process to indicate its progress. To name a few events, there is a `up_started` event which is invoked at the beginning of the cluster setup, a `run_setup_cmd` event invoked before setup commands are run, and `cluster_booting_completed` when the cluster is operationally ready. These events allow you to keep a historical track of a Ray cluster's lifecycle and are helpful for auditing and debugging purposes, i.e. troubleshooting a cluster that failed to launch. 

These cluster setup event callbacks would be especially helpful if the Autoscaler can be configured in such a way that these events can automatically be propagated to a managed cloud service, such as a pub-sub messaging service or a logging service. This PR is a first draft of this feature, with a `EventPublisher` plugin that can be extended to publish events to any managed service from cloud providers (e.g. AWS/GCP/Azure). A barebones `AwsEventPublisher` implementation is included in this PR, with basic support for Amazon SNS. Users can specify a SNS Topic ARN as the `notification_uri` in the Autoscaler Config to publish cluster setup events to the Topic. In addition to the cluster setup events, users can also implement their own custom events and publish them outside of the setup process (e.g. Ray application runtime).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
