### PR TITLE
[core] memory monitor to use the event loop from node manager 

### DIFF
--- a/src/ray/common/memory_monitor.cc
+++ b/src/ray/common/memory_monitor.cc
@@ -23,17 +23,13 @@
 
 namespace ray {
 
-MemoryMonitor::MemoryMonitor(float usage_threshold,
+MemoryMonitor::MemoryMonitor(instrumented_io_context &io_service,
+                             float usage_threshold,
                              uint64_t monitor_interval_ms,
                              MemoryUsageRefreshCallback monitor_callback)
     : usage_threshold_(usage_threshold),
       monitor_callback_(monitor_callback),
-      io_context_(),
-      monitor_thread_([this] {
-        boost::asio::io_service::work io_service_work_(io_context_);
-        io_context_.run();
-      }),
-      runner_(io_context_) {
+      runner_(io_service) {
   RAY_CHECK(monitor_callback_ != nullptr);
   RAY_CHECK_GE(usage_threshold_, 0);
   RAY_CHECK_LE(usage_threshold_, 1);
@@ -245,13 +241,6 @@ int64_t MemoryMonitor::NullableMin(int64_t left, int64_t right) {
     return left;
   } else {
     return std::min(left, right);
-  }
-}
-
-MemoryMonitor::~MemoryMonitor() {
-  io_context_.stop();
-  if (monitor_thread_.joinable()) {
-    monitor_thread_.join();
   }
 }
 

--- a/src/ray/common/memory_monitor.h
+++ b/src/ray/common/memory_monitor.h
@@ -49,16 +49,16 @@ class MemoryMonitor {
  public:
   /// Constructor.
   ///
+  /// \param io_service the event loop.
   /// \param usage_threshold a value in [0-1] to indicate the max usage.
   /// \param monitor_interval_ms the frequency to update the usage. 0 disables the
   /// the monitor and callbacks won't fire.
   /// \param monitor_callback function to execute on a dedicated thread owned by this
   /// monitor when the usage is refreshed.
-  MemoryMonitor(float usage_threshold,
+  MemoryMonitor(instrumented_io_context &io_service,
+                float usage_threshold,
                 uint64_t monitor_interval_ms,
                 MemoryUsageRefreshCallback monitor_callback);
-
-  ~MemoryMonitor();
 
  public:
   /// \param process_id the process id
@@ -110,8 +110,6 @@ class MemoryMonitor {
   /// Callback function that executes at each monitoring interval,
   /// on a dedicated thread managed by this class.
   const MemoryUsageRefreshCallback monitor_callback_;
-  instrumented_io_context io_context_;
-  std::thread monitor_thread_;
   PeriodicalRunner runner_;
 };
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -334,6 +334,7 @@ NodeManager::NodeManager(instrumented_io_context &io_service,
       ray_syncer_(io_service_, self_node_id_.Binary()),
       ray_syncer_service_(ray_syncer_),
       memory_monitor_(std::make_unique<MemoryMonitor>(
+          io_service,
           RayConfig::instance().memory_usage_threshold_fraction(),
           RayConfig::instance().memory_monitor_interval_ms(),
           CreateMemoryUsageRefreshCallback())) {


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

The objects accessed by the memory monitor callback are not thread-safe. The node manager runs on a specific event loop and this PR changes the memory monitor to share that same event loop similar to the rest of the components executed under the node manager.

## Related issue number

https://github.com/ray-project/ray/issues/28273

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(

