### PR TITLE
[Test][Client] Patch global/environment variables instead of overwriting in test_client_proxy

### DIFF
--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -80,20 +80,23 @@ def test_proxy_manager_bad_startup(shutdown_only):
     Test that when a SpecificServer fails to start (because of a bad JobConfig)
     that it is properly GC'd.
     """
-    proxier.CHECK_PROCESS_INTERVAL_S = 1
-    proxier.CHECK_CHANNEL_TIMEOUT_S = 1
-    pm, free_ports = start_ray_and_proxy_manager(n_ports=2)
-    client = "client1"
+    with patch("ray.util.client.server.proxier.CHECK_PROCESS_INTERVAL_S", 1), patch(
+        "ray.util.client.server.proxier.CHECK_CHANNEL_TIMEOUT_S", 1
+    ):
+        assert proxier.CHECK_PROCESS_INTERVAL_S == 1
+        pm, free_ports = start_ray_and_proxy_manager(n_ports=2)
+        client = "client1"
 
-    pm.create_specific_server(client)
-    assert not pm.start_specific_server(
-        client, JobConfig(runtime_env={"conda": "conda-env-that-sadly-does-not-exist"})
-    )
-    # Wait for reconcile loop
-    time.sleep(2)
-    assert pm.get_channel(client) is None
+        pm.create_specific_server(client)
+        assert not pm.start_specific_server(
+            client,
+            JobConfig(runtime_env={"conda": "conda-env-that-sadly-does-not-exist"}),
+        )
+        # Wait for reconcile loop
+        time.sleep(2)
+        assert pm.get_channel(client) is None
 
-    assert len(pm._free_ports) == 2
+        assert len(pm._free_ports) == 2
 
 
 @pytest.mark.skipif(
@@ -165,22 +168,23 @@ def test_delay_in_rewriting_environment(shutdown_only):
     Check that a delay in `ray_client_server_env_prep` does not break
     a Client connecting.
     """
-    proxier.LOGSTREAM_RETRIES = 3
-    proxier.LOGSTREAM_RETRY_INTERVAL_SEC = 1
-    ray_instance = ray.init()
-    server = proxier.serve_proxier(
-        "localhost:25010",
-        ray_instance["address"],
-        session_dir=ray_instance["session_dir"],
-    )
+    with patch("ray.util.client.server.proxier.LOGSTREAM_RETRIES", 3), patch(
+        "ray.util.client.server.proxier.LOGSTREAM_RETRY_INTERVAL_SEC", 1
+    ):
+        ray_instance = ray.init()
+        server = proxier.serve_proxier(
+            "localhost:25010",
+            ray_instance["address"],
+            session_dir=ray_instance["session_dir"],
+        )
 
-    def delay_in_rewrite(_input: JobConfig):
-        time.sleep(6)
-        return _input
+        def delay_in_rewrite(_input: JobConfig):
+            time.sleep(6)
+            return _input
 
