### PR TITLE
[Tune] Raise better error for incompatible `gcsfs` version

### DIFF
--- a/python/ray/air/_internal/remote_storage.py
+++ b/python/ray/air/_internal/remote_storage.py
@@ -1,5 +1,6 @@
 import fnmatch
 import os
+from packaging import version
 import urllib.parse
 from typing import List, Optional, Tuple
 
@@ -112,6 +113,23 @@ def get_fs_and_path(
 
     fsspec_handler = pyarrow.fs.FSSpecHandler
     if parsed.scheme in ["gs", "gcs"]:
+
+        # TODO(amogkam): Remove after https://github.com/fsspec/gcsfs/issues/498 is
+        #  resolved.
+        try:
+            import gcsfs
+
+            if version.parse(gcsfs.__version__) > "2022.7.1":
+                raise RuntimeError(
+                    "`gcsfs` versions greater than '2022.7.1' are not "
+                    f"compatible with Pyarrow. You have version "
+                    f"{gcsfs.__version__}. Please downgrade your gcsfs "
+                    f"version. See more details in "
+                    f"https://github.com/fsspec/gcsfs/issues/498."
+                )
+        except ImportError:
+            pass
+
         # GS doesn't support `create_parents` arg in `create_dir()`
         fsspec_handler = _CustomGCSHandler
 

--- a/python/ray/air/_internal/remote_storage.py
+++ b/python/ray/air/_internal/remote_storage.py
@@ -122,7 +122,7 @@ def get_fs_and_path(
             if version.parse(gcsfs.__version__) > "2022.7.1":
                 raise RuntimeError(
                     "`gcsfs` versions greater than '2022.7.1' are not "
-                    f"compatible with Pyarrow. You have version "
+                    f"compatible with pyarrow. You have gcsfs version "
                     f"{gcsfs.__version__}. Please downgrade your gcsfs "
                     f"version. See more details in "
                     f"https://github.com/fsspec/gcsfs/issues/498."

--- a/python/ray/air/_internal/remote_storage.py
+++ b/python/ray/air/_internal/remote_storage.py
@@ -119,7 +119,7 @@ def get_fs_and_path(
         try:
             import gcsfs
 
-            if version.parse(gcsfs.__version__) > "2022.7.1":
+            if version.parse(gcsfs.__version__) > version.parse("2022.7.1"):
                 raise RuntimeError(
                     "`gcsfs` versions greater than '2022.7.1' are not "
                     f"compatible with pyarrow. You have gcsfs version "


### PR DESCRIPTION
Signed-off-by: Amog Kamsetty <amogkamsetty@yahoo.com>

The latest `gcsfs` version is incompatible with `pyarrow`, leading to issues like  https://github.com/ray-project/ray/issues/28769 and https://github.com/ray-project/ray/issues/28691.

We should raise an error to the user about this incompatibility rather than letting this fall to a `No checkpoint was found`.

See https://github.com/fsspec/gcsfs/issues/498 for more details.

Closes https://github.com/ray-project/ray/issues/28691

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
