### PR TITLE
[RLlib] Pin ALE-py In Rllib Requirements And Other Release Test Fixes

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -34,6 +34,8 @@ flask
 pygame
 gym>=0.21.0,<0.24.0; python_version >= '3.7'
 gym==0.19.0; python_version < '3.7'
+autorom[accept-rom-license]
+ale-py~=0.8.0
 lz4
 scikit-image
 pandas>=1.0.5; python_version < '3.7'

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -32,10 +32,6 @@ virtualenv>=20.0.24
 dm_tree
 flask
 pygame
-gym>=0.21.0,<0.24.0; python_version >= '3.7'
-gym==0.19.0; python_version < '3.7'
-autorom[accept-rom-license]
-ale-py~=0.8.0
 lz4
 scikit-image
 pandas>=1.0.5; python_version < '3.7'

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -53,7 +53,6 @@ gradio; platform_system != "Windows"
 async-exit-stack
 async-generator
 asyncmock
-autorom[accept-rom-license]
 azure-cli-core==2.29.1
 azure-identity==1.7.0
 azure-mgmt-compute==23.1.0
@@ -69,7 +68,6 @@ feather-format
 google-api-python-client
 google-cloud-storage
 gym-minigrid==1.0.3
-gym[atari]
 kubernetes
 # higher version of llvmlite breaks windows
 llvmlite==0.34.0

--- a/python/requirements/ml/requirements_rllib.txt
+++ b/python/requirements/ml/requirements_rllib.txt
@@ -6,7 +6,7 @@
 autorom[accept-rom-license]
 gym>=0.21.0,<0.24.1; python_version >= '3.7'
 gym==0.19.0; python_version < '3.7'
-gym[atari]
+ale-py~=0.8.0
 # Kaggle envs.
 kaggle_environments==1.7.11
 # Unity3D testing

--- a/python/requirements/ml/requirements_rllib.txt
+++ b/python/requirements/ml/requirements_rllib.txt
@@ -6,7 +6,8 @@
 autorom[accept-rom-license]
 gym>=0.21.0,<0.24.1; python_version >= '3.7'
 gym==0.19.0; python_version < '3.7'
-ale-py~=0.8.0
+ale-py==0.7.5; python_version >= '3.7'
+ale-py==0.7.2; python_version < '3.7'
 # Kaggle envs.
 kaggle_environments==1.7.11
 # Unity3D testing

--- a/python/requirements/ml/requirements_rllib.txt
+++ b/python/requirements/ml/requirements_rllib.txt
@@ -5,7 +5,8 @@
 # Atari
 autorom[accept-rom-license]
 gym>=0.21.0,<0.24.1; python_version >= '3.7'
-gym[atari]==0.19.0; python_version < '3.7'
+gym==0.19.0; python_version < '3.7'
+gym[atari]
 # Kaggle envs.
 kaggle_environments==1.7.11
 # Unity3D testing

--- a/python/requirements/ml/requirements_rllib.txt
+++ b/python/requirements/ml/requirements_rllib.txt
@@ -7,7 +7,7 @@ autorom[accept-rom-license]
 gym>=0.21.0,<0.24.1; python_version >= '3.7'
 gym==0.19.0; python_version < '3.7'
 ale-py==0.7.5; python_version >= '3.7'
-ale-py==0.7.2; python_version < '3.7'
+ale-py==0.7.1; python_version < '3.7'
 # Kaggle envs.
 kaggle_environments==1.7.11
 # Unity3D testing

--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -10,7 +10,7 @@ python:
     # These dependencies should be handled by requirements_rllib.txt and
     # requirements_ml_docker.txt and removed here
     - gym>=0.21.0,<0.24.1
-    - ale-py~=0.8.0
+    - ale-py==0.7.5
     - autorom[accept-rom-license]
     - pytest
     - tensorflow

--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -9,6 +9,7 @@ python:
   pip_packages:
     - gym>=0.21.0,<0.24.1
     - ale-py~=0.8.0
+    - autorom[accept-rom-license]
     - pytest
     - tensorflow
   conda_packages: []

--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -7,6 +7,8 @@ debian_packages:
 
 python:
   pip_packages:
+    # These dependencies should be handled by requirements_rllib.txt and
+    # requirements_ml_docker.txt
     - gym>=0.21.0,<0.24.1
     - ale-py~=0.8.0
     - autorom[accept-rom-license]

--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -7,7 +7,6 @@ debian_packages:
 
 python:
   pip_packages:
-    - "gym[atari]>=0.21.0,<0.24.1"
     - pytest
     - tensorflow
   conda_packages: []
@@ -15,7 +14,7 @@ python:
 post_build_cmds:
   - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git /tmp/wrk && cd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin'
   - pip3 install pytest || true
-  - pip3 install -U ray[all] "gym[atari]>=0.21.0,<0.24.1" autorom[accept-rom-license]
+  - pip3 install -U ray[all]
   - pip3 install ray[all]
   # TODO (Alex): Ideally we would install all the dependencies from the new
   # version too, but pip won't be able to find the new version of ray-cpp.

--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -8,7 +8,7 @@ debian_packages:
 python:
   pip_packages:
     # These dependencies should be handled by requirements_rllib.txt and
-    # requirements_ml_docker.txt
+    # requirements_ml_docker.txt and removed here
     - gym>=0.21.0,<0.24.1
     - ale-py~=0.8.0
     - autorom[accept-rom-license]

--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -7,6 +7,8 @@ debian_packages:
 
 python:
   pip_packages:
