### PR TITLE
[core][ci] fixed skip rule on macos for osx://python/ray/tests:test_cli

### DIFF
--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -356,7 +356,7 @@ def test_ray_start_hook(configure_lang, monkeypatch, tmp_path):
 
 
 @pytest.mark.skipif(
-    sys.platform == "darwin" and "travis" in os.environ.get("USER", ""),
+    sys.platform == "darwin",
     reason=("Mac builds don't provide proper locale support. "),
 )
 @pytest.mark.skipif(
@@ -433,7 +433,7 @@ def test_ray_start_head_block_and_signals(configure_lang, monkeypatch, tmp_path)
 
 
 @pytest.mark.skipif(
-    sys.platform == "darwin" and "travis" in os.environ.get("USER", ""),
+    sys.platform == "darwin",
     reason=("Mac builds don't provide proper locale support. "),
 )
 @pytest.mark.skipif(


### PR DESCRIPTION
Signed-off-by: rickyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
#28892 

The macOS build was supposed to be skipped due to multiprocessing issue  - the forked processes might sometime not proceed, leading to timeout. 

Skipping macos builds for the two tests. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
