### PR TITLE
Revert "Remove pins for some Python dependencies"

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -41,9 +41,9 @@ pandas>=1.3.0; python_version >= '3.7'
 scipy >= 1.5
 tabulate
 tensorboardX >= 1.9
-uvicorn
+uvicorn==0.16.0
 dataclasses; python_version < '3.7'
-starlette
+starlette==0.18.0
 aiorwlock
 gradio; platform_system != "Windows"
 
@@ -89,12 +89,12 @@ pytest-lazy-fixture
 pytest-timeout
 pytest-virtualenv
 redis >= 3.5.0, < 4.0.0
-scikit-learn
+scikit-learn==0.24.2
 testfixtures
 werkzeug<2.2.0
 xlrd
 starlette
-fastapi
+fastapi==0.76.0
 smart_open[s3]
 tqdm
 async-exit-stack

--- a/python/requirements/ml/requirements_rllib.txt
+++ b/python/requirements/ml/requirements_rllib.txt
@@ -32,7 +32,7 @@ higher==0.2.1
 pyglet==1.5.15
 imageio-ffmpeg==0.4.5
 # Ray Serve example
-starlette
+starlette==0.16.0
 # ONNX
 onnx==1.9.0
 onnxruntime==1.9.0

--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -20,7 +20,8 @@ hyperopt==0.2.5
 jupyter==1.0.0
 kubernetes==17.17.0
 lightgbm==3.2.1
-matplotlib!=3.4.3
+matplotlib==3.3.4; python_version < '3.7'
+matplotlib==3.4.3; python_version >= '3.7'
 mlflow==1.21.0
 mxnet==1.8.0.post0
 nevergrad==0.4.3.post7
@@ -31,7 +32,7 @@ pytest-remotedata==0.3.2
 lightning-bolts==0.4.0
 pytorch-lightning==1.5.10
 shortuuid==1.0.1
-scikit-learn
+scikit-learn==0.24.2
 scikit-optimize==0.8.1
 sigopt==7.5.0
 timm==0.4.5

--- a/python/setup.py
+++ b/python/setup.py
@@ -233,7 +233,7 @@ if setup_spec.type == SetupType.RAY:
             "prometheus_client >= 0.7.1, < 0.14.0",
             "smart_open",
         ],
-        "serve": ["uvicorn", "requests", "starlette", "fastapi", "aiorwlock"],
+        "serve": ["uvicorn==0.16.0", "requests", "starlette", "fastapi", "aiorwlock"],
         "tune": ["pandas", "tabulate", "tensorboardX>=1.9", "requests"],
         "k8s": ["kubernetes", "urllib3"],
         "observability": [


### PR DESCRIPTION
Reverts ray-project/ray#25844

Starlette unpin leads to failures in examples

Instead of reverting the full commit, we could also try this instead: #28601