### PR TITLE
[RLlib] Fix ParametricRecSys observations

### DIFF
--- a/rllib/examples/env/bandit_envs_recommender_system.py
+++ b/rllib/examples/env/bandit_envs_recommender_system.py
@@ -127,9 +127,9 @@ class ParametricRecSys(gym.Env):
         # Action is the suggested slate (indices of the docs in the
         # suggested ones).
 
-        scores = [
+        scores = softmax([
             np.dot(self.current_user, doc) for doc in self.currently_suggested_docs
-        ]
+        ])
         best_reward = np.max(scores)
 
         # User choice model: User picks a doc stochastically,
@@ -143,9 +143,8 @@ class ParametricRecSys(gym.Env):
 
         reward = 0.0
         if which_clicked < self.slate_size:
-            # Reward is 1.0 - regret if clicked. 0.0 if not clicked.
             regret = best_reward - user_doc_overlaps[which_clicked]
-            reward = 1 - regret
+            reward = (1 - regret) * 100
             # If anything clicked, deduct from the current user's time budget.
             self.current_user_budget -= 1.0
         done = self.current_user_budget <= 0.0

--- a/rllib/examples/env/bandit_envs_recommender_system.py
+++ b/rllib/examples/env/bandit_envs_recommender_system.py
@@ -147,7 +147,10 @@ class ParametricRecSys(gym.Env):
 
         reward = 0.0
         if which_clicked < self.slate_size:
+            # Reward is 1.0 - regret if clicked. 0.0 if not clicked.
             regret = best_reward - user_doc_overlaps[which_clicked]
+            # The reward also represents the user engagement that we define to be
+            # withing the range [0...100].
             reward = (1 - regret) * 100
             # If anything clicked, deduct from the current user's time budget.
             self.current_user_budget -= 1.0

--- a/rllib/examples/env/bandit_envs_recommender_system.py
+++ b/rllib/examples/env/bandit_envs_recommender_system.py
@@ -127,6 +127,8 @@ class ParametricRecSys(gym.Env):
         # Action is the suggested slate (indices of the docs in the
         # suggested ones).
 
+        # We calculate scores as the dot product between document features and user
+        # features. The softmax ensures regret<1 further down.
         scores = softmax(
             [np.dot(self.current_user, doc) for doc in self.currently_suggested_docs]
         )
@@ -137,8 +139,10 @@ class ParametricRecSys(gym.Env):
         # (categories) vectors (rewards).
         # There is also a no-click doc whose weight is 0.0.
         user_doc_overlaps = np.array([scores[a] for a in action] + [0.0])
+        # We have to softmax again so that probabilities add up to 1
+        probabilities = softmax(user_doc_overlaps)
         which_clicked = np.random.choice(
-            np.arange(self.slate_size + 1), p=softmax(user_doc_overlaps)
+            np.arange(self.slate_size + 1), p=probabilities
         )
 
         reward = 0.0

--- a/rllib/examples/env/bandit_envs_recommender_system.py
+++ b/rllib/examples/env/bandit_envs_recommender_system.py
@@ -127,9 +127,9 @@ class ParametricRecSys(gym.Env):
         # Action is the suggested slate (indices of the docs in the
         # suggested ones).
 
-        scores = softmax([
-            np.dot(self.current_user, doc) for doc in self.currently_suggested_docs
-        ])
+        scores = softmax(
+            [np.dot(self.current_user, doc) for doc in self.currently_suggested_docs]
+        )
         best_reward = np.max(scores)
 
         # User choice model: User picks a doc stochastically,


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

The way observations are constructed right now, they don't necessarily fall into the observations space.
Furthermore, they don't make use of the complete observations space.

## Related issue number

#28231 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
