### PR TITLE
[RLlib] Error message badly formatted

### DIFF
--- a/rllib/models/preprocessors.py
+++ b/rllib/models/preprocessors.py
@@ -73,11 +73,11 @@ class Preprocessor:
                 if not self._obs_space.contains(observation):
                     raise ValueError(
                         "Observation ({} dtype={}) outside given space ({})!".format(
-                        observation,
-                        observation.dtype
-                        if isinstance(self._obs_space, gym.spaces.Box)
-                        else None,
-                        self._obs_space,
+                            observation,
+                            observation.dtype
+                            if isinstance(self._obs_space, gym.spaces.Box)
+                            else None,
+                            self._obs_space,
                         )
                     )
             except AttributeError as e:

--- a/rllib/models/preprocessors.py
+++ b/rllib/models/preprocessors.py
@@ -72,12 +72,13 @@ class Preprocessor:
             try:
                 if not self._obs_space.contains(observation):
                     raise ValueError(
-                        "Observation ({} dtype={}) outside given space ({})!",
+                        "Observation ({} dtype={}) outside given space ({})!".format(
                         observation,
                         observation.dtype
                         if isinstance(self._obs_space, gym.spaces.Box)
                         else None,
                         self._obs_space,
+                        )
                     )
             except AttributeError as e:
                 raise ValueError(


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

When running into the changed error message, one would not see the formatted string but the string plus the args appended.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
