### PR TITLE
[core] Dynamic generators that error return partial ObjectRefs followed by exception ObjectRef

### DIFF
--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -133,7 +133,8 @@ Status TaskExecutor::ExecuteTask(
     std::shared_ptr<ray::LocalMemoryBuffer> &creation_task_exception_pb_bytes,
     bool *is_retryable_error,
     const std::vector<ConcurrencyGroup> &defined_concurrency_groups,
-    const std::string name_of_concurrency_group_to_execute) {
+    const std::string name_of_concurrency_group_to_execute,
+    bool is_reattempt) {
   RAY_LOG(DEBUG) << "Execute task type: " << TaskType_Name(task_type)
                  << " name:" << task_name;
   RAY_CHECK(ray_function.GetLanguage() == ray::Language::CPP);

--- a/cpp/src/ray/runtime/task/task_executor.h
+++ b/cpp/src/ray/runtime/task/task_executor.h
@@ -89,7 +89,8 @@ class TaskExecutor {
       std::shared_ptr<ray::LocalMemoryBuffer> &creation_task_exception_pb_bytes,
       bool *is_retryable_error,
       const std::vector<ConcurrencyGroup> &defined_concurrency_groups,
-      const std::string name_of_concurrency_group_to_execute);
+      const std::string name_of_concurrency_group_to_execute,
+      bool is_reattempt);
 
   virtual ~TaskExecutor(){};
 

--- a/doc/source/ray-core/doc_code/generator.py
+++ b/doc/source/ray-core/doc_code/generator.py
@@ -88,18 +88,6 @@ try:
 except Exception as error:
     print(error)
 
-# Generators that yield more values than expected currently do not throw an
-# exception (the error is only logged).
-# See https://github.com/ray-project/ray/issues/28689.
-ref1, ref2 = generator.options(num_returns=2).remote()
-assert ray.get([ref1, ref2]) == [0, 1]
-"""
-(generator pid=2375938) 2022-09-28 11:08:51,386 ERROR worker.py:755 --
-    Unhandled error: Task threw exception, but all return values already
-    created.  This should only occur when using generator tasks.
-...
-"""
-
 dynamic_ref = generator.options(num_returns="dynamic").remote()
 ref_generator = ray.get(dynamic_ref)
 ref1, ref2, ref3 = ref_generator
@@ -111,4 +99,20 @@ try:
 except Exception as error:
     print(error)
 # __generator_errors_end__
+# fmt: on
+
+# fmt: off
+# __generator_errors_unsupported_start__
+# Generators that yield more values than expected currently do not throw an
+# exception (the error is only logged).
+# See https://github.com/ray-project/ray/issues/28689.
+ref1, ref2 = generator.options(num_returns=2).remote()
+assert ray.get([ref1, ref2]) == [0, 1]
+"""
+(generator pid=2375938) 2022-09-28 11:08:51,386 ERROR worker.py:755 --
+    Unhandled error: Task threw exception, but all return values already
+    created.  This should only occur when using generator tasks.
+...
+"""
+# __generator_errors_unsupported_end__
 # fmt: on

--- a/doc/source/ray-core/doc_code/generator.py
+++ b/doc/source/ray-core/doc_code/generator.py
@@ -69,3 +69,46 @@ assert array_size == ray.get(get_size.remote(ref_generator))
 # (get_size pid=1504184) <ray._raylet.ObjectRefGenerator object at 0x7f81c4251b50>
 # __dynamic_generator_pass_end__
 # fmt: on
