### PR TITLE
[RLlib] Pass input dict into action connectors, because sometimes input data is useful for adapting output actions.

### DIFF
--- a/doc/source/rllib/rllib-connector.rst
+++ b/doc/source/rllib/rllib-connector.rst
@@ -119,7 +119,7 @@ The output from RLlib's default agent connector pipeline is in ``AgentConnectors
    :start-after: __sphinx_doc_begin_agent_connector_output__
    :end-before: __sphinx_doc_end_agent_connector_output__
 
-Note that in addition to the processed sample batch which can be used for running the policy
+Note that in addition to the processed sample batch, which can be used for running the policy
 forward pass, ``AgentConnectorsOutput`` also provides the original raw input dict, because it
 sometimes contains data required for downstream processing (e.g. action masks).
 

--- a/doc/source/rllib/rllib-connector.rst
+++ b/doc/source/rllib/rllib-connector.rst
@@ -119,18 +119,17 @@ The output from RLlib's default agent connector pipeline is in ``AgentConnectors
    :start-after: __sphinx_doc_begin_agent_connector_output__
    :end-before: __sphinx_doc_end_agent_connector_output__
 
-Note that if ``AgentConnector._is_training`` is False, the ``for_training`` field of ``AgentConnectorsOutput``
-will not be populated. This is for more efficient inference.
-
-.. note::
-    There is a plan to consolidate training episode building into agent connectors, in which case there will
-    not be a need to output the ``for_training`` data piece.
+Note that in addition to the processed sample batch which can be used for running the policy
+forward pass, ``AgentConnectorsOutput`` also provides the original raw input dict, because it
+sometimes contains data required for downstream processing (e.g. action masks).
 
 ActionConnectorDataType
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 ``ActionConnectorDataType`` is the data type ``ActionConnector`` deals with.
-It is basically env and agent IDs plus ``PolicyOutputType``.
+It is basically env and agent IDs, input_dict, and ``PolicyOutputType``.
+The raw input dict is made available for action connectors in case some of the
+data fields are needed for adapting action outputs, for example action masks.
 
 .. literalinclude:: ../../../rllib/utils/typing.py
    :language: python

--- a/rllib/connectors/action/clip.py
+++ b/rllib/connectors/action/clip.py
@@ -26,6 +26,7 @@ class ClipActionsConnector(ActionConnector):
         return ActionConnectorDataType(
             ac_data.env_id,
             ac_data.agent_id,
+            ac_data.input_dict,
             (clip_action(actions, self._action_space_struct), states, fetches),
         )
 

--- a/rllib/connectors/action/immutable.py
+++ b/rllib/connectors/action/immutable.py
@@ -25,6 +25,7 @@ class ImmutableActionsConnector(ActionConnector):
         return ActionConnectorDataType(
             ac_data.env_id,
             ac_data.agent_id,
+            ac_data.input_dict,
             (actions, states, fetches),
         )
 

--- a/rllib/connectors/action/lambdas.py
+++ b/rllib/connectors/action/lambdas.py
@@ -44,6 +44,7 @@ def register_lambda_action_connector(
             return ActionConnectorDataType(
                 ac_data.env_id,
                 ac_data.agent_id,
+                ac_data.input_dict,
                 fn(actions, states, fetches),
             )
 

--- a/rllib/connectors/action/normalize.py
+++ b/rllib/connectors/action/normalize.py
@@ -29,6 +29,7 @@ class NormalizeActionsConnector(ActionConnector):
         return ActionConnectorDataType(
             ac_data.env_id,
             ac_data.agent_id,
+            ac_data.input_dict,
             (unsquash_action(actions, self._action_space_struct), states, fetches),
         )
 

--- a/rllib/connectors/action/pipeline.py
+++ b/rllib/connectors/action/pipeline.py
@@ -15,13 +15,7 @@ from ray.util.annotations import PublicAPI
 @PublicAPI(stability="alpha")
 class ActionConnectorPipeline(ConnectorPipeline, ActionConnector):
     def __init__(self, ctx: ConnectorContext, connectors: List[Connector]):
-        super().__init__(ctx)
-        self.connectors = connectors
-
-    def is_training(self, is_training: bool):
-        self._is_training = is_training
-        for c in self.connectors:
-            c.is_training(is_training)
+        super().__init__(ctx, connectors)
 
     def __call__(self, ac_data: ActionConnectorDataType) -> ActionConnectorDataType:
         for c in self.connectors:

--- a/rllib/connectors/agent/lambdas.py
+++ b/rllib/connectors/agent/lambdas.py
@@ -60,11 +60,11 @@ def flatten_data(data: AgentConnectorsOutput):
         data, AgentConnectorsOutput
     ), "Single agent data must be of type AgentConnectorsOutput"
 
-    for_training = data.for_training
-    for_action = data.for_action
+    raw_dict = data.raw_dict
+    sample_batch = data.sample_batch
 
     flattened = {}
-    for k, v in for_action.items():
+    for k, v in sample_batch.items():
         if k in [SampleBatch.INFOS, SampleBatch.ACTIONS] or k.startswith("state_out_"):
             # Do not flatten infos, actions, and state_out_ columns.
             flattened[k] = v
