### PR TITLE
Add TypeAlias annotations to RLlib typing.py

### DIFF
--- a/rllib/utils/typing.py
+++ b/rllib/utils/typing.py
@@ -131,7 +131,9 @@ ViewRequirementsDict: TypeAlias = Dict[str, "ViewRequirement"]
 ResultDict: TypeAlias = dict
 
 # A tf or torch local optimizer object.
-LocalOptimizer: TypeAlias = Union["tf.keras.optimizers.Optimizer", "torch.optim.Optimizer"]
+LocalOptimizer: TypeAlias = Union[
+    "tf.keras.optimizers.Optimizer", "torch.optim.Optimizer"
+]
 
 # Dict of tensors returned by compute gradients on the policy, e.g.,
 # {"td_error": [...], "learner_stats": {"vf_loss": ..., ...}}, for multi-agent,

--- a/rllib/utils/typing.py
+++ b/rllib/utils/typing.py
@@ -11,10 +11,16 @@ from typing import (
     Union,
 )
 
+import sys
 import numpy as np
 import gym
 
 from ray.rllib.utils.annotations import ExperimentalAPI
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
     from ray.rllib.env.env_context import EnvContext
@@ -30,136 +36,138 @@ if TYPE_CHECKING:
 
 # Represents a generic tensor type.
 # This could be an np.ndarray, tf.Tensor, or a torch.Tensor.
-TensorType = Union[np.array, "tf.Tensor", "torch.Tensor"]
+TensorType: TypeAlias = Union[np.array, "tf.Tensor", "torch.Tensor"]
 
 # Either a plain tensor, or a dict or tuple of tensors (or StructTensors).
-TensorStructType = Union[TensorType, dict, tuple]
+TensorStructType: TypeAlias = Union[TensorType, dict, tuple]
 
 # A shape of a tensor.
-TensorShape = Union[Tuple[int], List[int]]
+TensorShape: TypeAlias = Union[Tuple[int], List[int]]
 
 # Represents a fully filled out config of a Algorithm class.
 # Note: Policy config dicts are usually the same as AlgorithmConfigDict, but
 # parts of it may sometimes be altered in e.g. a multi-agent setup,
 # where we have >1 Policies in the same Algorithm.
-AlgorithmConfigDict = TrainerConfigDict = dict
+AlgorithmConfigDict: TypeAlias = dict
+TrainerConfigDict: TypeAlias = dict
 
 # An algorithm config dict that only has overrides. It needs to be combined with
 # the default algorithm config to be used.
-PartialAlgorithmConfigDict = PartialTrainerConfigDict = dict
+PartialAlgorithmConfigDict: TypeAlias = dict
+PartialTrainerConfigDict: TypeAlias = dict
 
 # Represents the model config sub-dict of the algo config that is passed to
 # the model catalog.
-ModelConfigDict = dict
+ModelConfigDict: TypeAlias = dict
 
 # Objects that can be created through the `from_config()` util method
 # need a config dict with a "type" key, a class path (str), or a type directly.
-FromConfigSpec = Union[Dict[str, Any], type, str]
+FromConfigSpec: TypeAlias = Union[Dict[str, Any], type, str]
 
 # Represents the env_config sub-dict of the algo config that is passed to
 # the env constructor.
-EnvConfigDict = dict
+EnvConfigDict: TypeAlias = dict
 
 # Represents an environment id. These could be:
 # - An int index for a sub-env within a vectorized env.
 # - An external env ID (str), which changes(!) each episode.
-EnvID = Union[int, str]
+EnvID: TypeAlias = Union[int, str]
 
 # Represents a BaseEnv, MultiAgentEnv, ExternalEnv, ExternalMultiAgentEnv,
 # VectorEnv, gym.Env, or ActorHandle.
-EnvType = Any
+EnvType: TypeAlias = Any
 
 # A callable, taking a EnvContext object
 # (config dict + properties: `worker_index`, `vector_index`, `num_workers`,
 # and `remote`) and returning an env object (or None if no env is used).
-EnvCreator = Callable[["EnvContext"], Optional[EnvType]]
+EnvCreator: TypeAlias = Callable[["EnvContext"], Optional[EnvType]]
 
 # Represents a generic identifier for an agent (e.g., "agent1").
-AgentID = Any
+AgentID: TypeAlias = Any
 
 # Represents a generic identifier for a policy (e.g., "pol1").
-PolicyID = str
+PolicyID: TypeAlias = str
 
 # Type of the config["multiagent"]["policies"] dict for multi-agent training.
-MultiAgentPolicyConfigDict = Dict[PolicyID, "PolicySpec"]
+MultiAgentPolicyConfigDict: TypeAlias = Dict[PolicyID, "PolicySpec"]
 
 # State dict of a Policy, mapping strings (e.g. "weights") to some state
 # data (TensorStructType).
-PolicyState = Dict[str, TensorStructType]
+PolicyState: TypeAlias = Dict[str, TensorStructType]
 
 # Any tf Policy type (static-graph or eager Policy).
-TFPolicyV2Type = Type[Union["DynamicTFPolicyV2", "EagerTFPolicyV2"]]
+TFPolicyV2Type: TypeAlias = Type[Union["DynamicTFPolicyV2", "EagerTFPolicyV2"]]
 
 # Represents an episode id.
-EpisodeID = int
+EpisodeID: TypeAlias = int
 
 # Represents an "unroll" (maybe across different sub-envs in a vector env).
-UnrollID = int
+UnrollID: TypeAlias = int
 
 # A dict keyed by agent ids, e.g. {"agent-1": value}.
