### PR TITLE
[AIR] Fix `datasets_modules` exception in HF

### DIFF
--- a/python/ray/train/huggingface/huggingface_trainer.py
+++ b/python/ray/train/huggingface/huggingface_trainer.py
@@ -1,6 +1,8 @@
+import importlib.util
 import inspect
 import os
 import shutil
+import sys
 import tempfile
 import warnings
 from distutils.version import LooseVersion
@@ -12,6 +14,7 @@ import transformers.modeling_utils
 import transformers.trainer
 import transformers.training_args
 from transformers.trainer_utils import IntervalStrategy
+from transformers.utils import is_datasets_available
 from torch.utils.data import Dataset as TorchDataset
 
 from ray.air import session
@@ -43,6 +46,30 @@ from ray.util import PublicAPI, get_node_ip_address
 
 if TYPE_CHECKING:
     from ray.data.preprocessor import Preprocessor
+
+# Due to HF Dataset's dynamic module system, we need to dynamically import the
+# datasets_modules module on every actor when training.
+# We accomplish this by simply running the following bit of code directly
+# in module you are currently viewing. This ensures that when we
+# unpickle the HuggingFaceTrainer, it will be ran before pickle tries to
+# import datasets_modules and prevents an exception from being thrown.
+# Same logic is present inside HF Transformers Ray integration:
+# https://github.com/huggingface/transformers/blob/\
+# 7d5fde991d598370d961be8cb7add6541e2b59ce/src/transformers/integrations.py#L271
+# Also see https://github.com/ray-project/ray/issues/28084
+if "datasets_modules" not in sys.modules and is_datasets_available():
+    import datasets.load
+
+    dynamic_modules_path = os.path.join(
+        datasets.load.init_dynamic_modules(), "__init__.py"
+    )
+    # load dynamic_modules from path
+    spec = importlib.util.spec_from_file_location(
+        "datasets_modules", dynamic_modules_path
+    )
+    datasets_modules = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = datasets_modules
+    spec.loader.exec_module(datasets_modules)
 
 # This trainer uses a special checkpoint syncing logic.
 # Because HF checkpoints are very large dirs (at least several GBs),


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

HF Datasets uses a dynamic `datasets_modules` module that needs to be imported in a special way on each Ray actor. Otherwise, an exception during deserialization of training functions making use of that module (eg. by using metrics from HF Datasets) will be thrown. This PR implements the same logic as in HF Transformer's [Ray Tune integration](https://sourcegraph.com/github.com/huggingface/transformers/-/blob/src/transformers/integrations.py?L271) and simply makes it ran whenever the `huggingface_trainer` Ray AIR module is imported, which ensures that the module is loaded onto the Ray actors.

## Related issue number

Closes https://github.com/ray-project/ray/issues/28084

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
