### PR TITLE
Migrate the deprecated placement_group option to PlacementGroupSchedulingStrategy

### DIFF
--- a/python/ray/data/tests/test_auto_parallelism.py
+++ b/python/ray/data/tests/test_auto_parallelism.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, astuple
 import ray
 from ray.data.context import DatasetContext
 from ray.data._internal.util import _autodetect_parallelism
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from ray.tests.conftest import *  # noqa
 
 
@@ -123,17 +124,29 @@ def test_auto_parallelism_placement_group(shutdown_only):
 
     # 1/16 * 4 * 16 = 4
     pg = ray.util.placement_group([{"CPU": 1}])
-    num_blocks = ray.get(run.options(placement_group=pg).remote())
+    num_blocks = ray.get(
+        run.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
+    )
     assert num_blocks == 4, num_blocks
 
     # 2/16 * 4 * 16 = 8
     pg = ray.util.placement_group([{"CPU": 2}])
-    num_blocks = ray.get(run.options(placement_group=pg).remote())
+    num_blocks = ray.get(
+        run.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
+    )
     assert num_blocks == 8, num_blocks
 
     # 1/8 * 4 * 16 = 8
     pg = ray.util.placement_group([{"CPU": 1, "GPU": 1}])
-    num_blocks = ray.get(run.options(placement_group=pg).remote())
+    num_blocks = ray.get(
+        run.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
+    )
     assert num_blocks == 8, num_blocks
 
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -32,6 +32,7 @@ from ray.data.extensions.tensor_extension import (
 from ray.data.row import TableRow
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 
 def maybe_pipeline(ds, enabled):
@@ -141,7 +142,9 @@ def test_avoid_placement_group_capture(shutdown_only, pipelined):
     pg = ray.util.placement_group([{"CPU": 1}])
     ray.get(
         run.options(
-            placement_group=pg, placement_group_capture_child_tasks=True
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg, placement_group_capture_child_tasks=True
+            )
         ).remote()
     )
 

--- a/python/ray/serve/benchmarks/scalability.py
+++ b/python/ray/serve/benchmarks/scalability.py
@@ -33,6 +33,7 @@ import subprocess
 import requests
 
 import ray
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from ray.util.placement_group import placement_group, remove_placement_group
 
 from ray import serve
@@ -108,7 +109,11 @@ def run_wrk():
 
 results = ray.get(
     [
-        run_wrk.options(placement_group=pg, placement_group_bundle_index=i).remote()
+        run_wrk.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg, placement_group_bundle_index=i
+            )
+        ).remote()
         for i in range(expected_num_nodes)
     ]
 )

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -6,6 +6,7 @@ from time import sleep
 import pytest
 
 import ray
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 import ray._private.gcs_utils as gcs_utils
 from ray._private.test_utils import (
     convert_actor_state,
@@ -594,7 +595,9 @@ def test_pg_actor_workloads(ray_start_regular_with_external_redis):
 
             return os.getpid()
 
-    c = Counter.options(placement_group=pg).remote()
+    c = Counter.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+    ).remote()
     r = ray.get(c.r.remote(10))
     assert r == 10
 

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -38,7 +38,10 @@ def test_placement_ready(ray_start_regular, connect_to_client):
     with connect_to_client_or_not(connect_to_client):
         pg = ray.util.placement_group(bundles=[{"CPU": 1}])
         ray.get(pg.ready())
-        a = Actor.options(num_cpus=1, placement_group=pg).remote()
+        a = Actor.options(
+            num_cpus=1,
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
+        ).remote()
         ray.get(a.v.remote())
         ray.get(pg.ready())
 
@@ -64,12 +67,20 @@ def test_placement_group_invalid_resource_request(shutdown_only):
     # The actor cannot be scheduled with the default because
     # it requires 1 cpu for the placement, but the pg doesn't have it.
     with pytest.raises(ValueError):
-        a = A.options(placement_group=pg).remote()
+        a = A.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
     # Shouldn't work with 1 CPU because pg doesn't contain CPUs.
     with pytest.raises(ValueError):
-        a = A.options(num_cpus=1, placement_group=pg).remote()
+        a = A.options(
+            num_cpus=1,
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
+        ).remote()
     # 0 CPU should work.
-    a = A.options(num_cpus=0, placement_group=pg).remote()
+    a = A.options(
+        num_cpus=0,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
+    ).remote()
     ray.get(a.ready.remote())
     del a
 
