### PR TITLE
[metrics] Fix tasks metrics conflict between two core worker submodules

### DIFF
--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -25,9 +25,12 @@ def tasks_by_state(info) -> dict:
     res = fetch_prometheus_metrics([metrics_page])
     if "ray_tasks" in res:
         states = defaultdict(int)
+        states_raw = defaultdict(list)
         for sample in res["ray_tasks"]:
             states[sample.labels["State"]] += sample.value
+            states_raw[(sample.labels["State"], sample.labels["WorkerId"])].append(sample.value)
         print("Tasks by state: {}".format(states))
+        print("Tasks by state raw: {}".format(states_raw))
         return states
     else:
         return {}
@@ -61,6 +64,41 @@ ray.get(a)
     # TODO(ekl) optimize the reporting interval to be faster for testing
     wait_for_condition(
         lambda: tasks_by_state(info) == expected, timeout=20, retry_interval_ms=500
+    )
+    proc.kill()
+
+
+def test_task_nested(shutdown_only):
+    info = ray.init(num_cpus=2, **METRIC_CONFIG)
+
+    driver = """
+import ray
+import time
+
+ray.init("auto")
+
+@ray.remote(num_cpus=0)
+def wrapper():
+    @ray.remote
+    def f():
+        time.sleep(999)
+
+    ray.get([f.remote() for _ in range(10)])
+
+w = wrapper.remote()
+ray.get(w)
+"""
+    proc = run_string_as_driver_nonblocking(driver)
+
+    expected = {
+        "RUNNING": 2.0,
+        "WAITING_FOR_EXECUTION": 0.0,
+        "SCHEDULED": 8.0,
+        "WAITING_FOR_DEPENDENCIES": 0.0,
+    }
+    # TODO(ekl) optimize the reporting interval to be faster for testing
+    wait_for_condition(
+        lambda: tasks_by_state(info) == expected, timeout=20, retry_interval_ms=2000
     )
     proc.kill()
 

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -25,12 +25,9 @@ def tasks_by_state(info) -> dict:
     res = fetch_prometheus_metrics([metrics_page])
     if "ray_tasks" in res:
         states = defaultdict(int)
-        states_raw = defaultdict(list)
         for sample in res["ray_tasks"]:
             states[sample.labels["State"]] += sample.value
-            states_raw[(sample.labels["State"], sample.labels["WorkerId"])].append(sample.value)
         print("Tasks by state: {}".format(states))
-        print("Tasks by state raw: {}".format(states_raw))
         return states
     else:
         return {}
@@ -91,7 +88,7 @@ ray.get(w)
     proc = run_string_as_driver_nonblocking(driver)
 
     expected = {
-        "RUNNING": 2.0,
+        "RUNNING": 3.0,
         "WAITING_FOR_EXECUTION": 0.0,
         "SCHEDULED": 8.0,
         "WAITING_FOR_DEPENDENCIES": 0.0,

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1301,12 +1301,16 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
     }
 
     void UpdateStats() EXCLUSIVE_LOCKS_REQUIRED(&tasks_counter_mutex_) {
-      ray::stats::STATS_tasks.Record(running_total_,
-                                     rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING));
-      // TODO(ekl) this conflicts with WAITING_FOR_EXECUTION recorded by task manager
-      // extract counter into a concrete structure
+      // Note that we set a Source=executor label so that metrics reported here don't
+      // conflict with metrics reported from task_manager.cc.
       ray::stats::STATS_tasks.Record(
-          -running_total_, rpc::TaskStatus_Name(rpc::TaskStatus::WAITING_FOR_EXECUTION));
+          running_total_,
+          {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING)},
+           {"Source", "executor"}});
+      ray::stats::STATS_tasks.Record(
+          -running_total_,
+          {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::WAITING_FOR_EXECUTION)},
+           {"Source", "executor"}});
     }
   };
   TaskCounter task_counter_;

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -34,13 +34,20 @@ void TaskStatusCounter::Swap(rpc::TaskStatus old_status, rpc::TaskStatus new_sta
   counters_[old_status] -= 1;
   counters_[new_status] += 1;
   RAY_CHECK(counters_[old_status] >= 0);
-  ray::stats::STATS_tasks.Record(counters_[old_status], rpc::TaskStatus_Name(old_status));
-  ray::stats::STATS_tasks.Record(counters_[new_status], rpc::TaskStatus_Name(new_status));
+  // Note that we set a Source=owner label so that metrics reported here don't
+  // conflict with metrics reported from core_worker.h.
+  ray::stats::STATS_tasks.Record(
+      counters_[old_status],
+      {{"State", rpc::TaskStatus_Name(old_status)}, {"Source", "owner"}});
+  ray::stats::STATS_tasks.Record(
+      counters_[new_status],
+      {{"State", rpc::TaskStatus_Name(new_status)}, {"Source", "owner"}});
 }
 
 void TaskStatusCounter::Increment(rpc::TaskStatus status) {
   counters_[status] += 1;
-  ray::stats::STATS_tasks.Record(counters_[status], rpc::TaskStatus_Name(status));
+  ray::stats::STATS_tasks.Record(
+      counters_[status], {{"State", rpc::TaskStatus_Name(status)}, {"Source", "owner"}});
 }
 
 std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(

--- a/src/ray/stats/metric_defs.cc
+++ b/src/ray/stats/metric_defs.cc
@@ -34,7 +34,7 @@ namespace stats {
 /// Scheduler
 DEFINE_stats(tasks,
              "Current number of tasks currently in a particular state.",
-             ("State"),
+             ("State", "Source"),
              (),
              ray::stats::GAUGE);
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Both the owner and task executor components of core worker write to the tasks gauge with `State=WAITING_FOR_EXECUTION`, leading to conflicts. Add a label to disambiguate between these two reports, which is simpler / faster than having them lock around a shared data structure.