### PR TITLE
Fix the peak memory usage calculation

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -335,7 +335,9 @@ class DatasetStats:
             )
 
             out += indent
-            memory_stats = [round(e.max_rss_bytes / 1024 * 1024, 2) for e in exec_stats]
+            memory_stats = [
+                round(e.max_rss_bytes / (1024 * 1024), 2) for e in exec_stats
+            ]
             out += "* Peak heap memory usage (MiB): {} min, {} max, {} mean\n".format(
                 min(memory_stats),
                 max(memory_stats),


### PR DESCRIPTION
Signed-off-by: jianoaix [iamjianxiao@gmail.com](mailto:iamjianxiao@gmail.com)

## Why are these changes needed?
"x / c * c" is still x, so it will make the stats off.

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