+    - gym>=0.21.0,<0.24.1
+    - ale-py~=0.8.0
     - pytest
     - tensorflow
   conda_packages: []

--- a/release/long_running_tests/app_config_np.yaml
+++ b/release/long_running_tests/app_config_np.yaml
@@ -8,6 +8,8 @@ debian_packages:
 python:
   pip_packages:
     - "gym[atari]>=0.21.0,<0.24.0"
+    - ale-py==0.7.5
+    - autorom[accept-rom-license]
     - pygame
     - pytest
     - tensorflow
@@ -18,7 +20,6 @@ post_build_cmds:
     - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git /tmp/wrk && cd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin'
     - pip3 install numpy==1.19 || true
     - pip3 install pytest || true
-    - pip3 install -U ray[all] "gym[atari]>=0.21.0,<0.24.0" autorom[accept-rom-license]
     - pip3 install ray[all]
     # TODO (Alex): Ideally we would install all the dependencies from the new
     # version too, but pip won't be able to find the new version of ray-cpp.

--- a/release/long_running_tests/workloads/apex.py
+++ b/release/long_running_tests/workloads/apex.py
@@ -49,7 +49,7 @@ run_experiments(
                 "num_steps_sampled_before_learning_starts": 0,
                 "rollout_fragment_length": 1,
                 "train_batch_size": 1,
-                "min_iter_time_s": 10,
+                "min_time_s_per_iteration": 10,
                 "min_sample_timesteps_per_iteration": 10,
             },
         }

--- a/release/rllib_tests/app_config.yaml
+++ b/release/rllib_tests/app_config.yaml
@@ -9,7 +9,7 @@ python:
       # These dependencies should be handled by requirements_rllib.txt and
       # requirements_ml_docker.txt and removed here
       - gym>=0.21.0,<0.24.1
-      - ale-py~=0.8.0
+      - ale-py==0.7.5
       - autorom[accept-rom-license]
   conda_packages: []
 

--- a/release/rllib_tests/app_config.yaml
+++ b/release/rllib_tests/app_config.yaml
@@ -6,6 +6,8 @@ debian_packages:
 
 python:
   pip_packages:
+      # These dependencies should be handled by requirements_rllib.txt and
+      # requirements_ml_docker.txt
       - gym>=0.21.0,<0.24.1
       - ale-py~=0.8.0
       - autorom[accept-rom-license]

--- a/release/rllib_tests/app_config.yaml
+++ b/release/rllib_tests/app_config.yaml
@@ -5,10 +5,7 @@ debian_packages:
   - zip
 
 python:
-  # These dependencies should be handled by requirements_rllib.txt and
-  # requirements_ml_docker.txt
-  pip_packages:
-      - gym>=0.21.0,<0.24.1
+  pip_packages: []
   conda_packages: []
 
 post_build_cmds:

--- a/release/rllib_tests/app_config.yaml
+++ b/release/rllib_tests/app_config.yaml
@@ -5,7 +5,9 @@ debian_packages:
   - zip
 
 python:
-  pip_packages: []
+  pip_packages:
+      - gym>=0.21.0,<0.24.1
+      - ale-py~=0.8.0
   conda_packages: []
 
 post_build_cmds:

--- a/release/rllib_tests/app_config.yaml
+++ b/release/rllib_tests/app_config.yaml
@@ -8,6 +8,7 @@ python:
   pip_packages:
       - gym>=0.21.0,<0.24.1
       - ale-py~=0.8.0
+      - autorom[accept-rom-license]
   conda_packages: []
 
 post_build_cmds:

--- a/release/rllib_tests/app_config.yaml
+++ b/release/rllib_tests/app_config.yaml
@@ -7,7 +7,7 @@ debian_packages:
 python:
   pip_packages:
       # These dependencies should be handled by requirements_rllib.txt and
-      # requirements_ml_docker.txt
+      # requirements_ml_docker.txt and removed here
       - gym>=0.21.0,<0.24.1
       - ale-py~=0.8.0
       - autorom[accept-rom-license]

--- a/release/rllib_tests/learning_tests/yaml_files/cql/cql-halfcheetahbulletenv-v0.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/cql/cql-halfcheetahbulletenv-v0.yaml
@@ -38,7 +38,7 @@ cql-halfcheetahbulletenv-v0:
             critic_learning_rate: 0.0003
             entropy_learning_rate: 0.0001
         num_gpus: 1
-        metrics_smoothing_episodes: 5
+        metrics_num_episodes_for_smoothing: 5
         min_time_s_per_iteration: 30
 
         # CQL Configs

--- a/release/rllib_tests/learning_tests/yaml_files/sac/sac-halfcheetahbulletenv-v0.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/sac/sac-halfcheetahbulletenv-v0.yaml
@@ -33,4 +33,4 @@ sac-halfcheetahbulletenv-v0:
             entropy_learning_rate: 0.0003
         num_workers: 0
         num_gpus: 1
-        metrics_smoothing_episodes: 5
+        metrics_num_episodes_for_smoothing: 5


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

The following issue persists in our RLlib release tests:
<img width="733" alt="Screenshot 2022-09-30 at 00 29 10" src="https://user-images.githubusercontent.com/9356806/193153435-48cbb5d4-c92d-43fc-bdd9-a87f7b6064d0.png">
The [initial fix](https://github.com/ray-project/ray/pull/28703) is overwritten when install the requirements_rllib.txt, since Python versions >=3.7 will reinstall gym instead of gym[atari].

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
