### PR TITLE
[Datasets] Prune unused columns before aggregate

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -269,8 +269,8 @@ class ArrowBlockAccessor(TableBlockAccessor):
     def select(self, keys: List[KeyFn]) -> "pyarrow.Table":
         if not all(isinstance(key, str) for key in keys):
             raise ValueError(
-                "keys must be a list of strings when aggregating on Arrow blocks, "
-                f"but got: {type(keys)}."
+                "keys must be a list of column name strings when aggregating on Arrow "
+                f"blocks, but got: {keys}."
             )
         return self._table.select(keys)
 

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -266,13 +266,13 @@ class ArrowBlockAccessor(TableBlockAccessor):
         """
         return transform_pyarrow.take_table(self._table, indices)
 
-    def select(self, keys: List[KeyFn]) -> "pyarrow.Table":
-        if not all(isinstance(key, str) for key in keys):
+    def select(self, columns: List[KeyFn]) -> "pyarrow.Table":
+        if not all(isinstance(col, str) for col in columns):
             raise ValueError(
-                "keys must be a list of column name strings when aggregating on Arrow "
-                f"blocks, but got: {keys}."
+                "Columns must be a list of column name strings when aggregating on "
+                f"Arrow blocks, but got: {columns}."
             )
-        return self._table.select(keys)
+        return self._table.select(columns)
 
     def _sample(self, n_samples: int, key: "SortKeyT") -> "pyarrow.Table":
         indices = random.sample(range(self._table.num_rows), n_samples)

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -266,6 +266,14 @@ class ArrowBlockAccessor(TableBlockAccessor):
         """
         return transform_pyarrow.take_table(self._table, indices)
 
+    def select(self, keys: List[KeyFn]) -> "pyarrow.Table":
+        if not all(isinstance(key, str) for key in keys):
+            raise ValueError(
+                "keys must be a list of strings when aggregating on Arrow blocks, "
+                f"but got: {type(keys)}."
+            )
+        return self._table.select(keys)
+
     def _sample(self, n_samples: int, key: "SortKeyT") -> "pyarrow.Table":
         indices = random.sample(range(self._table.num_rows), n_samples)
         table = self._table.select([k[0] for k in key])

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -153,13 +153,13 @@ class PandasBlockAccessor(TableBlockAccessor):
         table.reset_index(drop=True, inplace=True)
         return table
 
-    def select(self, keys: List[KeyFn]) -> "pandas.DataFrame":
-        if not all(isinstance(key, str) for key in keys):
+    def select(self, columns: List[KeyFn]) -> "pandas.DataFrame":
+        if not all(isinstance(col, str) for col in columns):
             raise ValueError(
-                "keys must be a list of column name strings when aggregating on Pandas "
-                f"blocks, but got: {keys}."
+                "Columns must be a list of column name strings when aggregating on "
+                f"Pandas blocks, but got: {columns}."
             )
-        return self._table[keys]
+        return self._table[columns]
 
     def random_shuffle(self, random_seed: Optional[int]) -> "pandas.DataFrame":
         table = self._table.sample(frac=1, random_state=random_seed)

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -156,8 +156,8 @@ class PandasBlockAccessor(TableBlockAccessor):
     def select(self, keys: List[KeyFn]) -> "pandas.DataFrame":
         if not all(isinstance(key, str) for key in keys):
             raise ValueError(
-                "keys must be a list of strings when aggregating on Pandas blocks, "
-                f"but got: {type(keys)}."
+                "keys must be a list of column name strings when aggregating on Pandas "
+                f"blocks, but got: {keys}."
             )
         return self._table[keys]
 

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -153,6 +153,14 @@ class PandasBlockAccessor(TableBlockAccessor):
         table.reset_index(drop=True, inplace=True)
         return table
 
+    def select(self, keys: List[KeyFn]) -> "pandas.DataFrame":
+        if not all(isinstance(key, str) for key in keys):
+            raise ValueError(
+                "keys must be a list of strings when aggregating on Pandas blocks, "
+                f"but got: {type(keys)}."
+            )
+        return self._table[keys]
+
     def random_shuffle(self, random_seed: Optional[int]) -> "pandas.DataFrame":
         table = self._table.sample(frac=1, random_state=random_seed)
         table.reset_index(drop=True, inplace=True)

--- a/python/ray/data/_internal/simple_block.py
+++ b/python/ray/data/_internal/simple_block.py
@@ -80,7 +80,7 @@ class SimpleBlockAccessor(BlockAccessor):
         if len(keys) != 1 or not callable(keys[0]):
             raise ValueError(
                 "keys must be a single callable when selecting on Simple blocks, but "
-                f"got: {type(keys)}."
+                f"got: {keys}."
             )
         callable_key = keys[0]
         return [callable_key(row) for row in self.iter_rows()]

