### PR TITLE
[tune] Fix trial checkpoint syncing after recovery from other node

### DIFF
--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -458,7 +458,7 @@ class Trial:
         if self.location.hostname:
             return self.location.hostname
 
-        hostname, pid = ray.get(self.runner.get_current_ip_pid())
+        hostname, pid = ray.get(self.runner.get_current_ip_pid.remote())
         self.location = _Location(hostname, pid)
         return self.location.hostname
 

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -451,6 +451,17 @@ class Trial:
     def last_result(self, val: dict):
         self._last_result = val
 
+    def get_runner_ip(self) -> Optional[str]:
+        if not self.runner:
+            return None
+
+        if self.location.hostname:
+            return self.location.hostname
+
+        hostname, pid = ray.get(self.runner.get_current_ip_pid())
+        self.location = _Location(hostname, pid)
+        return self.location.hostname
+
     @property
     def logdir(self):
         if not self.relative_logdir:

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -452,11 +452,11 @@ class Trial:
         self._last_result = val
 
     def get_runner_ip(self) -> Optional[str]:
-        if not self.runner:
-            return None
-
         if self.location.hostname:
             return self.location.hostname
+
+        if not self.runner:
+            return None
 
         hostname, pid = ray.get(self.runner.get_current_ip_pid.remote())
         self.location = _Location(hostname, pid)

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -631,3 +631,9 @@ class SyncerCallback(Callback):
                 f"At least one trial failed to sync down when waiting for all "
                 f"trials to sync: \n{sync_str}"
             )
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        for remove in ["_sync_times", "_sync_processes", "_trial_ips"]:
+            state.pop(remove, None)
+        return state

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -537,7 +537,16 @@ class SyncerCallback(Callback):
         if not force and (not self._should_sync(trial) or sync_process.is_running):
             return False
 
-        source_ip = self._trial_ips.setdefault(trial.trial_id, trial.get_runner_ip())
+        source_ip = self._trial_ips.get(trial.trial_id, None)
+
+        if not source_ip:
+            source_ip = trial.get_runner_ip()
+
+            # If it still does not exist, the runner is terminated.
+            if not source_ip:
+                return False
+
+        self._trial_ips[trial.trial_id] = source_ip
 
         try:
             sync_process.wait()

--- a/python/ray/tune/tests/test_syncer_callback.py
+++ b/python/ray/tune/tests/test_syncer_callback.py
@@ -11,7 +11,6 @@ import ray.util
 from ray.air._internal.checkpoint_manager import CheckpointStorage, _TrackedCheckpoint
 from ray.tune import TuneError
 from ray.tune.logger import NoopLogger
-from ray.tune.result import NODE_IP
 from ray.tune.syncer import (
     DEFAULT_SYNC_PERIOD,
     SyncConfig,
@@ -72,11 +71,14 @@ def assert_file(exists: bool, root: str, path: str):
 class MockTrial:
     def __init__(self, trial_id: str, logdir: str):
         self.trial_id = trial_id
-        self.last_result = {NODE_IP: ray.util.get_node_ip_address()}
         self.uses_cloud_checkpointing = False
         self.sync_on_checkpoint = True
 
         self.logdir = logdir
+        self._local_ip = ray.util.get_node_ip_address()
+
+    def get_runner_ip(self):
+        return self._local_ip
 
 
 class TestSyncerCallback(SyncerCallback):
@@ -198,6 +200,29 @@ def test_syncer_callback_sync(ray_start_2_cpus, temp_data_dirs):
     syncer_callback = TestSyncerCallback(local_logdir_override=tmp_target)
 
     trial1 = MockTrial(trial_id="a", logdir=tmp_source)
+
+    syncer_callback.on_trial_result(iteration=1, trials=[], trial=trial1, result={})
+    syncer_callback.wait_for_all()
+
+    assert_file(True, tmp_target, "level0.txt")
+    assert_file(True, tmp_target, "level0_exclude.txt")
+    assert_file(True, tmp_target, "subdir/level1.txt")
+    assert_file(True, tmp_target, "subdir/level1_exclude.txt")
+    assert_file(True, tmp_target, "subdir/nested/level2.txt")
+    assert_file(True, tmp_target, "subdir_nested_level2_exclude.txt")
+    assert_file(True, tmp_target, "subdir_exclude/something/somewhere.txt")
+
+
+def test_syncer_callback_sync_with_invalid_ip(ray_start_2_cpus, temp_data_dirs):
+    """Check that the sync client updates the IP correctly"""
+    tmp_source, tmp_target = temp_data_dirs
+
+    syncer_callback = TestSyncerCallback(local_logdir_override=tmp_target)
+
+    trial1 = MockTrial(trial_id="a", logdir=tmp_source)
+
+    syncer_callback._trial_ips[trial1.trial_id] = "invalid"
+    syncer_callback.on_trial_start(iteration=0, trials=[], trial=trial1)
 
     syncer_callback.on_trial_result(iteration=1, trials=[], trial=trial1, result={})
     syncer_callback.wait_for_all()

--- a/python/ray/tune/trainable/trainable.py
+++ b/python/ray/tune/trainable/trainable.py
@@ -156,7 +156,7 @@ class Trainable:
         self._stderr_file = stderr_file
 
         start_time = time.time()
-        self._local_ip = self.get_current_ip()
+        self._local_ip = ray.util.get_node_ip_address()
         self.setup(copy.deepcopy(self.config))
         setup_time = time.time() - start_time
         if setup_time > SETUP_TIME_THRESHOLD:
@@ -219,9 +219,8 @@ class Trainable:
         """
         return ""
 
-    def get_current_ip(self):
-        self._local_ip = ray.util.get_node_ip_address()
-        return self._local_ip
+    def get_current_ip_pid(self):
+        return self._local_ip, os.getpid()
 
     def get_auto_filled_metrics(
         self,
@@ -689,7 +688,7 @@ class Trainable:
         self._restored = True
 
         logger.info(
-            "Restored on %s from checkpoint: %s", self.get_current_ip(), checkpoint_dir
+            "Restored on %s from checkpoint: %s", self._local_ip, checkpoint_dir
         )
         state = {
             "_iteration": self._iteration,


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

On restore from a different IP, the SyncerCallback currently still tries to sync from a stale node IP, because `trial.last_result` has not been updated, yet. Instead, the syncer callback should keep its own map of trials to IPs, and only act on this.

## Related issue number

Closes #28468

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
