### PR TITLE
[RLlib] A few updates for offline DQN usage

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2013,6 +2013,13 @@ py_test(
 )
 
 py_test(
+    name = "test_fifo_replay_buffer",
+    tags = ["team:rllib", "utils"],
+    size = "small",
+    srcs = ["utils/replay_buffers/tests/test_fifo_replay_buffer.py"]
+)
+
+py_test(
     name = "test_reservoir_buffer",
     tags = ["team:rllib", "utils"],
     size = "small",

--- a/rllib/algorithms/apex_dqn/tests/test_apex_dqn.py
+++ b/rllib/algorithms/apex_dqn/tests/test_apex_dqn.py
@@ -147,7 +147,7 @@ class TestApexDQN(unittest.TestCase):
 
             lr = _step_n_times(algo, 3)  # 50 timesteps
             # Close to 0.2
-            self.assertGreaterEqual(lr, 0.1)
+            self.assertLessEqual(lr, 0.2)
 
             lr = _step_n_times(algo, 20)  # 200 timesteps
             # LR Annealed to 0.001

--- a/rllib/algorithms/dqn/dqn.py
+++ b/rllib/algorithms/dqn/dqn.py
@@ -134,6 +134,8 @@ class DQNConfig(SimpleQConfig):
         self.n_step = 1
         self.before_learn_on_batch = None
         self.training_intensity = None
+        self.td_error_loss_fn = "huber"
+        self.categorical_distribution_temperature = 1.0
 
         # Changes to SimpleQConfig's default:
         self.replay_buffer_config = {
@@ -177,6 +179,8 @@ class DQNConfig(SimpleQConfig):
         ] = None,
         training_intensity: Optional[float] = None,
         replay_buffer_config: Optional[dict] = None,
+        td_error_loss_fn: Optional[str] = None,
+        categorical_distribution_temperature: Optional[float] = None,
         **kwargs,
     ) -> "DQNConfig":
         """Sets the training related configuration.
@@ -246,6 +250,11 @@ class DQNConfig(SimpleQConfig):
                 prioritized_replay_eps: Epsilon parameter sets the baseline probability
                 for sampling so that when the temporal-difference error of a sample is
                 zero, there is still a chance of drawing the sample.
+            td_error_loss_fn: "huber" or "mse". loss function for calculating TD error
+                when num_atoms is 1. Note that if num_atoms is > 1, this parameter
+                is simply ignored, and softmax cross entropy loss will be used.
+            categorical_distribution_temperature: Set the temperature parameter used
+                by Categorical action distribution.
 
         Returns:
             This updated AlgorithmConfig object.
@@ -277,6 +286,13 @@ class DQNConfig(SimpleQConfig):
             self.training_intensity = training_intensity
         if replay_buffer_config is not None:
             self.replay_buffer_config = replay_buffer_config
+        if td_error_loss_fn is not None:
+            self.td_error_loss_fn = td_error_loss_fn
+            assert self.td_error_loss_fn in ["huber", "mse"], (
+                "td_error_loss_fn must be 'huber' or 'mse'."
+            )
+        if categorical_distribution_temperature is not None:
+            self.categorical_distribution_temperature = categorical_distribution_temperature
 
         return self
 

--- a/rllib/algorithms/dqn/dqn.py
+++ b/rllib/algorithms/dqn/dqn.py
@@ -254,7 +254,9 @@ class DQNConfig(SimpleQConfig):
                 when num_atoms is 1. Note that if num_atoms is > 1, this parameter
                 is simply ignored, and softmax cross entropy loss will be used.
             categorical_distribution_temperature: Set the temperature parameter used
-                by Categorical action distribution.
+                by Categorical action distribution. A valid temperature is in the range
+                of [0, 1]. Note that this mostly affects evaluation since TD error uses
+                argmax for return calculation.
 
         Returns:
             This updated AlgorithmConfig object.

--- a/rllib/algorithms/dqn/dqn.py
+++ b/rllib/algorithms/dqn/dqn.py
@@ -288,11 +288,14 @@ class DQNConfig(SimpleQConfig):
             self.replay_buffer_config = replay_buffer_config
         if td_error_loss_fn is not None:
             self.td_error_loss_fn = td_error_loss_fn
-            assert self.td_error_loss_fn in ["huber", "mse"], (
-                "td_error_loss_fn must be 'huber' or 'mse'."
-            )
+            assert self.td_error_loss_fn in [
+                "huber",
+                "mse",
+            ], "td_error_loss_fn must be 'huber' or 'mse'."
         if categorical_distribution_temperature is not None:
-            self.categorical_distribution_temperature = categorical_distribution_temperature
+            self.categorical_distribution_temperature = (
+                categorical_distribution_temperature
+            )
 
         return self
 

--- a/rllib/algorithms/dqn/dqn_tf_policy.py
+++ b/rllib/algorithms/dqn/dqn_tf_policy.py
@@ -35,11 +35,11 @@ tf1, tf, tfv = try_import_tf()
 PRIO_WEIGHTS = "weights"
 
 
-def get_dist_class_with_temperature(temperature):
-    """Custom Categorical distribution class that has temperature set."""
+def get_dist_class_with_temperature(t: float):
+    """Categorical distribution class that has customized default temperature."""
 
     class CategoricalWithTemperature(Categorical):
-        def __init__(self, inputs, model=None):
+        def __init__(self, inputs, model=None, temperature=t):
             super().__init__(inputs, model, temperature)
 
     return CategoricalWithTemperature

--- a/rllib/algorithms/dqn/dqn_tf_policy.py
+++ b/rllib/algorithms/dqn/dqn_tf_policy.py
@@ -51,7 +51,7 @@ class QLoss:
         num_atoms: int = 1,
         v_min: float = -10.0,
         v_max: float = 10.0,
-        loss_fn = huber_loss,
+        loss_fn=huber_loss,
     ):
 
         if num_atoms > 1:

--- a/rllib/algorithms/dqn/dqn_tf_policy.py
+++ b/rllib/algorithms/dqn/dqn_tf_policy.py
@@ -1,6 +1,5 @@
 """TensorFlow policy class used for DQN"""
 
-import functools
 from typing import Dict
 
 import gym

--- a/rllib/algorithms/dqn/dqn_tf_policy.py
+++ b/rllib/algorithms/dqn/dqn_tf_policy.py
@@ -1,5 +1,6 @@
 """TensorFlow policy class used for DQN"""
 
+import functools
 from typing import Dict
 
 import gym
@@ -22,6 +23,7 @@ from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.tf_utils import (
     huber_loss,
+    l2_loss,
     make_tf_callable,
     minimize_and_clip,
     reduce_mean_ignore_inf,
@@ -49,6 +51,7 @@ class QLoss:
         num_atoms: int = 1,
         v_min: float = -10.0,
         v_max: float = 10.0,
+        loss_fn = huber_loss,
     ):
 
         if num_atoms > 1:
@@ -103,7 +106,7 @@ class QLoss:
             # compute the error (potentially clipped)
             self.td_error = q_t_selected - tf.stop_gradient(q_t_selected_target)
             self.loss = tf.reduce_mean(
-                tf.cast(importance_weights, tf.float32) * huber_loss(self.td_error)
+                tf.cast(importance_weights, tf.float32) * loss_fn(self.td_error)
             )
             self.stats = {
                 "mean_q": tf.reduce_mean(q_t_selected),
@@ -230,6 +233,11 @@ def get_distribution_inputs_and_class(
 
     policy.q_values = q_vals
 
+    # Return a Torch TorchCategorical distribution where the temperature
+    # parameter is partially binded to the configured value.
+    temperature = policy.config["categorical_distribution_temperature"]
+    action_dist = functools.partial(Categorical, temperature=temperature)
+
     return policy.q_values, Categorical, []  # state-out
 
 
@@ -305,6 +313,8 @@ def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> Tensor
             q_dist_tp1 * tf.expand_dims(q_tp1_best_one_hot_selection, -1), 1
         )
 
+    loss_fn = huber_loss if policy.config["td_error_loss_fn"] == "huber" else l2_loss
+
     policy.q_loss = QLoss(
         q_t_selected,
         q_logits_t_selected,
@@ -318,6 +328,7 @@ def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> Tensor
         config["num_atoms"],
         config["v_min"],
         config["v_max"],
+        loss_fn,
     )
 
     return policy.q_loss.loss

--- a/rllib/algorithms/dqn/dqn_tf_policy.py
+++ b/rllib/algorithms/dqn/dqn_tf_policy.py
@@ -36,6 +36,17 @@ tf1, tf, tfv = try_import_tf()
 PRIO_WEIGHTS = "weights"
 
 
+def get_dist_class_with_temperature(temperature):
+    """Custom Categorical distribution class that has temperature set.
+    """
+
+    class CategoricalWithTemperature(Categorical):
+        def __init__(self, inputs, model = None):
+            super().__init__(inputs, model, temperature)
+
+    return CategoricalWithTemperature
+
+
 class QLoss:
     def __init__(
         self,
@@ -236,9 +247,8 @@ def get_distribution_inputs_and_class(
     # Return a Torch TorchCategorical distribution where the temperature
     # parameter is partially binded to the configured value.
     temperature = policy.config["categorical_distribution_temperature"]
-    action_dist = functools.partial(Categorical, temperature=temperature)
 
-    return policy.q_values, action_dist, []  # state-out
+    return policy.q_values, get_dist_class_with_temperature(temperature), []  # state-out
 
 
 def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> TensorType:

--- a/rllib/algorithms/dqn/dqn_tf_policy.py
+++ b/rllib/algorithms/dqn/dqn_tf_policy.py
@@ -238,7 +238,7 @@ def get_distribution_inputs_and_class(
     temperature = policy.config["categorical_distribution_temperature"]
     action_dist = functools.partial(Categorical, temperature=temperature)
 
-    return policy.q_values, Categorical, []  # state-out
+    return policy.q_values, action_dist, []  # state-out
 
 
 def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> TensorType:

--- a/rllib/algorithms/dqn/dqn_tf_policy.py
+++ b/rllib/algorithms/dqn/dqn_tf_policy.py
@@ -36,11 +36,10 @@ PRIO_WEIGHTS = "weights"
 
 
 def get_dist_class_with_temperature(temperature):
-    """Custom Categorical distribution class that has temperature set.
-    """
+    """Custom Categorical distribution class that has temperature set."""
 
     class CategoricalWithTemperature(Categorical):
-        def __init__(self, inputs, model = None):
+        def __init__(self, inputs, model=None):
             super().__init__(inputs, model, temperature)
 
     return CategoricalWithTemperature
@@ -247,7 +246,11 @@ def get_distribution_inputs_and_class(
     # parameter is partially binded to the configured value.
     temperature = policy.config["categorical_distribution_temperature"]
 
-    return policy.q_values, get_dist_class_with_temperature(temperature), []  # state-out
+    return (
+        policy.q_values,
+        get_dist_class_with_temperature(temperature),
+        [],
+    )  # state-out
 
 
 def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> TensorType:

--- a/rllib/algorithms/dqn/dqn_torch_policy.py
+++ b/rllib/algorithms/dqn/dqn_torch_policy.py
@@ -1,6 +1,5 @@
 """PyTorch policy class used for DQN"""
 
-import functools
 from typing import Dict, List, Tuple
 
 import gym

--- a/rllib/algorithms/dqn/dqn_torch_policy.py
+++ b/rllib/algorithms/dqn/dqn_torch_policy.py
@@ -45,11 +45,10 @@ if nn:
 
 
 def get_dist_class_with_temperature(temperature):
-    """Custom TorchCategorical distribution class that has temperature set.
-    """
+    """Custom TorchCategorical distribution class that has temperature set."""
 
     class TorchCategoricalWithTemperature(TorchCategorical):
-        def __init__(self, inputs, model = None):
+        def __init__(self, inputs, model=None):
             super().__init__(inputs, model, temperature)
 
     return TorchCategoricalWithTemperature

--- a/rllib/algorithms/dqn/dqn_torch_policy.py
+++ b/rllib/algorithms/dqn/dqn_torch_policy.py
@@ -45,6 +45,17 @@ if nn:
     F = nn.functional
 
 
+def get_dist_class_with_temperature(temperature):
+    """Custom TorchCategorical distribution class that has temperature set.
+    """
+
+    class TorchCategoricalWithTemperature(TorchCategorical):
+        def __init__(self, inputs, model = None):
+            super().__init__(inputs, model, temperature)
+
+    return TorchCategoricalWithTemperature
+
+
 class QLoss:
     def __init__(
         self,
@@ -223,9 +234,8 @@ def build_q_model_and_distribution(
     # Return a Torch TorchCategorical distribution where the temperature
     # parameter is partially binded to the configured value.
     temperature = config["categorical_distribution_temperature"]
-    action_dist = functools.partial(TorchCategorical, temperature=temperature)
 
-    return model, action_dist
+    return model, get_dist_class_with_temperature(temperature)
 
 
 def get_distribution_inputs_and_class(
@@ -247,9 +257,8 @@ def get_distribution_inputs_and_class(
     # Return a Torch TorchCategorical distribution where the temperature
     # parameter is partially binded to the configured value.
     temperature = policy.config["categorical_distribution_temperature"]
-    action_dist = functools.partial(TorchCategorical, temperature=temperature)
 
-    return q_vals, action_dist, []  # state-out
+    return q_vals, get_dist_class_with_temperature(temperature), []  # state-out
 
 
 def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> TensorType:

--- a/rllib/algorithms/dqn/dqn_torch_policy.py
+++ b/rllib/algorithms/dqn/dqn_torch_policy.py
@@ -1,5 +1,6 @@
 """PyTorch policy class used for DQN"""
 
+import functools
 from typing import Dict, List, Tuple
 
 import gym
@@ -32,6 +33,7 @@ from ray.rllib.utils.torch_utils import (
     concat_multi_gpu_td_errors,
     FLOAT_MIN,
     huber_loss,
+    l2_loss,
     reduce_mean_ignore_inf,
     softmax_cross_entropy_with_logits,
 )
@@ -58,6 +60,7 @@ class QLoss:
         num_atoms=1,
         v_min=-10.0,
         v_max=10.0,
+        loss_fn=huber_loss,
     ):
 
         if num_atoms > 1:
@@ -107,7 +110,7 @@ class QLoss:
             # compute the error (potentially clipped)
             self.td_error = q_t_selected - q_t_selected_target.detach()
             self.loss = torch.mean(
-                importance_weights.float() * huber_loss(self.td_error)
+                importance_weights.float() * loss_fn(self.td_error)
             )
             self.stats = {
                 "mean_q": torch.mean(q_t_selected),
@@ -219,7 +222,12 @@ def build_q_model_and_distribution(
         add_layer_norm=add_layer_norm,
     )
 
-    return model, TorchCategorical
+    # Return a Torch TorchCategorical distribution where the temperature
+    # parameter is partially binded to the configured value.
+    temperature = config["categorical_distribution_temperature"]
+    action_dist = functools.partial(TorchCategorical, temperature=temperature)
+
+    return model, action_dist
 
 
 def get_distribution_inputs_and_class(
@@ -238,7 +246,12 @@ def get_distribution_inputs_and_class(
 
     model.tower_stats["q_values"] = q_vals
 
-    return q_vals, TorchCategorical, []  # state-out
+    # Return a Torch TorchCategorical distribution where the temperature
+    # parameter is partially binded to the configured value.
+    temperature = policy.config["categorical_distribution_temperature"]
+    action_dist = functools.partial(TorchCategorical, temperature=temperature)
+
+    return q_vals, action_dist, []  # state-out
 
 
 def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> TensorType:
@@ -328,6 +341,8 @@ def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> Tensor
             q_probs_tp1 * torch.unsqueeze(q_tp1_best_one_hot_selection, -1), 1
         )
 
+    loss_fn = huber_loss if policy.config["td_error_loss_fn"] == "huber" else l2_loss
+
     q_loss = QLoss(
         q_t_selected,
         q_logits_t_selected,
@@ -341,6 +356,7 @@ def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> Tensor
         config["num_atoms"],
         config["v_min"],
         config["v_max"],
+        loss_fn,
     )
 
     # Store values for stats function in model (tower), such that for

--- a/rllib/algorithms/dqn/dqn_torch_policy.py
+++ b/rllib/algorithms/dqn/dqn_torch_policy.py
@@ -109,9 +109,7 @@ class QLoss:
 
             # compute the error (potentially clipped)
             self.td_error = q_t_selected - q_t_selected_target.detach()
-            self.loss = torch.mean(
-                importance_weights.float() * loss_fn(self.td_error)
-            )
+            self.loss = torch.mean(importance_weights.float() * loss_fn(self.td_error))
             self.stats = {
                 "mean_q": torch.mean(q_t_selected),
                 "min_q": torch.min(q_t_selected),

--- a/rllib/algorithms/dqn/dqn_torch_policy.py
+++ b/rllib/algorithms/dqn/dqn_torch_policy.py
@@ -44,11 +44,11 @@ if nn:
     F = nn.functional
 
 
-def get_dist_class_with_temperature(temperature):
-    """Custom TorchCategorical distribution class that has temperature set."""
+def get_dist_class_with_temperature(t: float):
+    """TorchCategorical distribution class that has customized default temperature."""
 
     class TorchCategoricalWithTemperature(TorchCategorical):
-        def __init__(self, inputs, model=None):
+        def __init__(self, inputs, model=None, temperature=t):
             super().__init__(inputs, model, temperature)
 
     return TorchCategoricalWithTemperature

--- a/rllib/utils/exploration/parameter_noise.py
+++ b/rllib/utils/exploration/parameter_noise.py
@@ -237,10 +237,10 @@ class ParameterNoise(Exploration):
         )
 
         # Categorical case (e.g. DQN).
-        if policy.dist_class in (Categorical, TorchCategorical):
+        if issubclass(policy.dist_class, (Categorical, TorchCategorical)):
             action_dist = softmax(fetches[SampleBatch.ACTION_DIST_INPUTS])
         # Deterministic (Gaussian actions, e.g. DDPG).
-        elif policy.dist_class in [Deterministic, TorchDeterministic]:
+        elif issubclass(policy.dist_class, (Deterministic, TorchDeterministic)):
             action_dist = fetches[SampleBatch.ACTION_DIST_INPUTS]
         else:
             raise NotImplementedError  # TODO(sven): Other action-dist cases.
@@ -255,10 +255,10 @@ class ParameterNoise(Exploration):
         )
 
         # Categorical case (e.g. DQN).
-        if policy.dist_class in (Categorical, TorchCategorical):
+        if issubclass(policy.dist_class, (Categorical, TorchCategorical)):
             action_dist = softmax(fetches[SampleBatch.ACTION_DIST_INPUTS])
             # Deterministic (Gaussian actions, e.g. DDPG).
-        elif policy.dist_class in [Deterministic, TorchDeterministic]:
+        elif issubclass(policy.dist_class, (Deterministic, TorchDeterministic)):
             action_dist = fetches[SampleBatch.ACTION_DIST_INPUTS]
 
         if noisy_action_dist is None:
@@ -268,7 +268,7 @@ class ParameterNoise(Exploration):
 
         delta = distance = None
         # Categorical case (e.g. DQN).
-        if policy.dist_class in (Categorical, TorchCategorical):
+        if issubclass(policy.dist_class, (Categorical, TorchCategorical)):
             # Calculate KL-divergence (DKL(clean||noisy)) according to [2].
             # TODO(sven): Allow KL-divergence to be calculated by our
             #  Distribution classes (don't support off-graph/numpy yet).
@@ -285,7 +285,7 @@ class ParameterNoise(Exploration):
                 "cur_epsilon"
             ]
             delta = -np.log(1 - current_epsilon + current_epsilon / self.action_space.n)
-        elif policy.dist_class in [Deterministic, TorchDeterministic]:
+        elif issubclass(policy.dist_class, (Deterministic, TorchDeterministic)):
             # Calculate MSE between noisy and non-noisy output (see [2]).
             distance = np.sqrt(
                 np.mean(np.square(noise_free_action_dist - noisy_action_dist))

--- a/rllib/utils/exploration/soft_q.py
+++ b/rllib/utils/exploration/soft_q.py
@@ -46,7 +46,7 @@ class SoftQ(StochasticSampling):
         explore: bool = True,
     ):
         cls = type(action_distribution)
-        assert issubclass(cls, [Categorical, TorchCategorical])
+        assert issubclass(cls, (Categorical, TorchCategorical))
         # Re-create the action distribution with the correct temperature
         # applied.
         dist = cls(action_distribution.inputs, self.model, temperature=self.temperature)

--- a/rllib/utils/exploration/soft_q.py
+++ b/rllib/utils/exploration/soft_q.py
@@ -46,7 +46,7 @@ class SoftQ(StochasticSampling):
         explore: bool = True,
     ):
         cls = type(action_distribution)
-        assert cls in [Categorical, TorchCategorical]
+        assert issubclass(cls, [Categorical, TorchCategorical])
         # Re-create the action distribution with the correct temperature
         # applied.
         dist = cls(action_distribution.inputs, self.model, temperature=self.temperature)

--- a/rllib/utils/replay_buffers/__init__.py
+++ b/rllib/utils/replay_buffers/__init__.py
@@ -1,3 +1,4 @@
+from ray.rllib.utils.replay_buffers.fifo_replay_buffer import FifoReplayBuffer
 from ray.rllib.utils.replay_buffers.multi_agent_mixin_replay_buffer import (
     MultiAgentMixInReplayBuffer,
 )
@@ -16,6 +17,7 @@ from ray.rllib.utils.replay_buffers.reservoir_replay_buffer import ReservoirRepl
 from ray.rllib.utils.replay_buffers import utils
 
 __all__ = [
+    "FifoReplayBuffer",
     "MultiAgentMixInReplayBuffer",
     "MultiAgentPrioritizedReplayBuffer",
     "MultiAgentReplayBuffer",

--- a/rllib/utils/replay_buffers/fifo_replay_buffer.py
+++ b/rllib/utils/replay_buffers/fifo_replay_buffer.py
@@ -10,7 +10,7 @@ from ray.util.annotations import DeveloperAPI
 
 @DeveloperAPI
 class FifoReplayBuffer(ReplayBuffer):
-    """This replay buffer implements an FIFO queue.
+    """This replay buffer implements a FIFO queue.
 
     Sometimes, e.g. for offline use cases, it may be desirable to use
     off-policy algorithms without a Replay Buffer.

--- a/rllib/utils/replay_buffers/fifo_replay_buffer.py
+++ b/rllib/utils/replay_buffers/fifo_replay_buffer.py
@@ -1,0 +1,109 @@
+import numpy as np
+from typing import Any, Dict, Optional
+
+from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.utils.annotations import override
+from ray.rllib.utils.replay_buffers.replay_buffer import ReplayBuffer, StorageUnit
+from ray.rllib.utils.typing import SampleBatchType
+from ray.util.annotations import DeveloperAPI
+
+
+@DeveloperAPI
+class FifoReplayBuffer(ReplayBuffer):
+    """This replay buffer implements an FIFO queue.
+
+    Sometimes, e.g. for offline use cases, it may be desirable to use
+    off-policy algorithms without a Replay Buffer.
+    This FifoReplayBuffer can be used in-place to achieve the same effect
+    without having to introduce separate algorithm execution branches.
+
+    For simplicity and efficiency reasons, this replay buffer stores incoming
+    sample batches as-is, and returns them one at time.
+    This is to avoid any additional load when this replay buffer is used.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initializes a FifoReplayBuffer.
+
+        Args:
+            ``*args``   : Forward compatibility args.
+            ``**kwargs``: Forward compatibility kwargs.
+        """
+        # Completely by-passing underlying ReplayBuffer by setting its
+        # capacity to 1 (lowest allowed capacity).
+        ReplayBuffer.__init__(self, 1, StorageUnit.FRAGMENTS, **kwargs)
+
+        self._queue = []
+
+    @DeveloperAPI
+    @override(ReplayBuffer)
+    def add(self, batch: SampleBatchType, **kwargs) -> None:
+        return self._queue.append(batch)
+
+    @DeveloperAPI
+    @override(ReplayBuffer)
+    def sample(self, *args, **kwargs) -> Optional[SampleBatchType]:
+        """Sample a saved training batch from this buffer.
+
+        Args:
+            ``*args``   : Forward compatibility args.
+            ``**kwargs``: Forward compatibility kwargs.
+
+        Returns:
+            A single training batch from the queue.
+        """
+        if len(self._queue) <= 0:
+            # Return empty SampleBatch if queue is empty.
+            return SampleBatch()
+        batch = self._queue.pop(0)
+        # Equal weights of 1.0.
+        batch["weights"] = np.ones(len(batch))
+        return batch
+
+    @DeveloperAPI
+    def update_priorities(self, *args, **kwargs) -> None:
+        """Update priorities of items at given indices.
+
+        No-op for this replay buffer.
+
+        Args:
+            ``*args``   : Forward compatibility args.
+            ``**kwargs``: Forward compatibility kwargs.
+        """
+        pass
+
+    @DeveloperAPI
+    @override(ReplayBuffer)
+    def stats(self, debug: bool = False) -> Dict:
+        """Returns the stats of this buffer.
+
+        Args:
+            debug: If true, adds sample eviction statistics to the returned stats dict.
+
+        Returns:
+            A dictionary of stats about this buffer.
+        """
+        # As if this replay buffer has never existed.
+        return {}
+
+    @DeveloperAPI
+    @override(ReplayBuffer)
+    def get_state(self) -> Dict[str, Any]:
+        """Returns all local state.
+
+        Returns:
+            The serializable local state.
+        """
+        # Pass through replay buffer does not save states.
+        return {}
+
+    @DeveloperAPI
+    @override(ReplayBuffer)
+    def set_state(self, state: Dict[str, Any]) -> None:
+        """Restores all local state to the provided `state`.
+
+        Args:
+            state: The new state to set this buffer. Can be obtained by calling
+            `self.get_state()`.
+        """
+        pass

--- a/rllib/utils/replay_buffers/fifo_replay_buffer.py
+++ b/rllib/utils/replay_buffers/fifo_replay_buffer.py
@@ -1,7 +1,7 @@
 import numpy as np
 from typing import Any, Dict, Optional
 
-from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.policy.sample_batch import MultiAgentBatch
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.replay_buffers.replay_buffer import ReplayBuffer, StorageUnit
 from ray.rllib.utils.typing import SampleBatchType
@@ -54,7 +54,7 @@ class FifoReplayBuffer(ReplayBuffer):
         """
         if len(self._queue) <= 0:
             # Return empty SampleBatch if queue is empty.
