### PR TITLE
[data] Re-init CSV invalid row handler to solve serialization issue 

### DIFF
--- a/python/ray/data/datasource/csv_datasource.py
+++ b/python/ray/data/datasource/csv_datasource.py
@@ -37,7 +37,8 @@ class CSVDatasource(FileBasedDatasource):
         )
         parse_options = reader_args.pop("parse_options", csv.ParseOptions())
         # Re-init invalid row handler: https://issues.apache.org/jira/browse/ARROW-17641
-        parse_options.invalid_row_handler = parse_options.invalid_row_handler
+        if hasattr(parse_options, "invalid_row_handler"):
+            parse_options.invalid_row_handler = parse_options.invalid_row_handler
 
         reader = csv.open_csv(
             f, read_options=read_options, parse_options=parse_options, **reader_args

--- a/python/ray/data/datasource/csv_datasource.py
+++ b/python/ray/data/datasource/csv_datasource.py
@@ -35,6 +35,10 @@ class CSVDatasource(FileBasedDatasource):
         read_options = reader_args.pop(
             "read_options", csv.ReadOptions(use_threads=False)
         )
+        parse_options = reader_args.pop("parse_options", csv.ParseOptions())
+        # Re-init invalid row handler: https://issues.apache.org/jira/browse/ARROW-17641
+        parse_options.invalid_row_handler = parse_options.invalid_row_handler
+
         reader = csv.open_csv(f, read_options=read_options, **reader_args)
         schema = None
         while True:

--- a/python/ray/data/datasource/csv_datasource.py
+++ b/python/ray/data/datasource/csv_datasource.py
@@ -39,7 +39,9 @@ class CSVDatasource(FileBasedDatasource):
         # Re-init invalid row handler: https://issues.apache.org/jira/browse/ARROW-17641
         parse_options.invalid_row_handler = parse_options.invalid_row_handler
 
-        reader = csv.open_csv(f, read_options=read_options, **reader_args)
+        reader = csv.open_csv(
+            f, read_options=read_options, parse_options=parse_options, **reader_args
+        )
         schema = None
         while True:
             try:

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from distutils.version import LooseVersion
 from functools import partial
 from io import BytesIO
 from typing import Any, Dict, List, Union
@@ -3102,6 +3103,10 @@ def test_csv_read_filter_no_file(shutdown_only, tmp_path):
         ray.data.read_csv(path)
 
 
+@pytest.mark.skipif(
+    LooseVersion(pa.__version__) < LooseVersion("7.0.0"),
+    reason="invalid_row_handler was added in pyarrow 7.0.0",
+)
 def test_csv_invalid_file_handler(shutdown_only, tmp_path):
     from pyarrow import csv
 

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -3080,7 +3080,7 @@ def test_csv_read_with_column_type_specified(shutdown_only, tmp_path):
             ),
         )
 
-    # Parsing scientific notation in double shoud work.
+    # Parsing scientific notation in double should work.
     ds = ray.data.read_csv(
         file_path,
         convert_options=csv.ConvertOptions(
@@ -3100,6 +3100,22 @@ def test_csv_read_filter_no_file(shutdown_only, tmp_path):
     error_message = "No input files found to read"
     with pytest.raises(ValueError, match=error_message):
         ray.data.read_csv(path)
+
+
+def test_csv_invalid_file_handler(shutdown_only, tmp_path):
+    from pyarrow import csv
+
+    invalid_txt = "f1,f2\n2,3\nx\n4,5"
+    invalid_file = os.path.join(tmp_path, "invalid.csv")
+    with open(invalid_file, "wt") as f:
+        f.write(invalid_txt)
+
+    ray.data.read_csv(
+        invalid_file,
+        parse_options=csv.ParseOptions(
+            delimiter=",", invalid_row_handler=lambda i: "skip"
+        ),
+    )
 
 
 class NodeLoggerOutputDatasource(Datasource[Union[ArrowRow, int]]):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This re-sets `pyarrow.csv.ParseOptions.invalid_row_handler` to deal with a deserizalization issue in pyarrow (https://issues.apache.org/jira/browse/ARROW-17641).

See #28326 for details.



## Related issue number

Closes #28326

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
