### PR TITLE
Revert "Add TypeAlias annotations to RLlib typing.py"

### DIFF
--- a/rllib/utils/typing.py
+++ b/rllib/utils/typing.py
@@ -16,11 +16,6 @@ import gym
 
 from ray.rllib.utils.annotations import ExperimentalAPI
 
-try:
-    from typing import TypeAlias
-except ImportError:
-    from typing_extensions import TypeAlias
-
 if TYPE_CHECKING:
     from ray.rllib.env.env_context import EnvContext
     from ray.rllib.policy.dynamic_tf_policy_v2 import DynamicTFPolicyV2
@@ -35,140 +30,136 @@ if TYPE_CHECKING:
 
 # Represents a generic tensor type.
 # This could be an np.ndarray, tf.Tensor, or a torch.Tensor.
-TensorType: TypeAlias = Union[np.array, "tf.Tensor", "torch.Tensor"]
+TensorType = Union[np.array, "tf.Tensor", "torch.Tensor"]
 
 # Either a plain tensor, or a dict or tuple of tensors (or StructTensors).
-TensorStructType: TypeAlias = Union[TensorType, dict, tuple]
+TensorStructType = Union[TensorType, dict, tuple]
 
 # A shape of a tensor.
-TensorShape: TypeAlias = Union[Tuple[int], List[int]]
+TensorShape = Union[Tuple[int], List[int]]
 
 # Represents a fully filled out config of a Algorithm class.
 # Note: Policy config dicts are usually the same as AlgorithmConfigDict, but
 # parts of it may sometimes be altered in e.g. a multi-agent setup,
 # where we have >1 Policies in the same Algorithm.
-AlgorithmConfigDict: TypeAlias = dict
-TrainerConfigDict: TypeAlias = dict
+AlgorithmConfigDict = TrainerConfigDict = dict
 
 # An algorithm config dict that only has overrides. It needs to be combined with
 # the default algorithm config to be used.
-PartialAlgorithmConfigDict: TypeAlias = dict
-PartialTrainerConfigDict: TypeAlias = dict
+PartialAlgorithmConfigDict = PartialTrainerConfigDict = dict
 
 # Represents the model config sub-dict of the algo config that is passed to
 # the model catalog.
-ModelConfigDict: TypeAlias = dict
+ModelConfigDict = dict
 
 # Objects that can be created through the `from_config()` util method
 # need a config dict with a "type" key, a class path (str), or a type directly.
-FromConfigSpec: TypeAlias = Union[Dict[str, Any], type, str]
+FromConfigSpec = Union[Dict[str, Any], type, str]
 
 # Represents the env_config sub-dict of the algo config that is passed to
 # the env constructor.
-EnvConfigDict: TypeAlias = dict
+EnvConfigDict = dict
 
 # Represents an environment id. These could be:
 # - An int index for a sub-env within a vectorized env.
 # - An external env ID (str), which changes(!) each episode.
-EnvID: TypeAlias = Union[int, str]
+EnvID = Union[int, str]
 
 # Represents a BaseEnv, MultiAgentEnv, ExternalEnv, ExternalMultiAgentEnv,
 # VectorEnv, gym.Env, or ActorHandle.
-EnvType: TypeAlias = Any
+EnvType = Any
 
 # A callable, taking a EnvContext object
 # (config dict + properties: `worker_index`, `vector_index`, `num_workers`,
 # and `remote`) and returning an env object (or None if no env is used).
-EnvCreator: TypeAlias = Callable[["EnvContext"], Optional[EnvType]]
+EnvCreator = Callable[["EnvContext"], Optional[EnvType]]
 
 # Represents a generic identifier for an agent (e.g., "agent1").
-AgentID: TypeAlias = Any
+AgentID = Any
 
 # Represents a generic identifier for a policy (e.g., "pol1").
-PolicyID: TypeAlias = str
+PolicyID = str
 
 # Type of the config["multiagent"]["policies"] dict for multi-agent training.
-MultiAgentPolicyConfigDict: TypeAlias = Dict[PolicyID, "PolicySpec"]
+MultiAgentPolicyConfigDict = Dict[PolicyID, "PolicySpec"]
 
 # State dict of a Policy, mapping strings (e.g. "weights") to some state
 # data (TensorStructType).
-PolicyState: TypeAlias = Dict[str, TensorStructType]
+PolicyState = Dict[str, TensorStructType]
 
 # Any tf Policy type (static-graph or eager Policy).
-TFPolicyV2Type: TypeAlias = Type[Union["DynamicTFPolicyV2", "EagerTFPolicyV2"]]
+TFPolicyV2Type = Type[Union["DynamicTFPolicyV2", "EagerTFPolicyV2"]]
 
 # Represents an episode id.
-EpisodeID: TypeAlias = int
+EpisodeID = int
 
 # Represents an "unroll" (maybe across different sub-envs in a vector env).
