### PR TITLE
Remove unnecessary link in documentation

### DIFF
--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -198,7 +198,7 @@ Ray has experimental support for machines running Apple Silicon (such as M1 macs
 
    * ``bash Miniforge3-MacOSX-arm64.sh``
 
-   * ``rm https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh # Cleanup.``
+   * ``rm Miniforge3-MacOSX-arm64.sh # Cleanup.``
 
 #. Ensure you're using the miniforge environment (you should see (base) in your terminal).
 


### PR DESCRIPTION

## Why are these changes needed?

A small documentation fix that refers to the URL instead of the local file that has to be cleaned up. 

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
