### PR TITLE
[ci/release] Enforce DeleteOnTermination is True for all Ebs volumes

### DIFF
--- a/release/air_tests/air_benchmarks/compute_gpu_1.yaml
+++ b/release/air_tests/air_benchmarks/compute_gpu_1.yaml
@@ -19,7 +19,6 @@ aws:
         - DeviceName: /dev/sda1
           Ebs:
             DeleteOnTermination: true
-            VolumeSize: 800
             Iops: 5000
             Throughput: 1000
             VolumeSize: 1000

--- a/release/air_tests/horovod/compute_tpl.yaml
+++ b/release/air_tests/horovod/compute_tpl.yaml
@@ -27,3 +27,4 @@ aws:
     - DeviceName: /dev/sda1
       Ebs:
         VolumeSize: 500
+        DeleteOnTermination: true

--- a/release/long_running_distributed_tests/compute_tpl.yaml
+++ b/release/long_running_distributed_tests/compute_tpl.yaml
@@ -27,3 +27,4 @@ aws:
     - DeviceName: /dev/sda1
       Ebs:
         VolumeSize: 400
+        DeleteOnTermination: true

--- a/release/long_running_tests/tpl_cpu_1.yaml
+++ b/release/long_running_tests/tpl_cpu_1.yaml
@@ -27,3 +27,4 @@ aws:
     - DeviceName: /dev/sda1
       Ebs:
         VolumeSize: 300
+        DeleteOnTermination: true

--- a/release/long_running_tests/tpl_cpu_1_large.yaml
+++ b/release/long_running_tests/tpl_cpu_1_large.yaml
@@ -27,3 +27,4 @@ aws:
     - DeviceName: /dev/sda1
       Ebs:
         VolumeSize: 202
+        DeleteOnTermination: true

--- a/release/ray_release/template.py
+++ b/release/ray_release/template.py
@@ -2,13 +2,12 @@ import copy
 import datetime
 import os
 import re
-from typing import Optional, Dict
+from typing import Optional, Dict, TYPE_CHECKING
 
 import jinja2
 import yaml
 
 from ray_release.config import (
-    Test,
     RELEASE_PACKAGE_DIR,
     parse_python_version,
     DEFAULT_PYTHON_VERSION,
@@ -16,6 +15,9 @@ from ray_release.config import (
 )
 from ray_release.exception import ReleaseTestConfigError
 from ray_release.util import python_version_str
+
+if TYPE_CHECKING:
+    from ray_release.config import Test
 
 
 DEFAULT_ENV = {
@@ -105,7 +107,7 @@ def render_yaml_template(template: str, env: Optional[Dict] = None):
         ) from e
 
 
-def load_test_cluster_env(test: Test, ray_wheels_url: str) -> Optional[Dict]:
+def load_test_cluster_env(test: "Test", ray_wheels_url: str) -> Optional[Dict]:
     cluster_env_file = test["cluster"]["cluster_env"]
     cluster_env_path = os.path.join(
         RELEASE_PACKAGE_DIR, test.get("working_dir", ""), cluster_env_file
@@ -116,7 +118,7 @@ def load_test_cluster_env(test: Test, ray_wheels_url: str) -> Optional[Dict]:
     return load_and_render_yaml_template(cluster_env_path, env=env)
 
 
-def populate_cluster_env_variables(test: Test, ray_wheels_url: str) -> Dict:
+def populate_cluster_env_variables(test: "Test", ray_wheels_url: str) -> Dict:
     env = get_test_environment()
 
     commit = env.get("RAY_COMMIT", None)
@@ -144,7 +146,7 @@ def populate_cluster_env_variables(test: Test, ray_wheels_url: str) -> Dict:
     return env
 
 
-def load_test_cluster_compute(test: Test) -> Optional[Dict]:
+def load_test_cluster_compute(test: "Test") -> Optional[Dict]:
     cluster_compute_file = test["cluster"]["cluster_compute"]
     cluster_compute_path = os.path.join(
         RELEASE_PACKAGE_DIR, test.get("working_dir", ""), cluster_compute_file
@@ -154,7 +156,7 @@ def load_test_cluster_compute(test: Test) -> Optional[Dict]:
     return load_and_render_yaml_template(cluster_compute_path, env=env)
 
 
-def populate_cluster_compute_variables(test: Test) -> Dict:
+def populate_cluster_compute_variables(test: "Test") -> Dict:
     env = get_test_environment()
 
     cloud_id = get_test_cloud_id(test)

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -117,6 +117,58 @@ def test_compute_config_invalid_ebs():
 
     assert not validate_cluster_compute(compute_config)
 
+    compute_config["head_node_type"] = {}
+    compute_config["head_node_type"]["aws_advanced_configurations"] = {
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "VolumeSize": 1000,
+                },
+            }
+        ]
+    }
+
+    assert validate_cluster_compute(compute_config)
+
+    compute_config["head_node_type"]["aws_advanced_configurations"][
+        "BlockDeviceMappings"
+    ][0]["Ebs"]["DeleteOnTermination"] = False
+
+    assert validate_cluster_compute(compute_config)
+
+    compute_config["head_node_type"]["aws_advanced_configurations"][
+        "BlockDeviceMappings"
+    ][0]["Ebs"]["DeleteOnTermination"] = True
+
+    assert not validate_cluster_compute(compute_config)
+
+    compute_config["worker_node_types"] = [{}]
+    compute_config["worker_node_types"][0]["aws_advanced_configurations"] = {
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "VolumeSize": 1000,
+                },
+            }
+        ]
+    }
+
+    assert validate_cluster_compute(compute_config)
+
+    compute_config["worker_node_types"][0]["aws_advanced_configurations"][
+        "BlockDeviceMappings"
+    ][0]["Ebs"]["DeleteOnTermination"] = False
+
+    assert validate_cluster_compute(compute_config)
+
+    compute_config["worker_node_types"][0]["aws_advanced_configurations"][
+        "BlockDeviceMappings"
+    ][0]["Ebs"]["DeleteOnTermination"] = True
+
+    assert not validate_cluster_compute(compute_config)
+
 
 def test_load_and_validate_test_collection_file():
     read_and_validate_release_test_collection(TEST_COLLECTION_FILE)

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -1,99 +1,125 @@
 import os
 import sys
