### PR TITLE
[docs] configurable ecosystem gallery

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -2,3 +2,6 @@
 _build
 source/_static/thumbs
 .ipynb_checkpoints/
+
+# Ignore generated gallery txt files
+eco-gallery.txt

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -326,3 +326,6 @@ def setup(app):
     linkcheck_summarizer = LinkcheckSummarizer()
     app.connect("builder-inited", linkcheck_summarizer.add_handler_to_linkcheck)
     app.connect("build-finished", linkcheck_summarizer.summarize)
+
+    # Create galleries on the fly
+    app.connect("builder-inited", build_gallery)

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -6,6 +6,9 @@ import urllib
 import urllib.request
 from pathlib import Path
 from queue import Queue
+from urllib.parse import urlparse
+import yaml
+
 
 import requests
 import scipy.linalg  # noqa: F401
@@ -23,8 +26,10 @@ __all__ = [
     "mock_modules",
     "update_context",
     "LinkcheckSummarizer",
+    "build_gallery",
 ]
 
+GALLERIES = ["ray-overview/eco-gallery.yml"]
 
 # Taken from https://github.com/edx/edx-documentation
 FEEDBACK_FORM_FMT = (
@@ -260,3 +265,70 @@ class LinkcheckSummarizer:
 
         if not has_broken_links:
             self.logger.info("No broken links found!")
+
+
+def build_gallery(app):
+    for gallery in GALLERIES:
+        panel_items = []
+        source = yaml.safe_load((Path(app.srcdir) / gallery).read_text())
+
+        meta = source["meta"]
+        is_titled = True if meta.get("section-titles") else False
+        meta.pop("section-titles")
+        projects = source["projects"]
+        buttons = source["buttons"]
+
+        for item in projects:
+            ref = ":type: url"
+            website = item["website"]
+            if "://" not in website:  # if it has no http/s protocol, it's a "ref"
+                ref = ref.replace("url", "ref")
+
+            if not item.get("image"):
+                item["image"] = "https://docs.ray.io/_images/ray_logo.png"
+            gh_stars = ""
+            if item["repo"]:
+                try:
+                    url = urlparse(item["repo"])
+                    if url.netloc == "github.com":
+                        _, org, repo = url.path.rstrip("/").split("/")
+                        gh_stars = (
+                            f".. image:: https://img.shields.io/github/"
+                            f"stars/{org}/{repo}?style=social)]\n"
+                            f"\t\t:target: {item['repo']})"
+                        )
+                except Exception:
+                    pass
+
+            item = f"""
+        ---
+        :img-top: {item["image"]}
+
+        {item["description"]}
+
+        {gh_stars}
+
+        +++
+        .. link-button:: {item["website"]}
+            {ref}
+            :text: {item["name"]}
+            :classes: {buttons["classes"]}
+            """
+            panel_items.append(item)
+
+        panel_header = ".. panels::\n"
+        for k, v in meta.items():
+            panel_header += f"\t:{k}: {v}\n"
+
+        if is_titled:
+            panels = ""
+            for item, panel in zip(projects, panel_items):
+                title = item["section_title"]
+                underline_title = "-" * len(title)
+                panels += f"{title}\n{underline_title}\n\n{panel_header}{panel}\n\n"
+        else:
+            panel_items = "\n".join(panel_items)
+            panels = panel_header + panel_items
+
+        gallery_out = gallery.replace(".yml", ".txt")
+        (Path(app.srcdir) / gallery_out).write_text(panels)

--- a/doc/source/ray-overview/eco-gallery.yml
+++ b/doc/source/ray-overview/eco-gallery.yml
@@ -1,7 +1,7 @@
 meta:
   section-titles: true
   container: container pb-12
-  column: col-md-9 px-2 py-2
+  column: col-md-12 px-2 py-2
   img-top-cls: pt-5 w-50 d-block mx-auto
 
 buttons:
@@ -54,13 +54,16 @@ projects:
     image: ../images/hugging.png
   - name: Intel Analytics Zoo Integration
     section_title: Intel Analytics Zoo
-    description: Analytics Zoo seamlessly scales TensorFlow, Keras and PyTorch to distributed big data (using Spark, Flink & Ray).
+    description: Analytics Zoo seamlessly scales TensorFlow, Keras and PyTorch
+      to distributed big data (using Spark, Flink & Ray).
     website: https://analytics-zoo.github.io/master/#ProgrammingGuide/rayonspark/
     repo: https://github.com/intel-analytics/analytics-zoo
     image: ../images/zoo.png
   - name: NLU Integration
     section_title: John Snow Labs' NLU
-    description: The power of 350+ pre-trained NLP models, 100+ Word Embeddings, 50+ Sentence Embeddings, and 50+ Classifiers in 46 languages with 1 line of Python code.
+    description: The power of 350+ pre-trained NLP models, 100+ Word Embeddings,
+      50+ Sentence Embeddings, and 50+ Classifiers in 46 languages
+      with 1 line of Python code.
     website: https://nlu.johnsnowlabs.com/docs/en/predict_api#modin-dataframe
     repo: https://github.com/JohnSnowLabs/nlu
     image: ../images/nlu.png

--- a/doc/source/ray-overview/eco-gallery.yml
+++ b/doc/source/ray-overview/eco-gallery.yml
@@ -1,0 +1,162 @@
+meta:
+  section-titles: true
+  container: container pb-12
+  column: col-md-9 px-2 py-2
+  img-top-cls: pt-5 w-50 d-block mx-auto
+
+buttons:
+  classes: btn-outline-info btn-block
+
+projects:
+  - name: Classy Vision Integration
+    section_title: Classy Vision
+    description: Classy Vision is a new end-to-end, PyTorch-based framework for
+      large-scale training of state-of-the-art image and video classification models.
+      The library features a modular, flexible design that allows anyone to train
+      machine learning models on top of PyTorch using very simple abstractions.
+    website: https://github.com/facebookresearch/ClassyVision/blob/main/tutorials/ray_aws.ipynb
+    repo: https://github.com/facebookresearch/ClassyVision
+    image: ../images/classyvision.png
+  - name: Dask Integration
+    section_title: Dask
+    description: Dask provides advanced parallelism for analytics, enabling performance
+      at scale for the tools you love. Dask uses existing Python APIs and data
+      structures to make it easy to switch between Numpy, Pandas,
+      Scikit-learn to their Dask-powered equivalents.
+    website: dask-on-ray
+    repo: https://github.com/dask/dask
+    image: ../images/dask.png
+  - name: Flambé Integration
+    section_title: Flambé
+    description: Flambé is a machine learning experimentation framework built to
+      accelerate the entire research life cycle. Flambé’s main objective is to
+      provide a unified interface for prototyping models, running experiments
+      containing complex pipelines, monitoring those experiments in real-time,
+      reporting results, and deploying a final model for inference.
+    website: https://github.com/asappresearch/flambe
+    repo: https://github.com/asappresearch/flambe
+    image: ../images/flambe.png
+  - name: Horovod Integration
+    section_title: Horovod
+    description: Horovod is a distributed deep learning training framework for
+      TensorFlow, Keras, PyTorch, and Apache MXNet. The goal of
+      Horovod is to make distributed deep learning fast and easy to use.
+    website: https://horovod.readthedocs.io/en/stable/ray_include.html
+    repo: https://github.com/horovod/horovod
+    image: ../images/horovod.png
+  - name: Hugging Face Integration
+    section_title: Hugging Face Transformers
+    description: State-of-the-art Natural Language Processing for
+      Pytorch and TensorFlow 2.0. It integrates with Ray for distributed
+      hyperparameter tuning of transformer models.
+    website: https://huggingface.co/transformers/master/main_classes/trainer.html#transformers.Trainer.hyperparameter_search
+    repo: https://github.com/huggingface/transformers
+    image: ../images/hugging.png
+  - name: Intel Analytics Zoo Integration
+    section_title: Intel Analytics Zoo
+    description: Analytics Zoo seamlessly scales TensorFlow, Keras and PyTorch to distributed big data (using Spark, Flink & Ray).
+    website: https://analytics-zoo.github.io/master/#ProgrammingGuide/rayonspark/
+    repo: https://github.com/intel-analytics/analytics-zoo
+    image: ../images/zoo.png
+  - name: NLU Integration
+    section_title: John Snow Labs' NLU
+    description: The power of 350+ pre-trained NLP models, 100+ Word Embeddings, 50+ Sentence Embeddings, and 50+ Classifiers in 46 languages with 1 line of Python code.
+    website: https://nlu.johnsnowlabs.com/docs/en/predict_api#modin-dataframe
+    repo: https://github.com/JohnSnowLabs/nlu
+    image: ../images/nlu.png
+  - name: Ludwig Integration
+    section_title: Ludwig AI
+    description: Ludwig is a toolbox that allows users to train and test deep learning
+      models without the need to write code. With Ludwig, you can train a deep learning
+      model on Ray in zero lines of code, automatically leveraging Dask on Ray for data
+      preprocessing, Horovod on Ray for distributed training, and Ray Tune for
+      hyperparameter optimization.
+    website: https://medium.com/ludwig-ai/ludwig-ai-v0-4-introducing-declarative-mlops-with-ray-dask-tabnet-and-mlflow-integrations-6509c3875c2e
+    repo: https://github.com/ludwig-ai/ludwig
+    image: ../images/ludwig.png
+  - name: MARS Integration
+    section_title: MARS
+    description: Mars is a tensor-based unified framework for large-scale data
+      computation which scales Numpy, Pandas and Scikit-learn. Mars can scale in to
+      a single machine, and scale out to a cluster with thousands of machines.
+    website: mars-on-ray
+    repo: https://github.com/mars-project/mars
+    image: ../images/mars.png
+  - name: Modin Integration
+    section_title: Modin
+    description: Scale your pandas workflows by changing one line of code.
+      Modin transparently distributes the data and computation so that all you need
+      to do is continue using the pandas API as you were before installing Modin.
+    website: https://github.com/modin-project/modin
+    repo: https://github.com/modin-project/modin
+    image: ../images/modin.png
+  - name: PyCaret Integration
+    section_title: PyCaret
+    description: PyCaret is an open source low-code machine learning library in Python
+      that aims to reduce the hypothesis to insights cycle time in a ML experiment.
+      It enables data scientists to perform end-to-end experiments quickly
+      and efficiently.
+    website: https://github.com/pycaret/pycaret
+    repo: https://github.com/pycaret/pycaret
+    image: ../images/pycaret.png
+  - name: PyTorch Lightning Integration
+    section_title: PyTorch Lightning
+    description: PyTorch Lightning is a popular open-source library that provides a
+      high level interface for PyTorch. The goal of PyTorch Lightning is to structure
+      your PyTorch code to abstract the details of training, making AI research
+      scalable and fast to iterate on.
+    website: https://github.com/ray-project/ray_lightning_accelerators
+    repo: https://github.com/ray-project/ray_lightning_accelerators
+    image: ../images/pytorch_lightning_small.png
+  - name: RayDP Integration
+    section_title: Spark on Ray (RayDP)
+    description: RayDP ("Spark on Ray") enables you to easily use Spark inside a
+      Ray program. You can use Spark to read the input data, process the data using
+      SQL, Spark DataFrame, or Pandas (via Koalas) API, extract and transform features
+      using Spark MLLib, and use RayDP Estimator API for distributed training
+      on the preprocessed dataset.
+    website: https://github.com/Intel-bigdata/oap-raydp <https://github.com/Intel-bigdata/oap-raydp
+    repo: https://github.com/Intel-bigdata/oap-raydp <https://github.com/Intel-bigdata/oap-raydp
+    image: ../images/intel.png
+  - name: Scikit Learn Integration
+    section_title: Scikit Learn
+    description: Scikit-learn is a free software machine learning library for
+      the Python programming language. It features various classification,
+      regression and clustering algorithms including support vector machines,
+      random forests, gradient boosting, k-means and DBSCAN, and is designed to
+      interoperate with the Python numerical and scientific libraries NumPy and SciPy.
+    website: https://docs.ray.io/en/master/joblib.html
+    repo: https://docs.ray.io/en/master/joblib.html
+    image: ../images/scikit.png
+  - name: Seldon Alibi Integration
+    section_title: Seldon Alibi
+    description: Alibi is an open source Python library aimed at machine learning model
+      inspection and interpretation. The focus of the library is to provide high-quality
+      implementations of black-box, white-box, local and global explanation methods for
+      classification and regression models.
+    website: https://github.com/SeldonIO/alibi
+    repo: https://github.com/SeldonIO/alibi
+    image: ../images/seldon.png
+  - name: spaCy Integration
+    section_title: spaCy
+    description: spaCy is a library for advanced Natural Language Processing in Python
+      and Cython. It's built on the very latest research, and was designed from
+      day one to be used in real products.
+    website: https://pypi.org/project/spacy-ray/
+    repo: https://github.com/explosion/spacy-ray
+    image: ../images/spacy.png
+  - name: XGBoost Integration
+    section_title: XGBoost
+    description: XGBoost is a popular gradient boosting library for classification
+      and regression. It is one of the most popular tools in data science and
+      workhorse of many top-performing Kaggle kernels.
+    website: https://github.com/ray-project/xgboost_ray
+    repo: https://github.com/ray-project/xgboost_ray
+    image: ../images/xgboost_logo.png
+  - name: LightGBM Integration
+    section_title: LightGBM
+    description: LightGBM is a high-performance gradient boosting library for
+      classification and regression. It is designed to be distributed and efficient.
+    website: https://github.com/ray-project/lightgbm_ray
+    repo: https://github.com/ray-project/lightgbm_ray
+    image: ../images/lightgbm_logo.png

--- a/doc/source/ray-overview/eco-gallery.yml
+++ b/doc/source/ray-overview/eco-gallery.yml
@@ -2,7 +2,7 @@ meta:
   section-titles: true
   container: container pb-12
   column: col-md-12 px-2 py-2
-  img-top-cls: pt-5 w-50 d-block mx-auto
+  img-top-cls: pt-10 w-50 d-block mx-auto
 
 buttons:
   classes: btn-outline-info btn-block

--- a/doc/source/ray-overview/ray-libraries.rst
+++ b/doc/source/ray-overview/ray-libraries.rst
@@ -1,210 +1,29 @@
 .. _ray-oss-list:
 
-Ecosystem
-=========
+The Ray Ecosystem
+=================
 
-This page lists libraries that have integrations with Ray for distributed execution.
-If you'd like to add your project to this list, feel free to file a pull request or open an issue on GitHub.
+This page lists libraries that have integrations with Ray for distributed execution
+in alphabetical order.
+It's easy to add your own integration to this list.
+Simply open a pull request with a few lines of text, see the dropdown below for
+more information.
 
-ClassyVision |classyvision|
----------------------------
+.. dropdown:: Adding Your Integration
 
-Classy Vision is a new end-to-end, PyTorch-based framework for large-scale training of state-of-the-art image and video classification models. The library features a modular, flexible design that allows anyone to train machine learning models on top of PyTorch using very simple abstractions.
+    To add an integration, simply add an entry to the `projects` list of our
+    Gallery YAML on `GitHub <https://github.com/ray-project/ray/tree/master/doc/source/ray-overview/eco-gallery.yml>`_.
 
+    .. code-block:: yaml
 
-[`Link to integration <https://github.com/facebookresearch/ClassyVision/blob/main/tutorials/ray_aws.ipynb>`__]
+          - name: the integration link button text
+            section_title: The section title for this integration
+            description: A quick description of your library and its integration with Ray
+            website: The URL of your website
+            repo: The URL of your project on GitHub
+            image: The URL of a logo of your project
 
-Dask |dask|
------------
+    That's all!
 
-Dask provides advanced parallelism for analytics, enabling performance at scale for the tools you love. Dask uses existing Python APIs and data structures to make it easy to switch between Numpy, Pandas, Scikit-learn to their Dask-powered equivalents.
+.. include:: eco-gallery.txt
 
-[:ref:`Link to integration <dask-on-ray>`]
-
-Flambe |flambe|
----------------
-
-Flambé is a machine learning experimentation framework built to accelerate the entire research life cycle. Flambé’s main objective is to provide a unified interface for prototyping models, running experiments containing complex pipelines, monitoring those experiments in real-time, reporting results, and deploying a final model for inference.
-
-GitHub: `https://github.com/asappresearch/flambe <https://github.com/asappresearch/flambe>`_
-
-Horovod |horovod|
------------------
-
-Horovod is a distributed deep learning training framework for TensorFlow, Keras, PyTorch, and Apache MXNet. The goal of Horovod is to make distributed deep learning fast and easy to use.
-
-[`Link to integration <https://horovod.readthedocs.io/en/stable/ray_include.html>`__]
-
-Hugging Face Transformers |hugging|
------------------------------------
-
-State-of-the-art Natural Language Processing for Pytorch and TensorFlow 2.0.
-
-It integrates with Ray for distributed hyperparameter tuning of transformer models:
-
-[`Link to integration <https://huggingface.co/transformers/master/main_classes/trainer.html#transformers.Trainer.hyperparameter_search>`__]
-
-As well as for distributed document retrieval for Retrieval Augmented Generation Models
-
-[`Link to integration <https://github.com/huggingface/transformers/tree/master/examples/research_projects/rag#document-retrieval>`__]
-
-Intel Analytics Zoo |zoo|
--------------------------
-
-Analytics Zoo seamless scales TensorFlow, Keras and PyTorch to distributed big data (using Spark, Flink & Ray).
-
-[`Link to integration <https://analytics-zoo.github.io/master/#ProgrammingGuide/rayonspark/>`__]
-
-John Snow Labs' NLU |NLU|
--------------------------
-The power of 350+ pre-trained NLP models, 100+ Word Embeddings, 50+ Sentence Embeddings, and 50+ Classifiers in 46 languages with 1 line of Python code.
-
-[`Link to integration <https://nlu.johnsnowlabs.com/docs/en/predict_api#modin-dataframe>`__]
-
-Ludwig AI |ludwig|
-------------------
-
-Ludwig is a toolbox that allows users to train and test deep learning models without the need to write code. With Ludwig, you can train a deep learning model on Ray in zero lines of code, automatically leveraging Dask on Ray for data preprocessing, Horovod on Ray for distributed training, and Ray Tune for hyperparameter optimization.
-
-[`Link to integration <https://medium.com/ludwig-ai/ludwig-ai-v0-4-introducing-declarative-mlops-with-ray-dask-tabnet-and-mlflow-integrations-6509c3875c2e>`__]
-
-
-MARS |mars|
------------
-
-Mars is a tensor-based unified framework for large-scale data computation which scales Numpy, Pandas and Scikit-learn. Mars can scale in to a single machine, and scale out to a cluster with thousands of machines.
-
-[:ref:`Link to integration <mars-on-ray>`]
-
-Modin |modin|
--------------
-
-Scale your pandas workflows by changing one line of code. Modin transparently distributes the data and computation so that all you need to do is continue using the pandas API as you were before installing Modin.
-
-GitHub: `https://github.com/modin-project/modin <https://github.com/modin-project/modin>`_
-
-PyCaret |pycaret|
------------------
-
-PyCaret is an open source low-code machine learning library in Python that aims to reduce the hypothesis to insights cycle time in a ML experiment. It enables data scientists to perform end-to-end experiments quickly and efficiently.
-
-GitHub: `https://github.com/pycaret/pycaret <https://github.com/pycaret/pycaret>`_
-
-PyTorch Lightning |ptl|
------------------------
-
-PyTorch Lightning is a popular open-source library that provides a high level interface for PyTorch. The goal of PyTorch Lightning is to structure your PyTorch code to abstract the details of training, making AI research scalable and fast to iterate on.
-
-[`Link to integration <https://github.com/ray-project/ray_lightning_accelerators>`__]
-
-RayDP |raydp|
--------------
-
-RayDP ("Spark on Ray") enables you to easily use Spark inside a Ray program. You can use Spark to read the input data, process the data using SQL, Spark DataFrame, or Pandas (via Koalas) API, extract and transform features using Spark MLLib, and use RayDP Estimator API for distributed training on the preprocessed dataset.
-
-GitHub: `https://github.com/Intel-bigdata/oap-raydp <https://github.com/Intel-bigdata/oap-raydp>`_
-
-Scikit Learn |scikit|
----------------------
-
-Scikit-learn is a free software machine learning library for the Python programming language. It features various classification, regression and clustering algorithms including support vector machines, random forests, gradient boosting, k-means and DBSCAN, and is designed to interoperate with the Python numerical and scientific libraries NumPy and SciPy.
-
-[`Link to integration <https://docs.ray.io/en/master/joblib.html>`__]
-
-Seldon Alibi |seldon|
----------------------
-
-Alibi is an open source Python library aimed at machine learning model inspection and interpretation. The focus of the library is to provide high-quality implementations of black-box, white-box, local and global explanation methods for classification and regression models.
-
-GitHub: `https://github.com/SeldonIO/alibi <https://github.com/SeldonIO/alibi>`__
-
-Spacy |spacy|
--------------
-spaCy is a library for advanced Natural Language Processing in Python and Cython. It's built on the very latest research, and was designed from day one to be used in real products.
-
-[`Link to integration <https://pypi.org/project/spacy-ray/>`__]
-
-XGBoost |xgboost|
------------------
-XGBoost is a popular gradient boosting library for classification and regression. It is one of the most popular tools in data science and workhorse of many top-performing Kaggle kernels.
-
-[`Link to integration <https://github.com/ray-project/xgboost_ray>`__]
-
-LightGBM |lightgbm|
--------------------
-LightGBM is a high-performance gradient boosting library for classification and regression. It is designed to be distributed and efficient.
-
-[`Link to integration <https://github.com/ray-project/lightgbm_ray>`__]
-
-
-.. |classyvision| image:: ../images/classyvision.png
-    :class: inline-figure
-    :height: 30
-
-.. |dask| image:: ../images/dask.png
-    :class: inline-figure
-    :height: 30
-
-.. |flambe| image:: ../images/flambe.png
-    :class: inline-figure
-    :height: 30
-
-.. |mars| image:: ../images/mars.png
-    :class: inline-figure
-    :height: 30
-
-.. |modin| image:: ../images/modin.png
-    :class: inline-figure
-    :height: 30
-
-.. |horovod| image:: ../images/horovod.png
-    :class: inline-figure
-    :height: 30
-
-.. |ludwig| image:: ../images/ludwig.png
-    :class: inline-figure
-    :height: 30
-
-.. |hugging| image:: ../images/hugging.png
-    :class: inline-figure
-    :height: 30
-
-.. |zoo| image:: ../images/zoo.png
-    :class: inline-figure
-    :height: 30
-
-.. |pycaret| image:: ../images/pycaret.png
-    :class: inline-figure
-    :height: 30
-
-.. |ptl| image:: ../images/pytorch_lightning_small.png
-    :class: inline-figure
-    :height: 30
-
-.. |raydp| image:: ../images/intel.png
-    :class: inline-figure
-    :height: 30
-
-.. |scikit| image:: ../images/scikit.png
-    :class: inline-figure
-    :height: 30
-
-.. |seldon| image:: ../images/seldon.png
-    :class: inline-figure
-    :height: 30
-
-.. |spacy| image:: ../images/spacy.png
-    :class: inline-figure
-    :height: 30
-
-.. |xgboost| image:: ../images/xgboost_logo.png
-    :class: inline-figure
-    :height: 30
-
-.. |lightgbm| image:: ../images/lightgbm_logo.png
-    :class: inline-figure
-    :height: 30
-
-.. |nlu| image:: ../images/nlu.png
-    :class: inline-figure
-    :height: 30


### PR DESCRIPTION
we've build a custom directive to read gallery information from a simple YAML file. This makes it much easier (presumably) to add new entries in the future and should hopefully attract more contributors. This PR is specifically set up for our "Ecosystems" gallery, but it's implemented to work for any other gallery on our docs as well. Apart from easier config, this should also look a bit more appealing.

On a side note, this simple format could be used for upcoming hackathons etc. to quickly display all projects in a concise way. (cc/ @zhe-thoughts @waleedkadous).

Before:

![Screenshot 2022-09-21 at 10 55 02](https://user-images.githubusercontent.com/3462566/191461144-54250935-6e36-4e1f-993a-e021675fd6da.png)

After:

![Screenshot 2022-09-21 at 10 54 50](https://user-images.githubusercontent.com/3462566/191461133-cc250bd7-6467-4d64-8600-00cf358367a8.png)
