### PR TITLE
[Serve] Disable async handles in Serve fault tolerance release test

### DIFF
--- a/release/k8s_tests/ray_v1alpha1_rayservice_template.yaml
+++ b/release/k8s_tests/ray_v1alpha1_rayservice_template.yaml
@@ -171,6 +171,8 @@ spec:
                   value: "120"
                 - name: RAY_gcs_failover_worker_reconnect_timeout
                   value: "600"
+                - name: SERVE_DEPLOYMENT_HANDLE_IS_SYNC
+                  value: "1"
               resources:
                 limits:
                   cpu: 2
@@ -289,6 +291,8 @@ spec:
                     value: "600"
                   - name: RAY_gcs_server_request_timeout_seconds
                     value: "5"
+                  - name: SERVE_DEPLOYMENT_HANDLE_IS_SYNC
+                    value: "1"
                 ports:
                   - containerPort: 80
                     name: client


### PR DESCRIPTION
Signed-off-by: Shreyas Krishnaswamy <shrekris@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Serve runs a fault tolerance release test that relies on synchronous handles in deployment graphs. However, [KubeRay plans to start using async handles by default](https://github.com/ray-project/kuberay/pull/606). This change explicitly disables async handles in the Kubernetes config for the fault tolerance release test.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change updates a release test.