@@ -84,16 +95,25 @@ def test_placement_group_invalid_resource_request(shutdown_only):
     # When resources are given to the placement group,
     # it automatically adds 1 CPU to resources, so it should fail.
     with pytest.raises(ValueError):
-        b = B.options(placement_group=pg).remote()
+        b = B.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
     # If 0 cpu is given, it should work.
-    b = B.options(num_cpus=0, placement_group=pg).remote()
+    b = B.options(
+        num_cpus=0,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
+    ).remote()
     ray.get(b.ready.remote())
     del b
     # If resources are requested too much, it shouldn't work.
     with pytest.raises(ValueError):
         # The actor cannot be scheduled with no resource specified.
         # Note that the default actor has 0 cpu.
-        B.options(num_cpus=0, resources={"a": 2}, placement_group=pg).remote()
+        B.options(
+            num_cpus=0,
+            resources={"a": 2},
+            schduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
+        ).remote()
 
     #
     # Test a function with 1 CPU.
@@ -104,9 +124,16 @@ def test_placement_group_invalid_resource_request(shutdown_only):
 
     # 1 CPU shouldn't work because the pg doesn't have CPU bundles.
     with pytest.raises(ValueError):
-        f.options(placement_group=pg).remote()
+        f.options(
+            schduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
     # 0 CPU should work.
-    ray.get(f.options(placement_group=pg, num_cpus=0).remote())
+    ray.get(
+        f.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
+            num_cpus=0,
+        ).remote()
+    )
 
     #
     # Test a function with 0 CPU.
@@ -116,7 +143,11 @@ def test_placement_group_invalid_resource_request(shutdown_only):
         pass
 
     # 0 CPU should work.
-    ray.get(g.options(placement_group=pg).remote())
+    ray.get(
+        g.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
+    )
 
     placement_group_assert_no_leak([pg])
 
@@ -158,10 +189,14 @@ def test_placement_group_pack(
         )
         ray.get(placement_group.ready())
         actor_1 = Actor.options(
-            placement_group=placement_group, placement_group_bundle_index=0
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=placement_group, placement_group_bundle_index=0
+            )
         ).remote()
         actor_2 = Actor.options(
-            placement_group=placement_group, placement_group_bundle_index=1
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=placement_group, placement_group_bundle_index=1
+            )
         ).remote()
 
         ray.get(actor_1.value.remote())
@@ -214,10 +249,14 @@ def test_placement_group_strict_pack(ray_start_cluster, connect_to_client):
         )
         ray.get(placement_group.ready())
         actor_1 = Actor.options(
-            placement_group=placement_group, placement_group_bundle_index=0
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=placement_group, placement_group_bundle_index=0
+            )
         ).remote()
         actor_2 = Actor.options(
-            placement_group=placement_group, placement_group_bundle_index=1
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=placement_group, placement_group_bundle_index=1
+            )
         ).remote()
 
         ray.get(actor_1.value.remote())
@@ -274,8 +313,9 @@ def test_placement_group_spread(
         ray.get(placement_group.ready())
         actors = [
             Actor.options(
-                placement_group=placement_group,
-                placement_group_bundle_index=i,
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=placement_group, placement_group_bundle_index=i
+                ),
                 num_cpus=2,
             ).remote()
             for i in range(num_nodes)
@@ -330,8 +370,9 @@ def test_placement_group_strict_spread(
         ray.get(placement_group.ready())
         actors = [
             Actor.options(
-                placement_group=placement_group,
-                placement_group_bundle_index=i,
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=placement_group, placement_group_bundle_index=i
+                ),
                 num_cpus=1,
             ).remote()
             for i in range(num_nodes)
@@ -350,7 +391,9 @@ def test_placement_group_strict_spread(
 
         actors_no_special_bundle = [
             Actor.options(
-                placement_group=placement_group,
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=placement_group
+                ),
                 num_cpus=1,
             ).remote()
             for _ in range(num_nodes)
@@ -358,7 +401,9 @@ def test_placement_group_strict_spread(
         [ray.get(actor.value.remote()) for actor in actors_no_special_bundle]
 
         actor_no_resource = Actor.options(
-            placement_group=placement_group,
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=placement_group
+            ),
             num_cpus=2,
         ).remote()
         with pytest.raises(ray.exceptions.GetTimeoutError):
@@ -382,7 +427,9 @@ def test_placement_group_actor_resource_ids(ray_start_cluster, connect_to_client
 
     with connect_to_client_or_not(connect_to_client):
         g1 = ray.util.placement_group([{"CPU": 2}])
-        a1 = F.options(placement_group=g1).remote()
+        a1 = F.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=g1)
+        ).remote()
         resources = ray.get(a1.f.remote())
         assert len(resources) == 1, resources
         assert "CPU_group_" in list(resources.keys())[0], resources
@@ -403,14 +450,20 @@ def test_placement_group_task_resource_ids(ray_start_cluster, connect_to_client)
 
     with connect_to_client_or_not(connect_to_client):
         g1 = ray.util.placement_group([{"CPU": 2}])
-        o1 = f.options(placement_group=g1).remote()
+        o1 = f.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=g1)
+        ).remote()
         resources = ray.get(o1)
         assert len(resources) == 1, resources
         assert "CPU_group_" in list(resources.keys())[0], resources
         assert "CPU_group_0_" not in list(resources.keys())[0], resources
 
         # Now retry with a bundle index constraint.
