### PR TITLE
[Datasets] Bundle blocks smaller than batch size in `map_batches` tasks.

### DIFF
--- a/doc/source/ray-air/examples/convert_existing_pytorch_code_to_ray_air.ipynb
+++ b/doc/source/ray-air/examples/convert_existing_pytorch_code_to_ray_air.ipynb
@@ -1229,6 +1229,7 @@
    "source": [
     "predicted_classes = results.map_batches(\n",
     "    lambda batch: [classes[pred.argmax(0)] for pred in batch[\"predictions\"]], \n",
+    "    batch_size=10,\n",
     "    batch_format=\"pandas\")"
    ]
   },

--- a/doc/source/ray-air/examples/convert_existing_pytorch_code_to_ray_air.ipynb
+++ b/doc/source/ray-air/examples/convert_existing_pytorch_code_to_ray_air.ipynb
@@ -1238,32 +1238,13 @@
    "id": "cb7040db",
    "metadata": {},
    "source": [
-    "To compare this with the actual labels, let's create a Ray dataset for these and zip it together with the predicted classes:"
+    "To see how well our prediction did, let's zip the predicted labels together with some of the actual labels to compare them:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 30,
    "id": "207e13b9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "real_classes = ray.data.from_items([classes[y] for x, y in test_data], parallelism=8)\n",
-    "merged = predicted_classes.zip(real_classes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "18b1012c",
-   "metadata": {},
-   "source": [
-    "Let's examine our results:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "id": "2b2decc6",
    "metadata": {},
    "outputs": [
     {
@@ -1294,7 +1275,9 @@
     }
    ],
    "source": [
-    "merged.show()"
+    "real_classes = [classes[y] for x, y in test_data]\n",
+    "for predicted, real in zip(predicted_classes.take(), real_classes):\n",
+    "    print((predicted, real))"
    ]
   },
   {

--- a/doc/source/ray-air/examples/convert_existing_pytorch_code_to_ray_air.ipynb
+++ b/doc/source/ray-air/examples/convert_existing_pytorch_code_to_ray_air.ipynb
@@ -1111,7 +1111,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Map Progress (2 actors 1 pending): 100%|██████████| 200/200 [00:02<00:00, 70.01it/s]\n"
+      "Map Progress (2 actors 1 pending): 100%|██████████| 8/8 [00:02<00:00, 70.01it/s]\n"
      ]
     }
    ],
@@ -1222,7 +1222,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Map_Batches: 100%|██████████| 200/200 [00:02<00:00, 80.05it/s]\n"
+      "Map_Batches: 100%|██████████| 8/8 [00:02<00:00, 80.05it/s]\n"
      ]
     }
    ],

--- a/doc/source/ray-air/examples/convert_existing_pytorch_code_to_ray_air.ipynb
+++ b/doc/source/ray-air/examples/convert_existing_pytorch_code_to_ray_air.ipynb
@@ -1090,7 +1090,7 @@
    "source": [
     "import ray.data\n",
     "\n",
-    "ds = ray.data.from_items([x.numpy() for x, y in test_data])"
+    "ds = ray.data.from_items([x.numpy() for x, y in test_data], parallelism=8)"
    ]
   },
   {
@@ -1116,7 +1116,7 @@
     }
    ],
    "source": [
-    "results = batch_predictor.predict(ds, min_scoring_workers=2)"
+    "results = batch_predictor.predict(ds, batch_size=32, min_scoring_workers=2)"
    ]
   },
   {
@@ -1229,7 +1229,7 @@
    "source": [
     "predicted_classes = results.map_batches(\n",
     "    lambda batch: [classes[pred.argmax(0)] for pred in batch[\"predictions\"]], \n",
-    "    batch_size=10,\n",
+    "    batch_size=32,\n",
     "    batch_format=\"pandas\")"
    ]
   },
@@ -1248,7 +1248,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "real_classes = ray.data.from_items([classes[y] for x, y in test_data])\n",
+    "real_classes = ray.data.from_items([classes[y] for x, y in test_data], parallelism=8)\n",
     "merged = predicted_classes.zip(real_classes)"
    ]
   },

