### PR TITLE
[RLlib] Add lr_schedule support to SimpleQ and PG.

### DIFF
--- a/rllib/algorithms/pg/pg.py
+++ b/rllib/algorithms/pg/pg.py
@@ -82,6 +82,8 @@ class PGConfig(AlgorithmConfig):
         if lr_schedule is not None:
             self.lr_schedule = lr_schedule
 
+        return self
+
 
 class PG(Algorithm):
     """Policy Gradient (PG) Trainer.

--- a/rllib/algorithms/pg/pg.py
+++ b/rllib/algorithms/pg/pg.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import List, Optional, Type, Union
 
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
@@ -47,10 +47,39 @@ class PGConfig(AlgorithmConfig):
         # __sphinx_doc_begin__
         # Override some of AlgorithmConfig's default values with PG-specific values.
         self.num_workers = 0
+        self.lr_schedule = None
         self.lr = 0.0004
         self._disable_preprocessor_api = True
         # __sphinx_doc_end__
         # fmt: on
+
+    @override(AlgorithmConfig)
+    def training(
+        self,
+        *,
+        lr_schedule: Optional[List[List[Union[int, float]]]] = None,
+        **kwargs,
+    ) -> "PGConfig":
+        """Sets the training related configuration.
+
+        Args:
+            gamma: Float specifying the discount factor of the Markov Decision process.
+            lr: The default learning rate.
+            train_batch_size: Training batch size, if applicable.
+            model: Arguments passed into the policy model. See models/catalog.py for a
+                full list of the available model options.
+            optimizer: Arguments to pass to the policy optimizer.
+            lr_schedule: Learning rate schedule. In the format of [[timestep, value],
+                [timestep, value], ...]. A schedule should normally start from
+                timestep 0.
+
+        Returns:
+            This updated AlgorithmConfig object.
+        """
+        # Pass kwargs onto super's `training()` method.
+        super().training(**kwargs)
+        if lr_schedule is not None:
+            self.lr_schedule = lr_schedule
 
 
 class PG(Algorithm):

--- a/rllib/algorithms/pg/pg.py
+++ b/rllib/algorithms/pg/pg.py
@@ -69,9 +69,10 @@ class PGConfig(AlgorithmConfig):
             model: Arguments passed into the policy model. See models/catalog.py for a
                 full list of the available model options.
             optimizer: Arguments to pass to the policy optimizer.
-            lr_schedule: Learning rate schedule. In the format of [[timestep, value],
-                [timestep, value], ...]. A schedule should normally start from
-                timestep 0.
+            lr_schedule: Learning rate schedule. In the format of
+                [[timestep, lr-value], [timestep, lr-value], ...]
+                Intermediary timesteps will be assigned to interpolated learning rate
+                values. A schedule should normally start from timestep 0.
 
         Returns:
             This updated AlgorithmConfig object.

--- a/rllib/algorithms/pg/pg_tf_policy.py
+++ b/rllib/algorithms/pg/pg_tf_policy.py
@@ -21,6 +21,7 @@ from ray.rllib.models.action_dist import ActionDistribution
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.policy.tf_mixins import LearningRateSchedule
 from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.typing import TensorType
 
@@ -41,6 +42,7 @@ def get_pg_tf_policy(name: str, base: TFPolicyV2Type) -> TFPolicyV2Type:
     """
 
     class PGTFPolicy(
+        LearningRateSchedule,
         base,
     ):
         def __init__(
@@ -65,6 +67,8 @@ def get_pg_tf_policy(name: str, base: TFPolicyV2Type) -> TFPolicyV2Type:
                 existing_inputs=existing_inputs,
                 existing_model=existing_model,
             )
+
+            LearningRateSchedule.__init__(self, config["lr"], config["lr_schedule"])
 
             # Note: this is a bit ugly, but loss and optimizer initialization must
             # happen after all the MixIns are initialized.
@@ -138,6 +142,7 @@ def get_pg_tf_policy(name: str, base: TFPolicyV2Type) -> TFPolicyV2Type:
 
             return {
                 "policy_loss": self.policy_loss,
+                "cur_lr": self.cur_lr,
             }
 
     PGTFPolicy.__name__ = name

