### PR TITLE
Fix deprecated import of MLflowLoggerCallback

### DIFF
--- a/python/ray/train/examples/mlflow_fashion_mnist_example.py
+++ b/python/ray/train/examples/mlflow_fashion_mnist_example.py
@@ -3,7 +3,7 @@ import argparse
 from ray.air.config import RunConfig, ScalingConfig
 from ray.train.examples.torch_fashion_mnist_example import train_func
 from ray.train.torch import TorchTrainer
-from ray.tune.integration.mlflow import MLflowLoggerCallback
+from ray.air.callbacks.mlflow import MLflowLoggerCallback
 
 
 def main(num_workers=2, use_gpu=False):

--- a/python/ray/train/examples/mlflow_simple_example.py
+++ b/python/ray/train/examples/mlflow_simple_example.py
@@ -1,6 +1,6 @@
 from ray.air import ScalingConfig, RunConfig, session
 from ray.train.torch import TorchTrainer
-from ray.tune.integration.mlflow import MLflowLoggerCallback
+from ray.air.callbacks.mlflow import MLflowLoggerCallback
 from ray.tune.logger import TBXLoggerCallback
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
