### PR TITLE
[core] Disable some `gcs_heartbeat_manager_test` in Mac.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -919,16 +919,16 @@ cc_test(
     ],
 )
 
-cc_test(
-    name = "gcs_heartbeat_manager_test",
-    srcs = ["src/ray/gcs/gcs_server/test/gcs_heartbeat_manager_test.cc"],
-    copts = COPTS,
-    tags = ["team:core"],
-    deps = [
-        ":gcs_server_lib",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
+# cc_test(
+#     name = "gcs_heartbeat_manager_test",
+#     srcs = ["src/ray/gcs/gcs_server/test/gcs_heartbeat_manager_test.cc"],
+#     copts = COPTS,
+#     tags = ["team:core"],
+#     deps = [
+#         ":gcs_server_lib",
+#         "@com_google_googletest//:gtest_main",
+#     ],
+# )
 
 cc_test(
     name = "dependency_resolver_test",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -919,18 +919,16 @@ cc_test(
     ],
 )
 
-# Disable this test for now.
-# (iycheng) Re-enable it or just use the new heartbeat manager.
-# cc_test(
-#     name = "gcs_heartbeat_manager_test",
-#     srcs = ["src/ray/gcs/gcs_server/test/gcs_heartbeat_manager_test.cc"],
-#     copts = COPTS,
-#     tags = ["team:core"],
-#     deps = [
-#         ":gcs_server_lib",
-#         "@com_google_googletest//:gtest_main",
-#     ],
-# )
+cc_test(
+    name = "gcs_heartbeat_manager_test",
+    srcs = ["src/ray/gcs/gcs_server/test/gcs_heartbeat_manager_test.cc"],
+    copts = COPTS,
+    tags = ["team:core"],
+    deps = [
+        ":gcs_server_lib",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
 
 cc_test(
     name = "dependency_resolver_test",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -919,6 +919,8 @@ cc_test(
     ],
 )
 
+# Disable this test for now.
+# (iycheng) Re-enable it or just use the new heartbeat manager.
 # cc_test(
 #     name = "gcs_heartbeat_manager_test",
 #     srcs = ["src/ray/gcs/gcs_server/test/gcs_heartbeat_manager_test.cc"],

--- a/src/ray/gcs/gcs_server/test/gcs_heartbeat_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_heartbeat_manager_test.cc
@@ -61,6 +61,7 @@ class GcsHeartbeatManagerTest : public ::testing::Test {
   ;
 };
 
+#ifndef __APPLE__
 TEST_F(GcsHeartbeatManagerTest, TestBasicTimeout) {
   auto node_1 = NodeID::FromRandom();
   auto start = absl::Now();
@@ -81,6 +82,7 @@ TEST_F(GcsHeartbeatManagerTest, TestBasicTimeout) {
     ASSERT_EQ(std::vector<NodeID>{node_1}, dead_nodes);
   }
 }
+#endif
 
 TEST_F(GcsHeartbeatManagerTest, TestBasicReport) {
   auto node_1 = NodeID::FromRandom();


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This test is very unstable and it seems hard to make it stable given that it highly depends on the time.
Fixing it on one platform will fail it on another platform. Given that 
- we don't have this test for a long time and things are ok
- we are replacing the heartbeat to pull mode in the near future

This test seems not important. So delete it.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
