### PR TITLE
Add script for basic memory pinning CUDA benchmark

### DIFF
--- a/python/ray/experimental/gpu_buffer/.gitignore
+++ b/python/ray/experimental/gpu_buffer/.gitignore
@@ -1,0 +1,2 @@
+data/
+__pycache__/

--- a/python/ray/experimental/gpu_buffer/models.py
+++ b/python/ray/experimental/gpu_buffer/models.py
@@ -1,0 +1,23 @@
+import torch
+
+import torch.nn as nn
+import torch.nn.functional as F
+
+class SimpleCNN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x):
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = torch.flatten(x, 1) # flatten all dimensions except batch
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x

--- a/python/ray/experimental/gpu_buffer/models.py
+++ b/python/ray/experimental/gpu_buffer/models.py
@@ -4,12 +4,13 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 class SimpleCNN(nn.Module):
-    def __init__(self):
+    def __init__(self, imgsize):
         super().__init__()
         self.conv1 = nn.Conv2d(3, 6, 5)
         self.pool = nn.MaxPool2d(2, 2)
         self.conv2 = nn.Conv2d(6, 16, 5)
-        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        n = (imgsize - 12) // 4
+        self.fc1 = nn.Linear(16 * n * n, 120)
         self.fc2 = nn.Linear(120, 84)
         self.fc3 = nn.Linear(84, 10)
 

--- a/python/ray/experimental/gpu_buffer/torch_test.py
+++ b/python/ray/experimental/gpu_buffer/torch_test.py
@@ -69,7 +69,7 @@ def parse_args():
 if __name__ == '__main__':
     NUM_WORKERS = 0
     BATCH_SIZE = 4
-    EPOCHS = 1
+    EPOCHS = 3
 
     if not torch.cuda.is_available():
         raise Exception('No GPU detected, cannot perform benchmark')