-        o1 = f.options(placement_group=g1, placement_group_bundle_index=0).remote()
+        o1 = f.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=g1, placement_group_bundle_index=0
+            )
+        ).remote()
         resources = ray.get(o1)
         assert len(resources) == 2, resources
         keys = list(resources.keys())
@@ -440,7 +493,9 @@ def test_placement_group_hang(ray_start_cluster, connect_to_client):
         g1 = ray.util.placement_group([{"CPU": 2}])
         # This will start out infeasible. The placement group will then be
         # created and it transitions to feasible.
-        o1 = f.options(placement_group=g1).remote()
+        o1 = f.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=g1)
+        ).remote()
 
         resources = ray.get(o1)
         assert len(resources) == 1, resources

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -539,8 +539,9 @@ def test_placement_group_scheduling_warning(ray_start_regular_shared):
     # No warning when scheduling_strategy is specified.
     with warnings.catch_warnings(record=True) as w:
         Foo.options(
-            placement_group_bundle_index=0,
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg, placement_group_bundle_index=0
+            ),
         ).remote()
     assert not w
 

--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -20,6 +20,7 @@ from ray.autoscaler._private.commands import debug_status
 from ray.exceptions import RaySystemError
 from ray.util.client.ray_client_helpers import connect_to_client_or_not
 from ray.util.placement_group import placement_group, remove_placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 try:
     import pytest_timeout
