### PR TITLE
[Rllib] Torch Policy spams global timesteps

### DIFF
--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -1019,7 +1019,6 @@ class TorchPolicy(Policy):
             extra_fetches[SampleBatch.ACTION_LOGP] = logp
 
         # Update our global timestep by the batch size.
-        print(f"increasing global_timestep by {len(input_dict[SampleBatch.CUR_OBS])}")
         self.global_timestep += len(input_dict[SampleBatch.CUR_OBS])
 
         return convert_to_numpy((actions, state_out, extra_fetches))


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Torch Policy spams the line in question.

<img width="733" alt="Screenshot 2022-09-30 at 18 05 41" src="https://user-images.githubusercontent.com/9356806/193311441-22271753-018b-4472-a1d8-f52e530ae1c2.png">

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
