### PR TITLE
[docs] Sphinx code callouts extension with example usage

### DIFF
--- a/doc/source/_ext/callouts.py
+++ b/doc/source/_ext/callouts.py
@@ -1,5 +1,3 @@
-import logging
-
 from docutils import nodes
 
 from sphinx.util.docutils import SphinxDirective

--- a/doc/source/_ext/callouts.py
+++ b/doc/source/_ext/callouts.py
@@ -1,0 +1,201 @@
+import logging
+
+from docutils import nodes
+
+from sphinx.util.docutils import SphinxDirective
+from sphinx.transforms import SphinxTransform
+from docutils.nodes import Node
+
+# BASE_NUM = 2775  # black circles, white numbers
+BASE_NUM = 2459  # white circle, black numbers
+
+
+class CalloutIncludePostTransform(SphinxTransform):
+    """Code block post-processor for `literalinclude` blocks used in callouts.
+    """
+    default_priority = 400
+
+    def apply(self, **kwargs) -> None:
+        visitor = LiteralIncludeVisitor(self.document)
+        self.document.walkabout(visitor)
+
+
+class LiteralIncludeVisitor(nodes.NodeVisitor):
+    """Change a literal block upon visiting it."""
+    def __init__(self, document: nodes.document) -> None:
+        super().__init__(document)
+
+    def unknown_visit(self, node: Node) -> None:
+        pass
+
+    def unknown_departure(self, node: Node) -> None:
+        pass
+
+    def visit_document(self, node: Node) -> None:
+        pass
+
+    def depart_document(self, node: Node) -> None:
+        pass
+
+    def visit_start_of_file(self, node: Node) -> None:
+        pass
+
+    def depart_start_of_file(self, node: Node) -> None:
+        pass
+
+    def visit_literal_block(self, node: nodes.literal_block) -> None:
+        if "<1>" in node.rawsource:
+            source = str(node.rawsource)
+            for i in range(1, 20):
+                source = source.replace(
+                    f"<{i}>", chr(int(f"0x{BASE_NUM + i}", base=16))
+                )
+            node.rawsource = source
+            node[:] = [nodes.Text(source)]
+
+
+class callout(nodes.General, nodes.Element):
+    """Sphinx callout node."""
+    pass
+
+
+def visit_callout_node(self, node):
+    """We pass on node visit to prevent the
+    callout being treated as admonition."""
+    pass
+
+
+def depart_callout_node(self, node):
+    """Departing a callout node is a no-op, too."""
+    pass
+
+
+class annotations(nodes.Element):
+    """Sphinx annotations node."""
+    pass
+
+
+def _replace_numbers(content: str):
+    """
+    Replaces strings of the form <x> with circled unicode numbers (e.g. ①) as text.
+
+    Args:
+        content: Python str from a callout or annotations directive.
+
+    Returns: The formatted content string.
+    """
+    for i in range(1, 20):
+        content.replace(f"<{i}>", chr(int(f"0x{BASE_NUM + i}", base=16)))
+    return content
+
+
+def _parse_recursively(self, node):
+    """Utility to recursively parse a node from the Sphinx AST."""
+    self.state.nested_parse(
+        self.content,
+        self.content_offset,
+        node)
+
+
+class CalloutDirective(SphinxDirective):
+    """Code callout directive with annotations for Sphinx.
+
+    Use this `callout` directive by wrapping either `code-block` or `literalinclude`
+    directives. Each line that's supposed to be equipped with an annotation should
+    have an inline comment of the form "# <x>" where x is an integer.
+
+    Afterwards use the `annotations` directive to add annotations to the previously
+    defined code labels ("<x>") by using the syntax "<x> my annotation" to produce an
+    annotation "my annotation" for x.
+    Note that annotation lines have to be separated by a new line, i.e.
+
+    .. annotations::
+
+        <1> First comment followed by a newline,
+
+        <2> second comment after the newline.
+
+
+    Usage example:
+    -------------
+
+    .. callout::
+
+        .. code-block:: python
+
+            from ray import tune
+            from ray.tune.search.hyperopt import HyperOptSearch
+            import keras
+
+            def objective(config):  # <1>
+                ...
+
+            search_space = {"activation": tune.choice(["relu", "tanh"])}  # <2>
+            algo = HyperOptSearch()
+
+            tuner = tune.Tuner(  # <3>
+                ...
+            )
+            results = tuner.fit()
+
+        .. annotations::
+
+            <1> Wrap a Keras model in an objective function.
+
+            <2> Define a search space and initialize the search algorithm.
+
+            <3> Start a Tune run that maximizes accuracy.
+    """
+
+    has_content = True
+
+    def run(self):
+        self.assert_has_content()
+
+        content = self.content
+        content = _replace_numbers(content)
+
+        callout_node = callout('\n'.join(content))
+        _parse_recursively(self, callout_node)
+
+        return [callout_node]
+
+
+class AnnotationsDirective(SphinxDirective):
+    """Annotations directive, which is only used nested within a Callout directive."""
+
+    has_content = True
+
+    def run(self):
+        content = self.content
+        content = _replace_numbers(content)
+        joined_content = '\n'.join(content)
+        logging.warning(str(joined_content))
+
+        annotations_node = callout(joined_content)
+        _parse_recursively(self, annotations_node)
+
+        return [annotations_node]
+
+
+def setup(app):
+    # Add new node types
+    app.add_node(callout,
+                 html=(visit_callout_node, depart_callout_node),
+                 latex=(visit_callout_node, depart_callout_node),
+                 text=(visit_callout_node, depart_callout_node)
+                 )
+    app.add_node(annotations)
+
+    # Add new directives
+    app.add_directive('callout', CalloutDirective)
+    app.add_directive('annotations', AnnotationsDirective)
+
+    # Add post-processor
+    app.add_post_transform(CalloutIncludePostTransform)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/doc/source/_ext/callouts.py
+++ b/doc/source/_ext/callouts.py
@@ -11,8 +11,7 @@ BASE_NUM = 2459  # white circle, black numbers
 
 
 class CalloutIncludePostTransform(SphinxTransform):
