### PR TITLE
[RLlib] Fix Ape-X release test deprecated config value

### DIFF
--- a/release/long_running_tests/workloads/apex.py
+++ b/release/long_running_tests/workloads/apex.py
@@ -49,7 +49,7 @@ run_experiments(
                 "num_steps_sampled_before_learning_starts": 0,
                 "rollout_fragment_length": 1,
                 "train_batch_size": 1,
-                "min_iter_time_s": 10,
+                "min_time_s_per_iteration": 10,
                 "min_sample_timesteps_per_iteration": 10,
             },
         }

--- a/rllib/utils/metrics/learner_info.py
+++ b/rllib/utils/metrics/learner_info.py
@@ -92,8 +92,8 @@ class LearnerInfoBuilder:
 
 def _all_tower_reduce(path, *tower_data):
     """Reduces stats across towers based on their stats-dict paths."""
-    # TD-errors: Need to stay per batch item in order to be able to update each
-    # item's weight in a prioritized replay buffer.
+    # TD-errors: Need to stay per batch item in order to be able to update
+    # each item's weight in a prioritized replay buffer.
     if len(path) == 1 and path[0] == "td_error":
         return np.concatenate(tower_data, axis=0)
     elif tower_data[0] is None:

--- a/rllib/utils/metrics/learner_info.py
+++ b/rllib/utils/metrics/learner_info.py
@@ -92,8 +92,8 @@ class LearnerInfoBuilder:
 
 def _all_tower_reduce(path, *tower_data):
     """Reduces stats across towers based on their stats-dict paths."""
-    # TD-errors: Need to stay per batch item in order to be able to update
-    # each item's weight in a prioritized replay buffer.
+    # TD-errors: Need to stay per batch item in order to be able to update each
+    # item's weight in a prioritized replay buffer.
     if len(path) == 1 and path[0] == "td_error":
         return np.concatenate(tower_data, axis=0)
     elif tower_data[0] is None:


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?
<img width="642" alt="Screenshot 2022-09-29 at 12 37 56" src="https://user-images.githubusercontent.com/9356806/193010085-4701b198-e8df-4bdf-8c3a-b245f4e00082.png">

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
