### PR TITLE
[Core] Batch ScheduleAndDispatchTasks calls

### DIFF
--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -275,15 +275,15 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// Handler for the addition or updation of a resource in the GCS
   /// \param node_id ID of the node that created or updated resources.
   /// \param createUpdatedResources Created or updated resources.
-  /// \return Void.
-  void ResourceCreateUpdated(const NodeID &node_id,
+  /// \return Whether the update is applied.
+  bool ResourceCreateUpdated(const NodeID &node_id,
                              const ResourceRequest &createUpdatedResources);
 
   /// Handler for the deletion of a resource in the GCS
   /// \param node_id ID of the node that deleted resources.
   /// \param resource_names Names of deleted resources.
-  /// \return Void.
-  void ResourceDeleted(const NodeID &node_id,
+  /// \return Whether the deletion is applied.
+  bool ResourceDeleted(const NodeID &node_id,
                        const std::vector<std::string> &resource_names);
 
   /// Evaluates the local infeasible queue to check if any tasks can be scheduled.
@@ -309,13 +309,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   ///
   /// \param id The ID of the node manager that sent the resources data.
   /// \param data The resources data including load information.
-  /// \return Void.
-  void UpdateResourceUsage(const NodeID &id, const rpc::ResourcesData &data);
-
-  /// Handler for a resource usage batch notification from the GCS
-  ///
-  /// \param resource_usage_batch The batch of resource usage data.
-  void ResourceUsageBatchReceived(const ResourceUsageBatchData &resource_usage_batch);
+  /// \return Whether the node resource usage is updated.
+  bool UpdateResourceUsage(const NodeID &id, const rpc::ResourcesData &data);
 
   /// Handle a worker finishing its assigned task.
   ///


### PR DESCRIPTION
Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently GCS broadcasts the entire cluster resource view periodically. When raylet receives the message, it will update the local resource view of each remote node. Currently for each update, node manager will call `ScheduleAndDispatchTasks`.  Ideally we should wait until all the remote nodes are updated and then call `ScheduleAndDispatchTasks` once. This has two main advantages: 1) it's faster since we only need to call it once instead of N times 2) better scheduling decision since we wait until all resource views are updated.

A relevant PR is https://github.com/ray-project/ray/pull/28290
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