-    """Code block post-processor for `literalinclude` blocks used in callouts.
-    """
+    """Code block post-processor for `literalinclude` blocks used in callouts."""
     default_priority = 400
 
     def apply(self, **kwargs) -> None:
@@ -22,6 +21,7 @@ class CalloutIncludePostTransform(SphinxTransform):
 
 class LiteralIncludeVisitor(nodes.NodeVisitor):
     """Change a literal block upon visiting it."""
+
     def __init__(self, document: nodes.document) -> None:
         super().__init__(document)
 
@@ -56,6 +56,7 @@ class LiteralIncludeVisitor(nodes.NodeVisitor):
 
 class callout(nodes.General, nodes.Element):
     """Sphinx callout node."""
+
     pass
 
 
@@ -72,6 +73,7 @@ def depart_callout_node(self, node):
 
 class annotations(nodes.Element):
     """Sphinx annotations node."""
+
     pass
 
 
@@ -91,10 +93,7 @@ def _replace_numbers(content: str):
 
 def _parse_recursively(self, node):
     """Utility to recursively parse a node from the Sphinx AST."""
-    self.state.nested_parse(
-        self.content,
-        self.content_offset,
-        node)
+    self.state.nested_parse(self.content, self.content_offset, node)
 
 
 class CalloutDirective(SphinxDirective):
@@ -155,7 +154,7 @@ class CalloutDirective(SphinxDirective):
         content = self.content
         content = _replace_numbers(content)
 
-        callout_node = callout('\n'.join(content))
+        callout_node = callout("\n".join(content))
         _parse_recursively(self, callout_node)
 
         return [callout_node]
@@ -169,7 +168,7 @@ class AnnotationsDirective(SphinxDirective):
     def run(self):
         content = self.content
         content = _replace_numbers(content)
-        joined_content = '\n'.join(content)
+        joined_content = "\n".join(content)
         logging.warning(str(joined_content))
 
         annotations_node = callout(joined_content)
@@ -180,22 +179,23 @@ class AnnotationsDirective(SphinxDirective):
 
 def setup(app):
     # Add new node types
-    app.add_node(callout,
-                 html=(visit_callout_node, depart_callout_node),
-                 latex=(visit_callout_node, depart_callout_node),
-                 text=(visit_callout_node, depart_callout_node)
-                 )
+    app.add_node(
+        callout,
+        html=(visit_callout_node, depart_callout_node),
+        latex=(visit_callout_node, depart_callout_node),
+        text=(visit_callout_node, depart_callout_node)
+    )
     app.add_node(annotations)
 
     # Add new directives
-    app.add_directive('callout', CalloutDirective)
-    app.add_directive('annotations', AnnotationsDirective)
+    app.add_directive("callout", CalloutDirective)
+    app.add_directive("annotations", AnnotationsDirective)
 
     # Add post-processor
     app.add_post_transform(CalloutIncludePostTransform)
 
     return {
-        'version': '0.1',
-        'parallel_read_safe': True,
-        'parallel_write_safe': True,
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
     }