--- a/python/ray/data/_internal/simple_block.py
+++ b/python/ray/data/_internal/simple_block.py
@@ -76,6 +76,15 @@ class SimpleBlockAccessor(BlockAccessor):
     def take(self, indices: List[int]) -> List[T]:
         return [self._items[i] for i in indices]
 
+    def select(self, keys: List[KeyFn]) -> List[T]:
+        if len(keys) != 1 or not callable(keys[0]):
+            raise ValueError(
+                "keys must be a single callable when selecting on Simple blocks, but "
+                f"got: {type(keys)}."
+            )
+        callable_key = keys[0]
+        return [callable_key(row) for row in self.iter_rows()]
+
     def random_shuffle(self, random_seed: Optional[int]) -> List[T]:
         random = np.random.RandomState(random_seed)
         items = self._items.copy()

--- a/python/ray/data/_internal/simple_block.py
+++ b/python/ray/data/_internal/simple_block.py
@@ -76,14 +76,14 @@ class SimpleBlockAccessor(BlockAccessor):
     def take(self, indices: List[int]) -> List[T]:
         return [self._items[i] for i in indices]
 
-    def select(self, keys: List[KeyFn]) -> List[T]:
-        if len(keys) != 1 or not callable(keys[0]):
+    def select(self, columns: List[KeyFn]) -> List[T]:
+        if len(columns) != 1 or not callable(columns[0]):
             raise ValueError(
-                "keys must be a single callable when selecting on Simple blocks, but "
-                f"got: {keys}."
+                "Column must be a single callable when selecting on Simple blocks, "
+                f"but got: {columns}."
             )
-        callable_key = keys[0]
-        return [callable_key(row) for row in self.iter_rows()]
+        callable_col = columns[0]
+        return [callable_col(row) for row in self.iter_rows()]
 
     def random_shuffle(self, random_seed: Optional[int]) -> List[T]:
         random = np.random.RandomState(random_seed)

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -276,8 +276,8 @@ class BlockAccessor(Generic[T]):
         """
         raise NotImplementedError
 
-    def select(self, keys: List[KeyFn]) -> Block:
-        """Return a new block containing the provided keys."""
+    def select(self, columns: List[KeyFn]) -> Block:
+        """Return a new block containing the provided columns."""
         raise NotImplementedError
 
     def random_shuffle(self, random_seed: Optional[int]) -> Block:

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -276,6 +276,10 @@ class BlockAccessor(Generic[T]):
         """
         raise NotImplementedError
 
+    def select(self, keys: List[KeyFn]) -> Block:
+        """Return a new block containing the provided keys."""
+        raise NotImplementedError
+
     def random_shuffle(self, random_seed: Optional[int]) -> Block:
         """Randomly shuffle this block."""
         raise NotImplementedError

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -44,7 +44,7 @@ class _GroupbyOp(ShuffleOp):
         """Partition the block and combine rows with the same key."""
         stats = BlockExecStats.builder()
 
-        block = _GroupbyOp._pruneUnusedColumns(block, key, aggs)
+        block = _GroupbyOp._prune_unused_columns(block, key, aggs)
 
         if key is None:
             partitions = [block]
@@ -73,7 +73,7 @@ class _GroupbyOp(ShuffleOp):
         )
 
     @staticmethod
