### PR TITLE
[Ray State API] Include `ray_namespace` in `ActorState`

### DIFF
--- a/python/ray/experimental/state/common.py
+++ b/python/ray/experimental/state/common.py
@@ -333,6 +333,8 @@ class ActorState(StateSchema):
     name: Optional[str] = state_column(filterable=True)
     #: The pid of the actor. 0 if it is not created yet.
     pid: int = state_column(filterable=True)
+    #: The namespace of the actor.
+    ray_namespace: str = state_column(filterable=True)
     #: The runtime environment information of the actor.
     serialized_runtime_env: str = state_column(filterable=False, detail=True)
     #: The resource requirement of the actor.

--- a/python/ray/experimental/state/common.py
+++ b/python/ray/experimental/state/common.py
@@ -304,6 +304,8 @@ class GetLogOptions:
             )
 
 
+# See the ActorTableData message in gcs.proto for all potential options that
+# can be included in this class.
 # TODO(sang): Replace it with Pydantic or gRPC schema (once interface is finalized).
 @dataclass(init=True)
 class ActorState(StateSchema):

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -199,6 +199,15 @@ def shutdown_only(maybe_external_redis):
     ray._private.utils.reset_ray_address()
 
 
+# Provide a shared Ray instance for a test class
+@pytest.fixture(scope="class")
+def class_ray_instance():
+    yield ray.init()
+    ray.shutdown()
+    # Delete the cluster address just in case.
+    ray._private.utils.reset_ray_address()
+
+
 @contextmanager
 def _ray_start(**kwargs):
     init_kwargs = get_default_fixture_ray_kwargs()

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -1571,57 +1571,53 @@ def test_cli_apis_sanity_check(ray_start_cluster):
     sys.platform == "win32",
     reason="Failed on Windows",
 )
-def test_list_get_actors(shutdown_only):
-    ray.init()
+class TestListActors:
+    def test_list_get_actors(self, class_ray_instance):
+        @ray.remote
+        class A:
+            pass
 
-    @ray.remote
-    class A:
-        pass
+        a = A.remote()  # noqa
 
-    a = A.remote()  # noqa
+        def verify():
+            # Test list
+            actors = list_actors()
+            assert len(actors) == 1
+            assert actors[0]["state"] == "ALIVE"
+            assert is_hex(actors[0]["actor_id"])
+            assert a._actor_id.hex() == actors[0]["actor_id"]
 
-    def verify():
-        # Test list
+            # Test get
+            actors = list_actors(detail=True)
+            for actor in actors:
+                get_actor_data = get_actor(actor["actor_id"])
+                assert get_actor_data is not None
+                assert get_actor_data == actor
+
+            return True
+
+        wait_for_condition(verify)
+        print(list_actors())
+
+    def test_list_actors_namespace(self, class_ray_instance):
+        """Check that list_actors returns namespaces."""
+
+        @ray.remote
+        class A:
+            pass
+
+        A.options(namespace="x").remote()
+        A.options(namespace="y").remote()
+
         actors = list_actors()
-        assert len(actors) == 1
-        assert actors[0]["state"] == "ALIVE"
-        assert is_hex(actors[0]["actor_id"])
-        assert a._actor_id.hex() == actors[0]["actor_id"]
+        namespaces = Counter([actor["ray_namespace"] for actor in actors])
+        assert namespaces["x"] == 1
+        assert namespaces["y"] == 1
 
-        # Test get
-        actors = list_actors(detail=True)
-        for actor in actors:
-            get_actor_data = get_actor(actor["actor_id"])
-            assert get_actor_data is not None
-            assert get_actor_data == actor
-
-        return True
-
-    wait_for_condition(verify)
-    print(list_actors())
-
-
-def test_list_actors_namespace(shutdown_only):
-    """Check that list_actors returns namespaces."""
-
-    ray.init()
-
-    @ray.remote
-    class A:
-        pass
-
-    A.options(namespace="x").remote()
-    A.options(namespace="y").remote()
-
-    actors = list_actors()
-    namespaces = Counter([actor["ray_namespace"] for actor in actors])
-    assert namespaces["x"] == 1
-    assert namespaces["y"] == 1
-
-    # Check that we can filter by namespace
-    x_actors = list_actors(filters=[("ray_namespace", "=", "x")])
-    assert len(x_actors) == 1
-    assert x_actors[0]["ray_namespace"] == "x"
+        # Check that we can filter by namespace
+        x_actors = list_actors(filters=[("ray_namespace", "=", "x")])
+        assert len(x_actors) == 1
+        assert x_actors[0]["ray_namespace"] == "x"
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -1619,7 +1619,7 @@ def test_list_actors_namespace(shutdown_only):
     assert namespaces["y"] == 1
 
     # Check that we can filter by namespace
-    x_actors = list_actors(filters=("ray_namespace", "=", "x"))
+    x_actors = list_actors(filters=[("ray_namespace", "=", "x")])
     assert len(x_actors) == 1
     assert x_actors[0]["ray_namespace"] == "x"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change adds `ray_namespace` to the `ActorState` dataclass. This allows functions like `list_actors` to return actor namespaces.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #28544.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - A new unit test is added to `test_state_api.py`.
