### PR TITLE
[core] Rename `OVERRIDE_NODE_ID_FOR_TESTING` to `RAYLET_NODE_ID` to make it a feature

### DIFF
--- a/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
@@ -322,7 +322,7 @@ class FakeMultiNodeProvider(NodeProvider):
                     ray._private.services.get_node_ip_address()
                 ),
                 env_vars={
-                    "RAY_OVERRIDE_NODE_ID_FOR_TESTING": next_id,
+                    "RAY_RAYLET_NODE_ID": next_id,
                     "RAY_OVERRIDE_RESOURCES": json.dumps(resources),
                 },
             )
@@ -472,7 +472,7 @@ class FakeMultiNodeDockerProvider(FakeMultiNodeProvider):
             host_client_port=self._host_client_port,
             resources=resources,
             env_vars={
-                "RAY_OVERRIDE_NODE_ID_FOR_TESTING": node_id,
+                "RAY_RAYLET_NODE_ID": node_id,
                 "RAY_OVERRIDE_RESOURCES": resource_str,
                 **self.provider_config.get("env_vars", {}),
             },

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -676,7 +676,7 @@ def start(
 
         if os.environ.get("RAY_FAKE_CLUSTER"):
             ray_params.env_vars = {
-                "RAY_OVERRIDE_NODE_ID_FOR_TESTING": FAKE_HEAD_NODE_ID
+                "RAY_RAYLET_NODE_ID": FAKE_HEAD_NODE_ID
             }
 
         num_redis_shards = None

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -675,9 +675,7 @@ def start(
         ray_params.gcs_server_port = port
 
         if os.environ.get("RAY_FAKE_CLUSTER"):
-            ray_params.env_vars = {
-                "RAY_RAYLET_NODE_ID": FAKE_HEAD_NODE_ID
-            }
+            ray_params.env_vars = {"RAY_RAYLET_NODE_ID": FAKE_HEAD_NODE_ID}
 
         num_redis_shards = None
         # Start Ray on the head node.

--- a/src/ray/common/ray_internal_flag_def.h
+++ b/src/ray/common/ray_internal_flag_def.h
@@ -29,4 +29,4 @@ RAY_INTERNAL_FLAG(std::string, JOB_ID, "")
 RAY_INTERNAL_FLAG(std::string, RAYLET_PID, "")
 
 /// Override the random node ID for testing.
-RAY_INTERNAL_FLAG(std::string, OVERRIDE_NODE_ID_FOR_TESTING, "")
+RAY_INTERNAL_FLAG(std::string, RAYLET_NODE_ID, "")

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -65,8 +65,8 @@ Raylet::Raylet(instrumented_io_context &main_service,
                int metrics_export_port)
     : main_service_(main_service),
       self_node_id_(
-          !RayConfig::instance().OVERRIDE_NODE_ID_FOR_TESTING().empty()
-              ? NodeID::FromHex(RayConfig::instance().OVERRIDE_NODE_ID_FOR_TESTING())
+          !RayConfig::instance().RAYLET_NODE_ID().empty()
+              ? NodeID::FromHex(RayConfig::instance().RAYLET_NODE_ID())
               : NodeID::FromRandom()),
       gcs_client_(gcs_client),
       node_manager_(main_service,

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -64,10 +64,9 @@ Raylet::Raylet(instrumented_io_context &main_service,
                std::shared_ptr<gcs::GcsClient> gcs_client,
                int metrics_export_port)
     : main_service_(main_service),
-      self_node_id_(
-          !RayConfig::instance().RAYLET_NODE_ID().empty()
-              ? NodeID::FromHex(RayConfig::instance().RAYLET_NODE_ID())
-              : NodeID::FromRandom()),
+      self_node_id_(!RayConfig::instance().RAYLET_NODE_ID().empty()
+                        ? NodeID::FromHex(RayConfig::instance().RAYLET_NODE_ID())
+                        : NodeID::FromRandom()),
       gcs_client_(gcs_client),
       node_manager_(main_service,
                     self_node_id_,


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR changed the `OVERRIDE_NODE_ID_FOR_TESTING` to `RAYLET_NODE_ID` so that this is a feature which can be used to start raylet with a given raylet id by setting os env `RAY_RAYLET_NODE_ID`.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
