### PR TITLE
[doc/tune] fix tune stopper attribute name

### DIFF
--- a/python/ray/tune/stopper/stopper.py
+++ b/python/ray/tune/stopper/stopper.py
@@ -26,7 +26,7 @@ class Stopper(abc.ABC):
                 return False
 
             def stop_all(self):
-                return time.time() - self._start > self.deadline
+                return time.time() - self._start > self._deadline
 
         tuner = Tuner(
             Trainable,


### PR DESCRIPTION
`deadline` -> `_deadline`

Signed-off-by: Árpád Rózsás <rozsasarpi@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Attribute `deadline` is not defined, `_` is forgotten from the variable name.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
