### PR TITLE
[Tune] Allow `Tune.restore` to be called from an experiment directory that has moved

### DIFF
--- a/python/ray/tune/execution/trial_runner.py
+++ b/python/ray/tune/execution/trial_runner.py
@@ -84,8 +84,8 @@ def _load_trial_from_checkpoint(
     local_dir_changed = local_dir and checkpoint_local_dir != local_dir
     remote_dir_changed = remote_dir and checkpoint_remote_dir != remote_dir
 
-    # NOTE: Skip initializing the logdir if local_dir has changed, since it will create
-    # a directory at the old path
+    # NOTE: If the local_dir has changed, wait to initialize the trial logdir
+    # so that a logdir doesn't get created in the old location
     new_trial.__setstate__(trial_cp, skip_init_logdir=local_dir_changed)
 
     if local_dir_changed:
@@ -106,11 +106,10 @@ def _load_trial_from_checkpoint(
 
         # Update trial local_dir
         new_trial.local_dir = local_dir
-        # Finish setting up the logdir with the new paths (since we skipped earlier)
+        # Finish setting up the logdir with the updated local_dir
         new_trial.init_logdir()
 
     if remote_dir_changed:
-        print("\n[DEBUGGING] Setting remote_checkpoint_dir_prefix = ", remote_dir)
         new_trial.remote_checkpoint_dir_prefix = remote_dir
 
     return new_trial

--- a/python/ray/tune/experiment/experiment.py
+++ b/python/ray/tune/experiment/experiment.py
@@ -126,7 +126,6 @@ class Experiment:
         max_failures=0,
         restore=None,
     ):
-
         local_dir = _get_local_dir_with_expand_user(local_dir)
         # `_experiment_checkpoint_dir` is for internal use only for better
         # support of Tuner API.
@@ -408,6 +407,10 @@ class Experiment:
             return self._experiment_checkpoint_dir
         assert self.local_dir
         return os.path.join(self.local_dir, self.dir_name)
+
+    @property
+    def relative_checkpoint_dir(self):
+        return self.dir_name
 
     @property
     def run_identifier(self):

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -860,7 +860,7 @@ class Trial:
 
         return copy.deepcopy(state)
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict, skip_init_logdir: bool = False):
 
         if state["status"] == Trial.RUNNING:
             state["status"] = Trial.PENDING
@@ -881,5 +881,5 @@ class Trial:
         # Avoid creating logdir in client mode for returned trial results,
         # since the dir might not be creatable locally.
         # TODO(ekl) this is kind of a hack.
-        if not ray.util.client.ray.is_connected():
+        if not skip_init_logdir and not ray.util.client.ray.is_connected():
             self.init_logdir()  # Create logdir if it does not exist

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -252,6 +252,7 @@ class Trial:
         placement_group_factory: Optional[PlacementGroupFactory] = None,
         stopping_criterion: Optional[Dict[str, float]] = None,
         remote_checkpoint_dir: Optional[str] = None,
+        # remote_dir: Optional[str] = None,
         custom_syncer: Optional[Syncer] = None,
         checkpoint_freq: int = 0,
         checkpoint_at_end: bool = False,
@@ -363,10 +364,7 @@ class Trial:
 
         # Checkpointing fields
         self.saving_to = None
-        if remote_checkpoint_dir:
-            self.remote_checkpoint_dir_prefix = remote_checkpoint_dir
-        else:
-            self.remote_checkpoint_dir_prefix = None
+        self.remote_checkpoint_dir_prefix = remote_checkpoint_dir
 
         if custom_syncer == "auto" or not isinstance(custom_syncer, Syncer):
             custom_syncer = None
@@ -553,7 +551,7 @@ class Trial:
             resources=None,
             placement_group_factory=placement_group_factory,
             stopping_criterion=self.stopping_criterion,
-            remote_checkpoint_dir=self.remote_checkpoint_dir,
+            remote_checkpoint_dir=self.remote_checkpoint_dir_prefix,
             checkpoint_freq=self.checkpoint_freq,
             checkpoint_at_end=self.checkpoint_at_end,
             sync_on_checkpoint=self.sync_on_checkpoint,

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -252,7 +252,6 @@ class Trial:
         placement_group_factory: Optional[PlacementGroupFactory] = None,
         stopping_criterion: Optional[Dict[str, float]] = None,
         remote_checkpoint_dir: Optional[str] = None,
