### PR TITLE
GitHub discussions isn't used anymore, dead link

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -6,7 +6,7 @@ Reporting bugs and asking questions
 
 You can post questions or issues or feedback through the following channels:
 
-1. `Github Discussions`_: For discussions about development, questions about usage, and feature requests.
+1. `Discourse forum`_: For discussions about development and questions about usage.
 2. `GitHub Issues`_: For bug reports and feature requests.
 3. `StackOverflow`_
 
@@ -19,7 +19,7 @@ For instructions on setting up your development environment, check out the
 `getting involved`_ documentation page.
 
 
-.. _`Github Discussions`: https://github.com/ray-project/ray/discussions
+.. _`Discourse forum`: https://discuss.ray.io/
 .. _`GitHub Issues`: https://github.com/ray-project/ray/issues
 .. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray
 .. _`getting involved`: https://docs.ray.io/en/master/getting-involved.html


### PR DESCRIPTION
Signed-off-by: Ram Rachum <ram@rachum.com>

## Why are these changes needed?

Dead link

## Related issue number

No issue

## Checks

- [V] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [V] I've run `scripts/format.sh` to lint the changes in this PR.
- [V] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [V] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
