### PR TITLE
Sample YAML for deploying static Ray cluster with external Redis

### DIFF
--- a/doc/kubernetes/ray-cluster-external-redis.yaml
+++ b/doc/kubernetes/ray-cluster-external-redis.yaml
@@ -1,0 +1,136 @@
+# Ray head node service, allowing worker pods to discover the head node.
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: ray
+  name: example-cluster-ray-head
+spec:
+  ports:
+  - name: client
+    protocol: TCP
+    port: 10001
+    targetPort: 10001
+  - name: dashboard
+    protocol: TCP
+    port: 8265
+    targetPort: 8265
+  - name: redis
+    protocol: TCP
+    port: 6379
+    targetPort: 6379
+  selector:
+    component: ray-head
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: ray
+  name: ray-head
+spec:
+  # Do not change this - Ray currently only supports one head node per cluster.
+  replicas: 1
+  selector:
+    matchLabels:
+      component: ray-head
+      type: ray
+  template:
+    metadata:
+      labels:
+        component: ray-head
+        type: ray
+    spec:
+      # If the head node goes down, the entire cluster (including all worker
+      # nodes) will go down as well. If you want Kubernetes to bring up a new
+      # head node in this case, set this to "Always," else set it to "Never."
+      restartPolicy: Always
+
+      # This volume allocates shared memory for Ray to use for its plasma
+      # object store. If you do not provide this, Ray will fall back to
+      # /tmp which cause slowdowns if is not a shared memory volume.
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      containers:
+        - name: ray-head
+          image: rayproject/ray:latest
+          env:
+            # RAY_REDIS_ADDRESS can force ray to use external redis
+            - name: RAY_REDIS_ADDRESS
+              value: redis:6379
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/bash", "-c", "--" ]
+          args:
+            - "ray start --head --num-cpus=$MY_CPU_REQUEST --object-manager-port=22345 --node-manager-port=22346 --dashboard-host=0.0.0.0 --block"
+          ports:
+            - containerPort: 6379 # Redis port
+            - containerPort: 10001 # Used by Ray Client
+            - containerPort: 8265 # Used by Ray Dashboard
+
+          # This volume allocates shared memory for Ray to use for its plasma
+          # object store. If you do not provide this, Ray will fall back to
+          # /tmp which cause slowdowns if is not a shared memory volume.
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+          env:
+            # This is used in the ray start command so that Ray can spawn the
+            # correct number of processes. Omitting this may lead to degraded
+            # performance.
+            - name: MY_CPU_REQUEST
+              valueFrom:
+                resourceFieldRef:
+                  resource: requests.cpu
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: ray
+  name: ray-worker
+spec:
+  # Change this to scale the number of worker nodes started in the Ray cluster.
+  replicas: 3
+  selector:
+    matchLabels:
+      component: ray-worker
+      type: ray
+  template:
+    metadata:
+      labels:
+        component: ray-worker
+        type: ray
+    spec:
+      restartPolicy: Always
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      containers:
+      - name: ray-worker
+        image: rayproject/ray:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash", "-c", "--"]
+        args:
+          - "ray start --num-cpus=$MY_CPU_REQUEST --address=$EXAMPLE_CLUSTER_RAY_HEAD_SERVICE_HOST:$EXAMPLE_CLUSTER_RAY_HEAD_SERVICE_PORT_REDIS --object-manager-port=22345 --node-manager-port=22346 --block"
+        # This volume allocates shared memory for Ray to use for its plasma
+        # object store. If you do not provide this, Ray will fall back to
+        # /tmp which cause slowdowns if is not a shared memory volume.
+        volumeMounts:
+          - mountPath: /dev/shm
+            name: dshm
+        env:
+          # This is used in the ray start command so that Ray can spawn the
+          # correct number of processes. Omitting this may lead to degraded
+          # performance.
+          - name: MY_CPU_REQUEST
+            valueFrom:
+              resourceFieldRef:
+                resource: requests.cpu
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi

--- a/doc/kubernetes/ray-cluster-external-redis.yaml
+++ b/doc/kubernetes/ray-cluster-external-redis.yaml
@@ -115,7 +115,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command: ["/bin/bash", "-c", "--"]
         args:
