### PR TITLE
[Train] Automatically set `NCCL_SOCKET_IFNAME` to use ethernet

### DIFF
--- a/doc/source/train/faq.rst
+++ b/doc/source/train/faq.rst
@@ -26,3 +26,66 @@ you can initialize the ``Trainer`` with ``resources_per_worker`` specified in ``
    Some GPU utility functions (e.g. :func:`ray.train.torch.get_device`, :func:`ray.train.torch.prepare_model`)
    currently assume each worker is allocated exactly 1 GPU. The partial GPU and multi GPU use-cases
    can still be run with Ray Train today without these functions.
+
+
+My multi-node  PyTorch GPU training is hanging or giving me obscure NCCL errors. What do I do?
+----------------------------------------------------------------------------------------------
+If you are on a multi-node GPU training setup and training is hanging, or you get errors like
+`RuntimeError: NCCL error in: /pytorch/torch/lib/c10d/ProcessGroupNCCL.cpp:911, unhandled system error`
+it could be that there is some networking misconfiguration in your cluster.
+
+To resolve these issues, you can do the following:
+
+1. First run the `ifconfig` command to get the supported network interfaces for your machine. You can install `ifconfig` via `sudo apt install net-tools`.
+   You should get an output like so:
+
+    .. code::
+
+        docker0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+                inet 172.17.0.1  netmask 255.255.0.0  broadcast 172.17.255.255
+                inet6 fe80::42:4cff:fe7e:eda  prefixlen 64  scopeid 0x20<link>
+                ether 02:42:4c:7e:0e:da  txqueuelen 0  (Ethernet)
+                RX packets 24041  bytes 94360851 (94.3 MB)
+                RX errors 0  dropped 0  overruns 0  frame 0
+                TX packets 24044  bytes 2216396 (2.2 MB)
+                TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+        ens5: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9001
+                inet 172.31.65.244  netmask 255.255.224.0  broadcast 172.31.95.255
+                inet6 fe80::81c:ddff:fe05:a5f1  prefixlen 64  scopeid 0x20<link>
+                ether 0a:1c:dd:05:a5:f1  txqueuelen 1000  (Ethernet)
+                RX packets 1237256  bytes 911474939 (911.4 MB)
+                RX errors 0  dropped 0  overruns 0  frame 0
+                TX packets 1772254  bytes 2265089819 (2.2 GB)
+                TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+        lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
+                inet 127.0.0.1  netmask 255.0.0.0
+                inet6 ::1  prefixlen 128  scopeid 0x10<host>
+                loop  txqueuelen 1000  (Local Loopback)
+                RX packets 2734593  bytes 6775739628 (6.7 GB)
+                RX errors 0  dropped 0  overruns 0  frame 0
+                TX packets 2734593  bytes 6775739628 (6.7 GB)
+                TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+        veth526c8fe: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+                inet6 fe80::44c:7bff:fe80:f02b  prefixlen 64  scopeid 0x20<link>
+                ether 06:4c:7b:80:f0:2b  txqueuelen 0  (Ethernet)
+                RX packets 24041  bytes 94697425 (94.6 MB)
+                RX errors 0  dropped 0  overruns 0  frame 0
+                TX packets 24062  bytes 2217752 (2.2 MB)
+                TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+2. Choose the network interface that corresponds to the private IP address of your node. In most cases, this will be either
+   `ens3` or `ens5`.
+
+3. Set this as the value for the `NCCL_SOCKET_IFNAME` environment variable. You must do this via Ray runtime environments so that it
+   gets propagated to all training workers.
+
+.. code-block:: python
+
+    # Add this at the top of your Ray application.
+    runtime_env = {"env_vars": {"NCCL_SOCKET_IFNAME": "ens5"}}
+    ray.init(runtime_env=runtime_env)
+
+
+

