### PR TITLE
[Serve] [Docs] Remove incorrect output

### DIFF
--- a/doc/source/serve/production-guide/kubernetes.md
+++ b/doc/source/serve/production-guide/kubernetes.md
@@ -33,12 +33,10 @@ Install the operator using `kubectl apply` and check that the controller pod is 
 $ kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/default?ref=v0.3.0&timeout=90s"
 $ kubectl get deployments -n ray-system
 NAME                READY   UP-TO-DATE   AVAILABLE   AGE
-kuberay-apiserver   1/1     1            1           13s
 kuberay-operator    1/1     1            1           13s
 
 $ kubectl get pods -n ray-system
 NAME                                 READY   STATUS    RESTARTS   AGE
-kuberay-apiserver-799bc6dd95-787w7   1/1     Running   0          42s
 kuberay-operator-68c75b5d5f-m8xd7    1/1     Running   0          42s
 ```
 


### PR DESCRIPTION
Signed-off-by: Shreyas Krishnaswamy <shrekris@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The [Serve production guide about Kubernetes](https://docs.ray.io/en/releases-2.0.0/serve/production-guide/kubernetes.html#installing-the-kuberay-operator) has an incorrect output in its example commands. This change removes that output.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change only modifies the docs.