### PR TITLE
Undeprecate actor pool for now

### DIFF
--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -1,8 +1,10 @@
 from typing import List, Callable, Any
 
 import ray
+from ray.util.annotations import DeveloperAPI
 
 
+@DeveloperAPI
 class ActorPool:
     """Utility class to operate on a fixed pool of actors.
 

--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -1,17 +1,8 @@
 from typing import List, Callable, Any
 
 import ray
-from ray.util.annotations import Deprecated
-from ray._private.utils import get_ray_doc_version
 
 
-@Deprecated(
-    message="For stateless/task processing, use ray.util.multiprocessing, see details "
-    f"in https://docs.ray.io/en/{get_ray_doc_version()}/ray-more-libs/multiprocessing.html. "  # noqa: E501
-    "For stateful/actor processing such as batch prediction, use "
-    "Datasets.map_batches(compute=ActorPoolStrategy, ...), see details in "
-    f"https://docs.ray.io/en/{get_ray_doc_version()}/data/api/dataset.html#ray.data.Dataset.map_batches."  # noqa: E501
-)
 class ActorPool:
     """Utility class to operate on a fixed pool of actors.
 


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Feedback from users is that there still isn't a 100% replacement for actor pool: https://discuss.ray.io/t/deprecation-of-ray-utils-actorpool/7648/2

Undeprecate this for now while we have to address gaps in multiprocessing.Pool.