### PR TITLE
[RLlib] Reinstate PPO + LSTM compilation tests.

### DIFF
--- a/rllib/algorithms/ppo/tests/test_ppo.py
+++ b/rllib/algorithms/ppo/tests/test_ppo.py
@@ -103,19 +103,17 @@ class TestPPO(unittest.TestCase):
                 # overridden by the schedule below (which is expected).
                 entropy_coeff=100.0,
                 entropy_coeff_schedule=[[0, 0.1], [256, 0.0]],
-            )
-            .rollouts(
-                num_rollout_workers=1,
-                # Test with compression.
-                compress_observations=True,
-            )
-            .training(
                 train_batch_size=128,
                 model=dict(
                     # Settings in case we use an LSTM.
                     lstm_cell_size=10,
                     max_seq_len=20,
                 ),
+            )
+            .rollouts(
+                num_rollout_workers=1,
+                # Test with compression.
+                compress_observations=True,
             )
             .callbacks(MyCallbacks)
         )  # For checking lr-schedule correctness.
@@ -125,7 +123,7 @@ class TestPPO(unittest.TestCase):
         for fw in framework_iterator(config, with_eager_tracing=True):
             for env in ["FrozenLake-v1", "MsPacmanNoFrameskip-v4"]:
                 print("Env={}".format(env))
-                for lstm in [False]:
+                for lstm in [True, False]:
                     print("LSTM={}".format(lstm))
                     config.training(
                         model=dict(


### PR DESCRIPTION
Signed-off-by: sven1977 <svenmika1977@gmail.com>

Reinstate PPO + LSTM compilation tests.

Not sure why these were disabled in the first place.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
