### PR TITLE
[DAG] Improve object scanner

### DIFF
--- a/python/ray/dag/py_obj_scanner.py
+++ b/python/ray/dag/py_obj_scanner.py
@@ -77,9 +77,9 @@ class PyObjScanner(ray.cloudpickle.CloudPickler, Generic[SourceType, Transformed
         to internal data structures, preventing actually writing them to
         the buffer.
         """
-        if obj is _get_object or obj is _get_object:
-            # Only fall back to cloudpickle for these two functions.
-            return super().reducer_override(obj)
+        if obj is _get_object or obj is _get_unrelated_object:
+            # Handle global function with pickle.
+            return NotImplemented
         elif isinstance(obj, self._source_type):
             index = len(self.found_objects)
             self.found_objects.append(obj)

--- a/python/ray/dag/py_obj_scanner.py
+++ b/python/ray/dag/py_obj_scanner.py
@@ -1,47 +1,41 @@
 import io
-import sys
-from typing import Generic, List, Dict, Any, Type, TypeVar
-
-# For python < 3.8 we need to explicitly use pickle5 to support protocol 5
-if sys.version_info < (3, 8):
-    try:
-        import pickle5 as pickle  # noqa: F401
-    except ImportError:
-        import pickle  # noqa: F401
-else:
-    import pickle  # noqa: F401
+import threading
+from typing import Generic, List, Any, Type, TypeVar, Callable, Dict
 
 import ray
 from ray.dag.base import DAGNodeBase
+from ray.cloudpickle.compat import pickle
 
-
-# Used in deserialization hooks to reference scanner instances.
-_instances: Dict[int, "_PyObjScanner"] = {}
+_local = threading.local()
 
 # Generic types for the scanner to transform from and to.
 SourceType = TypeVar("SourceType")
 TransformedType = TypeVar("TransformedType")
 
 
-def _get_node(instance_id: int, node_index: int) -> SourceType:
-    """Get the node instance.
+def _get_object(index: int) -> SourceType:
+    """Get the object of type SourceType.
 
     Note: This function should be static and globally importable,
     otherwise the serialization overhead would be very significant.
     """
-    return _instances[instance_id]._replace_index(node_index)
+    return _local.found_objects[index]
 
 
-def _get_object(instance_id: int, node_index: int) -> Any:
+def _get_unrelated_object(index: int) -> Any:
     """Used to get arbitrary object other than SourceType.
 
     Note: This function should be static and globally importable,
     otherwise the serialization overhead would be very significant.
     """
-    return _instances[instance_id]._objects[node_index]
+    return _local.scanner.unrelated_objects[index]
 
 
-class _PyObjScanner(ray.cloudpickle.CloudPickler, Generic[SourceType, TransformedType]):
+def _in_context() -> bool:
+    return hasattr(_local, "scanner")
+
+
+class PyObjScanner(ray.cloudpickle.CloudPickler, Generic[SourceType, TransformedType]):
     """Utility to find and replace the `source_type` in Python objects.
 
     This uses pickle to walk the PyObj graph and find first-level DAGNode
@@ -52,20 +46,29 @@ class _PyObjScanner(ray.cloudpickle.CloudPickler, Generic[SourceType, Transforme
         source_type: the type of object to find and replace. Default to DAGNodeBase.
     """
 
-    def __init__(self, source_type: Type = DAGNodeBase):
-        self.source_type = source_type
+    def __init__(self, obj, source_type: Type = DAGNodeBase):
+        self._obj = obj
+        self._source_type = source_type
         # Buffer to keep intermediate serialized state.
         self._buf = io.BytesIO()
+
         # List of top-level SourceType found during the serialization pass.
-        self._found = None
+        self.found_objects: List[SourceType] = []
         # List of other objects found during the serialization pass.
         # This is used to store references to objects so they won't be
         # serialized by cloudpickle.
-        self._objects = []
-        # Replacement table to consult during deserialization.
-        self._replace_table: Dict[SourceType, TransformedType] = None
-        _instances[id(self)] = self
+        self.unrelated_objects: List[Any] = []
         super().__init__(self._buf)
+
+    def __enter__(self):
+        if _in_context():
+            raise RuntimeError("Cannot use object scanner in a nested way.")
+        _local.scanner = self
+        self.dump(self._obj)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        del _local.scanner  # cleanup
 
     def reducer_override(self, obj):
         """Hook for reducing objects.
@@ -74,42 +77,70 @@ class _PyObjScanner(ray.cloudpickle.CloudPickler, Generic[SourceType, Transforme
         to internal data structures, preventing actually writing them to
         the buffer.
         """
-        if obj is _get_node or obj is _get_object:
+        if obj is _get_object or obj is _get_object:
             # Only fall back to cloudpickle for these two functions.
             return super().reducer_override(obj)
-        elif isinstance(obj, self.source_type):
-            index = len(self._found)
-            self._found.append(obj)
-            return _get_node, (id(self), index)
+        elif isinstance(obj, self._source_type):
+            index = len(self.found_objects)
+            self.found_objects.append(obj)
+            return _get_object, (index,)
         else:
-            index = len(self._objects)
-            self._objects.append(obj)
-            return _get_object, (id(self), index)
+            index = len(self.unrelated_objects)
+            self.unrelated_objects.append(obj)
+            return _get_unrelated_object, (index,)
 
-    def find_nodes(self, obj: Any) -> List[SourceType]:
-        """Find top-level DAGNodes."""
-        assert (
-            self._found is None
-        ), "find_nodes cannot be called twice on the same PyObjScanner instance."
-        self._found = []
-        self._objects = []
-        self.dump(obj)
-        return self._found
+    def replace_with_list(self, replace_list: List[TransformedType]):
+        """Replace found objects with a list.
 
-    def replace_nodes(self, table: Dict[SourceType, TransformedType]) -> Any:
-        """Replace previously found DAGNodes per the given table."""
-        assert self._found is not None, "find_nodes must be called first"
-        self._replace_table = table
+        Args:
+            replace_list: The list to replace the found objects.
+        """
+        if not _in_context():
+            raise RuntimeError("PyObjScanner must be used under 'with' context.")
+        if len(replace_list) != len(self.found_objects):
+            raise ValueError(
+                "The length of the replacement list should be same "
+                "as the found objects."
+            )
+        self.found_objects = replace_list
+
+    def replace_with_func(
+        self,
+        replace_func: Callable[[SourceType], TransformedType],
+        cache_inputs: bool = True,
+    ):
+        """Replace found objects with a function.
+
+        Args:
+            replace_func: The function that transforms the found objects.
+            cache_inputs: If True, the function would apply to the same objects
+                only once.
+        """
+        if not _in_context():
+            raise RuntimeError("PyObjScanner must be used under 'with' context.")
+        if cache_inputs:
+            replace_list = []
+            replace_table = {}
+            for v in self.found_objects:
+                if v not in replace_table:
+                    replace_table[v] = replace_func(v)
+                replace_list.append(replace_table[v])
+        else:
+            replace_list = [replace_func(v) for v in self.found_objects]
+        self.replace_with_list(replace_list)
+
+    def replace_with_dict(self, replace_dict: Dict[SourceType, TransformedType]):
+        """Replace found objects with a dict.
+
+        Args:
+            replace_dict: The dict to replace the found objects.
+        """
+        self.replace_with_func(replace_dict.__getitem__, False)
+
+    def reconstruct(self):
+        """Reconstruct the object. If objects in 'found_objects' are replaced,
+        these objects would reveal in the reconstructed object."""
+        if not _in_context():
+            raise RuntimeError("PyObjScanner must be used under 'with' context.")
         self._buf.seek(0)
         return pickle.load(self._buf)
-
-    def _replace_index(self, i: int) -> SourceType:
-        return self._replace_table[self._found[i]]
-
-    def clear(self):
-        """Clear the scanner from the _instances"""
-        if id(self) in _instances:
-            del _instances[id(self)]
-
-    def __del__(self):
-        self.clear()


### PR DESCRIPTION
Signed-off-by: Siyuan <suquark@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR improves object scanner in several ways:
1. Make object scanner thread-safe
2. Enable nesting the object scanner properly (use scanner inside another scanner).
3. Use context to prevent memory leaking (previously we need to manually call `scanner.clear()`)
4. Enhanced API, add support for replacement with function & list
5. Replace "node" with "object" in the code, because the object scanner already serves a more general purpose (handling any objects instead of just DAGs) in the code.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