@@ -76,7 +76,7 @@ def flatten_data(data: AgentConnectorsOutput):
         flattened[k] = np.array(tree.flatten(v))
     flattened = SampleBatch(flattened, is_training=False)
 
-    return AgentConnectorsOutput(for_training, flattened)
+    return AgentConnectorsOutput(raw_dict, flattened)
 
 
 # Agent connector to build and return a flattened observation SampleBatch

--- a/rllib/connectors/agent/pipeline.py
+++ b/rllib/connectors/agent/pipeline.py
@@ -15,13 +15,7 @@ from ray.util.annotations import PublicAPI
 @PublicAPI(stability="alpha")
 class AgentConnectorPipeline(ConnectorPipeline, AgentConnector):
     def __init__(self, ctx: ConnectorContext, connectors: List[Connector]):
-        super().__init__(ctx)
-        self.connectors = connectors
-
-    def is_training(self, is_training: bool):
-        self._is_training = is_training
-        for c in self.connectors:
-            c.is_training(is_training)
+        super().__init__(ctx, connectors)
 
     def reset(self, env_id: str):
         for c in self.connectors:

--- a/rllib/connectors/agent/view_requirement.py
+++ b/rllib/connectors/agent/view_requirement.py
@@ -27,7 +27,7 @@ class ViewRequirementAgentConnector(AgentConnector):
         "raw_dict": {"obs": ...}
         "sample_batch": SampleBatch
     }
-    raw_dict which contains raw data for the latest time slice,
+    raw_dict, which contains raw data for the latest time slice,
     can be used to construct a complete episode by Sampler for training purpose.
     The "for_action" SampleBatch can be used to directly call the policy.
     """
@@ -87,7 +87,7 @@ class ViewRequirementAgentConnector(AgentConnector):
         )
 
         vr = self._view_requirements
-        assert vr, "ViewRequirements required by ViewRequirementConnector"
+        assert vr, "ViewRequirements required by ViewRequirementAgentConnector"
 
         # Note(jungong) : we need to keep the entire input dict here.
         # A column may be used by postprocessing (GAE) even if its

--- a/rllib/connectors/agent/view_requirement.py
+++ b/rllib/connectors/agent/view_requirement.py
@@ -24,10 +24,10 @@ class ViewRequirementAgentConnector(AgentConnector):
     The output of this connector is AgentConnectorsOut, which basically is
     a tuple of 2 things:
     {
-        "for_training": {"obs": ...}
-        "for_action": SampleBatch
+        "raw_dict": {"obs": ...}
+        "sample_batch": SampleBatch
     }
-    The "for_training" dict, which contains data for the latest time slice,
+    raw_dict which contains raw data for the latest time slice,
     can be used to construct a complete episode by Sampler for training purpose.
     The "for_action" SampleBatch can be used to directly call the policy.
     """
@@ -89,13 +89,10 @@ class ViewRequirementAgentConnector(AgentConnector):
         vr = self._view_requirements
         assert vr, "ViewRequirements required by ViewRequirementConnector"
 
-        training_dict = None
-        # Return full training_dict for env runner to construct episodes.
-        if self._is_training:
-            # Note(jungong) : we need to keep the entire input dict here.
-            # A column may be used by postprocessing (GAE) even if its
-            # iew_requirement.used_for_training is False.
-            training_dict = d
+        # Note(jungong) : we need to keep the entire input dict here.
+        # A column may be used by postprocessing (GAE) even if its
+        # iew_requirement.used_for_training is False.
+        training_dict = d
 
         agent_collector = self.agent_collectors[env_id][agent_id]
 

--- a/rllib/connectors/connector.py
+++ b/rllib/connectors/connector.py
@@ -316,6 +316,7 @@ class ActionConnector(Connector):
 @PublicAPI(stability="alpha")
 class ConnectorPipeline(abc.ABC):
     """Utility class for quick manipulation of a connector pipeline."""
+
     def __init__(self, ctx: ConnectorContext, connectors: List[Connector]):
         self.connectors = connectors
 

--- a/rllib/connectors/connector.py
+++ b/rllib/connectors/connector.py
@@ -95,7 +95,7 @@ class Connector(abc.ABC):
 
     def __init__(self, ctx: ConnectorContext):
         # Default is training mode.
-        self.in_training()
+        self._is_training = True
 
     def in_training(self):
         self._is_training = True

--- a/rllib/connectors/connector.py
+++ b/rllib/connectors/connector.py
@@ -94,11 +94,14 @@ class Connector(abc.ABC):
     """
 
     def __init__(self, ctx: ConnectorContext):
-        # This gets flipped to False for inference.
+        # Default is training mode.
+        self.in_training()
+
+    def in_training(self):
         self._is_training = True
 
-    def is_training(self, is_training: bool):
-        self._is_training = is_training
+    def in_eval(self):
+        self._is_training = False
 
     def __str__(self, indentation: int = 0):
         return " " * indentation + self.__class__.__name__
@@ -313,6 +316,16 @@ class ActionConnector(Connector):
 @PublicAPI(stability="alpha")
 class ConnectorPipeline(abc.ABC):
     """Utility class for quick manipulation of a connector pipeline."""
+    def __init__(self, ctx: ConnectorContext, connectors: List[Connector]):
+        self.connectors = connectors
+
+    def in_training(self):
+        for c in self.connectors:
+            c.in_training()
+
+    def in_eval(self):
+        for c in self.connectors:
+            c.in_eval()
 
     def remove(self, name: str):
         """Remove a connector by <name>
