### PR TITLE
[Docs] Fix to the instructions for launching Ray on GCP

### DIFF
--- a/doc/source/cluster/vms/user-guides/launching-clusters/gcp.md
+++ b/doc/source/cluster/vms/user-guides/launching-clusters/gcp.md
@@ -1,4 +1,3 @@
-
 # Launching Ray Clusters on GCP
 
 This guide details the steps needed to start a Ray cluster in GCP.
@@ -7,7 +6,7 @@ To start a GCP Ray cluster, you will use the Ray cluster launcher with the Googl
 
 ## Install Ray cluster launcher
 
-The Ray cluster launcher is part of the `ray` CLI. Use the CLI to start, stop and attach to a running ray cluster using commands such as  `ray up`, `ray down` and `ray attach`. You can use pip to install the ray CLI with cluster launcher support. Follow [the Ray installation documentation](installation) for more detailed instructions.
+The Ray cluster launcher is part of the `ray` CLI. Use the CLI to start, stop and attach to a running ray cluster using commands such as `ray up`, `ray down` and `ray attach`. You can use pip to install the ray CLI with cluster launcher support. Follow [the Ray installation documentation](installation) for more detailed instructions.
 
 ```bash
 # install ray
@@ -19,7 +18,6 @@ pip install -U ray[default]
 If you have never created a Google APIs Console project, read google Cloud's [Managing Projects page](https://cloud.google.com/resource-manager/docs/creating-managing-projects?visit_id=637952351450670909-433962807&rd=1) and create a project in the [Google API Console](https://console.developers.google.com/).
 Next, install the Google API Client using `pip install -U google-api-python-client`.
 
-
 ```bash
 # Install the Google API Client.
 pip install google-api-python-client
@@ -29,12 +27,11 @@ pip install google-api-python-client
 
 Once the Google API client is configured to manage resources on your GCP account, you should be ready to launch your cluster. The provided [cluster config file](https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/gcp/example-full.yaml) will create a small cluster with an on-demand n1-standard-2 head node and is configured to autoscale to up to two n1-standard-2 [preemptible workers](https://cloud.google.com/preemptible-vms/). Note that you'll need to fill in your GCP [project_id](https://github.com/ray-project/ray/blob/eacc763c84d47c9c5b86b26a32fd62c685be84e6/python/ray/autoscaler/gcp/example-full.yaml#L42) in those templates.
 
-
 Test that it works by running the following commands from your local machine:
 
 ```bash
 # Download the example-full.yaml
-wget https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/gcp/example-full.yaml
+wget https://raw.githubusercontent.com/ray-project/ray/master/python/ray/autoscaler/gcp/example-full.yaml
 
 # Edit the example-full.yaml to update project_id.
 # vi example-full.yaml
@@ -57,7 +54,6 @@ ray down example-full.yaml
 Congrats, you have started a Ray cluster on GCP!
 
 ## GCP Configurations
-
 
 ### Running workers with Service Accounts
 


### PR DESCRIPTION
## Why are these changes needed?

A fix to the instructions for launching to GCP. The command should pull the raw `.yaml` file as opposed to github's HTML page.

See similar sibling documentation for AWS and Azure where this fix has already been implemented:
https://github.com/ray-project/ray/blob/master/doc/source/cluster/vms/user-guides/launching-clusters/aws.md?plain=1#L45

Additionally running our project's linter on the `gcp.md` file.

## Related issue number

N/A

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
