### PR TITLE
[tune] Fix trial cleanup after x seconds, set default to 600

### DIFF
--- a/doc/source/tune/api_docs/env.rst
+++ b/doc/source/tune/api_docs/env.rst
@@ -32,7 +32,7 @@ These are the environment variables Ray Tune currently considers:
 * **TUNE_FORCE_TRIAL_CLEANUP_S**: By default, Ray Tune will gracefully terminate trials,
   letting them finish the current training step and any user-defined cleanup.
   Setting this variable to a non-zero, positive integer will cause trials to be forcefully
-  terminated after a grace period of that many seconds. Defaults to ``0``.
+  terminated after a grace period of that many seconds. Defaults to ``600`` (seconds).
 * **TUNE_GET_EXECUTOR_EVENT_WAIT_S**: The time that TrialRunner waits for the
   next ExecutorEvent in a blocking fashion. Defaults to ``5``.
 * **TUNE_FUNCTION_THREAD_TIMEOUT_S**: Time in seconds the function API waits

--- a/python/ray/tune/execution/ray_trial_executor.py
+++ b/python/ray/tune/execution/ray_trial_executor.py
@@ -839,7 +839,7 @@ class RayTrialExecutor:
 
     def cleanup(self, trials: List[Trial]) -> None:
         while self._futures:
-            if self._trial_cleanup and (self._trial_cleanup.is_empty()):
+            if self._trial_cleanup and self._trial_cleanup.is_empty():
                 break
 
             # Non-blocking trial cleanup futures

--- a/python/ray/tune/tests/test_ray_trial_executor.py
+++ b/python/ray/tune/tests/test_ray_trial_executor.py
@@ -632,6 +632,9 @@ class LocalModeExecutorTest(RayTrialExecutorTest):
     def testTrialCleanup(self):
         self.skipTest("Skipping as trial cleanup is not applicable for local mode.")
 
+    def testTrialHangingCleanup(self):
+        self.skipTest("Skipping as trial cleanup is not applicable for local mode.")
+
 
 if __name__ == "__main__":
     import sys

--- a/python/ray/tune/tests/test_ray_trial_executor.py
+++ b/python/ray/tune/tests/test_ray_trial_executor.py
@@ -15,7 +15,6 @@ from ray.tune.execution.ray_trial_executor import (
     _ExecutorEvent,
     _ExecutorEventType,
     RayTrialExecutor,
-    _TrialCleanup,
 )
 from ray.tune.registry import _global_registry, TRAINABLE_CLASS, register_trainable
 from ray.tune.result import PID, TRAINING_ITERATION, TRIAL_ID
@@ -233,8 +232,13 @@ class RayTrialExecutorTest(unittest.TestCase):
         register_trainable("hanging", _HangingTrainable)
         trial = Trial("hanging")
 
-        self.trial_executor._trial_cleanup = _TrialCleanup(1)
-        self.trial_executor._get_next_event_wait = 30
+        os.environ["TUNE_FORCE_TRIAL_CLEANUP_S"] = "1"
+        os.environ["TUNE_GET_EXECUTOR_EVENT_WAIT_S"] = "30"
+
+        self.trial_executor = RayTrialExecutor()
+
+        os.environ.pop("TUNE_FORCE_TRIAL_CLEANUP_S")
+        os.environ.pop("TUNE_GET_EXECUTOR_EVENT_WAIT_S")
 
         # Schedule trial PG
         ev = self.trial_executor.get_next_executor_event(

--- a/python/ray/tune/tests/test_ray_trial_executor.py
+++ b/python/ray/tune/tests/test_ray_trial_executor.py
@@ -372,6 +372,11 @@ class RayTrialExecutorTest(unittest.TestCase):
                 time.sleep(4)
                 print("Cleanup done")
 
+        # Disable force cleanup
+        os.environ["TUNE_FORCE_TRIAL_CLEANUP_S"] = "0"
+        self.trial_executor = RayTrialExecutor()
+        os.environ.pop("TUNE_FORCE_TRIAL_CLEANUP_S")
+
         # First check if the trials terminate gracefully by default
         trials = self.generate_trials(
             {
@@ -403,12 +408,13 @@ class RayTrialExecutorTest(unittest.TestCase):
         trial = trials[0]
         os.environ["TUNE_FORCE_TRIAL_CLEANUP_S"] = "1"
         self.trial_executor = RayTrialExecutor()
-        os.environ["TUNE_FORCE_TRIAL_CLEANUP_S"] = "0"
+        os.environ.pop("TUNE_FORCE_TRIAL_CLEANUP_S")
         self._simulate_starting_trial(trial)
         self.assertEqual(Trial.RUNNING, trial.status)
         # This should be enough time for `trial._default_result_or_future`
         # to return. Otherwise, PID won't show up in `trial.last_result`,
         # which is asserted down below.
+        print("Fetching last result", trial.last_result)
         time.sleep(2)
         print("Stop trial")
         self.trial_executor.stop_trial(trial)

--- a/python/ray/tune/trainable/trainable.py
+++ b/python/ray/tune/trainable/trainable.py
@@ -1134,7 +1134,8 @@ class Trainable:
         This process should be lightweight. Per default,
 
         You can kill a Ray actor by calling `ray.kill(actor)`
-        on the actor.
+        on the actor or removing all references to it and waiting for garbage
+        collection
 
         .. versionadded:: 0.8.7
         """

--- a/python/ray/tune/trainable/trainable.py
+++ b/python/ray/tune/trainable/trainable.py
@@ -1131,6 +1131,8 @@ class Trainable:
         If any Ray actors are launched in the Trainable (i.e., with a RLlib
         trainer), be sure to kill the Ray actor process here.
 
+        This process should be lightweight. Per default,
+
         You can kill a Ray actor by calling `ray.kill(actor)`
         on the actor.
 

--- a/python/ray/tune/trainable/trainable.py
+++ b/python/ray/tune/trainable/trainable.py
@@ -1131,7 +1131,7 @@ class Trainable:
         If any Ray actors are launched in the Trainable (i.e., with a RLlib
         trainer), be sure to kill the Ray actor process here.
 
-        You can kill a Ray actor by calling `actor.__ray_terminate__.remote()`
+        You can kill a Ray actor by calling `ray.kill(actor)`
         on the actor.
 
         .. versionadded:: 0.8.7


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This currently does not work in three places: 1) We need to kill the actor as garbage collection will not work with futures in flight, 2) We need to trigger the _stop_actor method after clearing the futures, as it will create a new future, 3) the future was not fetched correctly.

We also set the default cleanup time to 10 minutes, which should suffice for most cases and avoids deadlocks in long-running tasks.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
