### PR TITLE
[Tune] [PB2] Correct pb2's beta_t parameter implementation

### DIFF
--- a/python/ray/tune/schedulers/pb2_utils.py
+++ b/python/ray/tune/schedulers/pb2_utils.py
@@ -98,7 +98,7 @@ def UCB(m, m1, x, fixed, kappa=0.5):
 
     c1 = 0.2
     c2 = 0.4
-    beta_t = c1 * np.log(c2 * m.X.shape[0])
+    beta_t = c1 + max(0, np.log(c2 * m.X.shape[0]))
     kappa = np.sqrt(beta_t)
 
     xtest = np.concatenate((fixed.reshape(-1, 1), np.array(x).reshape(-1, 1))).T


### PR DESCRIPTION
Closes #28267

`np.log` could yield a negative value and let `beta_t` become negative. The implementation should be:
`beta_t = c1 + max(0, log(c2 * t))`

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
