### PR TITLE
[Doc] [Build] Add M1 Mac conditional dependency for tensorflow-macos

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -29,7 +29,8 @@ tabulate
 uvicorn==0.16.0
 werkzeug
 wandb
-tensorflow
+tensorflow; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos; sys_platform == 'darwin' and platform_machine == 'arm64'
 transformers
 
 # Ray libraries


### PR DESCRIPTION
Signed-off-by: Justin Yu <justinvyu@berkeley.edu>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Building docs on M1 mac required me to comment out the `tensorflow` dependency in order to finish installing all the necessary packages for building. I had already installed `tensorflow-macos`, and `pip` couldn't find the `tensorflow` for my machine which errored out the `pip install` in the middle. This PR adds a conditional dependency to install the correct package given your machine.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
