### PR TITLE
[RLlib] Sync policy specs from local_worker_for_synching while recovering rollout/eval workers.

### DIFF
--- a/rllib/tests/test_worker_failures.py
+++ b/rllib/tests/test_worker_failures.py
@@ -516,7 +516,9 @@ class TestWorkerFailure(unittest.TestCase):
             )
 
             # Let's verify that our custom policy exists on both recovered workers.
-            has_test_policy = lambda w: "test_policy" in w.policy_map
+            def has_test_policy(w):
+                return "test_policy" in w.policy_map
+
             # Rollout worker has test policy.
             self.assertTrue(
                 all(

--- a/rllib/tests/test_worker_failures.py
+++ b/rllib/tests/test_worker_failures.py
@@ -458,7 +458,10 @@ class TestWorkerFailure(unittest.TestCase):
             self.assertTrue(
                 not any(
                     ray.get(
-                        [is_recreated(worker) for worker in a.evaluation_workers.remote_workers()]
+                        [
+                            is_recreated(worker)
+                            for worker in a.evaluation_workers.remote_workers()
+                        ]
                     )
                 )
             )
@@ -479,7 +482,10 @@ class TestWorkerFailure(unittest.TestCase):
             self.assertTrue(
                 all(
                     ray.get(
-                        [is_recreated(worker) for worker in a.evaluation_workers.remote_workers()]
+                        [
+                            is_recreated(worker)
+                            for worker in a.evaluation_workers.remote_workers()
+                        ]
                     )
                 )
             )
@@ -490,7 +496,10 @@ class TestWorkerFailure(unittest.TestCase):
             self.assertTrue(
                 all(
                     ray.get(
-                        [w.apply.remote(has_test_policy) for w in a.workers.remote_workers()]
+                        [
+                            w.apply.remote(has_test_policy)
+                            for w in a.workers.remote_workers()
+                        ]
                     )
                 )
             )
@@ -498,7 +507,10 @@ class TestWorkerFailure(unittest.TestCase):
             self.assertTrue(
                 all(
                     ray.get(
-                        [w.apply.remote(has_test_policy) for w in a.evaluation_workers.remote_workers()]
+                        [
+                            w.apply.remote(has_test_policy)
+                            for w in a.evaluation_workers.remote_workers()
+                        ]
                     )
                 )
             )

--- a/rllib/tests/test_worker_failures.py
+++ b/rllib/tests/test_worker_failures.py
@@ -10,6 +10,7 @@ from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 from ray.rllib.algorithms.a3c import A3CConfig
 from ray.rllib.algorithms.apex_dqn import ApexDQNConfig
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
+from ray.rllib.algorithms.dqn.dqn import DQNConfig
 from ray.rllib.algorithms.impala import ImpalaConfig
 from ray.rllib.algorithms.pg import PG, PGConfig
 from ray.rllib.algorithms.pg.pg_torch_policy import PGTorchPolicy
@@ -19,8 +20,6 @@ from ray.rllib.examples.env.random_env import RandomEnv
 from ray.rllib.policy.policy import PolicySpec
 from ray.rllib.utils.test_utils import framework_iterator
 from ray.tune.registry import register_env
-
-from rllib.algorithms.dqn.dqn import DQNConfig
 
 
 @ray.remote

--- a/rllib/tests/test_worker_failures.py
+++ b/rllib/tests/test_worker_failures.py
@@ -6,15 +6,21 @@ import gym
 import numpy as np
 
 import ray
+from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
+from ray.rllib.algorithms.a3c import A3CConfig
+from ray.rllib.algorithms.apex_dqn import ApexDQNConfig
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
+from ray.rllib.algorithms.impala import ImpalaConfig
 from ray.rllib.algorithms.pg import PG, PGConfig
 from ray.rllib.algorithms.pg.pg_torch_policy import PGTorchPolicy
-from ray.rllib.algorithms.registry import get_algorithm_class
+from ray.rllib.algorithms.ppo.ppo import PPOConfig
 from ray.rllib.env.multi_agent_env import make_multi_agent
 from ray.rllib.examples.env.random_env import RandomEnv
 from ray.rllib.policy.policy import PolicySpec
 from ray.rllib.utils.test_utils import framework_iterator
 from ray.tune.registry import register_env
+
+from rllib.algorithms.dqn.dqn import DQNConfig
 
 
 @ray.remote
@@ -162,18 +168,17 @@ class TestWorkerFailure(unittest.TestCase):
     def tearDownClass(cls) -> None:
         ray.shutdown()
 
-    def _do_test_fault_ignore(self, algo: str, config: dict, fail_eval: bool = False):
-        algo_cls = get_algorithm_class(algo)
-
+    def _do_test_fault_ignore(self, config: AlgorithmConfig, fail_eval: bool = False):
         # Test fault handling
-        config["num_workers"] = 2
-        config["ignore_worker_failures"] = True
+        config.num_workers = 2
+        config.ignore_worker_failures = True
+        config.env = "fault_env"
         # Make worker idx=1 fail. Other workers will be ok.
-        config["env_config"] = {"bad_indices": [1]}
+        config.env_config = {"bad_indices": [1]}
         if fail_eval:
-            config["evaluation_num_workers"] = 2
-            config["evaluation_interval"] = 1
-            config["evaluation_config"] = {
+            config.evaluation_num_workers = 2
+            config.evaluation_interval = 1
+            config.evaluation_config = {
                 "ignore_worker_failures": True,
                 "env_config": {
                     # Make worker idx=1 fail. Other workers will be ok.
@@ -183,7 +188,7 @@ class TestWorkerFailure(unittest.TestCase):
             }
 
         for _ in framework_iterator(config, frameworks=("tf2", "torch")):
-            algo = algo_cls(config=config, env="fault_env")
+            algo = config.build()
             result = algo.train()
 
             # Both rollout workers are healthy.
@@ -194,18 +199,17 @@ class TestWorkerFailure(unittest.TestCase):
 
             algo.stop()
 
-    def _do_test_fault_fatal(self, alg, config, fail_eval=False):
-        agent_cls = get_algorithm_class(alg)
-
+    def _do_test_fault_fatal(self, config, fail_eval=False):
         # Test raises real error when out of workers.
-        config["num_workers"] = 2
-        config["ignore_worker_failures"] = False
+        config.num_workers = 2
+        config.ignore_worker_failures = False
+        config.env = "fault_env"
         # Make both worker idx=1 and 2 fail.
-        config["env_config"] = {"bad_indices": [1, 2]}
+        config.env_config = {"bad_indices": [1, 2]}
         if fail_eval:
-            config["evaluation_num_workers"] = 2
-            config["evaluation_interval"] = 1
-            config["evaluation_config"] = {
+            config.evaluation_num_workers = 2
+            config.evaluation_interval = 1
+            config.evaluation_config = {
                 "ignore_worker_failures": False,
                 # Make eval worker (index 1) fail.
                 "env_config": {
@@ -215,19 +219,17 @@ class TestWorkerFailure(unittest.TestCase):
             }
 
         for _ in framework_iterator(config, frameworks=("torch", "tf")):
-            a = agent_cls(config=config, env="fault_env")
+            a = config.build()
             self.assertRaises(Exception, lambda: a.train())
             a.stop()
 
-    def _do_test_fault_fatal_but_recreate(self, alg, config):
-        register_env("fault_env", lambda c: FaultInjectEnv(c))
-        agent_cls = get_algorithm_class(alg)
-
+    def _do_test_fault_fatal_but_recreate(self, config):
         # Test raises real error when out of workers.
-        config["num_workers"] = 1
-        config["evaluation_num_workers"] = 1
-        config["evaluation_interval"] = 1
-        config["evaluation_config"] = {
+        config.num_workers = 1
+        config.evaluation_num_workers = 1
+        config.evaluation_interval = 1
+        config.env = "fault_env"
+        config.evaluation_config = {
             "recreate_failed_workers": True,
             # Make eval worker (index 1) fail.
             "env_config": {
@@ -236,7 +238,7 @@ class TestWorkerFailure(unittest.TestCase):
         }
 
         for _ in framework_iterator(config, frameworks=("tf", "tf2", "torch")):
-            a = agent_cls(config=config, env="fault_env")
+            a = config.build()
             # Expect this to go well and all faulty workers are recovered.
             self.assertTrue(
                 not any(
@@ -260,55 +262,63 @@ class TestWorkerFailure(unittest.TestCase):
 
     def test_fatal(self):
         # Test the case where all workers fail (w/o recovery).
-        self._do_test_fault_fatal("PG", {"optimizer": {}})
+        self._do_test_fault_fatal(PGConfig().training(optimizer={}))
 
     def test_async_grads(self):
-        self._do_test_fault_ignore("A3C", {"optimizer": {"grads_per_step": 1}})
+        self._do_test_fault_ignore(A3CConfig().training(optimizer={"grads_per_step": 1}))
 
     def test_async_replay(self):
-        self._do_test_fault_ignore(
-            "APEX",
-            {
-                "num_gpus": 0,
-                "min_sample_timesteps_per_iteration": 1000,
-                "min_time_s_per_iteration": 1,
-                "explore": False,
-                "num_steps_sampled_before_learning_starts": 1000,
-                "target_network_update_freq": 100,
-                "optimizer": {
+        config = (
+            ApexDQNConfig()
+            .training(
+                optimizer={
                     "num_replay_buffer_shards": 1,
                 },
-            },
+            )
+            .rollouts(
+                num_rollout_workers=2,
+            )
+            .reporting(
+                min_sample_timesteps_per_iteration=1000,
+                min_time_s_per_iteration=1,
+            )
+            .resources(num_gpus=0)
+            .exploration(explore=False)
         )
+        config.target_network_update_freq = 100
+        self._do_test_fault_ignore(config=config)
 
     def test_async_samples(self):
-        self._do_test_fault_ignore("IMPALA", {"num_gpus": 0})
+        self._do_test_fault_ignore(ImpalaConfig().resources(num_gpus=0))
 
     def test_sync_replay(self):
-        self._do_test_fault_ignore("DQN", {"min_sample_timesteps_per_iteration": 1})
+        self._do_test_fault_ignore(DQNConfig().reporting(
+            min_sample_timesteps_per_iteration=1
+        ))
 
     def test_multi_g_p_u(self):
         self._do_test_fault_ignore(
-            "PPO",
-            {
-                "num_sgd_iter": 1,
-                "train_batch_size": 10,
-                "rollout_fragment_length": 10,
-                "sgd_minibatch_size": 1,
-            },
+            PPOConfig()
+            .rollouts(rollout_fragment_length=10)
+            .training(
+                train_batch_size=10,
+                sgd_minibatch_size=1,
+                num_sgd_iter=1,
+            )
         )
 
     def test_sync_samples(self):
-        self._do_test_fault_ignore("PG", {"optimizer": {}})
+        self._do_test_fault_ignore(PGConfig().training(optimizer={}))
 
     def test_async_sampling_option(self):
-        self._do_test_fault_ignore("PG", {"optimizer": {}, "sample_async": True})
+        self._do_test_fault_ignore(
+            PGConfig().rollouts(sample_async=True).training(optimizer={})
+        )
 
     def test_eval_workers_failing_ignore(self):
         # Test the case where one eval worker fails, but we chose to ignore.
         self._do_test_fault_ignore(
-            "PG",
-            config={"model": {"fcnet_hiddens": [4]}},
+            PGConfig().training(model={"fcnet_hiddens": [4]}),
             fail_eval=True,
         )
 
@@ -324,13 +334,12 @@ class TestWorkerFailure(unittest.TestCase):
             .training(model={"fcnet_hiddens": [4]})
         )
 
-        self._do_test_fault_fatal_but_recreate("PG", config=config.to_dict())
+        self._do_test_fault_fatal_but_recreate(config)
 
     def test_eval_workers_failing_fatal(self):
         # Test the case where all eval workers fail (w/o recovery).
         self._do_test_fault_fatal(
-            "PG",
-            config={"model": {"fcnet_hiddens": [4]}},
+            PGConfig().training(model={"fcnet_hiddens": [4]}),
             fail_eval=True,
         )
 
@@ -339,27 +348,31 @@ class TestWorkerFailure(unittest.TestCase):
         COUNTER_NAME = "test_workers_fatal_but_recover"
         counter = Counter.options(name=COUNTER_NAME).remote()
 
-        config = {
-            "num_workers": 2,
-            # Worker fault tolerance.
-            "ignore_worker_failures": False,  # Do not ignore
-            "recreate_failed_workers": True,  # But recover.
-            "model": {"fcnet_hiddens": [4]},
-            "env_config": {
+        config = (
+            PGConfig()
+            .rollouts(
+                num_rollout_workers=2,
+                ignore_worker_failures=False,  # Do not ignore
+                recreate_failed_workers=True,  # But recover.
+            )
+            .training(
+                model={"fcnet_hiddens": [4]},
+            )
+            .environment(env="fault_env", env_config={
                 # Make both worker idx=1 and 2 fail.
                 "bad_indices": [1, 2],
                 # Env throws error between steps 100 and 102.
                 "failure_start_count": 100,
                 "failure_stop_count": 102,
                 "counter": COUNTER_NAME,
-            },
-        }
+            })
+        )
 
         for _ in framework_iterator(config, frameworks=("tf2", "torch")):
             # Reset interaciton counter.
             ray.wait([counter.reset.remote()])
 
-            a = PG(config=config, env="fault_env")
+            a = config.build()
 
             # Before train loop, workers are fresh and not recreated.
             self.assertTrue(
@@ -404,45 +417,50 @@ class TestWorkerFailure(unittest.TestCase):
         COUNTER_NAME = "test_policies_are_restored_on_recovered_worker"
         counter = Counter.options(name=COUNTER_NAME).remote()
 
-        config = {
-            "num_workers": 2,
-            # Worker fault tolerance.
-            "ignore_worker_failures": False,  # Do not ignore
-            "recreate_failed_workers": True,  # But recover.
-            "model": {"fcnet_hiddens": [4]},
-            "env_config": {
+        config = (
+            PGConfig()
+            .rollouts(
+                num_rollout_workers=2,
+                ignore_worker_failures=False,  # Do not ignore
+                recreate_failed_workers=True,  # But recover.
+            )
+            .training(
+                model={"fcnet_hiddens": [4]},
+            )
+            .environment(env="multi-agent-fault_env", env_config={
                 # Make both worker idx=1 and 2 fail.
                 "bad_indices": [1, 2],
                 # Env throws error between steps 100 and 102.
                 "failure_start_count": 100,
                 "failure_stop_count": 102,
                 "counter": COUNTER_NAME,
-            },
-            # 2 eval workers.
-            "evaluation_num_workers": 1,
-            "evaluation_interval": 1,
-            "evaluation_config": {
-                "ignore_worker_failures": False,
-                "recreate_failed_workers": True,
-                # Restart the entire eval worker.
-                "restart_failed_sub_environments": False,
-                "env_config": {
-                    "evaluation": True,
-                    # Make eval worker (index 1) fail.
-                    "bad_indices": [1],
-                    "failure_start_count": 10,
-                    "failure_stop_count": 12,
-                    "counter": COUNTER_NAME,
+            })
+            .evaluation(
+                evaluation_num_workers=1,
+                evaluation_interval=1,
+                evaluation_config={
+                    "ignore_worker_failures": False,
+                    "recreate_failed_workers": True,
+                    # Restart the entire eval worker.
+                    "restart_failed_sub_environments": False,
+                    "env_config": {
+                        "evaluation": True,
+                        # Make eval worker (index 1) fail.
+                        "bad_indices": [1],
+                        "failure_start_count": 10,
+                        "failure_stop_count": 12,
+                        "counter": COUNTER_NAME,
+                    },
                 },
-            },
-            "callbacks": AddPolicyCallback,
-        }
+            )
+            .callbacks(callbacks_class=AddPolicyCallback)
+        )
 
         for _ in framework_iterator(config, frameworks=("tf2", "torch")):
             # Reset interaciton counter.
             ray.wait([counter.reset.remote()])
 
-            a = PG(config=config, env="multi-agent-fault_env")
+            a = config.build()
 
             # Should have the custom policy.
             self.assertIsNotNone(a.get_policy("test_policy"))
@@ -520,35 +538,41 @@ class TestWorkerFailure(unittest.TestCase):
         COUNTER_NAME = "test_eval_workers_fault_but_recover"
         counter = Counter.options(name=COUNTER_NAME).remote()
 
-        config = {
-            "num_workers": 2,
-            # Worker fault tolerance.
-            "ignore_worker_failures": True,  # Ignore failure.
-            "recreate_failed_workers": True,  # And recover.
-            "model": {"fcnet_hiddens": [4]},
-            # 2 eval workers.
-            "evaluation_num_workers": 2,
-            "evaluation_interval": 1,
-            "evaluation_config": {
-                "env_config": {
-                    "evaluation": True,
-                    "p_done": 0.0,
-                    "max_episode_len": 20,
-                    # Make both eval workers fail.
-                    "bad_indices": [1, 2],
-                    # Env throws error between steps 10 and 12.
-                    "failure_start_count": 10,
-                    "failure_stop_count": 12,
-                    "counter": COUNTER_NAME,
-                }
-            },
-        }
+        config = (
+            PGConfig()
+            .rollouts(
+                num_rollout_workers=2,
+                ignore_worker_failures=True,   # Ignore failure.
+                recreate_failed_workers=True,  # And recover
+            )
+            .training(
+                model={"fcnet_hiddens": [4]},
+            )
+            .environment(env="fault_env")
+            .evaluation(
+                evaluation_num_workers=2,
+                evaluation_interval=1,
+                evaluation_config={
+                    "env_config": {
+                        "evaluation": True,
+                        "p_done": 0.0,
+                        "max_episode_len": 20,
+                        # Make both eval workers fail.
+                        "bad_indices": [1, 2],
+                        # Env throws error between steps 10 and 12.
+                        "failure_start_count": 10,
+                        "failure_stop_count": 12,
+                        "counter": COUNTER_NAME,
+                    },
+                },
+            )
+        )
 
         for _ in framework_iterator(config, frameworks=("tf2", "torch")):
             # Reset interaciton counter.
             ray.wait([counter.reset.remote()])
 
-            a = PG(config=config, env="fault_env")
+            a = config.build()
 
             # Before train loop, workers are fresh and not recreated.
             self.assertTrue(
@@ -602,35 +626,40 @@ class TestWorkerFailure(unittest.TestCase):
         COUNTER_NAME = "test_eval_workers_fault_but_restore_env"
         counter = Counter.options(name=COUNTER_NAME).remote()
 
-        config = {
-            "num_workers": 2,
-            # Worker fault tolerance.
-            "ignore_worker_failures": True,
-            "recreate_failed_workers": True,
-            "model": {"fcnet_hiddens": [4]},
-            "env_config": {
+        config = (
+            PGConfig()
+            .rollouts(
+                num_rollout_workers=2,
+                ignore_worker_failures=True,   # Ignore failure.
+                recreate_failed_workers=True,  # And recover
+            )
+            .training(
+                model={"fcnet_hiddens": [4]},
+            )
+            .environment(env="fault_env", env_config={
                 # Make both worker idx=1 and 2 fail.
                 "bad_indices": [1, 2],
                 # Env throws error before step 2.
                 "failure_stop_count": 2,
                 "counter": COUNTER_NAME,
-            },
-            # 2 eval workers.
-            "evaluation_num_workers": 2,
-            "evaluation_interval": 1,
-            "evaluation_config": {
-                "ignore_worker_failures": True,
-                "recreate_failed_workers": True,
-                # Now instead of recreating failed workers,
-                # we want to recreate the failed sub env instead.
-                "restart_failed_sub_environments": True,
-                "env_config": {
-                    "evaluation": True,
-                    # Make eval worker (index 1) fail.
-                    "bad_indices": [1],
+            })
+            .evaluation(
+                evaluation_num_workers=2,
+                evaluation_interval=1,
+                evaluation_config={
+                    "ignore_worker_failures": True,
+                    "recreate_failed_workers": True,
+                    # Now instead of recreating failed workers,
+                    # we want to recreate the failed sub env instead.
+                    "restart_failed_sub_environments": True,
+                    "env_config": {
+                        "evaluation": True,
+                        # Make eval worker (index 1) fail.
+                        "bad_indices": [1],
+                    },
                 },
-            },
-        }
+            )
+        )
 
         for _ in framework_iterator(config, frameworks=("tf2", "torch")):
             # Reset interaciton counter.
@@ -688,44 +717,53 @@ class TestWorkerFailure(unittest.TestCase):
         COUNTER_NAME = "test_multi_agent_env_eval_workers_fault_but_restore_env"
         counter = Counter.options(name=COUNTER_NAME).remote()
 
-        config = {
-            "num_workers": 2,
-            "model": {"fcnet_hiddens": [4]},
-            # Workers do not fault and no fault tolerance.
-            "env_config": {},
-            "multiagent": {
-                "policies": {
+        config = (
+            PGConfig()
+            .rollouts(
+                num_rollout_workers=2,
+            )
+            .training(
+                model={"fcnet_hiddens": [4]},
+            )
+            .environment(
+                env="multi-agent-fault_env",
+                # Workers do not fault and no fault tolerance.
+                env_config={},
+                disable_env_checking=True,
+            )
+            .multi_agent(
+                policies={
                     "main_agent": PolicySpec(),
                 },
-                "policies_to_train": ["main_agent"],
-                "policy_mapping_fn": lambda _: "main_agent",
-            },
-            # 2 eval workers.
-            "evaluation_num_workers": 2,
-            "evaluation_interval": 1,
-            "evaluation_config": {
-                # Now instead of recreating failed workers,
-                # we want to recreate the failed sub env instead.
-                "restart_failed_sub_environments": True,
-                "env_config": {
-                    "evaluation": True,
-                    "p_done": 0.0,
-                    "max_episode_len": 20,
-                    # Make eval worker (index 1) fail.
-                    "bad_indices": [1],
-                    "counter": COUNTER_NAME,
-                    "failure_start_count": 10,
-                    "failure_stop_count": 12,
+                policies_to_train=["main_agent"],
+                policy_mapping_fn=lambda _: "main_agent",
+            )
+            .evaluation(
+                evaluation_num_workers=2,
+                evaluation_interval=1,
+                evaluation_config={
+                    # Now instead of recreating failed workers,
+                    # we want to recreate the failed sub env instead.
+                    "restart_failed_sub_environments": True,
+                    "env_config": {
+                        "evaluation": True,
+                        "p_done": 0.0,
+                        "max_episode_len": 20,
+                        # Make eval worker (index 1) fail.
+                        "bad_indices": [1],
+                        "counter": COUNTER_NAME,
+                        "failure_start_count": 10,
+                        "failure_stop_count": 12,
+                    },
                 },
-            },
-            "disable_env_checking": True,
-        }
+            )
+        )
 
         for _ in framework_iterator(config, frameworks=("tf2", "torch")):
             # Reset interaciton counter.
             ray.wait([counter.reset.remote()])
 
-            a = PG(config=config, env="multi-agent-fault_env")
+            a = config.build()
 
             result = a.train()
 
@@ -753,37 +791,47 @@ class TestWorkerFailure(unittest.TestCase):
         COUNTER_NAME = "test_long_failure_period_restore_env"
         counter = Counter.options(name=COUNTER_NAME).remote()
 
-        config = {
-            "num_workers": 1,
-            "create_env_on_driver": False,
-            # Worker fault tolerance.
-            "recreate_failed_workers": True,  # Restore failed workers.
-            "restart_failed_sub_environments": True,  # And create failed envs.
-            "model": {"fcnet_hiddens": [4]},
-            "env_config": {
-                "p_done": 0.0,
-                "max_episode_len": 100,
-                "bad_indices": [1],
-                # Env throws error between steps 50 and 150.
-                "failure_start_count": 30,
-                "failure_stop_count": 80,
-                "counter": COUNTER_NAME,
-            },
-            # 2 eval workers.
-            "evaluation_num_workers": 1,
-            "evaluation_interval": 1,
-            "evaluation_config": {
-                "env_config": {
-                    "evaluation": True,
-                }
-            },
-        }
+        config = (
+            PGConfig()
+            .rollouts(
+                num_rollout_workers=1,
+                create_env_on_local_worker=False,
+                # Worker fault tolerance.
+                recreate_failed_workers=True,          # Restore failed workers.
+                restart_failed_sub_environments=True,  # And create failed envs.
+            )
+            .training(
+                model={"fcnet_hiddens": [4]},
+            )
+            .environment(
+                env="fault_env",
+                # Workers do not fault and no fault tolerance.
+                env_config={
+                    "p_done": 0.0,
+                    "max_episode_len": 100,
+                    "bad_indices": [1],
+                    # Env throws error between steps 50 and 150.
+                    "failure_start_count": 30,
+                    "failure_stop_count": 80,
+                    "counter": COUNTER_NAME,
+                },
+            )
+            .evaluation(
+                evaluation_num_workers=1,
+                evaluation_interval=1,
+                evaluation_config={
+                    "env_config": {
+                        "evaluation": True,
+                    }
+                },
+            )
+        )
 
         for _ in framework_iterator(config, frameworks=("tf2", "torch")):
             # Reset interaciton counter.
             ray.wait([counter.reset.remote()])
 
-            a = PG(config=config, env="fault_env")
+            a = config.build()
 
             # Before train loop, workers are fresh and not recreated.
             self.assertTrue(
@@ -839,40 +887,50 @@ class TestWorkerFailure(unittest.TestCase):
         COUNTER_NAME = "test_env_wait_time_workers_restore_env"
         counter = Counter.options(name=COUNTER_NAME).remote()
 
-        config = {
-            "num_workers": 1,
-            # Worker fault tolerance.
-            "ignore_worker_failures": False,  # Do not ignore
-            "recreate_failed_workers": True,  # But recover.
-            "restart_failed_sub_environments": True,
-            "model": {"fcnet_hiddens": [4]},
-            "rollout_fragment_length": 10,
-            "train_batch_size": 10,
-            "env_config": {
-                "p_done": 0.0,
-                "max_episode_len": 10,
-                "init_delay": 10,  # 10 sec init delay.
-                # Make both worker idx=1 and 2 fail.
-                "bad_indices": [1],
-                # Env throws error between steps 100 and 102.
-                "failure_start_count": 7,
-                "failure_stop_count": 8,
-                "counter": COUNTER_NAME,
-            },
-            # Use EMA PerfStat.
-            # Really large coeff to show the difference in env_wait_time_ms.
-            # Pretty much consider the last 2 data points.
-            "sampler_perf_stats_ema_coef": 0.5,
-            # Important, don't smooth over all the episodes,
-            # otherwise we don't see latency spike.
-            "metrics_num_episodes_for_smoothing": 1,
-        }
+        config = (
+            PGConfig()
+            .rollouts(
+                num_rollout_workers=1,
+                # Worker fault tolerance.
+                recreate_failed_workers=False,         # Do not ignore.
+                restart_failed_sub_environments=True,  # But recover.
+                rollout_fragment_length=10,
+                # Use EMA PerfStat.
+                # Really large coeff to show the difference in env_wait_time_ms.
+                # Pretty much consider the last 2 data points.
+                sampler_perf_stats_ema_coef=0.5,
+            )
+            .training(
+                model={"fcnet_hiddens": [4]},
+                train_batch_size=10,
+            )
+            .environment(
+                env="fault_env",
+                # Workers do not fault and no fault tolerance.
+                env_config={
+                    "p_done": 0.0,
+                    "max_episode_len": 10,
+                    "init_delay": 10,  # 10 sec init delay.
+                    # Make both worker idx=1 and 2 fail.
+                    "bad_indices": [1],
+                    # Env throws error between steps 100 and 102.
+                    "failure_start_count": 7,
+                    "failure_stop_count": 8,
+                    "counter": COUNTER_NAME,
+                },
+            )
+            .reporting(
+                # Important, don't smooth over all the episodes,
+                # otherwise we don't see latency spike.
+                metrics_num_episodes_for_smoothing=1
+            )
+        )
 
         for _ in framework_iterator(config, frameworks=("tf2", "torch")):
             # Reset interaciton counter.
             ray.wait([counter.reset.remote()])
 
-            a = PG(config=config, env="fault_env")
+            a = config.build()
 
             # Had to restore env during this iteration.
             result = a.train()

--- a/rllib/tests/test_worker_failures.py
+++ b/rllib/tests/test_worker_failures.py
@@ -265,7 +265,9 @@ class TestWorkerFailure(unittest.TestCase):
         self._do_test_fault_fatal(PGConfig().training(optimizer={}))
 
     def test_async_grads(self):
-        self._do_test_fault_ignore(A3CConfig().training(optimizer={"grads_per_step": 1}))
+        self._do_test_fault_ignore(
+            A3CConfig().training(optimizer={"grads_per_step": 1})
+        )
 
     def test_async_replay(self):
         config = (
@@ -292,9 +294,9 @@ class TestWorkerFailure(unittest.TestCase):
         self._do_test_fault_ignore(ImpalaConfig().resources(num_gpus=0))
 
     def test_sync_replay(self):
-        self._do_test_fault_ignore(DQNConfig().reporting(
-            min_sample_timesteps_per_iteration=1
-        ))
+        self._do_test_fault_ignore(
+            DQNConfig().reporting(min_sample_timesteps_per_iteration=1)
+        )
 
     def test_multi_g_p_u(self):
         self._do_test_fault_ignore(
@@ -358,14 +360,17 @@ class TestWorkerFailure(unittest.TestCase):
             .training(
                 model={"fcnet_hiddens": [4]},
             )
-            .environment(env="fault_env", env_config={
-                # Make both worker idx=1 and 2 fail.
-                "bad_indices": [1, 2],
-                # Env throws error between steps 100 and 102.
-                "failure_start_count": 100,
-                "failure_stop_count": 102,
-                "counter": COUNTER_NAME,
-            })
+            .environment(
+                env="fault_env",
+                env_config={
+                    # Make both worker idx=1 and 2 fail.
+                    "bad_indices": [1, 2],
+                    # Env throws error between steps 100 and 102.
+                    "failure_start_count": 100,
+                    "failure_stop_count": 102,
+                    "counter": COUNTER_NAME,
+                },
+            )
         )
 
         for _ in framework_iterator(config, frameworks=("tf2", "torch")):
@@ -427,14 +432,17 @@ class TestWorkerFailure(unittest.TestCase):
             .training(
                 model={"fcnet_hiddens": [4]},
             )
-            .environment(env="multi-agent-fault_env", env_config={
-                # Make both worker idx=1 and 2 fail.
-                "bad_indices": [1, 2],
-                # Env throws error between steps 100 and 102.
-                "failure_start_count": 100,
-                "failure_stop_count": 102,
-                "counter": COUNTER_NAME,
-            })
+            .environment(
+                env="multi-agent-fault_env",
+                env_config={
+                    # Make both worker idx=1 and 2 fail.
+                    "bad_indices": [1, 2],
+                    # Env throws error between steps 100 and 102.
+                    "failure_start_count": 100,
+                    "failure_stop_count": 102,
+                    "counter": COUNTER_NAME,
+                },
+            )
             .evaluation(
                 evaluation_num_workers=1,
                 evaluation_interval=1,
@@ -542,7 +550,7 @@ class TestWorkerFailure(unittest.TestCase):
             PGConfig()
             .rollouts(
                 num_rollout_workers=2,
-                ignore_worker_failures=True,   # Ignore failure.
+                ignore_worker_failures=True,  # Ignore failure.
                 recreate_failed_workers=True,  # And recover
             )
             .training(
@@ -630,19 +638,22 @@ class TestWorkerFailure(unittest.TestCase):
             PGConfig()
             .rollouts(
                 num_rollout_workers=2,
-                ignore_worker_failures=True,   # Ignore failure.
+                ignore_worker_failures=True,  # Ignore failure.
                 recreate_failed_workers=True,  # And recover
             )
             .training(
                 model={"fcnet_hiddens": [4]},
             )
-            .environment(env="fault_env", env_config={
-                # Make both worker idx=1 and 2 fail.
-                "bad_indices": [1, 2],
-                # Env throws error before step 2.
-                "failure_stop_count": 2,
-                "counter": COUNTER_NAME,
-            })
+            .environment(
+                env="fault_env",
+                env_config={
+                    # Make both worker idx=1 and 2 fail.
+                    "bad_indices": [1, 2],
+                    # Env throws error before step 2.
+                    "failure_stop_count": 2,
+                    "counter": COUNTER_NAME,
+                },
+            )
             .evaluation(
                 evaluation_num_workers=2,
                 evaluation_interval=1,
@@ -797,7 +808,7 @@ class TestWorkerFailure(unittest.TestCase):
                 num_rollout_workers=1,
                 create_env_on_local_worker=False,
                 # Worker fault tolerance.
-                recreate_failed_workers=True,          # Restore failed workers.
+                recreate_failed_workers=True,  # Restore failed workers.
                 restart_failed_sub_environments=True,  # And create failed envs.
             )
             .training(
@@ -892,7 +903,7 @@ class TestWorkerFailure(unittest.TestCase):
             .rollouts(
                 num_rollout_workers=1,
                 # Worker fault tolerance.
-                recreate_failed_workers=False,         # Do not ignore.
+                recreate_failed_workers=False,  # Do not ignore.
                 restart_failed_sub_environments=True,  # But recover.
                 rollout_fragment_length=10,
                 # Use EMA PerfStat.


### PR DESCRIPTION
When we recover failed workers, we need to sync the complete set of policy specs from local_worker_for_synching. Note that we can not simply rely on config["multiagent"]["policies"] because policies may be added dynamically during runtime.

Interestingly, this used to work for rollout workers by accident! We somehow happened to pass worker_set._remote_config["multiagent"]["policies"] into local rollout worker's __init__(), which became local_worker.policy_dict. Effectively, worker_set._remote_config["multiagent"] gets updated whenever a policy is dynamically added to local rollout worker's policy map. Since we use worker_set._remote_config to restore/recreate rollout workers, these new workers get access to the full policy spec dict.

But this was broken for evaluation workers, since evaluation_worker_set does NOT have a local worker. So evaluation_worker_set._remote_config would stay constant however many policies we add to remote evaluation workers.

This PR fixes things by de-coupling config dict from local worker's policy_dict. And provide proper policy_specs dict for recovering remote workers.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