-        # remote_dir: Optional[str] = None,
         custom_syncer: Optional[Syncer] = None,
         checkpoint_freq: int = 0,
         checkpoint_at_end: bool = False,

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -209,7 +209,8 @@ class TunerInternal:
             # If we didn't sync, use the restore_path local dir
             self._experiment_checkpoint_dir = os.path.expanduser(path_or_uri)
 
-            # Update local_dir
+            # Update local_dir to use the parent of the experiment path
+            # provided to `Tuner.restore`
             experiment_path = Path(self._experiment_checkpoint_dir)
             self._run_config.local_dir = str(experiment_path.parent)
         else:

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -207,6 +207,10 @@ class TunerInternal:
         if not synced:
             # If we didn't sync, use the restore_path local dir
             self._experiment_checkpoint_dir = os.path.expanduser(path_or_uri)
+
+            # Update local_dir
+            experiment_path = Path(self._experiment_checkpoint_dir)
+            self._run_config.local_dir = str(experiment_path.parents[0])
         else:
             # If we synced, `experiment_checkpoint_dir` will contain a temporary
             # directory. Create an experiment checkpoint dir instead and move

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -224,6 +224,7 @@ class TunerInternal:
                 file_dir.replace(new_exp_path / file_dir.name)
             shutil.rmtree(experiment_checkpoint_path)
             self._experiment_checkpoint_dir = str(new_exp_path)
+            self._run_config.local_dir = str(new_exp_path.parent)
 
             # TODO(justinvyu): Move this out to a util function
             # s3://parents/of/exp_dir -> s3://parents/of

--- a/python/ray/tune/tests/test_tuner_restore.py
+++ b/python/ray/tune/tests/test_tuner_restore.py
@@ -359,13 +359,15 @@ def test_tuner_restore_from_cloud(ray_start_2_cpus, tmpdir):
 
 @pytest.mark.parametrize(
     "use_tuner_restore,cloud_checkpointing",
-    [(True, True), (True, False), (False, True), (False, False)],
+    [(True, True), (True, False)],
 )
 def test_tuner_restore_from_moved_experiment_path(
-    ray_start_2_cpus, tmpdir, use_tuner_restore, cloud_checkpointing
+    ray_start_2_cpus, tmp_path, use_tuner_restore, cloud_checkpointing
 ):
     """Check that restoring Tuner() objects from a moved directory works"""
-    fail_marker = tmpdir / "fail_marker"
+    # Create a fail_marker dummy file that causes the first Tune run to fail and
+    # the second run to succeed
+    fail_marker = tmp_path / "fail_marker"
     fail_marker.write_text("", encoding="utf-8")
 
     # 1. Initial training run (that errors out in the middle)
@@ -391,8 +393,7 @@ def test_tuner_restore_from_moved_experiment_path(
             },
         )
 
-    tuner = init_tuner(str(tmpdir / "ray_results"), sync_config)
-
+    tuner = init_tuner(str(tmp_path / "ray_results"), sync_config)
     results = tuner.fit()
     assert len(results.errors) == 1
     training_iteration = results[0].metrics["it"]
@@ -400,54 +401,61 @@ def test_tuner_restore_from_moved_experiment_path(
         training_iteration == 1
     ), f"Should only have 1 session.report before erroring, got {training_iteration}"
 
-    # 2. Move the experiment parent directory
+    # 2. Move the experiment parent directory (on cloud/local)
     new_cloud_uri = None
     if cloud_checkpointing:
         # Move from memory:///original_dir/restore -> memory:///new_dir/restore
-        check_path = tmpdir / "check_save"
+        check_path = tmp_path / "check_save"
         assert cloud_uri
         download_from_uri(cloud_uri, str(check_path))
         delete_at_uri(cloud_uri)
         new_cloud_uri = "memory:///new_dir/restore"
         upload_to_uri(check_path, new_cloud_uri)
