### PR TITLE
[Datasets] Add `read_tfrecords`

### DIFF
--- a/doc/source/data/api/input_output.rst
+++ b/doc/source/data/api/input_output.rst
@@ -53,6 +53,12 @@ Binary
 
 .. autofunction:: ray.data.read_binary_files
 
+TFRecord
+--------
+
+.. autofunction:: ray.data.read_tf_records
+
+
 Pandas
 ------
 
@@ -177,6 +183,9 @@ Built-in Datasources
     :members:
 
 .. autoclass:: ray.data.datasource.SimpleTorchDatasource
+    :members:
+
+.. autoclass:: ray.data.datasource.TFRecordsDatasource
     :members:
 
 Partitioning API

--- a/doc/source/data/api/input_output.rst
+++ b/doc/source/data/api/input_output.rst
@@ -53,10 +53,10 @@ Binary
 
 .. autofunction:: ray.data.read_binary_files
 
-TFRecord
---------
+TFRecords
+---------
 
-.. autofunction:: ray.data.read_tf_records
+.. autofunction:: ray.data.read_tfrecords
 
 
 Pandas
@@ -185,7 +185,7 @@ Built-in Datasources
 .. autoclass:: ray.data.datasource.SimpleTorchDatasource
     :members:
 
-.. autoclass:: ray.data.datasource.TFRecordsDatasource
+.. autoclass:: ray.data.datasource.TFRecordDatasource
     :members:
 
 Partitioning API

--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -180,7 +180,7 @@ Supported File Formats
 
 .. tabbed:: TFRecords
 
-  Call :func:`~ray.data.read_tfrecords` to read TFRecord files a tabular
+  Call :func:`~ray.data.read_tfrecords` to read TFRecord files into a tabular
   :class:`~ray.data.Dataset`.
 
   .. warning::

--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -178,7 +178,7 @@ Supported File Formats
 
   See the API docs for :func:`read_binary_files() <ray.data.read_binary_files>`.
 
-.. tabbed:: TFRecord
+.. tabbed:: TFRecords
 
   TODO
 

--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -180,8 +180,16 @@ Supported File Formats
 
 .. tabbed:: TFRecords
 
-  TODO
+  Call :func:`~ray.data.read_tfrecords` to read TFRecord files a tabular
+  :class:`~ray.data.Dataset`.
 
+  .. warning::
+      Messages that aren't of type ``tf.train.Example`` are ignored.
+
+  .. literalinclude:: ./doc_code/creating_datasets.py
+    :language: python
+    :start-after: __read_tfrecords_begin__
+    :end-before: __read_tfrecords_end__
 
 .. _dataset_reading_remote_storage:
 

--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -184,7 +184,8 @@ Supported File Formats
   :class:`~ray.data.Dataset`.
 
   .. warning::
-      Messages that aren't of type ``tf.train.Example`` are ignored.
+      Only `tf.train.Example <https://www.tensorflow.org/api_docs/python/tf/train/Example>`_
+      records are supported.
 
   .. literalinclude:: ./doc_code/creating_datasets.py
     :language: python

--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -178,6 +178,11 @@ Supported File Formats
 
   See the API docs for :func:`read_binary_files() <ray.data.read_binary_files>`.
 
