### PR TITLE
[ci] Improve determine_tests_to_run.py for doc/ and ci/ files

### DIFF
--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -196,14 +196,25 @@ if __name__ == "__main__":
             elif changed_file.startswith("docker/"):
                 RAY_CI_DOCKER_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
-            elif changed_file.startswith("doc/") and (
-                changed_file.endswith(".py")
-                or changed_file.endswith(".ipynb")
-                or changed_file.endswith("BUILD")
-            ):
-                RAY_CI_DOC_AFFECTED = 1
+            elif changed_file.startswith("doc/"):
+                if (
+                    changed_file.endswith(".py")
+                    or changed_file.endswith(".ipynb")
+                    or changed_file.endswith("BUILD")
+                ):
+                    RAY_CI_DOC_AFFECTED = 1
+                # Else, this affects only a rst file or so. In that case,
+                # we pass, as the flag RAY_CI_DOC_AFFECTED is only
+                # used to indicate that tests/examples should be run
+                # (documentation will be built always)
             elif any(changed_file.startswith(prefix) for prefix in skip_prefix_list):
                 # nothing is run but linting in these cases
+                pass
+            elif changed_file.startswith("ci/lint"):
+                # Linter will always be run
+                pass
+            elif changed_file.startswith("ci/pipeline"):
+                # These scripts are always run as part of the build process
                 pass
             elif changed_file.endswith("build-docker-images.py"):
                 RAY_CI_DOCKER_AFFECTED = 1
@@ -223,6 +234,8 @@ if __name__ == "__main__":
                 RAY_CI_DASHBOARD_AFFECTED = 1
                 RAY_CI_DOC_AFFECTED = 1
             else:
+                print(f"Unhandled source code change: {changed_file}", file=sys.stderr)
+
                 RAY_CI_ML_AFFECTED = 1
                 RAY_CI_TUNE_AFFECTED = 1
                 RAY_CI_TRAIN_AFFECTED = 1


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current check for `doc/` will trigger all tests if RST files are changed.
Also, we dont need to run full CI for changes in `ci/lint` and `ci/pipeline`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
