### PR TITLE
[core] disable memory monitor for specific nightly tests that are fai…

### DIFF
--- a/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
@@ -1,5 +1,9 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
+# Test fails due to excessive retry from memory monitor. Re-enable after https://github.com/ray-project/ray/pull/28714
+# Tests this would address:
+# dask_on_ray_1tb
+# dask_on_ray_100gb_sort
 env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 
 python:

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
@@ -1,5 +1,6 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
+env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 
 python:
   pip_packages: ["dask[complete]", tqdm, scipy, xarray, zarr, boto, s3fs, pyarrow, pytest]

--- a/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
@@ -1,5 +1,6 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
+env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 
 python:
   pip_packages: ["dask[complete]", tqdm, scipy, xarray, zarr, boto, s3fs, pyarrow, pytest]

--- a/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
@@ -1,5 +1,9 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
+# Test fails due to excessive retry from memory monitor. Re-enable after https://github.com/ray-project/ray/pull/28714
+# Tests this would address:
+# dask_on_ray_large_scale_test_no_spilling
+# dask_on_ray_large_scale_test_spilling
 env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 
 python:

--- a/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
@@ -1,6 +1,6 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
-# Test fails due to excessive retry from memory monitor. Re-enable after https://github.com/ray-project/ray/pull/28714
+# Test fails due to actor killed by memory monitor. Re-enable when we address non-retrieable task / actor.
 # Tests this would address:
 # dask_on_ray_large_scale_test_no_spilling
 # dask_on_ray_large_scale_test_spilling

--- a/release/nightly_tests/decision_tree/decision_tree_app_config.yaml
+++ b/release/nightly_tests/decision_tree/decision_tree_app_config.yaml
@@ -1,5 +1,8 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
+# Test fails due to excessive retry from memory monitor. Re-enable after https://github.com/ray-project/ray/pull/28714
+# Tests this would address:
+# decision_tree_autoscaling_20_runs
 env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 
 python:

--- a/release/nightly_tests/decision_tree/decision_tree_app_config.yaml
+++ b/release/nightly_tests/decision_tree/decision_tree_app_config.yaml
@@ -1,5 +1,6 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
+env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 
 python:
   pip_packages:

--- a/release/nightly_tests/shuffle/shuffle_app_config.yaml
+++ b/release/nightly_tests/shuffle/shuffle_app_config.yaml
@@ -1,5 +1,10 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
+# Test fails due to excessive retry from memory monitor. Re-enable after https://github.com/ray-project/ray/pull/28714
+# Tests this would address:
+# chaos_dataset_shuffle_push_based_sort_1tb
+# chaos_dataset_shuffle_sort_1tb
+# chaos_dataset_shuffle_push_based_random_shuffle_1tb
 env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 
 python:

--- a/release/nightly_tests/shuffle/shuffle_app_config.yaml
+++ b/release/nightly_tests/shuffle/shuffle_app_config.yaml
@@ -1,5 +1,6 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
+env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 
 python:
   pip_packages: []


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

Some nighty tests are failing due to excessive task retry. This can happen when memory monitor is enabled as it prioritizes newest submitted tasks to kill, which then causes these tasks to use up its retry before the running task can finish. 

For now we disable the memory monitor and re-enable with https://github.com/ray-project/ray/pull/28714 

We also disable tests that are failing due to non-retriable actor getting killed. For this we re-enable once we merge patch to avoid killing non-retriable task

This PR disables memory monitor on more tests than listed since each cluster config applies to multiple tests, they will be covered once we re-enable them.

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
