### PR TITLE
[WIP] Data backend for Ray task / actor progress bars

### DIFF
--- a/bar.py
+++ b/bar.py
@@ -1,0 +1,16 @@
+import ray
+import time
+
+@ray.remote
+def f():
+    import time
+    time.sleep(.2)
+
+@ray.remote
+def g(x):
+    import time
+    time.sleep(.2)
+
+[g.remote(f.remote()) for _ in range(100)]
+
+ray.progress_bar()

--- a/bar.py
+++ b/bar.py
@@ -1,16 +1,35 @@
-import ray
 import time
 
-@ray.remote
-def f():
-    import time
-    time.sleep(.2)
+import ray
+
 
 @ray.remote
-def g(x):
-    import time
-    time.sleep(.2)
+def inc():
+    time.sleep(0.1)
+    return 1
 
-[g.remote(f.remote()) for _ in range(100)]
+
+@ray.remote
+def add(x):
+    time.sleep(0.1)
+    return x + 1
+
+
+@ray.remote
+def dec(x):
+    time.sleep(0.1)
+    return x - 1
+
+
+@ray.remote
+def sum(*x):
+    s = 0
+    for v in x:
+        s += v
+    return s
+
+
+result = sum.remote(*[dec.remote(add.remote(inc.remote())) for _ in range(100)])
 
 ray.progress_bar()
+print(ray.get(result))

--- a/bar.py
+++ b/bar.py
@@ -5,19 +5,19 @@ import ray
 
 @ray.remote
 def inc():
-    time.sleep(0.1)
+    time.sleep(0.2)
     return 1
 
 
 @ray.remote
 def add(x):
-    time.sleep(0.1)
+    time.sleep(0.2)
     return x + 1
 
 
 @ray.remote
 def dec(x):
-    time.sleep(0.1)
+    time.sleep(0.2)
     return x - 1
 
 

--- a/bar_nested.py
+++ b/bar_nested.py
@@ -10,7 +10,7 @@ def model():
 
 @ray.remote
 def subproc():
-    time.sleep(0.1)
+    time.sleep(1)
 
 
 @ray.remote

--- a/bar_nested.py
+++ b/bar_nested.py
@@ -12,6 +12,13 @@ def model():
 def subproc():
     time.sleep(0.1)
 
-result = [model.remote() for _ in range(5)]
+
+@ray.remote
+def main():
+    result = [model.remote() for _ in range(5)]
+    ray.get(result)
+
+
+m = main.remote()
 ray.progress_bar()
-ray.get(result)
+ray.get(m)

--- a/bar_nested.py
+++ b/bar_nested.py
@@ -1,0 +1,17 @@
+import time
+
+import ray
+
+
+@ray.remote
+def model():
+    ray.get([subproc.remote() for _ in range(20)])
+
+
+@ray.remote
+def subproc():
+    time.sleep(0.1)
+
+result = [model.remote() for _ in range(5)]
+ray.progress_bar()
+ray.get(result)

--- a/dashboard/modules/state/state_head.py
+++ b/dashboard/modules/state/state_head.py
@@ -298,6 +298,11 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
     async def list_tasks(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         return await self._handle_list_api(self._state_api.list_tasks, req)
 
+    @routes.get("/api/v0/task_groups")
+    @RateLimitedModule.enforce_max_concurrent_calls
+    async def list_task_groups(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        return await self._handle_list_api(self._state_api.list_task_groups, req)
+
     @routes.get("/api/v0/objects")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_objects(self, req: aiohttp.web.Request) -> aiohttp.web.Response:

--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -484,8 +484,8 @@ class StateAPIManager:
                             "finished_count": child_group.finished_count,
                             "running_count": running_tasks[key],
                             "creation_time_nanos": child_group.creation_time_nanos,
-                            "group_task_id": group.task_id,
-                            "group_parent_task_id": group.parent_task_id,
+                            "group_task_id": group.group_task_id,
+                            "group_parent_task_id": group.group_parent_task_id,
                             "group_depth": group.depth,
                         }
                     )

--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -466,16 +466,16 @@ class StateAPIManager:
         result = []
         for reply in successful_replies:
             assert not isinstance(reply, Exception)
-            tasks = reply.owned_task_info_entries
-            for task in tasks:
-                data = self._message_to_dict(
-                    message=task,
-                )
-                result.append(data)
+            print("REPLY", reply)
+            result.append({"task_id": "123", "name": "group"})
         result = list(islice(result, option.limit))
         return ListApiResponse(
             result=result,
             partial_failure_warning=partial_failure_warning,
+            total=len(result),
+            num_after_truncation=0,
+            num_filtered=0,
+            warnings=[],
         )
 
     async def list_objects(self, *, option: ListApiOptions) -> ListApiResponse:

--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -473,6 +473,10 @@ class StateAPIManager:
                             "name": child_group.name,
                             "count": child_group.count,
                             "finished_count": child_group.finished_count,
+                            "creation_time_nanos": child_group.creation_time_nanos,
+                            "group_task_id": group.task_id,
+                            "group_parent_task_id": group.parent_task_id,
+                            "group_depth": group.depth,
                         }
                     )
         result = list(islice(result, option.limit))

--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -466,14 +466,18 @@ class StateAPIManager:
         result = []
         for reply in successful_replies:
             assert not isinstance(reply, Exception)
-            print("REPLY", reply)
-            result.append({"task_id": "123", "name": "group"})
+            for group in reply.task_group_infos:
+                for child_group in group.child_group:
+                    result.append({
+                        "name": child_group.name,
+                        "count": child_group.count,
+                    })
         result = list(islice(result, option.limit))
         return ListApiResponse(
             result=result,
             partial_failure_warning=partial_failure_warning,
             total=len(result),
-            num_after_truncation=0,
+            num_after_truncation=len(result),
             num_filtered=0,
             warnings=[],
         )

--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -468,10 +468,13 @@ class StateAPIManager:
             assert not isinstance(reply, Exception)
             for group in reply.task_group_infos:
                 for child_group in group.child_group:
-                    result.append({
-                        "name": child_group.name,
-                        "count": child_group.count,
-                    })
+                    result.append(
+                        {
+                            "name": child_group.name,
+                            "count": child_group.count,
+                            "finished_count": child_group.finished_count,
+                        }
+                    )
         result = list(islice(result, option.limit))
         return ListApiResponse(
             result=result,

--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -476,7 +476,7 @@ class StateAPIManager:
                 f.write(str(running_tasks) + "\n")
             for group in reply.task_group_infos:
                 for child_group in group.child_group:
-                    key = (group.task_id, child_group.name)
+                    key = (group.group_task_id, child_group.name)
                     result.append(
                         {
                             "name": child_group.name,

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -5,6 +5,35 @@ import os
 logger = logging.getLogger(__name__)
 
 
+def progress_bar():
+    import time
+    import tqdm
+    import ray.experimental.state.api
+
+    bars = {}
+    keep_going = True
+    while keep_going:
+        task_groups = ray.experimental.state.api.list_task_groups()
+        keep_going = False
+        for g in task_groups:
+            if g["name"] not in bars:
+                bar = tqdm.tqdm(total=g["count"], position=len(bars))
+                bar.set_description(g["name"])
+                bars[g["name"]] = bar
+                bar.last_update = 0
+            bar = bars[g["name"]]
+            delta = g["finished_count"] - bar.last_update
+            if delta > 0:
+                bar.update(delta)
+            bar.last_update = g["finished_count"]
+            if g["count"] != g["finished_count"]:
+                keep_going = True
+        time.sleep(.2)
+    for bar in bars.values():
+        bar.close()
+    print("All current tasks completed, exiting progress bar.")
+
+
 def _configure_system():
     import os
     import platform

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -14,6 +14,12 @@ def progress_bar():
     keep_going = True
     while keep_going:
         task_groups = ray.experimental.state.api.list_task_groups()
+        print()
+        print(task_groups)
+        print()
+        task_groups = sorted(
+            task_groups, key=lambda group: group["creation_time_nanos"]
+        )
         keep_going = False
         for g in task_groups:
             if g["name"] not in bars:
@@ -28,7 +34,7 @@ def progress_bar():
             bar.last_update = g["finished_count"]
             if g["count"] != g["finished_count"]:
                 keep_going = True
-        time.sleep(.2)
+        time.sleep(0.2)
     for bar in bars.values():
         bar.close()
     print("All current tasks completed, exiting progress bar.")

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -19,12 +19,18 @@ def progress_bar():
         )
         keep_going = False
         for g in task_groups:
-            name = (".." * g["group_depth"]) + g["name"]
-            if name not in bars:
+            d = g["group_depth"]
+            name = ("  " * max(0, d - 1)) + ("\-" * min(1, d)) + g["name"]
+            key = (name, g["group_task_id"])
+            if key not in bars:
                 bar = tqdm.tqdm(total=g["count"], position=len(bars))
-                bar.set_description(name)
-                bars[name] = bar
-            bar = bars[name]
+                bars[key] = bar
+            bar = bars[key]
+            if g["count"] != g["finished_count"]:
+                bar_name = name + ", {} running".format(g["running_count"])
+            else:
+                bar_name = name
+            bar.set_description(bar_name)
             delta = g["finished_count"] - bar.n
             if delta > 0:
                 bar.update(delta)

--- a/python/ray/experimental/state/api.py
+++ b/python/ray/experimental/state/api.py
@@ -1017,7 +1017,7 @@ def list_task_groups(
     return StateApiClient(address=address).list(
         StateResource.TASK_GROUPS,
         options=ListApiOptions(
-            limit=limit, timeout=timeout, filters=filters, detail=detail
+            limit=limit, timeout=timeout, detail=detail
         ),
         raise_on_missing_output=raise_on_missing_output,
         _explain=_explain,

--- a/python/ray/experimental/state/api.py
+++ b/python/ray/experimental/state/api.py
@@ -1016,9 +1016,7 @@ def list_task_groups(
     """
     return StateApiClient(address=address).list(
         StateResource.TASK_GROUPS,
-        options=ListApiOptions(
-            limit=limit, timeout=timeout, detail=detail
-        ),
+        options=ListApiOptions(limit=limit, timeout=timeout, detail=detail),
         raise_on_missing_output=raise_on_missing_output,
         _explain=_explain,
     )

--- a/python/ray/experimental/state/api.py
+++ b/python/ray/experimental/state/api.py
@@ -983,6 +983,47 @@ def list_tasks(
     )
 
 
+def list_task_groups(
+    address: Optional[str] = None,
+    limit: int = DEFAULT_LIMIT,
+    timeout: int = DEFAULT_RPC_TIMEOUT,
+    detail: bool = False,
+    raise_on_missing_output: bool = True,
+    _explain: bool = False,
+) -> List[Dict]:
+    """List task groups in the cluster.
+
+    Args:
+        address: Ray bootstrap address, could be `auto`, `localhost:6379`.
+            If None, it will be resolved automatically from an initialized ray.
+        limit: Max number of entries returned by the state backend.
+        timeout: Max timeout value for the state APIs requests made.
+        detail: When True, more details info (specified in `WorkerState`)
+            will be queried and returned. See
+            :ref:`WorkerState <state-api-schema-worker>`.
+        raise_on_missing_output: When True, exceptions will be raised if
+            there is missing data due to truncation/data source unavailable.
+        _explain: Print the API information such as API latency or
+            failed query information.
+
+    Returns:
+        List of dictionarified
+        :ref:`WorkerState <state-api-schema-worker>`.
+
+    Raises:
+        Exceptions: :ref:`RayStateApiException <state-api-exceptions>` if the CLI
+            failed to query the data.
+    """
+    return StateApiClient(address=address).list(
+        StateResource.TASK_GROUPS,
+        options=ListApiOptions(
+            limit=limit, timeout=timeout, filters=filters, detail=detail
+        ),
+        raise_on_missing_output=raise_on_missing_output,
+        _explain=_explain,
+    )
+
+
 def list_objects(
     address: Optional[str] = None,
     filters: Optional[List[Tuple[str, PredicateType, SupportedFilterType]]] = None,

--- a/python/ray/experimental/state/common.py
+++ b/python/ray/experimental/state/common.py
@@ -486,6 +486,16 @@ class TaskState(StateSchema):
 
 
 @dataclass(init=True)
+class TaskGroupState(StateSchema):
+    """Task Group State"""
+
+    #: The id of the task.
+    task_id: str = state_column(filterable=True)
+    #: The name of the task if it is given by the name argument.
+    name: str = state_column(filterable=True)
+
+
+@dataclass(init=True)
 class ObjectState(StateSchema):
     """Object State"""
 
@@ -898,6 +908,8 @@ def resource_to_schema(resource: StateResource) -> StateSchema:
         return RuntimeEnvState
     elif resource == StateResource.TASKS:
         return TaskState
+    elif resource == StateResource.TASK_GROUPS:
+        return TaskGroupState
     elif resource == StateResource.WORKERS:
         return WorkerState
     else:

--- a/python/ray/experimental/state/common.py
+++ b/python/ray/experimental/state/common.py
@@ -60,6 +60,7 @@ class StateResource(Enum):
     TASKS = "tasks"
     OBJECTS = "objects"
     RUNTIME_ENVS = "runtime_envs"
+    TASK_GROUPS = "task_groups"
 
 
 @unique

--- a/python/ray/experimental/state/state_manager.py
+++ b/python/ray/experimental/state/state_manager.py
@@ -25,6 +25,8 @@ from ray.core.generated.gcs_service_pb2 import (
 from ray.core.generated.node_manager_pb2 import (
     GetObjectsInfoReply,
     GetObjectsInfoRequest,
+    GetTaskGroupsInfoReply,
+    GetTaskGroupsInfoRequest,
     GetTasksInfoReply,
     GetTasksInfoRequest,
 )
@@ -288,6 +290,22 @@ class StateDataSourceClient:
 
         reply = await stub.GetTasksInfo(
             GetTasksInfoRequest(limit=limit), timeout=timeout
+        )
+        return reply
+
+    @handle_grpc_network_errors
+    async def get_task_group_info(
+        self, node_id: str, timeout: int = None, limit: int = None
+    ) -> Optional[GetTaskGroupsInfoReply]:
+        if not limit:
+            limit = RAY_MAX_LIMIT_FROM_DATA_SOURCE
+
+        stub = self._raylet_stubs.get(node_id)
+        if not stub:
+            raise ValueError(f"Raylet for a node id, {node_id} doesn't exist.")
+
+        reply = await stub.GetTaskGroupsInfo(
+            GetTaskGroupsInfoRequest(limit=limit), timeout=timeout
         )
         return reply
 

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -121,6 +121,7 @@ class TaskSpecBuilder {
     message_->set_job_id(job_id.Binary());
     message_->set_task_id(task_id.Binary());
     message_->set_parent_task_id(parent_task_id.Binary());
+    RAY_LOG(ERROR) << "SetParentTaskId" << parent_task_id;
     message_->set_parent_counter(parent_counter);
     message_->set_caller_id(caller_id.Binary());
     message_->mutable_caller_address()->CopyFrom(caller_address);

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -121,7 +121,6 @@ class TaskSpecBuilder {
     message_->set_job_id(job_id.Binary());
     message_->set_task_id(task_id.Binary());
     message_->set_parent_task_id(parent_task_id.Binary());
-    RAY_LOG(ERROR) << "SetParentTaskId" << parent_task_id;
     message_->set_parent_counter(parent_counter);
     message_->set_caller_id(caller_id.Binary());
     message_->mutable_caller_address()->CopyFrom(caller_address);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -275,9 +275,11 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
                                     double timestamp) {
     return PushError(job_id, type, error_message, timestamp);
   };
+  task_group_manager_.reset(new TaskGroupManager());
   task_manager_.reset(new TaskManager(
       memory_store_,
       reference_counter_,
+      task_group_manager_,
       /*put_in_local_plasma_callback=*/
       [this](const RayObject &object, const ObjectID &object_id) {
         RAY_CHECK_OK(PutInLocalPlasmaStore(object, object_id, /*pin_object=*/true));

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3080,6 +3080,10 @@ void CoreWorker::HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest &
     }
   }
 
+  if (request.include_task_group_info()) {
+    task_manager_->FillTaskGroupInfo(reply, limit);
+  }
+
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -275,11 +275,10 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
                                     double timestamp) {
     return PushError(job_id, type, error_message, timestamp);
   };
-  task_group_manager_.reset(new TaskGroupManager());
   task_manager_.reset(new TaskManager(
       memory_store_,
       reference_counter_,
-      task_group_manager_,
+      worker_context_,
       /*put_in_local_plasma_callback=*/
       [this](const RayObject &object, const ObjectID &object_id) {
         RAY_CHECK_OK(PutInLocalPlasmaStore(object, object_id, /*pin_object=*/true));

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3082,6 +3082,12 @@ void CoreWorker::HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest &
 
   if (request.include_task_group_info()) {
     task_manager_->FillTaskGroupInfo(reply, limit);
+    // TODO: unify with running task ids above.
+    for (const auto &current_running_task : current_tasks_) {
+      auto task = reply->add_running_tasks();
+      task->set_name(current_running_task.second.GetName());
+      task->set_parent_task_id(current_running_task.second.ParentTaskId().Binary());
+    }
   }
 
   send_reply_callback(Status::OK(), nullptr, nullptr);

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -32,6 +32,7 @@
 #include "ray/core_worker/reference_count.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/core_worker/store_provider/plasma_store_provider.h"
+#include "ray/core_worker/task_group.h"
 #include "ray/core_worker/transport/direct_actor_transport.h"
 #include "ray/core_worker/transport/direct_task_transport.h"
 #include "ray/gcs/gcs_client/gcs_client.h"
@@ -1143,6 +1144,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///
   /// Fields related to task submission.
   ///
+
+  /// Tracks groups of tasks processed on this worker for metrics reporting.
+  std::shared_ptr<TaskGroupManager> task_group_manager_;
 
   // Tracks the currently pending tasks.
   std::shared_ptr<TaskManager> task_manager_;

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1145,9 +1145,6 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// Fields related to task submission.
   ///
 
-  /// Tracks groups of tasks processed on this worker for metrics reporting.
-  std::shared_ptr<TaskGroupManager> task_group_manager_;
-
   // Tracks the currently pending tasks.
   std::shared_ptr<TaskManager> task_manager_;
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -32,7 +32,6 @@
 #include "ray/core_worker/reference_count.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/core_worker/store_provider/plasma_store_provider.h"
-#include "ray/core_worker/task_group.h"
 #include "ray/core_worker/transport/direct_actor_transport.h"
 #include "ray/core_worker/transport/direct_task_transport.h"
 #include "ray/gcs/gcs_client/gcs_client.h"

--- a/src/ray/core_worker/task_group.cc
+++ b/src/ray/core_worker/task_group.cc
@@ -17,15 +17,28 @@
 namespace ray {
 namespace core {
 
+void TaskGroup::AddPendingTask(const TaskSpecification &spec) {
+  auto name = spec.GetName();
+  tasks_by_name_[name] += 1;
+}
+
 void TaskGroupManager::FillTaskGroupInfo(std::vector<TaskGroup> *output) {
-  absl::MutexLock lock(&mu_);
-  for (const auto &group : groups_) {
-    output->push_back(group);
-  }
+  // TODO
 }
 
 void TaskGroupManager::AddPendingTask(const TaskSpecification &spec) {
-  absl::MutexLock lock(&mu_);
+  auto group = GetOrCreateCurrentTaskGroup();
+  group.AddPendingTask(spec);
+}
+
+TaskGroup &TaskGroupManager::GetOrCreateCurrentTaskGroup() {
+  // TODO(ekl) also check if task id has changed, then also create a new task group
+  if (groups_.size() == 0) {
+    // TODO(ekl) bound groups size
+    groups_.push_back(std::make_unique<TaskGroup>(worker_context_.GetCurrentTask()));
+  }
+  RAY_CHECK(groups_.size() >= 1);
+  return *groups_.back();
 }
 
 }  // namespace core

--- a/src/ray/core_worker/task_group.cc
+++ b/src/ray/core_worker/task_group.cc
@@ -20,14 +20,30 @@ namespace core {
 void TaskGroup::AddPendingTask(const TaskSpecification &spec) {
   auto name = spec.GetName();
   tasks_by_name_[name] += 1;
+  RAY_LOG(ERROR) << "TASKS_BY_NAME " << name << " " << tasks_by_name_[name];
 }
 
-void TaskGroupManager::FillTaskGroupInfo(std::vector<TaskGroup> *output) {
-  // TODO
+void TaskGroup::FillTaskGroup(rpc::TaskGroupInfoEntry *entry) {
+  if (task_spec_ != nullptr) {
+    entry->set_name(task_spec_->GetName());
+  }
+  for (const auto& pair : tasks_by_name_) {
+    auto child_group =  entry->add_child_group();
+    child_group->set_name(pair.first);
+    child_group->set_count(pair.second);
+  }
+}
+
+void TaskGroupManager::FillTaskGroupInfo(rpc::GetCoreWorkerStatsReply *reply,
+                                    const int64_t limit) const {
+  for (const auto& group_data : groups_) {
+    auto group = reply->add_task_group_infos();
+    group_data->FillTaskGroup(group);
+  }
 }
 
 void TaskGroupManager::AddPendingTask(const TaskSpecification &spec) {
-  auto group = GetOrCreateCurrentTaskGroup();
+  auto& group = GetOrCreateCurrentTaskGroup();
   group.AddPendingTask(spec);
 }
 
@@ -36,6 +52,7 @@ TaskGroup &TaskGroupManager::GetOrCreateCurrentTaskGroup() {
   if (groups_.size() == 0) {
     // TODO(ekl) bound groups size
     groups_.push_back(std::make_unique<TaskGroup>(worker_context_.GetCurrentTask()));
+    RAY_LOG(ERROR) << "Create new task group";
   }
   RAY_CHECK(groups_.size() >= 1);
   return *groups_.back();

--- a/src/ray/core_worker/task_group.cc
+++ b/src/ray/core_worker/task_group.cc
@@ -71,6 +71,8 @@ TaskGroup &TaskGroupManager::GetOrCreateCurrentTaskGroup() {
   auto cur_task = worker_context_.GetCurrentTask();
   if (groups_.size() == 0 ||
       (cur_task != nullptr && groups_.back()->TaskId() != cur_task->TaskId())) {
+    // TODO(ekl) we should use actor id as the task id when in an actor, to avoid
+    // creating a new task group for each actor task.
     RAY_LOG(INFO) << "New task group " << worker_context_.GetCurrentTaskID();
     groups_.push_back(
         std::make_unique<TaskGroup>(cur_task, worker_context_.GetCurrentTaskID()));

--- a/src/ray/core_worker/task_group.cc
+++ b/src/ray/core_worker/task_group.cc
@@ -1,0 +1,32 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/core_worker/task_group.h"
+
+namespace ray {
+namespace core {
+
+void TaskGroupManager::FillTaskGroupInfo(std::vector<TaskGroup> *output) {
+  absl::MutexLock lock(&mu_);
+  for (const auto &group : groups_) {
+    output->push_back(group);
+  }
+}
+
+void TaskGroupManager::AddPendingTask(const TaskSpecification &spec) {
+  absl::MutexLock lock(&mu_);
+}
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/task_group.cc
+++ b/src/ray/core_worker/task_group.cc
@@ -35,10 +35,10 @@ void TaskGroup::FinishTask(const TaskSpecification &spec) {
 void TaskGroup::FillTaskGroup(rpc::TaskGroupInfoEntry *entry) {
   if (task_spec_ != nullptr) {
     entry->set_name(task_spec_->GetName());
-    entry->set_parent_task_id(task_spec_->ParentTaskId().Binary());
+    entry->set_group_parent_task_id(task_spec_->ParentTaskId().Binary());
     entry->set_depth(task_spec_->GetDepth());
   }
-  entry->set_task_id(current_task_id_.Binary());
+  entry->set_group_task_id(current_task_id_.Binary());
   for (const auto &pair : tasks_by_name_) {
     auto child_group = entry->add_child_group();
     child_group->set_name(pair.first);

--- a/src/ray/core_worker/task_group.cc
+++ b/src/ray/core_worker/task_group.cc
@@ -35,10 +35,10 @@ void TaskGroup::FinishTask(const TaskSpecification &spec) {
 void TaskGroup::FillTaskGroup(rpc::TaskGroupInfoEntry *entry) {
   if (task_spec_ != nullptr) {
     entry->set_name(task_spec_->GetName());
-    entry->set_task_id(current_task_id_.Binary());
     entry->set_parent_task_id(task_spec_->ParentTaskId().Binary());
     entry->set_depth(task_spec_->GetDepth());
   }
+  entry->set_task_id(current_task_id_.Binary());
   for (const auto &pair : tasks_by_name_) {
     auto child_group = entry->add_child_group();
     child_group->set_name(pair.first);
@@ -71,9 +71,9 @@ TaskGroup &TaskGroupManager::GetOrCreateCurrentTaskGroup() {
   auto cur_task = worker_context_.GetCurrentTask();
   if (groups_.size() == 0 ||
       (cur_task != nullptr && groups_.back()->TaskId() != cur_task->TaskId())) {
-    RAY_LOG(ERROR) << "New task group ";
+    RAY_LOG(INFO) << "New task group " << worker_context_.GetCurrentTaskID();
     groups_.push_back(
-        std::make_unique<TaskGroup>(cur_task, worker_context_.GetCurrentTaskId()));
+        std::make_unique<TaskGroup>(cur_task, worker_context_.GetCurrentTaskID()));
     // TODO(ekl) bound groups size
   }
   RAY_CHECK(groups_.size() >= 1);

--- a/src/ray/core_worker/task_group.h
+++ b/src/ray/core_worker/task_group.h
@@ -27,15 +27,29 @@ namespace core {
 
 class TaskGroup {
  public:
-  TaskGroup(std::shared_ptr<const TaskSpecification> task_spec) : task_spec_(task_spec){};
+  TaskGroup(std::shared_ptr<const TaskSpecification> task_spec, TaskID current_task_id)
+      : task_spec_(task_spec), current_task_id_(current_task_id){};
   void AddPendingTask(const TaskSpecification &spec);
   void FinishTask(const TaskSpecification &spec);
   void FillTaskGroup(rpc::TaskGroupInfoEntry *entry);
 
+  TaskID TaskId() const {
+    if (task_spec_ == nullptr) {
+      return TaskID::Nil();
+    } else {
+      return task_spec_->TaskId();
+    }
+  };
+
  private:
+  // Note: nullable.
   std::shared_ptr<const TaskSpecification> task_spec_;
+  TaskID current_task_id_;
   absl::flat_hash_map<std::string, int64_t> tasks_by_name_;
+  // TODO: revisit the task state strategy. We need executor workers to provide
+  // additional task state info that we merge with the group infos (e.g., RUNNING).
   absl::flat_hash_map<std::string, int64_t> finished_tasks_by_name_;
+  absl::flat_hash_map<std::string, int64_t> creation_time_by_name_;
   RAY_DISALLOW_COPY_AND_ASSIGN(TaskGroup);
 };
 

--- a/src/ray/core_worker/task_group.h
+++ b/src/ray/core_worker/task_group.h
@@ -38,7 +38,7 @@ class TaskGroup {
 class TaskGroupManager {
   // TODO: add enabled config flag
  public:
-  TaskGroupManager(WorkerContext &ctx) : worker_context_(ctx) {};
+  TaskGroupManager(WorkerContext &ctx) : worker_context_(ctx){};
   void FillTaskGroupInfo(std::vector<TaskGroup> *);
   void AddPendingTask(const TaskSpecification &spec);
 

--- a/src/ray/core_worker/task_group.h
+++ b/src/ray/core_worker/task_group.h
@@ -1,0 +1,44 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "absl/synchronization/mutex.h"
+#include "ray/common/grpc_util.h"
+#include "ray/common/id.h"
+#include "ray/common/task/task.h"
+#include "src/ray/protobuf/core_worker.pb.h"
+
+namespace ray {
+namespace core {
+
+class TaskGroup {};
+
+// This class is thread-safe.
+class TaskGroupManager {
+  // TODO: add enabled config flag
+ public:
+  void FillTaskGroupInfo(std::vector<TaskGroup> *);
+  void AddPendingTask(const TaskSpecification &spec);
+
+ private:
+  absl::Mutex mu_;
+
+  std::deque<TaskGroup> groups_ GUARDED_BY(mu_);
+
+  bool has_current_task_group GUARDED_BY(mu_) = false;
+};
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/task_group.h
+++ b/src/ray/core_worker/task_group.h
@@ -38,7 +38,7 @@ class TaskGroup {
 class TaskGroupManager {
   // TODO: add enabled config flag
  public:
-  TaskGroupManager(WorkerContext &ctx);
+  TaskGroupManager(WorkerContext &ctx) : worker_context_(ctx) {};
   void FillTaskGroupInfo(std::vector<TaskGroup> *);
   void AddPendingTask(const TaskSpecification &spec);
 

--- a/src/ray/core_worker/task_group.h
+++ b/src/ray/core_worker/task_group.h
@@ -29,11 +29,13 @@ class TaskGroup {
  public:
   TaskGroup(std::shared_ptr<const TaskSpecification> task_spec) : task_spec_(task_spec){};
   void AddPendingTask(const TaskSpecification &spec);
+  void FinishTask(const TaskSpecification &spec);
   void FillTaskGroup(rpc::TaskGroupInfoEntry *entry);
 
  private:
   std::shared_ptr<const TaskSpecification> task_spec_;
   absl::flat_hash_map<std::string, int64_t> tasks_by_name_;
+  absl::flat_hash_map<std::string, int64_t> finished_tasks_by_name_;
   RAY_DISALLOW_COPY_AND_ASSIGN(TaskGroup);
 };
 
@@ -42,9 +44,9 @@ class TaskGroupManager {
   // TODO: add enabled config flag
  public:
   TaskGroupManager(WorkerContext &ctx) : worker_context_(ctx){};
-  void FillTaskGroupInfo(rpc::GetCoreWorkerStatsReply *reply,
-                                      const int64_t limit) const;
+  void FillTaskGroupInfo(rpc::GetCoreWorkerStatsReply *reply, const int64_t limit) const;
   void AddPendingTask(const TaskSpecification &spec);
+  void FinishTask(const TaskSpecification &spec);
 
  private:
   TaskGroup &GetOrCreateCurrentTaskGroup();

--- a/src/ray/core_worker/task_group.h
+++ b/src/ray/core_worker/task_group.h
@@ -19,6 +19,7 @@
 #include "ray/common/id.h"
 #include "ray/common/task/task.h"
 #include "ray/core_worker/context.h"
+#include "ray/util/macros.h"
 #include "src/ray/protobuf/core_worker.pb.h"
 
 namespace ray {
@@ -28,10 +29,12 @@ class TaskGroup {
  public:
   TaskGroup(std::shared_ptr<const TaskSpecification> task_spec) : task_spec_(task_spec){};
   void AddPendingTask(const TaskSpecification &spec);
+  void FillTaskGroup(rpc::TaskGroupInfoEntry *entry);
 
  private:
   std::shared_ptr<const TaskSpecification> task_spec_;
   absl::flat_hash_map<std::string, int64_t> tasks_by_name_;
+  RAY_DISALLOW_COPY_AND_ASSIGN(TaskGroup);
 };
 
 // This class is NOT thread-safe.
@@ -39,7 +42,8 @@ class TaskGroupManager {
   // TODO: add enabled config flag
  public:
   TaskGroupManager(WorkerContext &ctx) : worker_context_(ctx){};
-  void FillTaskGroupInfo(std::vector<TaskGroup> *);
+  void FillTaskGroupInfo(rpc::GetCoreWorkerStatsReply *reply,
+                                      const int64_t limit) const;
   void AddPendingTask(const TaskSpecification &spec);
 
  private:

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -734,5 +734,10 @@ void TaskManager::FillTaskInfo(rpc::GetCoreWorkerStatsReply *reply,
   reply->set_tasks_total(total);
 }
 
+void TaskManager::FillTaskGroupInfo(rpc::GetCoreWorkerStatsReply *reply,
+                               const int64_t limit) const {
+  RAY_LOG(ERROR) << "TODO FILL TASK GROUP INFO";
+}
+
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -50,6 +50,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
     int max_retries) {
   RAY_LOG(DEBUG) << "Adding pending task " << spec.TaskId() << " with " << max_retries
                  << " retries";
+  task_group_manager_->AddPendingTask(spec);
 
   // Add references for the dependencies to the task.
   std::vector<ObjectID> task_deps;

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -736,7 +736,7 @@ void TaskManager::FillTaskInfo(rpc::GetCoreWorkerStatsReply *reply,
 
 void TaskManager::FillTaskGroupInfo(rpc::GetCoreWorkerStatsReply *reply,
                                     const int64_t limit) const {
-  RAY_LOG(ERROR) << "TODO FILL TASK GROUP INFO";
+  task_group_manager_.FillTaskGroupInfo(reply, limit);
 }
 
 }  // namespace core

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -735,7 +735,7 @@ void TaskManager::FillTaskInfo(rpc::GetCoreWorkerStatsReply *reply,
 }
 
 void TaskManager::FillTaskGroupInfo(rpc::GetCoreWorkerStatsReply *reply,
-                               const int64_t limit) const {
+                                    const int64_t limit) const {
   RAY_LOG(ERROR) << "TODO FILL TASK GROUP INFO";
 }
 

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -50,7 +50,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
     int max_retries) {
   RAY_LOG(DEBUG) << "Adding pending task " << spec.TaskId() << " with " << max_retries
                  << " retries";
-  task_group_manager_->AddPendingTask(spec);
+  task_group_manager_.AddPendingTask(spec);
 
   // Add references for the dependencies to the task.
   std::vector<ObjectID> task_deps;

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -356,6 +356,7 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
     it->second.num_successful_executions++;
 
     it->second.SetStatus(rpc::TaskStatus::FINISHED);
+    task_group_manager_.FinishTask(spec);
     num_pending_tasks_--;
 
     // A finished task can only be re-executed if it has some number of

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -20,6 +20,7 @@
 #include "ray/common/id.h"
 #include "ray/common/task/task.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
+#include "ray/core_worker/task_group.h"
 #include "ray/stats/metric_defs.h"
 #include "src/ray/protobuf/common.pb.h"
 #include "src/ray/protobuf/core_worker.pb.h"
@@ -105,12 +106,14 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
  public:
   TaskManager(std::shared_ptr<CoreWorkerMemoryStore> in_memory_store,
               std::shared_ptr<ReferenceCounter> reference_counter,
+              std::shared_ptr<TaskGroupManager> task_group_manager,
               PutInLocalPlasmaCallback put_in_local_plasma_callback,
               RetryTaskCallback retry_task_callback,
               PushErrorCallback push_error_callback,
               int64_t max_lineage_bytes)
       : in_memory_store_(in_memory_store),
         reference_counter_(reference_counter),
+        task_group_manager_(task_group_manager),
         put_in_local_plasma_callback_(put_in_local_plasma_callback),
         retry_task_callback_(retry_task_callback),
         push_error_callback_(push_error_callback),
@@ -389,6 +392,9 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// The task manager is responsible for managing all references related to
   /// submitted tasks (dependencies and return objects).
   std::shared_ptr<ReferenceCounter> reference_counter_;
+
+  /// Reference to the task groups tracker for this core worker process.
+  std::shared_ptr<TaskGroupManager> task_group_manager_;
 
   /// Callback to store objects in plasma. This is used for objects that were
   /// originally stored in plasma. During reconstruction, we ensure that these

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -19,6 +19,7 @@
 #include "absl/synchronization/mutex.h"
 #include "ray/common/id.h"
 #include "ray/common/task/task.h"
+#include "ray/core_worker/context.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/core_worker/task_group.h"
 #include "ray/stats/metric_defs.h"

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -294,6 +294,9 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// Fill every task information of the current worker to GetCoreWorkerStatsReply.
   void FillTaskInfo(rpc::GetCoreWorkerStatsReply *reply, const int64_t limit) const;
 
+  /// Fill every task information of the current worker to GetCoreWorkerStatsReply.
+  void FillTaskGroupInfo(rpc::GetCoreWorkerStatsReply *reply, const int64_t limit) const;
+
  private:
   struct TaskEntry {
     TaskEntry(const TaskSpecification &spec_arg,

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -691,7 +691,7 @@ message NamedActorInfo {
 message ChildTaskGroup {
   string name = 1;
   int64 count = 2;
-  int64 completed = 3;
+  int64 finished_count = 3;
 }
 
 message TaskGroupInfoEntry {

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -702,3 +702,8 @@ message TaskGroupInfoEntry {
   repeated ChildTaskGroup child_group = 4;
   int64 depth = 5;
 }
+
+message RunningTaskInfo {
+  string name = 1;
+  bytes parent_task_id = 2;
+}

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -687,3 +687,14 @@ message NamedActorInfo {
   string ray_namespace = 1;
   string name = 2;
 }
+
+message ChildTaskGroup {
+  string name = 1;
+  int64 count = 2;
+  int64 completed = 3;
+}
+
+message TaskGroupInfoEntry {
+  string name = 1;
+  repeated ChildTaskGroup child_group = 2;
+}

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -697,8 +697,8 @@ message ChildTaskGroup {
 
 message TaskGroupInfoEntry {
   string name = 1;
-  bytes task_id = 2;
-  bytes parent_task_id = 3;
+  bytes group_task_id = 2;
+  bytes group_parent_task_id = 3;
   repeated ChildTaskGroup child_group = 4;
   int64 depth = 5;
 }

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -692,9 +692,13 @@ message ChildTaskGroup {
   string name = 1;
   int64 count = 2;
   int64 finished_count = 3;
+  int64 creation_time_nanos = 4;
 }
 
 message TaskGroupInfoEntry {
   string name = 1;
-  repeated ChildTaskGroup child_group = 2;
+  bytes task_id = 2;
+  bytes parent_task_id = 3;
+  repeated ChildTaskGroup child_group = 4;
+  int64 depth = 5;
 }

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -294,6 +294,8 @@ message GetCoreWorkerStatsReply {
   repeated bytes running_task_ids = 3;
   // Length of the number of tasks without truncation.
   int64 tasks_total = 4;
+  // Optional list of task groups tracked by this worker.
+  repeated TaskGroupInfoEntry task_group_infos = 5;
 }
 
 message LocalGCRequest {

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -269,9 +269,11 @@ message GetCoreWorkerStatsRequest {
   // Whether to include task information. This could be large since it
   // includes metadata for all live tasks.
   bool include_task_info = 3;
+  // Whether to include task group information.
+  bool include_task_group_info = 4;
   // Maximum number of entries to return.
   // If not specified, return the whole entries without truncation.
-  optional int64 limit = 4;
+  optional int64 limit = 5;
 }
 
 message GetCoreWorkerStatsReply {

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -296,6 +296,8 @@ message GetCoreWorkerStatsReply {
   int64 tasks_total = 4;
   // Optional list of task groups tracked by this worker.
   repeated TaskGroupInfoEntry task_group_infos = 5;
+  // TODO: unify with running_task_ids above.
+  repeated RunningTaskInfo running_tasks = 6;
 }
 
 message LocalGCRequest {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -313,6 +313,16 @@ message GetTasksInfoReply {
   // actor). We should handle this better.
 }
 
+message GetTaskGroupsInfoRequest {
+  // Maximum number of entries to return.
+  // If not specified, return the whole entries without truncation.
+  optional int64 limit = 1;
+}
+
+message GetTaskGroupsInfoReply {
+  // TODO
+}
+
 message GetObjectsInfoRequest {
   // Maximum number of entries to return.
   // If not specified, return the whole entries without truncation.
@@ -396,6 +406,8 @@ service NodeManagerService {
   rpc GetSystemConfig(GetSystemConfigRequest) returns (GetSystemConfigReply);
   // [State API] Get the all task information of the node.
   rpc GetTasksInfo(GetTasksInfoRequest) returns (GetTasksInfoReply);
+  // [State API] Get the all task group information of the node.
+  rpc GetTaskGroupsInfo(GetTaskGroupsInfoRequest) returns (GetTaskGroupsInfoReply);
   // [State API] Get the all object information of the node.
   rpc GetObjectsInfo(GetObjectsInfoRequest) returns (GetObjectsInfoReply);
 }

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -320,7 +320,7 @@ message GetTaskGroupsInfoRequest {
 }
 
 message GetTaskGroupsInfoReply {
-  // TODO
+  repeated TaskGroupInfoEntry task_group_infos = 1;
 }
 
 message GetObjectsInfoRequest {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -321,6 +321,7 @@ message GetTaskGroupsInfoRequest {
 
 message GetTaskGroupsInfoReply {
   repeated TaskGroupInfoEntry task_group_infos = 1;
+  repeated RunningTaskInfo running_tasks = 2;
 }
 
 message GetObjectsInfoRequest {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -794,7 +794,9 @@ void NodeManager::HandleGetTaskGroupsInfo(const rpc::GetTaskGroupsInfoRequest &r
       [reply, total, limit, count](const ray::Status &status,
                                    const rpc::GetCoreWorkerStatsReply &r) {
         if (status.ok()) {
-          RAY_LOG(ERROR) << "IGNORING CORE WORKER RESPONSE";
+          for (auto i=0; i < r.task_group_infos_size(); i++) {
+            reply->add_task_group_infos()->CopyFrom(r.task_group_infos(i));
+          }
         } else {
           RAY_LOG(INFO) << "Failed to query task information from a worker.";
         }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -794,7 +794,7 @@ void NodeManager::HandleGetTaskGroupsInfo(const rpc::GetTaskGroupsInfoRequest &r
       [reply, total, limit, count](const ray::Status &status,
                                    const rpc::GetCoreWorkerStatsReply &r) {
         if (status.ok()) {
-          for (auto i=0; i < r.task_group_infos_size(); i++) {
+          for (auto i = 0; i < r.task_group_infos_size(); i++) {
             reply->add_task_group_infos()->CopyFrom(r.task_group_infos(i));
           }
         } else {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -781,8 +781,8 @@ void NodeManager::HandleGetTasksInfo(const rpc::GetTasksInfoRequest &request,
 }
 
 void NodeManager::HandleGetTaskGroupsInfo(const rpc::GetTaskGroupsInfoRequest &request,
-                                     rpc::GetTaskGroupsInfoReply *reply,
-                                     rpc::SendReplyCallback send_reply_callback) {
+                                          rpc::GetTaskGroupsInfoReply *reply,
+                                          rpc::SendReplyCallback send_reply_callback) {
   RAY_LOG(DEBUG) << "Received a HandleGetTaskGroupsInfo request";
   auto total = std::make_shared<int>(0);
   auto count = std::make_shared<int>(0);
@@ -793,18 +793,8 @@ void NodeManager::HandleGetTaskGroupsInfo(const rpc::GetTaskGroupsInfoRequest &r
       /*on_replied*/
       [reply, total, limit, count](const ray::Status &status,
                                    const rpc::GetCoreWorkerStatsReply &r) {
-        *total += r.tasks_total();
         if (status.ok()) {
-          for (const auto &task_info : r.owned_task_info_entries()) {
-            if (limit != -1 && *count >= limit) {
-              break;
-            }
-            *count += 1;
-            reply->add_owned_task_info_entries()->CopyFrom(task_info);
-          }
-          for (const auto &running_task_id : r.running_task_ids()) {
-            reply->add_running_task_ids(running_task_id);
-          }
+          RAY_LOG(ERROR) << "IGNORING CORE WORKER RESPONSE";
         } else {
           RAY_LOG(INFO) << "Failed to query task information from a worker.";
         }
@@ -814,7 +804,7 @@ void NodeManager::HandleGetTaskGroupsInfo(const rpc::GetTaskGroupsInfoRequest &r
       /*include_task_info*/ false,
       /*include_task_group_info*/ true,
       /*limit*/ limit,
-      /*on_all_replied*/ [total, reply]() { reply->set_total(*total); });
+      /*on_all_replied*/ [total, reply]() {});
 }
 
 void NodeManager::HandleGetObjectsInfo(const rpc::GetObjectsInfoRequest &request,

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -775,6 +775,44 @@ void NodeManager::HandleGetTasksInfo(const rpc::GetTasksInfoRequest &request,
       send_reply_callback,
       /*include_memory_info*/ false,
       /*include_task_info*/ true,
+      /*include_task_group_info*/ false,
+      /*limit*/ limit,
+      /*on_all_replied*/ [total, reply]() { reply->set_total(*total); });
+}
+
+void NodeManager::HandleGetTaskGroupsInfo(const rpc::GetTaskGroupsInfoRequest &request,
+                                     rpc::GetTaskGroupsInfoReply *reply,
+                                     rpc::SendReplyCallback send_reply_callback) {
+  RAY_LOG(DEBUG) << "Received a HandleGetTaskGroupsInfo request";
+  auto total = std::make_shared<int>(0);
+  auto count = std::make_shared<int>(0);
+  auto limit = request.has_limit() ? request.limit() : -1;
+  // Each worker query will have limit as well.
+  // At the end there will be limit * num_workers entries returned at max.
+  QueryAllWorkerStates(
+      /*on_replied*/
+      [reply, total, limit, count](const ray::Status &status,
+                                   const rpc::GetCoreWorkerStatsReply &r) {
+        *total += r.tasks_total();
+        if (status.ok()) {
+          for (const auto &task_info : r.owned_task_info_entries()) {
+            if (limit != -1 && *count >= limit) {
+              break;
+            }
+            *count += 1;
+            reply->add_owned_task_info_entries()->CopyFrom(task_info);
+          }
+          for (const auto &running_task_id : r.running_task_ids()) {
+            reply->add_running_task_ids(running_task_id);
+          }
+        } else {
+          RAY_LOG(INFO) << "Failed to query task information from a worker.";
+        }
+      },
+      send_reply_callback,
+      /*include_memory_info*/ false,
+      /*include_task_info*/ false,
+      /*include_task_group_info*/ true,
       /*limit*/ limit,
       /*on_all_replied*/ [total, reply]() { reply->set_total(*total); });
 }
@@ -810,6 +848,7 @@ void NodeManager::HandleGetObjectsInfo(const rpc::GetObjectsInfoRequest &request
       send_reply_callback,
       /*include_memory_info*/ true,
       /*include_task_info*/ false,
+      /*include_task_group_info*/ false,
       /*limit*/ limit,
       /*on_all_replied*/ [total, reply]() { reply->set_total(*total); });
 }
@@ -820,6 +859,7 @@ void NodeManager::QueryAllWorkerStates(
     rpc::SendReplyCallback &send_reply_callback,
     bool include_memory_info,
     bool include_task_info,
+    bool include_task_group_info,
     int64_t limit,
     const std::function<void()> &on_all_replied) {
   auto all_workers = worker_pool_.GetAllRegisteredWorkers(/* filter_dead_worker */ true,
@@ -858,6 +898,7 @@ void NodeManager::QueryAllWorkerStates(
     request.set_intended_worker_id(worker->WorkerId().Binary());
     request.set_include_memory_info(include_memory_info);
     request.set_include_task_info(include_task_info);
+    request.set_include_task_group_info(include_task_group_info);
     request.set_limit(limit);
     // TODO(sang): Add timeout to the RPC call.
     worker->rpc_client()->GetCoreWorkerStats(

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -797,6 +797,9 @@ void NodeManager::HandleGetTaskGroupsInfo(const rpc::GetTaskGroupsInfoRequest &r
           for (auto i = 0; i < r.task_group_infos_size(); i++) {
             reply->add_task_group_infos()->CopyFrom(r.task_group_infos(i));
           }
+          for (auto i = 0; i < r.running_tasks_size(); i++) {
+            reply->add_running_tasks()->CopyFrom(r.running_tasks(i));
+          }
         } else {
           RAY_LOG(INFO) << "Failed to query task information from a worker.";
         }

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -241,6 +241,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// from all workers.
   /// \param include_task_info If true, it requires every task metadata information
   /// from all workers.
+  /// \param include_task_group_info If true, it requires every task group metadata
+  /// from all workers.
   /// \param limit A maximum number of task/object entries to return from each core
   /// worker.
   /// \param on_all_replied A callback that's called when every worker replies.
@@ -250,6 +252,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
       rpc::SendReplyCallback &send_reply_callback,
       bool include_memory_info,
       bool include_task_info,
+      bool include_task_gruop_info,
       int64_t limit,
       const std::function<void()> &on_all_replied);
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -622,6 +622,11 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
                           rpc::GetTasksInfoReply *reply,
                           rpc::SendReplyCallback send_reply_callback) override;
 
+  /// Handle a `HandleGetTaskGroupsInfo` request.
+  void HandleGetTaskGroupsInfo(const rpc::GetTaskGroupsInfoRequest &request,
+                               rpc::GetTaskGroupsInfoReply *reply,
+                               rpc::SendReplyCallback send_reply_callback) override;
+
   /// Handle a `HandleGetObjectsInfo` request.
   void HandleGetObjectsInfo(const rpc::GetObjectsInfoRequest &request,
                             rpc::GetObjectsInfoReply *reply,

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -193,6 +193,12 @@ class NodeManagerWorkerClient
                          grpc_client_,
                          /*method_timeout_ms*/ -1, )
 
+  /// Get all the task group information from the node.
+  VOID_RPC_CLIENT_METHOD(NodeManagerService,
+                         GetTaskGroupsInfo,
+                         grpc_client_,
+                         /*method_timeout_ms*/ -1, )
+
   /// Get all the object information from the node.
   VOID_RPC_CLIENT_METHOD(NodeManagerService,
                          GetObjectsInfo,

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -46,6 +46,7 @@ namespace rpc {
   RPC_SERVICE_HANDLER(NodeManagerService, GetSystemConfig, -1)        \
   RPC_SERVICE_HANDLER(NodeManagerService, ShutdownRaylet, -1)         \
   RPC_SERVICE_HANDLER(NodeManagerService, GetTasksInfo, -1)           \
+  RPC_SERVICE_HANDLER(NodeManagerService, GetTaskGroupsInfo, -1)      \
   RPC_SERVICE_HANDLER(NodeManagerService, GetObjectsInfo, -1)
 
 /// Interface of the `NodeManagerService`, see `src/ray/protobuf/node_manager.proto`.
@@ -149,6 +150,11 @@ class NodeManagerServiceHandler {
   virtual void HandleGetTasksInfo(const GetTasksInfoRequest &request,
                                   GetTasksInfoReply *reply,
                                   SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleGetTaskGroupsInfo(const GetTaskGroupsInfoRequest &request,
+                                  GetTaskGroupsInfoReply *reply,
+                                  SendReplyCallback send_reply_callback) = 0;
+
 
   virtual void HandleGetObjectsInfo(const GetObjectsInfoRequest &request,
                                     GetObjectsInfoReply *reply,

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -152,9 +152,8 @@ class NodeManagerServiceHandler {
                                   SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleGetTaskGroupsInfo(const GetTaskGroupsInfoRequest &request,
-                                  GetTaskGroupsInfoReply *reply,
-                                  SendReplyCallback send_reply_callback) = 0;
-
+                                       GetTaskGroupsInfoReply *reply,
+                                       SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleGetObjectsInfo(const GetObjectsInfoRequest &request,
                                     GetObjectsInfoReply *reply,

--- a/x.py
+++ b/x.py
@@ -1,10 +1,13 @@
 import ray
 
+
 @ray.remote
 def f():
     import time
+
     time.sleep(1)
     print("F")
     ray.get(f.remote())
+
 
 ray.get(f.remote())

--- a/x.py
+++ b/x.py
@@ -1,0 +1,10 @@
+import ray
+
+@ray.remote
+def f():
+    import time
+    time.sleep(1)
+    print("F")
+    ray.get(f.remote())
+
+ray.get(f.remote())


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds a new resource called `TaskGroup` that can be queried via the Ray State API in order to report the progress of arbitrary Ray workloads.

A TaskGroup is a summary of child tasks launched from a driver, task, or actor. In the simplest case, when only the driver program is launching tasks, there is only a single TaskGroup for the entire job. When there are nested, hierarchical programs, there will be multiple TaskGroups that can be linked together via parent relationships.

You can query current and historical TaskGroups for a cluster via `ray list task-groups --format=json`, or by using `ray.experimental.state.api.list_task_groups()`. This can be used to render progress bars. Here are some example progress bars for a simple DAG as well as a nested DAG:

**Simple DAG**:
![Screenshot from 2022-09-16 16-23-37](https://user-images.githubusercontent.com/14922/190830347-da82f938-574b-4a88-8bb8-30f12508ea03.png)

**Nested DAG**:
![Screenshot from 2022-09-16 16-23-23](https://user-images.githubusercontent.com/14922/190830342-74695270-3323-4f03-b004-facb63cceda7.png)

### Known TODOs:
- [ ] Need to include job_id in task group information
- [ ] The task group id for actor-launched tasks should be the current actor id, not the current actor task id (which generates too many task group fragments)
- [ ] Implement limit on the max number of historical task groups
- [ ] Include more information on the fine-grained execution state of tasks (e.g., waiting for object transfer
- [ ] Other info like task resource requirements 