-import unittest
+import pytest
 
 from ray_release.config import (
     read_and_validate_release_test_collection,
     Test,
     validate_release_test_collection,
+    validate_cluster_compute,
 )
 from ray_release.exception import ReleaseTestConfigError
 
+TEST_COLLECTION_FILE = os.path.join(
+    os.path.dirname(__file__), "..", "..", "release_tests.yaml"
+)
 
-class ConfigTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.test_collection_file = os.path.join(
-            os.path.dirname(__file__), "..", "..", "release_tests.yaml"
-        )
 
-        self.valid_test = Test(
-            **{
-                "name": "validation_test",
-                "group": "validation_group",
-                "working_dir": "validation_dir",
-                "legacy": {
-                    "test_name": "validation_test",
-                    "test_suite": "validation_suite",
-                },
-                "python": "3.7",
-                "frequency": "nightly",
-                "team": "release",
-                "cluster": {
-                    "cluster_env": "app_config.yaml",
-                    "cluster_compute": "tpl_cpu_small.yaml",
-                    "autosuspend_mins": 10,
-                },
-                "run": {
-                    "timeout": 100,
-                    "script": "python validate.py",
-                    "wait_for_nodes": {"num_nodes": 2, "timeout": 100},
-                    "type": "client",
-                },
-                "smoke_test": {"run": {"timeout": 20}, "frequency": "multi"},
-                "alert": "default",
-            }
-        )
+VALID_TEST = Test(
+    **{
+        "name": "validation_test",
+        "group": "validation_group",
+        "working_dir": "validation_dir",
+        "legacy": {
+            "test_name": "validation_test",
+            "test_suite": "validation_suite",
+        },
+        "python": "3.7",
+        "frequency": "nightly",
+        "team": "release",
+        "cluster": {
+            "cluster_env": "app_config.yaml",
+            "cluster_compute": "tpl_cpu_small.yaml",
+            "autosuspend_mins": 10,
+        },
+        "run": {
+            "timeout": 100,
+            "script": "python validate.py",
+            "wait_for_nodes": {"num_nodes": 2, "timeout": 100},
+            "type": "client",
+        },
+        "smoke_test": {"run": {"timeout": 20}, "frequency": "multi"},
+        "alert": "default",
+    }
+)
 