@@ -144,6 +145,7 @@ def test_detached_placement_group(ray_start_cluster):
     # Make sure detached placement group will alive when job dead.
     driver_code = f"""
 import ray
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 ray.init(address="{info["address"]}")
 
@@ -158,8 +160,9 @@ class Actor:
         return True
 
 for bundle_index in range(2):
-    actor = Actor.options(lifetime="detached", placement_group=pg,
-                placement_group_bundle_index=bundle_index).remote()
+    actor = Actor.options(lifetime="detached",
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg,
+                placement_group_bundle_index=bundle_index)).remote()
     ray.get(actor.ready.remote())
 
 ray.shutdown()
@@ -224,8 +227,9 @@ ray.shutdown()
             # Schedule nested actor with the placement group.
             for bundle_index in range(2):
                 actor = NestedActor.options(
-                    placement_group=pg,
-                    placement_group_bundle_index=bundle_index,
+                    scheduling_strategy=PlacementGroupSchedulingStrategy(
+                        placement_group=pg, placement_group_bundle_index=bundle_index
+                    ),
                     lifetime="detached",
                 ).remote()
                 ray.get(actor.ready.remote())
@@ -292,7 +296,9 @@ ray.shutdown()
     assert placement_group is not None
     assert placement_group.wait(5)
     actor = Actor.options(
-        placement_group=placement_group, placement_group_bundle_index=0
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=0
+        )
     ).remote()
 
     ray.get(actor.ping.remote())
@@ -378,13 +384,17 @@ def test_placement_group_gpu_set(ray_start_cluster, connect_to_client):
             return ray.get_gpu_ids()
 
         result = get_gpus.options(
-            placement_group=placement_group, placement_group_bundle_index=0
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=placement_group, placement_group_bundle_index=0
+            )
         ).remote()
         result = ray.get(result)
         assert result == [0]
 
         result = get_gpus.options(
-            placement_group=placement_group, placement_group_bundle_index=1
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=placement_group, placement_group_bundle_index=1
+            )
         ).remote()
         result = ray.get(result)
         assert result == [0]
@@ -410,8 +420,24 @@ def test_placement_group_gpu_assigned(ray_start_cluster, connect_to_client):
         assert pg1.wait(10)
         assert pg2.wait(10)
 
-        gpu_ids_res.add(ray.get(f.options(placement_group=pg1).remote()))
-        gpu_ids_res.add(ray.get(f.options(placement_group=pg2).remote()))
+        gpu_ids_res.add(
+            ray.get(
+                f.options(
+                    scheduling_strategy=PlacementGroupSchedulingStrategy(
+                        placement_group=pg1
+                    )
+                ).remote()
+            )
+        )
+        gpu_ids_res.add(
+            ray.get(
+                f.options(
+                    scheduling_strategy=PlacementGroupSchedulingStrategy(
+                        placement_group=pg2
+                    )
+                ).remote()
+            )
+        )
 
         assert len(gpu_ids_res) == 2
 
@@ -435,7 +461,12 @@ def test_actor_scheduling_not_block_with_placement_group(ray_start_cluster):
 
     actor_num = 1000
     pgs = [ray.util.placement_group([{"CPU": 1}]) for _ in range(actor_num)]
-    actors = [A.options(placement_group=pg).remote() for pg in pgs]
+    actors = [
+        A.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
+        for pg in pgs
+    ]
     refs = [actor.ready.remote() for actor in actors]
 
     expected_created_num = 1
@@ -493,16 +524,32 @@ def test_placement_group_gpu_unique_assigned(ray_start_cluster, connect_to_clien
     # Create actors out of order.
     actors = []
     actors.append(
-        Actor.options(placement_group=pg, placement_group_bundle_index=0).remote()
+        Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg, placement_group_bundle_index=0
+            )
+        ).remote()
     )
     actors.append(
-        Actor.options(placement_group=pg, placement_group_bundle_index=3).remote()
+        Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg, placement_group_bundle_index=3
+            )
+        ).remote()
     )
     actors.append(
-        Actor.options(placement_group=pg, placement_group_bundle_index=2).remote()
+        Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg, placement_group_bundle_index=2
+            )
+        ).remote()
     )
     actors.append(
-        Actor.options(placement_group=pg, placement_group_bundle_index=1).remote()
+        Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg, placement_group_bundle_index=1
+            )
+        ).remote()
     )
 
     for actor in actors:
@@ -569,7 +616,12 @@ def test_placement_group_status(ray_start_cluster):
 
     # 2 CPU + 1 PG CPU == 3.0/4.0 CPU (1 used by pg)
     actors = [A.remote() for _ in range(2)]
-    actors_in_pg = [A.options(placement_group=pg).remote() for _ in range(1)]
+    actors_in_pg = [
+        A.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
+        for _ in range(1)
+    ]
 
     ray.get([actor.ready.remote() for actor in actors])
     ray.get([actor.ready.remote() for actor in actors_in_pg])
@@ -665,9 +717,14 @@ def test_placement_group_local_resource_view(monkeypatch, ray_start_cluster):
         # Local resource will be allocated and here we are to ensure
         # local view is consistent and node resouce updates are discarded
         workers = [
-            Worker.options(placement_group=pg).remote(i) for i in range(NUM_CPU_BUNDLES)
+            Worker.options(
+                scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+            ).remote(i)
+            for i in range(NUM_CPU_BUNDLES)
         ]
-        trainer = Trainer.options(placement_group=pg).remote(0)
+        trainer = Trainer.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote(0)
         ray.get([workers[i].work.remote() for i in range(NUM_CPU_BUNDLES)])
         ray.get(trainer.train.remote())
 

--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -5,6 +5,7 @@ import pytest
 import ray
 from ray.tests.test_placement_group import are_pairwise_unique
 from ray.util.client.ray_client_helpers import connect_to_client_or_not
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
@@ -23,11 +24,17 @@ def test_placement_group_bin_packing_priority(
     def index_to_actor(pg, index):
         if index < 2:
             return Actor.options(
-                placement_group=pg, placement_group_bundle_index=index, num_cpus=1
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=pg, placement_group_bundle_index=index
+                ),
+                num_cpus=1,
             ).remote()
         else:
             return Actor.options(
-                placement_group=pg, placement_group_bundle_index=index, num_gpus=1
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=pg, placement_group_bundle_index=index
+                ),
+                num_gpus=1,
             ).remote()
 
     def add_nodes_to_cluster(cluster):

--- a/python/ray/tests/test_placement_group_mini_integration.py
+++ b/python/ray/tests/test_placement_group_mini_integration.py
@@ -13,6 +13,7 @@ import ray
 import ray.cluster_utils
 from ray._private.test_utils import wait_for_condition
 from ray.util.placement_group import placement_group, remove_placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 
 def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
@@ -75,7 +76,9 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
             for i in range(num_nodes):
                 tasks.append(
                     mock_task.options(
-                        placement_group=pg, placement_group_bundle_index=i
+                        scheduling_strategy=PlacementGroupSchedulingStrategy(
+                            placement_group=pg, placement_group_bundle_index=i
+                        )
                     ).remote()
                 )
         # Remove the rest of placement groups.

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -6,6 +6,7 @@ import sys
 import pytest
 
 from ray._private.test_utils import SignalActor
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
@@ -264,7 +265,11 @@ def test_ids(ray_start_regular):
         assert isinstance(rtc.get_placement_group_id(), str)
         assert rtc.get_placement_group_id() == rtc.current_placement_group_id.hex()
 
-    ray.get(foo_pg.options(placement_group=pg).remote())
+    ray.get(
+        foo_pg.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
+    )
     ray.util.remove_placement_group(pg)
 
     # task id

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -14,6 +14,7 @@ import ray
 import ray.cluster_utils
 import ray.util.accelerators
 from ray._private.internal_api import memory_summary
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from ray._private.test_utils import (
     Semaphore,
     SignalActor,
@@ -674,9 +675,14 @@ def test_gpu_scheduling_liveness(ray_start_cluster):
     ray.get(o)
 
     workers = [
-        Worker.options(placement_group=pg).remote(i) for i in range(NUM_CPU_BUNDLES)
+        Worker.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote(i)
+        for i in range(NUM_CPU_BUNDLES)
     ]
-    trainer = Trainer.options(placement_group=pg).remote(0)
+    trainer = Trainer.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+    ).remote(0)
 
     # If the gpu scheduling doesn't properly work, the below
     # code will hang.

--- a/python/ray/train/tests/test_backend.py
+++ b/python/ray/train/tests/test_backend.py
@@ -407,7 +407,7 @@ def test_placement_group_parent(ray_4_node_4_cpu, placement_group_capture_child_
         return e.finish_training()
 
     results_future = test.options(
-        schduling_strategy=PlacementGroupSchedulingStrategy(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
             placement_group=placement_group,
             placement_group_capture_child_tasks=placement_group_capture_child_tasks,
         ),

--- a/python/ray/train/tests/test_backend.py
+++ b/python/ray/train/tests/test_backend.py
@@ -27,6 +27,7 @@ from ray.train.constants import (
 from ray.train.tensorflow import TensorflowConfig
 from ray.train.torch import TorchConfig
 from ray.util.placement_group import get_current_placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 
 @pytest.fixture
@@ -406,8 +407,10 @@ def test_placement_group_parent(ray_4_node_4_cpu, placement_group_capture_child_
         return e.finish_training()
 
     results_future = test.options(
-        placement_group=placement_group,
-        placement_group_capture_child_tasks=placement_group_capture_child_tasks,
+        schduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group,
+            placement_group_capture_child_tasks=placement_group_capture_child_tasks,
+        ),
     ).remote()
     results = ray.get(results_future)
     for worker_result in results:

--- a/python/ray/tune/tests/test_multinode_sync.py
+++ b/python/ray/tune/tests/test_multinode_sync.py
@@ -11,6 +11,7 @@ from ray.autoscaler._private.fake_multi_node.node_provider import FAKE_HEAD_NODE
 from ray.autoscaler._private.fake_multi_node.test_utils import DockerCluster
 from ray.tune.callback import Callback
 from ray.tune.experiment import Trial
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 
 @ray.remote
@@ -51,9 +52,13 @@ class MultiNodeSyncTest(unittest.TestCase):
         self.assertEquals(
             5,
             ray.get(
-                remote_task.options(num_cpus=1, num_gpus=1, placement_group=pg).remote(
-                    5
-                )
+                remote_task.options(
+                    num_cpus=1,
+                    num_gpus=1,
+                    scheduling_strategy=PlacementGroupSchedulingStrategy(
+                        placement_group=pg
+                    ),
+                ).remote(5)
             ),
         )
 

--- a/python/ray/util/client/options.py
+++ b/python/ray/util/client/options.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from ray._private import ray_option_utils
 from ray.util.placement_group import PlacementGroup, check_placement_group_index
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 
 def validate_options(kwargs_dict: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
@@ -28,8 +29,12 @@ def validate_options(kwargs_dict: Optional[Dict[str, Any]]) -> Optional[Dict[str
     # specified, placement group cannot be resolved at client. So this check
     # skips this case and relies on server to enforce any condition.
     bundle_index = out.get("placement_group_bundle_index", None)
+    pg = out.get("placement_group", None)
+    scheduling_strategy = out.get("scheduling_strategy", None)
+    if isinstance(scheduling_strategy, PlacementGroupSchedulingStrategy):
+        pg = scheduling_strategy.placement_group
+        bundle_index = scheduling_strategy.placement_group_bundle_index
     if bundle_index is not None:
-        pg = out.get("placement_group", None)
         if pg is None:
             pg = PlacementGroup.empty()
         if pg == "default" and (

--- a/release/benchmarks/distributed/test_many_pgs.py
+++ b/release/benchmarks/distributed/test_many_pgs.py
@@ -3,6 +3,7 @@ import os
 import ray
 import ray._private.test_utils as test_utils
 from ray.util.placement_group import placement_group, remove_placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 import time
 import tqdm
 
@@ -47,9 +48,21 @@ def test_many_placement_groups():
 
     actors = []
     for pg in tqdm.tqdm(pgs, desc="Scheduling tasks"):
-        actors.append(C1.options(placement_group=pg).remote())
-        actors.append(C2.options(placement_group=pg).remote())
-        actors.append(C3.options(placement_group=pg).remote())
+        actors.append(
+            C1.options(
+                scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+            ).remote()
+        )
+        actors.append(
+            C2.options(
+                scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+            ).remote()
+        )
+        actors.append(
+            C3.options(
+                scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+            ).remote()
+        )
 
     not_ready = [actor.ping.remote() for actor in actors]
     for _ in tqdm.trange(len(actors)):

--- a/release/nightly_tests/placement_group_tests/pg_run.py
+++ b/release/nightly_tests/placement_group_tests/pg_run.py
@@ -4,6 +4,7 @@ import json
 
 import ray
 from ray.util.placement_group import placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 # Tests are supposed to run for 10 minutes.
 RUNTIME = 600
@@ -41,10 +42,15 @@ def main():
     ray.get(pg.ready())
 
     workers = [
-        Worker.options(placement_group=pg).remote(i) for i in range(NUM_CPU_BUNDLES)
+        Worker.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote(i)
+        for i in range(NUM_CPU_BUNDLES)
     ]
 
-    trainer = Trainer.options(placement_group=pg).remote(0)
+    trainer = Trainer.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+    ).remote(0)
 
     start = time.time()
     while True:

--- a/release/nightly_tests/stress_tests/test_placement_group.py
+++ b/release/nightly_tests/stress_tests/test_placement_group.py
@@ -13,6 +13,7 @@ import os
 import ray
 
 from ray.util.placement_group import placement_group, remove_placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -67,10 +68,22 @@ def pg_launcher(pre_created_pgs, num_pgs_to_create):
         # TODO(sang): Comment in this line causes GCS actor management
         # failure. We need to fix it.
         if random() < 0.5:
-            tasks.append(mock_task.options(placement_group=pg).remote())
+            tasks.append(
+                mock_task.options(
+                    scheduling_strategy=PlacementGroupSchedulingStrategy(
+                        placement_group=pg
+                    )
+                ).remote()
+            )
         else:
             if actor_cnt < max_actor_cnt:
-                actors.append(MockActor.options(placement_group=pg).remote())
+                actors.append(
+                    MockActor.options(
+                        scheduling_strategy=PlacementGroupSchedulingStrategy(
+                            placement_group=pg
+                        )
+                    ).remote()
+                )
                 actor_cnt += 1
 
     # Remove the rest of placement groups.


### PR DESCRIPTION
Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
placement_group option is deprecated, use PlacementGroupSchedulingStrategy instead.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
