### PR TITLE
[docs][kubernetes] Update the document for metadata.name and metadata.generateName for Pods

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/config.md
+++ b/doc/source/cluster/kubernetes/user-guides/config.md
@@ -201,6 +201,11 @@ See {ref}`this guide <docker-images>` to learn more about the official Ray image
 For dynamic dependency management geared towards iteration and developement,
 you can also use {ref}`Runtime Environments <runtime-environments>`.
 
+#### metadata.name and metadata.generateName
+The KubeRay operator will ignore the values of `metadata.name` and `metadata.generateName` set by users.
+The KubeRay operator will generate a `generateName` automatically to avoid name conflicts.
+See [KubeRay issue #587](https://github.com/ray-project/kuberay/pull/587) for more details.
+
 (rayStartParams)=
 ## Ray Start Parameters
 The ``rayStartParams`` field of each group spec is a string-string map of arguments to the Ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This https://github.com/ray-project/kuberay/pull/587 sets ObjectMeta.Name to an empty string, and use GenerateName to prevent name conflicts. Hence, this [document](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#pod-templates) needs to be updated.

## Related issue number
Closes #28723
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