--- a/doc/source/ray-air/examples/torch_image_batch_pretrained.py
+++ b/doc/source/ray-air/examples/torch_image_batch_pretrained.py
@@ -23,7 +23,7 @@ def preprocess(df: pd.DataFrame) -> pd.DataFrame:
             transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ]
     )
-    df["image"] = [preprocess(x).numpy() for x in df["image"]]
+    df.loc[:, "image"] = [preprocess(x).numpy() for x in df["image"]]
     return df
 
 

--- a/doc/source/ray-air/examples/torch_image_batch_pretrained.py
+++ b/doc/source/ray-air/examples/torch_image_batch_pretrained.py
@@ -39,4 +39,4 @@ preprocessor = BatchMapper(preprocess)
 ckpt = TorchCheckpoint.from_model(model=model, preprocessor=preprocessor)
 
 predictor = BatchPredictor.from_checkpoint(ckpt, TorchPredictor)
-predictor.predict(dataset, feature_columns=["image"])
+predictor.predict(dataset, feature_columns=["image"], batch_size=80)

--- a/python/ray/air/tests/test_dataset_config.py
+++ b/python/ray/air/tests/test_dataset_config.py
@@ -255,13 +255,13 @@ def test_stream_inf_window_cache_prep(ray_start_4_cpus):
         assert results[0] == results[1], results
         stats = shard.stats()
         assert str(shard) == "DatasetPipeline(num_windows=inf, num_stages=1)", shard
-        assert "Stage 1 read->map_batches: 5/5 blocks executed " in stats, stats
+        assert "Stage 1 read->map_batches: 1/1 blocks executed " in stats, stats
 
     def rand(x):
         return [random.random() for _ in range(len(x))]
 
     prep = BatchMapper(rand)
