### PR TITLE
[runtime env] [Windows] [CI] Filter out all directories in GC test on Windows

### DIFF
--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -73,20 +73,6 @@ def check_internal_kv_gced():
     return len(kv._internal_kv_list("gcs://")) == 0
 
 
-def get_local_file_whitelist(cluster, option):
-    # On Windows the runtime directory itself is sometimes not deleted due
-    # to it being in use therefore whitelist it for the tests.
-    if sys.platform == "win32" and option != "py_modules":
-        runtime_dir = (
-            Path(cluster.list_all_nodes()[0].get_runtime_env_dir_path())
-            / "working_dir_files"
-        )
-        pkg_dirs = list(Path(runtime_dir).iterdir())
-        if pkg_dirs:
-            return {pkg_dirs[0].name}
-    return {}
-
-
 class TestGC:
     @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
     @pytest.mark.parametrize(
@@ -179,8 +165,7 @@ class TestGC:
         wait_for_condition(check_internal_kv_gced)
         print("check_internal_kv_gced passed wait_for_condition block.")
 
-        whitelist = get_local_file_whitelist(cluster, option)
-        wait_for_condition(lambda: check_local_files_gced(cluster, whitelist=whitelist))
+        wait_for_condition(lambda: check_local_files_gced(cluster))
         print("check_local_files_gced passed wait_for_condition block.")
 
     @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
@@ -240,8 +225,7 @@ class TestGC:
             ray.kill(actors[i])
             print(f"Issued ray.kill for actor {i}.")
 
-        whitelist = get_local_file_whitelist(cluster, option)
-        wait_for_condition(lambda: check_local_files_gced(cluster, whitelist))
+        wait_for_condition(lambda: check_local_files_gced(cluster))
         print("check_local_files_gced passed wait_for_condition block.")
 
     @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
@@ -338,8 +322,7 @@ class TestGC:
         wait_for_condition(check_internal_kv_gced)
         print("check_internal_kv_gced passed wait_for_condition block.")
 
-        whitelist = get_local_file_whitelist(cluster, option)
-        wait_for_condition(lambda: check_local_files_gced(cluster, whitelist=whitelist))
+        wait_for_condition(lambda: check_local_files_gced(cluster))
         print("check_local_files_gced passed wait_for_condition block.")
 
     def test_hit_cache_size_limit(


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Partially addresses #28816.  On Windows, directories that are in use cannot be deleted.  This PR allows all directories to pass the garbage collection check in the runtime_env GC test on Windows.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
