### PR TITLE
[Core] Make `ray.get_gpu_ids()` always return `List[int]`

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -18,7 +18,7 @@ import uuid
 import warnings
 from inspect import signature
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, List, Sequence, Tuple, Union
 
 import grpc
 import numpy as np
@@ -319,11 +319,11 @@ def compute_driver_id_from_job(job_id):
     return ray.WorkerID(driver_id_str)
 
 
-def get_cuda_visible_devices():
+def get_cuda_visible_devices() -> Optional[List[str]]:
     """Get the device IDs in the CUDA_VISIBLE_DEVICES environment variable.
 
     Returns:
-        devices (List[str]): If CUDA_VISIBLE_DEVICES is set, returns a
+        devices: If CUDA_VISIBLE_DEVICES is set, returns a
             list of strings representing the IDs of the visible GPUs.
             If it is not set or is set to NoDevFiles, returns empty list.
     """

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -851,14 +851,14 @@ def get_gpu_ids() -> List[int]:
     if global_worker.original_gpu_ids is not None:
         # Use the assigned ids to index into the user provided CUDA_VISIBLE_DEVICES.
         assigned_ids = [
-            int(global_worker.original_gpu_ids[gpu_id]) for gpu_id in assigned_ids if
-            len(global_worker.original_gpu_ids) >= gpu_id # Avoid IndexError.
+            int(global_worker.original_gpu_ids[gpu_id]) for gpu_id in assigned_ids
         ]
         # Give all GPUs in local_mode.
         if global_worker.mode == LOCAL_MODE:
             max_gpus = global_worker.node.get_resource_spec().num_gpus
-            assigned_ids = [int(gpu_id) for gpu_id in global_worker.original_gpu_ids[
-                                                      :max_gpus]]
+            assigned_ids = [
+                int(gpu_id) for gpu_id in global_worker.original_gpu_ids[:max_gpus]
+            ]
 
     return assigned_ids
 

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -809,7 +809,7 @@ class Worker:
 
 @PublicAPI
 @client_mode_hook(auto_init=True)
-def get_gpu_ids():
+def get_gpu_ids() -> List[int]:
     """Get the IDs of the GPUs that are available to the worker.
 
     If the CUDA_VISIBLE_DEVICES environment variable was set when the worker
@@ -849,13 +849,16 @@ def get_gpu_ids():
     # the sense that only GPU IDs that appear in CUDA_VISIBLE_DEVICES should be
     # returned).
     if global_worker.original_gpu_ids is not None:
+        # Use the assigned ids to index into the user provided CUDA_VISIBLE_DEVICES.
         assigned_ids = [
-            global_worker.original_gpu_ids[gpu_id] for gpu_id in assigned_ids
+            int(global_worker.original_gpu_ids[gpu_id]) for gpu_id in assigned_ids if
+            len(global_worker.original_gpu_ids) >= gpu_id # Avoid IndexError.
         ]
         # Give all GPUs in local_mode.
         if global_worker.mode == LOCAL_MODE:
             max_gpus = global_worker.node.get_resource_spec().num_gpus
-            assigned_ids = global_worker.original_gpu_ids[:max_gpus]
+            assigned_ids = [int(gpu_id) for gpu_id in global_worker.original_gpu_ids[
+                                                      :max_gpus]]
 
     return assigned_ids
 

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -14,7 +14,11 @@ from ray._private.test_utils import RayTestTimeoutException, wait_for_condition
 logger = logging.getLogger(__name__)
 
 
-def test_gpu_ids(shutdown_only):
+@pytest.mark.parametrize("cuda_visible_devices", ["", "4,5,6"])
+def test_gpu_ids(shutdown_only, cuda_visible_devices, monkeypatch):
+    if cuda_visible_devices:
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", cuda_visible_devices)
+
     num_gpus = 3
     ray.init(num_cpus=num_gpus, num_gpus=num_gpus)
 

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -19,6 +19,8 @@ def test_gpu_ids(shutdown_only, cuda_visible_devices, monkeypatch):
     num_gpus = 3
 
     if cuda_visible_devices:
+        # Test if gpu_ids are correct even when CUDA_VISIBLE_DEVICES env var is set on
+        # the driver.
         device_ids = [int(i) for i in cuda_visible_devices.split(",")]
         assert len(device_ids) == num_gpus
         monkeypatch.setenv("CUDA_VISIBLE_DEVICES", cuda_visible_devices)

--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -82,7 +82,14 @@ class NonTensorDataset(LinearDataset):
 
 # TODO: Refactor as a backend test.
 @pytest.mark.parametrize("num_gpus_per_worker", [0.5, 1])
-def test_torch_get_device(ray_start_4_cpus_2_gpus, num_gpus_per_worker):
+@pytest.mark.parametrize("cuda_visible_devices", ["", "1"])
+def test_torch_get_device(
+    ray_start_4_cpus_2_gpus, num_gpus_per_worker, cuda_visible_devices, monkeypatch
+):
+    if cuda_visible_devices:
+        # Test if `get_device` is correct even with user specified env var.
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", cuda_visible_devices)
+
     def train_fn():
         return train.torch.get_device().index
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Previously, `ray.get_gpu_ids()` would sometimes return a List of ints and sometimes return a List of strings depending on if the user has set the `CUDA_VISIBLE_DEVICES` env var, which made the API difficult to program against.

Instead, `ray.get_gpu_ids()` should always return a List of ints.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/28467

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
