### PR TITLE
Revert "[RLlib] Deprecate legacy callbacks."

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2729,6 +2729,15 @@ py_test(
 )
 
 py_test(
+    name = "examples/custom_metrics_and_callbacks_legacy",
+    main = "examples/custom_metrics_and_callbacks_legacy.py",
+    tags = ["team:rllib", "exclusive", "examples", "examples_C", "examples_C_UtoZ"],
+    size = "small",
+    srcs = ["examples/custom_metrics_and_callbacks_legacy.py"],
+    args = ["--stop-iters=2"]
+)
+
+py_test(
     name = "examples/custom_model_api_tf",
     main = "examples/custom_model_api.py",
     tags = ["team:rllib", "exclusive", "examples", "examples_C", "examples_C_UtoZ"],

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -1768,7 +1768,7 @@ class Algorithm(Trainable):
         # Log after the callback is invoked, so that the user has a chance
         # to mutate the result.
         # TODO: Remove `trainer` arg at some point to fully deprecate the old signature.
-        self.callbacks.on_train_result(algorithm=self, result=result)
+        self.callbacks.on_train_result(algorithm=self, result=result, trainer=self)
         # Then log according to Trainable's logging logic.
         Trainable.log_result(self, result)
 
@@ -1994,13 +1994,13 @@ class Algorithm(Trainable):
         """
         config1 = copy.deepcopy(config1)
         if "callbacks" in config2 and type(config2["callbacks"]) is dict:
-            deprecation_warning(
-                "callbacks dict interface",
-                "a class extending rllib.algorithms.callbacks.DefaultCallbacks; "
-                "see `rllib/examples/custom_metrics_and_callbacks.py` for an example.",
-                error=True,
-            )
+            legacy_callbacks_dict = config2["callbacks"]
 
+            def make_callbacks():
+                # Deprecation warning will be logged by DefaultCallbacks.
+                return DefaultCallbacks(legacy_callbacks_dict=legacy_callbacks_dict)
+
+            config2["callbacks"] = make_callbacks
         if _allow_unknown_configs is None:
             _allow_unknown_configs = cls._allow_unknown_configs
         return deep_update(

--- a/rllib/evaluation/tests/test_rollout_worker.py
+++ b/rllib/evaluation/tests/test_rollout_worker.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import gym
 from gym.spaces import Box, Discrete
 import json
@@ -197,6 +198,32 @@ class TestRolloutWorker(unittest.TestCase):
                     },
                 ),
             )
+
+    def test_callbacks(self):
+        for fw in framework_iterator(frameworks=("torch", "tf")):
+            counts = Counter()
+            pg = PG(
+                env="CartPole-v0",
+                config={
+                    "num_workers": 0,
+                    "rollout_fragment_length": 50,
+                    "train_batch_size": 50,
+                    "callbacks": {
+                        "on_episode_start": lambda x: counts.update({"start": 1}),
+                        "on_episode_step": lambda x: counts.update({"step": 1}),
+                        "on_episode_end": lambda x: counts.update({"end": 1}),
+                        "on_sample_end": lambda x: counts.update({"sample": 1}),
+                    },
+                    "framework": fw,
+                },
+            )
+            pg.train()
+            pg.train()
+            self.assertGreater(counts["sample"], 0)
+            self.assertGreater(counts["start"], 0)
+            self.assertGreater(counts["end"], 0)
+            self.assertGreater(counts["step"], 0)
+            pg.stop()
 
     def test_query_evaluators(self):
         register_env("test", lambda _: gym.make("CartPole-v0"))

--- a/rllib/examples/custom_keras_model.py
+++ b/rllib/examples/custom_keras_model.py
@@ -5,7 +5,6 @@ import os
 
 import ray
 from ray import air, tune
-from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.algorithms.dqn.distributional_q_tf_model import DistributionalQTFModel
 from ray.rllib.models import ModelCatalog
 from ray.rllib.models.tf.misc import normc_initializer
@@ -110,12 +109,11 @@ if __name__ == "__main__":
     )
 
     # Tests https://github.com/ray-project/ray/issues/7293
-    class MyCallbacks(DefaultCallbacks):
-        def on_train_result(self, algorithm, result, **kwargs):
-            r = result["result"]["info"][LEARNER_INFO]
-            if DEFAULT_POLICY_ID in r:
-                r = r[DEFAULT_POLICY_ID].get(LEARNER_STATS_KEY, r[DEFAULT_POLICY_ID])
-            assert r["model"]["foo"] == 42, result
+    def check_has_custom_metric(result):
+        r = result["result"]["info"][LEARNER_INFO]
+        if DEFAULT_POLICY_ID in r:
+            r = r[DEFAULT_POLICY_ID].get(LEARNER_STATS_KEY, r[DEFAULT_POLICY_ID])
+        assert r["model"]["foo"] == 42, result
 
     if args.run == "DQN":
         extra_config = {"num_steps_sampled_before_learning_starts": 0}
@@ -135,7 +133,9 @@ if __name__ == "__main__":
                 else "CartPole-v0",
                 # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
                 "num_gpus": int(os.environ.get("RLLIB_NUM_GPUS", "0")),
-                "callbacks": MyCallbacks,
+                "callbacks": {
+                    "on_train_result": check_has_custom_metric,
+                },
                 "model": {
                     "custom_model": "keras_q_model"
                     if args.run == "DQN"

--- a/rllib/examples/custom_metrics_and_callbacks_legacy.py
+++ b/rllib/examples/custom_metrics_and_callbacks_legacy.py
@@ -1,0 +1,98 @@
+"""Deprecated API; see custom_metrics_and_callbacks.py instead."""
+
+import argparse
+import numpy as np
+import os
+
+import ray
+from ray import air, tune
+
+
+def on_episode_start(info):
+    episode = info["episode"]
+    print("episode {} started".format(episode.episode_id))
+    episode.user_data["pole_angles"] = []
+    episode.hist_data["pole_angles"] = []
+
+
+def on_episode_step(info):
+    episode = info["episode"]
+    pole_angle = abs(episode.last_observation_for()[2])
+    raw_angle = abs(episode.last_raw_obs_for()[2])
+    assert pole_angle == raw_angle
+    episode.user_data["pole_angles"].append(pole_angle)
+
+
+def on_episode_end(info):
+    episode = info["episode"]
+    pole_angle = np.mean(episode.user_data["pole_angles"])
+    print(
+        "episode {} ended with length {} and pole angles {}".format(
+            episode.episode_id, episode.length, pole_angle
+        )
+    )
+    episode.custom_metrics["pole_angle"] = pole_angle
+    episode.hist_data["pole_angles"] = episode.user_data["pole_angles"]
+
+
+def on_sample_end(info):
+    print("returned sample batch of size {}".format(info["samples"].count))
+
+
+def on_train_result(info):
+    print(
+        "trainer.train() result: {} -> {} episodes".format(
+            info["trainer"], info["result"]["episodes_this_iter"]
+        )
+    )
+    # you can mutate the result dict to add new fields to return
+    info["result"]["callback_ok"] = True
+
+
+def on_postprocess_traj(info):
+    episode = info["episode"]
+    batch = info["post_batch"]
+    print("postprocessed {} steps".format(batch.count))
+    if "num_batches" not in episode.custom_metrics:
+        episode.custom_metrics["num_batches"] = 0
+    episode.custom_metrics["num_batches"] += 1
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stop-iters", type=int, default=2000)
+    args = parser.parse_args()
+
+    ray.init()
+    tuner = tune.Tuner(
+        "PG",
+        run_config=air.RunConfig(
+            stop={
+                "training_iteration": args.stop_iters,
+            },
+        ),
+        param_space={
+            "env": "CartPole-v0",
+            "callbacks": {
+                "on_episode_start": on_episode_start,
+                "on_episode_step": on_episode_step,
+                "on_episode_end": on_episode_end,
+                "on_sample_end": on_sample_end,
+                "on_train_result": on_train_result,
+                "on_postprocess_traj": on_postprocess_traj,
+            },
+            "framework": "tf",
+            # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
+            "num_gpus": int(os.environ.get("RLLIB_NUM_GPUS", "0")),
+        },
+    )
+    results = tuner.fit()
+
+    # verify custom metrics for integration tests
+    custom_metrics = results.get_best_result().metrics["custom_metrics"]
+    print(custom_metrics)
+    assert "pole_angle_mean" in custom_metrics
+    assert "pole_angle_min" in custom_metrics
+    assert "pole_angle_max" in custom_metrics
+    assert "num_batches_mean" in custom_metrics
+    assert "callback_ok" in results.get_best_result().metrics


### PR DESCRIPTION
Reverts ray-project/ray#28697

Signed-off-by: Amog Kamsetty amogkamsetty@yahoo.com

Breaks `tune:test_trial_runner_3`

```
ray.tune.error._TuneNoNextExecutorEventError: Traceback (most recent call last):
--
  | File "/ray/python/ray/tune/execution/ray_trial_executor.py", line 1035, in get_next_executor_event
  | future_result = ray.get(ready_future)
  | File "/ray/python/ray/_private/client_mode_hook.py", line 105, in wrapper
  | return func(*args, **kwargs)
  | File "/ray/python/ray/_private/worker.py", line 2281, in get
  | raise value
  | File "python/ray/_raylet.pyx", line 919, in ray._raylet.task_execution_handler
  | File "python/ray/_raylet.pyx", line 686, in ray._raylet.execute_task
  | File "python/ray/_raylet.pyx", line 877, in ray._raylet.execute_task
  | ray.exceptions.RayActorError: The actor died because of an error raised in its creation task, ray::_MockTrainer.__init__() (pid=12312, ip=172.16.16.3, repr=_MockTrainer)
  | File "/ray/python/ray/rllib/algorithms/algorithm.py", line 313, in __init__
  | super().__init__(config=config, logger_creator=logger_creator, **kwargs)
  | File "/ray/python/ray/tune/trainable/trainable.py", line 160, in __init__
  | self.setup(copy.deepcopy(self.config))
  | File "/ray/python/ray/rllib/algorithms/mock.py", line 37, in setup
  | self.get_default_config(), config, self._allow_unknown_configs
  | File "/ray/python/ray/rllib/algorithms/algorithm.py", line 2001, in merge_trainer_configs
  | error=True,
  | File "/ray/python/ray/rllib/utils/deprecation.py", line 43, in deprecation_warning
  | raise DeprecationWarning(msg)
  | DeprecationWarning: `callbacks dict interface` has been deprecated. Use `a class extending rllib.algorithms.callbacks.DefaultCallbacks; see `rllib/examples/custom_metrics_and_callbacks.py` for an example.` instead.
```

https://buildkite.com/ray-project/oss-ci-build-branch/builds/180#01836a85-62dd-4698-ae45-a911d3c246c8