### PR TITLE
[core] actors are not retried when OOM killed. Switch to system exit

### DIFF
--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -158,7 +158,7 @@ def test_restartable_actor_killed_by_memory_monitor_with_actor_error(
         timeout=10,
         retry_interval_ms=100,
         tag="MemoryManager.ActorEviction.Total",
-        value=1.0,  # TODO(clarng): This should be 2. Look at why restart doesn't work
+        value=2.0,
     )
 
 

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -51,6 +51,7 @@ class ClusterManager(abc.ABC):
         self.cluster_env["env_vars"]["RAY_bootstrap_with_gcs"] = "1"
         self.cluster_env["env_vars"]["RAY_USAGE_STATS_ENABLED"] = "1"
         self.cluster_env["env_vars"]["RAY_USAGE_STATS_SOURCE"] = "nightly-tests"
+        self.cluster_env["env_vars"]["RAY_task_oom_retries"] = "15"
         self.cluster_env["env_vars"][
             "RAY_memory_monitor_interval_ms"
         ] = self.cluster_env["env_vars"].get("RAY_memory_monitor_interval_ms", "250")

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -51,7 +51,6 @@ class ClusterManager(abc.ABC):
         self.cluster_env["env_vars"]["RAY_bootstrap_with_gcs"] = "1"
         self.cluster_env["env_vars"]["RAY_USAGE_STATS_ENABLED"] = "1"
         self.cluster_env["env_vars"]["RAY_USAGE_STATS_SOURCE"] = "nightly-tests"
-        self.cluster_env["env_vars"]["RAY_task_oom_retries"] = "15"
         self.cluster_env["env_vars"][
             "RAY_memory_monitor_interval_ms"
         ] = self.cluster_env["env_vars"].get("RAY_memory_monitor_interval_ms", "250")

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -96,7 +96,7 @@ RAY_CONFIG(uint64_t, task_failure_entry_ttl_ms, 15 * 60 * 1000)
 /// the retry counter of the task or actor is only used when it fails in other ways
 /// that is not related to running out of memory. Note infinite retry (-1) is not
 /// supported.
-RAY_CONFIG(uint64_t, task_oom_retries, 3)
+RAY_CONFIG(uint64_t, task_oom_retries, 15)
 
 /// If the raylet fails to get agent info, we will retry after this interval.
 RAY_CONFIG(uint64_t, raylet_get_agent_info_interval_ms, 1)

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2985,7 +2985,7 @@ MemoryUsageRefreshCallback NodeManager::CreateMemoryUsageRefreshCallback() {
           /// since we print the process memory in the message. Destroy should be called
           /// as soon as possible to free up memory.
           DestroyWorker(high_memory_eviction_target_,
-                        rpc::WorkerExitType::USER_ERROR,
+                        rpc::WorkerExitType::INTENDED_SYSTEM_EXIT,
                         worker_exit_message,
                         true /* force */);
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2985,7 +2985,7 @@ MemoryUsageRefreshCallback NodeManager::CreateMemoryUsageRefreshCallback() {
           /// since we print the process memory in the message. Destroy should be called
           /// as soon as possible to free up memory.
           DestroyWorker(high_memory_eviction_target_,
-                        rpc::WorkerExitType::INTENDED_SYSTEM_EXIT,
+                        rpc::WorkerExitType::SYSTEM_ERROR,
                         worker_exit_message,
                         true /* force */);
 


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

Right now actors that are restartable don't restart when OOM killed. GCS does not retry actor if the failure reason is INTENDED_USER_EXIT or USER_ERROR.

This PR changes the OOM killer exit to be system error so that GCS can retry the actor.

## Related issue number

https://github.com/ray-project/ray/issues/28920

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