@@ -321,14 +334,15 @@ class ConnectorPipeline(abc.ABC):
             name: name of the connector to be removed.
         """
         idx = -1
-        for idx, c in enumerate(self.connectors):
+        for i, c in enumerate(self.connectors):
             if c.__class__.__name__ == name:
+                idx = i
                 break
-        if idx < 0:
-            raise ValueError(f"Can not find connector {name}")
-        del self.connectors[idx]
-
-        logger.info(f"Removed connector {name} from {self.__class__.__name__}.")
+        if idx >= 0:
+            del self.connectors[idx]
+            logger.info(f"Removed connector {name} from {self.__class__.__name__}.")
+        else:
+            logger.warning(f"Trying to remove a non-existent connector {name}.")
 
     def insert_before(self, name: str, connector: Connector):
         """Insert a new connector before connector <name>

--- a/rllib/connectors/tests/test_action.py
+++ b/rllib/connectors/tests/test_action.py
@@ -38,7 +38,7 @@ class TestActionConnector(unittest.TestCase):
 
         action = torch.Tensor([8, 9])
         states = torch.Tensor([[1, 1, 1], [2, 2, 2]])
-        ac_data = ActionConnectorDataType(0, 1, (action, states, {}))
+        ac_data = ActionConnectorDataType(0, 1, {}, (action, states, {}))
 
         converted = c(ac_data)
         self.assertTrue(isinstance(converted.output[0], np.ndarray))
@@ -56,7 +56,7 @@ class TestActionConnector(unittest.TestCase):
         restored = get_connector(ctx, name, params)
         self.assertTrue(isinstance(restored, NormalizeActionsConnector))
 
-        ac_data = ActionConnectorDataType(0, 1, (0.5, [], {}))
+        ac_data = ActionConnectorDataType(0, 1, {}, (0.5, [], {}))
 
         normalized = c(ac_data)
         self.assertEqual(normalized.output[0], 4.5)
@@ -73,7 +73,7 @@ class TestActionConnector(unittest.TestCase):
         restored = get_connector(ctx, name, params)
         self.assertTrue(isinstance(restored, ClipActionsConnector))
 
-        ac_data = ActionConnectorDataType(0, 1, (8.8, [], {}))
+        ac_data = ActionConnectorDataType(0, 1, {}, (8.8, [], {}))
 
         clipped = c(ac_data)
         self.assertEqual(clipped.output[0], 6.0)
@@ -90,7 +90,7 @@ class TestActionConnector(unittest.TestCase):
         restored = get_connector(ctx, name, params)
         self.assertTrue(isinstance(restored, ImmutableActionsConnector))
 
-        ac_data = ActionConnectorDataType(0, 1, (np.array([8.8]), [], {}))
+        ac_data = ActionConnectorDataType(0, 1, {}, (np.array([8.8]), [], {}))
 
         immutable = c(ac_data)
 

--- a/rllib/connectors/tests/test_agent.py
+++ b/rllib/connectors/tests/test_agent.py
@@ -1,4 +1,3 @@
-from random import sample
 import gym
 import numpy as np
 import unittest
@@ -250,7 +249,7 @@ class TestViewRequirementAgentConnector(unittest.TestCase):
                 check(sample_batch["prev_state"], obs_list[-2][None])
 
     def test_vr_connector_causal_slice(self):
