### PR TITLE
[air/tune] Catch empty hyperopt search space, raise better Tuner error message

### DIFF
--- a/python/ray/tune/search/hyperopt/hyperopt_search.py
+++ b/python/ray/tune/search/hyperopt/hyperopt_search.py
@@ -40,6 +40,13 @@ from ray.tune.error import TuneError
 logger = logging.getLogger(__name__)
 
 
+HYPEROPT_UNDEFINED_DETAILS = (
+    " This issue can also come up with HyperOpt if your search space only "
+    "contains constant variables, which is not supported by HyperOpt. In that case, "
+    "don't pass any searcher or add sample variables to the search space."
+)
+
+
 class HyperOptSearch(Searcher):
     """A wrapper around HyperOpt to provide trial suggestions.
 
@@ -192,6 +199,14 @@ class HyperOptSearch(Searcher):
     def _setup_hyperopt(self) -> None:
         from hyperopt.fmin import generate_trials_to_calculate
 
+        if not self._space:
+            raise RuntimeError(
+                UNDEFINED_SEARCH_SPACE.format(
+                    cls=self.__class__.__name__, space="space"
+                )
+                + HYPEROPT_UNDEFINED_DETAILS
+            )
+
         if self._metric is None and self._mode:
             # If only a mode was passed, use anonymous metric
             self._metric = DEFAULT_METRIC
@@ -283,6 +298,7 @@ class HyperOptSearch(Searcher):
                 UNDEFINED_SEARCH_SPACE.format(
                     cls=self.__class__.__name__, space="space"
                 )
+                + HYPEROPT_UNDEFINED_DETAILS
             )
         if not self._metric or not self._mode:
             raise RuntimeError(

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -1071,6 +1071,17 @@ class SearchSpaceTest(unittest.TestCase):
 
             self.assertIn(config["domain_nested"], ["M", "N", "O", "P"])
 
+    def testConvertHyperOptConstant(self):
+        from ray.tune.search.hyperopt import HyperOptSearch
+
+        config = {"a": 4}
+
+        searcher = HyperOptSearch()
+        with self.assertRaisesRegex(
+            RuntimeError, "This issue can also come up with HyperOpt"
+        ):
+            searcher.set_search_properties(metric="a", mode="max", config=config)
+
     def testSampleBoundsHyperopt(self):
         from ray.tune.search.hyperopt import HyperOptSearch
 

--- a/python/ray/tune/tuner.py
+++ b/python/ray/tune/tuner.py
@@ -32,7 +32,7 @@ _TUNER_FAILED_MSG = (
     "The Ray Tune run failed. Please inspect the previous error messages for a "
     "cause. After fixing the issue, you can restart the run from scratch or "
     "continue this run. To continue this run, you can use "
-    "`tuner = Tuner.restore(\"{path}\")`."
+    '`tuner = Tuner.restore("{path}")`.'
 )
 
 

--- a/python/ray/tune/tuner.py
+++ b/python/ray/tune/tuner.py
@@ -28,6 +28,14 @@ _TUNER_INTERNAL = "_tuner_internal"
 _SELF = "self"
 
 
+_TUNER_FAILED_MSG = (
+    "The Ray Tune run failed. Please inspect the previous error messages for a "
+    "cause. After fixing the issue, you can restart the run from scratch or "
+    "continue this run. To continue this run, you can use "
+    "`tuner = Tuner.restore(\"{path}\")`."
+)
+
+
 @PublicAPI(stability="beta")
 class Tuner:
     """Tuner is the recommended way of launching hyperparameter tuning jobs with Ray Tune.
@@ -235,9 +243,9 @@ class Tuner:
                 return self._local_tuner.fit()
             except Exception as e:
                 raise TuneError(
-                    f"Tune run failed. "
-                    f'Please use tuner = Tuner.restore("'
-                    f'{self._local_tuner.get_experiment_checkpoint_dir()}") to resume.'
+                    _TUNER_FAILED_MSG.format(
+                        path=self._local_tuner.get_experiment_checkpoint_dir()
+                    )
                 ) from e
         else:
             experiment_checkpoint_dir = ray.get(
@@ -247,7 +255,5 @@ class Tuner:
                 return ray.get(self._remote_tuner.fit.remote())
             except Exception as e:
                 raise TuneError(
-                    f"Tune run failed. "
-                    f'Please use tuner = Tuner.restore("'
-                    f'{experiment_checkpoint_dir}") to resume.'
+                    _TUNER_FAILED_MSG.format(path=experiment_checkpoint_dir)
                 ) from e


### PR DESCRIPTION


Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

HyperOpt fails when constant (i.e. empty) search spaces are passed, but we should raise a better error message early. The Tuner restore message is also not actionable, so it has been expanded.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
