### PR TITLE
[Core][Nightly Test] Remove customized rpc server thread num in nightly test

### DIFF
--- a/release/nightly_tests/many_nodes_tests/app_config.yaml
+++ b/release/nightly_tests/many_nodes_tests/app_config.yaml
@@ -1,5 +1,4 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
-env_vars: {"RAY_gcs_server_rpc_server_thread_num": "8"}
 debian_packages: []
 
 python:


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Try not to set special flags for nightly test. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Release tests: https://buildkite.com/ray-project/release-tests-pr/builds/14798#0182fa40-61f3-40f1-adf0-245b57780639