-UnrollID: TypeAlias = int
+UnrollID = int
 
 # A dict keyed by agent ids, e.g. {"agent-1": value}.
-MultiAgentDict: TypeAlias = Dict[AgentID, Any]
+MultiAgentDict = Dict[AgentID, Any]
 
 # A dict keyed by env ids that contain further nested dictionaries keyed by
 # agent ids. e.g., {"env-1": {"agent-1": value}}.
-MultiEnvDict: TypeAlias = Dict[EnvID, MultiAgentDict]
+MultiEnvDict = Dict[EnvID, MultiAgentDict]
 
 # Represents an observation returned from the env.
-EnvObsType: TypeAlias = Any
+EnvObsType = Any
 
 # Represents an action passed to the env.
-EnvActionType: TypeAlias = Any
+EnvActionType = Any
 
 # Info dictionary returned by calling step() on gym envs. Commonly empty dict.
-EnvInfoDict: TypeAlias = dict
+EnvInfoDict = dict
 
 # Represents a File object
-FileType: TypeAlias = Any
+FileType = Any
 
 # Represents a ViewRequirements dict mapping column names (str) to
 # ViewRequirement objects.
-ViewRequirementsDict: TypeAlias = Dict[str, "ViewRequirement"]
+ViewRequirementsDict = Dict[str, "ViewRequirement"]
 
 # Represents the result dict returned by Algorithm.train().
-ResultDict: TypeAlias = dict
+ResultDict = dict
 
 # A tf or torch local optimizer object.
-LocalOptimizer: TypeAlias = Union[
-    "tf.keras.optimizers.Optimizer", "torch.optim.Optimizer"
-]
+LocalOptimizer = Union["tf.keras.optimizers.Optimizer", "torch.optim.Optimizer"]
 
 # Dict of tensors returned by compute gradients on the policy, e.g.,
 # {"td_error": [...], "learner_stats": {"vf_loss": ..., ...}}, for multi-agent,
 # {"policy1": {"learner_stats": ..., }, "policy2": ...}.
-GradInfoDict: TypeAlias = dict
+GradInfoDict = dict
 
 # Dict of learner stats returned by compute gradients on the policy, e.g.,
 # {"vf_loss": ..., ...}. This will always be nested under the "learner_stats"
 # key(s) of a GradInfoDict. In the multi-agent case, this will be keyed by
 # policy id.
-LearnerStatsDict: TypeAlias = dict
+LearnerStatsDict = dict
 
 # List of grads+var tuples (tf) or list of gradient tensors (torch)
 # representing model gradients and returned by compute_gradients().
-ModelGradients: TypeAlias = Union[List[Tuple[TensorType, TensorType]], List[TensorType]]
+ModelGradients = Union[List[Tuple[TensorType, TensorType]], List[TensorType]]
 
 # Type of dict returned by get_weights() representing model weights.
-ModelWeights: TypeAlias = dict
+ModelWeights = dict
 
 # An input dict used for direct ModelV2 calls.
-ModelInputDict: TypeAlias = Dict[str, TensorType]
+ModelInputDict = Dict[str, TensorType]
 
 # Some kind of sample batch.
-SampleBatchType: TypeAlias = Union["SampleBatch", "MultiAgentBatch"]
+SampleBatchType = Union["SampleBatch", "MultiAgentBatch"]
 
 # A (possibly nested) space struct: Either a gym.spaces.Space or a
 # (possibly nested) dict|tuple of gym.space.Spaces.
-SpaceStruct: TypeAlias = Union[gym.spaces.Space, dict, tuple]
+SpaceStruct = Union[gym.spaces.Space, dict, tuple]
 
 # A list of batches of RNN states.
 # Each item in this list has dimension [B, S] (S=state vector size)
-StateBatches: TypeAlias = List[List[Any]]
+StateBatches = List[List[Any]]
 
 # Format of data output from policy forward pass.
 # __sphinx_doc_begin_policy_output_type__
-PolicyOutputType: TypeAlias = Tuple[TensorStructType, StateBatches, Dict]
+PolicyOutputType = Tuple[TensorStructType, StateBatches, Dict]
 # __sphinx_doc_end_policy_output_type__
 
 


### PR DESCRIPTION
Reverts ray-project/ray#28386

This is breaking tests like [python/ray/tests/test_usage_stats.py](https://buildkite.com/ray-project/oss-ci-build-branch/builds/244#0183832b-1b9b-4583-acb2-43c8f8d0a4a8):


<img width="990" alt="image" src="https://user-images.githubusercontent.com/11676094/192865132-e989e4b8-fddf-4768-9d55-4b62b2105375.png">


This is probably because we only have [`typing_extensions` < 3.8](https://github.com/ray-project/ray/blob/9505cd164ac99ed0cd4406d7197c1fb1db8b9c74/python/setup.py#L319), and `TypeAlias` is only available in 3.10 

