### PR TITLE
Revert "[tune] Raise error in PGF if head and worker bundles are empty"

### DIFF
--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -11,7 +11,7 @@ from ray.tune.execution import trial_runner
 from ray.tune.resources import Resources
 from ray.tune.schedulers.trial_scheduler import FIFOScheduler, TrialScheduler
 from ray.tune.experiment import Trial
-from ray.tune.execution.placement_groups import PlacementGroupFactory, _sum_bundles
+from ray.tune.execution.placement_groups import PlacementGroupFactory
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +117,8 @@ class DistributeResources:
         """Get total sums of resources in bundles"""
         if not bundles:
             return {"CPU": 0, "GPU": 0}
-        return _sum_bundles(bundles)
+        pgf = PlacementGroupFactory(bundles)
+        return pgf.required_resources
 
     def _is_bundle_empty(self, bundle: Dict[str, float]) -> bool:
         return not (bundle.get("CPU", 0) or bundle.get("GPU", 0))

--- a/python/ray/tune/tests/test_ray_trial_executor.py
+++ b/python/ray/tune/tests/test_ray_trial_executor.py
@@ -548,15 +548,6 @@ class RayExecutorPlacementGroupTest(unittest.TestCase):
         assert executor.has_resources_for_trial(trial2)
         assert not executor.has_resources_for_trial(trial3)
 
-    def testEmptyPlacementGroupFactory(self):
-        # Empty bundles
-        with self.assertRaises(ValueError):
-            PlacementGroupFactory([])
-
-        # Empty head, empty workers
-        with self.assertRaises(ValueError):
-            PlacementGroupFactory([{}])
-
 
 class LocalModeExecutorTest(RayTrialExecutorTest):
     def setUp(self):


### PR DESCRIPTION
Reverts ray-project/ray#28445

Looks like this breaks linux://python/ray/air:test_api.