-    def testSchemaValidation(self):
-        test = self.valid_test.copy()
 
-        validate_release_test_collection([test])
+def test_schema_validation():
+    test = VALID_TEST.copy()
 
-        # Remove some optional arguments
-        del test["alert"]
-        del test["python"]
-        del test["run"]["wait_for_nodes"]
-        del test["cluster"]["autosuspend_mins"]
+    validate_release_test_collection([test])
 
-        validate_release_test_collection([test])
+    # Remove some optional arguments
+    del test["alert"]
+    del test["python"]
+    del test["run"]["wait_for_nodes"]
+    del test["cluster"]["autosuspend_mins"]
 
-        # Add some faulty arguments
+    validate_release_test_collection([test])
 
-        # Faulty frequency
-        invalid_test = test.copy()
-        invalid_test["frequency"] = "invalid"
-        with self.assertRaises(ReleaseTestConfigError):
-            validate_release_test_collection([invalid_test])
+    # Add some faulty arguments
 
-        # Faulty job type
-        invalid_test = test.copy()
-        invalid_test["run"]["type"] = "invalid"
-        with self.assertRaises(ReleaseTestConfigError):
-            validate_release_test_collection([invalid_test])
+    # Faulty frequency
+    invalid_test = test.copy()
+    invalid_test["frequency"] = "invalid"
 
-        # Faulty file manager type
-        invalid_test = test.copy()
-        invalid_test["run"]["file_manager"] = "invalid"
-        with self.assertRaises(ReleaseTestConfigError):
-            validate_release_test_collection([invalid_test])
+    with pytest.raises(ReleaseTestConfigError):
+        validate_release_test_collection([invalid_test])
 
-        # Faulty smoke test
-        invalid_test = test.copy()
-        del invalid_test["smoke_test"]["frequency"]
-        with self.assertRaises(ReleaseTestConfigError):
-            validate_release_test_collection([invalid_test])
+    # Faulty job type
+    invalid_test = test.copy()
+    invalid_test["run"]["type"] = "invalid"
+    with pytest.raises(ReleaseTestConfigError):
+        validate_release_test_collection([invalid_test])
 
-        # Faulty Python version
-        invalid_test = test.copy()
-        invalid_test["python"] = "invalid"
-        with self.assertRaises(ReleaseTestConfigError):
-            validate_release_test_collection([invalid_test])
+    # Faulty file manager type
+    invalid_test = test.copy()
+    invalid_test["run"]["file_manager"] = "invalid"
+    with pytest.raises(ReleaseTestConfigError):
+        validate_release_test_collection([invalid_test])
 
-    def testLoadAndValidateTestCollectionFile(self):
-        read_and_validate_release_test_collection(self.test_collection_file)
+    # Faulty smoke test
+    invalid_test = test.copy()
+    del invalid_test["smoke_test"]["frequency"]
+    with pytest.raises(ReleaseTestConfigError):
+        validate_release_test_collection([invalid_test])
+
+    # Faulty Python version
+    invalid_test = test.copy()
+    invalid_test["python"] = "invalid"
+    with pytest.raises(ReleaseTestConfigError):
+        validate_release_test_collection([invalid_test])
+
+
+def test_compute_config_invalid_ebs():
+    compute_config = {
+        "aws": {
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "VolumeSize": 1000,
+                    },
+                }
+            ]
+        }
+    }
+    assert validate_cluster_compute(compute_config)
+
+    compute_config["aws"]["BlockDeviceMappings"][0]["Ebs"][
+        "DeleteOnTermination"
+    ] = False
+
+    assert validate_cluster_compute(compute_config)
+
+    compute_config["aws"]["BlockDeviceMappings"][0]["Ebs"]["DeleteOnTermination"] = True
+
+    assert not validate_cluster_compute(compute_config)
+
+
+def test_load_and_validate_test_collection_file():
+    read_and_validate_release_test_collection(TEST_COLLECTION_FILE)
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As a follow-up from #28707, this new check enforces that `DeleteOnTermination` is set to `true` for all Ebs volumes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
