### PR TITLE
Revert "Improve Ray client error message when exception can't be unpickled"

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -46,8 +46,6 @@ class RayError(Exception):
                 return pickle.loads(ray_exception.serialized_exception)
             except Exception as e:
                 msg = "Failed to unpickle serialized exception"
-                msg += " -- original error message is: "
-                msg += ray_exception.formatted_exception_string
                 raise RuntimeError(msg) from e
         else:
             return CrossLanguageError(ray_exception)

--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -284,13 +284,7 @@ def test_actor_repr_in_traceback(ray_start_regular):
 
 
 def test_unpickleable_stacktrace(shutdown_only):
-    expected_output = """System error: Failed to unpickle serialized exception -- original error message is: ray.exceptions.RayTaskError: ray::f() (pid=XXX, ip=YYY)
-  File "FILE", line ZZ, in f
-    return g(c)
-  File "FILE", line ZZ, in g
-    raise NoPickleError("FILE")
-test_traceback.NoPickleError
-
+    expected_output = """System error: Failed to unpickle serialized exception
 traceback: Traceback (most recent call last):
   File "FILE", line ZZ, in from_ray_exception
     return pickle.loads(ray_exception.serialized_exception)
@@ -307,12 +301,7 @@ Traceback (most recent call last):
     return RayError.from_ray_exception(ray_exception)
   File "FILE", line ZZ, in from_ray_exception
     raise RuntimeError(msg) from e
-RuntimeError: Failed to unpickle serialized exception -- original error message is: ray.exceptions.RayTaskError: ray::f() (pid=XXX, ip=YYY)
-  File "FILE", line ZZ, in f
-    return g(c)
-  File "FILE", line ZZ, in g
-    raise NoPickleError("FILE")
-test_traceback.NoPickleError"""  # noqa: E501
+RuntimeError: Failed to unpickle serialized exception"""
 
     class NoPickleError(OSError):
         def __init__(self, arg):


### PR DESCRIPTION
Reverts ray-project/ray#28684


Looks like this PR fails the `windows://python/ray/tests:test_traceback` test: https://buildkite.com/ray-project/oss-ci-build-branch/builds/217#01837c87-d422-45c6-9a15-60e768258b18, and all subsequent builds. 
