### PR TITLE
[Serve] Move `test_recovering_controller_no_redeploy` to prevent it being affected by state from other tests

### DIFF
--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -647,35 +647,6 @@ def test_serve_start_different_http_checkpoint_options_warning(caplog):
     ray.shutdown()
 
 
-def test_recovering_controller_no_redeploy():
-    """Ensure controller doesn't redeploy running deployments when recovering."""
-    ray.init(namespace="x")
-    client = serve.start(detached=True)
-
-    @serve.deployment
-    def f():
-        pass
-
-    serve.run(f.bind())
-
-    num_actors = len(ray.util.list_named_actors(all_namespaces=True))
-    pid = ray.get(client._controller.get_pid.remote())
-
-    ray.kill(client._controller, no_restart=False)
-
-    wait_for_condition(lambda: ray.get(client._controller.get_pid.remote()) != pid)
-
-    # Confirm that no new deployment is deployed over the next 10 seconds
-    with pytest.raises(RuntimeError):
-        wait_for_condition(
-            lambda: len(ray.util.list_named_actors(all_namespaces=True)) > num_actors,
-            timeout=5,
-        )
-
-    serve.shutdown()
-    ray.shutdown()
-
-
 def test_updating_status_message(lower_slow_startup_threshold_and_reset):
     """Check if status message says if a serve deployment has taken a long time"""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
