### PR TITLE
fix bug that start default worker failed when args contains whitespace

### DIFF
--- a/java/test/src/main/java/io/ray/test/SetupJavaWorkerTest.java
+++ b/java/test/src/main/java/io/ray/test/SetupJavaWorkerTest.java
@@ -5,12 +5,6 @@ import io.ray.api.Ray;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-/**
- * afafafa
- *
- * @author sunkunjian1
- * @date 2022/09/12
- **/
 @Test
 public class SetupJavaWorkerTest {
 
@@ -25,23 +19,23 @@ public class SetupJavaWorkerTest {
     public int getValue() {
       return value;
     }
-
   }
 
   /**
-   * raylet will call setup_worker.py with arguments to start java workers after Ray 2.0.0,
-   * and setup_worker.py can not start java workers correctly when argumens contian space.
-   * This test case is used to test whether the bug is fixed.
+   * raylet will call setup_worker.py with arguments to start java workers after Ray 2.0.0, and
+   * setup_worker.py can not start java workers correctly when argumens contian space. This test
+   * case is used to test whether the bug is fixed.
    */
-  public void testCreateActorFail() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+  public void testCreateActorFail()
+      throws InterruptedException, NoSuchFieldException, IllegalAccessException {
     String oldCodeSearchPathStr = System.getProperty("java.class.path");
-    //mock a fake code search path contains space
+    // mock a fake code search path contains space
     String newCodeSearchPathStr = oldCodeSearchPathStr + ":fakepathStart fakePathEnd";
     System.setProperty("java.class.path", newCodeSearchPathStr);
     Ray.init();
     ActorHandle<ActorTest.Counter> actor = Ray.actor(ActorTest.Counter::new, 1).remote();
     // throw RayTimeoutException exception if actor is not started correctly by raylet
-    Integer value = actor.task(ActorTest.Counter::getValue).remote().get(3*1000);
+    Integer value = actor.task(ActorTest.Counter::getValue).remote().get(3 * 1000);
     Assert.assertEquals(Integer.valueOf(1), value);
     System.setProperty("java.class.path", oldCodeSearchPathStr);
     Ray.shutdown();

--- a/java/test/src/main/java/io/ray/test/SetupJavaWorkerTest.java
+++ b/java/test/src/main/java/io/ray/test/SetupJavaWorkerTest.java
@@ -1,0 +1,49 @@
+package io.ray.test;
+
+import io.ray.api.ActorHandle;
+import io.ray.api.Ray;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * afafafa
+ *
+ * @author sunkunjian1
+ * @date 2022/09/12
+ **/
+@Test
+public class SetupJavaWorkerTest {
+
+  public static class Counter {
+
+    private int value;
+
+    public Counter(int initValue) {
+      this.value = initValue;
+    }
+
+    public int getValue() {
+      return value;
+    }
+
+  }
+
+  /**
+   * raylet will call setup_worker.py with arguments to start java workers after Ray 2.0.0,
+   * and setup_worker.py can not start java workers correctly when argumens contian space.
+   * This test case is used to test whether the bug is fixed.
+   */
+  public void testCreateActorFail() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+    String oldCodeSearchPathStr = System.getProperty("java.class.path");
+    //mock a fake code search path contains space
+    String newCodeSearchPathStr = oldCodeSearchPathStr + ":fakepathStart fakePathEnd";
+    System.setProperty("java.class.path", newCodeSearchPathStr);
+    Ray.init();
+    ActorHandle<ActorTest.Counter> actor = Ray.actor(ActorTest.Counter::new, 1).remote();
+    // throw RayTimeoutException exception if actor is not started correctly by raylet
+    Integer value = actor.task(ActorTest.Counter::getValue).remote().get(3*1000);
+    Assert.assertEquals(Integer.valueOf(1), value);
+    System.setProperty("java.class.path", oldCodeSearchPathStr);
+    Ray.shutdown();
+  }
+}

--- a/java/test/src/main/java/io/ray/test/SetupJavaWorkerTest.java
+++ b/java/test/src/main/java/io/ray/test/SetupJavaWorkerTest.java
@@ -3,10 +3,14 @@ package io.ray.test;
 import io.ray.api.ActorHandle;
 import io.ray.api.Ray;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Test
-public class SetupJavaWorkerTest {
+public class SetupJavaWorkerTest extends BaseTest {
+
+  private static final String CODE_SEARCH_PATH = System.getProperty("java.class.path");;
 
   public static class Counter {
 
@@ -21,23 +25,27 @@ public class SetupJavaWorkerTest {
     }
   }
 
+  @BeforeClass
+  public void setup() {
+    // mock a fake code search path contains whitespace
+    String newCodeSearchPathStr = CODE_SEARCH_PATH + ":fakepathStart fakePathEnd";
+    System.setProperty("java.class.path", newCodeSearchPathStr);
+  }
+
+  @AfterClass
+  public void clean() {
+    // restore class path
+    System.setProperty("java.class.path", CODE_SEARCH_PATH);
+  }
   /**
    * raylet will call setup_worker.py with arguments to start java workers after Ray 2.0.0, and
-   * setup_worker.py can not start java workers correctly when argumens contian space. This test
-   * case is used to test whether the bug is fixed.
+   * setup_worker.py can not start java workers correctly when argumens contian whitespace. This
+   * test case is used to test whether the bug is fixed.
    */
-  public void testCreateActorFail()
-      throws InterruptedException, NoSuchFieldException, IllegalAccessException {
-    String oldCodeSearchPathStr = System.getProperty("java.class.path");
-    // mock a fake code search path contains space
-    String newCodeSearchPathStr = oldCodeSearchPathStr + ":fakepathStart fakePathEnd";
-    System.setProperty("java.class.path", newCodeSearchPathStr);
-    Ray.init();
+  public void testCreateActorFail() {
     ActorHandle<ActorTest.Counter> actor = Ray.actor(ActorTest.Counter::new, 1).remote();
     // throw RayTimeoutException exception if actor is not started correctly by raylet
     Integer value = actor.task(ActorTest.Counter::getValue).remote().get(3 * 1000);
     Assert.assertEquals(Integer.valueOf(1), value);
-    System.setProperty("java.class.path", oldCodeSearchPathStr);
-    Ray.shutdown();
   }
 }

--- a/java/test/src/main/java/io/ray/test/WorkerJvmOptionsTest.java
+++ b/java/test/src/main/java/io/ray/test/WorkerJvmOptionsTest.java
@@ -25,6 +25,6 @@ public class WorkerJvmOptionsTest extends BaseTest {
                 ImmutableList.of("-Dtest.suffix=suffix", "-Dtest.suffix1=suffix1 suffix1"))
             .remote();
     ObjectRef<String> obj = actor.task(Echo::getOptions).remote();
-    Assert.assertEquals(obj.get(3*1000), "suffix");
+    Assert.assertEquals(obj.get(3 * 1000), "suffix");
   }
 }

--- a/java/test/src/main/java/io/ray/test/WorkerJvmOptionsTest.java
+++ b/java/test/src/main/java/io/ray/test/WorkerJvmOptionsTest.java
@@ -25,6 +25,6 @@ public class WorkerJvmOptionsTest extends BaseTest {
                 ImmutableList.of("-Dtest.suffix=suffix", "-Dtest.suffix1=suffix1 suffix1"))
             .remote();
     ObjectRef<String> obj = actor.task(Echo::getOptions).remote();
-    Assert.assertEquals(obj.get(), "suffix");
+    Assert.assertEquals(obj.get(3*1000), "suffix");
   }
 }

