### PR TITLE
[core] Move test_actor_failures to large test for osx test timeout of 5min

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -34,7 +34,6 @@ py_test_module_list(
     "test_actor_pool.py",
     "test_async.py",
     "test_asyncio.py",
-    "test_actor_failures.py",
     "test_actor_resources.py",
     "test_actor_lifetime.py",
     "test_advanced.py",
@@ -253,6 +252,7 @@ py_test_module_list(
 py_test_module_list(
   files = [
     "test_actor.py",
+    "test_actor_failures.py",
     "test_failure.py",
     "test_actor_advanced.py",
     "test_threaded_actor.py",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Many of the flaky tests on macOS currently timeout while running the test, e.g.: 
<img width="951" alt="image" src="https://user-images.githubusercontent.com/11676094/192914837-ae9e715e-bef5-40f9-bdfd-ad9bede1e419.png">


Moving this test to large test.

However, I do notice there is a large variance in the test duration: https://b534fd88.us1a.app.preset.io/superset/dashboard/p/kJ2wP8xwA6j/

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
