### PR TITLE
[tune/rllib] Ignore directory exists errors to tackle race conditions

### DIFF
--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -258,7 +258,7 @@ class TunerInternal:
             run_config.name,
         )
         if not os.path.exists(path):
-            os.makedirs(path)
+            os.makedirs(path, exist_ok=True)
         return path
 
     # This has to be done through a function signature (@property won't do).

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -260,7 +260,9 @@ class Algorithm(Trainable):
             timestr = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
             logdir_prefix = "{}_{}_{}".format(str(self), env_descr, timestr)
             if not os.path.exists(DEFAULT_RESULTS_DIR):
-                os.makedirs(DEFAULT_RESULTS_DIR)
+                # Possible race condition if dir is created several times on
+                # rollout workers
+                os.makedirs(DEFAULT_RESULTS_DIR, exist_ok=True)
             logdir = tempfile.mkdtemp(prefix=logdir_prefix, dir=DEFAULT_RESULTS_DIR)
 
             # Allow users to more precisely configure the created logger

--- a/rllib/offline/json_writer.py
+++ b/rllib/offline/json_writer.py
@@ -60,10 +60,7 @@ class JsonWriter(OutputWriter):
         else:
             path = os.path.abspath(os.path.expanduser(path))
             # Try to create local dirs if they don't exist
-            try:
-                os.makedirs(path)
-            except OSError:
-                pass  # already exists
+            os.makedirs(path, exist_ok=True)
             assert os.path.exists(path), "Failed to create {}".format(path)
             self.path_is_uri = False
         self.path = path

--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -1,4 +1,3 @@
-import errno
 import logging
 import math
 import os
@@ -529,12 +528,7 @@ class TFPolicy(Policy):
         self, export_dir: str, filename_prefix: str = "model"
     ) -> None:
         """Export tensorflow checkpoint to export_dir."""
-        try:
-            os.makedirs(export_dir)
-        except OSError as e:
-            # ignore error if export dir already exists
-            if e.errno != errno.EEXIST:
-                raise
+        os.makedirs(export_dir, exist_ok=True)
         save_path = os.path.join(export_dir, filename_prefix)
         with self.get_session().graph.as_default():
             saver = tf1.train.Saver()

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -876,7 +876,7 @@ class TorchPolicy(Policy):
         }
 
         if not os.path.exists(export_dir):
-            os.makedirs(export_dir)
+            os.makedirs(export_dir, exist_ok=True)
 
         seq_lens = self._dummy_batch[SampleBatch.SEQ_LENS]
         if onnx:

--- a/rllib/policy/torch_policy_v2.py
+++ b/rllib/policy/torch_policy_v2.py
@@ -940,7 +940,7 @@ class TorchPolicyV2(Policy):
         }
 
         if not os.path.exists(export_dir):
-            os.makedirs(export_dir)
+            os.makedirs(export_dir, exist_ok=True)
 
         seq_lens = self._dummy_batch[SampleBatch.SEQ_LENS]
         if onnx:


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Rollout workers can run into race conditions when creating directories - with this PR we ignore existing directory errors on `os.makedirs` in various locations in tune/rllib.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
