### PR TITLE
[tune] Disable pytorch-lightning multiprocessing per default

### DIFF
--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -377,8 +377,6 @@ install_dependencies() {
   # Additional Tune/Doc test dependencies.
   if [ "${TUNE_TESTING-}" = 1 ] || [ "${DOC_TESTING-}" = 1 ]; then
     pip install -r "${WORKSPACE_DIR}"/python/requirements/ml/requirements_tune.txt
-    # Todo: move to requirements_tune.txt when we upgraded tensorflow (conflicting typing-extensions dependency)
-    pip install "pytorch-lightning~=1.7.0"
     download_mnist
   fi
 
@@ -421,6 +419,12 @@ install_dependencies() {
   # RLlib testing with TF 1.x.
   if [ "${RLLIB_TESTING-}" = 1 ] && { [ -n "${TF_VERSION-}" ] || [ -n "${TFP_VERSION-}" ]; }; then
     pip install --upgrade tensorflow-probability=="${TFP_VERSION}" tensorflow=="${TF_VERSION}"
+  fi
+
+  # For Tune, install specific requirements
+  if [ "${TUNE_TESTING-}" = 1 ] ||  [ "${DOC_TESTING-}" = 1 ]; then
+    # Todo: move to requirements_tune.txt when we upgraded tensorflow (conflicting typing-extensions dependency)
+    pip install "pytorch-lightning~=1.7.0"
   fi
 
   # Additional Tune dependency for Horovod.

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -424,7 +424,7 @@ install_dependencies() {
   # For Tune, install specific requirements
   if [ "${TUNE_TESTING-}" = 1 ] ||  [ "${DOC_TESTING-}" = 1 ]; then
     # Todo: move to requirements_tune.txt when we upgraded tensorflow (conflicting typing-extensions dependency)
-    pip install "pytorch-lightning~=1.7.0"
+    pip install "pytorch-lightning~=1.7.0" "ray_lightning==0.3.0"
   fi
 
   # Additional Tune dependency for Horovod.

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -424,7 +424,8 @@ install_dependencies() {
   # For Tune, install specific requirements
   if [ "${TUNE_TESTING-}" = 1 ] ||  [ "${DOC_TESTING-}" = 1 ]; then
     # Todo: move to requirements_tune.txt when we upgraded tensorflow (conflicting typing-extensions dependency)
-    pip install "pytorch-lightning~=1.7.0" "ray_lightning==0.3.0"
+    pip install "ray_lightning==0.3.0"
+    pip install "pytorch-lightning~=1.7.0"
   fi
 
   # Additional Tune dependency for Horovod.

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -377,6 +377,8 @@ install_dependencies() {
   # Additional Tune/Doc test dependencies.
   if [ "${TUNE_TESTING-}" = 1 ] || [ "${DOC_TESTING-}" = 1 ]; then
     pip install -r "${WORKSPACE_DIR}"/python/requirements/ml/requirements_tune.txt
+    # Todo: move to requirements_tune.txt when we upgraded tensorflow (conflicting typing-extensions dependency)
+    pip install "pytorch-lightning~=1.7.0"
     download_mnist
   fi
 

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -421,13 +421,6 @@ install_dependencies() {
     pip install --upgrade tensorflow-probability=="${TFP_VERSION}" tensorflow=="${TF_VERSION}"
   fi
 
-  # For Tune, install specific requirements
-  if [ "${TUNE_TESTING-}" = 1 ] ||  [ "${DOC_TESTING-}" = 1 ]; then
-    # Todo: move to requirements_tune.txt when we upgraded tensorflow (conflicting typing-extensions dependency)
-    pip install "ray_lightning==0.3.0"
-    pip install "pytorch-lightning~=1.7.0"
-  fi
-
   # Additional Tune dependency for Horovod.
   # This must be run last (i.e., torch cannot be re-installed after this)
   if [ "${INSTALL_HOROVOD-}" = 1 ]; then

--- a/python/ray/tune/execution/ray_trial_executor.py
+++ b/python/ray/tune/execution/ray_trial_executor.py
@@ -40,6 +40,11 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_GET_TIMEOUT = 60.0  # seconds
 
+DEFAULT_ENV_VARS = {
+    # https://github.com/ray-project/ray/issues/28197
+    "PL_DISABLE_FORK": "1"
+}
+
 
 class _ActorClassCache:
     """Caches actor classes.
@@ -66,7 +71,10 @@ class _ActorClassCache:
 
     def get(self, trainable_cls):
         """Gets the wrapped trainable_cls, otherwise calls ray.remote."""
-        runtime_env = {"env_vars": {"TUNE_ORIG_WORKING_DIR": os.getcwd()}}
+        env_vars = DEFAULT_ENV_VARS.copy()
+        env_vars["TUNE_ORIG_WORKING_DIR"] = os.getcwd()
+
+        runtime_env = {"env_vars": env_vars}
         if trainable_cls not in self._cache:
             remote_cls = ray.remote(runtime_env=runtime_env)(trainable_cls)
             self._cache[trainable_cls] = remote_cls

--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -27,10 +27,10 @@ mxnet==1.8.0.post0
 nevergrad==0.4.3.post7
 optuna==2.10.0
 # For HEBO compatibility
-pymoo==0.5.0 
+pymoo==0.5.0
 pytest-remotedata==0.3.2
 lightning-bolts==0.4.0
-pytorch-lightning==1.7.5
+pytorch-lightning==1.5.10
 shortuuid==1.0.1
 scikit-learn==0.24.2
 scikit-optimize==0.8.1

--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -30,7 +30,7 @@ optuna==2.10.0
 pymoo==0.5.0 
 pytest-remotedata==0.3.2
 lightning-bolts==0.4.0
-pytorch-lightning==1.5.10
+pytorch-lightning==1.7.5
 shortuuid==1.0.1
 scikit-learn==0.24.2
 scikit-optimize==0.8.1


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Pytorch lightning uses multiprocessing pools per default (e.g. for device lookup), which can lead to hangs (see https://github.com/ray-project/ray/issues/28328). This PR sets an environment variable to disable this until https://github.com/ray-project/ray/issues/28328 is addressed.

## Related issue number

Closes #28197

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
