### PR TITLE
[AIR] Maintain dtype info in LightGBMPredictor

### DIFF
--- a/python/ray/train/lightgbm/lightgbm_predictor.py
+++ b/python/ray/train/lightgbm/lightgbm_predictor.py
@@ -1,8 +1,8 @@
-import numpy as np
 from typing import TYPE_CHECKING, List, Optional, Union
 
 import lightgbm
 import pandas as pd
+from pandas.api.types import is_object_dtype
 
 from ray.air.checkpoint import Checkpoint
 from ray.air.constants import TENSOR_COLUMN_NAME
@@ -129,33 +129,33 @@ class LightGBMPredictor(Predictor):
             if feature_columns:
                 # In this case feature_columns is a list of integers
                 data = data[:, feature_columns]
+            # Turn into dataframe to make dtype resolution easy
+            data = pd.DataFrame(data, columns=feature_names)
+            data = data.infer_objects()
+
+            # Pandas does not detect categorical dtypes. Any remaining object
+            # dtypes are probably categories, so convert them.
+            # This will fail if we have a category composed entirely of
+            # integers, but this is the best we can do here.
+            update_dtypes = {}
+            for column in data.columns:
+                dtype = data.dtypes[column]
+                if is_object_dtype(dtype):
+                    update_dtypes[column] = pd.CategoricalDtype()
+
+            if update_dtypes:
+                data = data.astype(update_dtypes, copy=False)
         elif feature_columns:
             # feature_columns is a list of integers or strings
-            data = data[feature_columns].to_numpy()
+            data = data[feature_columns]
             # Only set the feature names if they are strings
             if all(isinstance(fc, str) for fc in feature_columns):
                 feature_names = feature_columns
         else:
             feature_columns = data.columns.tolist()
-            data = data.to_numpy()
 
             if all(isinstance(fc, str) for fc in feature_columns):
                 feature_names = feature_columns
-
-        # Turn into dataframe to make dtype resolution easy
-        data = pd.DataFrame(data, columns=feature_names)
-        data = data.infer_objects()
-
-        # Pandas does not detect categorical dtypes. Any remaining object
-        # dtypes are probably categories, so convert them.
-        update_dtypes = {}
-        for column in data.columns:
-            dtype = data.dtypes[column]
-            if dtype == np.object:
-                update_dtypes[column] = pd.CategoricalDtype()
-
-        if update_dtypes:
-            data = data.astype(update_dtypes, copy=False)
 
         df = pd.DataFrame(self.model.predict(data, **predict_kwargs))
         df.columns = (

--- a/python/ray/train/lightgbm/lightgbm_predictor.py
+++ b/python/ray/train/lightgbm/lightgbm_predictor.py
@@ -148,14 +148,6 @@ class LightGBMPredictor(Predictor):
         elif feature_columns:
             # feature_columns is a list of integers or strings
             data = data[feature_columns]
-            # Only set the feature names if they are strings
-            if all(isinstance(fc, str) for fc in feature_columns):
-                feature_names = feature_columns
-        else:
-            feature_columns = data.columns.tolist()
-
-            if all(isinstance(fc, str) for fc in feature_columns):
-                feature_names = feature_columns
 
         df = pd.DataFrame(self.model.predict(data, **predict_kwargs))
         df.columns = (

--- a/python/ray/train/xgboost/xgboost_predictor.py
+++ b/python/ray/train/xgboost/xgboost_predictor.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import pandas as pd
-from ray.train.xgboost.xgboost_checkpoint import XGBoostCheckpoint
+from pandas.api.types import is_object_dtype
 import xgboost
 
 from ray.air.checkpoint import Checkpoint
@@ -9,6 +9,7 @@ from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.data_batch_type import DataBatchType
 from ray.air.util.data_batch_conversion import _unwrap_ndarray_object_type_if_needed
 from ray.train.predictor import Predictor
+from ray.train.xgboost.xgboost_checkpoint import XGBoostCheckpoint
 from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
@@ -143,15 +144,30 @@ class XGBoostPredictor(Predictor):
             if feature_columns:
                 # In this case feature_columns is a list of integers
                 data = data[:, feature_columns]
+            # Turn into dataframe to make dtype resolution easy
+            data = pd.DataFrame(data, columns=feature_names)
+            data = data.infer_objects()
+
+            # Pandas does not detect categorical dtypes. Any remaining object
+            # dtypes are probably categories, so convert them.
+            # This will fail if we have a category composed entirely of
+            # integers, but this is the best we can do here.
+            update_dtypes = {}
+            for column in data.columns:
+                dtype = data.dtypes[column]
+                if is_object_dtype(dtype):
+                    update_dtypes[column] = pd.CategoricalDtype()
+
+            if update_dtypes:
+                data = data.astype(update_dtypes, copy=False)
         elif feature_columns:
             # feature_columns is a list of integers or strings
-            data = data[feature_columns].to_numpy()
+            data = data[feature_columns]
             # Only set the feature names if they are strings
             if all(isinstance(fc, str) for fc in feature_columns):
                 feature_names = feature_columns
         else:
             feature_columns = data.columns.tolist()
-            data = data.to_numpy()
 
             if all(isinstance(fc, str) for fc in feature_columns):
                 feature_names = feature_columns


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We always convert to numpy and then back to dataframe in `LightGBMPredictor`, and try to infer dtypes in between. This is imprecise and allows for an edge case where a Categorical column composed of integers is classified as an int column, and it also decreases performance. This PR keeps dtype information if possible by not converting to numpy unnecessarily. The inference logic is still present for the tensor column case - I am not familiar enough with it to fix it here (if it needs fixing in the first place).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/28619

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
