### PR TITLE
[cli] Add flags to start gcs only or dashboard only.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -373,7 +373,7 @@
       --test_tag_filters=client_tests,small_size_python_tests
       -- python/ray/tests/...
     - bazel test --config=ci $(./ci/run/bazel_export_options)
-      --test_tag_filters=ray_ha
+      --test_tag_filters=ray_e2e
       --test_env=DOCKER_HOST=tcp://docker:2376
       --test_env=DOCKER_TLS_VERIFY=1
       --test_env=DOCKER_CERT_PATH=/certs/client

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -641,7 +641,7 @@ def start(
 
     redirect_output = None if not no_redirect_output else True
 
-    if head:
+    if head and ray_client_server_port is None:
         ray_client_server_port = 10001
 
     ray_params = ray._private.parameter.RayParams(
@@ -689,7 +689,7 @@ def start(
             cli_logger.abort("`--api-server` should not be used with `--head`")
         if raylet is not True:
             cli_logger.abort("`--api-server` can only be used when `--raylet` is used")
-            
+
         start_services.add(ray_constants.PROCESS_TYPE_DASHBOARD)
 
     if raylet is True:

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -687,6 +687,9 @@ def start(
     if api_server is True:
         if head is not False:
             cli_logger.abort("`--api-server` should not be used with `--head`")
+        if raylet is not True:
+            cli_logger.abort("`--api-server` can only be used when `--raylet` is used")
+            
         start_services.add(ray_constants.PROCESS_TYPE_DASHBOARD)
 
     if raylet is True:

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -351,7 +351,7 @@ def debug(address):
     "--ray-client-server-port",
     required=False,
     type=int,
-    default=10001,
+    default=None,
     help="the port number the ray client server binds on, default to 10001.",
 )
 @click.option(
@@ -397,6 +397,24 @@ def debug(address):
     is_flag=True,
     default=False,
     help="provide this argument for the head node",
+)
+@click.option(
+    "--api-server",
+    is_flag=True,
+    default=False,
+    help="provide this argument if api server need to start",
+)
+@click.option(
+    "--gcs",
+    is_flag=True,
+    default=False,
+    help="provide this argument if need to start",
+)
+@click.option(
+    "--raylet",
+    is_flag=True,
+    default=False,
+    help="provide this argument if need to start",
 )
 @click.option(
     "--include-dashboard",
@@ -550,6 +568,9 @@ def start(
     num_gpus,
     resources,
     head,
+    api_server,
+    gcs,
+    raylet,
     include_dashboard,
     dashboard_host,
     dashboard_port,
@@ -619,6 +640,10 @@ def start(
         )
 
     redirect_output = None if not no_redirect_output else True
+
+    if head:
+        ray_client_server_port = 10001
+
     ray_params = ray._private.parameter.RayParams(
         node_ip_address=node_ip_address,
         node_name=node_name if node_name else node_ip_address,
@@ -657,6 +682,26 @@ def start(
 
     if ray_constants.RAY_START_HOOK in os.environ:
         _load_class(os.environ[ray_constants.RAY_START_HOOK])(ray_params, head)
+
+    start_services = set()
+    if api_server is True:
+        if head is not False:
+            cli_logger.abort("`--api-server` should not be used with `--head`")
+        start_services.add(ray_constants.PROCESS_TYPE_DASHBOARD)
+
+    if raylet is True:
+        if head is not False:
+            cli_logger.abort("`--raylet` should not be used with `--head`")
+        start_services.add(ray_constants.PROCESS_TYPE_RAYLET)
+
+    if gcs is True:
+        if head is not False:
+            cli_logger.abort("`--gcs` should not be used with `--head`")
+        head = True
+        start_services.add(ray_constants.PROCESS_TYPE_GCS_SERVER)
+
+    if len(start_services) == 0:
+        start_services = None
 
     if head:
         # Start head node.
@@ -744,7 +789,11 @@ def start(
                 )
 
         node = ray._private.node.Node(
-            ray_params, head=True, shutdown_at_exit=block, spawn_reaper=block
+            ray_params,
+            head=True,
+            shutdown_at_exit=block,
+            spawn_reaper=block,
+            start_services=start_services,
         )
 
         bootstrap_address = node.address
@@ -845,7 +894,6 @@ def start(
         head_only_flags = {
             "--port": port,
             "--redis-shard-ports": redis_shard_ports,
-            "--include-dashboard": include_dashboard,
         }
         for flag, val in head_only_flags.items():
             if val is None:
@@ -883,7 +931,11 @@ def start(
         cli_logger.labeled_value("Local node IP", ray_params.node_ip_address)
 
         node = ray._private.node.Node(
-            ray_params, head=False, shutdown_at_exit=block, spawn_reaper=block
+            ray_params,
+            head=False,
+            shutdown_at_exit=block,
+            spawn_reaper=block,
+            start_services=start_services,
         )
 
         # Ray and Python versions should probably be checked before

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -195,9 +195,10 @@ py_test_module_list(
 py_test_module_list(
   files = [
     "test_gcs_ha_e2e.py",
+    "test_ray_deploy.py",
   ],
   size = "small",
-  tags = ["exclusive", "ray_ha", "team:core"],
+  tags = ["exclusive", "ray_e2e", "team:core"],
   deps = ["//:ray_lib", ":conftest"],
 )
 

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -831,6 +831,9 @@ def test_ray_start_gcs_and_dashboard(call_ray_stop_only, shutdown_only):
     result = runner.invoke(scripts.start, ["--head", "--api-server"])
     assert result.exit_code == 1, result.output
 
+    result = runner.invoke(scripts.start, ["--api-server"])
+    assert result.exit_code == 1, result.output
+
     result = runner.invoke(scripts.start, ["--gcs", "--port", "9007"])
     assert result.exit_code == 0, result.output
 
@@ -842,6 +845,7 @@ def test_ray_start_gcs_and_dashboard(call_ray_stop_only, shutdown_only):
             "localhost:9007",
             "--dashboard-port",
             "9008",
+            "--raylet",
         ],
     )
     assert result.exit_code == 0, result.output

--- a/python/ray/tests/test_ray_deploy.py
+++ b/python/ray/tests/test_ray_deploy.py
@@ -1,0 +1,163 @@
+import pytest
+from pytest_docker_tools import container
+import subprocess
+
+from ray.tests.test_gcs_ha_e2e import Container, gcs_network  # noqa: F401
+
+
+gcs_node = container(
+    image="ray_ci:v1",
+    name="gcs",
+    network="{gcs_network.name}",
+    command=["ray", "start", "--gcs", "--block", "--port=9001"],
+    wrapper_class=Container,
+)
+
+
+rayelt_1 = container(
+    image="ray_ci:v1",
+    name="raylet_1",
+    network="{gcs_network.name}",
+    command=[
+        "ray",
+        "start",
+        "--block",
+        "--address=gcs:9001",
+        "--api-server",
+        "--raylet",
+        "--dashboard-port=9002",
+        "--dashboard-host=0.0.0.0",
+        "--ray-client-server-port=9003",
+    ],
+    wrapper_class=Container,
+    ports={
+        "9002/tcp": "9002",
+        "9003/tcp": "9003",
+    },
+)
+
+rayelt_2 = container(
+    image="ray_ci:v1",
+    name="raylet_2",
+    network="{gcs_network.name}",
+    command=[
+        "ray",
+        "start",
+        "--block",
+        "--address=gcs:9001",
+        "--api-server",
+        "--raylet",
+        "--dashboard-port=9002",
+        "--dashboard-host=0.0.0.0",
+        "--ray-client-server-port=9003",
+    ],
+    wrapper_class=Container,
+    ports={
+        "9002/tcp": "8002",
+        "9003/tcp": "8003",
+    },
+)
+
+
+@pytest.fixture
+def docker_cluster(gcs_node, rayelt_1, rayelt_2):
+    yield (gcs_node, rayelt_1, rayelt_2)
+
+
+def test_ray_deploy_e2e(docker_cluster, tmp_path):
+    """In this test we run an e2e test to make sure ray components can be deployed
+    independently and still able to serve the traffic.
+    node-1:
+        GCS
+    node-2:
+        dashboard + raylet + client server
+    node-3:
+        dashboard + raylet + client server
+
+    In this test we make sure the client server is available in both node-2 and
+    node-3.
+
+    It also tested that the dashboard in node-2 and node-3 works.
+    """
+
+    with (tmp_path / "script.py").open("w") as f:
+        scripts = """
+import ray
+
+@ray.remote
+def hello_world():
+    return "hello world"
+
+ray.init()
+print(ray.get(hello_world.remote()))
+"""
+        f.write(scripts)
+
+    head, r1, r2 = docker_cluster
+    result = head.exec_run(cmd="bash -c 'ps -ef | grep gcs_server | grep -v grep'")
+    assert "ray/core/src/ray/gcs/gcs_server" in result.output.decode()
+
+    # Make sure ray client is still working
+    import ray
+
+    ray.init("ray://localhost:9003")
+
+    @ray.remote
+    def hello():
+        return "world"
+
+    assert ray.get(hello.remote()) == "world"
+    ray.shutdown()
+
+    # Make sure the ray client on the other server is also working
+    ray.init("ray://localhost:8003")
+    assert ray.get(hello.remote()) == "world"
+    ray.shutdown()
+
+    # Make sure the job submission is working
+    import uuid
+
+    submission_id = str(uuid.uuid1())
+    subprocess.check_output(
+        [
+            "ray",
+            "job",
+            "submit",
+            "--working-dir",
+            str(tmp_path),
+            "--submission-id",
+            submission_id,
+            "--address=http://localhost:9002",
+            "--",
+            "python",
+            "script.py",
+        ]
+    )
+
+    output = subprocess.check_output(
+        f"ray job logs {submission_id} --address=http://localhost:9002", shell=True
+    ).decode()
+    assert "world" in output
+
+    # Test it on the other dashboard
+    submission_id = str(uuid.uuid1())
+    subprocess.check_output(
+        [
+            "ray",
+            "job",
+            "submit",
+            "--working-dir",
+            str(tmp_path),
+            "--submission-id",
+            submission_id,
+            "--address=http://localhost:8002",
+            "--",
+            "python",
+            "script.py",
+        ]
+    )
+
+    output = subprocess.check_output(
+        f"ray job logs {submission_id} --address=http://localhost:8002", shell=True
+    ).decode()
+    assert "world" in output


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR add the ability to the ray cli to start specific component.

```
ray start --gcs --raylet --api-server
```

`--gcs` will start the gcs server
`--raylet` will start the raylet
`--api-server` will start the dashboard

This flags can be used together or separately, but `--api-server` has to be used when `--raylet` is used for now.

Non of these flags can be used with `--head`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
