### PR TITLE
[autoscaler][cleanup] Remove dead resource demand scheduler code from legacy config

### DIFF
--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -83,11 +83,8 @@ class ResourceDemandScheduler:
         For legacy yamls, it merges previous state and new state to make sure
         inferered resources are not lost.
         """
-        new_node_types = copy.deepcopy(node_types)
-        final_node_types = _convert_memory_unit(new_node_types)
-
         self.provider = provider
-        self.node_types = copy.deepcopy(final_node_types)
+        self.node_types = _convert_memory_unit(node_types)
         self.node_resource_updated = set()
         self.max_workers = max_workers
         self.head_node_type = head_node_type

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -30,8 +30,6 @@ from ray.autoscaler.tags import (
     NODE_KIND_HEAD,
     NODE_KIND_UNMANAGED,
     NODE_KIND_WORKER,
-    NODE_TYPE_LEGACY_HEAD,
-    NODE_TYPE_LEGACY_WORKER,
     TAG_RAY_NODE_KIND,
     TAG_RAY_USER_NODE_TYPE,
 )
@@ -87,26 +85,6 @@ class ResourceDemandScheduler:
         """
         new_node_types = copy.deepcopy(node_types)
         final_node_types = _convert_memory_unit(new_node_types)
-        if self.is_legacy_yaml(new_node_types):  # If new configs are legacy.
-            if self.is_legacy_yaml():  # If old configs were legacy.
-
-                def _update_based_on_node_config(node_type: NodeType) -> None:
-                    if (
-                        self.node_types[node_type]["node_config"]
-                        == new_node_types[node_type]["node_config"]
-                    ):  # If node config didnt change.
-                        if self.node_types[node_type]["resources"]:
-                            # If we already know the resources, do not
-                            # overwrite them. This helps also if in legacy
-                            # yamls the user provides "resources" field.
-                            del new_node_types[node_type]["resources"]
-                        self.node_types[node_type].update(new_node_types[node_type])
-                    else:
-                        self.node_types[node_type] = new_node_types[node_type]
-
-                _update_based_on_node_config(NODE_TYPE_LEGACY_HEAD)
-                _update_based_on_node_config(NODE_TYPE_LEGACY_WORKER)
-                final_node_types = self.node_types
 
         self.provider = provider
         self.node_types = copy.deepcopy(final_node_types)
@@ -114,19 +92,6 @@ class ResourceDemandScheduler:
         self.max_workers = max_workers
         self.head_node_type = head_node_type
         self.upscaling_speed = upscaling_speed
-
-    def is_legacy_yaml(
-        self, node_types: Dict[NodeType, NodeTypeConfigDict] = None
-    ) -> bool:
-        """Returns if the node types came from a legacy yaml.
-
-        A legacy yaml is one that was originally without available_node_types
-        and was autofilled with available_node_types."""
-        node_types = node_types or self.node_types
-        return (
-            NODE_TYPE_LEGACY_HEAD in node_types
-            and NODE_TYPE_LEGACY_WORKER in node_types
-        )
 
     def is_feasible(self, bundle: ResourceDict) -> bool:
         for node_type, config in self.node_types.items():
@@ -175,11 +140,6 @@ class ResourceDemandScheduler:
             Dict of count to add for each node type, and residual of resources
             that still cannot be fulfilled.
         """
-        if self.is_legacy_yaml():
-            # When using legacy yaml files we need to infer the head & worker
-            # node resources from the static node resources from LoadMetrics.
-            self._infer_legacy_node_resources_if_needed(nodes, max_resources_by_ip)
-
         self._update_node_resources_from_runtime(nodes, max_resources_by_ip)
 
         node_resources: List[ResourceDict]
@@ -230,29 +190,6 @@ class ResourceDemandScheduler:
         # demands vector to make it consistent (results in the same types of
         # nodes to add) with pg_demands_nodes_max_launch_limit calculated later
         resource_demands = placement_group_demand_vector + resource_demands
-
-        if (
-            self.is_legacy_yaml()
-            and not self.node_types[NODE_TYPE_LEGACY_WORKER]["resources"]
-        ):
-            # Need to launch worker nodes to later infer their
-            # resources.
-            # We add request_resources() demands here to make sure we launch
-            # a single worker sometimes even if min_workers = 0 and resource
-            # demands is empty.
-            if ensure_min_cluster_size:
-                request_resources_demands = ensure_min_cluster_size
-            else:
-                request_resources_demands = []
-            return (
-                self._legacy_worker_node_to_launch(
-                    nodes,
-                    launching_nodes,
-                    node_resources,
-                    resource_demands + request_resources_demands,
-                ),
-                [],
-            )
 
         (
             spread_pg_nodes_to_add,
@@ -325,41 +262,6 @@ class ResourceDemandScheduler:
         logger.debug("Node requests: {}".format(total_nodes_to_add))
         return total_nodes_to_add, final_unfulfilled
 
-    def _legacy_worker_node_to_launch(
-        self,
-        nodes: List[NodeID],
-        launching_nodes: Dict[NodeType, int],
-        node_resources: List[ResourceDict],
-        resource_demands: List[ResourceDict],
-    ) -> Dict[NodeType, int]:
-        """Get worker nodes to launch when resources missing in legacy yamls.
-
-        If there is unfulfilled demand and we don't know the resources of the
-        workers, it returns max(1, min_workers) worker nodes from which we
-        later calculate the node resources.
-        """
-        # Populate worker list.
-        _, worker_nodes = self._get_head_and_workers(nodes)
-
-        if self.max_workers == 0:
-            return {}
-        elif sum(launching_nodes.values()) + len(worker_nodes) > 0:
-            # If we are already launching a worker node, wait for its resources
-            # to be known.
-            # TODO(ameer): Note that if first worker node fails this will never
-            # launch any more nodes.
-            return {}
-        else:
-            unfulfilled, _ = get_bin_pack_residual(node_resources, resource_demands)
-            workers_to_add = min(
-                self.node_types[NODE_TYPE_LEGACY_WORKER].get("min_workers", 0),
-                self.node_types[NODE_TYPE_LEGACY_WORKER].get("max_workers", 0),
-            )
-            if workers_to_add > 0 or unfulfilled:
-                return {NODE_TYPE_LEGACY_WORKER: max(1, workers_to_add)}
-            else:
-                return {}
-
     def _update_node_resources_from_runtime(
         self, nodes: List[NodeID], max_resources_by_ip: Dict[NodeIP, ResourceDict]
     ):
@@ -406,41 +308,6 @@ class ResourceDemandScheduler:
                     # node needs to configure redis memory which is not needed
                     # for worker nodes.
                     self.node_resource_updated.add(node_type)
-
-    def _infer_legacy_node_resources_if_needed(
-        self, nodes: List[NodeIP], max_resources_by_ip: Dict[NodeIP, ResourceDict]
-    ) -> (bool, Dict[NodeType, int]):
-        """Infers node resources for legacy config files.
-
-        Updates the resources of the head and worker node types in
-        self.node_types.
-        Args:
-            nodes: List of all node ids in the cluster
-            max_resources_by_ip: Mapping from ip to static node resources.
-        """
-        head_node, worker_nodes = self._get_head_and_workers(nodes)
-        # We fill the head node resources only once.
-        if not self.node_types[NODE_TYPE_LEGACY_HEAD]["resources"]:
-            try:
-                head_ip = self.provider.internal_ip(head_node)
-                self.node_types[NODE_TYPE_LEGACY_HEAD]["resources"] = copy.deepcopy(
-                    max_resources_by_ip[head_ip]
-                )
-            except (IndexError, KeyError):
-                logger.exception("Could not reach the head node.")
-        # We fill the worker node resources only once.
-        if not self.node_types[NODE_TYPE_LEGACY_WORKER]["resources"]:
-            # Set the node_types here in case we already launched a worker node
-            # from which we can directly get the node_resources.
-            worker_node_ips = [
-                self.provider.internal_ip(node_id) for node_id in worker_nodes
-            ]
-            for ip in worker_node_ips:
-                if ip in max_resources_by_ip:
-                    self.node_types[NODE_TYPE_LEGACY_WORKER][
-                        "resources"
-                    ] = copy.deepcopy(max_resources_by_ip[ip])
-                    break
 
     def _get_concurrent_resource_demand_to_launch(
         self,

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -265,7 +265,7 @@ class ResourceDemandScheduler:
         """Update static node type resources with runtime resources
 
         This will update the cached static node type resources with the runtime
