### PR TITLE
[AIR] Fix `Checkpoint.to_dict` metadata serialization

### DIFF
--- a/python/ray/tune/tests/test_trainable.py
+++ b/python/ray/tune/tests/test_trainable.py
@@ -66,6 +66,11 @@ class SavingTrainable(tune.Trainable):
             with open(checkpoint_file, "rb") as f:
                 checkpoint_data = json.load(f)
 
+        checkpoint_data = {
+            key: value
+            for key, value in checkpoint_data.items()
+            if not key.startswith("_")
+        }
         assert checkpoint_data == {"data": 1}, checkpoint_data
 
 


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Checkpoints returned from `session.report` don't contain metadata because `session.report` converts `_CheckpointDict` objects to `dict`.

```
    def report(self, metrics: Dict, checkpoint: Optional[Checkpoint] = None) -> None:
        ...
        if checkpoint:
            checkpoint_dict = checkpoint.to_dict()
            self.checkpoint(**checkpoint_dict)
        ...
```

I've changed `to_dict` to store metadata directly in the dictionary as opposed to in an object attribute. The downside with this approach is that we now leak implementation details.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