+
+
+# fmt: off
+# __generator_errors_start__
+@ray.remote
+def generator():
+    for i in range(2):
+        yield i
+    raise Exception("error")
+
+
+ref1, ref2, ref3, ref4 = generator.options(num_returns=4).remote()
+assert ray.get([ref1, ref2]) == [0, 1]
+# All remaining ObjectRefs will contain the error.
+try:
+    ray.get([ref3, ref4])
+except Exception as error:
+    print(error)
+
+# Generators that yield more values than expected currently do not throw an
+# exception (the error is only logged).
+# See https://github.com/ray-project/ray/issues/28689.
+ref1, ref2 = generator.options(num_returns=2).remote()
+assert ray.get([ref1, ref2]) == [0, 1]
+"""
+(generator pid=2375938) 2022-09-28 11:08:51,386 ERROR worker.py:755 --
+    Unhandled error: Task threw exception, but all return values already
+    created.  This should only occur when using generator tasks.
+...
+"""
+
+dynamic_ref = generator.options(num_returns="dynamic").remote()
+ref_generator = ray.get(dynamic_ref)
+ref1, ref2, ref3 = ref_generator
+assert ray.get([ref1, ref2]) == [0, 1]
+# Generators with num_returns="dynamic" will store the exception in the final
+# ObjectRef.
+try:
+    ray.get(ref3)
+except Exception as error:
+    print(error)
+# __generator_errors_end__
+# fmt: on

--- a/doc/source/ray-core/tasks/generators.rst
+++ b/doc/source/ray-core/tasks/generators.rst
@@ -69,8 +69,8 @@ We can also pass the ``ObjectRef`` returned by a task with ``num_returns="dynami
     :start-after: __dynamic_generator_pass_start__
     :end-before: __dynamic_generator_pass_end__
 
-Limitations
------------
+Exception handling and limitations
+----------------------------------
 
 Although a generator function creates ``ObjectRefs`` one at a time, currently Ray will not schedule dependent tasks until the entire task is complete and all values have been created. This is similar to the semantics used by tasks that return multiple values as a list.
 
@@ -80,14 +80,17 @@ If a generator function raises an exception before yielding all its values, the 
 The remaining ``ObjectRefs`` will contain the thrown exception.
 If the task was called with ``num_returns="dynamic"``, the exception will be stored as an additional final ``ObjectRef`` in the ``ObjectRefGenerator``.
 
-Note that there is currently a known bug where exceptions will not be propagated for generators that yield more values than expected. This can occur in two cases:
-1. When ``num_returns`` is set by the caller, but the generator task returns more than this value.
-2. When a generator task with ``num_returns="dynamic"`` is :ref:`re-executed <task-retries>`, and the re-executed task yields more values than the original execution. Note that in general, Ray does not guarantee correctness for task re-execution if a generator task is nondeterministic, and it is recommended to set ``@ray.remote(num_retries=0)`` for such tasks.
-
-Here is an example showing exception handling using generator tasks:
-
 .. literalinclude:: ../doc_code/generator.py
     :language: python
     :start-after: __generator_errors_start__
     :end-before: __generator_errors_end__
 
+Note that there is currently a known bug where exceptions will not be propagated for generators that yield more values than expected. This can occur in two cases:
+
+1. When ``num_returns`` is set by the caller, but the generator task returns more than this value.
+2. When a generator task with ``num_returns="dynamic"`` is :ref:`re-executed <task-retries>`, and the re-executed task yields more values than the original execution. Note that in general, Ray does not guarantee correctness for task re-execution if the task is nondeterministic, and it is recommended to set ``@ray.remote(num_retries=0)`` for such tasks.
+
+.. literalinclude:: ../doc_code/generator.py
+    :language: python
+    :start-after: __generator_errors_unsupported_start__
+    :end-before: __generator_errors_unsupported_end__

--- a/doc/source/ray-core/tasks/generators.rst
+++ b/doc/source/ray-core/tasks/generators.rst
@@ -69,15 +69,12 @@ We can also pass the ``ObjectRef`` returned by a task with ``num_returns="dynami
     :start-after: __dynamic_generator_pass_start__
     :end-before: __dynamic_generator_pass_end__
 