--- a/java/test/src/main/java/io/ray/test/WorkerJvmOptionsTest.java
+++ b/java/test/src/main/java/io/ray/test/WorkerJvmOptionsTest.java
@@ -21,7 +21,8 @@ public class WorkerJvmOptionsTest extends BaseTest {
     // that raylet can correctly handle dynamic options with whitespaces.
     ActorHandle<Echo> actor =
         Ray.actor(Echo::new)
-            .setJvmOptions(ImmutableList.of("-Dtest.suffix=suffix", "-Dtest.suffix1=suffix1 suffix1"))
+            .setJvmOptions(
+                ImmutableList.of("-Dtest.suffix=suffix", "-Dtest.suffix1=suffix1 suffix1"))
             .remote();
     ObjectRef<String> obj = actor.task(Echo::getOptions).remote();
     Assert.assertEquals(obj.get(), "suffix");

--- a/java/test/src/main/java/io/ray/test/WorkerJvmOptionsTest.java
+++ b/java/test/src/main/java/io/ray/test/WorkerJvmOptionsTest.java
@@ -21,7 +21,7 @@ public class WorkerJvmOptionsTest extends BaseTest {
     // that raylet can correctly handle dynamic options with whitespaces.
     ActorHandle<Echo> actor =
         Ray.actor(Echo::new)
-            .setJvmOptions(ImmutableList.of("-Dtest.suffix=suffix", "-Dtest.suffix1=suffix1"))
+            .setJvmOptions(ImmutableList.of("-Dtest.suffix=suffix", "-Dtest.suffix1=suffix1 suffix1"))
             .remote();
     ObjectRef<String> obj = actor.task(Echo::getOptions).remote();
     Assert.assertEquals(obj.get(), "suffix");

--- a/python/ray/_private/runtime_env/context.py
+++ b/python/ray/_private/runtime_env/context.py
@@ -66,6 +66,7 @@ class RuntimeEnvContext:
         else:
             executable = "exec "
 
+        passthrough_args = [s.replace(" ", "\ ") for s in passthrough_args]
         exec_command = " ".join([f"{executable}"] + passthrough_args)
         command_str = " && ".join(self.command_prefix + [exec_command])
         # TODO(SongGuyang): We add this env to command for macOS because it doesn't


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fix the issue that java worker cannot start correctly when the arguments contains space.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#28331

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
