### PR TITLE
[core] default memory threshold for release tests

### DIFF
--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -52,6 +52,7 @@ class ClusterManager(abc.ABC):
         self.cluster_env["env_vars"]["RAY_USAGE_STATS_ENABLED"] = "1"
         self.cluster_env["env_vars"]["RAY_USAGE_STATS_SOURCE"] = "nightly-tests"
         self.cluster_env["env_vars"]["RAY_memory_monitor_interval_ms"] = "250"
+        self.cluster_env["env_vars"]["memory_usage_threshold_fraction"] = "0.95"
         self.cluster_env["env_vars"][
             "RAY_USAGE_STATS_EXTRA_TAGS"
         ] = f"test_name={self.test_name};smoke_test={self.smoke_test}"

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -52,7 +52,7 @@ class ClusterManager(abc.ABC):
         self.cluster_env["env_vars"]["RAY_USAGE_STATS_ENABLED"] = "1"
         self.cluster_env["env_vars"]["RAY_USAGE_STATS_SOURCE"] = "nightly-tests"
         self.cluster_env["env_vars"]["RAY_memory_monitor_interval_ms"] = "250"
-        self.cluster_env["env_vars"]["memory_usage_threshold_fraction"] = "0.95"
+        self.cluster_env["env_vars"]["RAY_memory_usage_threshold_fraction"] = "0.95"
         self.cluster_env["env_vars"][
             "RAY_USAGE_STATS_EXTRA_TAGS"
         ] = f"test_name={self.test_name};smoke_test={self.smoke_test}"


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

Noticed that the release tests are using a lower memory threshold. This comes from Anyscale setting a specific value that can change based on what it needs. Anyscale recently made a change to respect the override that is set in the cluster env. This PR overrides the memory threshold so it will always use the value we set, regardless of what is set by Anyscale for its other clusters.

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(

Example where the value is to 0.8 in Anyscale:

https://console.anyscale-staging.com/o/anyscale-internal/projects/prj_qC3ZfndQWYYjx2cz8KWGNUL4/clusters/ses_q8FSbfqSTBdQDY45EEY8RKzt?command-history-section=command_history