### PR TITLE
[tune] Right-aline + wrapped abbreviated columns in table output

### DIFF
--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -6,6 +6,7 @@ import numbers
 
 import os
 import sys
+import textwrap
 import time
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -902,7 +903,9 @@ def _trial_progress_str(
     return delim.join(messages)
 
 
-def _max_len(value: Any, max_len: int = 20, add_addr: bool = False) -> Any:
+def _max_len(
+    value: Any, max_len: int = 20, add_addr: bool = False, wrap: bool = False
+) -> Any:
     """Abbreviate a string representation of an object to `max_len` characters.
 
     For numbers, booleans and None, the original value will be returned for
@@ -921,6 +924,15 @@ def _max_len(value: Any, max_len: int = 20, add_addr: bool = False) -> Any:
     string = str(value)
     if len(string) <= max_len:
         return string
+
+    if wrap:
+        # Maximum two rows.
+        # Todo: Make this configurable in the refactor
+        if len(value) > max_len * 2:
+            value = "..." + string[(3 - (max_len * 2)) :]
+
+        wrapped = textwrap.wrap(value, width=max_len)
+        return "\n".join(wrapped)
 
     if add_addr and not isinstance(value, (int, float, bool)):
         result = f"{string[: (max_len - 5)]}_{hex(id(value))[-4:]}"
@@ -1039,19 +1051,29 @@ def _get_progress_table_data(
     # Format column headings
     if isinstance(metric_columns, Mapping):
         formatted_metric_columns = [
-            _max_len(metric_columns[k], max_len=max_column_length, add_addr=False)
+            _max_len(
+                metric_columns[k], max_len=max_column_length, add_addr=False, wrap=True
+            )
             for k in metric_keys
         ]
     else:
-        formatted_metric_columns = metric_keys
+        formatted_metric_columns = [
+            _max_len(k, max_len=max_column_length, add_addr=False, wrap=True)
+            for k in metric_keys
+        ]
     if isinstance(parameter_columns, Mapping):
         formatted_parameter_columns = [
-            _max_len(parameter_columns[k], max_len=max_column_length, add_addr=False)
+            _max_len(
+                parameter_columns[k],
+                max_len=max_column_length,
+                add_addr=False,
+                wrap=True,
+            )
             for k in parameter_keys
         ]
     else:
         formatted_parameter_columns = [
-            _max_len(k, max_len=max_column_length, add_addr=False)
+            _max_len(k, max_len=max_column_length, add_addr=False, wrap=True)
             for k in parameter_keys
         ]
     columns = (

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -926,7 +926,7 @@ def _max_len(value: Any, max_len: int = 20, add_addr: bool = False) -> Any:
         result = f"{string[: (max_len - 5)]}_{hex(id(value))[-4:]}"
         return result
 
-    result = f"{string[: (max_len - 3)]}..."
+    result = "..." + string[(3 - max_len) :]
     return result
 
 

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -747,6 +747,13 @@ def test_max_len():
     )
     assert _max_len("some_long_string/even_longer", max_len=15) == ".../even_longer"
 
+    assert (
+        _max_len(
+            "19_character_string/19_character_string/too_long", max_len=20, wrap=True
+        )
+        == "...r_string/19_chara\ncter_string/too_long"
+    )
+
 
 if __name__ == "__main__":
     import sys

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -17,6 +17,7 @@ from ray.tune.progress_reporter import (
     _time_passed_str,
     _trial_progress_str,
     TuneReporterBase,
+    _max_len,
 )
 from ray.tune.result import AUTO_RESULT_KEYS
 from ray.tune.trial import Trial
@@ -737,6 +738,14 @@ class ProgressReporterTest(unittest.TestCase):
             trials, metric_columns=["some_metric"], force_table=True
         )
         assert any(len(row) <= 90 for row in progress_str.split("\n"))
+
+
+def test_max_len():
+    assert (
+        _max_len("some_long_string/even_longer", max_len=28)
+        == "some_long_string/even_longer"
+    )
+    assert _max_len("some_long_string/even_longer", max_len=15) == ".../even_longer"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Parameter columns are currently left-aligned. In long parameter names, this means the table columns share the same abbreviated column name, which makes it unusable. Users can pass a custom CLIReporter, but to alleviate the problem in the default case, this PR updates the render function to right-align abbreviated column names.

Before:

```
+---------------------------------+----------+-----------------+------------------------+------------------------+
| Trial name                      | status   | loc             |   train_loop_per_wo... |   train_loop_per_wo... |
|---------------------------------+----------+-----------------+------------------------+------------------------|
| DataParallelTrainer_e670e_00000 | ERROR    | 127.0.0.1:50895 |                0.14336 |              0.0372097 |
+---------------------------------+----------+-----------------+------------------------+------------------------+
```

After:

```
+---------------------------------+----------+-----------------+------------------------+------------------------+
| Trial name                      | status   | loc             |   ...p_per_worker/beta |   ...oop_per_worker/lr |
|---------------------------------+----------+-----------------+------------------------+------------------------|
| DataParallelTrainer_65099_00000 | ERROR    | 127.0.0.1:49806 |               0.110931 |              0.0350912 |
+---------------------------------+----------+-----------------+------------------------+------------------------+
```

## Related issue number

Closes #27011

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
