### PR TITLE
[AIR] Skip checkpoint cast if checkpoint is same type

### DIFF
--- a/python/ray/air/checkpoint.py
+++ b/python/ray/air/checkpoint.py
@@ -467,6 +467,9 @@ class Checkpoint:
             >>> model = checkpoint.get_model()  # doctest: +SKIP
             Linear(in_features=1, out_features=1, bias=True)
         """
+        if type(other) is cls:
+            return other
+
         return cls(
             local_path=other._local_path,
             data_dict=other._data_dict,

--- a/python/ray/air/tests/test_checkpoints.py
+++ b/python/ray/air/tests/test_checkpoints.py
@@ -47,6 +47,16 @@ class OtherStubCheckpoint(Checkpoint):
     pass
 
 
+def test_from_checkpoint():
+    checkpoint = Checkpoint.from_dict({"spam": "ham"})
+    assert type(StubCheckpoint.from_checkpoint(checkpoint)) is StubCheckpoint
+
+    # Check that attributes persist if same checkpoint type.
+    checkpoint = StubCheckpoint.from_dict({"spam": "ham"})
+    checkpoint.foo = "bar"
+    assert StubCheckpoint.from_checkpoint(checkpoint).foo == "bar"
+
+
 class TestCheckpointTypeCasting:
     def test_dict(self):
         data = StubCheckpoint.from_dict({"foo": "bar"}).to_dict()


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Checkpoints attributes are reset when passed to `TensorflowPredictor.from_checkpoint`. 

`TensorflowPredictor.from_checkpoint` calls `TensorflowCheckpoint.from_checkpoint`, which creates a new checkpoint with default object attributes -- even if the passed-in checkpoint is already a `TensorflowCheckpoint`.

These changes are needed to merge https://github.com/ray-project/ray/pull/28474.

## Related issue number

<!-- For example: "Closes #1234" -->

See https://github.com/ray-project/ray/pull/28474 and see https://github.com/ray-project/ray/pull/26777

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(