-            return SampleBatch()
+            return MultiAgentBatch({}, 0)
         batch = self._queue.pop(0)
         # Equal weights of 1.0.
         batch["weights"] = np.ones(len(batch))

--- a/rllib/utils/replay_buffers/tests/test_fifo_replay_buffer.py
+++ b/rllib/utils/replay_buffers/tests/test_fifo_replay_buffer.py
@@ -14,26 +14,30 @@ class TestFifoReplayBuffer(unittest.TestCase):
     def test_sample(self):
         buffer = FifoReplayBuffer()
 
-        buffer.add(SampleBatch(
-            {
-                SampleBatch.T: [1],
-                SampleBatch.ACTIONS: [np.random.choice([0, 1])],
-                SampleBatch.REWARDS: [np.random.rand()],
-                SampleBatch.OBS: [np.random.random((4,))],
-                SampleBatch.NEXT_OBS: [np.random.random((4,))],
-                SampleBatch.DONES: [np.random.choice([False, True])],
-            }
-        ))
-        buffer.add(SampleBatch(
-            {
-                SampleBatch.T: [2],
-                SampleBatch.ACTIONS: [np.random.choice([0, 1])],
-                SampleBatch.REWARDS: [np.random.rand()],
-                SampleBatch.OBS: [np.random.random((4,))],
-                SampleBatch.NEXT_OBS: [np.random.random((4,))],
-                SampleBatch.DONES: [np.random.choice([False, True])],
-            }
-        ))
+        buffer.add(
+            SampleBatch(
+                {
+                    SampleBatch.T: [1],
+                    SampleBatch.ACTIONS: [np.random.choice([0, 1])],
+                    SampleBatch.REWARDS: [np.random.rand()],
+                    SampleBatch.OBS: [np.random.random((4,))],
+                    SampleBatch.NEXT_OBS: [np.random.random((4,))],
+                    SampleBatch.DONES: [np.random.choice([False, True])],
+                }
+            )
+        )
+        buffer.add(
+            SampleBatch(
+                {
+                    SampleBatch.T: [2],
+                    SampleBatch.ACTIONS: [np.random.choice([0, 1])],
+                    SampleBatch.REWARDS: [np.random.rand()],
+                    SampleBatch.OBS: [np.random.random((4,))],
+                    SampleBatch.NEXT_OBS: [np.random.random((4,))],
+                    SampleBatch.DONES: [np.random.choice([False, True])],
+                }
+            )
+        )
 
         batch = buffer.sample()
         self.assertEqual(batch[SampleBatch.T][0], 1)

