### PR TITLE
[docs] No mocking in make doctest

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -306,7 +306,7 @@ build_sphinx_docs() {
       echo "WARNING: Documentation not built on Windows due to currently-unresolved issues"
     else
       make html
-      make doctest
+      RAY_MOCK_MODULES=0 make doctest
     fi
   )
 }

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -308,7 +308,7 @@ build_sphinx_docs() {
       make html
       # The following avoids
       # ImportError: cannot import name '_mul_broadcast_shape' from 'gpytorch.utils.broadcasting'
-      pip install gpytorch==1.8.1  # See https://github.com/pytorch/botorch/issues/1370
+      pip install gpytorch==1.6.0  # See https://github.com/pytorch/botorch/issues/1370
       RAY_MOCK_MODULES=0 make doctest
     fi
   )

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -306,9 +306,6 @@ build_sphinx_docs() {
       echo "WARNING: Documentation not built on Windows due to currently-unresolved issues"
     else
       make html
-      # The following avoids
-      # ImportError: cannot import name '_mul_broadcast_shape' from 'gpytorch.utils.broadcasting'
-      pip install gpytorch==1.6.0  # See https://github.com/pytorch/botorch/issues/1370
       RAY_MOCK_MODULES=0 make doctest
     fi
   )

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -306,6 +306,9 @@ build_sphinx_docs() {
       echo "WARNING: Documentation not built on Windows due to currently-unresolved issues"
     else
       make html
+      # The following avoids
+      # ImportError: cannot import name '_mul_broadcast_shape' from 'gpytorch.utils.broadcasting'
+      pip install gpytorch==1.8.1  # See https://github.com/pytorch/botorch/issues/1370
       RAY_MOCK_MODULES=0 make doctest
     fi
   )

--- a/doc/README.md
+++ b/doc/README.md
@@ -62,7 +62,7 @@ make linkcheck
 To run tests for examples shipping with docstrings in Python files, run the following command:
 
 ```shell
-make doctest
+RAY_MOCK_MODULES=0 make doctest
 ```
 
 ## Adding examples as MyST Markdown Notebooks

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -1,5 +1,6 @@
 import logging
 import logging.handlers
+import os
 import sys
 import urllib
 import urllib.request
@@ -117,6 +118,9 @@ def make_typing_mock(module, name):
 
 
 def mock_modules():
+    if os.environ.get("RAY_MOCK_MODULES", "1") == "0":
+        return
+
     for mod_name in MOCK_MODULES:
         mock_module = mock.MagicMock()
         mock_module.__spec__ = mock.MagicMock()

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -138,9 +138,9 @@ class Dataset(Generic[T]):
     Examples:
         >>> import ray
         >>> # Create dataset from synthetic data.
-        >>> ds = ray.data.range(1000) # doctest: +SKIP
+        >>> ds = ray.data.range(1000)
         >>> # Create dataset from in-memory data.
-        >>> ds = ray.data.from_items( # doctest: +SKIP
+        >>> ds = ray.data.from_items(
         ...     [{"col1": i, "col2": i * 2} for i in range(1000)])
         >>> # Create dataset from external storage system.
         >>> ds = ray.data.read_parquet("s3://bucket/path") # doctest: +SKIP

--- a/python/ray/tune/search/__init__.py
+++ b/python/ray/tune/search/__init__.py
@@ -133,8 +133,8 @@ def create_searcher(
     Returns:
         ray.tune.search.Searcher: The search algorithm.
     Example:
-        >>> from ray import tune
-        >>> search_alg = tune.create_searcher('ax')
+        >>> from ray import tune # doctest: +SKIP
+        >>> search_alg = tune.create_searcher('ax') # doctest: +SKIP
     """
 
     search_alg = search_alg.lower()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

First step for fixing https://github.com/ray-project/ray/issues/27853 -- don't run doctest in Ray mock mode. Will activate more doc tests in follow up PRs.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
