### PR TITLE
[Docs/AIR] Various fixes for AIR examples

### DIFF
--- a/doc/source/ray-air/examples/feast_example.ipynb
+++ b/doc/source/ray-air/examples/feast_example.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Integrate Ray AIR with Feast feature store"
    ]
@@ -38,20 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "id": "DcPIskZlzSal"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "WORKING_DIR = os.path.expanduser(\"~/ray-air-feast-example/\")\n",
-    "%env WORKING_DIR=$WORKING_DIR"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 1,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -64,21 +53,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2022-06-02 14:22:50--  https://github.com/ray-project/air-sample-data/raw/main/air-feast-example.zip\n",
+      "--2022-09-12 19:24:21--  https://github.com/ray-project/air-sample-data/raw/main/air-feast-example.zip\n",
+      "Loaded CA certificate '/etc/ssl/certs/ca-certificates.crt'\n",
       "Resolving github.com (github.com)... 192.30.255.113\n",
       "Connecting to github.com (github.com)|192.30.255.113|:443... connected.\n",
       "HTTP request sent, awaiting response... 302 Found\n",
       "Location: https://raw.githubusercontent.com/ray-project/air-sample-data/main/air-feast-example.zip [following]\n",
-      "--2022-06-02 14:22:50--  https://raw.githubusercontent.com/ray-project/air-sample-data/main/air-feast-example.zip\n",
-      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.110.133, 185.199.111.133, 185.199.108.133, ...\n",
-      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.110.133|:443... connected.\n",
+      "--2022-09-12 19:24:21--  https://raw.githubusercontent.com/ray-project/air-sample-data/main/air-feast-example.zip\n",
+      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.111.133, 185.199.110.133, ...\n",
+      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.\n",
       "HTTP request sent, awaiting response... 200 OK\n",
       "Length: 23715107 (23M) [application/zip]\n",
       "Saving to: ‘air-feast-example.zip’\n",
       "\n",
-      "air-feast-example.z 100%[===================>]  22.62M   114MB/s    in 0.2s    \n",
+      "air-feast-example.z 100%[===================>]  22.62M  8.79MB/s    in 2.6s    \n",
       "\n",
-      "2022-06-02 14:22:51 (114 MB/s) - ‘air-feast-example.zip’ saved [23715107/23715107]\n",
+      "2022-09-12 19:24:25 (8.79 MB/s) - ‘air-feast-example.zip’ saved [23715107/23715107]\n",
       "\n",
       "Archive:  air-feast-example.zip\n",
       "   creating: air-feast-example/\n",
@@ -96,21 +86,20 @@
       "  inflating: air-feast-example/.DS_Store  \n",
       "   creating: air-feast-example/data/\n",
       "  inflating: air-feast-example/data/loan_table.parquet  \n",
