### PR TITLE
Add --wait-for-workers flag to `ray up`

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1164,7 +1164,10 @@ def stop(force, grace_period):
     "--wait-for-workers",
     required=False,
     type=int,
-    help="If set, the command will block until the specified number of workers nodes have launched.",
+    help=(
+        "If set, the command will block until the specified number "
+        "of workers nodes have launched."
+    ),
 )
 @add_click_logging_options
 @PublicAPI

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1160,6 +1160,12 @@ def stop(force, grace_period):
     default=False,
     help="If True, the usage stats collection will be disabled.",
 )
+@click.option(
+    "--wait-for-workers",
+    is_flag=True,
+    default=False,
+    help="If True, the command will block until there are no pending worker nodes.",
+)
 @add_click_logging_options
 @PublicAPI
 def up(
@@ -1174,6 +1180,7 @@ def up(
     redirect_command_output,
     use_login_shells,
     disable_usage_stats,
+    wait_for_workers,
 ):
     """Create or update a Ray cluster."""
     if disable_usage_stats:
@@ -1212,6 +1219,7 @@ def up(
         no_config_cache=no_config_cache,
         redirect_command_output=redirect_command_output,
         use_login_shells=use_login_shells,
+        wait_for_workers=wait_for_workers,
     )
 
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1162,9 +1162,9 @@ def stop(force, grace_period):
 )
 @click.option(
     "--wait-for-workers",
-    is_flag=True,
-    default=False,
-    help="If True, the command will block until there are no pending worker nodes.",
+    required=False,
+    type=int,
+    help="If set, the command will block until the specified number of workers nodes have launched.",
 )
 @add_click_logging_options
 @PublicAPI


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As discussed in #26499, currently, running the `ray up` command from a clean environment blocks until the head node is started. This adds a flag to `ray up` that blocks until there are no more pending worker nodes.

## Related issue number

Closes #26499.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
