### PR TITLE
[Core][WIP] Optimize the memory footprint by extracting the first NestedRefCount element

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -813,6 +813,7 @@ cc_library(
         ":worker_rpc",
         "//src/ray/protobuf:worker_cc_proto",
         "@boost//:fiber",
+        "@boost//:flyweight",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -168,6 +168,7 @@ def ray_deps_setup():
         sha256 = "c1b8b2adc3b4201683cf94dda7eef3fc0f4f4c0ea5caa3ed3feffe07e1fb5b15",
         patches = [
             "@com_github_ray_project_ray//thirdparty/patches:rules_boost-windows-linkopts.patch",
+            "@com_github_ray_project_ray//thirdparty/patches:rules_boost-flyweight.patch",
         ],
     )
 

--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -88,6 +88,11 @@ class BaseID {
   mutable size_t hash_ = 0;
 };
 
+template<typename T>
+size_t hash_value(const BaseID<T>& id) {
+  return id.Hash();
+}
+
 class UniqueID : public BaseID<UniqueID> {
  public:
   static constexpr size_t Size() { return kUniqueIDSize; }

--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -88,8 +88,8 @@ class BaseID {
   mutable size_t hash_ = 0;
 };
 
-template<typename T>
-size_t hash_value(const BaseID<T>& id) {
+template <typename T>
+size_t hash_value(const BaseID<T> &id) {
   return id.Hash();
 }
 

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -573,7 +573,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
         : call_site(call_site),
           object_size(object_size),
           owner_address(owner_address),
-          pinned_at_raylet_id(pinned_at_raylet_id),
+          pinned_at_raylet_id(boost::flyweight<NodeID>(pinned_at_raylet_id.value_or(NodeID::Nil()))),
           owned_by_us(true),
           is_reconstructable(is_reconstructable),
           foreign_owner_already_monitoring(false),
@@ -684,7 +684,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
     /// If this object is owned by us and stored in plasma, and reference
     /// counting is enabled, then some raylet must be pinning the object value.
     /// This is the address of that raylet.
-    absl::optional<NodeID> pinned_at_raylet_id;
+    absl::optional<boost::flyweight<NodeID>> pinned_at_raylet_id;
     /// Whether we own the object. If we own the object, then we are
     /// responsible for tracking the state of the task that creates the object
     /// (see task_manager.h).
@@ -728,7 +728,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
     /// The ID of the node that spilled the object.
     /// This will be Nil if the object has not been spilled or if it is spilled
     /// distributed external storage.
-    NodeID spilled_node_id = NodeID::Nil();
+    boost::flyweight<NodeID> spilled_node_id = boost::flyweight<NodeID>(NodeID::Nil());
     /// Whether this object has been spilled to external storage.
     bool spilled = false;
 

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -768,14 +768,16 @@ class ReferenceCounter : public ReferenceCounterInterface,
       return extra->insert(id).second;
     }
 
-    static const absl::flat_hash_set<ObjectID> GetNestedRefCount(
-        const std::unique_ptr<ObjectID> &first,
-        const std::unique_ptr<absl::flat_hash_set<ObjectID>> &extra) {
-      absl::flat_hash_set<ObjectID> *copied_extra;
+    static const absl::flat_hash_set<ObjectID> 
+    GetNestedRefCount(
+        const std::unique_ptr<ObjectID>& first, 
+        const std::unique_ptr<absl::flat_hash_set<ObjectID>>& extra) {
+      std::unique_ptr<absl::flat_hash_set<ObjectID>> copied_extra;
+
       if (extra == nullptr) {
-        copied_extra = new absl::flat_hash_set<ObjectID>();
-      } else {
-        copied_extra = new absl::flat_hash_set<ObjectID>(*extra);
+        copied_extra.reset(new absl::flat_hash_set<ObjectID>());
+      }else {
+        copied_extra.reset(new absl::flat_hash_set<ObjectID>(*extra));
       }
 
       if (first != nullptr) {

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -768,15 +768,14 @@ class ReferenceCounter : public ReferenceCounterInterface,
       return extra->insert(id).second;
     }
 
-    static const absl::flat_hash_set<ObjectID> 
-    GetNestedRefCount(
-        const std::unique_ptr<ObjectID>& first, 
-        const std::unique_ptr<absl::flat_hash_set<ObjectID>>& extra) {
+    static const absl::flat_hash_set<ObjectID> GetNestedRefCount(
+        const std::unique_ptr<ObjectID> &first,
+        const std::unique_ptr<absl::flat_hash_set<ObjectID>> &extra) {
       std::unique_ptr<absl::flat_hash_set<ObjectID>> copied_extra;
 
       if (extra == nullptr) {
         copied_extra.reset(new absl::flat_hash_set<ObjectID>());
-      }else {
+      } else {
         copied_extra.reset(new absl::flat_hash_set<ObjectID>(*extra));
       }
 

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -34,19 +34,20 @@
 namespace ray {
 namespace core {
 
-/// Extract a key to identify a Address so that the flyweight can look 
+/// Extract a key to identify a Address so that the flyweight can look
 /// up the Address from the pool.
 struct AddressWorkeridExtractor {
-  const std::string& operator()(const rpc::Address& addr)const
-  {
+  const std::string &operator()(const rpc::Address &addr) const {
     return addr.worker_id();
   }
 };
 
-/// Since the owner address has high redundency across objects, 
+/// Since the owner address has high redundency across objects,
 /// we use boost::flyweight to maintain an intern table to reduce
-/// memory footprint per object. 
-typedef boost::flyweight<boost::flyweights::key_value<std::string,rpc::Address,AddressWorkeridExtractor>> InternAddress;
+/// memory footprint per object.
+typedef boost::flyweight<
+    boost::flyweights::key_value<std::string, rpc::Address, AddressWorkeridExtractor>>
+    InternAddress;
 
 // Interface for mocking.
 class ReferenceCounterInterface {
@@ -570,7 +571,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
 
   struct OptBorrowInfo {
     std::unique_ptr<std::pair<ObjectID, rpc::WorkerAddress>> first_stored_in_objects;
-    std::unique_ptr<absl::flat_hash_map<ObjectID, rpc::WorkerAddress>> extra_stored_in_objects;
+    std::unique_ptr<absl::flat_hash_map<ObjectID, rpc::WorkerAddress>>
+        extra_stored_in_objects;
     std::unique_ptr<rpc::WorkerAddress> first_borrower;
     std::unique_ptr<absl::flat_hash_set<rpc::WorkerAddress>> extra_borrowers;
   };
@@ -589,7 +591,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
         : call_site(call_site),
           object_size(object_size),
           owner_address(owner_address),
-          pinned_at_raylet_id(boost::flyweight<NodeID>(pinned_at_raylet_id.value_or(NodeID::Nil()))),
+          pinned_at_raylet_id(
+              boost::flyweight<NodeID>(pinned_at_raylet_id.value_or(NodeID::Nil()))),
           owned_by_us(true),
           is_reconstructable(is_reconstructable),
           foreign_owner_already_monitoring(false),
@@ -609,8 +612,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
     /// - ObjectIDs containing this ObjectID that we own and that are still in
     /// scope.
     size_t RefCount() const {
-      return local_ref_count + submitted_task_ref_count + 
-             GetContainedInOwned().size();
+      return local_ref_count + submitted_task_ref_count + GetContainedInOwned().size();
     }
 
     /// Whether this reference is no longer in scope. A reference is in scope
@@ -685,48 +687,52 @@ class ReferenceCounter : public ReferenceCounterInterface,
       return opt_nested_reference_count.get();
     }
 
-    int EraseContains(const ObjectID& id){
-      return EraseNestedRefCount(id, mutable_nested()->first_contains, mutable_nested()->extra_contains);
+    int EraseContains(const ObjectID &id) {
+      return EraseNestedRefCount(
+          id, mutable_nested()->first_contains, mutable_nested()->extra_contains);
     }
-    bool InsertContains(const ObjectID& id){
-      return InsertNestedRefCount(id, mutable_nested()->first_contains, mutable_nested()->extra_contains);
+    bool InsertContains(const ObjectID &id) {
+      return InsertNestedRefCount(
+          id, mutable_nested()->first_contains, mutable_nested()->extra_contains);
     }
-    const absl::flat_hash_set<ObjectID> GetContains() const{
+    const absl::flat_hash_set<ObjectID> GetContains() const {
       return GetNestedRefCount(nested().first_contains, nested().extra_contains);
     }
-    int EraseContainedInOwned(const ObjectID& id){
-      return EraseNestedRefCount(id, mutable_nested()->first_contained_in_owned, mutable_nested()->extra_contained_in_owned);
+    int EraseContainedInOwned(const ObjectID &id) {
+      return EraseNestedRefCount(id,
+                                 mutable_nested()->first_contained_in_owned,
+                                 mutable_nested()->extra_contained_in_owned);
     }
-    bool InsertContainedInOwned(const ObjectID& id){
-      return InsertNestedRefCount(id, mutable_nested()->first_contained_in_owned, mutable_nested()->extra_contained_in_owned);
+    bool InsertContainedInOwned(const ObjectID &id) {
+      return InsertNestedRefCount(id,
+                                  mutable_nested()->first_contained_in_owned,
+                                  mutable_nested()->extra_contained_in_owned);
     }
-    const absl::flat_hash_set<ObjectID> GetContainedInOwned() const{
-      return GetNestedRefCount(nested().first_contained_in_owned, nested().extra_contained_in_owned);
+    const absl::flat_hash_set<ObjectID> GetContainedInOwned() const {
+      return GetNestedRefCount(nested().first_contained_in_owned,
+                               nested().extra_contained_in_owned);
     }
-    int EraseContainedInBorrowedIds(const ObjectID& id){
-      return EraseNestedRefCount(
-        id, 
-        mutable_nested()->first_contained_in_borrowed_ids, 
-        mutable_nested()->extra_contained_in_borrowed_ids);
+    int EraseContainedInBorrowedIds(const ObjectID &id) {
+      return EraseNestedRefCount(id,
+                                 mutable_nested()->first_contained_in_borrowed_ids,
+                                 mutable_nested()->extra_contained_in_borrowed_ids);
     }
-    bool InsertContainedInBorrowedIds(const ObjectID& id){
-      return InsertNestedRefCount(
-        id, 
-        mutable_nested()->first_contained_in_borrowed_ids, 
-        mutable_nested()->extra_contained_in_borrowed_ids);
+    bool InsertContainedInBorrowedIds(const ObjectID &id) {
+      return InsertNestedRefCount(id,
+                                  mutable_nested()->first_contained_in_borrowed_ids,
+                                  mutable_nested()->extra_contained_in_borrowed_ids);
     }
-    const absl::flat_hash_set<ObjectID> GetContainedInBorrowedIds() const{
-      return GetNestedRefCount(
-        nested().first_contained_in_borrowed_ids, 
-        nested().extra_contained_in_borrowed_ids);
+    const absl::flat_hash_set<ObjectID> GetContainedInBorrowedIds() const {
+      return GetNestedRefCount(nested().first_contained_in_borrowed_ids,
+                               nested().extra_contained_in_borrowed_ids);
     }
 
     static int EraseNestedRefCount(
-        const ObjectID& id, 
-        std::unique_ptr<ObjectID>& first, 
+        const ObjectID &id,
+        std::unique_ptr<ObjectID> &first,
         std::unique_ptr<absl::flat_hash_set<ObjectID>> &extra) {
       if (first == nullptr) {
-          return 0;
+        return 0;
       }
       if (*first == id) {
         first.reset();
@@ -741,16 +747,16 @@ class ReferenceCounter : public ReferenceCounterInterface,
     }
 
     static bool InsertNestedRefCount(
-        const ObjectID& id, 
-        std::unique_ptr<ObjectID>& first, 
-        std::unique_ptr<absl::flat_hash_set<ObjectID>>& extra) {
+        const ObjectID &id,
+        std::unique_ptr<ObjectID> &first,
+        std::unique_ptr<absl::flat_hash_set<ObjectID>> &extra) {
       // init and set the first
-      if(first == nullptr) {
+      if (first == nullptr) {
         first = std::make_unique<ObjectID>(id);
         return true;
       }
 
-      if(*first == id) {
+      if (*first == id) {
         // duplicate insert
         return false;
       }
@@ -762,9 +768,10 @@ class ReferenceCounter : public ReferenceCounterInterface,
       return extra->insert(id).second;
     }
 
-    static const absl::flat_hash_set<ObjectID> 
-    GetNestedRefCount(const std::unique_ptr<ObjectID>& first, const std::unique_ptr<absl::flat_hash_set<ObjectID>>& extra) {
-      absl::flat_hash_set<ObjectID>* copied_extra;
+    static const absl::flat_hash_set<ObjectID> GetNestedRefCount(
+        const std::unique_ptr<ObjectID> &first,
+        const std::unique_ptr<absl::flat_hash_set<ObjectID>> &extra) {
+      absl::flat_hash_set<ObjectID> *copied_extra;
       if (extra == nullptr) {
         copied_extra = new absl::flat_hash_set<ObjectID>();
       } else {

--- a/src/ray/core_worker/test/reference_count_test.cc
+++ b/src/ray/core_worker/test/reference_count_test.cc
@@ -789,18 +789,22 @@ TEST_F(ReferenceCountTest, TestOwnerAddress) {
   auto object_id = ObjectID::FromRandom();
   rpc::Address address;
   address.set_ip_address("1234");
+  address.set_worker_id("1234");
   rc->AddOwnedObject(object_id, {}, address, "", 0, false, /*add_local_ref=*/true);
 
   TaskID added_id;
   rpc::Address added_address;
   ASSERT_TRUE(rc->GetOwner(object_id, &added_address));
   ASSERT_EQ(address.ip_address(), added_address.ip_address());
+  ASSERT_EQ(address.worker_id(), added_address.worker_id());
 
   auto object_id2 = ObjectID::FromRandom();
   address.set_ip_address("5678");
+  address.set_worker_id("5678");
   rc->AddOwnedObject(object_id2, {}, address, "", 0, false, /*add_local_ref=*/true);
   ASSERT_TRUE(rc->GetOwner(object_id2, &added_address));
   ASSERT_EQ(address.ip_address(), added_address.ip_address());
+  ASSERT_EQ(address.worker_id(), added_address.worker_id());
 
   auto object_id3 = ObjectID::FromRandom();
   ASSERT_FALSE(rc->GetOwner(object_id3, &added_address));

--- a/thirdparty/patches/rules_boost-flyweight.patch
+++ b/thirdparty/patches/rules_boost-flyweight.patch
@@ -1,0 +1,28 @@
+diff --git BUILD.boost BUILD.boost
+index bd52876..692a6de 100644
+--- BUILD.boost
++++ BUILD.boost
+@@ -807,6 +807,23 @@ boost_library(
+     ],
+ )
+
++boost_library(
++    name = "flyweight",
++    deps = [
++        ":core",
++        ":detail",
++        ":interprocess",
++        ":mpl",
++        ":multi_index",
++        ":parameter",
++        ":preprocessor",
++        ":serialization",
++        ":smart_ptr",
++        ":throw_exception",
++        ":type_traits",
++    ],
++)
++
+ boost_library(
+     name = "foreach",
+     deps = [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The motivation is the same as #28806 that aims to reduce the meta-data memory footprint.
After analyzing runtime status of the `Reference`, we notice that each shuffle partition object's `NestedRefCount.contained_in_owned` only has one element, which is the return value owned by caller.

However, the current implementation directly initiates three hashset instance, each takes 48 bytes in stack, no matter the number of the actual elements. 
To mitigate this, we :
1. Extract the first element from the hashset;
2. Wrap the first element and the hashset that may contain extra elements with `unique_ptr`.

### Result
Before optimize, the average rss is about 1860 bytes (based on #28839 );
After optimize, the average rss is about 1750 bytes.

See the[ example running case.](https://gist.github.com/NKcqx/a45ab1fafacecdc0ff705a985cb28710)
<!-- Please give a short summary of the change and the problem this solves. -->

**Therefore, this optimization can save about 110 bytes.**

## Related issue number

One optimization for #28765 
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