-      "  inflating: air-feast-example/data/loan_table_sample.csv  \n"
+      "  inflating: air-feast-example/data/loan_table_sample.csv  \n",
+      "/home/ray/Desktop/workspace/ray/doc/source/ray-air/examples/air-feast-example\n"
      ]
     }
    ],
    "source": [
-    "! mkdir -p $WORKING_DIR\n",
     "! wget --no-check-certificate https://github.com/ray-project/air-sample-data/raw/main/air-feast-example.zip\n",
     "! unzip air-feast-example.zip \n",
-    "! mv air-feast-example/* $WORKING_DIR\n",
-    "%cd $WORKING_DIR"
+    "%cd air-feast-example"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -144,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -233,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -241,14 +230,29 @@
     "id": "SbL_EbMC2MFS",
     "outputId": "13b07f1f-d52a-4c4e-a73f-f5478c0304de"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created entity \u001b[1m\u001b[32mzipcode\u001b[0m\n",
+      "Created entity \u001b[1m\u001b[32mdob_ssn\u001b[0m\n",
+      "Created feature view \u001b[1m\u001b[32mcredit_history\u001b[0m\n",
+      "Created feature view \u001b[1m\u001b[32mzipcode_features\u001b[0m\n",
+      "\n",
+      "Created sqlite table \u001b[1m\u001b[32mfeature_repo_credit_history\u001b[0m\n",
+      "Created sqlite table \u001b[1m\u001b[32mfeature_repo_zipcode_features\u001b[0m\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "! cd feature_repo && feast apply"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -274,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 6,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -570,7 +574,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 7,
    "metadata": {
     "id": "hAHAb2nS6ClR"
    },
@@ -613,7 +617,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 8,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1029,11 +1033,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "id": "KpiOm00789Rd"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-09-12 19:25:14,018\tINFO worker.py:1508 -- Started a local Ray instance. View the dashboard at \u001b[1m\u001b[32m127.0.0.1:8265 \u001b[39m\u001b[22m\n"
+     ]
+    }
+   ],
    "source": [
     "# Convert into Train and Validation datasets.\n",
     "import ray\n",
@@ -1055,7 +1067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 10,
    "metadata": {
     "id": "qravnrt9EBuW"
    },
@@ -1069,7 +1081,7 @@
     "    \"location_type\",\n",
     "]\n",
     "\n",
-    "from ray.ml.preprocessors import Chain, OrdinalEncoder, SimpleImputer\n",
+    "from ray.data.preprocessors import Chain, OrdinalEncoder, SimpleImputer\n",
     "\n",
     "imputer = SimpleImputer(categorical_features, strategy=\"most_frequent\")\n",
     "encoder = OrdinalEncoder(columns=categorical_features)\n",
@@ -1088,7 +1100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 11,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1099,27 +1111,70 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ray/anaconda3/lib/python3.8/site-packages/xgboost_ray/main.py:131: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.\n",
-      "  XGBOOST_LOOSE_VERSION = LooseVersion(xgboost_version)\n",
-      "E0602 14:26:17.861773834    4511 fork_posix.cc:76]           Other threads are currently calling into gRPC, skipping fork() handlers\n",
-      "/home/ray/anaconda3/lib/python3.8/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    },
-    {
      "data": {
       "text/html": [
-       "== Status ==<br>Current time: 2022-06-02 14:26:33 (running for 00:00:14.95)<br>Memory usage on this node: 3.5/30.6 GiB<br>Using FIFO scheduling algorithm.<br>Resources requested: 0/8 CPUs, 0/0 GPUs, 0.0/18.04 GiB heap, 0.0/9.02 GiB objects<br>Result logdir: /home/ray/ray_results/XGBoostTrainer_2022-06-02_14-26-17<br>Number of trials: 1/1 (1 TERMINATED)<br><table>\n",
+       "<div class=\"tuneStatus\">\n",
+       "  <div style=\"display: flex;flex-direction: row\">\n",
+       "    <div style=\"display: flex;flex-direction: column;\">\n",
+       "      <h3>Tune Status</h3>\n",
+       "      <table>\n",
+       "<tbody>\n",
+       "<tr><td>Current time:</td><td>2022-09-12 19:25:28</td></tr>\n",
+       "<tr><td>Running for: </td><td>00:00:09.09        </td></tr>\n",
+       "<tr><td>Memory:      </td><td>12.3/62.7 GiB      </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n",
+       "    </div>\n",
+       "    <div class=\"vDivider\"></div>\n",
+       "    <div class=\"systemInfo\">\n",
+       "      <h3>System Info</h3>\n",
+       "      Using FIFO scheduling algorithm.<br>Resources requested: 0/24 CPUs, 0/0 GPUs, 0.0/32.5 GiB heap, 0.0/16.25 GiB objects\n",
+       "    </div>\n",
+       "    \n",
+       "  </div>\n",
+       "  <div class=\"hDivider\"></div>\n",
+       "  <div class=\"trialStatus\">\n",
+       "    <h3>Trial Status</h3>\n",
+       "    <table>\n",
        "<thead>\n",
-       "<tr><th>Trial name                </th><th>status    </th><th>loc               </th><th style=\"text-align: right;\">  iter</th><th style=\"text-align: right;\">  total time (s)</th><th style=\"text-align: right;\">  train-logloss</th><th style=\"text-align: right;\">  train-error</th><th style=\"text-align: right;\">  validation-logloss</th></tr>\n",
+       "<tr><th>Trial name                </th><th>status    </th><th>loc                 </th><th style=\"text-align: right;\">  iter</th><th style=\"text-align: right;\">  total time (s)</th><th style=\"text-align: right;\">  train-logloss</th><th style=\"text-align: right;\">  train-error</th><th style=\"text-align: right;\">  validation-logloss</th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "<tr><td>XGBoostTrainer_a3a2c_00000</td><td>TERMINATED</td><td>172.31.71.98:12634</td><td style=\"text-align: right;\">   100</td><td style=\"text-align: right;\">         11.9561</td><td style=\"text-align: right;\">      0.0578837</td><td style=\"text-align: right;\">    0.0127019</td><td style=\"text-align: right;\">            0.225994</td></tr>\n",
+       "<tr><td>XGBoostTrainer_4f411_00000</td><td>TERMINATED</td><td>10.108.96.251:348845</td><td style=\"text-align: right;\">   101</td><td style=\"text-align: right;\">         7.67137</td><td style=\"text-align: right;\">      0.0578837</td><td style=\"text-align: right;\">    0.0127019</td><td style=\"text-align: right;\">            0.225994</td></tr>\n",
        "</tbody>\n",
-       "</table><br><br>"
+       "</table>\n",
+       "  </div>\n",
+       "</div>\n",
+       "<style>\n",
+       ".tuneStatus {\n",
+       "  color: var(--jp-ui-font-color1);\n",
+       "}\n",
+       ".tuneStatus .systemInfo {\n",
+       "  display: flex;\n",
+       "  flex-direction: column;\n",
+       "}\n",
+       ".tuneStatus td {\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       ".tuneStatus .trialStatus {\n",
+       "  display: flex;\n",
+       "  flex-direction: column;\n",
+       "}\n",
+       ".tuneStatus h3 {\n",
+       "  font-weight: bold;\n",
+       "}\n",
+       ".tuneStatus .hDivider {\n",
+       "  border-bottom-width: var(--jp-border-width);\n",
+       "  border-bottom-color: var(--jp-border-color0);\n",
+       "  border-bottom-style: solid;\n",
+       "}\n",
+       ".tuneStatus .vDivider {\n",
+       "  border-left-width: var(--jp-border-width);\n",
+       "  border-left-color: var(--jp-border-color0);\n",
+       "  border-left-style: solid;\n",
+       "  margin: 0.5em 1em 0.5em 1em;\n",
+       "}\n",
+       "</style>\n"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1132,103 +1187,51 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "(GBDTTrainable pid=12634) 2022-06-02 14:26:23,018\tINFO main.py:980 -- [RayXGBoost] Created 1 new actors (1 total actors). Waiting until actors are ready for training.\n",
-      "(GBDTTrainable pid=12634) 2022-06-02 14:26:25,230\tINFO main.py:1025 -- [RayXGBoost] Starting XGBoost training.\n",
-      "(GBDTTrainable pid=12634) E0602 14:26:25.231635524   12691 fork_posix.cc:76]           Other threads are currently calling into gRPC, skipping fork() handlers\n",
-      "(_RemoteRayXGBoostActor pid=12769) [14:26:25] task [xgboost.ray]:139712002042896 got new rank 0\n"
+      "\u001b[2m\u001b[36m(XGBoostTrainer pid=348845)\u001b[0m /home/ray/.pyenv/versions/mambaforge/envs/ray/lib/python3.9/site-packages/xgboost_ray/main.py:431: UserWarning: `num_actors` in `ray_params` is smaller than 2 (1). XGBoost will NOT be distributed!\n",
+      "\u001b[2m\u001b[36m(XGBoostTrainer pid=348845)\u001b[0m   warnings.warn(\n",
+      "\u001b[2m\u001b[36m(_RemoteRayXGBoostActor pid=348922)\u001b[0m [19:25:23] task [xgboost.ray]:140319682474864 got new rank 0\n"
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result for XGBoostTrainer_a3a2c_00000:\n",
-      "  date: 2022-06-02_14-26-26\n",
-      "  done: false\n",
-      "  experiment_id: 14b63d641b8e4583b3551b1af113ec6d\n",
-      "  hostname: ip-172-31-71-98\n",
-      "  iterations_since_restore: 1\n",
-      "  node_ip: 172.31.71.98\n",
-      "  pid: 12634\n",
-      "  should_checkpoint: true\n",
-      "  time_since_restore: 5.432286262512207\n",
-      "  time_this_iter_s: 5.432286262512207\n",
-      "  time_total_s: 5.432286262512207\n",
-      "  timestamp: 1654205186\n",
-      "  timesteps_since_restore: 0\n",
-      "  train-error: 0.09502400698384984\n",
-      "  train-logloss: 0.5147884634112437\n",
-      "  training_iteration: 1\n",
-      "  trial_id: a3a2c_00000\n",
-      "  validation-error: 0.1627094972067039\n",
-      "  validation-logloss: 0.5557328870197414\n",
-      "  warmup_time: 0.004194974899291992\n",
-      "  \n",
-      "Result for XGBoostTrainer_a3a2c_00000:\n",
-      "  date: 2022-06-02_14-26-31\n",
-      "  done: false\n",
-      "  experiment_id: 14b63d641b8e4583b3551b1af113ec6d\n",
-      "  hostname: ip-172-31-71-98\n",
-      "  iterations_since_restore: 81\n",
-      "  node_ip: 172.31.71.98\n",
-      "  pid: 12634\n",
-      "  should_checkpoint: true\n",
-      "  time_since_restore: 10.460175275802612\n",
-      "  time_this_iter_s: 0.03925156593322754\n",
-      "  time_total_s: 10.460175275802612\n",
-      "  timestamp: 1654205191\n",
-      "  timesteps_since_restore: 0\n",
-      "  train-error: 0.01802706241815801\n",
-      "  train-logloss: 0.07058723671627426\n",
-      "  training_iteration: 81\n",
-      "  trial_id: a3a2c_00000\n",
-      "  validation-error: 0.0824022346368715\n",
-      "  validation-logloss: 0.22556984905196217\n",
-      "  warmup_time: 0.004194974899291992\n",
-      "  \n"
-     ]
+     "data": {
+      "text/html": [
+       "<div class=\"trialProgress\">\n",
+       "  <h3>Trial Progress</h3>\n",
+       "  <table>\n",
+       "<thead>\n",
+       "<tr><th>Trial name                </th><th>date               </th><th>done  </th><th>episodes_total  </th><th>experiment_id                   </th><th style=\"text-align: right;\">  experiment_tag</th><th>hostname  </th><th style=\"text-align: right;\">  iterations_since_restore</th><th>node_ip      </th><th style=\"text-align: right;\">   pid</th><th style=\"text-align: right;\">  time_since_restore</th><th style=\"text-align: right;\">  time_this_iter_s</th><th style=\"text-align: right;\">  time_total_s</th><th style=\"text-align: right;\">  timestamp</th><th style=\"text-align: right;\">  timesteps_since_restore</th><th>timesteps_total  </th><th style=\"text-align: right;\">  train-error</th><th style=\"text-align: right;\">  train-logloss</th><th style=\"text-align: right;\">  training_iteration</th><th>trial_id   </th><th style=\"text-align: right;\">  validation-error</th><th style=\"text-align: right;\">  validation-logloss</th><th style=\"text-align: right;\">  warmup_time</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "<tr><td>XGBoostTrainer_4f411_00000</td><td>2022-09-12_19-25-28</td><td>True  </td><td>                </td><td>83cacc5068a84efc8998c269bc054088</td><td style=\"text-align: right;\">               0</td><td>corvus    </td><td style=\"text-align: right;\">                       101</td><td>10.108.96.251</td><td style=\"text-align: right;\">348845</td><td style=\"text-align: right;\">             7.67137</td><td style=\"text-align: right;\">           1.01445</td><td style=\"text-align: right;\">       7.67137</td><td style=\"text-align: right;\"> 1663035928</td><td style=\"text-align: right;\">                        0</td><td>                 </td><td style=\"text-align: right;\">    0.0127019</td><td style=\"text-align: right;\">      0.0578837</td><td style=\"text-align: right;\">                 101</td><td>4f411_00000</td><td style=\"text-align: right;\">         0.0825768</td><td style=\"text-align: right;\">            0.225994</td><td style=\"text-align: right;\">   0.00293422</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n",
+       "</div>\n",
+       "<style>\n",
+       ".trialProgress {\n",
+       "  display: flex;\n",
+       "  flex-direction: column;\n",
+       "  color: var(--jp-ui-font-color1);\n",
+       "}\n",
+       ".trialProgress h3 {\n",
+       "  font-weight: bold;\n",
+       "}\n",
+       ".trialProgress td {\n",
+       "  white-space: nowrap;\n",
+       "}\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "(GBDTTrainable pid=12634) 2022-06-02 14:26:32,801\tINFO main.py:1516 -- [RayXGBoost] Finished XGBoost training on training data with total N=22,910 in 9.81 seconds (7.57 pure XGBoost training time).\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result for XGBoostTrainer_a3a2c_00000:\n",
-      "  date: 2022-06-02_14-26-32\n",
-      "  done: true\n",
-      "  experiment_id: 14b63d641b8e4583b3551b1af113ec6d\n",
-      "  experiment_tag: '0'\n",
-      "  hostname: ip-172-31-71-98\n",
-      "  iterations_since_restore: 100\n",
-      "  node_ip: 172.31.71.98\n",
-      "  pid: 12634\n",
-      "  should_checkpoint: true\n",
-      "  time_since_restore: 11.956074953079224\n",
-      "  time_this_iter_s: 0.022900104522705078\n",
-      "  time_total_s: 11.956074953079224\n",
-      "  timestamp: 1654205192\n",
-      "  timesteps_since_restore: 0\n",
-      "  train-error: 0.01270187690964644\n",
-      "  train-logloss: 0.05788368908741939\n",
-      "  training_iteration: 100\n",
-      "  trial_id: a3a2c_00000\n",
-      "  validation-error: 0.0825768156424581\n",
-      "  validation-logloss: 0.22599449588356768\n",
-      "  warmup_time: 0.004194974899291992\n",
-      "  \n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-06-02 14:26:33,481\tINFO tune.py:752 -- Total run time: 15.62 seconds (14.94 seconds for the tuning loop).\n"
+      "2022-09-12 19:25:28,422\tINFO tune.py:762 -- Total run time: 9.86 seconds (9.09 seconds for the tuning loop).\n"
      ]
     },
     {
@@ -1237,7 +1240,7 @@
        "'checkpoint'"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1248,7 +1251,7 @@
     "NUM_WORKERS = 1  # Change this based on the resources in the cluster.\n",
     "\n",
     "\n",
-    "from ray.ml.train.integrations.xgboost import XGBoostTrainer\n",
+    "from ray.train.xgboost import XGBoostTrainer\n",
     "from ray.air.config import ScalingConfig\n",
     "params = {\n",
     "    \"tree_method\": \"approx\",\n",
@@ -1286,35 +1289,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 12,
    "metadata": {
     "id": "wE8ielQlKYSi"
    },
    "outputs": [],
    "source": [
-    "from ray.ml.checkpoint import Checkpoint\n",
-    "from ray.ml.predictors.integrations.xgboost import XGBoostPredictor\n",
+    "from ray.air.checkpoint import Checkpoint\n",
+    "from ray.train.xgboost import XGBoostPredictor\n",
     "predictor = XGBoostPredictor.from_checkpoint(Checkpoint.from_directory(CHECKPOINT_PATH))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 13,
    "metadata": {
     "id": "K9Y9UiD3KqSW"
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_4511/2153939661.py:23: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.\n",
-      "Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations\n",
-      "  loan_request_df = pd.DataFrame.from_dict(loan_request_dict, dtype=np.float)\n",
-      "/tmp/ipykernel_4511/2153939661.py:23: FutureWarning: Could not cast to float64, falling back to object. This behavior is deprecated. In a future version, when a dtype is passed to 'DataFrame', either all columns will be cast to that dtype, or a TypeError will be raised.\n",
-      "  loan_request_df = pd.DataFrame.from_dict(loan_request_dict, dtype=np.float)\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -1343,46 +1335,46 @@
        "      <th>loan_intent</th>\n",
        "      <th>loan_amnt</th>\n",
        "      <th>loan_int_rate</th>\n",
-       "      <th>state</th>\n",
-       "      <th>population</th>\n",
        "      <th>location_type</th>\n",
+       "      <th>city</th>\n",
+       "      <th>population</th>\n",
        "      <th>...</th>\n",
-       "      <th>tax_returns_filed</th>\n",
-       "      <th>student_loan_due</th>\n",
-       "      <th>missed_payments_1y</th>\n",
+       "      <th>total_wages</th>\n",
        "      <th>hard_pulls</th>\n",
-       "      <th>mortgage_due</th>\n",
        "      <th>bankruptcies</th>\n",
+       "      <th>missed_payments_1y</th>\n",
+       "      <th>mortgage_due</th>\n",
        "      <th>credit_card_due</th>\n",
        "      <th>missed_payments_2y</th>\n",
        "      <th>missed_payments_6m</th>\n",
+       "      <th>student_loan_due</th>\n",
        "      <th>vehicle_loan_due</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>133.0</td>\n",
-       "      <td>59000.0</td>\n",
+       "      <td>133</td>\n",
+       "      <td>59000</td>\n",
        "      <td>RENT</td>\n",
        "      <td>123.0</td>\n",
        "      <td>PERSONAL</td>\n",
-       "      <td>35000.0</td>\n",
+       "      <td>35000</td>\n",
        "      <td>16.02</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
        "      <td>...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1391,19 +1383,19 @@
       ],
       "text/plain": [
        "   person_age  person_income person_home_ownership  person_emp_length  \\\n",
-       "0       133.0        59000.0                  RENT              123.0   \n",
+       "0         133          59000                  RENT              123.0   \n",
        "\n",
-       "  loan_intent  loan_amnt  loan_int_rate  state  population  location_type  \\\n",
-       "0    PERSONAL    35000.0          16.02    NaN         NaN            NaN   \n",
+       "  loan_intent  loan_amnt  loan_int_rate location_type  city population  ...  \\\n",
+       "0    PERSONAL      35000          16.02          None  None       None  ...   \n",
        "\n",
-       "   ...  tax_returns_filed  student_loan_due  missed_payments_1y  hard_pulls  \\\n",
-       "0  ...                NaN               NaN                 NaN         NaN   \n",
+       "  total_wages hard_pulls bankruptcies missed_payments_1y mortgage_due  \\\n",
+       "0        None       None         None               None         None   \n",
        "\n",
-       "   mortgage_due  bankruptcies  credit_card_due  missed_payments_2y  \\\n",
-       "0           NaN           NaN              NaN                 NaN   \n",
+       "  credit_card_due missed_payments_2y missed_payments_6m student_loan_due  \\\n",
+       "0            None               None               None             None   \n",
        "\n",
-       "   missed_payments_6m  vehicle_loan_due  \n",
-       "0                 NaN               NaN  \n",
+       "  vehicle_loan_due  \n",
+       "0             None  \n",
        "\n",
        "[1 rows x 22 columns]"
       ]
@@ -1435,14 +1427,14 @@
     "    features=feast_features,\n",
     ").to_dict()\n",
     "loan_request_dict.update(online_features)\n",
-    "loan_request_df = pd.DataFrame.from_dict(loan_request_dict, dtype=np.float)\n",
+    "loan_request_df = pd.DataFrame.from_dict(loan_request_dict)\n",
     "loan_request_df = loan_request_df.drop([\"zipcode\", \"dob_ssn\"], axis=1)\n",
     "display(loan_request_df)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 14,
    "metadata": {
     "id": "eS7_n1GPLL1e"
    },
@@ -1464,6 +1456,13 @@
     "elif loan_result == 1:\n",
     "    print(\"Loan rejected!\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1487,7 +1486,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/doc/source/ray-air/examples/rl_offline_example.ipynb
+++ b/doc/source/ray-air/examples/rl_offline_example.ipynb
@@ -92,7 +92,7 @@
     "        algorithm=\"PPO\",\n",
     "        run_config=RunConfig(stop={\"timesteps_total\": 5000}),\n",
     "        config={\n",
-    "            \"env\": \"CartPole-v0\",\n",
+    "            \"env\": \"CartPole-v1\",\n",
     "            \"output\": \"dataset\",\n",
     "            \"output_config\": {\n",
     "                \"format\": \"json\",\n",
@@ -110,7 +110,7 @@
    "id": "8bca906c",
    "metadata": {},
    "source": [
-    "Here we define the training function. It will create an `RLTrainer` using the `PPO` algorithm and kick off training on the `CartPole-v0` environment. It will use the offline data provided in `path` for this."
+    "Here we define the training function. It will create an `RLTrainer` using the `PPO` algorithm and kick off training on the `CartPole-v1` environment. It will use the offline data provided in `path` for this."
    ]
   },
   {
@@ -132,7 +132,7 @@
     "        datasets={\"train\": dataset},\n",
     "        algorithm=BCTrainer,\n",
     "        config={\n",
-    "            \"env\": \"CartPole-v0\",\n",
+    "            \"env\": \"CartPole-v1\",\n",
     "            \"framework\": \"tf\",\n",
     "            \"evaluation_num_workers\": 1,\n",
     "            \"evaluation_interval\": 1,\n",
@@ -168,7 +168,7 @@
     "def evaluate_using_checkpoint(checkpoint: Checkpoint, num_episodes) -> list:\n",
     "    predictor = RLPredictor.from_checkpoint(checkpoint)\n",
     "\n",
-    "    env = gym.make(\"CartPole-v0\")\n",
+    "    env = gym.make(\"CartPole-v1\")\n",
     "\n",
     "    rewards = []\n",
     "    for i in range(num_episodes):\n",

--- a/doc/source/ray-air/examples/rl_online_example.ipynb
+++ b/doc/source/ray-air/examples/rl_online_example.ipynb
@@ -74,7 +74,7 @@
    "id": "a13db7e4",
    "metadata": {},
    "source": [
-    "Here we define the training function. It will create an `RLTrainer` using the `PPO` algorithm and kick off training on the `CartPole-v0` environment:"
+    "Here we define the training function. It will create an `RLTrainer` using the `PPO` algorithm and kick off training on the `CartPole-v1` environment:"
    ]
   },
   {
@@ -91,7 +91,7 @@
     "        scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=use_gpu),\n",
     "        algorithm=\"PPO\",\n",
     "        config={\n",
-    "            \"env\": \"CartPole-v0\",\n",
+    "            \"env\": \"CartPole-v1\",\n",
     "            \"framework\": \"tf\",\n",
     "        },\n",
     "    )\n",
@@ -123,7 +123,7 @@
     "def evaluate_using_checkpoint(checkpoint: Checkpoint, num_episodes) -> list:\n",
     "    predictor = RLPredictor.from_checkpoint(checkpoint)\n",
     "\n",
-    "    env = gym.make(\"CartPole-v0\")\n",
+    "    env = gym.make(\"CartPole-v1\")\n",
     "\n",
     "    rewards = []\n",
     "    for i in range(num_episodes):\n",

--- a/doc/source/ray-air/examples/rl_serving_example.ipynb
+++ b/doc/source/ray-air/examples/rl_serving_example.ipynb
@@ -66,7 +66,7 @@
    "id": "144e26c8",
    "metadata": {},
    "source": [
-    "Since we'll be serving a reinforcement learning policy, we need to train one first. Thus we define a simple training function which will kick off online reinforcement learning of a PPO agent on the `CartPole-v0` environment."
+    "Since we'll be serving a reinforcement learning policy, we need to train one first. Thus we define a simple training function which will kick off online reinforcement learning of a PPO agent on the `CartPole-v1` environment."
    ]
   },
   {
@@ -83,7 +83,7 @@
     "        scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=use_gpu),\n",
     "        algorithm=\"PPO\",\n",
     "        config={\n",
-    "            \"env\": \"CartPole-v0\",\n",
+    "            \"env\": \"CartPole-v1\",\n",
     "            \"framework\": \"tf\",\n",
     "        },\n",
     "    )\n",
@@ -147,7 +147,7 @@
     "    This function will create an RL environment and step through it.\n",
     "    To obtain the actions, it will query the deployed RL model.\n",
     "    \"\"\"\n",
-    "    env = gym.make(\"CartPole-v0\")\n",
+    "    env = gym.make(\"CartPole-v1\")\n",
     "\n",
     "    rewards = []\n",
     "    for i in range(num_episodes):\n",


### PR DESCRIPTION
- Switch from deprecated CartPole-v0 to v1, fixing deprecation warnings in `rl_offline_example`, `rl_online_example`, and `rl_serving_example`.
- Fixed `feast_example` issues:
  - Numpy float warning
  - Deprecated `ray.ml` imports
  - Switch to downloading data to the current directory

## Why are these changes needed?

Addresses multiple deprecation warnings as well as a few issues which break the Feast example. See #27851 for more information.

## Related issue number

Partially addresses #27851.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
