### PR TITLE
[RLlib] Add `before_sub_environment_reset` callback.

### DIFF
--- a/doc/source/rllib/rllib-training.rst
+++ b/doc/source/rllib/rllib-training.rst
@@ -1013,9 +1013,21 @@ Ray actors provide high levels of performance, so in more complex cases they can
 Callbacks and Custom Metrics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can provide callbacks to be called at points during policy evaluation. These callbacks have access to state for the current `episode <https://github.com/ray-project/ray/blob/master/rllib/evaluation/episode.py>`__. Certain callbacks such as ``on_postprocess_trajectory``, ``on_sample_end``, and ``on_train_result`` are also places where custom postprocessing can be applied to intermediate data or results.
+You can provide callbacks to be called at points during policy evaluation.
+These callbacks have access to state for the current
+`episode <https://github.com/ray-project/ray/blob/master/rllib/evaluation/episode.py>`__.
+Certain callbacks such as ``on_postprocess_trajectory``, ``on_sample_end``,
+and ``on_train_result`` are also places where custom postprocessing can be applied to
+intermediate data or results.
 
-User-defined state can be stored for the `episode <https://github.com/ray-project/ray/blob/master/rllib/evaluation/episode.py>`__ in the ``episode.user_data`` dict, and custom scalar metrics reported by saving values to the ``episode.custom_metrics`` dict. These custom metrics will be aggregated and reported as part of training results. For a full example, see `custom_metrics_and_callbacks.py <https://github.com/ray-project/ray/blob/master/rllib/examples/custom_metrics_and_callbacks.py>`__.
+User-defined state can be stored for the
+`episode <https://github.com/ray-project/ray/blob/master/rllib/evaluation/episode.py>`__
+in the ``episode.user_data`` dict, and custom scalar metrics reported by saving values
+to the ``episode.custom_metrics`` dict. These custom metrics will be aggregated and
+reported as part of training results. For a full example, take a look at
+`this example script here <https://github.com/ray-project/ray/blob/master/rllib/examples/custom_metrics_and_callbacks.py>`__
+and
+`these unit test cases here <https://github.com/ray-project/ray/blob/master/rllib/algorithms/tests/test_callbacks.py>`__.
 
 .. tip::
     You can create custom logic that can run on each evaluation episode by checking if the

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -450,8 +450,8 @@ class AlgorithmConfig:
 
     def environment(
         self,
-        *,
         env: Optional[Union[str, EnvType]] = None,
+        *,
         env_config: Optional[EnvConfigDict] = None,
         observation_space: Optional[gym.spaces.Space] = None,
         action_space: Optional[gym.spaces.Space] = None,

--- a/rllib/algorithms/callbacks.py
+++ b/rllib/algorithms/callbacks.py
@@ -119,7 +119,8 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
         """Callback run before a sub-environment is reset.
 
         This method gets called before every `try_reset()` is called by RLlib
-        on a sub-environment (usually a gym.Env).
+        on a sub-environment (usually a gym.Env). This includes the very first (initial)
+        reset performed on each sub-environment.
 
         Args:
             worker: Reference to the current rollout worker.

--- a/rllib/algorithms/callbacks.py
+++ b/rllib/algorithms/callbacks.py
@@ -12,6 +12,7 @@ from ray.rllib.evaluation.postprocessing import Postprocessing
 from ray.rllib.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import (
+    override,
     OverrideToImplementCustomLogic,
     PublicAPI,
 )
@@ -52,32 +53,6 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
         self.legacy_callbacks = legacy_callbacks_dict or {}
 
     @OverrideToImplementCustomLogic
-    def on_sub_environment_created(
-        self,
-        *,
-        worker: "RolloutWorker",
-        sub_environment: EnvType,
-        env_context: EnvContext,
-        **kwargs,
-    ) -> None:
-        """Callback run when a new sub-environment has been created.
-
-        This method gets called after each sub-environment (usually a
-        gym.Env) has been created, validated (RLlib built-in validation
-        + possible custom validation function implemented by overriding
-        `Algorithm.validate_env()`), wrapped (e.g. video-wrapper), and seeded.
-
-        Args:
-            worker: Reference to the current rollout worker.
-            sub_environment: The sub-environment instance that has been
-                created. This is usually a gym.Env object.
-            env_context: The `EnvContext` object that has been passed to
-                the env's constructor.
-            kwargs: Forward compatibility placeholder.
-        """
-        pass
-
-    @OverrideToImplementCustomLogic
     def on_algorithm_init(
         self,
         *,
@@ -106,6 +81,57 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
         pass
 
     @OverrideToImplementCustomLogic
+    def on_sub_environment_created(
+        self,
+        *,
+        worker: "RolloutWorker",
+        sub_environment: EnvType,
+        env_context: EnvContext,
+        env_index: Optional[int] = None,
+        **kwargs,
+    ) -> None:
+        """Callback run when a new sub-environment has been created.
+
+        This method gets called after each sub-environment (usually a
+        gym.Env) has been created, validated (RLlib built-in validation
+        + possible custom validation function implemented by overriding
+        `Algorithm.validate_env()`), wrapped (e.g. video-wrapper), and seeded.
+
+        Args:
+            worker: Reference to the current rollout worker.
+            sub_environment: The sub-environment instance that has been
+                created. This is usually a gym.Env object.
+            env_context: The `EnvContext` object that has been passed to
+                the env's constructor.
+            kwargs: Forward compatibility placeholder.
+        """
+        pass
+
+    @OverrideToImplementCustomLogic
+    def before_sub_environment_reset(
+        self,
+        *,
+        worker: "RolloutWorker",
+        sub_environment: EnvType,
+        env_index: int,
+        **kwargs,
+    ) -> None:
+        """Callback run before a sub-environment is reset.
+
+        This method gets called before every `try_reset()` is called by RLlib
+        on a sub-environment (usually a gym.Env).
+
+        Args:
+            worker: Reference to the current rollout worker.
+            sub_environment: The sub-environment instance that we are about to reset.
+                This is usually a gym.Env object.
+            env_index: The index of the sub-environment that is about to be reset
+                (within the vector of sub-environments of the BaseEnv).
+            kwargs: Forward compatibility placeholder.
+        """
+        pass
+
+    @OverrideToImplementCustomLogic
     def on_episode_start(
         self,
         *,
@@ -113,6 +139,7 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
         base_env: BaseEnv,
         policies: Dict[PolicyID, Policy],
         episode: Union[Episode, EpisodeV2],
+        env_index: Optional[int] = None,
         **kwargs,
     ) -> None:
         """Callback run on the rollout worker before each episode starts.
@@ -128,6 +155,8 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
                 state. You can use the `episode.user_data` dict to store
                 temporary data, and `episode.custom_metrics` to store custom
                 metrics for the episode.
+            env_index: The index of the sub-environment that started the episode
+                (within the vector of sub-environments of the BaseEnv).
             kwargs: Forward compatibility placeholder.
         """
 
@@ -148,6 +177,7 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
         base_env: BaseEnv,
         policies: Optional[Dict[PolicyID, Policy]] = None,
         episode: Union[Episode, EpisodeV2],
+        env_index: Optional[int] = None,
         **kwargs,
     ) -> None:
         """Runs on each episode step.
@@ -164,6 +194,8 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
                 state. You can use the `episode.user_data` dict to store
                 temporary data, and `episode.custom_metrics` to store custom
                 metrics for the episode.
+            env_index: The index of the sub-environment that stepped the episode
+                (within the vector of sub-environments of the BaseEnv).
             kwargs: Forward compatibility placeholder.
         """
 
@@ -180,6 +212,7 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
         base_env: BaseEnv,
         policies: Dict[PolicyID, Policy],
         episode: Union[Episode, EpisodeV2, Exception],
+        env_index: Optional[int] = None,
         **kwargs,
     ) -> None:
         """Runs when an episode is done.
@@ -200,6 +233,8 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
                 that gets thrown from the environment before the episode finishes.
                 Users of this callback may then handle these error cases properly
                 with their custom logics.
+            env_index: The index of the sub-environment that ended the episode
+                (within the vector of sub-environments of the BaseEnv).
             kwargs: Forward compatibility placeholder.
         """
 
@@ -403,6 +438,7 @@ class MemoryTrackingCallbacks(DefaultCallbacks):
         # Will track the top 10 lines where memory is allocated
         tracemalloc.start(10)
 
+    @override(DefaultCallbacks)
     def on_episode_end(
         self,
         *,
@@ -469,21 +505,24 @@ class MultiCallbacks(DefaultCallbacks):
     def on_trainer_init(self, *args, **kwargs):
         raise DeprecationWarning
 
+    @override(DefaultCallbacks)
     def on_algorithm_init(self, *, algorithm: "Algorithm", **kwargs) -> None:
         for callback in self._callback_list:
             callback.on_algorithm_init(algorithm=algorithm, **kwargs)
 
-    @OverrideToImplementCustomLogic
+    @override(DefaultCallbacks)
     def on_create_policy(self, *, policy_id: PolicyID, policy: Policy) -> None:
         for callback in self._callback_list:
             callback.on_create_policy(policy_id=policy_id, policy=policy)
 
+    @override(DefaultCallbacks)
     def on_sub_environment_created(
         self,
         *,
         worker: "RolloutWorker",
         sub_environment: EnvType,
         env_context: EnvContext,
+        env_index: Optional[int] = None,
         **kwargs,
     ) -> None:
         for callback in self._callback_list:
@@ -494,6 +533,24 @@ class MultiCallbacks(DefaultCallbacks):
                 **kwargs,
             )
 
+    @override(DefaultCallbacks)
+    def before_sub_environment_reset(
+        self,
+        *,
+        worker: "RolloutWorker",
+        sub_environment: EnvType,
+        env_index: Optional[int] = None,
+        **kwargs,
+    ) -> None:
+        for callback in self._callback_list:
+            callback.before_sub_environment_reset(
+                worker=worker,
+                sub_environment=sub_environment,
+                env_index=env_index,
+                **kwargs,
+            )
+
+    @override(DefaultCallbacks)
     def on_episode_start(
         self,
         *,
@@ -514,6 +571,7 @@ class MultiCallbacks(DefaultCallbacks):
                 **kwargs,
             )
 
+    @override(DefaultCallbacks)
     def on_episode_step(
         self,
         *,
@@ -534,6 +592,7 @@ class MultiCallbacks(DefaultCallbacks):
                 **kwargs,
             )
 
+    @override(DefaultCallbacks)
     def on_episode_end(
         self,
         *,
@@ -554,6 +613,7 @@ class MultiCallbacks(DefaultCallbacks):
                 **kwargs,
             )
 
+    @override(DefaultCallbacks)
     def on_evaluate_start(
         self,
         *,
@@ -566,6 +626,7 @@ class MultiCallbacks(DefaultCallbacks):
                 **kwargs,
             )
 
+    @override(DefaultCallbacks)
     def on_evaluate_end(
         self,
         *,
@@ -580,6 +641,7 @@ class MultiCallbacks(DefaultCallbacks):
                 **kwargs,
             )
 
+    @override(DefaultCallbacks)
     def on_postprocess_trajectory(
         self,
         *,
@@ -604,12 +666,14 @@ class MultiCallbacks(DefaultCallbacks):
                 **kwargs,
             )
 
+    @override(DefaultCallbacks)
     def on_sample_end(
         self, *, worker: "RolloutWorker", samples: SampleBatch, **kwargs
     ) -> None:
         for callback in self._callback_list:
             callback.on_sample_end(worker=worker, samples=samples, **kwargs)
 
+    @override(DefaultCallbacks)
     def on_learn_on_batch(
         self, *, policy: Policy, train_batch: SampleBatch, result: dict, **kwargs
     ) -> None:
@@ -618,6 +682,7 @@ class MultiCallbacks(DefaultCallbacks):
                 policy=policy, train_batch=train_batch, result=result, **kwargs
             )
 
+    @override(DefaultCallbacks)
     def on_train_result(
         self, *, algorithm=None, result: dict, trainer=None, **kwargs
     ) -> None:
@@ -656,6 +721,7 @@ class RE3UpdateCallbacks(DefaultCallbacks):
         self._rms = _MovingMeanStd()
         super().__init__(*args, **kwargs)
 
+    @override(DefaultCallbacks)
     def on_learn_on_batch(
         self,
         *,
@@ -687,6 +753,7 @@ class RE3UpdateCallbacks(DefaultCallbacks):
                 train_batch[Postprocessing.VALUE_TARGETS] + states_entropy
             )
 
+    @override(DefaultCallbacks)
     def on_train_result(
         self, *, result: dict, algorithm=None, trainer=None, **kwargs
     ) -> None:

--- a/rllib/algorithms/tests/test_callbacks.py
+++ b/rllib/algorithms/tests/test_callbacks.py
@@ -3,6 +3,7 @@ import unittest
 import ray
 from ray.rllib.algorithms.callbacks import DefaultCallbacks, MultiCallbacks
 import ray.rllib.algorithms.dqn as dqn
+from ray.rllib.examples.env.random_env import RandomEnv
 from ray.rllib.utils.test_utils import framework_iterator
 
 
@@ -20,6 +21,18 @@ class OnSubEnvironmentCreatedCallback(DefaultCallbacks):
             f"worker={worker.worker_index}; "
             f"vector-idx={env_context.vector_index}"
         )
+
+
+class BeforeSubEnvironmentResetCallback(DefaultCallbacks):
+    def __init__(self):
+        super().__init__()
+        self._reset_counter = 0
+
+    def before_sub_environment_reset(
+        self, *, worker, sub_environment, env_index, **kwargs
+    ):
+        print(f"Sub-env {env_index} is going to be reset.")
+        self._reset_counter += 1
 
 
 class TestCallbacks(unittest.TestCase):
@@ -101,6 +114,41 @@ class TestCallbacks(unittest.TestCase):
                 self.assertTrue(sum_sub_env_vector_indices[1] == 6)
                 self.assertTrue(sum_sub_env_vector_indices[2] == 6)
                 algo.stop()
+
+    def test_before_sub_environment_reset(self):
+        # 1000 steps sampled (2.5 episodes on each sub-environment) before training
+        # starts.
+        config = (
+            dqn.DQNConfig()
+            .environment(
+                RandomEnv,
+                env_config={
+                    "max_episode_len": 200,
+                    "p_done": 0.0,
+                },
+            )
+            .rollouts(num_envs_per_worker=2, num_rollout_workers=1)
+            .callbacks(BeforeSubEnvironmentResetCallback)
+        )
+
+        for _ in framework_iterator(config, frameworks=("tf", "torch")):
+            algo = config.build()
+            algo.train()
+            # Two sub-environments share 1000 steps in the first training iteration
+            # (min_sample_timesteps_per_iteration = 1000).
+            # -> 1000 / 2 [sub-envs] = 500 [per sub-env]
+            # -> 1 episode = 200 timesteps
+            # -> 2.5 episodes per sub-env
+            # -> 3 resets [per sub-env] = 6 resets total
+            self.assertTrue(
+                6
+                == ray.get(
+                    algo.workers.remote_workers()[0].apply.remote(
+                        lambda w: w.callbacks._reset_counter
+                    )
+                )
+            )
+            algo.stop()
 
 
 if __name__ == "__main__":

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -393,6 +393,17 @@ class EnvRunnerV2:
             Object containing state, action, reward, terminal condition,
             and other fields as dictated by `policy`.
         """
+        # Before the very first poll (this will reset all vector sub-environments):
+        # Call custom `before_sub_environment_reset` callbacks for all sub-environments.
+        for env_id, sub_env in self._base_env.get_sub_environments(
+            as_dict=True
+        ).items():
+            self._callbacks.before_sub_environment_reset(
+                worker=self._worker,
+                sub_environment=sub_env,
+                env_index=env_id,
+            )
+
         while True:
             self._perf_stats.incr("iters", 1)
 
@@ -773,6 +784,15 @@ class EnvRunnerV2:
             # Basically carry RNN and other buffered state to the
             # next episode from the same env.
         else:
+            # Call custom `before_sub_environment_reset` callback.
+            self._callbacks.before_sub_environment_reset(
+                worker=self._worker,
+                sub_environment=self._base_env.get_sub_environments(as_dict=True)[
+                    env_id
+                ],
+                env_index=env_id,
+            )
+
             # TODO(jungong) : This will allow a single faulty env to
             # take out the entire RolloutWorker indefinitely. Revisit.
             while True:

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -1091,11 +1091,13 @@ def _process_observations(
                 del active_episodes[env_id]
 
                 # Call custom `before_sub_environment_reset` callback.
-                callbacks.before_sub_environment_reset(
-                    worker=worker,
-                    sub_environment=base_env.get_sub_environments(as_dict=True)[env_id],
-                    env_index=env_id,
-                )
+                sub_envs = base_env.get_sub_environments(as_dict=True)
+                if env_id in sub_envs:
+                    callbacks.before_sub_environment_reset(
+                        worker=worker,
+                        sub_environment=sub_envs[env_id],
+                        env_index=env_id,
+                    )
 
                 # TODO(jungong) : This will allow a single faulty env to
                 # take out the entire RolloutWorker indefinitely. Revisit.

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -664,6 +664,15 @@ def _env_runner(
 
     active_episodes: Dict[EnvID, Episode] = _NewEpisodeDefaultDict(new_episode)
 
+    # Before the very first poll (this will reset all vector sub-environments):
+    # Call custom `before_sub_environment_reset` callbacks for all sub-environments.
+    for env_id, sub_env in base_env.get_sub_environments(as_dict=True).items():
+        callbacks.before_sub_environment_reset(
+            worker=worker,
+            sub_environment=sub_env,
+            env_index=env_id,
+        )
+
     while True:
         perf_stats.incr("iters", 1)
 
@@ -1080,6 +1089,14 @@ def _process_observations(
                 }
             else:
                 del active_episodes[env_id]
+
+                # Call custom `before_sub_environment_reset` callback.
+                callbacks.before_sub_environment_reset(
+                    worker=worker,
+                    sub_environment=base_env.get_sub_environments(as_dict=True)[env_id],
+                    env_index=env_id,
+                )
+
                 # TODO(jungong) : This will allow a single faulty env to
                 # take out the entire RolloutWorker indefinitely. Revisit.
                 while True:

--- a/rllib/tests/test_nested_observation_spaces.py
+++ b/rllib/tests/test_nested_observation_spaces.py
@@ -352,7 +352,7 @@ class TupleSpyModel(TFModelV2):
 class NestedObservationSpacesTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        ray.init(num_cpus=5, local_mode=True)  # TODO
+        ray.init(num_cpus=5)
 
     @classmethod
     def tearDownClass(cls):

--- a/rllib/tests/test_nested_observation_spaces.py
+++ b/rllib/tests/test_nested_observation_spaces.py
@@ -352,7 +352,7 @@ class TupleSpyModel(TFModelV2):
 class NestedObservationSpacesTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        ray.init(num_cpus=5)
+        ray.init(num_cpus=5, local_mode=True)  # TODO
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Signed-off-by: sven1977 <svenmika1977@gmail.com>

This PR adds a new `before_sub_environment_reset` callback:

* It is fired before each sub-environment (within a vectorized env stack/BaseEnv) is reset via a `try_reset()` (by RLlib's env runners) OR before the very first `BaseEnv.poll()` (which triggers a reset on ALL vector sub-envs automatically).

* Test case added.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