-        resources. Because we can not know the correctly memory or
+        resources. Because we can not know the exact autofilled memory or
         object_store_memory from config file.
         """
         need_update = len(self.node_types) != len(self.node_resource_updated)

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -266,13 +266,10 @@ class MockProcessRunner:
             if pattern is not None:
                 for cmd in self.command_history():
                     if ip in cmd:
-                        print(f"{ip} in {cmd}")
                         debug_output += cmd
                         debug_output += "\n"
-                    else:
-                        print(f"{ip} not in {cmd}")
-                    if re.search(pattern, cmd):
-                        return True
+                        if re.search(pattern, cmd):
+                            return True
                 else:
                     raise Exception(
                         f"Did not find [{pattern}] in [{debug_output}] for "
@@ -3049,8 +3046,8 @@ class AutoscalingTest(unittest.TestCase):
 
         # Check the node was indeed reused
         self.provider.terminate_node(1)
-        autoscaler.update()
         runner.clear_history()
+        autoscaler.update()
         self.waitForNodes(1, tag_filters=WORKER_FILTER)
         self.provider.finish_starting_nodes()
         autoscaler.update()
@@ -3068,11 +3065,10 @@ class AutoscalingTest(unittest.TestCase):
         # Check that run_init happens when file_mounts have updated
         self.provider.terminate_node(1)
         autoscaler.update()
-        self.waitForNodes(1, tag_filters=WORKER_FILTER)
         runner.clear_history()
+        self.waitForNodes(1, tag_filters=WORKER_FILTER)
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        runner.clear_history()
         self.waitForNodes(
             1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER}
         )

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -51,8 +51,6 @@ from ray.autoscaler.sdk import get_docker_host_mount_location
 from ray.autoscaler.tags import (
     NODE_KIND_HEAD,
     NODE_KIND_WORKER,
-    NODE_TYPE_LEGACY_HEAD,
-    NODE_TYPE_LEGACY_WORKER,
     STATUS_UNINITIALIZED,
     STATUS_UP_TO_DATE,
     STATUS_UPDATE_FAILED,
@@ -399,6 +397,7 @@ class MockProvider(NodeProvider):
         if self.fail_creates:
             return
         with self.lock:
+            print("Creating nodes", node_config, tags, count)
             if self.cache_stopped:
                 for node in self.mock_nodes.values():
                     if node.state == "stopped" and count > 0:
@@ -421,6 +420,7 @@ class MockProvider(NodeProvider):
 
     def terminate_node(self, node_id):
         with self.lock:
+            print("Terminating node", node_id)
             if self.cache_stopped:
                 self.mock_nodes[node_id].state = "stopped"
             else:
@@ -485,23 +485,23 @@ SMALL_CLUSTER = {
         "ssh_private_key": os.devnull,
     },
     "available_node_types": {
-        NODE_TYPE_LEGACY_HEAD: {
+        "head": {
             "node_config": {
                 "TestProp": 1,
             },
-            "resources": {},
+            "resources": {"CPU": 1},
             "max_workers": 0,
         },
-        NODE_TYPE_LEGACY_WORKER: {
+        "worker": {
             "node_config": {
                 "TestProp": 2,
             },
-            "resources": {},
-            "min_workers": 2,
+            "resources": {"CPU": 1},
+            "min_workers": 0,
             "max_workers": 2,
         },
     },
-    "head_node_type": NODE_TYPE_LEGACY_HEAD,
+    "head_node_type": "head",
     "file_mounts": {},
     "cluster_synced_files": [],
     "initialization_commands": ["init_cmd"],
@@ -670,14 +670,16 @@ class AutoscalingTest(unittest.TestCase):
     def num_nodes(self, tag_filters=None):
         if tag_filters is None:
             tag_filters = {}
-        return len(self.provider.non_terminated_nodes(tag_filters))
+        temp = self.provider.non_terminated_nodes(tag_filters)
+        print("~~~~~~~~~~~~~~~~~", temp)
+        return len(temp)
 
     def waitForNodes(self, expected, comparison=None, tag_filters=None):
+        if comparison is None:
+            comparison = self.assertEqual
         MAX_ITER = 50
         for i in range(MAX_ITER):
             n = self.num_nodes(tag_filters)
-            if comparison is None:
-                comparison = self.assertEqual
             try:
                 comparison(n, expected, msg="Unexpected node quantity.")
                 return
@@ -739,9 +741,9 @@ class AutoscalingTest(unittest.TestCase):
         )
         assert len(self.provider.non_terminated_nodes({})) == 0
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(1)
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(1)
 
     def testValidation(self):
         """Ensures that schema validation is working."""
@@ -825,7 +827,7 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", "init_cmd")
         runner.assert_has_call("1.2.3.4", "head_setup_cmd")
         runner.assert_has_call("1.2.3.4", "start_ray_head")
-        self.assertEqual(self.provider.mock_nodes[0].node_type, NODE_TYPE_LEGACY_HEAD)
+        self.assertEqual(self.provider.mock_nodes[0].node_type, "head")
         runner.assert_has_call("1.2.3.4", pattern="docker run")
         runner.assert_has_call("1.2.3.4", pattern=head_run_option)
         runner.assert_has_call("1.2.3.4", pattern=standard_run_option)
@@ -1018,7 +1020,7 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", "init_cmd")
         runner.assert_has_call("1.2.3.4", "head_setup_cmd")
         runner.assert_has_call("1.2.3.4", "start_ray_head")
-        self.assertEqual(self.provider.mock_nodes[0].node_type, NODE_TYPE_LEGACY_HEAD)
+        self.assertEqual(self.provider.mock_nodes[0].node_type, "head")
         runner.assert_has_call("1.2.3.4", pattern="podman run")
 
         docker_mount_prefix = get_docker_host_mount_location(
@@ -1068,7 +1070,7 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", "init_cmd")
         runner.assert_has_call("1.2.3.4", "head_setup_cmd")
         runner.assert_has_call("1.2.3.4", "start_ray_head")
-        self.assertEqual(self.provider.mock_nodes[0].node_type, NODE_TYPE_LEGACY_HEAD)
+        self.assertEqual(self.provider.mock_nodes[0].node_type, "head")
         runner.assert_has_call("1.2.3.4", pattern="docker run")
 
         docker_mount_prefix = get_docker_host_mount_location(
@@ -1180,7 +1182,7 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", "init_cmd")
         runner.assert_has_call("1.2.3.4", "head_setup_cmd")
         runner.assert_has_call("1.2.3.4", "start_ray_head")
-        self.assertEqual(self.provider.mock_nodes[0].node_type, NODE_TYPE_LEGACY_HEAD)
+        self.assertEqual(self.provider.mock_nodes[0].node_type, "head")
         runner.assert_has_call("1.2.3.4", pattern="docker stop")
         runner.assert_has_call("1.2.3.4", pattern="docker run")
 
@@ -1232,7 +1234,7 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", "init_cmd")
         runner.assert_has_call("1.2.3.4", "head_setup_cmd")
         runner.assert_has_call("1.2.3.4", "start_ray_head")
-        self.assertEqual(self.provider.mock_nodes[0].node_type, NODE_TYPE_LEGACY_HEAD)
+        self.assertEqual(self.provider.mock_nodes[0].node_type, "head")
         # We only removed amount from the YAML, no changes should happen.
         runner.assert_not_has_call("1.2.3.4", pattern="docker stop")
         runner.assert_not_has_call("1.2.3.4", pattern="docker run")
@@ -1364,11 +1366,21 @@ class AutoscalingTest(unittest.TestCase):
     def testSummarizerFailedCreate(self):
         """Checks that event summarizer reports failed node creation."""
         config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
         config_path = self.write_config(config)
         self.provider = MockProvider()
-        self.provider.error_creates = Exception(":(")
         runner = MockProcessRunner()
         mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
+        self.provider.error_creates = Exception(":(")
         autoscaler = MockAutoscaler(
             config_path,
             LoadMetrics(),
@@ -1378,11 +1390,11 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0,
             prom_metrics=mock_metrics,
         )
-        assert len(self.provider.non_terminated_nodes({})) == 0
+        assert len(self.provider.non_terminated_nodes(WORKER_FILTER)) == 0
         autoscaler.update()
 
         # Expect the next two messages in the logs.
-        msg = "Failed to launch 2 node(s) of type ray-legacy-worker-node-type."
+        msg = "Failed to launch 2 node(s) of type worker."
 
         def expected_message_logged():
             return msg in autoscaler.event_summarizer.summary()
@@ -1394,13 +1406,23 @@ class AutoscalingTest(unittest.TestCase):
         additional details when the node provider thorws a
         NodeLaunchException."""
         config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
         config_path = self.write_config(config)
         self.provider = MockProvider()