--- a/rllib/utils/replay_buffers/tests/test_fifo_replay_buffer.py
+++ b/rllib/utils/replay_buffers/tests/test_fifo_replay_buffer.py
@@ -1,0 +1,48 @@
+import unittest
+import numpy as np
+from ray.rllib.policy.sample_batch import SampleBatch
+
+from ray.rllib.utils.replay_buffers.fifo_replay_buffer import FifoReplayBuffer
+
+
+class TestFifoReplayBuffer(unittest.TestCase):
+    def test_empty_buffer(self):
+        buffer = FifoReplayBuffer()
+        batch = buffer.sample()
+        self.assertEqual(len(batch), 0)
+
+    def test_sample(self):
+        buffer = FifoReplayBuffer()
+
+        buffer.add(SampleBatch(
+            {
+                SampleBatch.T: [1],
+                SampleBatch.ACTIONS: [np.random.choice([0, 1])],
+                SampleBatch.REWARDS: [np.random.rand()],
+                SampleBatch.OBS: [np.random.random((4,))],
+                SampleBatch.NEXT_OBS: [np.random.random((4,))],
+                SampleBatch.DONES: [np.random.choice([False, True])],
+            }
+        ))
+        buffer.add(SampleBatch(
+            {
+                SampleBatch.T: [2],
+                SampleBatch.ACTIONS: [np.random.choice([0, 1])],
+                SampleBatch.REWARDS: [np.random.rand()],
+                SampleBatch.OBS: [np.random.random((4,))],
+                SampleBatch.NEXT_OBS: [np.random.random((4,))],
+                SampleBatch.DONES: [np.random.choice([False, True])],
+            }
+        ))
+
+        batch = buffer.sample()
+        self.assertEqual(batch[SampleBatch.T][0], 1)
+        batch = buffer.sample()
+        self.assertEqual(batch[SampleBatch.T][0], 2)
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/utils/tests/test_utils.py
+++ b/rllib/utils/tests/test_utils.py
@@ -10,10 +10,12 @@ from ray.rllib.utils.numpy import make_action_immutable
 from ray.rllib.utils.test_utils import check
 from ray.rllib.utils.tf_utils import (
     flatten_inputs_to_1d_tensor as flatten_tf,
+    l2_loss as tf_l2_loss,
     one_hot as one_hot_tf,
 )
 from ray.rllib.utils.torch_utils import (
     flatten_inputs_to_1d_tensor as flatten_torch,
+    l2_loss as torch_l2_loss,
     one_hot as one_hot_torch,
 )
 