-    else:
-        # Move local dir from tmpdir/ray_results -> tmpdir/moved_ray_results
-        shutil.move(tmpdir / "ray_results", tmpdir / "moved_ray_results")
+    # Move local dir from tmp_path/ray_results -> tmp_path/moved_ray_results
+    shutil.move(str(tmp_path / "ray_results"), str(tmp_path / "moved_ray_results"))
 
     # Remove fail_marker so that the restored Tuner doesn't error again
     del tuner
-    fail_marker.remove(ignore_errors=True)
+    fail_marker.unlink()
 
     # 3. Restore from moved experiment directory location
     if use_tuner_restore:
         restore_path = (
             "memory:///new_dir/restore/exp_dir"
             if cloud_checkpointing
-            else str(tmpdir / "moved_ray_results" / "exp_dir")
+            else str(tmp_path / "moved_ray_results" / "exp_dir")
         )
         tuner = Tuner.restore(restore_path, resume_errored=True)
     else:
         if cloud_checkpointing:
             sync_config = tune.SyncConfig(upload_dir=new_cloud_uri)
-        tuner = init_tuner(str(tmpdir / "moved_ray_results"), sync_config)
+        tuner = init_tuner(str(tmp_path / "moved_ray_results"), sync_config)
 
     # 4. Should be able to fit using the restored Tuner
     results = tuner.fit()
-
     assert len(results.errors) == 0
+    # Check that we restored iter=1, then made 2 calls to session.report -> iter=3
     training_iteration = results[0].metrics["it"]
-    # Check that we loaded iter=1, then 2 calls to session.report -> iter=3
     assert training_iteration == 3, training_iteration
 
-    # Make sure that we did not create a logdir in the old location
+    # 5. Make sure that we did not create a logdir in the old location
     if cloud_checkpointing:
-        check_path = tmpdir / "cloud_root_dir"
-        download_from_uri("memory:///", str(check_path))
-        remote_contents = os.listdir(check_path)
-        assert "original_dir" not in remote_contents
+        cloud_root_path = tmp_path / "cloud_root_dir"
+        download_from_uri("memory:///", str(cloud_root_path))
+        remote_contents = os.listdir(cloud_root_path)
+        original_remote_contents = os.listdir(cloud_root_path / "original_dir")
+
+        assert not original_remote_contents, "Original dir should be empty"
         assert "new_dir" in remote_contents
+
+        # We should have synced down from the cloud, which results in:
+        # - tmp_path/ray_results being downloaded from cloud (newly created)
+        # - tmp_path/moved_ray_results exists as the moved copy of the first run, but
+        #   not used at all
+        assert (tmp_path / "ray_results").exists()
+        assert (tmp_path / "moved_ray_results").exists()
     else:
-        assert not (tmpdir / "ray_results").exists()
+        assert not (tmp_path / "ray_results").exists()
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tests/test_tuner_restore.py
+++ b/python/ray/tune/tests/test_tuner_restore.py
@@ -359,7 +359,8 @@ def test_tuner_restore_from_cloud(ray_start_2_cpus, tmpdir):
 
 
 @pytest.mark.parametrize(
-    "cloud_checkpointing", [True, False],
+    "cloud_checkpointing",
+    [True, False],
 )
 def test_tuner_restore_from_moved_experiment_path(
     ray_start_2_cpus, tmp_path, cloud_checkpointing
@@ -378,6 +379,7 @@ def test_tuner_restore_from_moved_experiment_path(
         sync_config = tune.SyncConfig(upload_dir=cloud_uri)
 
     exp_name = "exp_dir"
+
     def init_tuner(local_dir, sync_config):
         return Tuner(
             _train_fn_sometimes_failing,

--- a/python/ray/tune/trainable/util.py
+++ b/python/ray/tune/trainable/util.py
@@ -95,7 +95,7 @@ class TrainableUtil:
         """
         assert checkpoint_path.startswith(
             logdir
-        ), "expecting `logdir` to be a prefix of `checkpoint_path`"
+        ), f"expecting {logdir} to be a prefix of {checkpoint_path}"
         rel_path = os.path.relpath(checkpoint_path, logdir)
         tokens = rel_path.split(os.sep)
         return os.path.join(tokens[0])

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -631,9 +631,9 @@ def run(
     runner = TrialRunner(
         search_alg=search_alg,
         scheduler=scheduler,
-        root_dir=experiments[0].local_dir,
-        local_checkpoint_dir=experiments[0].relative_checkpoint_dir,
-        remote_checkpoint_dir=experiments[0].remote_checkpoint_dir,
+        local_dir=experiments[0].local_dir,
+        remote_dir=sync_config.upload_dir,
+        relative_checkpoint_dir=experiments[0].relative_checkpoint_dir,
         sync_config=sync_config,
         stopper=experiments[0].stopper,
         resume=resume,

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -631,7 +631,8 @@ def run(
     runner = TrialRunner(
         search_alg=search_alg,
         scheduler=scheduler,
-        local_checkpoint_dir=experiments[0].checkpoint_dir,
+        root_dir=experiments[0].local_dir,
+        local_checkpoint_dir=experiments[0].relative_checkpoint_dir,
         remote_checkpoint_dir=experiments[0].remote_checkpoint_dir,
         sync_config=sync_config,
         stopper=experiments[0].stopper,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

### The problem

Calling `Tuner.restore("/moved/path/exp_name")` doesn't work if the original Tune experiment saved to `"/original/path/exp_name"`. This is because most things are saved as absolute paths, and there's no way to pass in a new `local_dir` that the experiment has moved to. See issues below for more information.

### Solution

This PR introduces a few fixes:
1. For local checkpointing, `Tuner.restore(new_experiment_path)` now properly sets the new `local_dir` for restored trials based on the parent of the path that is passed in.
    - Example: `/original/path/exp_name/` -> `/moved/path/exp_name/`, `/moved/path` is the new `local_dir`
2. For cloud checkpointing, `Tuner.restore(new_remote_experiment_path)` now properly sets the `remote_dir` for restored trials.
    - Example: `s3://original/bucket/exp_name` -> `s3://moved/bucket/exp_name`, `s3://moved/bucket` is the new `remote_dir`
3. Added better test coverage (see `ray/tune/tests/test_tuner_restore.py` and `ray/tune/tests/test_result_grid.py`.

There are quite a few places where the local/cloud directory is referenced. Here is a table containing them with examples of each:

| State relating to filepaths | Example |
| ------ | ------ |
| `TrialRunner._local_dir` | `~/ray_results/` |
| `TrialRunner._remote_dir` | `s3://cloud/bucket/` |
| `TrialRunner._relative_checkpoint_dir` | `exp_name` |
| `TrialRunner._local_checkpoint_dir` | `~/ray_results/exp_name` |
| `TrialRunner._remote_checkpoint_dir` | `s3://cloud_bucket/exp_name` |
| `Trial.local_dir` | `~/ray_results/exp_name/` |
| `Trial.remote_checkpoint_dir_prefix` | `s3://cloud/bucket/exp_name/` |
| `Trial.remote_checkpoint_dir` | `s3://cloud/bucket/exp_name/trial_.../` |
 
### Usage

#### Restoring from local checkpoint

```python
tuner = Tuner(
    my_trainable,
    run_config=RunConfig(name="exp_name", local_dir="~/ray_results")
)
tuner.fit()

# Local dir changes from `~/ray_results` to `~/moved_ray_results`, and I want to restore

tuner = Tuner.restore("~/moved_ray_results/exp_name")
results_grid = tuner.fit()
assert results_grid[0].checkpoint
```

#### Restoring from cloud checkpoint

```python
tuner = Tuner(
    my_trainable,
    run_config=RunConfig(
        name="exp_name",
        local_dir="~/ray_results",
        sync_config=SyncConfig(upload_dir="s3://original/bucket/")
    )
)
tuner.fit()

# Remote dir changes from `s3://original/bucket` to `s3://moved/bucket`, and I want to restore

tuner = Tuner.restore("s3://moved/bucket/exp_name")
results_grid = tuner.fit()
assert results_grid[0].checkpoint
```

#### Old `tune.run` API

```python
tune.run(
    my_trainable,
    name="exp_name",
    local_dir="~/moved_ray_results",
    sync_config=tune.SyncConfig(upload_dir="s3://moved/bucket/exp_name"),
    resume="AUTO",
)
```

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #28082
Closes #28621

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
