### PR TITLE
[Release Test] Make sure to delete all EBS volumes

### DIFF
--- a/release/air_tests/air_benchmarks/compute_gpu_1.yaml
+++ b/release/air_tests/air_benchmarks/compute_gpu_1.yaml
@@ -18,6 +18,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 800
             Iops: 5000
             Throughput: 1000

--- a/release/air_tests/air_benchmarks/compute_gpu_16.yaml
+++ b/release/air_tests/air_benchmarks/compute_gpu_16.yaml
@@ -18,6 +18,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 800
             Iops: 5000
             Throughput: 1000

--- a/release/air_tests/air_benchmarks/xgboost_compute_tpl.yaml
+++ b/release/air_tests/air_benchmarks/xgboost_compute_tpl.yaml
@@ -18,6 +18,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             Iops: 5000
             Throughput: 1000
             VolumeSize: 1000

--- a/release/benchmarks/single_node.yaml
+++ b/release/benchmarks/single_node.yaml
@@ -7,6 +7,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/ml_user_tests/tune_rllib/compute_tpl.yaml
+++ b/release/ml_user_tests/tune_rllib/compute_tpl.yaml
@@ -23,4 +23,5 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500

--- a/release/nightly_tests/dask_on_ray/1tb_sort_compute.yaml
+++ b/release/nightly_tests/dask_on_ray/1tb_sort_compute.yaml
@@ -6,6 +6,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 2000
 
 head_node_type:

--- a/release/nightly_tests/dask_on_ray/chaos_dask_on_ray_stress_compute.yaml
+++ b/release/nightly_tests/dask_on_ray/chaos_dask_on_ray_stress_compute.yaml
@@ -5,6 +5,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_sort_compute_template.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_sort_compute_template.yaml
@@ -5,6 +5,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_stress_compute.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_stress_compute.yaml
@@ -5,6 +5,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_compute_template.yaml
+++ b/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_compute_template.yaml
@@ -6,6 +6,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/dataset/dataset_ingest_400G_compute.yaml
+++ b/release/nightly_tests/dataset/dataset_ingest_400G_compute.yaml
@@ -8,6 +8,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/dataset/inference.yaml
+++ b/release/nightly_tests/dataset/inference.yaml
@@ -7,6 +7,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
@@ -8,6 +8,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/dataset/pipelined_training_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_training_compute.yaml
@@ -10,6 +10,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/dataset/ray_sgd_training_compute.yaml
+++ b/release/nightly_tests/dataset/ray_sgd_training_compute.yaml
@@ -10,6 +10,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/dataset/ray_sgd_training_compute_no_gpu.yaml
+++ b/release/nightly_tests/dataset/ray_sgd_training_compute_no_gpu.yaml
@@ -10,6 +10,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/dataset/ray_sgd_training_smoke_compute.yaml
+++ b/release/nightly_tests/dataset/ray_sgd_training_smoke_compute.yaml
@@ -10,6 +10,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/dataset/shuffle_compute.yaml
+++ b/release/nightly_tests/dataset/shuffle_compute.yaml
@@ -8,6 +8,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/decision_tree/autoscaling_compute.yaml
+++ b/release/nightly_tests/decision_tree/autoscaling_compute.yaml
@@ -7,6 +7,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/placement_group_tests/compute.yaml
+++ b/release/nightly_tests/placement_group_tests/compute.yaml
@@ -5,6 +5,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/placement_group_tests/long_running_test_compute.yaml
+++ b/release/nightly_tests/placement_group_tests/long_running_test_compute.yaml
@@ -5,6 +5,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/placement_group_tests/pg_perf_test_compute.yaml
+++ b/release/nightly_tests/placement_group_tests/pg_perf_test_compute.yaml
@@ -5,6 +5,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
@@ -5,9 +5,11 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 2000
         - DeviceName: /dev/sda2
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 2000
 
 head_node_type:

--- a/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances.yaml
+++ b/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances.yaml
@@ -5,6 +5,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 1000
 
 head_node_type:

--- a/release/nightly_tests/shuffle/shuffle_compute_autoscaling.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_autoscaling.yaml
@@ -5,6 +5,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
@@ -5,6 +5,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/shuffle/shuffle_compute_multi.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_multi.yaml
@@ -7,6 +7,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/shuffle/shuffle_compute_single.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_single.yaml
@@ -7,6 +7,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/stress_tests/placement_group_tests_compute.yaml
+++ b/release/nightly_tests/stress_tests/placement_group_tests_compute.yaml
@@ -7,6 +7,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/stress_tests/smoke_test_compute.yaml
+++ b/release/nightly_tests/stress_tests/smoke_test_compute.yaml
@@ -7,6 +7,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/stress_tests/stress_test_threaded_actor_compute.yaml
+++ b/release/nightly_tests/stress_tests/stress_test_threaded_actor_compute.yaml
@@ -5,6 +5,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/stress_tests/stress_tests_compute.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_compute.yaml
@@ -7,6 +7,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/nightly_tests/stress_tests/stress_tests_compute_large.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_compute_large.yaml
@@ -7,6 +7,7 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500
 
 head_node_type:

--- a/release/rllib_tests/12gpus_192cpus.yaml
+++ b/release/rllib_tests/12gpus_192cpus.yaml
@@ -18,4 +18,5 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500

--- a/release/rllib_tests/1gpu_16cpus.yaml
+++ b/release/rllib_tests/1gpu_16cpus.yaml
@@ -18,4 +18,5 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500

--- a/release/rllib_tests/1gpu_24cpus.yaml
+++ b/release/rllib_tests/1gpu_24cpus.yaml
@@ -18,4 +18,5 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500

--- a/release/rllib_tests/1gpu_4cpus.yaml
+++ b/release/rllib_tests/1gpu_4cpus.yaml
@@ -18,4 +18,5 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500

--- a/release/rllib_tests/2gpus_32cpus.yaml
+++ b/release/rllib_tests/2gpus_32cpus.yaml
@@ -18,4 +18,5 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500

--- a/release/rllib_tests/4gpus_544_cpus.yaml
+++ b/release/rllib_tests/4gpus_544_cpus.yaml
@@ -18,4 +18,5 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500

--- a/release/rllib_tests/4gpus_64cpus.yaml
+++ b/release/rllib_tests/4gpus_64cpus.yaml
@@ -18,4 +18,5 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500

--- a/release/rllib_tests/8gpus_64cpus.yaml
+++ b/release/rllib_tests/8gpus_64cpus.yaml
@@ -18,4 +18,5 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500

--- a/release/rllib_tests/8gpus_96cpus.yaml
+++ b/release/rllib_tests/8gpus_96cpus.yaml
@@ -18,4 +18,5 @@ aws:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 500


### PR DESCRIPTION
Signed-off-by: simon-mo <simon.mo@hey.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
From [AWS Documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#preserving-volumes-on-termination:~:text=choose%20Apply.-,Preserve%20Amazon%20EBS%20volumes%20on%20instance%20termination,-When%20an%20instance):

> Non-root volume
By default, when you [attach a non-root EBS volume to an instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-attaching-volume.html), its DeleteOnTermination attribute is set to false. Therefore, the default is to preserve these volumes. After the instance terminates, you can take a snapshot of the preserved volume or attach it to another instance. You must delete a volume to avoid incurring further charges. For more information, see [Delete an Amazon EBS volume](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-deleting-volume.html).

This has caused us some pretty bad costly volume leaks in our testing CI account.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