-    with patch.object(proxier, "ray_client_server_env_prep", delay_in_rewrite):
-        run_string_as_driver(check_connection)
-    server.stop(0)
+        with patch.object(proxier, "ray_client_server_env_prep", delay_in_rewrite):
+            run_string_as_driver(check_connection)
+        server.stop(0)
 
 
 get_error = """
@@ -323,81 +327,82 @@ def test_match_running_client_server(test_case):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="PSUtil does not work the same on windows."
 )
-def test_proxy_manager_internal_kv(shutdown_only, with_specific_server):
+def test_proxy_manager_internal_kv(shutdown_only, with_specific_server, monkeypatch):
     """
     Test that proxy manager can use internal kv with and without a
     SpecificServer and that once a SpecificServer is started up, it
     goes through it.
     """
 
-    proxier.CHECK_PROCESS_INTERVAL_S = 1
-    # The timeout has likely been set to 1 in an earlier test. Increase timeout
-    # to wait for the channel to become ready.
-    proxier.CHECK_CHANNEL_TIMEOUT_S = 5
-    os.environ["TIMEOUT_FOR_SPECIFIC_SERVER_S"] = "5"
-    pm, free_ports = start_ray_and_proxy_manager(n_ports=2)
-    client = "client1"
+    with patch("ray.util.client.server.proxier.CHECK_PROCESS_INTERVAL_S", 1), patch(
+        "ray.util.client.server.proxier.CHECK_CHANNEL_TIMEOUT_S", 5
+    ):
+        monkeypatch.setenv("TIMEOUT_FOR_SPECIFIC_SERVER_S", "5")
+        pm, free_ports = start_ray_and_proxy_manager(n_ports=2)
+        client = "client1"
 
-    task_servicer = proxier.RayletServicerProxy(None, pm)
+        task_servicer = proxier.RayletServicerProxy(None, pm)
 
-    def make_internal_kv_calls():
-        response = task_servicer.KVPut(
-            ray_client_pb2.KVPutRequest(key=b"key", value=b"val")
-        )
-        assert isinstance(response, ray_client_pb2.KVPutResponse)
-        assert not response.already_exists
-
-        response = task_servicer.KVPut(
-            ray_client_pb2.KVPutRequest(key=b"key", value=b"val2")
-        )
-        assert isinstance(response, ray_client_pb2.KVPutResponse)
-        assert response.already_exists
-
-        response = task_servicer.KVGet(ray_client_pb2.KVGetRequest(key=b"key"))
-        assert isinstance(response, ray_client_pb2.KVGetResponse)
-        assert response.value == b"val"
-
-        response = task_servicer.KVPut(
-            ray_client_pb2.KVPutRequest(key=b"key", value=b"val2", overwrite=True)
-        )
-        assert isinstance(response, ray_client_pb2.KVPutResponse)
-        assert response.already_exists
-
-        response = task_servicer.KVGet(ray_client_pb2.KVGetRequest(key=b"key"))
-        assert isinstance(response, ray_client_pb2.KVGetResponse)
-        assert response.value == b"val2"
-
-    with patch(
-        "ray.util.client.server.proxier._get_client_id_from_context"
-    ) as mock_get_client_id:
-        mock_get_client_id.return_value = client
-
-        if with_specific_server:
-            pm.create_specific_server(client)
-            assert pm.start_specific_server(client, JobConfig())
-            channel = pm.get_channel(client)
-            assert channel is not None
-            task_servicer.Init(
-                ray_client_pb2.InitRequest(job_config=pickle.dumps(JobConfig()))
+        def make_internal_kv_calls():
+            response = task_servicer.KVPut(
+                ray_client_pb2.KVPutRequest(key=b"key", value=b"val")
             )
+            assert isinstance(response, ray_client_pb2.KVPutResponse)
+            assert not response.already_exists
 
-            # Mock out the internal kv calls in this process to raise an
-            # exception if they're called. This verifies that we are not
-            # making any calls in the proxier if there is a SpecificServer
-            # started up.
-            with patch(
-                "ray.experimental.internal_kv._internal_kv_put"
-            ) as mock_put, patch(
-                "ray.experimental.internal_kv._internal_kv_get"
-            ) as mock_get, patch(
-                "ray.experimental.internal_kv._internal_kv_initialized"
-            ) as mock_initialized:
-                mock_put.side_effect = Exception("This shouldn't be called!")
-                mock_get.side_effect = Exception("This shouldn't be called!")
-                mock_initialized.side_effect = Exception("This shouldn't be called!")
+            response = task_servicer.KVPut(
+                ray_client_pb2.KVPutRequest(key=b"key", value=b"val2")
+            )
+            assert isinstance(response, ray_client_pb2.KVPutResponse)
+            assert response.already_exists
+
+            response = task_servicer.KVGet(ray_client_pb2.KVGetRequest(key=b"key"))
+            assert isinstance(response, ray_client_pb2.KVGetResponse)
+            assert response.value == b"val"
+
+            response = task_servicer.KVPut(
+                ray_client_pb2.KVPutRequest(key=b"key", value=b"val2", overwrite=True)
+            )
+            assert isinstance(response, ray_client_pb2.KVPutResponse)
+            assert response.already_exists
+
+            response = task_servicer.KVGet(ray_client_pb2.KVGetRequest(key=b"key"))
+            assert isinstance(response, ray_client_pb2.KVGetResponse)
+            assert response.value == b"val2"
+
+        with patch(
+            "ray.util.client.server.proxier._get_client_id_from_context"
+        ) as mock_get_client_id:
+            mock_get_client_id.return_value = client
+
+            if with_specific_server:
+                pm.create_specific_server(client)
+                assert pm.start_specific_server(client, JobConfig())
+                channel = pm.get_channel(client)
+                assert channel is not None
+                task_servicer.Init(
+                    ray_client_pb2.InitRequest(job_config=pickle.dumps(JobConfig()))
+                )
+
+                # Mock out the internal kv calls in this process to raise an
+                # exception if they're called. This verifies that we are not
+                # making any calls in the proxier if there is a SpecificServer
+                # started up.
+                with patch(
+                    "ray.experimental.internal_kv._internal_kv_put"
+                ) as mock_put, patch(
+                    "ray.experimental.internal_kv._internal_kv_get"
+                ) as mock_get, patch(
+                    "ray.experimental.internal_kv._internal_kv_initialized"
+                ) as mock_initialized:
+                    mock_put.side_effect = Exception("This shouldn't be called!")
+                    mock_get.side_effect = Exception("This shouldn't be called!")
+                    mock_initialized.side_effect = Exception(
+                        "This shouldn't be called!"
+                    )
+                    make_internal_kv_calls()
+            else:
                 make_internal_kv_calls()
-        else:
-            make_internal_kv_calls()
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -75,28 +75,26 @@ def test_proxy_manager_lifecycle(shutdown_only):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="PSUtil does not work the same on windows."
 )
+@patch("ray.util.client.server.proxier.CHECK_PROCESS_INTERVAL_S", 1)
+@patch("ray.util.client.server.proxier.CHECK_CHANNEL_TIMEOUT_S", 1)
 def test_proxy_manager_bad_startup(shutdown_only):
     """
     Test that when a SpecificServer fails to start (because of a bad JobConfig)
     that it is properly GC'd.
     """
-    with patch("ray.util.client.server.proxier.CHECK_PROCESS_INTERVAL_S", 1), patch(
-        "ray.util.client.server.proxier.CHECK_CHANNEL_TIMEOUT_S", 1
-    ):
-        assert proxier.CHECK_PROCESS_INTERVAL_S == 1
-        pm, free_ports = start_ray_and_proxy_manager(n_ports=2)
-        client = "client1"
+    pm, free_ports = start_ray_and_proxy_manager(n_ports=2)
+    client = "client1"
 
-        pm.create_specific_server(client)
-        assert not pm.start_specific_server(
-            client,
-            JobConfig(runtime_env={"conda": "conda-env-that-sadly-does-not-exist"}),
-        )
-        # Wait for reconcile loop
-        time.sleep(2)
-        assert pm.get_channel(client) is None
+    pm.create_specific_server(client)
+    assert not pm.start_specific_server(
+        client,
+        JobConfig(runtime_env={"conda": "conda-env-that-sadly-does-not-exist"}),
+    )
+    # Wait for reconcile loop
+    time.sleep(2)
+    assert pm.get_channel(client) is None
 
-        assert len(pm._free_ports) == 2
+    assert len(pm._free_ports) == 2
 
 
 @pytest.mark.skipif(
@@ -163,28 +161,27 @@ assert ray.util.client.ray.worker.log_client.log_thread.is_alive()
     sys.platform != "linux",
     reason="PSUtil does not work the same on windows & MacOS if flaky.",
 )
+@patch("ray.util.client.server.proxier.LOGSTREAM_RETRIES", 3)
+@patch("ray.util.client.server.proxier.LOGSTREAM_RETRY_INTERVAL_SEC", 1)
 def test_delay_in_rewriting_environment(shutdown_only):
     """
     Check that a delay in `ray_client_server_env_prep` does not break
     a Client connecting.
     """
-    with patch("ray.util.client.server.proxier.LOGSTREAM_RETRIES", 3), patch(
-        "ray.util.client.server.proxier.LOGSTREAM_RETRY_INTERVAL_SEC", 1
-    ):
-        ray_instance = ray.init()
-        server = proxier.serve_proxier(
-            "localhost:25010",
-            ray_instance["address"],
-            session_dir=ray_instance["session_dir"],
-        )
+    ray_instance = ray.init()
+    server = proxier.serve_proxier(
+        "localhost:25010",
+        ray_instance["address"],
+        session_dir=ray_instance["session_dir"],
+    )
 
-        def delay_in_rewrite(_input: JobConfig):
-            time.sleep(6)
-            return _input
+    def delay_in_rewrite(_input: JobConfig):
+        time.sleep(6)
+        return _input
 
-        with patch.object(proxier, "ray_client_server_env_prep", delay_in_rewrite):
-            run_string_as_driver(check_connection)
-        server.stop(0)
+    with patch.object(proxier, "ray_client_server_env_prep", delay_in_rewrite):
+        run_string_as_driver(check_connection)
+    server.stop(0)
 
 
 get_error = """