-Exception handling and limitations
-----------------------------------
-
-Although a generator function creates ``ObjectRefs`` one at a time, currently Ray will not schedule dependent tasks until the entire task is complete and all values have been created. This is similar to the semantics used by tasks that return multiple values as a list.
-
-``num_returns="dynamic"`` is not yet supported for actor tasks.
+Exception handling
+------------------
 
 If a generator function raises an exception before yielding all its values, the values that it already stored will still be accessible through their ``ObjectRefs``.
 The remaining ``ObjectRefs`` will contain the thrown exception.
+This is true for both static and dynamic ``num_returns``.
 If the task was called with ``num_returns="dynamic"``, the exception will be stored as an additional final ``ObjectRef`` in the ``ObjectRefGenerator``.
 
 .. literalinclude:: ../doc_code/generator.py
@@ -94,3 +91,10 @@ Note that there is currently a known bug where exceptions will not be propagated
     :language: python
     :start-after: __generator_errors_unsupported_start__
     :end-before: __generator_errors_unsupported_end__
+
+Limitations
+-----------
+
+Although a generator function creates ``ObjectRefs`` one at a time, currently Ray will not schedule dependent tasks until the entire task is complete and all values have been created. This is similar to the semantics used by tasks that return multiple values as a list.
+
+``num_returns="dynamic"`` is not yet supported for actor tasks.

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -299,7 +299,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             &creation_task_exception_pb_bytes,
             c_bool *is_retryable_error,
             const c_vector[CConcurrencyGroup] &defined_concurrency_groups,
-            const c_string name_of_concurrency_group_to_execute) nogil
+            const c_string name_of_concurrency_group_to_execute,
+            c_bool is_reattempt) nogil
          ) task_execution_callback
         (void(const CWorkerID &) nogil) on_worker_shutdown
         (CRayStatus() nogil) check_signals

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2303,7 +2303,8 @@ Status CoreWorker::ExecuteTask(
       creation_task_exception_pb_bytes,
       is_retryable_error,
       defined_concurrency_groups,
-      name_of_concurrency_group_to_execute);
+      name_of_concurrency_group_to_execute,
+      /*is_reattempt=*/task_spec.AttemptNumber() > 0);
 
   // Get the reference counts for any IDs that we borrowed during this task,
   // remove the local reference for these IDs, and return the ref count info to

--- a/src/ray/core_worker/core_worker_options.h
+++ b/src/ray/core_worker/core_worker_options.h
@@ -53,7 +53,8 @@ struct CoreWorkerOptions {
       // Defined concurrency groups of this actor. Note this is only
       // used for actor creation task.
       const std::vector<ConcurrencyGroup> &defined_concurrency_groups,
-      const std::string name_of_concurrency_group_to_execute)>;
+      const std::string name_of_concurrency_group_to_execute,
+      bool is_reattempt)>;
 
   CoreWorkerOptions()
       : store_socket(""),

--- a/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
@@ -122,7 +122,8 @@ Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(JNIEnv *env,
          std::shared_ptr<LocalMemoryBuffer> &creation_task_exception_pb,
          bool *is_retryable_error,
          const std::vector<ConcurrencyGroup> &defined_concurrency_groups,
-         const std::string name_of_concurrency_group_to_execute) {
+         const std::string name_of_concurrency_group_to_execute,
+         bool is_reattempt) {
         // These 2 parameters are used for Python only, and Java worker
         // will not use them.
         RAY_UNUSED(defined_concurrency_groups);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously if a dynamic generator task errored, we would store the error as the top-level ObjectRef, which could lead to a leak of any objects already stored, since the ObjectRefs are never returned to Python.

This PR improves usability by storing the exception as an additional final ObjectRef returned by the generator (see included examples in docs code). All successfully stored objects will still be returned by the generator as usual. Updated some tests to match this new behavior.

## Related issue number

Part 1 of #28686:
Handles application-level errors: we now make the partially stored ObjectRefs visible to the application.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
