### PR TITLE
[RLlib] Cast rewards as tf.float32 to fix error in DQN in tf2

### DIFF
--- a/rllib/algorithms/dqn/dqn_tf_policy.py
+++ b/rllib/algorithms/dqn/dqn_tf_policy.py
@@ -311,7 +311,7 @@ def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> Tensor
         q_tp1_best,
         q_dist_tp1_best,
         train_batch[PRIO_WEIGHTS],
-        train_batch[SampleBatch.REWARDS],
+        tf.cast(train_batch[SampleBatch.REWARDS], tf.float32),
         tf.cast(train_batch[SampleBatch.DONES], tf.float32),
         config["gamma"],
         config["n_step"],

--- a/rllib/algorithms/dqn/tests/test_dqn.py
+++ b/rllib/algorithms/dqn/tests/test_dqn.py
@@ -58,6 +58,45 @@ class TestDQN(unittest.TestCase):
 
             trainer.stop()
 
+    def test_dqn_compilation_integer_rewards(self):
+        """Test whether DQN can be built on all frameworks.
+        Unlike the previous test, this uses an environment with integer rewards
+        in order to test that type conversions are working correctly."""
+        num_iterations = 1
+        config = (
+            dqn.dqn.DQNConfig()
+            .rollouts(num_rollout_workers=2)
+            .training(num_steps_sampled_before_learning_starts=0)
+        )
+
+        for _ in framework_iterator(config, with_eager_tracing=True):
+            # Double-dueling DQN.
+            print("Double-dueling")
+            plain_config = deepcopy(config)
+            trainer = dqn.DQN(config=plain_config, env="Taxi-v3")
+            for i in range(num_iterations):
+                results = trainer.train()
+                check_train_results(results)
+                print(results)
+
+            check_compute_single_action(trainer)
+            trainer.stop()
+
+            # Rainbow.
+            print("Rainbow")
+            rainbow_config = deepcopy(config).training(
+                num_atoms=10, noisy=True, double_q=True, dueling=True, n_step=5
+            )
+            trainer = dqn.DQN(config=rainbow_config, env="Taxi-v3")
+            for i in range(num_iterations):
+                results = trainer.train()
+                check_train_results(results)
+                print(results)
+
+            check_compute_single_action(trainer)
+
+            trainer.stop()
+
     def test_dqn_exploration_and_soft_q_config(self):
         """Tests, whether a DQN Agent outputs exploration/softmaxed actions."""
         config = (

--- a/rllib/algorithms/simple_q/simple_q_tf_policy.py
+++ b/rllib/algorithms/simple_q/simple_q_tf_policy.py
@@ -163,7 +163,7 @@ def get_simple_q_tf_policy(
 
             # compute RHS of bellman equation
             q_t_selected_target = (
-                train_batch[SampleBatch.REWARDS]
+                tf.cast(train_batch[SampleBatch.REWARDS], tf.float32)
                 + self.config["gamma"] * q_tp1_best_masked
             )
 


### PR DESCRIPTION
Signed-off-by: mgerstgrasser <matthias@gerstgrasser.net>

## Why are these changes needed?

DQN, Apex-DQN and SimpleQ all fail when using tf2.

## Related issue number

Closes #28382

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