@@ -561,6 +563,13 @@ class TestUtils(unittest.TestCase):
         x = torch.tensor([[0, 2, 1, 0]], dtype=torch.int32)
         y = one_hot_torch(x, space)
         self.assertTrue(([1, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0] == y.numpy()).all())
+
+    def test_l2_loss(self):
+        for _ in range(10):
+            tensor = np.random.random(8)
+            tf_loss = tf_l2_loss(tf.constant(tensor))
+            torch_loss = torch_l2_loss(torch.Tensor(tensor))
+            self.assertAlmostEqual(tf_loss.numpy(), torch_loss.numpy(), places=3)
 
 
 if __name__ == "__main__":

--- a/rllib/utils/tf_utils.py
+++ b/rllib/utils/tf_utils.py
@@ -298,6 +298,21 @@ def huber_loss(x: TensorType, delta: float = 1.0) -> TensorType:
 
 
 @PublicAPI
+def l2_loss(x: TensorType) -> TensorType:
+    """Computes half the L2 norm over a tensor's values without the sqrt.
+
+    output = 0.5 * sum(x ** 2)
+
+    Args:
+        x: The input tensor.
+
+    Returns:
+        0.5 times the L2 norm over the given tensor's values (w/o sqrt).
+    """
+    return 0.5 * tf.reduce_sum(tf.pow(x, 2.0))
+
+
+@PublicAPI
 def make_tf_callable(
     session_or_none: Optional["tf1.Session"], dynamic_shape: bool = False
 ) -> Callable:


### PR DESCRIPTION
## Why are these changes needed?

1. Allow users to select between huber or mse losses for num_atoms=1 case.
2. Allow users to configure temperature parameter for Categorical distribution.
3. Introduce FifoReplayBuffer to allow off-policy algorithms to be used without a real ReplayBuffer.

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
