### PR TITLE
[metrics] Add job_id label for all core worker metrics

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -36,9 +36,6 @@
 
 namespace ray {
 namespace core {
-namespace {
-
-using ActorLifetime = ray::rpc::JobConfig_ActorLifetime;
 
 JobID GetProcessJobID(const CoreWorkerOptions &options) {
   if (options.worker_type == WorkerType::DRIVER) {
@@ -55,6 +52,10 @@ JobID GetProcessJobID(const CoreWorkerOptions &options) {
   }
   return options.job_id;
 }
+
+namespace {
+
+using ActorLifetime = ray::rpc::JobConfig_ActorLifetime;
 
 // Helper function converts GetObjectLocationsOwnerReply to ObjectLocation
 ObjectLocation CreateObjectLocation(const rpc::GetObjectLocationsOwnerReply &reply) {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -57,6 +57,8 @@
 namespace ray {
 namespace core {
 
+JobID GetProcessJobID(const CoreWorkerOptions &options);
+
 /// The root class that contains all the core and language-independent functionalities
 /// of the worker. This class is supposed to be used to implement app-language (Java,
 /// Python, etc) workers.

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -119,13 +119,13 @@ CoreWorkerProcessImpl::CoreWorkerProcessImpl(const CoreWorkerOptions &options)
   // Assume stats module will be initialized exactly once in once process.
   // So it must be called in CoreWorkerProcess constructor and will be reused
   // by all of core worker.
-  RAY_LOG(DEBUG) << "Stats setup in core worker with JobID "
-                 << GetProcessJobID(options).Hex();
+  auto process_job_id = GetProcessJobID(options);
+  RAY_LOG(DEBUG) << "Stats setup in core worker with JobID " << process_job_id;
   // Initialize stats in core worker global tags.
   const ray::stats::TagsType global_tags = {
       {ray::stats::ComponentKey, "core_worker"},
       {ray::stats::WorkerIdKey, worker_id_.Hex()},
-      {ray::stats::JobIdKey, GetProcessJobID(options).Hex()},
+      {ray::stats::JobIdKey, process_job_id.Hex()},
       {ray::stats::VersionKey, kRayVersion},
       {ray::stats::NodeAddressKey, options_.node_ip_address}};
 

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -119,11 +119,13 @@ CoreWorkerProcessImpl::CoreWorkerProcessImpl(const CoreWorkerOptions &options)
   // Assume stats module will be initialized exactly once in once process.
   // So it must be called in CoreWorkerProcess constructor and will be reused
   // by all of core worker.
-  RAY_LOG(DEBUG) << "Stats setup in core worker.";
+  RAY_LOG(DEBUG) << "Stats setup in core worker with JobID "
+                 << GetProcessJobID(options).Hex();
   // Initialize stats in core worker global tags.
   const ray::stats::TagsType global_tags = {
       {ray::stats::ComponentKey, "core_worker"},
       {ray::stats::WorkerIdKey, worker_id_.Hex()},
+      {ray::stats::JobIdKey, GetProcessJobID(options).Hex()},
       {ray::stats::VersionKey, kRayVersion},
       {ray::stats::NodeAddressKey, options_.node_ip_address}};
 

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -67,6 +67,7 @@ int main(int argc, char *argv[]) {
   const ray::stats::TagsType global_tags = {
       {ray::stats::ComponentKey, "gcs_server"},
       {ray::stats::WorkerIdKey, ""},
+      {ray::stats::JobIdKey, ""},
       {ray::stats::VersionKey, kRayVersion},
       {ray::stats::NodeAddressKey, node_ip_address}};
   ray::stats::Init(global_tags, metrics_agent_port);

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -259,6 +259,7 @@ int main(int argc, char *argv[]) {
         const ray::stats::TagsType global_tags = {
             {ray::stats::ComponentKey, "raylet"},
             {ray::stats::WorkerIdKey, ""},
+            {ray::stats::JobIdKey, ""},
             {ray::stats::VersionKey, kRayVersion},
             {ray::stats::NodeAddressKey, node_ip_address}};
         ray::stats::Init(global_tags, metrics_agent_port);

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -392,6 +392,7 @@ std::tuple<Process, StartupToken> WorkerPool::StartWorkerProcess(
     // We pass the job ID to worker processes via an environment variable, so we don't
     // need to add a new CLI parameter for both Python and Java workers.
     env.emplace(kEnvVarKeyJobId, job_id.Hex());
+    RAY_LOG(DEBUG) << "Launch worker with " << kEnvVarKeyJobId << " " << job_id.Hex();
   }
   env.emplace(kEnvVarKeyRayletPid, std::to_string(GetPID()));
 

--- a/src/ray/stats/tag_defs.cc
+++ b/src/ray/stats/tag_defs.cc
@@ -37,5 +37,7 @@ const TagKeyType ResourceNameKey = TagKeyType::Register("ResourceName");
 const TagKeyType ActorIdKey = TagKeyType::Register("ActorId");
 
 const TagKeyType WorkerIdKey = TagKeyType::Register("WorkerId");
+
+const TagKeyType JobIdKey = TagKeyType::Register("JobId");
 }  // namespace stats
 }  // namespace ray

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -41,3 +41,5 @@ extern const TagKeyType ResourceNameKey;
 extern const TagKeyType ActorIdKey;
 
 extern const TagKeyType WorkerIdKey;
+
+extern const TagKeyType JobIdKey;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This adds the JobID label to global metrics tags for the core worker process. We need to add it to the other processes as empty due to our current metric collection logic (same reason for empty WorkerId).

Tested manually and with unit test.