-MultiAgentDict = Dict[AgentID, Any]
+MultiAgentDict: TypeAlias = Dict[AgentID, Any]
 
 # A dict keyed by env ids that contain further nested dictionaries keyed by
 # agent ids. e.g., {"env-1": {"agent-1": value}}.
-MultiEnvDict = Dict[EnvID, MultiAgentDict]
+MultiEnvDict: TypeAlias = Dict[EnvID, MultiAgentDict]
 
 # Represents an observation returned from the env.
-EnvObsType = Any
+EnvObsType: TypeAlias = Any
 
 # Represents an action passed to the env.
-EnvActionType = Any
+EnvActionType: TypeAlias = Any
 
 # Info dictionary returned by calling step() on gym envs. Commonly empty dict.
-EnvInfoDict = dict
+EnvInfoDict: TypeAlias = dict
 
 # Represents a File object
-FileType = Any
+FileType: TypeAlias = Any
 
 # Represents a ViewRequirements dict mapping column names (str) to
 # ViewRequirement objects.
-ViewRequirementsDict = Dict[str, "ViewRequirement"]
+ViewRequirementsDict: TypeAlias = Dict[str, "ViewRequirement"]
 
 # Represents the result dict returned by Algorithm.train().
-ResultDict = dict
+ResultDict: TypeAlias = dict
 
 # A tf or torch local optimizer object.
-LocalOptimizer = Union["tf.keras.optimizers.Optimizer", "torch.optim.Optimizer"]
+LocalOptimizer: TypeAlias = Union["tf.keras.optimizers.Optimizer", "torch.optim.Optimizer"]
 
 # Dict of tensors returned by compute gradients on the policy, e.g.,
 # {"td_error": [...], "learner_stats": {"vf_loss": ..., ...}}, for multi-agent,
 # {"policy1": {"learner_stats": ..., }, "policy2": ...}.
-GradInfoDict = dict
+GradInfoDict: TypeAlias = dict
 
 # Dict of learner stats returned by compute gradients on the policy, e.g.,
 # {"vf_loss": ..., ...}. This will always be nested under the "learner_stats"
 # key(s) of a GradInfoDict. In the multi-agent case, this will be keyed by
 # policy id.
-LearnerStatsDict = dict
+LearnerStatsDict: TypeAlias = dict
 
 # List of grads+var tuples (tf) or list of gradient tensors (torch)
 # representing model gradients and returned by compute_gradients().
-ModelGradients = Union[List[Tuple[TensorType, TensorType]], List[TensorType]]
+ModelGradients: TypeAlias = Union[List[Tuple[TensorType, TensorType]], List[TensorType]]
 
 # Type of dict returned by get_weights() representing model weights.
-ModelWeights = dict
+ModelWeights: TypeAlias = dict
 
 # An input dict used for direct ModelV2 calls.
-ModelInputDict = Dict[str, TensorType]
+ModelInputDict: TypeAlias = Dict[str, TensorType]
 
 # Some kind of sample batch.
-SampleBatchType = Union["SampleBatch", "MultiAgentBatch"]
+SampleBatchType: TypeAlias = Union["SampleBatch", "MultiAgentBatch"]
 
 # A (possibly nested) space struct: Either a gym.spaces.Space or a
 # (possibly nested) dict|tuple of gym.space.Spaces.
-SpaceStruct = Union[gym.spaces.Space, dict, tuple]
+SpaceStruct: TypeAlias = Union[gym.spaces.Space, dict, tuple]
 
 # A list of batches of RNN states.
 # Each item in this list has dimension [B, S] (S=state vector size)
-StateBatches = List[List[Any]]
+StateBatches: TypeAlias = List[List[Any]]
 
 # Format of data output from policy forward pass.
 # __sphinx_doc_begin_policy_output_type__
-PolicyOutputType = Tuple[TensorStructType, StateBatches, Dict]
+PolicyOutputType: TypeAlias = Tuple[TensorStructType, StateBatches, Dict]
 # __sphinx_doc_end_policy_output_type__
 
 

--- a/rllib/utils/typing.py
+++ b/rllib/utils/typing.py
@@ -17,9 +17,9 @@ import gym
 
 from ray.rllib.utils.annotations import ExperimentalAPI
 
-if sys.version_info >= (3, 10):
+try:
     from typing import TypeAlias
-else:
+except ImportError:
     from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:

--- a/rllib/utils/typing.py
+++ b/rllib/utils/typing.py
@@ -11,7 +11,6 @@ from typing import (
     Union,
 )
 
-import sys
 import numpy as np
 import gym
 


### PR DESCRIPTION
## Why are these changes needed?

In newer versions of python, type aliases (e.g., where you do TrainerConfigDict = dict) have to be explicitly defined as a TypeAlias (e.g., TrainerConfigDict: TypeAlias = dict). Not doing this will cause MyPy to error (see [here](https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases)). For instance, take the following script:
```python3
import ray.rllib.algorithms.ppo as ppo

config = ppo.DEFAULT_CONFIG.copy()
algo = ppo.PPO(config=config, env="CartPole-v0")

algo.get_policy().config["num_workers"]
reveal_type(algo.get_policy().config)
```
If we save this to `test.py` and run `mypy test.py`, it complains:
```
test.py:7: error: Value of type AlgorithmConfigDict? is not indexable
test.py:8: note: Revealed type is "AlgorithmConfigDict?"
Found 1 error in 1 file (checked 1 source file)
```
However, with this PR, now the output is:
```
test.py:8: note: Revealed type is "builtins.dict[Any, Any]"
Success: no issues found in 1 source file
```

## Related issue number

Closes #28383

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
