### PR TITLE
Convert floats to integers before using randrange

### DIFF
--- a/rllib/evaluation/episode.py
+++ b/rllib/evaluation/episode.py
@@ -89,7 +89,7 @@ class Episode:
         self.total_reward: float = 0.0
         self.length: int = 0
         self.started = False
-        self.episode_id: int = random.randrange(2e9)
+        self.episode_id: int = random.randrange(int(2e9))
         self.env_id = env_id
         self.worker = worker
         self.agent_rewards: Dict[Tuple[AgentID, PolicyID], float] = defaultdict(float)
@@ -124,7 +124,7 @@ class Episode:
         same env (i.e., if `soft_horizon` is set).
         """
         self.length = 0
-        self.episode_id = random.randrange(2e9)
+        self.episode_id = random.randrange(int(2e9))
         self.total_reward = 0.0
         self.agent_rewards = defaultdict(float)
         self._agent_reward_history = defaultdict(list)

--- a/rllib/evaluation/episode_v2.py
+++ b/rllib/evaluation/episode_v2.py
@@ -43,7 +43,7 @@ class EpisodeV2:
             worker: The RolloutWorker instance, in which this episode runs.
         """
         # Unique id identifying this trajectory.
-        self.episode_id: int = random.randrange(2e9)
+        self.episode_id: int = random.randrange(int(2e9))
         # ID of the environment this episode is tracking.
         self.env_id = env_id
         # Summed reward across all agents in this episode.


### PR DESCRIPTION
## Why are these changes needed?

Some lines in RLlib cause this warning:

```
DeprecationWarning: non-integer arguments to randrange() have been deprecated since Python 3.10 and will be removed in a subsequent version
```

## Related issue number

Fixes #28961

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
