### PR TITLE
[Jobs] Add workaround for hanging caused by ignored exception #28058

### DIFF
--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -452,7 +452,7 @@ class JobManager:
                 ref = job_supervisor.ping.remote()
                 not_ready = [ref]
                 while not_ready:
-                    ready, not_ready = ray.wait(ref, timeout=0.1)
+                    ready, not_ready = ray.wait(not_ready, timeout=0.1)
                     if ready:
                         ray.get(ready)
                     else:


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Adds a workaround for a dashboard hang on long running clusters caused by an ignored exception (See the issue for more details: #28058).  The workaround is to use `ray.get()` instead of `await`.  We don't have a reproduction for the root cause, but anecdotally this fixed the problem for a user who encountered the issue, and there should be no bad side effects of this workaround.
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
