### PR TITLE
[Serve] Match `serve run` HTTP options with `serve.run()`

### DIFF
--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -300,11 +300,17 @@ def run(
 
     if is_config:
         client = _private_api.serve_start(
-            detached=True, http_options={"host": config.host, "port": config.port}
+            detached=True,
+            http_options={
+                "host": config.host,
+                "port": config.port,
+                "location": "EveryNode",
+            },
         )
     else:
         client = _private_api.serve_start(
-            detached=True, http_options={"host": host, "port": port}
+            detached=True,
+            http_options={"host": host, "port": port, "location": "EveryNode"},
         )
 
     try:


### PR DESCRIPTION
Signed-off-by: Shreyas Krishnaswamy <shrekris@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `serve run` CLI command starts Serve with user-configured `host` and `port` HTTP options. However, it omits the `location` option, which the `serve.run()` Python API call [attempts to set](https://github.com/ray-project/ray/blob/518c74020c0f51ce7194e95d6434efbd9a250540/python/ray/serve/api.py#L456) under the hood. This prints a warning:

```
The new client HTTP config differs from the existing one in the following fields: ['location']. The new HTTP config is ignored.
```

This change includes the `location` option in `serve run`'s HTTP options.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