@@ -327,82 +324,78 @@ def test_match_running_client_server(test_case):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="PSUtil does not work the same on windows."
 )
+@patch("ray.util.client.server.proxier.CHECK_PROCESS_INTERVAL_S", 1)
+@patch("ray.util.client.server.proxier.CHECK_CHANNEL_TIMEOUT_S", 5)
 def test_proxy_manager_internal_kv(shutdown_only, with_specific_server, monkeypatch):
     """
     Test that proxy manager can use internal kv with and without a
     SpecificServer and that once a SpecificServer is started up, it
     goes through it.
     """
+    monkeypatch.setenv("TIMEOUT_FOR_SPECIFIC_SERVER_S", "5")
+    pm, free_ports = start_ray_and_proxy_manager(n_ports=2)
+    client = "client1"
 
-    with patch("ray.util.client.server.proxier.CHECK_PROCESS_INTERVAL_S", 1), patch(
-        "ray.util.client.server.proxier.CHECK_CHANNEL_TIMEOUT_S", 5
-    ):
-        monkeypatch.setenv("TIMEOUT_FOR_SPECIFIC_SERVER_S", "5")
-        pm, free_ports = start_ray_and_proxy_manager(n_ports=2)
-        client = "client1"
+    task_servicer = proxier.RayletServicerProxy(None, pm)
 
