### PR TITLE
[tune] Test background syncer serialization

### DIFF
--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -446,7 +446,7 @@ class _BackgroundSyncer(Syncer):
 
     def __getstate__(self):
         state = self.__dict__.copy()
-        state.pop("_sync_process", None)
+        state["_sync_process"] = None
         return state
 
 

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -444,6 +444,11 @@ class _BackgroundSyncer(Syncer):
         self._sync_process = _BackgroundProcess(cmd)
         self._sync_process.start(**kwargs)
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state.pop("_sync_process", None)
+        return state
+
 
 class _DefaultSyncer(_BackgroundSyncer):
     """Default syncer between local storage and remote URI."""

--- a/python/ray/tune/tests/test_syncer.py
+++ b/python/ray/tune/tests/test_syncer.py
@@ -9,6 +9,7 @@ import pytest
 from freezegun import freeze_time
 
 import ray
+import ray.cloudpickle as pickle
 from ray import tune
 from ray.tune import TuneError
 from ray.tune.syncer import Syncer, _DefaultSyncer, _validate_upload_dir
@@ -471,6 +472,19 @@ def test_trainable_syncer_custom_command(ray_start_2_cpus, temp_data_dirs):
     ray.get(trainable.delete_checkpoint.remote(checkpoint_dir))
 
     assert_file(False, tmp_target, os.path.join(checkpoint_dir, "checkpoint.data"))
+
+
+def test_syncer_serialize(temp_data_dirs):
+    """Check that syncing up and down works"""
+    tmp_source, tmp_target = temp_data_dirs
+
+    syncer = _DefaultSyncer()
+
+    syncer.sync_up(
+        local_dir=tmp_source, remote_dir="memory:///test/test_syncer_sync_up_down"
+    )
+
+    pickle.dumps(syncer)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Syncer (and thus Trial and Trial Runner) serialization fails because of threading objects that are not correctly unset on getstate.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
