### PR TITLE
[tune] Raise error in PGF if head and worker bundles are empty

### DIFF
--- a/python/ray/tune/execution/placement_groups.py
+++ b/python/ray/tune/execution/placement_groups.py
@@ -55,8 +55,7 @@ def _get_tune_pg_prefix():
     return _tune_pg_prefix
 
 
-@DeveloperAPI
-def sum_bundles(bundles: List[Dict[str, float]]) -> Dict[str, float]:
+def _sum_bundles(bundles: List[Dict[str, float]]) -> Dict[str, float]:
     """Sum all resources in a list of resource bundles.
 
     Args:
@@ -216,7 +215,7 @@ class PlacementGroupFactory:
     @property
     def required_resources(self) -> Dict[str, float]:
         """Returns a dict containing the sums of all resources"""
-        return sum_bundles(self._bundles)
+        return _sum_bundles(self._bundles)
 
     @property
     @DeveloperAPI

--- a/python/ray/tune/execution/placement_groups.py
+++ b/python/ray/tune/execution/placement_groups.py
@@ -55,6 +55,22 @@ def _get_tune_pg_prefix():
     return _tune_pg_prefix
 
 
+@DeveloperAPI
+def sum_bundles(bundles: List[Dict[str, float]]) -> Dict[str, float]:
+    """Sum all resources in a list of resource bundles.
+
+    Args:
+        bundles: List of resource bundles.
+
+    Returns: Dict containing all resources summed up.
+    """
+    resources = {}
+    for bundle in bundles:
+        for k, v in bundle.items():
+            resources[k] = resources.get(k, 0) + v
+    return resources
+
+
 @PublicAPI(stability="beta")
 class PlacementGroupFactory:
     """Wrapper class that creates placement groups for trials.
@@ -200,11 +216,7 @@ class PlacementGroupFactory:
     @property
     def required_resources(self) -> Dict[str, float]:
         """Returns a dict containing the sums of all resources"""
-        resources = {}
-        for bundle in self._bundles:
-            for k, v in bundle.items():
-                resources[k] = resources.get(k, 0) + v
-        return resources
+        return sum_bundles(self._bundles)
 
     @property
     @DeveloperAPI

--- a/python/ray/tune/execution/placement_groups.py
+++ b/python/ray/tune/execution/placement_groups.py
@@ -146,9 +146,10 @@ class PlacementGroupFactory:
         *args,
         **kwargs,
     ):
-        assert (
-            len(bundles) > 0
-        ), "Cannot initialize a PlacementGroupFactory with zero bundles."
+        if not bundles:
+            raise ValueError(
+                "Cannot initialize a PlacementGroupFactory with zero bundles."
+            )
 
         self._bundles = [
             {k: float(v) for k, v in bundle.items() if v != 0} for bundle in bundles
@@ -158,6 +159,12 @@ class PlacementGroupFactory:
             # This is when trainable itself doesn't need resources.
             self._head_bundle_is_empty = True
             self._bundles.pop(0)
+
+            if not self._bundles:
+                raise ValueError(
+                    "Cannot initialize a PlacementGroupFactory with an empty head "
+                    "and zero worker bundles."
+                )
         else:
             self._head_bundle_is_empty = False
 

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -11,7 +11,7 @@ from ray.tune.execution import trial_runner
 from ray.tune.resources import Resources
 from ray.tune.schedulers.trial_scheduler import FIFOScheduler, TrialScheduler
 from ray.tune.experiment import Trial
-from ray.tune.execution.placement_groups import PlacementGroupFactory, sum_bundles
+from ray.tune.execution.placement_groups import PlacementGroupFactory, _sum_bundles
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +117,7 @@ class DistributeResources:
         """Get total sums of resources in bundles"""
         if not bundles:
             return {"CPU": 0, "GPU": 0}
-        return sum_bundles(bundles)
+        return _sum_bundles(bundles)
 
     def _is_bundle_empty(self, bundle: Dict[str, float]) -> bool:
         return not (bundle.get("CPU", 0) or bundle.get("GPU", 0))

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -11,7 +11,7 @@ from ray.tune.execution import trial_runner
 from ray.tune.resources import Resources
 from ray.tune.schedulers.trial_scheduler import FIFOScheduler, TrialScheduler
 from ray.tune.experiment import Trial
-from ray.tune.execution.placement_groups import PlacementGroupFactory
+from ray.tune.execution.placement_groups import PlacementGroupFactory, sum_bundles
 
 logger = logging.getLogger(__name__)
 
@@ -117,8 +117,7 @@ class DistributeResources:
         """Get total sums of resources in bundles"""
         if not bundles:
             return {"CPU": 0, "GPU": 0}
-        pgf = PlacementGroupFactory(bundles)
-        return pgf.required_resources
+        return sum_bundles(bundles)
 
     def _is_bundle_empty(self, bundle: Dict[str, float]) -> bool:
         return not (bundle.get("CPU", 0) or bundle.get("GPU", 0))

--- a/python/ray/tune/tests/test_ray_trial_executor.py
+++ b/python/ray/tune/tests/test_ray_trial_executor.py
@@ -548,6 +548,15 @@ class RayExecutorPlacementGroupTest(unittest.TestCase):
         assert executor.has_resources_for_trial(trial2)
         assert not executor.has_resources_for_trial(trial3)
 
+    def testEmptyPlacementGroupFactory(self):
+        # Empty bundles
+        with self.assertRaises(ValueError):
+            PlacementGroupFactory([])
+
+        # Empty head, empty workers
+        with self.assertRaises(ValueError):
+            PlacementGroupFactory([{}])
+
 
 class LocalModeExecutorTest(RayTrialExecutorTest):
     def setUp(self):


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Scheduling empty placement groups is not supported by Ray core (see e.g. #28443), so we shouldn't allow them to be created in the first place.

If we need fully empty resource requests, we can include this in the upcoming execution/resource refactor.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
