### PR TITLE
[tune] Add logdir to W&B run config

### DIFF
--- a/python/ray/air/callbacks/wandb.py
+++ b/python/ray/air/callbacks/wandb.py
@@ -175,11 +175,13 @@ class _WandbLoggingProcess(Process):
         self.kwargs = kwargs
 
         self._trial_name = self.kwargs.get("name", "unknown")
+        self._logdir = logdir
 
     def run(self):
         # Since we're running in a separate process already, use threads.
         os.environ["WANDB_START_METHOD"] = "thread"
         run = wandb.init(*self.args, **self.kwargs)
+        run.config.trial_log_path = self._logdir
 
         # Run external hook to process information about wandb run
         if WANDB_PROCESS_RUN_INFO_HOOK in os.environ:

--- a/python/ray/tune/tests/test_integration_wandb.py
+++ b/python/ray/tune/tests/test_integration_wandb.py
@@ -132,6 +132,9 @@ class WandbIntegrationTest(unittest.TestCase):
         mock_external_hook.assert_called_once_with(mock_run)
         mock_finish.assert_called_once()
 
+        # Test `trial_log_path` of W&B run config is correctly set
+        assert mock_run.config.trial_log_path == "mock_logdir"
+
     def testWandbLoggerConfig(self):
         trial_config = {"par1": 4, "par2": 9.12345678}
         trial = Trial(


### PR DESCRIPTION
Signed-off-by: Nikita Vemuri <nikitavemuri@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Adds `trial_log_dir` field to the W&B run config page, so users can more easily find logs associated with their W&B run. Log messages from Tune trials are currently not visible in the W&B log tab when using `WandbLoggerCallback` (https://github.com/anyscale/product/issues/12775), so this is a workaround that allows finding the logs locally.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