--- a/rllib/algorithms/pg/pg_tf_policy.py
+++ b/rllib/algorithms/pg/pg_tf_policy.py
@@ -129,8 +129,14 @@ def get_pg_tf_policy(name: str, base: TFPolicyV2Type) -> TFPolicyV2Type:
             )
 
         @override(base)
+        def extra_learn_fetches_fn(self) -> Dict[str, TensorType]:
+            return {
+                "learner_stats": {"cur_lr": self.cur_lr},
+            }
+
+        @override(base)
         def stats_fn(self, train_batch: SampleBatch) -> Dict[str, TensorType]:
-            """Returns the calculated loss in a stats dict.
+            """Returns the calculated loss and learning rate in a stats dict.
 
             Args:
                 policy: The Policy object.

--- a/rllib/algorithms/pg/tests/test_pg.py
+++ b/rllib/algorithms/pg/tests/test_pg.py
@@ -42,8 +42,8 @@ class TestPG(unittest.TestCase):
             num_rollout_workers=1,
             rollout_fragment_length=500,
             observation_filter="MeanStdFilter",
-        ).training(lr_schedule=[1, 1e-3, [500, 5e-3]])
-        num_iterations = 2
+        )
+        num_iterations = 1
 
         image_space = Box(-1.0, 1.0, shape=(84, 84, 3))
         simple_space = Box(-1.0, 1.0, shape=(3,))
@@ -210,21 +210,22 @@ class TestPG(unittest.TestCase):
                 "cur_lr"
             ]
 
-        algo = config.build(env="CartPole-v0")
+        for _ in framework_iterator(config):
+            algo = config.build(env="CartPole-v0")
 
-        lr = _step_n_times(algo, 1)  # 50 timesteps
-        # Close to 0.2
-        self.assertGreaterEqual(lr, 0.15)
+            lr = _step_n_times(algo, 1)  # 50 timesteps
+            # Close to 0.2
+            self.assertGreaterEqual(lr, 0.15)
 
-        lr = _step_n_times(algo, 8)  # Close to 500 timesteps
-        # LR Annealed to 0.001
-        self.assertLessEqual(float(lr), 0.5)
+            lr = _step_n_times(algo, 8)  # Close to 500 timesteps
+            # LR Annealed to 0.001
+            self.assertLessEqual(float(lr), 0.5)
 
-        lr = _step_n_times(algo, 2)  # > 500 timesteps
-        # LR == 0.001
-        self.assertAlmostEqual(lr, 0.001)
+            lr = _step_n_times(algo, 2)  # > 500 timesteps
+            # LR == 0.001
+            self.assertAlmostEqual(lr, 0.001)
 
-        algo.stop()
+            algo.stop()
 
 
 if __name__ == "__main__":