-        """Test that the ViewRequirementAgentConnector can handle slice shifts correctly."""
+        """Test that the ViewRequirementAgentConnector can handle slice shifts."""
         view_rq_dict = {
             "state": ViewRequirement("obs"),
             # shift array should be [-2, -1, 0]

--- a/rllib/connectors/tests/test_agent.py
+++ b/rllib/connectors/tests/test_agent.py
@@ -1,3 +1,4 @@
+from random import sample
 import gym
 import numpy as np
 import unittest
@@ -112,7 +113,7 @@ class TestAgentConnector(unittest.TestCase):
         d = AgentConnectorDataType(
             0,
             1,
-            # FlattenDataAgentConnector does NOT touch for_training dict,
+            # FlattenDataAgentConnector does NOT touch raw_dict,
             # so simply pass None here.
             AgentConnectorsOutput(None, sample_batch),
         )
@@ -120,7 +121,7 @@ class TestAgentConnector(unittest.TestCase):
         flattened = c([d])
         self.assertEqual(len(flattened), 1)
 
-        batch = flattened[0].data.for_action
+        batch = flattened[0].data.sample_batch
         self.assertTrue((batch[SampleBatch.NEXT_OBS] == [1, 1, 2, 2, 8.8]).all())
         self.assertEqual(batch[SampleBatch.REWARDS][0], 5.8)
         # Not flattened.
@@ -151,7 +152,7 @@ class TestAgentConnector(unittest.TestCase):
         self.assertEqual(len(with_buffered), 1)
         self.assertTrue((with_buffered[0].data[SampleBatch.ACTIONS] == [0, 0, 0]).all())
 
-        c.on_policy_output(ActionConnectorDataType(0, 1, ([1, 2, 3], [], {})))
+        c.on_policy_output(ActionConnectorDataType(0, 1, {}, ([1, 2, 3], [], {})))
 
         with_buffered = c([d])
         self.assertEqual(len(with_buffered), 1)
@@ -161,14 +162,11 @@ class TestAgentConnector(unittest.TestCase):
 class TestViewRequirementConnector(unittest.TestCase):
     def test_vr_connector_respects_training_or_inference_vr_flags(self):
         """Tests that the connector respects the flags within view_requirements (i.e.
-        used_for_training, used_for_compute_actions) under different is_training modes.
-        is_training = False (inference mode)
-            the returned data is a SampleBatch that can be used to run corresponding
-            policy.
-        is_training = True (training mode)
-            the returned data is the input dict itself, which the policy collector in
-            env_runner will use to construct the episode, and a SampleBatch that can be
-            used to run corresponding policy.
+        used_for_training, used_for_compute_actions).
+
+        the returned data is the input dict itself, which the policy collector in
+        env_runner will use to construct the episode, and a SampleBatch that can be
+        used to run corresponding policy.
         """
         view_rq_dict = {
             "both": ViewRequirement(
@@ -196,7 +194,7 @@ class TestViewRequirementConnector(unittest.TestCase):
             is_policy_recurrent=True,
         )
 
-        for_action_expected = SampleBatch(
+        sample_batch_expected = SampleBatch(
             {
                 "both": obs_arr[None],
                 "only_inference": obs_arr[None],
@@ -204,31 +202,22 @@ class TestViewRequirementConnector(unittest.TestCase):
             }
         )
 
-        for_training_expected_list = [
-            # is_training = False
-            None,
-            # is_training = True
-            agent_data,
-        ]
+        c = ViewRequirementAgentConnector(ctx)
+        c.in_training()
+        processed = c([data])
 
-        for is_training in [True, False]:
-            c = ViewRequirementAgentConnector(ctx)
-            c.is_training(is_training)
-            processed = c([data])
+        raw_dict = processed[0].data.raw_dict
+        raw_dict_expected = agent_data
+        sample_batch = processed[0].data.sample_batch
 
-            for_training = processed[0].data.for_training
-            for_training_expected = for_training_expected_list[is_training]
-            for_action = processed[0].data.for_action
+        print("-" * 30)
+        print("for action:")
+        print(sample_batch)
+        print("for training:")
+        print(raw_dict)
 
-            print("-" * 30)
-            print(f"is_training = {is_training}")
-            print("for action:")
-            print(for_action)
-            print("for training:")
-            print(for_training)
-
-            check(for_training, for_training_expected)
-            check(for_action, for_action_expected)
+        check(raw_dict, agent_data)
+        check(sample_batch, sample_batch_expected)
 
     def test_vr_connector_shift_by_one(self):
         """Test that the ViewRequirementConnector can handle shift by one correctly and
@@ -256,15 +245,15 @@ class TestViewRequirementConnector(unittest.TestCase):
                 0, 1, {SampleBatch.NEXT_OBS: obs, SampleBatch.T: t - 1}
             )
             processed = c([data])  # env.reset() for t == -1 else env.step()
-            for_action = processed[0].data.for_action
+            sample_batch = processed[0].data.sample_batch
             # add cur obs to the list
             obs_list.append(obs)
 
             if t == 0:
-                check(for_action["prev_state"], for_action["state"])
+                check(sample_batch["prev_state"], sample_batch["state"])
             else:
                 # prev state should be equal to the prev time step obs
-                check(for_action["prev_state"], obs_list[-2][None])
+                check(sample_batch["prev_state"], obs_list[-2][None])
 
     def test_vr_connector_causal_slice(self):
         """Test that the ViewRequirementConnector can handle slice shifts correctly."""
@@ -293,7 +282,7 @@ class TestViewRequirementConnector(unittest.TestCase):
                 0, 1, {SampleBatch.NEXT_OBS: obs, SampleBatch.T: t - 1}
             )
             processed = c([data])
-            for_action = processed[0].data.for_action
+            sample_batch = processed[0].data.sample_batch
 
             if t == 0:
                 obs_list.extend([obs for _ in range(5)])
@@ -303,22 +292,22 @@ class TestViewRequirementConnector(unittest.TestCase):
                 obs_list.append(obs)
 
             # check state
-            check(for_action["state"], obs[None])
+            check(sample_batch["state"], obs[None])
 
             # check prev_states
             check(
-                for_action["prev_states"],
+                sample_batch["prev_states"],
                 np.stack(obs_list)[np.array([-3, -2, -1])][None],
             )
 
             # check prev_strided_states_even
             check(
-                for_action["prev_strided_states_even"],
+                sample_batch["prev_strided_states_even"],
                 np.stack(obs_list)[np.array([-5, -3, -1])][None],
             )
 
             check(
-                for_action["prev_strided_states_odd"],
+                sample_batch["prev_strided_states_odd"],
                 np.stack(obs_list)[np.array([-4, -2])][None],
             )
 
@@ -363,7 +352,7 @@ class TestViewRequirementConnector(unittest.TestCase):
             }
             data = AgentConnectorDataType(0, 1, timestep_data)
             processed = c([data])
-            for_action = processed[0].data.for_action
+            sample_batch = processed[0].data.sample_batch
 
             if t == 0:
                 obs_list.extend([obs_arrs[0] for _ in range(context_len)])
@@ -376,9 +365,9 @@ class TestViewRequirementConnector(unittest.TestCase):
                 obs_list.append(obs_arrs[t])
                 act_list.append(act_arrs[t - 1])
 
-            self.assertTrue("context_next_obs" not in for_action)
-            check(for_action["context_obs"], np.stack(obs_list)[None])
-            check(for_action["context_act"], np.stack(act_list[:-1])[None])
+            self.assertTrue("context_next_obs" not in sample_batch)
+            check(sample_batch["context_obs"], np.stack(obs_list)[None])
+            check(sample_batch["context_act"], np.stack(act_list[:-1])[None])
 
     def test_connector_pipline_with_view_requirement(self):
         """A very minimal test that checks wheter pipeline connectors work in a
@@ -430,10 +419,10 @@ class TestViewRequirementConnector(unittest.TestCase):
         total_rewards = 0
         while t < n_steps:
             policy_output = policy.compute_actions_from_input_dict(
-                agent_obs.data.for_action
+                agent_obs.data.sample_batch
             )
             agent_connector.on_policy_output(
-                ActionConnectorDataType(0, 1, policy_output)
+                ActionConnectorDataType(0, 1, {}, policy_output)
             )
             action = policy_output[0][0]
 

--- a/rllib/connectors/tests/test_agent.py
+++ b/rllib/connectors/tests/test_agent.py
@@ -159,7 +159,7 @@ class TestAgentConnector(unittest.TestCase):
         self.assertEqual(with_buffered[0].data[SampleBatch.ACTIONS], [1, 2, 3])
 
 
-class TestViewRequirementConnector(unittest.TestCase):
+class TestViewRequirementAgentConnector(unittest.TestCase):
     def test_vr_connector_respects_training_or_inference_vr_flags(self):
         """Tests that the connector respects the flags within view_requirements (i.e.
         used_for_training, used_for_compute_actions).
@@ -197,6 +197,7 @@ class TestViewRequirementConnector(unittest.TestCase):
         sample_batch_expected = SampleBatch(
             {
                 "both": obs_arr[None],
+                # Output in training model as well.
                 "only_inference": obs_arr[None],
                 "seq_lens": np.array([1]),
             }
@@ -207,20 +208,13 @@ class TestViewRequirementConnector(unittest.TestCase):
         processed = c([data])
 
         raw_dict = processed[0].data.raw_dict
-        raw_dict_expected = agent_data
         sample_batch = processed[0].data.sample_batch
-
-        print("-" * 30)
-        print("for action:")
-        print(sample_batch)
-        print("for training:")
-        print(raw_dict)
 
         check(raw_dict, agent_data)
         check(sample_batch, sample_batch_expected)
 
     def test_vr_connector_shift_by_one(self):
-        """Test that the ViewRequirementConnector can handle shift by one correctly and
+        """Test that the ViewRequirementAgentConnector can handle shift by one correctly and
         can ignore future referencing view_requirements to respect causality"""
         view_rq_dict = {
             "state": ViewRequirement("obs"),
@@ -256,7 +250,7 @@ class TestViewRequirementConnector(unittest.TestCase):
                 check(sample_batch["prev_state"], obs_list[-2][None])
 
     def test_vr_connector_causal_slice(self):
-        """Test that the ViewRequirementConnector can handle slice shifts correctly."""
+        """Test that the ViewRequirementAgentConnector can handle slice shifts correctly."""
         view_rq_dict = {
             "state": ViewRequirement("obs"),
             # shift array should be [-2, -1, 0]
@@ -312,7 +306,7 @@ class TestViewRequirementConnector(unittest.TestCase):
             )
 
     def test_vr_connector_with_multiple_buffers(self):
-        """Test that the ViewRequirementConnector can handle slice shifts correctly
+        """Test that the ViewRequirementAgentConnector can handle slice shifts correctly
         when it has multiple buffers to shift."""
         context_len = 5
         # This view requirement simulates the use-case of a decision transformer

--- a/rllib/connectors/tests/test_connector.py
+++ b/rllib/connectors/tests/test_connector.py
@@ -51,6 +51,12 @@ class TestConnectorPipeline(unittest.TestCase):
         self.assertEqual(m.connectors[0].__class__.__name__, "Tom")
         self.assertEqual(m.connectors[1].__class__.__name__, "Mary")
 
+        m.remove("Bob")
+        # Bob does not exist anymore, still 2.
+        self.assertEqual(len(m.connectors), 2)
+        self.assertEqual(m.connectors[0].__class__.__name__, "Tom")
+        self.assertEqual(m.connectors[1].__class__.__name__, "Mary")
+
         self.assertEqual(m["Tom"], [m.connectors[0]])
         self.assertEqual(m[0], [m.connectors[0]])
         self.assertEqual(m[m.connectors[1].__class__], [m.connectors[1]])

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -633,9 +633,7 @@ class EnvRunnerV2:
                         d.data.raw_dict[SampleBatch.NEXT_OBS],
                     )
                 else:
-                    episode.add_action_reward_done_next_obs(
-                        d.agent_id, d.data.raw_dict
-                    )
+                    episode.add_action_reward_done_next_obs(d.agent_id, d.data.raw_dict)
 
                 if not all_agents_done and not agent_dones[d.agent_id]:
                     # Add to eval set if env is not done and this particular agent
@@ -1044,7 +1042,10 @@ class EnvRunnerV2:
                 # Notify agent connectors with this new policy output.
                 # Necessary for state buffering agent connectors, for example.
                 ac_data: AgentConnectorDataType = ActionConnectorDataType(
-                    env_id, agent_id, input_dict, (action_to_buffer, rnn_states, fetches)
+                    env_id,
+                    agent_id,
+                    input_dict,
+                    (action_to_buffer, rnn_states, fetches),
                 )
                 policy.agent_connectors.on_policy_output(ac_data)
 

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -50,9 +50,6 @@ DEFAULT_LARGE_BATCH_THRESHOLD = 5000
 MS_TO_SEC = 1000.0
 
 
-_PolicyEvalData = namedtuple("_PolicyEvalData", ["env_id", "agent_id", "sample_batch"])
-
-
 class _PerfStats:
     """Sampler perf stats that will be included in rollout metrics."""
 
@@ -410,7 +407,7 @@ class EnvRunnerV2:
 
             # Process observations and prepare for policy evaluation.
             t1 = time.time()
-            # types: Set[EnvID], Dict[PolicyID, List[_PolicyEvalData]],
+            # types: Set[EnvID], Dict[PolicyID, List[AgentConnectorDataType]],
             #       List[Union[RolloutMetrics, SampleBatchType]]
             to_eval, outputs = self._process_observations(
                 unfiltered_obs=unfiltered_obs,
@@ -477,7 +474,7 @@ class EnvRunnerV2:
         dones: MultiEnvDict,
         infos: MultiEnvDict,
     ) -> Tuple[
-        Dict[PolicyID, List[_PolicyEvalData]],
+        Dict[PolicyID, List[AgentConnectorDataType]],
         List[Union[RolloutMetrics, SampleBatchType]],
     ]:
         """Process raw obs from env.
@@ -492,11 +489,11 @@ class EnvRunnerV2:
 
         Returns:
             A tuple of:
-                _PolicyEvalData for active agents for policy evaluation.
+                AgentConnectorDataType for active agents for policy evaluation.
                 SampleBatches and RolloutMetrics for completed agents for output.
         """
         # Output objects.
-        to_eval: Dict[PolicyID, List[_PolicyEvalData]] = defaultdict(list)
+        to_eval: Dict[PolicyID, List[AgentConnectorDataType]] = defaultdict(list)
         outputs: List[Union[RolloutMetrics, SampleBatchType]] = []
 
         # For each (vectorized) sub-environment.
@@ -632,18 +629,18 @@ class EnvRunnerV2:
                 if not episode.has_init_obs(d.agent_id):
                     episode.add_init_obs(
                         d.agent_id,
-                        d.data.for_training[SampleBatch.T],
-                        d.data.for_training[SampleBatch.NEXT_OBS],
+                        d.data.raw_dict[SampleBatch.T],
+                        d.data.raw_dict[SampleBatch.NEXT_OBS],
                     )
                 else:
                     episode.add_action_reward_done_next_obs(
-                        d.agent_id, d.data.for_training
+                        d.agent_id, d.data.raw_dict
                     )
 
                 if not all_agents_done and not agent_dones[d.agent_id]:
                     # Add to eval set if env is not done and this particular agent
                     # is also not done.
-                    item = _PolicyEvalData(d.env_id, d.agent_id, d.data.for_action)
+                    item = AgentConnectorDataType(d.env_id, d.agent_id, d.data)
                     to_eval[policy_id].append(item)
 
             # Finished advancing episode by 1 step, mark it so.
@@ -694,7 +691,7 @@ class EnvRunnerV2:
         env_obs: MultiAgentDict,
         is_done: bool,
         hit_horizon: bool,
-        to_eval: Dict[PolicyID, List[_PolicyEvalData]],
+        to_eval: Dict[PolicyID, List[AgentConnectorDataType]],
         outputs: List[SampleBatchType],
     ) -> None:
         """Handle an all-finished episode.
@@ -825,11 +822,10 @@ class EnvRunnerV2:
                 # Add initial obs to buffer.
                 new_episode.add_init_obs(
                     d.agent_id,
-                    d.data.for_training[SampleBatch.T],
-                    d.data.for_training[SampleBatch.NEXT_OBS],
+                    d.data.raw_dict[SampleBatch.T],
+                    d.data.raw_dict[SampleBatch.NEXT_OBS],
                 )
-                item = _PolicyEvalData(d.env_id, d.agent_id, d.data.for_action)
-                to_eval[policy_id].append(item)
+                to_eval[policy_id].append(d)
 
             # Step after adding initial obs. This will give us 0 env and agent step.
             new_episode.step()
@@ -918,12 +914,12 @@ class EnvRunnerV2:
 
     def _do_policy_eval(
         self,
-        to_eval: Dict[PolicyID, List[_PolicyEvalData]],
+        to_eval: Dict[PolicyID, List[AgentConnectorDataType]],
     ) -> Dict[PolicyID, PolicyOutputType]:
         """Call compute_actions on collected episode data to get next action.
 
         Args:
-            to_eval: Mapping of policy IDs to lists of _PolicyEvalData objects
+            to_eval: Mapping of policy IDs to lists of AgentConnectorDataType objects
                 (items in these lists will be the batch's items for the model
                 forward pass).
 
@@ -936,7 +932,7 @@ class EnvRunnerV2:
         # should handle all these per-agent eval data.
         # Throws exception if these agents are mapped to multiple different
         # policies now.
-        def _try_find_policy_again(eval_data: _PolicyEvalData):
+        def _try_find_policy_again(eval_data: AgentConnectorDataType):
             policy_id = None
             for d in eval_data:
                 episode = self._active_episodes[d.env_id]
@@ -964,7 +960,7 @@ class EnvRunnerV2:
                 policy: Policy = _try_find_policy_again(eval_data)
 
             input_dict = _batch_inference_sample_batches(
-                [d.sample_batch for d in eval_data]
+                [d.data.sample_batch for d in eval_data]
             )
             eval_results[policy_id] = policy.compute_actions_from_input_dict(
                 input_dict,
@@ -976,7 +972,7 @@ class EnvRunnerV2:
 
     def _process_policy_eval_results(
         self,
-        to_eval: Dict[PolicyID, List[_PolicyEvalData]],
+        to_eval: Dict[PolicyID, List[AgentConnectorDataType]],
         eval_results: Dict[PolicyID, PolicyOutputType],
         off_policy_actions: MultiEnvDict,
     ):
@@ -986,7 +982,7 @@ class EnvRunnerV2:
         returns replies to send back to agents in the env.
 
         Args:
-            to_eval: Mapping of policy IDs to lists of _PolicyEvalData objects.
+            to_eval: Mapping of policy IDs to lists of AgentConnectorDataType objects.
             eval_results: Mapping of policy IDs to list of
                 actions, rnn-out states, extra-action-fetches dicts.
             off_policy_actions: Doubly keyed dict of env-ids -> agent ids ->
@@ -1001,7 +997,7 @@ class EnvRunnerV2:
             for d in eval_data:
                 actions_to_send[d.env_id] = {}  # at minimum send empty dict
 
-        # types: PolicyID, List[_PolicyEvalData]
+        # types: PolicyID, List[AgentConnectorDataType]
         for policy_id, eval_data in to_eval.items():
             actions: TensorStructType = eval_results[policy_id][0]
             actions = convert_to_numpy(actions)
@@ -1025,13 +1021,14 @@ class EnvRunnerV2:
             for i, action in enumerate(actions):
                 env_id: int = eval_data[i].env_id
                 agent_id: AgentID = eval_data[i].agent_id
+                input_dict: TensorStructType = eval_data[i].data.raw_dict
 
                 rnn_states: List[StateBatches] = [c[i] for c in rnn_out]
                 fetches: Dict = {k: v[i] for k, v in extra_action_out.items()}
 
                 # Post-process policy output by running them through action connectors.
                 ac_data = ActionConnectorDataType(
-                    env_id, agent_id, (action, rnn_states, fetches)
+                    env_id, agent_id, input_dict, (action, rnn_states, fetches)
                 )
                 action_to_send, rnn_states, fetches = policy.action_connectors(
                     ac_data
@@ -1047,7 +1044,7 @@ class EnvRunnerV2:
                 # Notify agent connectors with this new policy output.
                 # Necessary for state buffering agent connectors, for example.
                 ac_data: AgentConnectorDataType = ActionConnectorDataType(
-                    env_id, agent_id, (action_to_buffer, rnn_states, fetches)
+                    env_id, agent_id, input_dict, (action_to_buffer, rnn_states, fetches)
                 )
                 policy.agent_connectors.on_policy_output(ac_data)
 

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np

--- a/rllib/evaluation/tests/test_env_runner_v2.py
+++ b/rllib/evaluation/tests/test_env_runner_v2.py
@@ -1,7 +1,10 @@
+from gc import callbacks
 import unittest
 
 import ray
+from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.algorithms.ppo import PPO, PPOConfig
+from ray.rllib.connectors.connector import ActionConnector, ConnectorContext
 from ray.rllib.examples.env.debug_counter_env import DebugCounterEnv
 from ray.rllib.examples.env.multi_agent import BasicMultiAgent
 from ray.tune import register_env
@@ -70,6 +73,43 @@ class TestEnvRunnerV2(unittest.TestCase):
         # 200 env steps, and 400 agent steps.
         self.assertEqual(sample_batch.env_steps(), 200)
         self.assertEqual(sample_batch.agent_steps(), 400)
+
+    def test_action_connector_gets_raw_input_dict(self):
+        class CheckInputDictActionConnector(ActionConnector):
+            def __call__(self, ac_data):
+                assert ac_data.input_dict, "raw input dict should be available"
+                return ac_data
+
+        class AddActionConnectorCallbacks(DefaultCallbacks):
+            def on_create_policy(self, *, policy_id, policy) -> None:
+                policy.action_connectors.append(
+                    CheckInputDictActionConnector(ConnectorContext.from_policy(policy))
+                )
+
+        config = (
+            PPOConfig()
+            .framework("torch")
+            .training(
+                # Specifically ask for a batch of 200 samples.
+                train_batch_size=200,
+            )
+            .callbacks(
+                callbacks_class=AddActionConnectorCallbacks,
+            )
+            .rollouts(
+                num_envs_per_worker=1,
+                horizon=4,
+                num_rollout_workers=0,
+                # Enable EnvRunnerV2.
+                enable_connectors=True,
+            )
+        )
+
+        algo = PPO(config, env="basic_multiagent")
+
+        rollout_worker = algo.workers.local_worker()
+        # As long as we can successfully sample(), things should be good.
+        _ = rollout_worker.sample()
 
 
 if __name__ == "__main__":

--- a/rllib/evaluation/tests/test_env_runner_v2.py
+++ b/rllib/evaluation/tests/test_env_runner_v2.py
@@ -1,4 +1,3 @@
-from gc import callbacks
 import unittest
 
 import ray

--- a/rllib/utils/typing.py
+++ b/rllib/utils/typing.py
@@ -192,7 +192,7 @@ class ActionConnectorDataType:
     Args:
         env_id: ID of the environment.
         agent_id: ID to help identify the agent from which the data is received.
-        input: Input data that was passed into the policy.
+        input_dict: Input data that was passed into the policy.
             Sometimes output must be adapted based on the input, for example
             action masking. So the entire input data structure is provided here.
         output: An object of PolicyOutputType. It is is composed of the

--- a/rllib/utils/typing.py
+++ b/rllib/utils/typing.py
@@ -201,10 +201,11 @@ class ActionConnectorDataType:
     """
 
     def __init__(
-        self, env_id: str,
+        self,
+        env_id: str,
         agent_id: str,
         input_dict: TensorStructType,
-        output: PolicyOutputType
+        output: PolicyOutputType,
     ):
         self.env_id = env_id
         self.agent_id = agent_id

--- a/rllib/utils/typing.py
+++ b/rllib/utils/typing.py
@@ -192,14 +192,23 @@ class ActionConnectorDataType:
     Args:
         env_id: ID of the environment.
         agent_id: ID to help identify the agent from which the data is received.
+        input: Input data that was passed into the policy.
+            Sometimes output must be adapted based on the input, for example
+            action masking. So the entire input data structure is provided here.
         output: An object of PolicyOutputType. It is is composed of the
             action output, the internal state output, and additional data fetches.
 
     """
 
-    def __init__(self, env_id: str, agent_id: str, output: PolicyOutputType):
+    def __init__(
+        self, env_id: str,
+        agent_id: str,
+        input_dict: TensorStructType,
+        output: PolicyOutputType
+    ):
         self.env_id = env_id
         self.agent_id = agent_id
+        self.input_dict = input_dict
         self.output = output
 
 
@@ -215,17 +224,19 @@ class AgentConnectorsOutput:
     The branching happens in ViewRequirementAgentConnector.
 
     Args:
-        for_training: The raw input dictionary that sampler can use to
-            build episodes and training batches,
-        for_action: The SampleBatch that can be immediately used for
+        raw_dict: The raw input dictionary that sampler can use to
+            build episodes and training batches.
+            This raw dict also gets passed into ActionConnectors in case
+            it contains data useful for action adaptation (e.g. action masks).
+        sample_batch: The SampleBatch that can be immediately used for
             querying the policy for next action.
     """
 
     def __init__(
-        self, for_training: Dict[str, TensorStructType], for_action: "SampleBatch"
+        self, raw_dict: Dict[str, TensorStructType], sample_batch: "SampleBatch"
     ):
-        self.for_training = for_training
-        self.for_action = for_action
+        self.raw_dict = raw_dict
+        self.sample_batch = sample_batch
 
 
 # __sphinx_doc_end_agent_connector_output__


### PR DESCRIPTION
## Why are these changes needed?

Based on user feedback. Input data is sometimes useful for adapting outputs, for example action masks.

## Related issue number

## Checks

- [*] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
