### PR TITLE
[core] Introduce an os env to set the headnode resource to zero.

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -619,6 +619,13 @@ def start(
         )
 
     redirect_output = None if not no_redirect_output else True
+
+    # Prevent jobs from running in the head node.
+    # The head node is defined to be the node having GCS.
+    if os.environ.get("RAY_head_no_compute_resources") == "1" and head is True:
+        num_cpus = 0
+        num_gpus = 0
+
     ray_params = ray._private.parameter.RayParams(
         node_ip_address=node_ip_address,
         node_name=node_name if node_name else node_ip_address,


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
For some cases, we don't want the head node to run ray worker, so we'll set `--num-cpus=0`, `--num-gpus=0`. This PR introduce an OS env for this because sometimes the info is baked in docker image and the start cmd is fixed and hard to change.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