-        task_servicer = proxier.RayletServicerProxy(None, pm)
+    def make_internal_kv_calls():
+        response = task_servicer.KVPut(
+            ray_client_pb2.KVPutRequest(key=b"key", value=b"val")
+        )
+        assert isinstance(response, ray_client_pb2.KVPutResponse)
+        assert not response.already_exists
 
-        def make_internal_kv_calls():
-            response = task_servicer.KVPut(
-                ray_client_pb2.KVPutRequest(key=b"key", value=b"val")
+        response = task_servicer.KVPut(
+            ray_client_pb2.KVPutRequest(key=b"key", value=b"val2")
+        )
+        assert isinstance(response, ray_client_pb2.KVPutResponse)
+        assert response.already_exists
+
+        response = task_servicer.KVGet(ray_client_pb2.KVGetRequest(key=b"key"))
+        assert isinstance(response, ray_client_pb2.KVGetResponse)
+        assert response.value == b"val"
+
+        response = task_servicer.KVPut(
+            ray_client_pb2.KVPutRequest(key=b"key", value=b"val2", overwrite=True)
+        )
+        assert isinstance(response, ray_client_pb2.KVPutResponse)
+        assert response.already_exists
+
+        response = task_servicer.KVGet(ray_client_pb2.KVGetRequest(key=b"key"))
+        assert isinstance(response, ray_client_pb2.KVGetResponse)
+        assert response.value == b"val2"
+
+    with patch(
+        "ray.util.client.server.proxier._get_client_id_from_context"
+    ) as mock_get_client_id:
+        mock_get_client_id.return_value = client
+
+        if with_specific_server:
+            pm.create_specific_server(client)
+            assert pm.start_specific_server(client, JobConfig())
+            channel = pm.get_channel(client)
+            assert channel is not None
+            task_servicer.Init(
+                ray_client_pb2.InitRequest(job_config=pickle.dumps(JobConfig()))
             )
-            assert isinstance(response, ray_client_pb2.KVPutResponse)
-            assert not response.already_exists
 
-            response = task_servicer.KVPut(
-                ray_client_pb2.KVPutRequest(key=b"key", value=b"val2")
-            )
-            assert isinstance(response, ray_client_pb2.KVPutResponse)
-            assert response.already_exists
-
-            response = task_servicer.KVGet(ray_client_pb2.KVGetRequest(key=b"key"))
-            assert isinstance(response, ray_client_pb2.KVGetResponse)
-            assert response.value == b"val"
-
-            response = task_servicer.KVPut(
-                ray_client_pb2.KVPutRequest(key=b"key", value=b"val2", overwrite=True)
-            )
-            assert isinstance(response, ray_client_pb2.KVPutResponse)
-            assert response.already_exists
-
-            response = task_servicer.KVGet(ray_client_pb2.KVGetRequest(key=b"key"))
-            assert isinstance(response, ray_client_pb2.KVGetResponse)
-            assert response.value == b"val2"
-
-        with patch(
-            "ray.util.client.server.proxier._get_client_id_from_context"
-        ) as mock_get_client_id:
-            mock_get_client_id.return_value = client
-
-            if with_specific_server:
-                pm.create_specific_server(client)
-                assert pm.start_specific_server(client, JobConfig())
-                channel = pm.get_channel(client)
-                assert channel is not None
-                task_servicer.Init(
-                    ray_client_pb2.InitRequest(job_config=pickle.dumps(JobConfig()))
-                )
-
-                # Mock out the internal kv calls in this process to raise an
-                # exception if they're called. This verifies that we are not
-                # making any calls in the proxier if there is a SpecificServer
-                # started up.
-                with patch(
-                    "ray.experimental.internal_kv._internal_kv_put"
-                ) as mock_put, patch(
-                    "ray.experimental.internal_kv._internal_kv_get"
-                ) as mock_get, patch(
-                    "ray.experimental.internal_kv._internal_kv_initialized"
-                ) as mock_initialized:
-                    mock_put.side_effect = Exception("This shouldn't be called!")
-                    mock_get.side_effect = Exception("This shouldn't be called!")
-                    mock_initialized.side_effect = Exception(
-                        "This shouldn't be called!"
-                    )
-                    make_internal_kv_calls()
-            else:
+            # Mock out the internal kv calls in this process to raise an
+            # exception if they're called. This verifies that we are not
+            # making any calls in the proxier if there is a SpecificServer
+            # started up.
+            with patch(
+                "ray.experimental.internal_kv._internal_kv_put"
+            ) as mock_put, patch(
+                "ray.experimental.internal_kv._internal_kv_get"
+            ) as mock_get, patch(
+                "ray.experimental.internal_kv._internal_kv_initialized"
+            ) as mock_initialized:
+                mock_put.side_effect = Exception("This shouldn't be called!")
+                mock_get.side_effect = Exception("This shouldn't be called!")
+                mock_initialized.side_effect = Exception("This shouldn't be called!")
                 make_internal_kv_calls()
+        else:
+            make_internal_kv_calls()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test_delay_in_rewriting_environment` is consistently failing after upgrading grpc, but only if `test_proxy_manager_bad_startup` is also run. I'm guessing that the new version of gprc takes a bit longer than the old version to start a channel, and `test_proxy_manager_bad_startup` sets `CHECK_CHANNEL_TIMEOUT_S` low (30 seconds -> 1 second). Use patch and monkeypatch to make sure that global values are overwritten only for the duration of the expected tests, and prevent tests from interfering with each other.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #28802

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
