### PR TITLE
[core] [release] added wait_for_nodes for stress_test_many_tasks

### DIFF
--- a/release/nightly_tests/stress_tests/test_many_tasks.py
+++ b/release/nightly_tests/stress_tests/test_many_tasks.py
@@ -178,13 +178,11 @@ if __name__ == "__main__":
     is_smoke_test = args.smoke_test
 
     result = {"success": 0}
-    # Wait until the expected number of nodes have joined the cluster.
-    while True:
-        num_nodes = len(ray.nodes())
-        logger.info("Waiting for nodes {}/{}".format(num_nodes, num_remote_nodes + 1))
-        if num_nodes >= num_remote_nodes + 1:
-            break
-        time.sleep(5)
+    num_nodes = len(ray.nodes())
+    assert (
+        num_nodes == num_remote_nodes + 1
+    ), f"{num_nodes}/{num_remote_nodes+1} are available"
+
     logger.info(
         "Nodes have all joined. There are %s resources.", ray.cluster_resources()
     )

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3620,6 +3620,8 @@
 
     run:
       timeout: 3600
+      wait_for_nodes:
+        num_nodes: 5
       script: python stress_tests/test_many_tasks.py --num-nodes=4 --smoke-test
 
 - name: stress_test_dead_actors

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3605,6 +3605,9 @@
 
   run:
     timeout: 7200
+    wait_for_nodes:
+      num_nodes: 101
+
     script: python stress_tests/test_many_tasks.py
     type: sdk_command
     file_manager: sdk


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently the waiting for nodes logic is embedded in the test, which results in false positive test failures if not enough nodes could be started. However, this should be reported as an infra error. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
- Testing Strategy
   - [x] Release tests: triggering a release test run. 
