### PR TITLE
Add @ericl as codeowner of autoscaler

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,7 @@
 /python/ray/autoscaler/_private/monitor.py @wuisawesome @DmitriGekhtman
 
 # Autoscaler
-/python/ray/autoscaler/ @wuisawesome @DmitriGekhtman
+/python/ray/autoscaler/ @wuisawesome @DmitriGekhtman @ericl
 
 # Metrics
 /src/ray/stats/metric_defs.h @ericl @scv119 @rkooo567


### PR DESCRIPTION
Reasonable point was made offline about the perils of having only 2 code owners on a thing, so adding @ericl and a 3rd code owner as he's likely contributed the 3rd most code to the autoscaler. 

Signed-off-by: Alex Wu <alex@anyscale.io>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