--- a/python/ray/train/constants.py
+++ b/python/ray/train/constants.py
@@ -79,3 +79,6 @@ PYTORCH_PROFILER_KEY = "_train_torch_profiler"
 # By default these will be filtered out from ``session.report()``.
 # See ``TrainingCallback._preprocess_results`` for more details.
 ALL_RESERVED_KEYS = {PYTORCH_PROFILER_KEY}
+
+# Default NCCL_SOCKET_IFNAME.
+DEFAULT_NCCL_SOCKET_IFNAME = "en,eth,bond"

--- a/python/ray/train/constants.py
+++ b/python/ray/train/constants.py
@@ -81,4 +81,7 @@ PYTORCH_PROFILER_KEY = "_train_torch_profiler"
 ALL_RESERVED_KEYS = {PYTORCH_PROFILER_KEY}
 
 # Default NCCL_SOCKET_IFNAME.
+# Use ethernet when possible.
+# NCCL_SOCKET_IFNAME does a prefix match so "ens3" or "ens5" will match with
+# "en".
 DEFAULT_NCCL_SOCKET_IFNAME = "en,eth,bond"

--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -337,7 +337,6 @@ def test_torch_backend_nccl_socket_ifname(ray_start_4_cpus_2_gpus, nccl_socket_i
         assert os.environ["NCCL_SOCKET_IFNAME"] == value
 
     worker_group = WorkerGroup(num_workers=2, num_gpus_per_worker=1)
-    worker_group.start()
 
     torch_backend = _TorchBackend()
     torch_backend.on_start(worker_group, backend_config=TorchConfig(backend="nccl"))

--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -327,7 +327,7 @@ def test_checkpoint_torch_model_with_amp(ray_start_4_cpus_2_gpus):
 
 
 @pytest.mark.parametrize("nccl_socket_ifname", ["", "ens3"])
-def test_torch_backend_nccl_socket_ifname(ray_start_2_gpus, nccl_socket_ifname):
+def test_torch_backend_nccl_socket_ifname(ray_start_4_cpus_2_gpus, nccl_socket_ifname):
 
     if nccl_socket_ifname:
         os.environ["NCCL_SOCKET_IFNAME"] = nccl_socket_ifname

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -56,6 +56,13 @@ def _set_nccl_network_interface() -> str:
     """Set the appropriate NCCL network interface to use."""
 
     if "NCCL_SOCKET_IFNAME" not in os.environ:
+        logger.debug(
+            f"Setting NCCL_SOCKET_IFNAME to {DEFAULT_NCCL_SOCKET_IFNAME} "
+            f"to prioritize ethernet connection. To override this behavior, set the "
+            f"`NCCL_SOCKET_IFNAME` environment variable in your Ray runtime "
+            "environment: "
+            "`ray.init(runtime_env={{'env_vars': {'NCCL_SOCKET_IFNAME': 'ens5'}}}`"
+        )
         os.environ["NCCL_SOCKET_IFNAME"] = DEFAULT_NCCL_SOCKET_IFNAME
 
 

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -56,9 +56,6 @@ def _set_nccl_network_interface() -> str:
     """Set the appropriate NCCL network interface to use."""
 
     if "NCCL_SOCKET_IFNAME" not in os.environ:
-        # Use ethernet when possible.
-        # NCCL_SOCKET_IFNAME does a prefix match so "ens3" or "ens5" will match with
-        # "en".
         os.environ["NCCL_SOCKET_IFNAME"] = DEFAULT_NCCL_SOCKET_IFNAME
 
 

--- a/release/air_tests/air_benchmarks/workloads/benchmark_util.py
+++ b/release/air_tests/air_benchmarks/workloads/benchmark_util.py
@@ -6,7 +6,7 @@ from contextlib import closing
 from pathlib import Path
 
 import ray
-from typing import List, Dict, Union, Callable
+from typing import Any, List, Dict, Union, Callable
 
 
 def _schedule_remote_fn_on_node(node_ip: str, remote_fn, *args, **kwargs):
@@ -75,18 +75,20 @@ class CommandRunner:
         return fn(*args, **kwargs)
 
 
-def create_actors_with_resources(
-    num_actors: int, resources: Dict[str, Union[float, int]]
+def create_actors_with_options(
+    num_actors: int,
+    resources: Dict[str, Union[float, int]],
+    runtime_env: Dict[str, Any] = None,
 ) -> List[ray.actor.ActorHandle]:
     num_cpus = resources.pop("CPU", 1)
     num_gpus = resources.pop("GPU", 0)
 
-    return [
-        CommandRunner.options(
-            num_cpus=num_cpus, num_gpus=num_gpus, resources=resources
-        ).remote()
-        for _ in range(num_actors)
-    ]
+    options = {"num_cpus": num_cpus, "num_gpus": num_gpus, "resources": resources}
+
+    if runtime_env:
+        options["runtime_env"] = runtime_env
+
+    return [CommandRunner.options(**options).remote() for _ in range(num_actors)]
 
 
 def run_commands_on_actors(actors: List[ray.actor.ActorHandle], cmds: List[List[str]]):

--- a/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
+++ b/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
@@ -86,9 +86,6 @@ def main(data_size_gb: int, num_epochs=2, num_workers=1):
     )
     print(f"Training for {num_epochs} epochs with {num_workers} workers.")
     start = time.time()
-    # Enable cross host NCCL for larger scale tests
-    runtime_env = {"env_vars": {"NCCL_SOCKET_IFNAME": "ens3"}}
-    ray.init(runtime_env=runtime_env)
     dataset = ray.data.read_datasource(
         ImageFolderDatasource(), root=data_url, size=(256, 256)
     )

--- a/release/air_tests/air_benchmarks/workloads/tensorflow_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tensorflow_benchmark.py
@@ -160,7 +160,7 @@ def train_tf_vanilla(
     # off tasks that run train_tf_vanilla_worker() on the worker nodes.
     from benchmark_util import (
         upload_file_to_all_nodes,
-        create_actors_with_resources,
+        create_actors_with_options,
         run_commands_on_actors,
         run_fn_on_actors,
         get_ip_port_actors,
@@ -171,7 +171,7 @@ def train_tf_vanilla(
 
     num_epochs = config["epochs"]
 
-    actors = create_actors_with_resources(
+    actors = create_actors_with_options(
         num_actors=num_workers,
         resources={
             "CPU": cpus_per_worker,

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -17,6 +17,17 @@ CONFIG = {"lr": 1e-3, "batch_size": 64}
 VANILLA_RESULT_JSON = "/tmp/vanilla_out.json"
 
 
+def find_network_interface():
+    for iface in os.listdir("/sys/class/net"):
+        if iface.startswith("ens"):
+            network_interface = iface
+            break
+    else:
+        network_interface = "^lo,docker"
+
+    return network_interface
+
+
 # Define model
 class NeuralNetwork(nn.Module):
     def __init__(self):
@@ -283,7 +294,7 @@ def train_torch_vanilla(
     # off tasks that run train_torch_vanilla_worker() on the worker nodes.
     from benchmark_util import (
         upload_file_to_all_nodes,
-        create_actors_with_resources,
+        create_actors_with_options,
         run_commands_on_actors,
         run_fn_on_actors,
         get_ip_port_actors,
@@ -297,12 +308,15 @@ def train_torch_vanilla(
 
     num_epochs = config["epochs"]
 
-    actors = create_actors_with_resources(
+    nccl_network_interface = find_network_interface()
+
+    actors = create_actors_with_options(
         num_actors=num_workers,
         resources={
             "CPU": cpus_per_worker,
             "GPU": int(use_gpu),
         },
+        runtime_env={"env_vars": {"NCCL_SOCKET_IFNAME": nccl_network_interface}},
     )
 
     run_fn_on_actors(actors=actors, fn=lambda: os.environ.pop("OMP_NUM_THREADS", None))
@@ -407,6 +421,7 @@ def run(
     ray.init(
         "auto",
     )
+
     print("Preparing Torch benchmark: Downloading MNIST")
 
     path = os.path.abspath("workloads/_torch_prepare.py")

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -404,17 +404,8 @@ def run(
     config["epochs"] = num_epochs
     config["batch_size"] = batch_size
 
-    # Find interface
-    for iface in os.listdir("/sys/class/net"):
-        if iface.startswith("ens"):
-            network_interface = iface
-            break
-    else:
-        network_interface = "^lo,docker"
-
     ray.init(
         "auto",
-        runtime_env={"env_vars": {"NCCL_SOCKET_IFNAME": network_interface}},
     )
     print("Preparing Torch benchmark: Downloading MNIST")
 

--- a/release/ml_user_tests/ray-lightning/ray_lightning_user_test.py
+++ b/release/ml_user_tests/ray-lightning/ray_lightning_user_test.py
@@ -11,13 +11,9 @@ if __name__ == "__main__":
     addr = os.environ.get("RAY_ADDRESS")
     job_name = os.environ.get("RAY_JOB_NAME", "ray_lightning_user_test")
 
-    # Manually set NCCL_SOCKET_IFNAME to "ens3" so NCCL training works on
-    # anyscale_default_cloud.
-    # See https://github.com/pytorch/pytorch/issues/68893 for more details.
     # Passing in runtime_env to ray.init() will also set it for all the
     # workers.
     runtime_env = {
-        "env_vars": {"NCCL_SOCKET_IFNAME": "ens3"},
         "working_dir": os.path.dirname(__file__),
     }
 

--- a/release/ml_user_tests/ray-lightning/ray_lightning_user_test.py
+++ b/release/ml_user_tests/ray-lightning/ray_lightning_user_test.py
@@ -11,9 +11,13 @@ if __name__ == "__main__":
     addr = os.environ.get("RAY_ADDRESS")
     job_name = os.environ.get("RAY_JOB_NAME", "ray_lightning_user_test")
 
+    # Manually set NCCL_SOCKET_IFNAME to "ens3" so NCCL training works on
+    # anyscale_default_cloud.
+    # See https://github.com/pytorch/pytorch/issues/68893 for more details.
     # Passing in runtime_env to ray.init() will also set it for all the
     # workers.
     runtime_env = {
+        "env_vars": {"NCCL_SOCKET_IFNAME": "ens3"},
         "working_dir": os.path.dirname(__file__),
     }
 

--- a/release/ml_user_tests/train/train_torch_linear_test.py
+++ b/release/ml_user_tests/train/train_torch_linear_test.py
@@ -12,17 +12,10 @@ if __name__ == "__main__":
     addr = os.environ.get("RAY_ADDRESS")
     job_name = os.environ.get("RAY_JOB_NAME", "train_torch_linear_test")
 
-    # Manually set NCCL_SOCKET_IFNAME to "ens3" so NCCL training works on
-    # anyscale_default_cloud.
-    # See https://github.com/pytorch/pytorch/issues/68893 for more details.
-    # Passing in runtime_env to ray.init() will also set it for all the
-    # workers.
-    runtime_env = {"env_vars": {"NCCL_SOCKET_IFNAME": "ens3"}}
-
     if addr is not None and addr.startswith("anyscale://"):
-        ray.init(address=addr, job_name=job_name, runtime_env=runtime_env)
+        ray.init(address=addr, job_name=job_name)
     else:
-        ray.init(address="auto", runtime_env=runtime_env)
+        ray.init(address="auto")
 
     results = train_linear(num_workers=6, use_gpu=True, epochs=20)
 


### PR DESCRIPTION
Signed-off-by: Amog Kamsetty <amogkamsetty@yahoo.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Automatically set `NCCL_SOCKET_IFNAME` to prefer ethernet. Also adds a FAQ section in the docs on how to diagnose this issue.

Closes https://github.com/ray-project/ray/issues/26663

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
