### PR TITLE
[docs] setup doc fixes

### DIFF
--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -79,9 +79,9 @@ You will probably want to have some type of Python virtual environment. For exam
 
 .. code-block:: shell
 
-    python -m venv env
+    python -m venv venv
 
-That will create a virtual environment called ``env`` in the current directory, it will contain a directory with all the packages used by the local Python of your project. You only need to do this step once.
+That will create a virtual environment called ``venv`` in the current directory, it will contain a directory with all the packages used by the local Python of your project. You only need to do this step once.
 
 Next, you need to activate the environment to tell your shell/terminal to use this particular Python. This will also depend on the system you use to set up your virtual environment (conda, venv, or other methods).
 
@@ -89,7 +89,7 @@ If you are using the example from above using ``venv``, you would activate your 
 
 .. code-block:: shell
 
-    source env/bin/activate
+    source venv/bin/activate
 
 You will need to activate the virtual environment every time you start a new shell/terminal to work on Ray.
 

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -261,7 +261,7 @@ If you use `Anaconda`_ (`installation instructions`_) and want to use Ray in a d
 .. code-block:: bash
 
   conda config --env --add channels conda-forge
-  conda env create -n ray  # works with mamba too
+  conda create -n ray  # works with mamba too
   conda activate ray
   pip install ray  # or `conda install ray-core`
 


### PR DESCRIPTION
## Why are these changes needed?

I wanted to share one fix and one improvement that was necessary to complete my local python development setup:

1. **If using virtualenv**, it is preferable for the environment's name to be `venv`, instead of `env` as is currently suggested in the current setup guide. This will allow the generated directory and its contents to be covered by the [existing .gitgnore entry](https://github.com/ray-project/ray/blob/master/.gitignore#L180).

2. **If using conda**, the suggested command `conda env create -n ray` failed for me and seems to fail for many users as documented in a[ longstanding conda issue](https://github.com/conda/conda/issues/3859). This PR updates the command to the preferred workaround (`conda create -n ray`).

## Related Issue Number
N/A

## Checks
- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(