-    def _pruneUnusedColumns(
+    def _prune_unused_columns(
         block: Block,
         key: KeyFn,
         aggs: Tuple[AggregateFn],

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Generic, List, Tuple, Union, Optional
+from typing import Any, Callable, Generic, List, Tuple, Union
 
 from ray.data._internal import sort
 from ray.data._internal.compute import CallableClass, ComputeStrategy

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -5,7 +5,17 @@ from ray.data._internal.compute import CallableClass, ComputeStrategy
 from ray.data._internal.plan import AllToAllStage
 from ray.data._internal.shuffle import ShuffleOp, SimpleShufflePlan
 from ray.data._internal.push_based_shuffle import PushBasedShufflePlan
-from ray.data.aggregate import AggregateFn, Count, Max, Mean, Min, Std, Sum
+from ._internal.table_block import TableBlockAccessor
+from ray.data.aggregate import (
+    _AggregateOnKeyBase,
+    AggregateFn,
+    Count,
+    Max,
+    Mean,
+    Min,
+    Std,
+    Sum,
+)
 from ray.data.block import (
     Block,
     BlockAccessor,
@@ -33,6 +43,9 @@ class _GroupbyOp(ShuffleOp):
     ) -> List[Union[BlockMetadata, Block]]:
         """Partition the block and combine rows with the same key."""
         stats = BlockExecStats.builder()
+
+        block = _GroupbyOp._pruneUnusedColumns(block, key, aggs)
+
         if key is None:
             partitions = [block]
         else:
@@ -58,6 +71,38 @@ class _GroupbyOp(ShuffleOp):
         return BlockAccessor.for_block(mapper_outputs[0]).aggregate_combined_blocks(
             list(mapper_outputs), key, aggs, finalize=not partial_reduce
         )
+
+    @staticmethod
+    def _pruneUnusedColumns(
+        block: Block,
+        key: KeyFn,
+        aggs: Tuple[AggregateFn],
+    ) -> Block:
+        """Prune unused columns from block before aggregate."""
+        prune_columns = True
+        columns = set()
+
+        if isinstance(key, str):
+            columns.add(key)
+        elif callable(key):
+            prune_columns = False
+
+        for agg in aggs:
+            if isinstance(agg, _AggregateOnKeyBase) and isinstance(agg._key_fn, str):
+                columns.add(agg._key_fn)
+            elif not isinstance(agg, Count):
+                # Not prune columns if any aggregate key is not string.
+                prune_columns = False
+
+        block_accessor = BlockAccessor.for_block(block)
+        if (
+            prune_columns
+            and isinstance(block_accessor, TableBlockAccessor)
+            and block_accessor.num_rows() > 0
+        ):
+            return block_accessor.select(list(columns))
+        else:
+            return block
 
 
 class SimpleShuffleGroupbyOp(_GroupbyOp, SimpleShufflePlan):
@@ -249,31 +294,14 @@ class GroupedDataset(Generic[T]):
         else:
             sorted_ds = self._dataset.repartition(1)
 
-        import numpy as np
-
-        # Returns the keys of the batch in numpy array.
-        # Returns None if the self._key is None.
-        def get_keys(batch) -> Optional[np.ndarray]:
-            import pandas as pd
-            import pyarrow as pa
-
-            if self._key is None:
-                return None
-            if isinstance(batch, pd.DataFrame) or isinstance(batch, pa.Table):
-                assert isinstance(self._key, str)
-                return batch[self._key].to_numpy()
-            elif isinstance(batch, List):
-                assert callable(self._key)
-                return np.array([self._key(item) for item in batch])
-            else:
-                raise ValueError(
-                    f"Unsupported batch type for map_groups: {type(batch)}"
-                )
-
         # Returns the group boundaries.
-        def get_key_boundaries(batch):
+        def get_key_boundaries(block_accessor: BlockAccessor):
+            import numpy as np
+
             boundaries = []
-            keys = get_keys(batch)
+            # Get the keys of the batch in numpy array format
+            keys_block = block_accessor.select([self._key])
+            keys = BlockAccessor.for_block(keys_block).to_numpy()
             start = 0
             while start < keys.size:
                 end = start + np.searchsorted(keys[start:], keys[start], side="right")
@@ -286,7 +314,7 @@ class GroupedDataset(Generic[T]):
         def group_fn(batch):
             block_accessor = BlockAccessor.for_block(batch)
             if self._key:
-                boundaries = get_key_boundaries(batch)
+                boundaries = get_key_boundaries(block_accessor)
             else:
                 boundaries = [block_accessor.num_rows()]
             builder = block_accessor.builder()

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -91,7 +91,7 @@ class _GroupbyOp(ShuffleOp):
             if isinstance(agg, _AggregateOnKeyBase) and isinstance(agg._key_fn, str):
                 columns.add(agg._key_fn)
             elif not isinstance(agg, Count):
-                # Not prune columns if any aggregate key is not string.
+                # Don't prune columns if any aggregate key is not string.
                 prune_columns = False
 
         block_accessor = BlockAccessor.for_block(block)


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to prune (remove) unused columns before doing aggregate (in `_GroupbyOp.map()`). Only keeps the group-by column and columns used in aggregate functions. All other columns can be pruned, so it reduces the cost during sort and aggregate.

Also introduce `BlockAccessor.select(keys)` to get a new `Block` with only selected `keys`/columns. Refactored existing code path in `map_groups` to also use the API. Later on, we can use this API to implement `Dataset.select_columns`.

Tested with query in h2oai benchmark - https://github.com/ray-project/ray/pull/28486 . Reduced query runtime by 50% with this PR.

After this PR, the query takes 7 seconds:

```
>>> path = "/Users/chengsu/db-benchmark/G1_1e7_1e2_0_0.csv"
>>> input_ds = ray.data.read_csv(path).repartition(10).fully_executed()
>>> input_ds.groupby("id1").sum("v1")
Sort Sample: 100%|███████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 13.08it/s]
Shuffle Map: 100%|███████████████████████████████████████████████████████████████| 10/10 [00:07<00:00,  1.30it/s]
Shuffle Reduce: 100%|██████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 1022.28it/s]
Dataset(num_blocks=10, num_rows=100, schema={id1: string, sum(v1): int64})
```

Before this PR, the query takes 13 seconds:

```
>>> input_ds.groupby("id1").sum("v1")
Sort Sample: 100%|███████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 11.50it/s]
Shuffle Map: 100%|███████████████████████████████████████████████████████████████| 10/10 [00:13<00:00,  1.31s/it]
Shuffle Reduce: 100%|███████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 851.34it/s]
Dataset(num_blocks=10, num_rows=100, schema={id1: string, sum(v1): int64})
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