--- a/python/ray/experimental/gpu_buffer/torch_test.py
+++ b/python/ray/experimental/gpu_buffer/torch_test.py
@@ -1,0 +1,100 @@
+import argparse
+import time
+
+import torch
+import torchvision
+import torchvision.transforms as transforms
+import torch.optim as optim
+import torch.nn as nn
+
+from models import SimpleCNN
+
+
+def download_dataset():
+    transform = transforms.Compose(
+    [transforms.ToTensor(),
+     transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+    trainset = torchvision.datasets.CIFAR10(root='./data', train=True, download=True, transform=transform)
+    testset = torchvision.datasets.CIFAR10(root='./data', train=False, download=True, transform=transform)
+    return trainset, testset
+
+def train_epoch(net, criterion, optimizer, trainloader):
+    net.train()
+    for i,data in enumerate(trainloader):
+        inputs, labels = data[0].to(device), data[1].to(device)
+        optimizer.zero_grad()
+        
+        out = net(inputs)
+        loss = criterion(out, labels)
+        loss.backward()
+        optimizer.step()
+
+def test(net, testloader):
+    net.eval()
+    total = 0
+    correct = 0
+    with torch.no_grad():
+        for data in testloader:
+            images, labels = data[0].to(device), data[1].to(device)
+            outputs = net(images)
+            _, predicted = torch.max(outputs.data, 1)
+            total += labels.size(0)
+            correct += (predicted == labels).sum().item()
+    return correct / total
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Pytorch CUDA benchmark. Loads CIFAR10 and runs 3 training epochs.')
+    parser.add_argument(
+        '--download-only',
+        action='store_true',
+        required=False
+    )
+    parser.add_argument(
+        '--pin',
+        help='Pins memory. Default is false.',
+        action='store_true',
+        required=False
+    )
+    parser.add_argument(
+        '--model',
+        help='Which model to train. Small is simple CNN, large is VGG11.',
+        choices=['small', 'large'],
+        default='large',
+        required=False,
+    )
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == '__main__':
+    NUM_WORKERS = 0
+    BATCH_SIZE = 4
+    EPOCHS = 1
+
+    if not torch.cuda.is_available():
+        raise Exception('No GPU detected, cannot perform benchmark')
+    device = torch.device('cuda')
+    print('Using device:', device)
+
+    args = parse_args()
+    trainset, testset = download_dataset()
+    print('Dataset Downloaded!')
+    if args.download_only:
+        exit()
+
+    start_time = time.time()
+    trainloader = torch.utils.data.DataLoader(trainset, batch_size=BATCH_SIZE, num_workers=NUM_WORKERS, pin_memory=args.pin)
+    testloader = torch.utils.data.DataLoader(testset, batch_size=BATCH_SIZE, num_workers=NUM_WORKERS, pin_memory=args.pin)
+    print('Dataset Loaded!')
+
+    print(f'Mode: {args.model}, Pin: {args.pin}')
+    net = torchvision.models.vgg11() if args.model == 'large' else SimpleCNN()
+    net.to(device)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
+    for epoch in range(EPOCHS):
+        train_epoch(net, criterion, optimizer, trainloader)
+        accuracy = test(net, testloader)
+        print(f"Accuracy after epoch {epoch + 1}: {accuracy*100}%")
+    end_time = time.time()
+    print(f'total time: {end_time - start_time}s')

--- a/python/ray/experimental/gpu_buffer/torch_test.py
+++ b/python/ray/experimental/gpu_buffer/torch_test.py
@@ -9,6 +9,14 @@ import torch.nn as nn
 
 from models import SimpleCNN
 
+def prepare_imagenet(imagenet_path, imgsize = 256):
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Resize((imgsize, imgsize)),
+    ])
+    trainset = torchvision.datasets.ImageFolder(root=imagenet_path, transform=transform)
+    return trainset
+
 def download_dataset(imgsize):
     transform = transforms.Compose([
         transforms.ToTensor(),
@@ -18,37 +26,8 @@ def download_dataset(imgsize):
     testset = torchvision.datasets.CIFAR10(root='./data', train=False, download=True, transform=transform)
     return trainset, testset
 
-def train_epoch(net, criterion, optimizer, trainloader, pinned):
-    net.train()
-    for i,data in enumerate(trainloader):
-        inputs, labels = data[0].to(device, non_blocking=pinned), data[1].to(device, non_blocking=pinned)
-        optimizer.zero_grad()
-        
-        out = net(inputs)
-        loss = criterion(out, labels)
-        loss.backward()
-        optimizer.step()
-
-def test(net, testloader, pinned):
-    net.eval()
-    total = 0
-    correct = 0
-    with torch.no_grad():
-        for data in testloader:
-            images, labels = data[0].to(device, non_blocking=pinned), data[1].to(device, non_blocking=pinned)
-            outputs = net(images)
-            _, predicted = torch.max(outputs.data, 1)
-            total += labels.size(0)
-            correct += (predicted == labels).sum().item()
-    return correct / total
-
 def parse_args():
     parser = argparse.ArgumentParser(description='Pytorch CUDA benchmark. Loads CIFAR10 and runs 3 training epochs.')
-    parser.add_argument(
-        '--download-only',
-        action='store_true',
-        required=False
-    )
     parser.add_argument(
         '--pin',
         help='Pins memory. Default is false.',
@@ -69,14 +48,50 @@ def parse_args():
         default=32,
         required=False,
     )
+    parser.add_argument(
+        '--dataset',
+        help='Which dataset to use. Default is CIFAR10.',
+        choices=['cifar10', 'imagenet'],
+        default='cifar10',
+        required=False
+    )
+    parser.add_argument(
+        '--imagenetpath',
+        help='Root path to imagenet. Only applies if the selected dataset is imagenet.',
+        default='/mnt/cluster_storage/aviv/testnet/files',
+        required=False
+    )
     args = parser.parse_args()
     return args
 
+def train_epoch(net, criterion, optimizer, trainloader, pinned):
+    net.train()
+    for i,data in enumerate(trainloader):
+        inputs, labels = data[0].to(device, non_blocking=pinned), data[1].to(device, non_blocking=pinned)
+        optimizer.zero_grad()
+        
+        out = net(inputs)
+        loss = criterion(out, labels)
+        loss.backward()
+        optimizer.step()
+
+def test(net, testloader, pinned):
+    net.eval()
+    total = torch.zeros(1, dtype=torch.int).to(device, non_blocking=pinned)
+    correct = torch.zeros(1, dtype=torch.int).to(device, non_blocking=pinned)
+    with torch.no_grad():
+        for data in testloader:
+            images, labels = data[0].to(device, non_blocking=pinned), data[1].to(device, non_blocking=pinned)
+            outputs = net(images)
+            _, predicted = torch.max(outputs.data, 1)
+            total += labels.size(0)
+            correct += (predicted == labels).sum()
+    return correct.item() / total.item()
 
 if __name__ == '__main__':
     NUM_WORKERS = 8
     BATCH_SIZE = 100
-    EPOCHS = 1
+    EPOCHS = 5
 
     if not torch.cuda.is_available():
         raise Exception('No GPU detected, cannot perform benchmark')
@@ -84,24 +99,27 @@ if __name__ == '__main__':
     print('Using device:', device)
 
     args = parse_args()
-    trainset, testset = download_dataset(args.size)
-    print('Dataset Downloaded!')
-    if args.download_only:
-        exit()
-
-    start_time = time.time()
+    testloader = None
+    if args.dataset == 'imagenet':
+        trainset = prepare_imagenet(args.imagenetpath)
+    else:
+        trainset, testset = download_dataset(args.size)
+        testloader = torch.utils.data.DataLoader(testset, batch_size=BATCH_SIZE, num_workers=NUM_WORKERS, pin_memory=args.pin)
     trainloader = torch.utils.data.DataLoader(trainset, batch_size=BATCH_SIZE, num_workers=NUM_WORKERS, pin_memory=args.pin)
-    testloader = torch.utils.data.DataLoader(testset, batch_size=BATCH_SIZE, num_workers=NUM_WORKERS, pin_memory=args.pin)
     print('Dataset Loaded!')
 
-    print(f'Model: {args.model}, Pinned: {args.pin}, Size: {args.size}')
-    net = torchvision.models.vgg11() if args.model == 'large' else SimpleCNN(args.size)
+    start_time = time.time()
+
+    size = 256 if args.dataset == "imagenet" else args.size
+    print(f'Model: {args.model}, Dataset: {args.dataset}, Pinned: {args.pin}, Size: {size}')
+    net = torchvision.models.vgg11() if args.model == 'large' else SimpleCNN(size)
     net.to(device)
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
     for epoch in range(EPOCHS):
         train_epoch(net, criterion, optimizer, trainloader, args.pin)
-        accuracy = test(net, testloader, args.pin)
-        print(f"Accuracy after epoch {epoch + 1}: {accuracy*100}%")
+        if testloader:
+            accuracy = test(net, testloader, args.pin)
+            print(f"Accuracy after epoch {epoch + 1}: {accuracy*100}%")
     end_time = time.time()
     print(f'total time: {end_time - start_time}s')


### PR DESCRIPTION
Signed-off-by: Aviv Haber <aviv@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Script for benchmarking memory pinning on pytorch. The program trains one of two models on CIFAR10 and reports the time taken loading and training.

The first model (small) is a simple CNN described in [this tutorial](https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html).  The second model (large) is the [torch VGG11 model](https://pytorch.org/vision/main/models/generated/torchvision.models.vgg11.html).

## Usage
The timer starts after the dataset has been loaded and the model has begun training.

To run the benchmark:
`python torch_test.py --model=simplecnn --pin`
or `python torch_test.py --model=simplecnn`

You can also use `--model=vgg11`. This is a larger model and will take longer. 

The `--pin` option determines whether to use memory pinning.

You can select the dataset with `--dataset=imagenet` or `--dataset=cifar10`. The default is CIFAR. If you use imagenet you must also pass `--imagenetpath=/path/to/imagenet/root`.

You can use `--size=512` to transform the images to 512x512, for instance. The default for CIFAR10 is 32x32. The default for ImageNet is 256x256.

## Results \# 1
Following are typical results (little change between runs). Default 32x32 images, CIFAR10.
Code was run on a single g4dn.4xlarge node. `BATCH_SIZE=4, NUM_WORKERS=0, EPOCHS=1`
| | Small Model | Large Model|
|---|---|---|
| Pinning off | 41s | 469s |
| Pinning on | 41s | 466s |

There is little to no difference. Maybe this is because the node has enough system memory that it rarely needs to spill to disk when pinning is off. I'm going to run more benchmarks on larger datasets

## Results \# 2
Using the same CIFAR10 dataset, but transforming the images to be 512x512 (Use `--size=512`), we get the following results. `BATCH_SIZE=100, NUM_WORKERS=8, EPOCHS=1`
| | Small Model | Large Model|
|---|---|---|
| Pinning off | 354s |  |
| Pinning on | 334s |  |

Here with the larger tensor size, the pinning actually has an effect (~6% difference).

## Results \# 3
Using a small subset of imagenet and only doing training (no testing). The images were transformed to 256x256. `BATCH_SIZE=100, NUM_WORKERS=8, EPOCHS=5`
| | Small Model | Large Model|
|---|---|---|
| Pinning off | 40s | 217s  |
| Pinning on | 35s | 203s |

~6% difference for large model, ~13% difference for small model.