### PR TITLE
[metrics] Also flush DeltaProducer on ExportNow

### DIFF
--- a/thirdparty/patches/opencensus-cpp-shutdown-api.patch
+++ b/thirdparty/patches/opencensus-cpp-shutdown-api.patch
@@ -85,7 +85,7 @@ diff --git opencensus/stats/internal/stats_exporter.cc opencensus/stats/internal
 index 43ddbc7..37b4ae1 100644
 --- opencensus/stats/internal/stats_exporter.cc
 +++ opencensus/stats/internal/stats_exporter.cc
-@@ -95,25 +95,56 @@ void StatsExporterImpl::ClearHandlersForTesting() {
+@@ -95,25 +95,57 @@ void StatsExporterImpl::ClearHandlersForTesting() {
  }
  
  void StatsExporterImpl::StartExportThread() EXCLUSIVE_LOCKS_REQUIRED(mu_) {
@@ -140,6 +140,7 @@ index 43ddbc7..37b4ae1 100644
 +}
 +
 +void StatsExporter::ExportNow() {
++  DeltaProducer::Get()->Flush();
 +  StatsExporterImpl::Get()->Export();
 +}
 +


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The internal delta producer needs to be flushed, otherwise you might see stale metrics exported on ExportNow().