### PR TITLE
[runtime env] Fix segfault by sending RPC reply only after we're done accessing the request

### DIFF
--- a/src/ray/gcs/gcs_server/runtime_env_handler.cc
+++ b/src/ray/gcs/gcs_server/runtime_env_handler.cc
@@ -36,6 +36,8 @@ void RuntimeEnvHandler::HandlePinRuntimeEnvURI(
       },
       /* expiration_ms= */ request.expiration_s() * 1000);
 
+  // The `request` object will be destroyed when the reply is sent, so this
+  // must be called after the delay executor is set up.
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
 }
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/runtime_env_handler.cc
+++ b/src/ray/gcs/gcs_server/runtime_env_handler.cc
@@ -27,7 +27,7 @@ void RuntimeEnvHandler::HandlePinRuntimeEnvURI(
   FillRandom(&hex_id);
 
   runtime_env_manager_.AddURIReference(hex_id, request.uri());
-  GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+
   delay_executor_(
       [this, hex_id, request] {
         runtime_env_manager_.RemoveURIReference(hex_id);
@@ -35,6 +35,8 @@ void RuntimeEnvHandler::HandlePinRuntimeEnvURI(
                        << "with URI:" << request.uri();
       },
       /* expiration_ms= */ request.expiration_s() * 1000);
+
+  GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
 }
 }  // namespace gcs
 }  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Debugged together with @iycheng.

In the current design, the owner of the gRPC request object is the gRPC call, so when the gRPC reply is sent the request object is destroyed.  This caused a race condition in the runtime env gRPC handler where sometimes a request object was being accessed after it was being destroyed, causing a segfault.  This PR moves the gRPC reply after the request object is used. 

As a followup, we should improve the design so the developer doesn't need to be aware of these memory issues.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/28198
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
