### PR TITLE
[CI] [Windows] [runtime env] Fix flakiness in rare case when directory is deleted

### DIFF
--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -74,14 +74,16 @@ def check_internal_kv_gced():
 
 
 def get_local_file_whitelist(cluster, option):
-    # On Windows the runtime directory itself is not deleted due to it being in use
-    # therefore whitelist it for the tests.
+    # On Windows the runtime directory itself is sometimes not deleted due
+    # to it being in use therefore whitelist it for the tests.
     if sys.platform == "win32" and option != "py_modules":
         runtime_dir = (
             Path(cluster.list_all_nodes()[0].get_runtime_env_dir_path())
             / "working_dir_files"
         )
-        return {list(Path(runtime_dir).iterdir())[0].name}
+        pkg_dirs = list(Path(runtime_dir).iterdir())
+        if pkg_dirs:
+            return {pkg_dirs[0].name}
     return {}
 
 


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR fixes flakiness of a test for garbage collection of the runtime_env working_dir.  

Usually the `runtime_env` local working directory on Windows can't be deleted because it's in use, but in rare cases it is successfully deleted (possibly due to some race condition.).  This is not a big concern because the files themselves are deleted, which consist of most of the space, only the directory is not deleted.  

This PR updates the test to allow for the possibility that the directory is successfully deleted.  Previously the test would error in this case.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #28816 
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
