### PR TITLE
[core] Raise an error on empty placement group creation

### DIFF
--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -449,6 +449,13 @@ def test_placement_group_hang(ray_start_cluster, connect_to_client):
         placement_group_assert_no_leak([g1])
 
 
+@pytest.mark.parametrize("connect_to_client", [True, False])
+def test_placement_group_empty_bundle_error(ray_start_regular, connect_to_client):
+    with connect_to_client_or_not(connect_to_client):
+        with pytest.raises(ValueError):
+            ray.util.placement_group([])
+
+
 def test_placement_group_scheduling_warning(ray_start_regular_shared):
     @ray.remote
     class Foo:

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -174,6 +174,11 @@ def placement_group(
     if not isinstance(bundles, list):
         raise ValueError("The type of bundles must be list, got {}".format(bundles))
 
+    if not bundles:
+        raise ValueError(
+            "The placement group `bundles` argument cannot contain an empty list"
+        )
+
     assert _max_cpu_fraction_per_node is not None
 
     if _max_cpu_fraction_per_node <= 0 or _max_cpu_fraction_per_node > 1:


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Requesting an empty placement group leads to a raylet crash - instead we should catch this early.

## Related issue number

Closes #28443

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
