### PR TITLE
[RLlib] Make pickle5 RLlib's requirement now that we use cloudpickle to save/restore checkpoints.

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -19,6 +19,7 @@ msgpack >= 1.0.0, < 2.0.0
 numpy >= 1.16
 opencensus
 packaging; python_version >= '3.10'
+pickle5; python_version < '3.8.2'
 prometheus_client >= 0.7.1, < 0.14.0
 protobuf >= 3.15.3, < 4.0.0
 py-spy >= 0.2.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -586,12 +586,6 @@ def pip_run(build_ext):
 
     if setup_spec.type == SetupType.RAY:
         setup_spec.files_to_include += ray_files
-        # We also need to install pickle5 along with Ray, so make sure that the
-        # relevant non-Python pickle5 files get copied.
-        pickle5_dir = os.path.join(ROOT_DIR, PICKLE5_SUBDIR)
-        setup_spec.files_to_include += walk_directory(
-            os.path.join(pickle5_dir, "pickle5")
-        )
 
         thirdparty_dir = os.path.join(ROOT_DIR, THIRDPARTY_SUBDIR)
         setup_spec.files_to_include += walk_directory(thirdparty_dir)

--- a/python/setup.py
+++ b/python/setup.py
@@ -264,6 +264,7 @@ if setup_spec.type == SetupType.RAY:
         "scikit-image",
         "pyyaml",
         "scipy",
+        "pickle5",
     ]
 
     setup_spec.extras["train"] = setup_spec.extras["tune"]


### PR DESCRIPTION
## Why are these changes needed?

RLlib Algorithm now relies on cloudpickle for saving and restoring checkpoints.
https://github.com/ray-project/ray/blob/master/rllib/algorithms/algorithm.py#L32
That means pickle5 getting used for python versions 3.6 and 3.7 on Anyscale.
If they don't have pickle5 installed in their local environment, they wouldn't be able to restore the checkpoint for inference.

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