+        runner = MockProcessRunner()
+        mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         self.provider.error_creates = NodeLaunchException(
             "didn't work", "never did", exc_info
         )
-        runner = MockProcessRunner()
-        mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
         autoscaler = MockAutoscaler(
             config_path,
             LoadMetrics(),
@@ -1410,12 +1432,12 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0,
             prom_metrics=mock_metrics,
         )
-        assert len(self.provider.non_terminated_nodes({})) == 0
+        assert len(self.provider.non_terminated_nodes(WORKER_FILTER)) == 0
         autoscaler.update()
 
         # Expect the next message in the logs.
         msg = (
-            "Failed to launch 2 node(s) of type ray-legacy-worker-node-type. "
+            "Failed to launch 2 node(s) of type worker. "
             "(didn't work): never did."
         )
 
@@ -1430,13 +1452,23 @@ class AutoscalingTest(unittest.TestCase):
         additional details when the node provider thorws a
         NodeLaunchException."""
         config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
         config_path = self.write_config(config)
         self.provider = MockProvider()
+        runner = MockProcessRunner()
+        mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         self.provider.error_creates = NodeLaunchException(
             "didn't work", "never did", src_exc_info=None
         )
-        runner = MockProcessRunner()
-        mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
         autoscaler = MockAutoscaler(
             config_path,
             LoadMetrics(),
@@ -1446,12 +1478,12 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0,
             prom_metrics=mock_metrics,
         )
-        assert len(self.provider.non_terminated_nodes({})) == 0
+        assert len(self.provider.non_terminated_nodes(WORKER_FILTER)) == 0
         autoscaler.update()
 
         # Expect the next message in the logs.
         msg = (
-            "Failed to launch 2 node(s) of type ray-legacy-worker-node-type. "
+            "Failed to launch 2 node(s) of type worker. "
             "(didn't work): never did."
         )
 
@@ -1463,6 +1495,7 @@ class AutoscalingTest(unittest.TestCase):
 
     def testReadonlyNodeProvider(self):
         config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
         config_path = self.write_config(config)
         self.provider = ReadOnlyNodeProvider(config_path, "readonly")
         runner = MockProcessRunner()
@@ -1505,11 +1538,22 @@ class AutoscalingTest(unittest.TestCase):
 
     def ScaleUpHelper(self, disable_node_updaters):
         config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
+        config_path = self.write_config(config)
         config["provider"]["disable_node_updaters"] = disable_node_updaters
         config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
         mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         if disable_node_updaters:
             # This class raises an assertion error if we try to create
             # a node updater thread.
@@ -1525,9 +1569,9 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0,
             prom_metrics=mock_metrics,
         )
-        assert len(self.provider.non_terminated_nodes({})) == 0
+        assert len(self.provider.non_terminated_nodes(WORKER_FILTER)) == 0
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
 
         # started_nodes metric should have been incremented by 2
         assert mock_metrics.started_nodes.inc.call_count == 1
@@ -1537,7 +1581,7 @@ class AutoscalingTest(unittest.TestCase):
         # The two autoscaler update iterations in this test led to two
         # observations of the update time.
         assert mock_metrics.update_time.observe.call_count == 2
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
 
         # running_workers metric should be set to 2
         mock_metrics.running_workers.set.assert_called_with(2)
@@ -1548,14 +1592,14 @@ class AutoscalingTest(unittest.TestCase):
             assert len(runner.calls) == 0
             # Nodes were create in uninitialized and not updated.
             self.waitForNodes(
-                2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UNINITIALIZED}
+                2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UNINITIALIZED, **WORKER_FILTER}
             )
         else:
             # Node Updaters have been invoked.
             self.waitFor(lambda: len(runner.calls) > 0)
             # The updates failed. Key thing is that the updates completed.
             self.waitForNodes(
-                2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UPDATE_FAILED}
+                2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UPDATE_FAILED, **WORKER_FILTER}
             )
         assert mock_metrics.drain_node_exceptions.inc.call_count == 0
 
@@ -1567,17 +1611,26 @@ class AutoscalingTest(unittest.TestCase):
 
     def testTerminateOutdatedNodesGracefully(self):
         config = copy.deepcopy(SMALL_CLUSTER)
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 5
+        config["available_node_types"]["worker"]["min_workers"] = 5
         config["max_workers"] = 5
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 5
+        config["available_node_types"]["worker"]["max_workers"] = 5
         config_path = self.write_config(config)
         self.provider = MockProvider()
         self.provider.create_node(
             {},
             {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
+        self.provider.create_node(
+            {},
+            {
                 TAG_RAY_NODE_KIND: "worker",
                 TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
-                TAG_RAY_USER_NODE_TYPE: NODE_TYPE_LEGACY_WORKER,
+                TAG_RAY_USER_NODE_TYPE: "worker",
             },
             10,
         )
@@ -1594,24 +1647,24 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0,
             prom_metrics=mock_metrics,
         )
-        self.waitForNodes(10)
+        self.waitForNodes(10, tag_filters=WORKER_FILTER)
 
         fill_in_raylet_ids(self.provider, lm)
         # Gradually scales down to meet target size, never going too low
         for _ in range(10):
             autoscaler.update()
-            self.waitForNodes(5, comparison=self.assertLessEqual)
-            self.waitForNodes(4, comparison=self.assertGreaterEqual)
+            self.waitForNodes(5, comparison=self.assertLessEqual, tag_filters=WORKER_FILTER)
+            self.waitForNodes(4, comparison=self.assertGreaterEqual, tag_filters=WORKER_FILTER)
 
         # Eventually reaches steady state
-        self.waitForNodes(5)
+        self.waitForNodes(5, tag_filters=WORKER_FILTER)
 
         # Check the outdated node removal event is generated.
         autoscaler.update()
         events = autoscaler.event_summarizer.summary()
         assert (
             "Removing 10 nodes of type "
-            "ray-legacy-worker-node-type (outdated)." in events
+            "worker (outdated)." in events
         ), events
         assert mock_metrics.stopped_nodes.inc.call_count == 10
         mock_metrics.started_nodes.inc.assert_called_with(5)
@@ -1719,6 +1772,7 @@ class AutoscalingTest(unittest.TestCase):
         disable_drain=False,
     ):
         config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
         if foreground_node_launcher:
             config["provider"][FOREGROUND_NODE_LAUNCH_KEY] = True
         if disable_drain:
@@ -1734,7 +1788,7 @@ class AutoscalingTest(unittest.TestCase):
             {
                 TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
                 TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
-                TAG_RAY_USER_NODE_TYPE: NODE_TYPE_LEGACY_HEAD,
+                TAG_RAY_USER_NODE_TYPE: "head",
             },
             1,
         )
@@ -1764,21 +1818,29 @@ class AutoscalingTest(unittest.TestCase):
         # Update the config to reduce the cluster size
         new_config = copy.deepcopy(SMALL_CLUSTER)
         new_config["max_workers"] = 1
-        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 1
+        new_config["available_node_types"]["worker"]["max_workers"] = 1
+        new_config["available_node_types"]["worker"]["mix_workers"] = 1
         self.write_config(new_config)
         fill_in_raylet_ids(self.provider, lm)
         autoscaler.update()
         self.waitForNodes(1, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
 
+        # Check the launch failure event is generated.
+        events = autoscaler.event_summarizer.summary()
+        assert (
+            "Removing 1 nodes of type worker "
+            "(max_workers_per_type)." in events
+        )
+        assert mock_metrics.stopped_nodes.inc.call_count == 1
+
         # Update the config to increase the cluster size
-        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 10
-        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 10
+        new_config["available_node_types"]["worker"]["min_workers"] = 10
+        new_config["available_node_types"]["worker"]["max_workers"] = 10
         new_config["max_workers"] = 10
         self.write_config(new_config)
         autoscaler.update()
         # Because one worker already started, the scheduler waits for its
         # resources to be updated before it launches the remaining min_workers.
-        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
         worker_ip = self.provider.non_terminated_node_ips(
             tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER},
         )[0]
@@ -1793,14 +1855,7 @@ class AutoscalingTest(unittest.TestCase):
 
         self.worker_node_thread_check(foreground_node_launcher)
 
-        # Check the launch failure event is generated.
         autoscaler.update()
-        events = autoscaler.event_summarizer.summary()
-        assert (
-            "Removing 1 nodes of type ray-legacy-worker-node-type "
-            "(max_workers_per_type)." in events
-        )
-        assert mock_metrics.stopped_nodes.inc.call_count == 1
         mock_metrics.running_workers.set.assert_called_with(10)
 
     def testAggressiveAutoscaling(self):
@@ -1811,12 +1866,12 @@ class AutoscalingTest(unittest.TestCase):
 
     def _aggressiveAutoscalingHelper(self, foreground_node_launcher: bool = False):
         config = copy.deepcopy(SMALL_CLUSTER)
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 0
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 10
+        config["available_node_types"]["worker"]["min_workers"] = 0
+        config["available_node_types"]["worker"]["max_workers"] = 10
         config["max_workers"] = 10
         config["idle_timeout_minutes"] = 0
         config["upscaling_speed"] = config["available_node_types"][
-            NODE_TYPE_LEGACY_WORKER
+            "worker"
         ]["max_workers"]
         if foreground_node_launcher:
             config["provider"][FOREGROUND_NODE_LAUNCH_KEY] = True
@@ -1827,7 +1882,7 @@ class AutoscalingTest(unittest.TestCase):
             {},
             {
                 TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
-                TAG_RAY_USER_NODE_TYPE: NODE_TYPE_LEGACY_HEAD,
+                TAG_RAY_USER_NODE_TYPE: "head",
             },
             1,
         )
@@ -1860,22 +1915,22 @@ class AutoscalingTest(unittest.TestCase):
             infeasible_bundles=[{"CPU": 1}] * 3,
         )
         autoscaler.update()
-        self.waitForNodes(2)  # launches a single node to get its resources
-        worker_ip = self.provider.non_terminated_node_ips(
-            tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER},
-        )[0]
-        lm.update(
-            worker_ip,
-            mock_raylet_id(),
-            {"CPU": 1},
-            {"CPU": 1},
-            {},
-            waiting_bundles=[{"CPU": 1}] * 7,
-            infeasible_bundles=[{"CPU": 1}] * 3,
-        )
-        # Otherwise the worker is immediately terminated due to being idle.
-        lm.last_used_time_by_ip[worker_ip] = time.time() + 5
-        autoscaler.update()
+        # self.waitForNodes(2)  # launches a single node to get its resources
+        # worker_ip = self.provider.non_terminated_node_ips(
+        #     tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER},
+        # )[0]
+        # lm.update(
+        #     worker_ip,
+        #     mock_raylet_id(),
+        #     {"CPU": 1},
+        #     {"CPU": 1},
+        #     {},
+        #     waiting_bundles=[{"CPU": 1}] * 7,
+        #     infeasible_bundles=[{"CPU": 1}] * 3,
+        # )
+        # # Otherwise the worker is immediately terminated due to being idle.
+        # lm.last_used_time_by_ip[worker_ip] = time.time() + 5
+        # autoscaler.update()
 
         if foreground_node_launcher:
             # No wait if node launch is blocking and happens in the foreground.
@@ -1894,7 +1949,7 @@ class AutoscalingTest(unittest.TestCase):
         # Otherwise in "foreground launcher" mode, workers would be deleted
         # for being idle and instantly re-created due to resource demand!
         lm.update(
-            worker_ip,
+            head_ip,
             mock_raylet_id(),
             {},
             {},
@@ -1905,17 +1960,17 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
         self.waitForNodes(1)  # only the head node
         # Make sure they don't get overwritten.
-        assert autoscaler.resource_demand_scheduler.node_types[NODE_TYPE_LEGACY_HEAD][
+        assert autoscaler.resource_demand_scheduler.node_types["head"][
             "resources"
         ] == {"CPU": 1}
-        assert autoscaler.resource_demand_scheduler.node_types[NODE_TYPE_LEGACY_WORKER][
+        assert autoscaler.resource_demand_scheduler.node_types["worker"][
             "resources"
         ] == {"CPU": 1}
 
     def testUnmanagedNodes(self):
         config = copy.deepcopy(SMALL_CLUSTER)
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 0
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 20
+        config["available_node_types"]["worker"]["min_workers"] = 0
+        config["available_node_types"]["worker"]["max_workers"] = 20
         config["max_workers"] = 20
         config["idle_timeout_minutes"] = 0
         config["upscaling_speed"] = 9999
@@ -1926,7 +1981,7 @@ class AutoscalingTest(unittest.TestCase):
             {},
             {
                 TAG_RAY_NODE_KIND: "head",
-                TAG_RAY_USER_NODE_TYPE: NODE_TYPE_LEGACY_HEAD,
+                TAG_RAY_USER_NODE_TYPE: "head",
                 TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
             },
             1,
@@ -1978,8 +2033,8 @@ class AutoscalingTest(unittest.TestCase):
     def testUnmanagedNodes2(self):
         config = copy.deepcopy(SMALL_CLUSTER)
         config = copy.deepcopy(SMALL_CLUSTER)
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 0
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 20
+        config["available_node_types"]["worker"]["min_workers"] = 0
+        config["available_node_types"]["worker"]["max_workers"] = 20
         config["max_workers"] = 20
         config["idle_timeout_minutes"] = 0
         config["upscaling_speed"] = 9999
@@ -1990,7 +2045,7 @@ class AutoscalingTest(unittest.TestCase):
             {},
             {
                 TAG_RAY_NODE_KIND: "head",
-                TAG_RAY_USER_NODE_TYPE: NODE_TYPE_LEGACY_HEAD,
+                TAG_RAY_USER_NODE_TYPE: "head",
                 TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
             },
             1,
@@ -2040,6 +2095,18 @@ class AutoscalingTest(unittest.TestCase):
         runner = MockProcessRunner()
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(2)])
         lm = LoadMetrics()
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
+        head_ip = self.provider.non_terminated_node_ips(
+            tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_HEAD},
+        )[0]
         autoscaler = MockAutoscaler(
             config_path,
             lm,
@@ -2050,37 +2117,47 @@ class AutoscalingTest(unittest.TestCase):
             process_runner=runner,
             update_interval_s=0,
         )
-        assert len(self.provider.non_terminated_nodes({})) == 0
+        assert len(self.provider.non_terminated_nodes({TAG_RAY_NODE_KIND: NODE_KIND_WORKER})) == 0
 
         # Update will try to create, but will block until we set the flag
         self.provider.ready_to_create.clear()
+        lm.update(head_ip, mock_raylet_id(), {"CPU": 1}, {"CPU": 0}, {}, waiting_bundles=[{"CPU": 1}]*2)
         autoscaler.update()
+        assert len(self.provider.non_terminated_nodes({TAG_RAY_NODE_KIND: NODE_KIND_WORKER})) == 0
         assert autoscaler.pending_launches.value == 2
-        assert len(self.provider.non_terminated_nodes({})) == 0
 
         # Set the flag, check it updates
         self.provider.ready_to_create.set()
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
         assert autoscaler.pending_launches.value == 0
 
         # Update the config to reduce the cluster size
         new_config = copy.deepcopy(SMALL_CLUSTER)
-        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 1
+        new_config["available_node_types"]["worker"]["max_workers"] = 1
         self.write_config(new_config)
         fill_in_raylet_ids(self.provider, lm)
         autoscaler.update()
-        assert len(self.provider.non_terminated_nodes({})) == 1
+        assert len(self.provider.non_terminated_nodes({TAG_RAY_NODE_KIND: NODE_KIND_WORKER})) == 1
 
     def testDelayedLaunchWithMinWorkers(self):
         config = copy.deepcopy(SMALL_CLUSTER)
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 10
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 10
+        config["available_node_types"]["worker"]["min_workers"] = 10
+        config["available_node_types"]["worker"]["max_workers"] = 10
         config["max_workers"] = 10
         config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(10)])
         mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             LoadMetrics(),
@@ -2092,7 +2169,7 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0,
             prom_metrics=mock_metrics,
         )
-        assert len(self.provider.non_terminated_nodes({})) == 0
+        assert len(self.provider.non_terminated_nodes({TAG_RAY_NODE_KIND: NODE_KIND_WORKER})) == 0
 
         # update() should launch a wave of 5 nodes (max_launch_batch)
         # Force this first wave to block.
@@ -2104,25 +2181,36 @@ class AutoscalingTest(unittest.TestCase):
         self.waitFor(lambda: len(waiters) == 2)
         assert autoscaler.pending_launches.value == 10
         mock_metrics.pending_nodes.set.assert_called_with(10)
-        assert len(self.provider.non_terminated_nodes({})) == 0
+        assert len(self.provider.non_terminated_nodes({TAG_RAY_NODE_KIND: NODE_KIND_WORKER})) == 0
         autoscaler.update()
-        self.waitForNodes(0)  # Nodes are not added on top of pending.
+        self.waitForNodes(0, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})  # Nodes are not added on top of pending.
         rtc1.set()
         self.waitFor(lambda: autoscaler.pending_launches.value == 0)
-        assert len(self.provider.non_terminated_nodes({})) == 10
-        self.waitForNodes(10)
+        assert len(self.provider.non_terminated_nodes({TAG_RAY_NODE_KIND: NODE_KIND_WORKER})) == 10
+        self.waitForNodes(10, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
         assert autoscaler.pending_launches.value == 0
         mock_metrics.pending_nodes.set.assert_called_with(0)
         autoscaler.update()
-        self.waitForNodes(10)
+        self.waitForNodes(10, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
         assert autoscaler.pending_launches.value == 0
         mock_metrics.pending_nodes.set.assert_called_with(0)
         assert mock_metrics.drain_node_exceptions.inc.call_count == 0
 
     def testUpdateThrottling(self):
-        config_path = self.write_config(SMALL_CLUSTER)
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
+        config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             LoadMetrics(),
@@ -2134,7 +2222,7 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=10,
         )
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
         assert autoscaler.pending_launches.value == 0
         new_config = copy.deepcopy(SMALL_CLUSTER)
         new_config["max_workers"] = 1
@@ -2143,22 +2231,33 @@ class AutoscalingTest(unittest.TestCase):
         # not updated yet
         # note that node termination happens in the main thread, so
         # we do not need to add any delay here before checking
-        assert len(self.provider.non_terminated_nodes({})) == 2
+        assert len(self.provider.non_terminated_nodes(WORKER_FILTER)) == 2
         assert autoscaler.pending_launches.value == 0
 
     def testLaunchConfigChange(self):
-        config_path = self.write_config(SMALL_CLUSTER)
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
+        config_path = self.write_config(config)
         self.provider = MockProvider()
         lm = LoadMetrics()
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path, lm, MockNodeInfoStub(), max_failures=0, update_interval_s=0
         )
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
 
         # Update the config to change the node type
-        new_config = copy.deepcopy(SMALL_CLUSTER)
-        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["node_config"][
+        new_config = copy.deepcopy(config)
+        new_config["available_node_types"]["worker"]["node_config"][
             "InstanceType"
         ] = "updated"
         self.write_config(new_config)
@@ -2166,12 +2265,14 @@ class AutoscalingTest(unittest.TestCase):
         fill_in_raylet_ids(self.provider, lm)
         for _ in range(5):
             autoscaler.update()
-        self.waitForNodes(0)
+        self.waitForNodes(0, tag_filters=WORKER_FILTER)
         self.provider.ready_to_create.set()
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
 
     def testIgnoresCorruptedConfig(self):
-        config_path = self.write_config(SMALL_CLUSTER)
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
+        config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(11)])
@@ -2180,7 +2281,7 @@ class AutoscalingTest(unittest.TestCase):
             {
                 TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
                 TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
-                TAG_RAY_USER_NODE_TYPE: NODE_TYPE_LEGACY_HEAD,
+                TAG_RAY_USER_NODE_TYPE: "head",
             },
             1,
         )
@@ -2200,7 +2301,7 @@ class AutoscalingTest(unittest.TestCase):
         )
         autoscaler.update()
         assert mock_metrics.config_validation_exceptions.inc.call_count == 0
-        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
 
         # Write a corrupted config
         self.write_config("asdf", call_prepare_config=False)
@@ -2221,9 +2322,9 @@ class AutoscalingTest(unittest.TestCase):
 
         # New a good config again
         new_config = copy.deepcopy(SMALL_CLUSTER)
-        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 10
+        new_config["available_node_types"]["worker"]["min_workers"] = 10
         new_config["max_workers"] = 10
-        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 10
+        new_config["available_node_types"]["worker"]["max_workers"] = 10
         self.write_config(new_config)
         worker_ip = self.provider.non_terminated_node_ips(
             tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER},
@@ -2260,10 +2361,24 @@ class AutoscalingTest(unittest.TestCase):
         assert mock_metrics.drain_node_exceptions.inc.call_count == 0
 
     def testLaunchNewNodeOnOutOfBandTerminate(self):
-        config_path = self.write_config(SMALL_CLUSTER)
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
+        config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(4)])
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
+        head_ip = self.provider.non_terminated_node_ips(
+            tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_HEAD},
+        )[0]
         autoscaler = MockAutoscaler(
             config_path,
             LoadMetrics(),
@@ -2274,18 +2389,31 @@ class AutoscalingTest(unittest.TestCase):
         )
         autoscaler.update()
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
         for node in self.provider.mock_nodes.values():
+            if node.internal_ip == head_ip:
+                continue
             node.state = "terminated"
-        assert len(self.provider.non_terminated_nodes({})) == 0
+        assert len(self.provider.non_terminated_nodes(WORKER_FILTER)) == 0
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
 
     def testConfiguresNewNodes(self):
-        config_path = self.write_config(SMALL_CLUSTER)
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 1
+        config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(2)])
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             LoadMetrics(),
@@ -2303,12 +2431,23 @@ class AutoscalingTest(unittest.TestCase):
 
     def testReportsConfigFailures(self):
         config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
+        config_path = self.write_config(config)
         config["provider"]["type"] = "mock"
         config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner(fail_cmds=["setup_cmd"])
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(2)])
         lm = LoadMetrics()
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             lm,
@@ -2318,13 +2457,13 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0,
         )
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
         self.provider.finish_starting_nodes()
         fill_in_raylet_ids(self.provider, lm)
         autoscaler.update()
         try:
             self.waitForNodes(
-                2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UPDATE_FAILED}
+                2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UPDATE_FAILED, **WORKER_FILTER}
             )
         except AssertionError:
             # The failed nodes might have been already terminated by autoscaler
@@ -2335,7 +2474,7 @@ class AutoscalingTest(unittest.TestCase):
         events = autoscaler.event_summarizer.summary()
         assert (
             "Removing 2 nodes of type "
-            "ray-legacy-worker-node-type (launch failed)." in events
+            "worker (launch failed)." in events
         ), events
 
     def testConfiguresOutdatedNodes(self):
@@ -2346,10 +2485,21 @@ class AutoscalingTest(unittest.TestCase):
 
         cli_logger._print = type(cli_logger._print)(do_nothing, type(cli_logger))
 
-        config_path = self.write_config(SMALL_CLUSTER)
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 1
+        config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(4)])
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             LoadMetrics(),
@@ -2465,12 +2615,23 @@ class AutoscalingTest(unittest.TestCase):
         assert lm
 
     def testRecoverUnhealthyWorkers(self):
-        config_path = self.write_config(SMALL_CLUSTER)
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
+        config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(3)])
         lm = LoadMetrics()
         mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             lm,
@@ -2481,10 +2642,10 @@ class AutoscalingTest(unittest.TestCase):
             prom_metrics=mock_metrics,
         )
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
 
         # Mark a node as unhealthy
         for _ in range(5):
@@ -2494,7 +2655,7 @@ class AutoscalingTest(unittest.TestCase):
         assert not autoscaler.updaters
         mock_metrics.recovering_nodes.set.assert_called_with(0)
         num_calls = len(runner.calls)
-        lm.last_heartbeat_time_by_ip["172.0.0.0"] = 0
+        lm.last_heartbeat_time_by_ip["172.0.0.1"] = 0
         autoscaler.update()
         mock_metrics.recovering_nodes.set.assert_called_with(1)
         self.waitFor(lambda: len(runner.calls) > num_calls, num_retries=150)
@@ -2504,7 +2665,7 @@ class AutoscalingTest(unittest.TestCase):
         events = autoscaler.event_summarizer.summary()
         assert (
             "Restarting 1 nodes of type "
-            "ray-legacy-worker-node-type (lost contact with raylet)." in events
+            "worker (lost contact with raylet)." in events
         ), events
         assert mock_metrics.drain_node_exceptions.inc.call_count == 0
 
@@ -2531,6 +2692,7 @@ class AutoscalingTest(unittest.TestCase):
         on unhealthy nodes, instead delegating node management to another component.
         """
         config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
         # Make it clear we're not timing out idle nodes here.
         config["idle_timeout_minutes"] = 1000000000
         if disable_liveness_check:
@@ -2541,6 +2703,15 @@ class AutoscalingTest(unittest.TestCase):
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(3)])
         lm = LoadMetrics()
         mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             lm,
@@ -2551,10 +2722,10 @@ class AutoscalingTest(unittest.TestCase):
             prom_metrics=mock_metrics,
         )
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
 
         # Clear out updaters.
         for _ in range(5):
@@ -2566,11 +2737,11 @@ class AutoscalingTest(unittest.TestCase):
         num_calls = len(runner.calls)
 
         # Mark a node as unhealthy
-        lm.last_heartbeat_time_by_ip["172.0.0.0"] = 0
+        lm.last_heartbeat_time_by_ip["172.0.0.1"] = 0
         # Turn off updaters.
         autoscaler.disable_node_updaters = True
         # Reduce min_workers to 1
-        autoscaler.config["available_node_types"][NODE_TYPE_LEGACY_WORKER][
+        autoscaler.config["available_node_types"]["worker"][
             "min_workers"
         ] = 1
         fill_in_raylet_ids(self.provider, lm)
@@ -2583,7 +2754,7 @@ class AutoscalingTest(unittest.TestCase):
             for _ in range(10):
                 autoscaler.update()
             # The nodes are still there.
-            assert self.num_nodes() == 2
+            assert self.num_nodes(tag_filters=WORKER_FILTER) == 2
             # There's no synchronization required to make the last assertion valid:
             # The autoscaler's node termination is synchronous and blocking, as is
             # the terminate_node method of the mock node provider used in this test.
@@ -2598,14 +2769,14 @@ class AutoscalingTest(unittest.TestCase):
             # Stopped node metric incremented.
             mock_metrics.stopped_nodes.inc.assert_called_once_with()
             # One node left.
-            self.waitForNodes(1)
+            self.waitForNodes(1, tag_filters=WORKER_FILTER)
 
             # Check the node removal event is generated.
             autoscaler.update()
             events = autoscaler.event_summarizer.summary()
             assert (
                 "Removing 1 nodes of type "
-                "ray-legacy-worker-node-type (lost contact with raylet)." in events
+                "worker (lost contact with raylet)." in events
             ), events
 
             # No additional runner calls, since updaters were disabled.
@@ -2621,11 +2792,21 @@ class AutoscalingTest(unittest.TestCase):
         """
         config = copy.deepcopy(SMALL_CLUSTER)
         config["provider"]["disable_node_updaters"] = True
+        config["available_node_types"]["worker"]["min_workers"] = 2
         config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
         mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
         lm = LoadMetrics()
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             lm,
@@ -2635,32 +2816,32 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0,
             prom_metrics=mock_metrics,
         )
-        assert len(self.provider.non_terminated_nodes({})) == 0
+        assert len(self.provider.non_terminated_nodes(WORKER_FILTER)) == 0
         for _ in range(10):
             autoscaler.update()
             # Nodes stay in uninitialized state because no one has finished
             # updating them.
             self.waitForNodes(
-                2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UNINITIALIZED}
+                2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UNINITIALIZED, **WORKER_FILTER}
             )
-        nodes = self.provider.non_terminated_nodes({})
+        nodes = self.provider.non_terminated_nodes(WORKER_FILTER)
         ips = [self.provider.internal_ip(node) for node in nodes]
         # No heartbeats recorded yet.
         assert not any(ip in lm.last_heartbeat_time_by_ip for ip in ips)
         for node in nodes:
-            self.provider.set_node_tags(node, {TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+            self.provider.set_node_tags(node, {TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
         autoscaler.update()
         # Nodes marked active after up-to-date status detected.
         assert all(ip in lm.last_heartbeat_time_by_ip for ip in ips)
         # Nodes are kept.
-        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
         # Mark nodes unhealthy.
         for ip in ips:
             lm.last_heartbeat_time_by_ip[ip] = 0
         fill_in_raylet_ids(self.provider, lm)
         autoscaler.update()
         # Unhealthy nodes are gone.
-        self.waitForNodes(0)
+        self.waitForNodes(0, tag_filters=WORKER_FILTER)
         autoscaler.update()
         # IPs pruned
         assert lm.last_heartbeat_time_by_ip == {}
@@ -2708,14 +2889,23 @@ class AutoscalingTest(unittest.TestCase):
 
     def testSetupCommandsWithNoNodeCaching(self):
         config = copy.deepcopy(SMALL_CLUSTER)
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 1
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 1
+        config["available_node_types"]["worker"]["min_workers"] = 1
+        config["available_node_types"]["worker"]["max_workers"] = 1
         config["max_workers"] = 1
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=False)
         runner = MockProcessRunner()
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(2)])
         lm = LoadMetrics()
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             lm,
@@ -2725,27 +2915,27 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0,
         )
         autoscaler.update()
-        self.waitForNodes(1)
+        self.waitForNodes(1, tag_filters=WORKER_FILTER)
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
-        runner.assert_has_call("172.0.0.0", "init_cmd")
-        runner.assert_has_call("172.0.0.0", "setup_cmd")
-        runner.assert_has_call("172.0.0.0", "worker_setup_cmd")
-        runner.assert_has_call("172.0.0.0", "start_ray_worker")
-
-        # Check the node was not reused
-        self.provider.terminate_node(0)
-        autoscaler.update()
-        self.waitForNodes(1)
-        runner.clear_history()
-        self.provider.finish_starting_nodes()
-        autoscaler.update()
-        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
         runner.assert_has_call("172.0.0.1", "init_cmd")
         runner.assert_has_call("172.0.0.1", "setup_cmd")
         runner.assert_has_call("172.0.0.1", "worker_setup_cmd")
         runner.assert_has_call("172.0.0.1", "start_ray_worker")
+
+        # Check the node was not reused
+        self.provider.terminate_node(1)
+        autoscaler.update()
+        self.waitForNodes(1, tag_filters=WORKER_FILTER)
+        runner.clear_history()
+        self.provider.finish_starting_nodes()
+        autoscaler.update()
+        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
+        runner.assert_has_call("172.0.0.2", "init_cmd")
+        runner.assert_has_call("172.0.0.2", "setup_cmd")
+        runner.assert_has_call("172.0.0.2", "worker_setup_cmd")
+        runner.assert_has_call("172.0.0.2", "start_ray_worker")
 
     def testSetupCommandsWithStoppedNodeCachingNoDocker(self):
         file_mount_dir = tempfile.mkdtemp()
@@ -2753,14 +2943,23 @@ class AutoscalingTest(unittest.TestCase):
         del config["docker"]
         config["file_mounts"] = {"/root/test-folder": file_mount_dir}
         config["file_mounts_sync_continuously"] = True
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 1
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 1
+        config["available_node_types"]["worker"]["min_workers"] = 1
+        config["available_node_types"]["worker"]["max_workers"] = 1
         config["max_workers"] = 1
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=True)
         runner = MockProcessRunner()
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(3)])
         lm = LoadMetrics()
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             lm,
@@ -2770,50 +2969,50 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0,
         )
         autoscaler.update()
-        self.waitForNodes(1)
+        self.waitForNodes(1, tag_filters=WORKER_FILTER)
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
-        runner.assert_has_call("172.0.0.0", "init_cmd")
-        runner.assert_has_call("172.0.0.0", "setup_cmd")
-        runner.assert_has_call("172.0.0.0", "worker_setup_cmd")
-        runner.assert_has_call("172.0.0.0", "start_ray_worker")
+        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
+        runner.assert_has_call("172.0.0.1", "init_cmd")
+        runner.assert_has_call("172.0.0.1", "setup_cmd")
+        runner.assert_has_call("172.0.0.1", "worker_setup_cmd")
+        runner.assert_has_call("172.0.0.1", "start_ray_worker")
 
         # Check the node was indeed reused
-        self.provider.terminate_node(0)
+        self.provider.terminate_node(1)
         autoscaler.update()
-        self.waitForNodes(1)
+        self.waitForNodes(1, tag_filters=WORKER_FILTER)
         runner.clear_history()
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
-        runner.assert_not_has_call("172.0.0.0", "init_cmd")
-        runner.assert_not_has_call("172.0.0.0", "setup_cmd")
-        runner.assert_not_has_call("172.0.0.0", "worker_setup_cmd")
-        runner.assert_has_call("172.0.0.0", "start_ray_worker")
+        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
+        runner.assert_not_has_call("172.0.0.1", "init_cmd")
+        runner.assert_not_has_call("172.0.0.1", "setup_cmd")
+        runner.assert_not_has_call("172.0.0.1", "worker_setup_cmd")
+        runner.assert_has_call("172.0.0.1", "start_ray_worker")
 
         with open(f"{file_mount_dir}/new_file", "w") as f:
             f.write("abcdefgh")
 
         # Check that run_init happens when file_mounts have updated
-        self.provider.terminate_node(0)
+        self.provider.terminate_node(1)
         autoscaler.update()
-        self.waitForNodes(1)
+        self.waitForNodes(1, tag_filters=WORKER_FILTER)
         runner.clear_history()
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
-        runner.assert_not_has_call("172.0.0.0", "init_cmd")
-        runner.assert_not_has_call("172.0.0.0", "setup_cmd")
-        runner.assert_not_has_call("172.0.0.0", "worker_setup_cmd")
-        runner.assert_has_call("172.0.0.0", "start_ray_worker")
+        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
+        runner.assert_not_has_call("172.0.0.1", "init_cmd")
+        runner.assert_not_has_call("172.0.0.1", "setup_cmd")
+        runner.assert_not_has_call("172.0.0.1", "worker_setup_cmd")
+        runner.assert_has_call("172.0.0.1", "start_ray_worker")
 
         runner.clear_history()
         autoscaler.update()
-        runner.assert_not_has_call("172.0.0.0", "setup_cmd")
+        runner.assert_not_has_call("172.0.0.1", "setup_cmd")
 
         # We did not start any other nodes
-        runner.assert_not_has_call("172.0.0.1", " ")
+        runner.assert_not_has_call("172.0.0.2", " ")
 
     def testSetupCommandsWithStoppedNodeCachingDocker(self):
         # NOTE(ilr) Setup & Init commands **should** run with stopped nodes
@@ -2822,14 +3021,23 @@ class AutoscalingTest(unittest.TestCase):
         config = copy.deepcopy(SMALL_CLUSTER)
         config["file_mounts"] = {"/root/test-folder": file_mount_dir}
         config["file_mounts_sync_continuously"] = True
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 1
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 1
+        config["available_node_types"]["worker"]["min_workers"] = 1
+        config["available_node_types"]["worker"]["max_workers"] = 1
         config["max_workers"] = 1
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=True)
         runner = MockProcessRunner()
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(3)])
         lm = LoadMetrics()
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             lm,
@@ -2839,30 +3047,30 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0,
         )
         autoscaler.update()
-        self.waitForNodes(1)
+        self.waitForNodes(1, tag_filters=WORKER_FILTER)
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
-        runner.assert_has_call("172.0.0.0", "init_cmd")
-        runner.assert_has_call("172.0.0.0", "setup_cmd")
-        runner.assert_has_call("172.0.0.0", "worker_setup_cmd")
-        runner.assert_has_call("172.0.0.0", "start_ray_worker")
-        runner.assert_has_call("172.0.0.0", "docker run")
+        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
+        runner.assert_has_call("172.0.0.1", "init_cmd")
+        runner.assert_has_call("172.0.0.1", "setup_cmd")
+        runner.assert_has_call("172.0.0.1", "worker_setup_cmd")
+        runner.assert_has_call("172.0.0.1", "start_ray_worker")
+        runner.assert_has_call("172.0.0.1", "docker run")
 
         # Check the node was indeed reused
-        self.provider.terminate_node(0)
+        self.provider.terminate_node(1)
         autoscaler.update()
-        self.waitForNodes(1)
+        self.waitForNodes(1, tag_filters=WORKER_FILTER)
         runner.clear_history()
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
         # These all must happen when the node is stopped and resued
-        runner.assert_has_call("172.0.0.0", "init_cmd")
-        runner.assert_has_call("172.0.0.0", "setup_cmd")
-        runner.assert_has_call("172.0.0.0", "worker_setup_cmd")
-        runner.assert_has_call("172.0.0.0", "start_ray_worker")
-        runner.assert_has_call("172.0.0.0", "docker run")
+        runner.assert_has_call("172.0.0.1", "init_cmd")
+        runner.assert_has_call("172.0.0.1", "setup_cmd")
+        runner.assert_has_call("172.0.0.1", "worker_setup_cmd")
+        runner.assert_has_call("172.0.0.1", "start_ray_worker")
+        runner.assert_has_call("172.0.0.1", "docker run")
 
         with open(f"{file_mount_dir}/new_file", "w") as f:
             f.write("abcdefgh")
@@ -2870,16 +3078,16 @@ class AutoscalingTest(unittest.TestCase):
         # Check that run_init happens when file_mounts have updated
         self.provider.terminate_node(0)
         autoscaler.update()
-        self.waitForNodes(1)
+        self.waitForNodes(1, tag_filters=WORKER_FILTER)
         runner.clear_history()
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
-        runner.assert_has_call("172.0.0.0", "init_cmd")
-        runner.assert_has_call("172.0.0.0", "setup_cmd")
-        runner.assert_has_call("172.0.0.0", "worker_setup_cmd")
-        runner.assert_has_call("172.0.0.0", "start_ray_worker")
-        runner.assert_has_call("172.0.0.0", "docker run")
+        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
+        runner.assert_has_call("172.0.0.1", "init_cmd")
+        runner.assert_has_call("172.0.0.1", "setup_cmd")
+        runner.assert_has_call("172.0.0.1", "worker_setup_cmd")
+        runner.assert_has_call("172.0.0.1", "start_ray_worker")
+        runner.assert_has_call("172.0.0.1", "docker run")
 
         docker_run_cmd_indx = [
             i for i, cmd in enumerate(runner.command_history()) if "docker run" in cmd
@@ -2890,22 +3098,30 @@ class AutoscalingTest(unittest.TestCase):
         assert mkdir_cmd_indx < docker_run_cmd_indx
         runner.clear_history()
         autoscaler.update()
-        runner.assert_not_has_call("172.0.0.0", "setup_cmd")
+        runner.assert_not_has_call("172.0.0.1", "setup_cmd")
 
         # We did not start any other nodes
-        runner.assert_not_has_call("172.0.0.1", " ")
+        runner.assert_not_has_call("172.0.0.2", " ")
 
     def testMultiNodeReuse(self):
         config = copy.deepcopy(SMALL_CLUSTER)
         # Docker re-runs setup commands when nodes are reused.
         del config["docker"]
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 3
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 3
+        config["available_node_types"]["worker"]["min_workers"] = 3
+        config["available_node_types"]["worker"]["max_workers"] = 3
         config["max_workers"] = 3
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=True)
         runner = MockProcessRunner()
         lm = LoadMetrics()
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             lm,
@@ -2915,32 +3131,32 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0,
         )
         autoscaler.update()
-        self.waitForNodes(3)
+        self.waitForNodes(3, tag_filters=WORKER_FILTER)
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(3, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+        self.waitForNodes(3, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
 
-        self.provider.terminate_node(0)
         self.provider.terminate_node(1)
         self.provider.terminate_node(2)
+        self.provider.terminate_node(3)
         runner.clear_history()
 
-        # Scale up to 10 nodes, check we reuse the first 3 and add 7 more.
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 10
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 10
-        config["max_workers"] = 10
+        # Scale up to 10 nodes, check we reuse the first 3 and add 5 more.
+        config["available_node_types"]["worker"]["min_workers"] = 8
+        config["available_node_types"]["worker"]["max_workers"] = 8
+        config["max_workers"] = 8
         self.write_config(config)
         autoscaler.update()
         autoscaler.update()
-        self.waitForNodes(10)
+        self.waitForNodes(8, tag_filters=WORKER_FILTER)
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(10, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+        self.waitForNodes(8, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
         autoscaler.update()
-        for i in [0, 1, 2]:
+        for i in [1, 2, 3]:
             runner.assert_not_has_call("172.0.0.{}".format(i), "setup_cmd")
             runner.assert_has_call("172.0.0.{}".format(i), "start_ray_worker")
-        for i in [3, 4, 5, 6, 7, 8, 9]:
+        for i in range(4, 9):
             runner.assert_has_call("172.0.0.{}".format(i), "setup_cmd")
             runner.assert_has_call("172.0.0.{}".format(i), "start_ray_worker")
 
@@ -2951,13 +3167,21 @@ class AutoscalingTest(unittest.TestCase):
         config = copy.deepcopy(SMALL_CLUSTER)
         config["file_mounts"] = {"/home/test-folder": file_mount_dir}
         config["file_mounts_sync_continuously"] = True
-        config["min_workers"] = 2
-        config["max_workers"] = 2
+        config["available_node_types"]["worker"]["min_workers"] = 2
         config_path = self.write_config(config)
         runner = MockProcessRunner()
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(4)])
         runner.respond_to_call("command -v docker", ["docker" for _ in range(4)])
         lm = LoadMetrics()
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             lm,
@@ -2968,13 +3192,13 @@ class AutoscalingTest(unittest.TestCase):
         )
 
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(3)
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+        self.waitForNodes(3, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
         autoscaler.update()
         docker_mount_prefix = get_docker_host_mount_location(config["cluster_name"])
-        for i in [0, 1]:
+        for i in self.provider.non_terminated_nodes(tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER}):
             runner.assert_has_call(f"172.0.0.{i}", "setup_cmd")
             runner.assert_has_call(
                 f"172.0.0.{i}",
@@ -2990,13 +3214,13 @@ class AutoscalingTest(unittest.TestCase):
         runner.respond_to_call(".Config.Image", ["example" for _ in range(4)])
         runner.respond_to_call(".State.Running", ["true" for _ in range(4)])
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(3)
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+        self.waitForNodes(3, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
         autoscaler.update()
 
-        for i in [0, 1]:
+        for i in self.provider.non_terminated_nodes(tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER}):
             runner.assert_not_has_call(f"172.0.0.{i}", "setup_cmd")
             runner.assert_has_call(
                 f"172.0.0.{i}",
@@ -3010,12 +3234,20 @@ class AutoscalingTest(unittest.TestCase):
         self.provider = MockProvider()
         config = copy.deepcopy(SMALL_CLUSTER)
         config["file_mounts"] = {"/home/test-folder": file_mount_dir}
-        config["min_workers"] = 2
-        config["max_workers"] = 2
+        config["available_node_types"]["worker"]["min_workers"] = 2
         config_path = self.write_config(config)
         runner = MockProcessRunner()
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(2)])
         lm = LoadMetrics()
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             lm,
@@ -3026,14 +3258,14 @@ class AutoscalingTest(unittest.TestCase):
         )
 
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
         autoscaler.update()
         docker_mount_prefix = get_docker_host_mount_location(config["cluster_name"])
 
-        for i in [0, 1]:
+        for i in self.provider.non_terminated_nodes(WORKER_FILTER):
             runner.assert_has_call(f"172.0.0.{i}", "setup_cmd")
             runner.assert_has_call(
                 f"172.0.0.{i}",
@@ -3047,11 +3279,11 @@ class AutoscalingTest(unittest.TestCase):
             temp_file.write("hello".encode())
 
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
         self.provider.finish_starting_nodes()
-        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
 
-        for i in [0, 1]:
+        for i in self.provider.non_terminated_nodes(WORKER_FILTER):
             runner.assert_not_has_call(f"172.0.0.{i}", "setup_cmd")
             runner.assert_not_has_call(
                 f"172.0.0.{i}",
@@ -3076,12 +3308,12 @@ class AutoscalingTest(unittest.TestCase):
         )
 
         autoscaler.update()
-        self.waitForNodes(2)
+        self.waitForNodes(2, tag_filters=WORKER_FILTER)
         self.provider.finish_starting_nodes()
-        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, **WORKER_FILTER})
         autoscaler.update()
 
-        for i in [0, 1]:
+        for i in self.provider.non_terminated_nodes(WORKER_FILTER):
             runner.assert_has_call(f"172.0.0.{i}", "setup_cmd")
             runner.assert_has_call(
                 f"172.0.0.{i}",
@@ -3089,49 +3321,25 @@ class AutoscalingTest(unittest.TestCase):
                 f"{docker_mount_prefix}/home/test-folder/",
             )
 
-    def testAutodetectResources(self):
-        self.provider = MockProvider()
-        config = copy.deepcopy(SMALL_CLUSTER)
-        config_path = self.write_config(config)
-        runner = MockProcessRunner()
-        proc_meminfo = """
-MemTotal:       16396056 kB
-MemFree:        12869528 kB
-MemAvailable:   33000000 kB
-        """
-        runner.respond_to_call("cat /proc/meminfo", 2 * [proc_meminfo])
-        runner.respond_to_call(".Runtimes", 2 * ["nvidia-container-runtime"])
-        runner.respond_to_call("nvidia-smi", 2 * ["works"])
-        runner.respond_to_call("json .Config.Env", 2 * ["[]"])
-        lm = LoadMetrics()
-        autoscaler = MockAutoscaler(
-            config_path,
-            lm,
-            MockNodeInfoStub(),
-            max_failures=0,
-            process_runner=runner,
-            update_interval_s=0,
-        )
-
-        autoscaler.update()
-        self.waitForNodes(2)
-        self.provider.finish_starting_nodes()
-        autoscaler.update()
-        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
-        autoscaler.update()
-        runner.assert_has_call("172.0.0.0", pattern="--shm-size")
-        runner.assert_has_call("172.0.0.0", pattern="--runtime=nvidia")
-
     def testDockerImageExistsBeforeInspect(self):
         config = copy.deepcopy(SMALL_CLUSTER)
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 1
-        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 1
+        config["available_node_types"]["worker"]["min_workers"] = 1
+        config["available_node_types"]["worker"]["max_workers"] = 1
         config["max_workers"] = 1
         config["docker"]["pull_before_run"] = False
         config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
         runner.respond_to_call("json .Config.Env", ["[]" for i in range(1)])
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
         autoscaler = MockAutoscaler(
             config_path,
             LoadMetrics(),
@@ -3142,10 +3350,10 @@ MemAvailable:   33000000 kB
         )
         autoscaler.update()
         autoscaler.update()
-        self.waitForNodes(1)
+        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
         self.provider.finish_starting_nodes()
         autoscaler.update()
-        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
+        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE, TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
         first_pull = [
             (i, cmd)
             for i, cmd in enumerate(runner.command_history())
@@ -3362,11 +3570,22 @@ MemAvailable:   33000000 kB
         assert mock_metrics.drain_node_exceptions.inc.call_count == 0
 
     def testProviderException(self):
-        config_path = self.write_config(SMALL_CLUSTER)
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 2
+        config_path = self.write_config(config)
         self.provider = MockProvider()
-        self.provider.error_creates = Exception(":(")
         runner = MockProcessRunner()
         mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
+        self.provider.error_creates = Exception(":(")
         autoscaler = MockAutoscaler(
             config_path,
             LoadMetrics(),

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -1852,7 +1852,7 @@ class AutoscalingTest(unittest.TestCase):
         self.worker_node_thread_check(foreground_node_launcher)
 
         autoscaler.update()
-        mock_metrics.running_workers.set.assert_called_with(10)
+        assert mock_metrics.running_workers.set.call_args_list[-1][0][0] >= 10
 
     def testAggressiveAutoscaling(self):
         self._aggressiveAutoscalingHelper()
@@ -1911,22 +1911,6 @@ class AutoscalingTest(unittest.TestCase):
             infeasible_bundles=[{"CPU": 1}] * 3,
         )
         autoscaler.update()
-        # self.waitForNodes(2)  # launches a single node to get its resources
-        # worker_ip = self.provider.non_terminated_node_ips(
-        #     tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER},
-        # )[0]
-        # lm.update(
-        #     worker_ip,
-        #     mock_raylet_id(),
-        #     {"CPU": 1},
-        #     {"CPU": 1},
-        #     {},
-        #     waiting_bundles=[{"CPU": 1}] * 7,
-        #     infeasible_bundles=[{"CPU": 1}] * 3,
-        # )
-        # # Otherwise the worker is immediately terminated due to being idle.
-        # lm.last_used_time_by_ip[worker_ip] = time.time() + 5
-        # autoscaler.update()
 
         if foreground_node_launcher:
             # No wait if node launch is blocking and happens in the foreground.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Removes dead code from the resource demand scheduler that was used for config options removed in 2.0.

The general methodology in fixing test_autoscaler was:
* Replace the special legacy strings with "head" and "worker"
* Add a head node to all the autoscaler tests so the autoscaler doesn't try to launch a head node
* Make most of the `non_terminated_nodes` calls filter for worker nodes (since we now have a head node)
* Change some hardcoded node ids to reflect that there's a head node now.
* Some incidental deflaking of race conditions in `testDynamicScaling*` and `testSetupCommands*`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