--- a/doc/source/_ext/callouts.py
+++ b/doc/source/_ext/callouts.py
@@ -12,6 +12,7 @@ BASE_NUM = 2459  # white circle, black numbers
 
 class CalloutIncludePostTransform(SphinxTransform):
     """Code block post-processor for `literalinclude` blocks used in callouts."""
+
     default_priority = 400
 
     def apply(self, **kwargs) -> None:
@@ -168,9 +169,8 @@ class AnnotationsDirective(SphinxDirective):
     def run(self):
         content = self.content
         content = _replace_numbers(content)
-        joined_content = "\n".join(content)
-        logging.warning(str(joined_content))
 
+        joined_content = "\n".join(content)
         annotations_node = callout(joined_content)
         _parse_recursively(self, annotations_node)
 
@@ -183,7 +183,7 @@ def setup(app):
         callout,
         html=(visit_callout_node, depart_callout_node),
         latex=(visit_callout_node, depart_callout_node),
-        text=(visit_callout_node, depart_callout_node)
+        text=(visit_callout_node, depart_callout_node),
     )
     app.add_node(annotations)
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,7 +31,10 @@ import ray
 
 default_role = "py:obj"
 
+sys.path.append(os.path.abspath("./_ext"))
+
 extensions = [
+    "callouts",  # custom extension from _ext folder
     "sphinx_panels",
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",

--- a/doc/source/tune/doc_code/keras_hyperopt.py
+++ b/doc/source/tune/doc_code/keras_hyperopt.py
@@ -8,8 +8,7 @@ from ray.tune.search.hyperopt import HyperOptSearch
 import keras
 
 
-# 1. Wrap a Keras model in an objective function.
-def objective(config):
+def objective(config):  # <1>
     model = keras.models.Sequential()
     model.add(keras.layers.Dense(784, activation=config["activation"]))
     model.add(keras.layers.Dense(10, activation="softmax"))
@@ -20,12 +19,10 @@ def objective(config):
     return {"accuracy": accuracy}
 
 
-# 2. Define a search space and initialize the search algorithm.
-search_space = {"activation": tune.choice(["relu", "tanh"])}
+search_space = {"activation": tune.choice(["relu", "tanh"])}  # <2>
 algo = HyperOptSearch()
 
-# 3. Start a Tune run that maximizes accuracy.
-tuner = tune.Tuner(
+tuner = tune.Tuner(  # <3>
     objective,
     tune_config=tune.TuneConfig(
         metric="accuracy",

--- a/doc/source/tune/doc_code/pytorch_optuna.py
+++ b/doc/source/tune/doc_code/pytorch_optuna.py
@@ -78,15 +78,13 @@ class ConvNet(nn.Module):
 
 
 # __pytorch_optuna_start__
-# 1. Wrap your PyTorch model in an objective function.
 import torch
 from ray import tune, air
 from ray.air import session
 from ray.tune.search.optuna import OptunaSearch
 
 
-# 1. Wrap a PyTorch model in an objective function.
-def objective(config):
+def objective(config):  # <1>
     train_loader, test_loader = load_data()  # Load some data
     model = ConvNet().to("cpu")  # Create a PyTorch conv net
     optimizer = torch.optim.SGD(  # Tune the optimizer
@@ -99,12 +97,10 @@ def objective(config):
         session.report({"mean_accuracy": acc})  # Report to Tune
 
 
-# 2. Define a search space and initialize the search algorithm.
 search_space = {"lr": tune.loguniform(1e-4, 1e-2), "momentum": tune.uniform(0.1, 0.9)}
-algo = OptunaSearch()
+algo = OptunaSearch()  # <2>
 
-# 3. Start a Tune run that maximizes mean accuracy and stops after 5 iterations.
-tuner = tune.Tuner(
+tuner = tune.Tuner(  # <3>
     objective,
     tune_config=tune.TuneConfig(
         metric="mean_accuracy",

--- a/doc/source/tune/index.rst
+++ b/doc/source/tune/index.rst
@@ -23,10 +23,20 @@ Tune further integrates with a wide range of additional hyperparameter optimizat
     The closer ``a`` is to zero and the smaller ``b`` is, the smaller the total value of ``f(x)``.
     We will define a so-called `search space` for  ``a`` and ``b`` and let Ray Tune explore the space for good values.
 
-    .. literalinclude:: ../../../python/ray/tune/tests/example.py
-       :language: python
-       :start-after: __quick_start_begin__
-       :end-before: __quick_start_end__
+    .. callout::
+
+        .. literalinclude:: ../../../python/ray/tune/tests/example.py
+           :language: python
+           :start-after: __quick_start_begin__
+           :end-before: __quick_start_end__
+
+        .. annotations::
+            <1> Define an objective function.
+
+            <2> Define a search space.
+
+            <3> Start a Tune run and print the best result.
+
 
 .. tabbed:: Keras+Hyperopt
 
@@ -37,10 +47,19 @@ Tune further integrates with a wide range of additional hyperparameter optimizat
     After defining the search space, you can simply initialize the ``HyperOptSearch`` object and pass it to ``run``.
     It's important to tell Ray Tune which metric you want to optimize and whether you want to maximize or minimize it.
 
-    .. literalinclude:: doc_code/keras_hyperopt.py
-        :language: python
-        :start-after: __keras_hyperopt_start__
-        :end-before: __keras_hyperopt_end__
+    .. callout::
+
+        .. literalinclude:: doc_code/keras_hyperopt.py
+            :language: python
+            :start-after: __keras_hyperopt_start__
+            :end-before: __keras_hyperopt_end__
+
+        .. annotations::
+            <1> Wrap a Keras model in an objective function.
+
+            <2> Define a search space and initialize the search algorithm.
+
+            <3> Start a Tune run that maximizes accuracy.
 
 .. tabbed:: PyTorch+Optuna
 
@@ -52,11 +71,20 @@ Tune further integrates with a wide range of additional hyperparameter optimizat
     It's important to tell Ray Tune which metric you want to optimize and whether you want to maximize or minimize it.
     We stop tuning this training run after ``5`` iterations, but you can easily define other stopping rules as well.
 
-    .. literalinclude:: doc_code/pytorch_optuna.py
-        :language: python
-        :start-after: __pytorch_optuna_start__
-        :end-before: __pytorch_optuna_end__
 
+    .. callout::
+
+        .. literalinclude:: doc_code/pytorch_optuna.py
+            :language: python
+            :start-after: __pytorch_optuna_start__
+            :end-before: __pytorch_optuna_end__
+
+        .. annotations::
+            <1> Wrap a PyTorch model in an objective function.
+
+            <2> Define a search space and initialize the search algorithm.
+
+            <3> Start a Tune run that maximizes mean accuracy and stops after 5 iterations.
 
 With Tune you can also launch a multi-node :ref:`distributed hyperparameter sweep <tune-distributed-ref>`
 in less than 10 lines of code.

--- a/python/ray/tune/tests/example.py
+++ b/python/ray/tune/tests/example.py
@@ -13,20 +13,19 @@
 # __quick_start_begin__
 from ray import tune
 
-# 1. Define an objective function.
-def objective(config):
+
+def objective(config):  # <1>
     score = config["a"] ** 2 + config["b"]
     return {"score": score}
 
 
-# 2. Define a search space.
-search_space = {
+search_space = {  # <2>
     "a": tune.grid_search([0.001, 0.01, 0.1, 1.0]),
     "b": tune.choice([1, 2, 3]),
 }
 
-# 3. Start a Tune run and print the best result.
-tuner = tune.Tuner(objective, param_space=search_space)
+tuner = tune.Tuner(objective, param_space=search_space)  # <3>
+
 results = tuner.fit()
 print(results.get_best_result(metric="score", mode="min").config)
 # __quick_start_end__


### PR DESCRIPTION
The Sphinx ecosystem was missing "callouts", which I find to be very useful for extended code examples, and it's been a requested feature (see https://github.com/sphinx-doc/sphinx/issues/1098).

This PR adds such an extension, which can later be improved and uploaded to PyPI for better distribution. It looks as follows:

![Screenshot 2022-09-08 at 14 45 01](https://user-images.githubusercontent.com/3462566/189125890-c26003f2-1f16-47d7-9396-63a16a548545.png)

and the syntax works like this:

```
    .. callout::

        .. code-block:: python

            from ray import tune
            from ray.tune.search.hyperopt import HyperOptSearch
            import keras

            def objective(config):  # <1>
                ...

            search_space = {"activation": tune.choice(["relu", "tanh"])}  # <2>
            algo = HyperOptSearch()

            tuner = tune.Tuner(  # <3>
                ...
            )
            results = tuner.fit()

        .. annotations::

            <1> Wrap a Keras model in an objective function.

            <2> Define a search space and initialize the search algorithm.

            <3> Start a Tune run that maximizes accuracy.
```
