### PR TITLE
[release test] add test for not overriding env var from cluster config

### DIFF
--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -69,10 +69,6 @@ class ClusterManager(abc.ABC):
             f"{dict_hash(self.cluster_env)}"
         )
 
-    def override_env_var_if_not_already_set(self, key, value):
-        if key not in self.cluster_env["env_vars"]:
-            self.cluster_env["env_vars"][key] = value
-
     def set_cluster_compute(self, cluster_compute: Dict[str, Any]):
         self.cluster_compute = cluster_compute
         self.cluster_compute_name = (

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -52,22 +52,24 @@ class ClusterManager(abc.ABC):
         self.cluster_env["env_vars"]["RAY_USAGE_STATS_ENABLED"] = "1"
         self.cluster_env["env_vars"]["RAY_USAGE_STATS_SOURCE"] = "nightly-tests"
         self.cluster_env["env_vars"][
-            "RAY_memory_monitor_interval_ms"
-        ] = self.cluster_env["env_vars"].get("RAY_memory_monitor_interval_ms", "250")
-        self.cluster_env["env_vars"][
-            "RAY_memory_usage_threshold_fraction"
-        ] = self.cluster_env["env_vars"].get(
-            "RAY_memory_usage_threshold_fraction", "0.95"
-        )
-        self.cluster_env["env_vars"][
             "RAY_USAGE_STATS_EXTRA_TAGS"
         ] = f"test_name={self.test_name};smoke_test={self.smoke_test}"
+        self.override_env_var_if_not_already_set(
+            "RAY_memory_monitor_interval_ms", "250"
+        )
+        self.override_env_var_if_not_already_set(
+            "RAY_memory_monitor_interval_ms", "0.95"
+        )
 
         self.cluster_env_name = (
             f"{self.project_name}_{self.project_id[4:8]}"
             f"__env__{self.test_name}__"
             f"{dict_hash(self.cluster_env)}"
         )
+
+    def override_env_var_if_not_already_set(self, key, value):
+        if key not in self.cluster_env["env_vars"]:
+            self.cluster_env["env_vars"][key] = value
 
     def set_cluster_compute(self, cluster_compute: Dict[str, Any]):
         self.cluster_compute = cluster_compute

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -54,11 +54,13 @@ class ClusterManager(abc.ABC):
         self.cluster_env["env_vars"][
             "RAY_USAGE_STATS_EXTRA_TAGS"
         ] = f"test_name={self.test_name};smoke_test={self.smoke_test}"
-        self.override_env_var_if_not_already_set(
-            "RAY_memory_monitor_interval_ms", "250"
-        )
-        self.override_env_var_if_not_already_set(
-            "RAY_memory_monitor_interval_ms", "0.95"
+        self.cluster_env["env_vars"][
+            "RAY_memory_monitor_interval_ms"
+        ] = self.cluster_env["env_vars"].get("RAY_memory_monitor_interval_ms", "250")
+        self.cluster_env["env_vars"][
+            "RAY_memory_usage_threshold_fraction"
+        ] = self.cluster_env["env_vars"].get(
+            "RAY_memory_usage_threshold_fraction", "0.95"
         )
 
         self.cluster_env_name = (

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -132,6 +132,26 @@ class MinimalSessionManagerTest(unittest.TestCase):
             "test_name=Test;smoke_test=True",
         )
 
+    def testSetClusterManagerOptionallyOverrideClusterConfig(self):
+        sdk = MockSDK()
+        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
+        cluster_manager = self.cls(
+            test_name="test", project_id=UNIT_TEST_PROJECT_ID, smoke_test=False, sdk=sdk
+        )
+        cluster_manager.set_cluster_env({})
+        self.assertEqual(
+            cluster_manager.cluster_env["env_vars"]["RAY_memory_monitor_interval_ms"],
+            "250",
+        )
+
+        cluster_manager.set_cluster_env(
+            {"env_vars": {"RAY_memory_monitor_interval_ms": "0"}}
+        )
+        self.assertEqual(
+            cluster_manager.cluster_env["env_vars"]["RAY_memory_monitor_interval_ms"],
+            "0",
+        )
+
     @patch("time.sleep", lambda *a, **kw: None)
     def testFindCreateClusterComputeExisting(self):
         # Find existing compute and succeed


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

When we set the env var in cluster manager by default it overrides what is specified in the cluster config, which may be undesirable. This PR adds the ability to set the env var from the cluster manager only when the cluster config does not specify on already

This fixes the release test where we want to disable oom killer via cluster config by overriding the value set in cluster manager

## Related issue number


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(