-          - "ray start --num-cpus=$MY_CPU_REQUEST --address=$EXAMPLE_CLUSTER_RAY_HEAD_SERVICE_HOST:$EXAMPLE_CLUSTER_RAY_HEAD_SERVICE_PORT_REDIS --object-manager-port=22345 --node-manager-port=22346 --block"
+          - "ray start --num-cpus=$MY_CPU_REQUEST --address=$EXAMPLE_CLUSTER_RAY_HEAD_SERVICE_HOST:$EXAMPLE_CLUSTER_RAY_HEAD_SERVICE_PORT_GCS_SERVER --block"
         # This volume allocates shared memory for Ray to use for its plasma
         # object store. If you do not provide this, Ray will fall back to
         # /tmp which cause slowdowns if is not a shared memory volume.

--- a/doc/kubernetes/ray-cluster-external-redis.yaml
+++ b/doc/kubernetes/ray-cluster-external-redis.yaml
@@ -14,7 +14,7 @@ spec:
     protocol: TCP
     port: 8265
     targetPort: 8265
-  - name: redis
+  - name: gcs-server
     protocol: TCP
     port: 6379
     targetPort: 6379

--- a/doc/kubernetes/ray-cluster-external-redis.yaml
+++ b/doc/kubernetes/ray-cluster-external-redis.yaml
@@ -63,7 +63,7 @@ spec:
           args:
             - "ray start --head --num-cpus=$MY_CPU_REQUEST --object-manager-port=22345 --node-manager-port=22346 --dashboard-host=0.0.0.0 --block"
           ports:
-            - containerPort: 6379 # Redis port
+            - containerPort: 6380 # GCS server
             - containerPort: 10001 # Used by Ray Client
             - containerPort: 8265 # Used by Ray Dashboard
 

--- a/doc/kubernetes/ray-cluster-external-redis.yaml
+++ b/doc/kubernetes/ray-cluster-external-redis.yaml
@@ -16,7 +16,7 @@ spec:
     targetPort: 8265
   - name: gcs-server
     protocol: TCP
-    port: 6379
+    port: 6380
     targetPort: 6379
   selector:
     component: ray-head

--- a/doc/kubernetes/ray-cluster-external-redis.yaml
+++ b/doc/kubernetes/ray-cluster-external-redis.yaml
@@ -17,7 +17,7 @@ spec:
   - name: gcs-server
     protocol: TCP
     port: 6380
-    targetPort: 6379
+    targetPort: 6380
   selector:
     component: ray-head
 ---

--- a/doc/kubernetes/ray-cluster-external-redis.yaml
+++ b/doc/kubernetes/ray-cluster-external-redis.yaml
@@ -61,7 +61,7 @@ spec:
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "-c", "--" ]
           args:
-            - "ray start --head --num-cpus=$MY_CPU_REQUEST --object-manager-port=22345 --node-manager-port=22346 --dashboard-host=0.0.0.0 --block"
+            - "ray start --head --port=6380 --num-cpus=$MY_CPU_REQUEST --dashboard-host=0.0.0.0 --block"
           ports:
             - containerPort: 6380 # GCS server
             - containerPort: 10001 # Used by Ray Client


### PR DESCRIPTION
Signed-off-by: Yiqing Wang <yqw@wangemail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR includes a sample YAML that deploys the static Ray Cluster on K8S with external Redis. Although there is an existing [KubeRay yaml](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.external-redis.yaml) that supports connecting to an external Redis for FT, it requires additional CRDs which might cause permission issue. 

The PR removes `--port=6379 --redis-shard-ports=6380,6381` from the head node start command and adds `RAY_REDIS_ADDRESS` to the head node env var as suggested by this [closed PR](https://github.com/ray-project/ray/pull/27279). 

The Redis is deployed in the same K8S namespace.
![Screenshot from 2022-09-21 17-54-00](https://user-images.githubusercontent.com/20148872/191636293-8eebe30b-0f7a-46e4-a53a-ebc954c6a405.png)
However, the head node seems still connected to the internal datastore IP address, and the external Redis has no new keys created.
![Screenshot from 2022-09-21 18-05-37](https://user-images.githubusercontent.com/20148872/191636419-75668857-13f3-4b07-bb7e-7cb9c5f92d2b.png)
![Screenshot from 2022-09-21 18-04-28](https://user-images.githubusercontent.com/20148872/191636422-bb29af3b-1653-4d97-a00e-cbb73b044e21.png)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