+.. tabbed:: TFRecord
+
+  TODO
+
+
 .. _dataset_reading_remote_storage:
 
 Reading from Remote Storage

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -110,7 +110,7 @@ Advanced users can refer directly to the Ray Datasets :ref:`API reference <data-
         :text: Start Using Ray Datasets
         :classes: btn-outline-info btn-block
     ---
-    
+
     **Examples**
     ^^^
 
@@ -203,6 +203,9 @@ Supported Input Formats
    * - Binary Files
      - :func:`ray.data.read_binary_files()`
      - ✅
+   * - TFRecord Files
+     - :func:`ray.data.read_tf_records()`
+     - 🚧
    * - Python Objects
      - :func:`ray.data.from_items()`
      - ✅

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -204,7 +204,7 @@ Supported Input Formats
      - :func:`ray.data.read_binary_files()`
      - ✅
    * - TFRecord Files
-     - :func:`ray.data.read_tf_records()`
+     - :func:`ray.data.read_tfrecords()`
      - 🚧
    * - Python Objects
      - :func:`ray.data.from_items()`

--- a/doc/source/data/doc_code/creating_datasets.py
+++ b/doc/source/data/doc_code/creating_datasets.py
@@ -597,5 +597,5 @@ ds = ray.data.read_tfrecords(path)
 # -> Dataset(num_blocks=10, num_rows=150, schema={length: float64, width: float64, species: object})
 
 ds.show(1)
-# -> {'length': 5.099999904632568, 'width': 3.5, 'species': b'setosa'}
+# -> {'length': 5.1, 'width': 3.5, 'species': b'setosa'}
 # __read_tfrecords_end__

--- a/doc/source/data/doc_code/creating_datasets.py
+++ b/doc/source/data/doc_code/creating_datasets.py
@@ -590,3 +590,13 @@ ds = ray.data.read_parquet(
 )
 # __read_parquet_az_end__
 # fmt: on
+
+# __read_tfrecords_begin__
+# Create a tabular Dataset by reading a TFRecord file.
+ds = ray.data.read_tfrecords(path)
+# -> Dataset(num_blocks=10, num_rows=150, schema={length: float64, width: float64, species: object})
+
+ds.show(1)
+# -> {'length': 5.099999904632568, 'width': 3.5, 'species': b'setosa'}
+
+# __read_tfrecords_end__

--- a/doc/source/data/doc_code/creating_datasets.py
+++ b/doc/source/data/doc_code/creating_datasets.py
@@ -598,5 +598,4 @@ ds = ray.data.read_tfrecords(path)
 
 ds.show(1)
 # -> {'length': 5.099999904632568, 'width': 3.5, 'species': b'setosa'}
-
 # __read_tfrecords_end__

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -34,6 +34,7 @@ from ray.data.read_api import (  # noqa: F401
     read_parquet,
     read_parquet_bulk,
     read_text,
+    read_tf_records,
 )
 
 # Register custom Arrow JSON ReadOptions and ParseOptions serializer after worker has
@@ -74,6 +75,7 @@ __all__ = [
     "read_numpy",
     "read_parquet",
     "read_parquet_bulk",
+    "read_tf_records",
     "set_progress_bars",
     "Preprocessor",
 ]

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -34,7 +34,7 @@ from ray.data.read_api import (  # noqa: F401
     read_parquet,
     read_parquet_bulk,
     read_text,
-    read_tf_records,
+    read_tfrecords,
 )
 
 # Register custom Arrow JSON ReadOptions and ParseOptions serializer after worker has
@@ -75,7 +75,7 @@ __all__ = [
     "read_numpy",
     "read_parquet",
     "read_parquet_bulk",
-    "read_tf_records",
+    "read_tfrecords",
     "set_progress_bars",
     "Preprocessor",
 ]

--- a/python/ray/data/datasource/__init__.py
+++ b/python/ray/data/datasource/__init__.py
@@ -36,7 +36,7 @@ from ray.data.datasource.partitioning import (
     PathPartitionParser,
     Partitioning,
 )
-from ray.data.datasource.tfrecords_datasource import TFRecordsDatasource
+from ray.data.datasource.tfrecords_datasource import TFRecordDatasource
 from ray.data.datasource.tensorflow_datasource import SimpleTensorFlowDatasource
 from ray.data.datasource.torch_datasource import SimpleTorchDatasource
 

--- a/python/ray/data/datasource/__init__.py
+++ b/python/ray/data/datasource/__init__.py
@@ -36,6 +36,7 @@ from ray.data.datasource.partitioning import (
     PathPartitionParser,
     Partitioning,
 )
+from ray.data.datasource.tfrecords_datasource import TFRecordsDatasource
 from ray.data.datasource.tensorflow_datasource import SimpleTensorFlowDatasource
 from ray.data.datasource.torch_datasource import SimpleTorchDatasource
 
@@ -70,6 +71,7 @@ __all__ = [
     "Reader",
     "SimpleTensorFlowDatasource",
     "SimpleTorchDatasource",
+    "TFRecordDatasource",
     "WriteResult",
     "_S3FileSystemWrapper",
 ]

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -1,6 +1,6 @@
-from multiprocessing.sharedctypes import Value
 import tempfile
 from typing import Dict, List, Union
+import warnings
 
 import os
 import pandas as pd
@@ -36,7 +36,7 @@ class TFRecordDatasource(FileBasedDatasource):
                 try:
                     example.ParseFromString(record.numpy())
                 except DecodeError:
-                    raise ValueError(
+                    warnings.warn(
                         "`TFRecordDatasource` failed to parse `tf.train.Example` "
                         f"record in '{path}'. This error can occur if your TFRecord "
                         "file contains a message type other than `tf.train.Example`."
@@ -47,7 +47,9 @@ class TFRecordDatasource(FileBasedDatasource):
             return pd.DataFrame.from_records(data)
 
 
-def _convert_example_to_dict(example: tf.train.Example) -> pd.DataFrame:
+def _convert_example_to_dict(
+    example: tf.train.Example,
+) -> Dict[str, Union[bytes, List[bytes], float, List[float], int, List[int]]]:
     record = {}
     for feature_name, feature in example.features.feature.items():
         value = _get_feature_value(feature)

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -1,8 +1,7 @@
-import tempfile
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Iterable
 import warnings
+import struct
 
-import os
 import pandas as pd
 import pyarrow
 import tensorflow as tf
@@ -18,33 +17,21 @@ class TFRecordDatasource(FileBasedDatasource):
     def _read_file(self, f: "pyarrow.NativeFile", path: str, **reader_args) -> Block:
         from google.protobuf.message import DecodeError
 
-        with tempfile.NamedTemporaryFile() as temporary_file:
-            # TensorFlow doesn't expose a function for reading TFRecords with a file
-            # handle; you can only read TFRecords with a file path. So, if the TFRecord
-            # doesn't exist locally (e.g., because it's stored in S3), we have to
-            # download a copy.
-            local_path = path
-            if not os.path.exists(local_path):
-                f.write(temporary_file)
-                local_path = temporary_file.name
+        data = []
+        for record in _read_records(f):
+            example = tf.train.Example()
+            try:
+                example.ParseFromString(record)
+            except DecodeError:
+                warnings.warn(
+                    "`TFRecordDatasource` failed to parse `tf.train.Example` "
+                    f"message in '{path}'. This warning can occur if your TFRecord "
+                    "file contains a message type other than `tf.train.Example`."
+                )
 
-            dataset = tf.data.TFRecordDataset([local_path])
+            data.append(_convert_example_to_dict(example))
 
-            data = []
-            for record in dataset:
-                example = tf.train.Example()
-                try:
-                    example.ParseFromString(record.numpy())
-                except DecodeError:
-                    warnings.warn(
-                        "`TFRecordDatasource` failed to parse `tf.train.Example` "
-                        f"message in '{path}'. This warning can occur if your TFRecord "
-                        "file contains a message type other than `tf.train.Example`."
-                    )
-
-                data.append(_convert_example_to_dict(example))
-
-            return pd.DataFrame.from_records(data)
+        return pd.DataFrame.from_records(data)
 
 
 def _convert_example_to_dict(
@@ -76,3 +63,51 @@ def _get_feature_value(
         return list(feature.float_list.value)
     if feature.int64_list.value:
         return list(feature.int64_list.value)
+
+
+# Adapted from https://github.com/vahidk/tfrecord/blob/master/tfrecord/reader.py#L16-L96
+#
+# MIT License
+#
+# Copyright (c) 2020 Vahid Kazemi
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+def _read_records(
+    file: "pyarrow.NativeFile",
+) -> Iterable[memoryview]:
+    length_bytes = bytearray(8)
+    crc_bytes = bytearray(4)
+    datum_bytes = bytearray(1024 * 1024)
+    while True:
+        num_length_bytes_read = file.readinto(length_bytes)
+        if num_length_bytes_read == 0:
+            break
+        elif num_length_bytes_read != 8:
+            raise RuntimeError("Failed to read the record size.")
+        if file.readinto(crc_bytes) != 4:
+            raise RuntimeError("Failed to read the start token.")
+        (length,) = struct.unpack("<Q", length_bytes)
+        if length > len(datum_bytes):
+            datum_bytes = datum_bytes.zfill(int(length * 1.5))
+        datum_bytes_view = memoryview(datum_bytes)[:length]
+        if file.readinto(datum_bytes_view) != length:
+            raise RuntimeError("Failed to read the record.")
+        if file.readinto(crc_bytes) != 4:
+            raise RuntimeError("Failed to read the end token.")
+        yield datum_bytes_view

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -29,7 +29,7 @@ class TFRecordDatasource(FileBasedDatasource):
                 raise ValueError(
                     "`TFRecordDatasource` failed to parse `tf.train.Example` "
                     f"record in '{path}'. This error can occur if your TFRecord "
-                    f"file contains a message type other than `tf.train.Example`: {e}."
+                    f"file contains a message type other than `tf.train.Example`: {e}"
                 )
 
             data.append(_convert_example_to_dict(example))

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -1,0 +1,53 @@
+from typing import Dict, List, Union
+
+import pandas as pd
+import pyarrow
+import tensorflow as tf
+
+from ray.data.block import Block
+from ray.data.datasource.file_based_datasource import FileBasedDatasource
+
+
+class TFRecordsDatasource(FileBasedDatasource):
+
+    _FILE_EXTENSION = "tfrecords"
+
+    def _read_file(self, f: "pyarrow.NativeFile", path: str, **reader_args) -> Block:
+        dataset = tf.data.TFRecordDataset([path])
+
+        data = []
+        for record in dataset:
+            example = tf.train.Example()
+            example.ParseFromString(record.numpy())
+            data.append(_convert_example_to_dict(example))
+
+        return pd.DataFrame.from_records(data)
+
+
+def _convert_example_to_dict(example: tf.train.Example) -> pd.DataFrame:
+    record = {}
+    for feature_name, feature in example.features.feature.items():
+        value = _get_feature_value(feature)
+        if len(value) == 1:
+            value = value[0]
+        record[feature_name] = value
+    return record
+
+
+def _get_feature_value(
+    feature: tf.train.Feature,
+) -> Union[List[bytes], List[float], List[int]]:
+    values = (
+        feature.bytes_list.value,
+        feature.float_list.value,
+        feature.int64_list.value,
+    )
+    # Exactly one of `bytes_list`, `float_list`, and `int64_list` should contain data.
+    assert sum(bool(value) for value in values) == 1
+
+    if feature.bytes_list.value:
+        return feature.bytes_list.value
+    if feature.float_list.value:
+        return feature.float_list.value
+    if feature.int64_list.value:
+        return feature.int64_list.value

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -1,13 +1,15 @@
-from typing import Dict, List, Union, Iterable
+from typing import TYPE_CHECKING, Dict, List, Union, Iterable
 import warnings
 import struct
 
-import pyarrow
 import tensorflow as tf
 
 from ray.util.annotations import PublicAPI
 from ray.data.block import Block
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
+
+if TYPE_CHECKING:
+    import pyarrow
 
 
 @PublicAPI(stability="alpha")

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -2,8 +2,6 @@ from typing import TYPE_CHECKING, Dict, List, Union, Iterable
 import warnings
 import struct
 
-import tensorflow as tf
-
 from ray.util.annotations import PublicAPI
 from ray.data.block import Block
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
@@ -20,6 +18,7 @@ class TFRecordDatasource(FileBasedDatasource):
     def _read_file(self, f: "pyarrow.NativeFile", path: str, **reader_args) -> Block:
         from google.protobuf.message import DecodeError
         import pandas as pd
+        import tensorflow as tf
 
         data = []
         for record in _read_records(f):

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -38,7 +38,7 @@ class TFRecordDatasource(FileBasedDatasource):
                 except DecodeError:
                     warnings.warn(
                         "`TFRecordDatasource` failed to parse `tf.train.Example` "
-                        f"record in '{path}'. This error can occur if your TFRecord "
+                        f"message in '{path}'. This warning can occur if your TFRecord "
                         "file contains a message type other than `tf.train.Example`."
                     )
 

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -5,10 +5,12 @@ import struct
 import pyarrow
 import tensorflow as tf
 
+from ray.util.annotations import PublicAPI
 from ray.data.block import Block
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 
 
+@PublicAPI(stability="alpha")
 class TFRecordDatasource(FileBasedDatasource):
 
     _FILE_EXTENSION = "tfrecords"

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -2,7 +2,6 @@ from typing import Dict, List, Union, Iterable
 import warnings
 import struct
 
-import pandas as pd
 import pyarrow
 import tensorflow as tf
 
@@ -16,6 +15,7 @@ class TFRecordDatasource(FileBasedDatasource):
 
     def _read_file(self, f: "pyarrow.NativeFile", path: str, **reader_args) -> Block:
         from google.protobuf.message import DecodeError
+        import pandas as pd
 
         data = []
         for record in _read_records(f):

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -10,7 +10,7 @@ from ray.data.block import Block
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 
 
-class TFRecordsDatasource(FileBasedDatasource):
+class TFRecordDatasource(FileBasedDatasource):
 
     _FILE_EXTENSION = "tfrecords"
 

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -25,11 +25,11 @@ class TFRecordDatasource(FileBasedDatasource):
             example = tf.train.Example()
             try:
                 example.ParseFromString(record)
-            except DecodeError:
+            except DecodeError as e:
                 raise ValueError(
                     "`TFRecordDatasource` failed to parse `tf.train.Example` "
                     f"record in '{path}'. This error can occur if your TFRecord "
-                    "file contains a message type other than `tf.train.Example`."
+                    f"file contains a message type other than `tf.train.Example`: {e}."
                 )
 
             data.append(_convert_example_to_dict(example))

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -751,8 +751,34 @@ def read_tfrecords(
 ) -> Dataset[PandasRow]:
     """Create a dataset from TFRecord files that contain ``tf.train.Example`` messages.
 
+    .. warning::
+        This function exclusively supports ``tf.train.Example`` messages. If your
+        TFRecord files contain messages of other types, this function will error.
+
     Examples:
-        # TODO
+        >>> import os
+        >>> import tempfile
+        >>> import tensorflow as tf
+        >>> features = tf.train.Features(
+        ...     feature={
+        ...         "length": tf.train.Feature(float_list=tf.train.FloatList(value=[5.1])),
+        ...         "width": tf.train.Feature(float_list=tf.train.FloatList(value=[3.5])),
+        ...         "species": tf.train.Feature(bytes_list=tf.train.BytesList(value=[b"setosa"])),
+        ...     }
+        ... )
+        >>> example = tf.train.Example(features=features)
+        >>> path = os.path.join(tempfile.gettempdir(), "data.tfrecords")
+        >>> with tf.io.TFRecordWriter(path=path) as writer:
+        ...     writer.write(example.SerializeToString())
+
+        This function reads ``tf.train.Example`` messages into a tabular
+        :class:`~ray.data.Dataset`.
+
+        >>> import ray
+        >>> ds = ray.data.read_tfrecords(path)
+        >>> ds.to_pandas()
+           length  width    species
+        0     5.1    3.5  b'setosa'
 
     Args:
         paths: A single file/directory path or a list of file/directory paths.

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -752,8 +752,9 @@ def read_tfrecords(
     """Create a dataset from TFRecord files that contain ``tf.train.Example`` messages.
 
     .. warning::
-        This function exclusively supports ``tf.train.Example`` messages. Messages that
-        aren't of type ``tf.train.Example`` are ignored.
+        This function exclusively supports ``tf.train.Example`` messages. If a file
+        contains a message that isn't of type ``tf.train.Example``, then this function
+        errors.
 
     Examples:
         >>> import os
@@ -797,6 +798,9 @@ def read_tfrecords(
 
     Returns:
         A :class:`~ray.data.Dataset` that contains the example features.
+
+    Raises:
+        ValueError: If a file contains a message that isn't a ``tf.train.Example``.
     """  # noqa: E501
     return read_datasource(
         TFRecordDatasource(),

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -753,7 +753,7 @@ def read_tfrecords(
 
     .. warning::
         This function exclusively supports ``tf.train.Example`` messages. Messages that
-        aren't of type ``tf.train.Example`` are skipped.
+        aren't of type ``tf.train.Example`` are ignored.
 
     Examples:
         >>> import os

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -749,7 +749,9 @@ def read_tfrecords(
     meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
     partition_filter: Optional[PathPartitionFilter] = None,
 ) -> Dataset[PandasRow]:
-    """Create a dataset from TFRecord files that contain ``tf.train.Example`` messages.
+    """Create a dataset from TFRecord files that contain
+    `tf.train.Example <https://www.tensorflow.org/api_docs/python/tf/train/Example>`_
+    messages.
 
     .. warning::
         This function exclusively supports ``tf.train.Example`` messages. If a file

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -36,7 +36,7 @@ from ray.data.datasource import (
     PathPartitionFilter,
     RangeDatasource,
     ReadTask,
-    TFRecordsDatasource,
+    TFRecordDatasource,
 )
 from ray.data.datasource.file_based_datasource import (
     _unwrap_arrow_serialization_workaround,
@@ -740,7 +740,7 @@ def read_numpy(
 
 
 @PublicAPI(stability="alpha")
-def read_tf_records(
+def read_tfrecords(
     paths: Union[str, List[str]],
     *,
     filesystem: Optional["pyarrow.fs.FileSystem"] = None,
@@ -773,7 +773,7 @@ def read_tf_records(
         A :class:`~ray.data.Dataset` that contains the example features.
     """
     return read_datasource(
-        TFRecordsDatasource(),
+        TFRecordDatasource(),
         parallelism=parallelism,
         paths=paths,
         filesystem=filesystem,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -776,7 +776,7 @@ def read_tfrecords(
 
         >>> import ray
         >>> ds = ray.data.read_tfrecords(path)
-        >>> ds.to_pandas()
+        >>> ds.to_pandas()  # doctest: +SKIP
            length  width    species
         0     5.1    3.5  b'setosa'
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -752,8 +752,8 @@ def read_tfrecords(
     """Create a dataset from TFRecord files that contain ``tf.train.Example`` messages.
 
     .. warning::
-        This function exclusively supports ``tf.train.Example`` messages. If your
-        TFRecord files contain messages of other types, this function will error.
+        This function exclusively supports ``tf.train.Example`` messages. Messages that
+        aren't of type ``tf.train.Example`` are skipped.
 
     Examples:
         >>> import os
@@ -797,7 +797,7 @@ def read_tfrecords(
 
     Returns:
         A :class:`~ray.data.Dataset` that contains the example features.
-    """
+    """  # noqa: E501
     return read_datasource(
         TFRecordDatasource(),
         parallelism=parallelism,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -9,6 +9,7 @@ from ray.data._internal.arrow_block import ArrowRow
 from ray.data._internal.block_list import BlockList
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.lazy_block_list import LazyBlockList
+from ray.data._internal.pandas_block import PandasRow
 from ray.data._internal.plan import ExecutionPlan
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.stats import DatasetStats
@@ -35,6 +36,7 @@ from ray.data.datasource import (
     PathPartitionFilter,
     RangeDatasource,
     ReadTask,
+    TFRecordsDatasource,
 )
 from ray.data.datasource.file_based_datasource import (
     _unwrap_arrow_serialization_workaround,
@@ -734,6 +736,50 @@ def read_numpy(
         meta_provider=meta_provider,
         partition_filter=partition_filter,
         **numpy_load_args,
+    )
+
+
+@PublicAPI(stability="alpha")
+def read_tf_records(
+    paths: Union[str, List[str]],
+    *,
+    filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    parallelism: int = -1,
+    arrow_open_stream_args: Optional[Dict[str, Any]] = None,
+    meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
+    partition_filter: Optional[PathPartitionFilter] = None,
+) -> Dataset[PandasRow]:
+    """Create a dataset from TFRecord files that contain ``tf.train.Example`` messages.
+
+    Examples:
+        # TODO
+
+    Args:
+        paths: A single file/directory path or a list of file/directory paths.
+            A list of paths can contain both files and directories.
+        filesystem: The filesystem implementation to read from.
+        parallelism: The requested parallelism of the read. Parallelism may be
+            limited by the number of files in the dataset.
+        arrow_open_stream_args: Key-word arguments passed to
+            ``pyarrow.fs.FileSystem.open_input_stream``.
+        meta_provider: File metadata provider. Custom metadata providers may
+            be able to resolve file metadata more quickly and/or accurately.
+        partition_filter: Path-based partition filter, if any. Can be used
+            with a custom callback to read only selected partitions of a dataset.
+            By default, this filters out any file paths whose file extension does not
+            match ``"*.tfrecords*"``.
+
+    Returns:
+        A :class:`~ray.data.Dataset` that contains the example features.
+    """
+    return read_datasource(
+        TFRecordsDatasource(),
+        parallelism=parallelism,
+        paths=paths,
+        filesystem=filesystem,
+        open_stream_args=arrow_open_stream_args,
+        meta_provider=meta_provider,
+        partition_filter=partition_filter,
     )
 
 

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -3297,7 +3297,7 @@ def test_read_tfrecords(ray_start_regular_shared, tmp_path):
     example = tf.train.Example(features=features)
     path = os.path.join(tmp_path, "data.tfrecords")
     with tf.io.TFRecordWriter(path=path) as writer:
-        writer.write(features.SerializeToString())
+        writer.write(example.SerializeToString())
 
     ds = ray.data.read_tfrecords(path)
 

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -3299,7 +3299,7 @@ def test_read_tf_records(ray_start_regular_shared, tmp_path):
     with tf.io.TFRecordWriter(path=path) as writer:
         writer.write(example.SerializeToString())
 
-    ds = ray.data.read_tf_records(path)
+    ds = ray.data.read_tfrecords(path)
 
     df = ds.to_pandas()
     assert list(df.columns) == [

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -3302,15 +3302,15 @@ def test_read_tfrecords(ray_start_regular_shared, tmp_path):
     ds = ray.data.read_tfrecords(path)
 
     df = ds.to_pandas()
-    assert list(df.columns) == [
-        "int64",
-        "int64_list",
-        "float",
-        "float_list",
-        "bytes",
-        "bytes_list",
-    ]
-    assert list(df.dtypes) == [np.int64, object, np.float, object, object, object]
+    # Protobuf serializes features in a non-deterministic order.
+    assert dict(df.dtypes) == {
+        "int64": np.int64,
+        "int64_list": object,
+        "float": np.float,
+        "float_list": object,
+        "bytes": object,
+        "bytes_list": object,
+    }
     assert list(df["int64"]) == [1]
     assert list(df["int64_list"]) == [[1, 2, 3, 4]]
     assert list(df["float"]) == [1.0]

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -3275,7 +3275,7 @@ def test_read_s3_file_error(ray_start_regular_shared, s3_path):
     assert error_message in str(e.value)
 
 
-def test_read_tf_records(ray_start_regular_shared, tmp_path):
+def test_read_tfrecords(ray_start_regular_shared, tmp_path):
     import tensorflow as tf
 
     features = tf.train.Features(
@@ -3297,7 +3297,7 @@ def test_read_tf_records(ray_start_regular_shared, tmp_path):
     example = tf.train.Example(features=features)
     path = os.path.join(tmp_path, "data.tfrecords")
     with tf.io.TFRecordWriter(path=path) as writer:
-        writer.write(example.SerializeToString())
+        writer.write(features.SerializeToString())
 
     ds = ray.data.read_tfrecords(path)
 


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Users want to read data stored in TFRecords. For example, see read [TFRecordDataset -> ray.data.Dataset for TensorflowTrainer](https://discuss.ray.io/t/tfrecorddataset-ray-data-dataset-for-tensorflowtrainer/7021).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
