### PR TITLE
[Datasets] Support `None` partition field name

### DIFF
--- a/python/ray/data/datasource/partitioning.py
+++ b/python/ray/data/datasource/partitioning.py
@@ -402,7 +402,14 @@ class PathPartitionParser:
             f"Expected {len(field_names)} partition value(s) but found "
             f"{len(dirs)}: {dirs}."
         )
-        return {field_names[i]: d for i, d in enumerate(dirs)} if dirs else {}
+
+        if not dirs:
+            return {}
+        return {
+            field: directory
+            for field, directory in zip(field_names, dirs)
+            if field is not None
+        }
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/data/tests/test_partitioning.py
+++ b/python/ray/data/tests/test_partitioning.py
@@ -330,7 +330,6 @@ def test_path_partition_parser_dir(fs, base_dir):
     )
 
     partitioned_path = posixpath.join(base_dir, "1970/countries/fr/products.csv")
-    # The parser shouldn't parse `countries`.
     assert partition_parser(partitioned_path) == {"year": "1970", "country": "fr"}
 
 

--- a/python/ray/data/tests/test_partitioning.py
+++ b/python/ray/data/tests/test_partitioning.py
@@ -322,6 +322,17 @@ def test_path_partition_parser_dir(fs, base_dir):
     partitioned_path = posixpath.join(base_dir, "2/1/test")
     assert partition_parser(partitioned_path) == {"bar": "2", "foo": "1"}
 
+    partition_parser = PathPartitionParser.of(
+        PartitionStyle.DIRECTORY,
+        base_dir=base_dir,
+        field_names=["year", None, "country"],
+        filesystem=fs,
+    )
+
+    partitioned_path = posixpath.join(base_dir, "1970/countries/fr/products.csv")
+    # The parser shouldn't parse `countries`.
+    assert partition_parser(partitioned_path) == {"year": "1970", "country": "fr"}
+
 
 @pytest.mark.parametrize(
     "fs,base_dir",


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Some datasets are stored like

```
root/cat/images/cat1.png
root/cat/images/cat2.png
...
root/dog/images/dog.png
...
```

To read these datasets, we want to parse the label (e.g., `"cat"` or `"dog"`) but not `"images"`:

```
read_images(..., partitioning=Partitioning("dir", labels=["label", None], base_dir=root]))
```

This PR makes it possible to exclude certain directory partitions (e.g., `"images"`).

## Related issue number

<!-- For example: "Closes #1234" -->

See #28413 and #28256

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