-    ds = ray.data.range_table(5)
+    ds = ray.data.range_table(5, parallelism=1)
     test = TestStream(
         checker,
         preprocessor=prep,

--- a/python/ray/air/tests/test_dataset_config.py
+++ b/python/ray/air/tests/test_dataset_config.py
@@ -287,7 +287,7 @@ def test_stream_finite_window_nocache_prep(ray_start_4_cpus):
         stats = shard.stats()
         assert str(shard) == "DatasetPipeline(num_windows=inf, num_stages=1)", shard
         assert (
-            "Stage 1 read->randomize_block_order->map_batches: 5/5 blocks executed "
+            "Stage 1 read->randomize_block_order->map_batches: 1/1 blocks executed "
             in stats
         ), stats
 

--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -49,12 +49,20 @@ class Batcher(BatcherInterface):
     # zero-copy views, we sacrifice what should be a small performance hit for better
     # readability.
 
-    def __init__(self, batch_size: Optional[int], zero_copy: bool = True):
+    def __init__(self, batch_size: Optional[int], ensure_copy: bool = False):
+        """
+        Construct a batcher that yields batches of batch_sizes rows.
+
+        Args:
+            batch_size: The size of batches to yield.
+            ensure_copy: Whether the Batcher should guarantee that batches are copied
+                slice copies of the base blocks (not zero-copy views).
+        """
         self._batch_size = batch_size
         self._buffer = []
         self._buffer_size = 0
         self._done_adding = False
-        self._zero_copy = zero_copy
+        self._ensure_copy = ensure_copy
 
     def add(self, block: Block):
         """Add a block to the block buffer.
@@ -95,8 +103,8 @@ class Batcher(BatcherInterface):
         if self._batch_size is None:
             assert len(self._buffer) == 1
             block = self._buffer[0]
-            if not self._zero_copy:
-                # Copy block if not zero-copy.
+            if self._ensure_copy:
+                # Copy block if needing to ensure fresh batch copy.
                 block = BlockAccessor.for_block(block)
                 block = block.slice(0, block.num_rows(), copy=True)
             self._buffer = []
@@ -115,26 +123,28 @@ class Batcher(BatcherInterface):
                 # We need this entire block to fill out a batch.
                 # We need to call `accessor.slice()` to ensure
                 # the subsequent block's type are the same.
-                output.add_block(
-                    accessor.slice(0, accessor.num_rows(), copy=not self._zero_copy)
-                )
+                output.add_block(accessor.slice(0, accessor.num_rows(), copy=False))
                 needed -= accessor.num_rows()
             else:
                 # We only need part of the block to fill out a batch.
-                output.add_block(accessor.slice(0, needed, copy=not self._zero_copy))
+                output.add_block(accessor.slice(0, needed, copy=False))
                 # Add the rest of the block to the leftovers.
-                leftover.append(
-                    accessor.slice(
-                        needed, accessor.num_rows(), copy=not self._zero_copy
-                    )
-                )
+                leftover.append(accessor.slice(needed, accessor.num_rows(), copy=False))
                 needed = 0
 
         # Move the leftovers into the block buffer so they're the first
         # blocks consumed on the next batch extraction.
         self._buffer = leftover
         self._buffer_size -= self._batch_size
-        return output.build()
+        batch = output.build()
+        if self._ensure_copy:
+            # Need to ensure that the batch is a fresh copy.
+            batch = BlockAccessor.for_block(batch)
+            # TOOD(Clark): This copy will often be unnecessary, e.g. for pandas
+            # DataFrame batches that have required concatenation to construct, which
+            # always requires a copy. We should elide this copy in those cases.
+            batch = batch.slice(0, batch.num_rows(), copy=True)
+        return batch
 
 
 class ShufflingBatcher(BatcherInterface):

--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -55,8 +55,8 @@ class Batcher(BatcherInterface):
 
         Args:
             batch_size: The size of batches to yield.
-            ensure_copy: Whether the Batcher should guarantee that batches are copied
-                slice copies of the base blocks (not zero-copy views).
+            ensure_copy: Whether batches are always copied from the underlying base
+                blocks (not zero-copy views).
         """
         self._batch_size = batch_size
         self._buffer = []

--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -130,7 +130,7 @@ class TaskPoolStrategy(ComputeStrategy):
         in_block_owned_by_consumer = block_list._owned_by_consumer
         # Release input block references.
         if clear_input_blocks:
-            del binned_blocks
+            del block_bundles
             block_list.clear()
 
         # Common wait for non-data refs.
@@ -536,6 +536,7 @@ def _check_batch_size(
     for _, meta in blocks_and_meta:
         if meta.num_rows and meta.size_bytes:
             batch_size_bytes = math.ceil(batch_size * (meta.size_bytes / meta.num_rows))
+            break
     context = DatasetContext.get_current()
     if (
         batch_size_bytes is not None

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import itertools
 import uuid
 from typing import (
@@ -533,6 +534,7 @@ class OneToOneStage(Stage):
         block_fn: BlockTransform,
         compute: Union[str, ComputeStrategy],
         ray_remote_args: dict,
+        target_block_size: Optional[int] = None,
         fn: Optional[UDF] = None,
         fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
@@ -543,6 +545,7 @@ class OneToOneStage(Stage):
         self.block_fn = block_fn
         self.compute = compute or "tasks"
         self.ray_remote_args = ray_remote_args or {}
+        self.target_block_size = target_block_size
         self.fn = fn
         self.fn_args = fn_args
         self.fn_kwargs = fn_kwargs
@@ -610,9 +613,15 @@ class OneToOneStage(Stage):
 
         block_fn1 = prev.block_fn
         block_fn2 = self.block_fn
+        if prev.target_block_size is not None and self.target_block_size is not None:
+            target_block_size = max(prev.target_block_size, self.target_block_size)
+        elif prev.target_block_size is not None:
+            target_block_size = prev.target_block_size
+        else:
+            target_block_size = self.target_block_size
 
         def block_fn(
-            block: Block,
+            blocks: Iterable[Block],
             fn: UDF,
             *fn_args,
             **fn_kwargs,
@@ -630,15 +639,15 @@ class OneToOneStage(Stage):
             prev_fn_args = (
                 prev_fn_args if prev_fn_ is None else (prev_fn_,) + prev_fn_args
             )
-            for tmp1 in block_fn1(block, *prev_fn_args, **prev_fn_kwargs):
-                for tmp2 in block_fn2(tmp1, *self_fn_args, **self_fn_kwargs):
-                    yield tmp2
+            blocks = block_fn1(blocks, *prev_fn_args, **prev_fn_kwargs)
+            return block_fn2(blocks, *self_fn_args, **self_fn_kwargs)
 
         return OneToOneStage(
             name,
             block_fn,
             self.compute,
             prev.ray_remote_args,
+            target_block_size=target_block_size,
             fn=self.fn,
             fn_args=fn_args,
             fn_kwargs={},
@@ -665,6 +674,7 @@ class OneToOneStage(Stage):
             blocks,
             clear_input_blocks,
             name=self.name,
+            target_block_size=self.target_block_size,
             fn=self.fn,
             fn_args=self.fn_args,
             fn_kwargs=self.fn_kwargs,
@@ -723,20 +733,19 @@ class AllToAllStage(Stage):
         prev_block_fn = prev.block_fn
         if self.block_udf is None:
 
-            def block_udf(block: Block) -> Iterable[Block]:
-                yield from prev_block_fn(block, *prev_fn_args, **prev_fn_kwargs)
+            def block_udf(blocks: Iterable[Block]) -> Iterable[Block]:
+                yield from prev_block_fn(blocks, *prev_fn_args, **prev_fn_kwargs)
 
         else:
             self_block_udf = self.block_udf
 
-            def block_udf(block: Block) -> Iterable[Block]:
-                for tmp1 in prev_block_fn(
-                    block,
+            def block_udf(blocks: Iterable[Block]) -> Iterable[Block]:
+                blocks = prev_block_fn(
+                    blocks,
                     *prev_fn_args,
                     **prev_fn_kwargs,
-                ):
-                    for tmp2 in self_block_udf(tmp1):
-                        yield tmp2
+                )
+                yield from self_block_udf(blocks)
 
         return AllToAllStage(
             name, self.num_blocks, self.fn, True, block_udf, prev.ray_remote_args
@@ -811,6 +820,7 @@ def _rewrite_read_stage(
         blocks, metadata, owned_by_consumer=in_blocks._owned_by_consumer
     )
 
+    @_adapt_for_multiple_blocks
     def block_fn(read_fn: Callable[[], Iterator[Block]]) -> Iterator[Block]:
         for block in read_fn():
             yield block
@@ -924,3 +934,15 @@ def _canonicalize(remote_args: dict) -> dict:
 def _is_lazy(blocks: BlockList) -> bool:
     """Whether the provided block list is lazy."""
     return isinstance(blocks, LazyBlockList)
+
+
+def _adapt_for_multiple_blocks(
+    fn: Callable[..., Iterable[Block]],
+) -> Callable[..., Iterable[Block]]:
+    @functools.wraps(fn)
+    def wrapper(blocks: Iterable[Block], *args, **kwargs):
+        print("blocks:", blocks)
+        for block in blocks:
+            yield from fn(block, *args, **kwargs)
+
+    return wrapper

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -941,7 +941,6 @@ def _adapt_for_multiple_blocks(
 ) -> Callable[..., Iterable[Block]]:
     @functools.wraps(fn)
     def wrapper(blocks: Iterable[Block], *args, **kwargs):
-        print("blocks:", blocks)
         for block in blocks:
             yield from fn(block, *args, **kwargs)
 

--- a/python/ray/data/_internal/shuffle_and_partition.py
+++ b/python/ray/data/_internal/shuffle_and_partition.py
@@ -37,7 +37,7 @@ class _ShufflePartitionOp(ShuffleOp):
         stats = BlockExecStats.builder()
         if block_udf:
             # TODO(ekl) note that this effectively disables block splitting.
-            blocks = list(block_udf(block))
+            blocks = list(block_udf([block]))
             if len(blocks) > 1:
                 builder = BlockAccessor.for_block(blocks[0]).builder()
                 for b in blocks:

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -4,6 +4,8 @@ from typing import Union, Optional, TYPE_CHECKING
 from types import ModuleType
 import sys
 
+import numpy as np
+
 import ray
 from ray.data.context import DatasetContext
 
@@ -96,7 +98,7 @@ def _autodetect_parallelism(
     max_reasonable_parallelism = sys.maxsize
     if reader:
         mem_size = reader.estimate_inmemory_data_size()
-        if mem_size is not None:
+        if mem_size is not None and not np.isnan(mem_size):
             min_safe_parallelism = max(1, int(mem_size / ctx.target_max_block_size))
             max_reasonable_parallelism = max(
                 1, int(mem_size / ctx.target_min_block_size)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -527,7 +527,9 @@ class Dataset(Generic[T]):
         ) -> Iterable[Block]:
             DatasetContext._set_current(context)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
-            batcher = Batcher(batch_size)
+            # Ensure that zero-copy batch views are copied so mutating UDFs don't error.
+            # TODO(Clark): Expose this zero-copy behavior as a map_batches parameter.
+            batcher = Batcher(batch_size, zero_copy=False)
             for block in blocks:
                 batcher.add(block)
             batcher.done_adding()

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -537,8 +537,9 @@ class Dataset(Generic[T]):
             DatasetContext._set_current(context)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
             # Ensure that zero-copy batch views are copied so mutating UDFs don't error.
-            # TODO(Clark): Expose this zero-copy behavior as a map_batches parameter.
-            batcher = Batcher(batch_size, ensure_copy=batch_size is not None)
+            batcher = Batcher(
+                batch_size, ensure_copy=allow_mutate_batch and batch_size is not None
+            )
             for block in blocks:
                 batcher.add(block)
             batcher.done_adding()

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -538,7 +538,7 @@ class Dataset(Generic[T]):
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
             # Ensure that zero-copy batch views are copied so mutating UDFs don't error.
             # TODO(Clark): Expose this zero-copy behavior as a map_batches parameter.
-            batcher = Batcher(batch_size, ensure_copy=True)
+            batcher = Batcher(batch_size, ensure_copy=batch_size is not None)
             for block in blocks:
                 batcher.add(block)
             batcher.done_adding()
@@ -597,6 +597,7 @@ class Dataset(Generic[T]):
                 transform,
                 compute,
                 ray_remote_args,
+                # TODO(Clark): Add a strict cap here.
                 target_block_size=batch_size,
                 fn=fn,
                 fn_args=fn_args,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -27,6 +27,7 @@ import numpy as np
 import ray
 import ray.cloudpickle as pickle
 from ray._private.usage import usage_lib
+from ray.data._internal.batcher import Batcher
 from ray.data._internal.block_batching import BatchType, batch_blocks
 from ray.data._internal.block_list import BlockList
 from ray.data._internal.compute import (
@@ -44,6 +45,7 @@ from ray.data._internal.pandas_block import PandasBlockSchema
 from ray.data._internal.plan import (
     ExecutionPlan,
     OneToOneStage,
+    _adapt_for_multiple_blocks,
 )
 from ray.data._internal.stage_impl import (
     RandomizeBlocksStage,
@@ -290,6 +292,7 @@ class Dataset(Generic[T]):
         self._warn_slow()
         context = DatasetContext.get_current()
 
+        @_adapt_for_multiple_blocks
         def transform(block: Block, fn: RowUDF[T, U]) -> Iterable[Block]:
             DatasetContext._set_current(context)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
@@ -424,16 +427,16 @@ class Dataset(Generic[T]):
             fn: The function to apply to each record batch, or a class type
                 that can be instantiated to create such a callable. Callable classes are
                 only supported for the actor compute strategy.
-            batch_size: The number of rows in each batch, or ``None`` to use entire
-                blocks as batches. Blocks can contain different number of rows, and
-                the last batch can include fewer than ``batch_size`` rows. Defaults to
-                ``4096``.
+            batch_size: The desired number of rows in each batch, or None to use entire
+                blocks as batches (blocks may contain different number of rows).
+                The actual batch size provided to fn may be smaller than ``batch_size``.
+                Defaults to 4096.
             compute: The compute strategy, either ``"tasks"`` (default) to use Ray
                 tasks, or ``"actors"`` to use an autoscaling actor pool. If you want to
                 configure the size of the autoscaling actor pool, provide an
                 :class:`ActorPoolStrategy <ray.data.ActorPoolStrategy>` instance.
                 If you're passing callable type to ``fn``, you must pass an
-                :class:`ActorPoolStrategy <ray.data.ActorPoolStrategy>`.
+                :class:`ActorPoolStrategy <ray.data.ActorPoolStrategy>` or ``"actors"``.
             batch_format: Specify ``"default"`` to use the default block format
                 (promotes tables to Pandas and tensors to NumPy), ``"pandas"`` to select
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
@@ -517,28 +520,24 @@ class Dataset(Generic[T]):
         context = DatasetContext.get_current()
 
         def transform(
-            block: Block,
+            blocks: Iterable[Block],
             batch_fn: BatchUDF,
             *fn_args,
             **fn_kwargs,
         ) -> Iterable[Block]:
             DatasetContext._set_current(context)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
-            block = BlockAccessor.for_block(block)
-            total_rows = block.num_rows()
-            max_batch_size = batch_size
-            if max_batch_size is None:
-                max_batch_size = max(total_rows, 1)
-
-            for start in range(0, total_rows, max_batch_size):
-                # Build a block for each batch.
-                end = min(total_rows, start + max_batch_size)
-                view = block.slice(start, end, copy=allow_mutate_batch)
+            batcher = Batcher(batch_size)
+            for block in blocks:
+                batcher.add(block)
+            batcher.done_adding()
+            while batcher.has_any():
+                batch = batcher.next_batch()
                 # Convert to batch format.
-                view = BlockAccessor.for_block(view).to_batch_format(batch_format)
-
+                batch = BlockAccessor.for_block(batch).to_batch_format(batch_format)
+                # Apply UDF.
                 try:
-                    applied = batch_fn(view, *fn_args, **fn_kwargs)
+                    batch = batch_fn(batch, *fn_args, **fn_kwargs)
                 except ValueError as e:
                     read_only_msgs = [
                         "assignment destination is read-only",
@@ -557,22 +556,23 @@ class Dataset(Generic[T]):
                     else:
                         raise e from None
                 if not (
-                    isinstance(applied, list)
-                    or isinstance(applied, pa.Table)
-                    or isinstance(applied, np.ndarray)
+                    isinstance(batch, list)
+                    or isinstance(batch, pa.Table)
+                    or isinstance(batch, np.ndarray)
                     or (
-                        isinstance(applied, dict)
-                        and all(isinstance(col, np.ndarray) for col in applied.values())
+                        isinstance(batch, dict)
+                        and all(isinstance(col, np.ndarray) for col in batch.values())
                     )
-                    or isinstance(applied, pd.core.frame.DataFrame)
+                    or isinstance(batch, pd.core.frame.DataFrame)
                 ):
                     raise ValueError(
                         "The map batches UDF returned the value "
-                        f"{applied} of type {type(applied)}, "
+                        f"{batch} of type {type(batch)}, "
                         "which is not allowed. "
                         f"The return type must be one of: {BatchType}"
                     )
-                output_buffer.add_batch(applied)
+                # Add output batch to output buffer.
+                output_buffer.add_batch(batch)
                 if output_buffer.has_next():
                     yield output_buffer.next()
 
@@ -586,6 +586,7 @@ class Dataset(Generic[T]):
                 transform,
                 compute,
                 ray_remote_args,
+                target_block_size=batch_size,
                 fn=fn,
                 fn_args=fn_args,
                 fn_kwargs=fn_kwargs,
@@ -731,6 +732,7 @@ class Dataset(Generic[T]):
         self._warn_slow()
         context = DatasetContext.get_current()
 
+        @_adapt_for_multiple_blocks
         def transform(block: Block, fn: RowUDF[T, U]) -> Iterable[Block]:
             DatasetContext._set_current(context)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
@@ -798,6 +800,7 @@ class Dataset(Generic[T]):
         self._warn_slow()
         context = DatasetContext.get_current()
 
+        @_adapt_for_multiple_blocks
         def transform(block: Block, fn: RowUDF[T, U]) -> Iterable[Block]:
             DatasetContext._set_current(context)
             block = BlockAccessor.for_block(block)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2692,7 +2692,6 @@ def test_map_batches_actors_preserves_order(ray_start_regular_shared):
     [
         (10, 5, 2),
         (10, 1, 10),
-        (10, 1, None),
         (12, 3, 2),
     ],
 )

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2409,7 +2409,7 @@ def test_map_batches_basic(ray_start_regular_shared, tmp_path):
     ds = ray.data.range(size)
     ds2 = ds.map_batches(lambda df: df + 1, batch_size=17, batch_format="pandas")
     assert ds2._dataset_format() == "pandas"
-    ds_list = ds2.take(limit=size)
+    ds_list = ds2.take_all()
     for i in range(size):
         # The pandas column is "value", and it originally has rows from 0~299.
         # After the map batch, it should have 1~300.
@@ -2459,8 +2459,8 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
         ds.map_batches(Foo, compute="tasks")
 
     with pytest.raises(ValueError):
-        # fn_constructor_args and fn_constructor_kwargs only supported for actor compute
-        # strategy.
+        # fn_constructor_args and fn_constructor_kwargs only supported for actor
+        # compute strategy.
         ds.map_batches(
             lambda x: x,
             compute="tasks",

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2713,6 +2713,34 @@ def test_map_batches_batch_mutation(
     assert [row["value"] for row in ds.iter_rows()] == list(range(1, num_rows + 1))
 
 
+@pytest.mark.parametrize(
+    "num_rows,num_blocks,batch_size",
+    [
+        (10, 5, 2),
+        (10, 1, 10),
+        (12, 3, 2),
+    ],
+)
+def test_map_batches_batch_zero_copy(
+    ray_start_regular_shared, num_rows, num_blocks, batch_size
+):
+    # Test that batches are zero-copy read-only views when allow_mutate_batch=False.
+    def mutate(df):
+        # Check that batch is read-only.
+        assert not df.values.flags.writeable
+        df["value"] += 1
+        return df
+
+    ds = ray.data.range_table(num_rows, parallelism=num_blocks).repartition(num_blocks)
+    # Convert to Pandas blocks.
+    ds = ds.map_batches(lambda df: df, batch_format="pandas", batch_size=None)
+
+    # Apply UDF that mutates the batches, which should fail since the batch is
+    # read-only.
+    with pytest.raises(ValueError, match="tried to mutate a zero-copy read-only batch"):
+        ds.map_batches(mutate, batch_size=batch_size, allow_mutate_batch=False)
+
+
 BLOCK_BUNDLING_TEST_CASES = [
     (block_size, batch_size)
     for batch_size in range(1, 8)

--- a/python/ray/data/tests/test_object_gc.py
+++ b/python/ray/data/tests/test_object_gc.py
@@ -66,8 +66,8 @@ def test_iter_batches_no_spilling_upon_post_transformation(shutdown_only):
     ds = ray.data.range_tensor(500, shape=(80, 80, 4), parallelism=100)
 
     # Repeat, with transformation post the pipeline creation.
-    check_no_spill(ctx, ds.repeat().map_batches(lambda x: x))
-    check_no_spill(ctx, ds.repeat().map_batches(lambda x: x), 5)
+    check_no_spill(ctx, ds.repeat().map_batches(lambda x: x, batch_size=5))
+    check_no_spill(ctx, ds.repeat().map_batches(lambda x: x, batch_size=5), 5)
 
     # Window, with transformation post the pipeline creation.
     check_no_spill(ctx, ds.window(blocks_per_window=20).map_batches(lambda x: x))
@@ -81,9 +81,18 @@ def test_iter_batches_no_spilling_upon_transformations(shutdown_only):
     ds = ray.data.range_tensor(500, shape=(80, 80, 4), parallelism=100)
 
     # Repeat, with transformation before and post the pipeline.
-    check_no_spill(ctx, ds.map_batches(lambda x: x).repeat().map_batches(lambda x: x))
     check_no_spill(
-        ctx, ds.map_batches(lambda x: x).repeat().map_batches(lambda x: x), 5
+        ctx,
+        ds.map_batches(lambda x: x, batch_size=5)
+        .repeat()
+        .map_batches(lambda x: x, batch_size=5),
+    )
+    check_no_spill(
+        ctx,
+        ds.map_batches(lambda x: x, batch_size=5)
+        .repeat()
+        .map_batches(lambda x: x, batch_size=5),
+        5,
     )
 
     # Window, with transformation before and post the pipeline.


### PR DESCRIPTION
When blocks are smaller than the batch size in `map_batches()`, the actual size of batches provided to the UDF can be much smaller (order of magnitude) than the specified batch size, resulting in very poor batch mapping throughput when the UDF's performance is sensitive to the batch size (such as in batch inference on GPUs).

This PR optimistically sends multiple blocks to a single mapper task up to (but not past) the provided batch size, mitigating the case in which block size << batch size without needing a shuffle step.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #28564 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