--- a/rllib/algorithms/simple_q/simple_q_tf_policy.py
+++ b/rllib/algorithms/simple_q/simple_q_tf_policy.py
@@ -192,7 +192,23 @@ def get_simple_q_tf_policy(
         def extra_learn_fetches_fn(self) -> Dict[str, TensorType]:
             return {
                 "td_error": self.td_error,
-                "learner_stats": {"learning_rate": self.cur_lr},
+                "learner_stats": {"cur_lr": self.cur_lr},
+            }
+
+        @override(base)
+        def stats_fn(self, train_batch: SampleBatch) -> Dict[str, TensorType]:
+            """Returns the learning rate in a stats dict.
+
+            Args:
+                policy: The Policy object.
+                train_batch: The data used for training.
+
+            Returns:
+                Dict[str, TensorType]: The stats dict.
+            """
+
+            return {
+                "cur_lr": self.cur_lr,
             }
 
         def _compute_q_values(

--- a/rllib/algorithms/simple_q/simple_q_torch_policy.py
+++ b/rllib/algorithms/simple_q/simple_q_torch_policy.py
@@ -11,7 +11,7 @@ from ray.rllib.models.torch.torch_action_dist import (
     TorchDistributionWrapper,
 )
 from ray.rllib.policy.sample_batch import SampleBatch
-from ray.rllib.policy.torch_mixins import TargetNetworkMixin
+from ray.rllib.policy.torch_mixins import TargetNetworkMixin, LearningRateSchedule
 from ray.rllib.policy.torch_policy_v2 import TorchPolicyV2
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_torch
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class SimpleQTorchPolicy(
+    LearningRateSchedule,
     TargetNetworkMixin,
     TorchPolicyV2,
 ):
@@ -44,6 +45,8 @@ class SimpleQTorchPolicy(
             config,
             max_seq_len=config["model"]["max_seq_len"],
         )
+
+        LearningRateSchedule.__init__(self, config["lr"], config["lr_schedule"])
 
         # TODO: Don't require users to call this manually.
         self._initialize_loss_from_dummy_batch()
@@ -166,7 +169,10 @@ class SimpleQTorchPolicy(
     @override(TorchPolicyV2)
     def stats_fn(self, train_batch: SampleBatch) -> Dict[str, TensorType]:
         return convert_to_numpy(
-            {"loss": torch.mean(torch.stack(self.get_tower_stats("loss")))}
+            {
+                "loss": torch.mean(torch.stack(self.get_tower_stats("loss"))),
+                "cur_lr": self.cur_lr,
+            }
         )
 
     def _compute_q_values(

--- a/rllib/algorithms/simple_q/tests/test_simple_q.py
+++ b/rllib/algorithms/simple_q/tests/test_simple_q.py
@@ -176,24 +176,25 @@ class TestSimpleQ(unittest.TestCase):
             for _ in range(n):
                 results = algo.train()
             return results["info"][LEARNER_INFO][DEFAULT_POLICY_ID][LEARNER_STATS_KEY][
-                "learning_rate"
+                "cur_lr"
             ]
 
-        algo = config.build(env="CartPole-v0")
+        for _ in framework_iterator(config):
+            algo = config.build(env="CartPole-v0")
 
-        lr = _step_n_times(algo, 1)  # 50 timesteps
-        # Close to 0.2
-        self.assertGreaterEqual(lr, 0.15)
+            lr = _step_n_times(algo, 1)  # 50 timesteps
+            # Close to 0.2
+            self.assertGreaterEqual(lr, 0.15)
 
-        lr = _step_n_times(algo, 8)  # Close to 500 timesteps
-        # LR Annealed to 0.001
-        self.assertLessEqual(float(lr), 0.5)
+            lr = _step_n_times(algo, 8)  # Close to 500 timesteps
+            # LR Annealed to 0.001
+            self.assertLessEqual(float(lr), 0.5)
 
-        lr = _step_n_times(algo, 2)  # > 500 timesteps
-        # LR == 0.001
-        self.assertAlmostEqual(lr, 0.001)
+            lr = _step_n_times(algo, 2)  # > 500 timesteps
+            # LR == 0.001
+            self.assertAlmostEqual(lr, 0.001)
 
-        algo.stop()
+            algo.stop()
 
 
 if __name__ == "__main__":

--- a/rllib/tests/test_nested_action_spaces.py
+++ b/rllib/tests/test_nested_action_spaces.py
@@ -74,7 +74,7 @@ class NestedActionSpacesTest(unittest.TestCase):
         # Pretend actions in offline files are already normalized.
         config["actions_in_input_normalized"] = True
 
-        # Remove lr schedule from config, as it's not needed here, and not supported by BC.
+        # Remove lr schedule from config, not needed here, and not supported by BC.
         del config["lr_schedule"]
 
         for _ in framework_iterator(config):

--- a/rllib/tests/test_nested_action_spaces.py
+++ b/rllib/tests/test_nested_action_spaces.py
@@ -74,6 +74,9 @@ class NestedActionSpacesTest(unittest.TestCase):
         # Pretend actions in offline files are already normalized.
         config["actions_in_input_normalized"] = True
 
+        # Remove lr schedule from config, as it's not needed here, and not supported by BC.
+        del config["lr_schedule"]
+
         for _ in framework_iterator(config):
             for name, action_space in SPACES.items():
                 config["env_config"] = {


### PR DESCRIPTION
## Why are these changes needed?

SimpleQ and PG currently don't support a learning rate schedule. SimpleQ does list a `lr_schedule` key in its default config, but will simply ignore it, which could lead to user confusion. PG does not accept a `lr_schedule` key, but there is no reason why it shouldn't support a learning rate schedule.

## Related issue number

Closes #28266 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
