### PR TITLE
Asking Bazel to announce config it finds in bazelrcs to make CI comprehension easier

### DIFF
--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -76,10 +76,6 @@ fi
 # clear bazelrc
 echo > ~/.bazelrc
 
-# Ask bazel to anounounce the config it finds in bazelrcs, which makes
-# understanding how to reproduce bazel easier.
-echo "build --announce_rc" >> ~/.bazelrc
-
 for bazel_cfg in ${BAZEL_CONFIG-}; do
   echo "build --config=${bazel_cfg}" >> ~/.bazelrc
 done
@@ -100,6 +96,11 @@ if [ "${GITHUB_ACTIONS-}" = true ]; then
   echo "build --jobs="$(($(nproc)+2)) >> ~/.bazelrc
 fi
 if [ "${CI-}" = true ]; then
+
+  # Ask bazel to anounounce the config it finds in bazelrcs, which makes
+  # understanding how to reproduce bazel easier.
+  echo "build --announce_rc" >> ~/.bazelrc
+
   echo "build --config=ci" >> ~/.bazelrc
 
   # In Windows CI we want to use this to avoid long path issue

--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -76,6 +76,10 @@ fi
 # clear bazelrc
 echo > ~/.bazelrc
 
+# Ask bazel to anounounce the config it finds in bazelrcs, which makes
+# understanding how to reproduce bazel easier.
+echo "build --announce_rc" >> ~/.bazelrc
+
 for bazel_cfg in ${BAZEL_CONFIG-}; do
   echo "build --config=${bazel_cfg}" >> ~/.bazelrc
 done


### PR DESCRIPTION
I had to debug a windows failure last week and it was a major pain. I managed to create the BK environment to iterate faster. This flag helped me understand what Bazel does in CI. See [this slack thread](https://anyscaleteam.slack.com/archives/CLJQR6420/p1664233110897999?thread_ts=1663874896.237369&cid=CLJQR6420) for more context.

Example output on windows:
```
(22:29:21) INFO: Reading 'startup' options from c:\users\containeradministrator\.bazelrc: --output_user_root=C:/tmp, --output_user_root=c:/tmp
(22:29:21) INFO: Options provided by the client:
  Inherited 'common' options: --isatty=0 --terminal_columns=80
(22:29:21) INFO: Options provided by the client:
  'build' options: --python_path=C:/Miniconda3/python.exe
(22:29:21) INFO: Reading rc options for 'build' from c:\install\ray\.bazelrc:
  'build' options: --enable_platform_specific_config --compilation_mode=opt --per_file_copt=\.pb\.cc$@-w --per_file_copt=-\.(asm|S)$,external/.*@-w --per_file_copt=-\.(asm|S)$,external/com_github_grpc_grpc/.*@-DGRPC_BAZEL_BUILD --http_time
out_scaling=5.0 --verbose_failures --strict_java_deps=off
(22:29:21) INFO: Reading rc options for 'build' from c:\users\containeradministrator\.bazelrc:
  'build' options: --config=ci --announce_rc --config=ci --remote_upload_local_results=false
(22:29:21) INFO: Found applicable config definition build:ci in file c:\install\ray\.bazelrc: --color=yes --curses=no --keep_going --progress_report_interval=100 --show_progress_rate_limit=15 --show_task_finish --ui_actions_shown=1024 --sh
ow_timestamps
(22:29:21) INFO: Found applicable config definition build:ci in file c:\install\ray\.bazelrc: --color=yes --curses=no --keep_going --progress_report_interval=100 --show_progress_rate_limit=15 --show_task_finish --ui_actions_shown=1024 --sh
ow_timestamps
(22:29:21) INFO: Found applicable config definition build:windows in file c:\install\ray\.bazelrc: --action_env=PATH --cxxopt=/std:c++17 --enable_runfiles --attempt_to_print_relative_paths --experimental_repository_cache_hardlinks --incomp
atible_strict_action_env --color=yes
(22:29:22) INFO: Current date is 2022-09-26
(22:29:22) Loading:
(22:29:22) Loading: 0 packages loaded
```