### PR TITLE
[docs/tune] Fix custom command syncer snippet

### DIFF
--- a/doc/source/tune/doc_code/faq.py
+++ b/doc/source/tune/doc_code/faq.py
@@ -301,6 +301,7 @@ if not MOCK:
                 subprocess.check_call(cmd_str, shell=True)
             except Exception as e:
                 print(f"Exception when syncing up {local_dir} to {remote_dir}: {e}")
+                return False
             return True
 
         def sync_down(
@@ -314,6 +315,7 @@ if not MOCK:
                 subprocess.check_call(cmd_str, shell=True)
             except Exception as e:
                 print(f"Exception when syncing down {remote_dir} to {local_dir}: {e}")
+                return False
             return True
 
         def delete(self, remote_dir: str) -> bool:
@@ -324,6 +326,7 @@ if not MOCK:
                 subprocess.check_call(cmd_str, shell=True)
             except Exception as e:
                 print(f"Exception when deleting {remote_dir}: {e}")
+                return False
             return True
 
         def retry(self):

--- a/doc/source/tune/doc_code/faq.py
+++ b/doc/source/tune/doc_code/faq.py
@@ -297,7 +297,10 @@ if not MOCK:
                 source=local_dir,
                 target=remote_dir,
             )
-            subprocess.check_call(cmd_str, shell=True)
+            try:
+                subprocess.check_call(cmd_str, shell=True)
+            except Exception as e:
+                print(f"Exception when syncing up {local_dir} to {remote_dir}: {e}")
             return True
 
         def sync_down(
@@ -307,14 +310,20 @@ if not MOCK:
                 source=remote_dir,
                 target=local_dir,
             )
-            subprocess.check_call(cmd_str, shell=True)
+            try:
+                subprocess.check_call(cmd_str, shell=True)
+            except Exception as e:
+                print(f"Exception when syncing down {remote_dir} to {local_dir}: {e}")
             return True
 
         def delete(self, remote_dir: str) -> bool:
             cmd_str = self.delete_template.format(
                 target=remote_dir,
             )
-            subprocess.check_call(cmd_str, shell=True)
+            try:
+                subprocess.check_call(cmd_str, shell=True)
+            except Exception as e:
+                print(f"Exception when deleting {remote_dir}: {e}")
             return True
 
         def retry(self):

--- a/python/ray/tune/tests/test_syncer.py
+++ b/python/ray/tune/tests/test_syncer.py
@@ -123,6 +123,7 @@ class CustomCommandSyncer(Syncer):
             subprocess.check_call(cmd_str, shell=True)
         except Exception as e:
             print(f"Exception when syncing up {local_dir} to {remote_dir}: {e}")
+            return False
         return True
 
     def sync_down(self, remote_dir: str, local_dir: str, exclude: list = None) -> bool:
@@ -134,6 +135,7 @@ class CustomCommandSyncer(Syncer):
             subprocess.check_call(cmd_str, shell=True)
         except Exception as e:
             print(f"Exception when syncing down {remote_dir} to {local_dir}: {e}")
+            return False
         return True
 
     def delete(self, remote_dir: str) -> bool:
@@ -144,6 +146,7 @@ class CustomCommandSyncer(Syncer):
             subprocess.check_call(cmd_str, shell=True)
         except Exception as e:
             print(f"Exception when deleting {remote_dir}: {e}")
+            return False
         return True
 
     def retry(self):

--- a/python/ray/tune/tests/test_syncer.py
+++ b/python/ray/tune/tests/test_syncer.py
@@ -114,31 +114,36 @@ class CustomCommandSyncer(Syncer):
 
         super().__init__(sync_period=sync_period)
 
-    def sync_up(
-        self, local_dir: str, remote_dir: str, exclude: Optional[List] = None
-    ) -> bool:
+    def sync_up(self, local_dir: str, remote_dir: str, exclude: list = None) -> bool:
         cmd_str = self.sync_up_template.format(
             source=local_dir,
             target=remote_dir,
         )
-        subprocess.check_call(cmd_str, shell=True)
+        try:
+            subprocess.check_call(cmd_str, shell=True)
+        except Exception as e:
+            print(f"Exception when syncing up {local_dir} to {remote_dir}: {e}")
         return True
 
-    def sync_down(
-        self, remote_dir: str, local_dir: str, exclude: Optional[List] = None
-    ) -> bool:
+    def sync_down(self, remote_dir: str, local_dir: str, exclude: list = None) -> bool:
         cmd_str = self.sync_down_template.format(
             source=remote_dir,
             target=local_dir,
         )
-        subprocess.check_call(cmd_str, shell=True)
+        try:
+            subprocess.check_call(cmd_str, shell=True)
+        except Exception as e:
+            print(f"Exception when syncing down {remote_dir} to {local_dir}: {e}")
         return True
 
     def delete(self, remote_dir: str) -> bool:
         cmd_str = self.delete_template.format(
             target=remote_dir,
         )
-        subprocess.check_call(cmd_str, shell=True)
+        try:
+            subprocess.check_call(cmd_str, shell=True)
+        except Exception as e:
+            print(f"Exception when deleting {remote_dir}: {e}")
         return True
 
     def retry(self):


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current snippet will fail with `resume=AUTO` and gsutil as the directory will not exist on the first run.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
