### PR TITLE
[Core, RLlib, AIR] Fix multiple deprecation warnings

### DIFF
--- a/dashboard/http_server_agent.py
+++ b/dashboard/http_server_agent.py
@@ -1,7 +1,10 @@
 import asyncio
 import logging
 
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import LooseVersion as Version
 
 import ray.dashboard.optional_utils as dashboard_optional_utils
 
@@ -22,7 +25,7 @@ class HttpServerAgent:
 
         # Create a http session for all modules.
         # aiohttp<4.0.0 uses a 'loop' variable, aiohttp>=4.0.0 doesn't anymore
-        if LooseVersion(aiohttp.__version__) < LooseVersion("4.0.0"):
+        if Version(aiohttp.__version__) < Version("4.0.0"):
             self.http_session = aiohttp.ClientSession(loop=asyncio.get_event_loop())
         else:
             self.http_session = aiohttp.ClientSession()

--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -4,7 +4,11 @@ import ipaddress
 import logging
 import os
 import sys
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import LooseVersion as Version
 
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
@@ -70,7 +74,7 @@ class HttpServerDashboardHead:
 
         # Create a http session for all modules.
         # aiohttp<4.0.0 uses a 'loop' variable, aiohttp>=4.0.0 doesn't anymore
-        if LooseVersion(aiohttp.__version__) < LooseVersion("4.0.0"):
+        if Version(aiohttp.__version__) < Version("4.0.0"):
             self.http_session = aiohttp.ClientSession(loop=asyncio.get_event_loop())
         else:
             self.http_session = aiohttp.ClientSession()

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -186,14 +186,11 @@ class _DeprecationWrapper(object):
     def __getattr__(self, attr):
         value = getattr(self._real_worker, attr)
         if attr not in self._warned:
-            import traceback
-
             self._warned.add(attr)
             logger.warning(
                 f"DeprecationWarning: `ray.{self._name}.{attr}` is a private "
                 "attribute and access will be removed in a future Ray version."
             )
-            traceback.print_stack()
         return value
 
 

--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -32,7 +32,7 @@
 import itertools
 import numbers
 import os
-from distutils.version import LooseVersion
+from packaging.version import Version
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -166,7 +166,7 @@ if os.getenv(_FORMATTER_ENABLED_ENV_VAR, "1") == "1":
     ExtensionArrayFormatter._format_strings_orig = (
         ExtensionArrayFormatter._format_strings
     )
-    if LooseVersion("1.1.0") <= LooseVersion(pd.__version__) < LooseVersion("1.3.0"):
+    if Version("1.1.0") <= Version(pd.__version__) < Version("1.3.0"):
         ExtensionArrayFormatter._format_strings = _format_strings_patched
     else:
         ExtensionArrayFormatter._format_strings = _format_strings_patched_v1_0_0

--- a/python/ray/train/huggingface/huggingface_trainer.py
+++ b/python/ray/train/huggingface/huggingface_trainer.py
@@ -3,9 +3,14 @@ import os
 import shutil
 import tempfile
 import warnings
-from distutils.version import LooseVersion
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Type
+
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import LooseVersion as Version
+
 
 import transformers
 import transformers.modeling_utils
@@ -292,7 +297,7 @@ class HuggingFaceTrainer(TorchTrainer):
 
         # Functionality required for HuggingFaceTrainer only added in this
         # version
-        if LooseVersion(transformers.__version__) < LooseVersion("4.19.0"):
+        if Version(transformers.__version__) < Version("4.19.0"):
             raise RuntimeError(
                 "HuggingFaceTrainer requires transformers>=4.19.0, but you "
                 f"have {transformers.__version__} which is incompatible. "

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -7,6 +7,7 @@ from ray._private.ray_constants import to_memory_units
 from ray._private.utils import hex_to_binary, get_ray_doc_version
 from ray._raylet import PlacementGroupID
 from ray.util.annotations import DeveloperAPI, PublicAPI
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 bundle_reservation_check = None
 BUNDLE_RESOURCE_LABEL = "bundle"
@@ -76,7 +77,8 @@ class PlacementGroup:
         )
 
         return bundle_reservation_check.options(
-            placement_group=self, resources={BUNDLE_RESOURCE_LABEL: 0.001}
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=self),
+            resources={BUNDLE_RESOURCE_LABEL: 0.001},
         ).remote(self)
 
     def wait(self, timeout_seconds: Union[float, int]) -> bool:

--- a/python/ray/util/scheduling_strategies.py
+++ b/python/ray/util/scheduling_strategies.py
@@ -1,6 +1,8 @@
-from typing import Union, Optional
+from typing import Union, Optional, TYPE_CHECKING
 from ray.util.annotations import PublicAPI
-from ray.util.placement_group import PlacementGroup
+
+if TYPE_CHECKING:
+    from ray.util.placement_group import PlacementGroup
 
 # "DEFAULT": The default hybrid scheduling strategy
 # based on config scheduler_spread_threshold.
@@ -26,7 +28,7 @@ class PlacementGroupSchedulingStrategy:
 
     def __init__(
         self,
-        placement_group: PlacementGroup,
+        placement_group: "PlacementGroup",
         placement_group_bundle_index: int = -1,
         placement_group_capture_child_tasks: Optional[bool] = None,
     ):

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -17,6 +17,7 @@ jsonschema
 msgpack >= 1.0.0, < 2.0.0
 numpy >= 1.16
 opencensus
+packaging; python_version >= '3.10'
 prometheus_client >= 0.7.1, < 0.14.0
 protobuf >= 3.15.3, < 4.0.0
 py-spy >= 0.2.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -297,6 +297,7 @@ if setup_spec.type == SetupType.RAY:
         "msgpack >= 1.0.0, < 2.0.0",
         "numpy >= 1.16; python_version < '3.9'",
         "numpy >= 1.19.3; python_version >= '3.9'",
+        "packaging; python_version >= '3.10'",
         "protobuf >= 3.15.3, < 4.0.0",
         "pyyaml",
         "aiosignal",

--- a/rllib/examples/export/onnx_torch.py
+++ b/rllib/examples/export/onnx_torch.py
@@ -1,4 +1,7 @@
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import LooseVersion as Version
 
 import numpy as np
 import ray
@@ -54,7 +57,7 @@ exported_model_file = os.path.join(outdir, "model.onnx")
 session = onnxruntime.InferenceSession(exported_model_file, None)
 
 # Pass the same test batch to the ONNX model
-if LooseVersion(torch.__version__) < LooseVersion("1.9.0"):
+if Version(torch.__version__) < Version("1.9.0"):
     # In torch < 1.9.0 the second input/output name gets mixed up
     test_data["state_outs"] = test_data.pop("state_ins")
 

--- a/rllib/utils/debug/deterministic.py
+++ b/rllib/utils/debug/deterministic.py
@@ -37,9 +37,12 @@ def update_global_seed_if_necessary(
         if cuda_version is not None and float(torch.version.cuda) >= 10.2:
             os.environ["CUBLAS_WORKSPACE_CONFIG"] = "4096:8"
         else:
-            from distutils.version import LooseVersion
+            try:
+                from packaging.version import Version
+            except ImportError:
+                from distutils.version import LooseVersion as Version
 
-            if LooseVersion(torch.__version__) >= LooseVersion("1.8.0"):
+            if Version(torch.__version__) >= Version("1.8.0"):
                 # Not all Operations support this.
                 torch.use_deterministic_algorithms(True)
             else:


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes multiple deprecation warnings affecting AIR examples. There's still work to be done on other deprecations, but I've bundled these changes together to avoid making a huge PR.

- Fixed scheduling strategy deprecation warnings by making use of `PlacementGroupSchedulingStrategy`. This change takes care of the warnings associated with:
  - `placement_group`
  - `placement_group_bundle_index`
  - `placement_group_capture_child_tasks`
- Removed `object_store_memory` argument in a few actor instantiations to avoid deprecation warnings
- Removed `traceback.print_stack` from `python/ray/__init__.py` which prints the call stack any time there is a deprecation warning.
- Remove use of deprecated `distutils.version.Version` in favor of `packaging.version.Version`. Added `packaging` as a soft dependency: it is installed for Python >= 3.10; otherwise `distutils.version.Version` is still used. See [PEP 632](https://peps.python.org/pep-0632/) for more information about this deprecation. In short, `distutils` will be removed in Python 3.12, and is deprecated for 3.10 and 3.11.

## Related issue number

Partially addresses some of the issues in #27851.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
