### PR TITLE
[Runtime Environment] Parse special characters in private Git URIs

### DIFF
--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -163,8 +163,8 @@ def parse_uri(pkg_uri: str) -> Tuple[Protocol, str]:
                 netloc='_ray_pkg_029f88d5ecc55e1e4d64fc6e388fd103.zip'
             )
             -> ("gcs", "_ray_pkg_029f88d5ecc55e1e4d64fc6e388fd103.zip")
-    For HTTPS URIs, the netloc will have '.' replaced with '_', and
-    the path will have '/' replaced with '_'. The package name will be the
+    For HTTPS URIs, the netloc will have '.', ':', and '@' swapped with '_',
+    and the path will have '/' replaced with '_'. The package name will be the
     adjusted path with 'https_' prepended.
         urlparse(
             "https://github.com/shrekris-anyscale/test_module/archive/HEAD.zip"
@@ -216,9 +216,10 @@ def parse_uri(pkg_uri: str) -> Tuple[Protocol, str]:
     if protocol == Protocol.S3 or protocol == Protocol.GS:
         return (protocol, f"{protocol.value}_{uri.netloc}{uri.path.replace('/', '_')}")
     elif protocol == Protocol.HTTPS:
+        parsed_netloc = uri.netloc.replace(".", "_").replace(":", "_").replace("@", "_")
         return (
             protocol,
-            f"https_{uri.netloc.replace('.', '_')}{uri.path.replace('/', '_')}",
+            f"https_{parsed_netloc}{uri.path.replace('/', '_')}",
         )
     elif protocol == Protocol.FILE:
         return (

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -411,7 +411,9 @@ class TestParseUri:
     )
     def test_parse_private_git_https_uris(self, parsing_tuple):
         raw_uri, parsed_uri = parsing_tuple
-        assert parse_uri(raw_uri) == parsed_uri
+        parsed_protocol, parsed_package_name = parse_uri(raw_uri)
+        assert parsed_protocol == Protocol.HTTPS
+        assert parsed_package_name == parsed_uri
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Users can access private Git repos via runtime environments by specifying an archive link, usually containing a username and private token. For example, from [the Ray documentation](https://docs.ray.io/en/releases-2.0.0/ray-core/handling-dependencies.html#option-2-manually-create-url-slower-to-implement-but-recommended-for-production-environments), the GitHub format is

```
https://[username]:[personal access token]@github.com/[username]/[private repository]/archive/[commit hash].zip
```

However, the colon (`:`) and at (`@`) symbols are not removed before parsing the URI as a directory name for the runtime environment. Since PYTHONPATHs use colons as package name separators, Python modules in this private repo can't be imported.

This change converts the colon and at symbols to underscores (`_`) when converting the URI into a directory name. This allows modules stored in private repos to be imported.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds new unit tests to `test_runtime_env_packaging.py`.
