### PR TITLE
[RLlib] Stop rllib from "silently" selecting atari preprocessors.

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -718,6 +718,7 @@ class AlgorithmConfig:
         if no_done_at_end is not None:
             self.no_done_at_end = no_done_at_end
         if preprocessor_pref is not None:
+            assert preprocessor_pref in ("rllib", "deepmind", None)
             self.preprocessor_pref = preprocessor_pref
         if observation_filter is not None:
             self.observation_filter = observation_filter

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -528,8 +528,7 @@ class RolloutWorker(ParallelIteratorWorker):
                     return env
 
             elif (
-                is_atari(self.env)
-                and not model_config.get("custom_preprocessor")
+                not model_config.get("custom_preprocessor")
                 and preprocessor_pref is None
             ):
                 # Only turn off preprocessing

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -497,6 +497,7 @@ class RolloutWorker(ParallelIteratorWorker):
             # algorithm trainer.
             if validate_env is not None:
                 validate_env(self.env, self.env_context)
+
             # We can't auto-wrap a BaseEnv.
             if isinstance(self.env, (BaseEnv, ray.actor.ActorHandle)):
 
@@ -509,7 +510,6 @@ class RolloutWorker(ParallelIteratorWorker):
                 and not model_config.get("custom_preprocessor")
                 and preprocessor_pref == "deepmind"
             ):
-
                 # Deepmind wrappers already handle all preprocessing.
                 self.preprocessing_enabled = False
 
@@ -525,6 +525,17 @@ class RolloutWorker(ParallelIteratorWorker):
                     env = wrap_deepmind(
                         env, dim=model_config.get("dim"), framestack=use_framestack
                     )
+                    return env
+
+            elif (
+                is_atari(self.env)
+                and not model_config.get("custom_preprocessor")
+                and preprocessor_pref is None
+            ):
+                # Only turn off preprocessing
+                self.preprocessing_enabled = False
+
+                def wrap(env):
                     return env
 
             else:

--- a/rllib/models/preprocessors.py
+++ b/rllib/models/preprocessors.py
@@ -353,8 +353,23 @@ def get_preprocessor(space: gym.Space) -> type:
     if isinstance(space, (gym.spaces.Discrete, gym.spaces.MultiDiscrete)):
         preprocessor = OneHotPreprocessor
     elif obs_shape == ATARI_OBS_SHAPE:
+        logger.debug(
+            "Defaulting to RLlib's GenericPixelPreprocessor because input "
+            "space has the atari-typical shape {}. Turn this behaviour off by setting "
+            "`preprocessor_pref=None` or "
+            "`preprocessor_pref='deepmind'` or disabling the preprocessing API "
+            "altogether with `_disable_preprocessor_api=True`.".format(ATARI_OBS_SHAPE)
+        )
         preprocessor = GenericPixelPreprocessor
     elif obs_shape == ATARI_RAM_OBS_SHAPE:
+        logger.debug(
+            "Defaulting to RLlib's AtariRamPreprocessor because input "
+            "space has the atari-typical shape {}. Turn this behaviour off by setting "
+            "`preprocessor_pref=None` or "
+            "`preprocessor_pref='deepmind' or disabling the preprocessing API "
+            "altogether with `_disable_preprocessor_api=True`."
+            "`.".format(ATARI_OBS_SHAPE)
+        )
         preprocessor = AtariRamPreprocessor
     elif isinstance(space, gym.spaces.Tuple):
         preprocessor = TupleFlatteningPreprocessor


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

I myself had to debug this way back, and we have heard complaints that RLlib "silently" wraps the environment with RLlib's Atari preprocessors. The standard choice for preprocessor_pref is None, which leaves preprocessors enabled and selects Atari-style ones based on obs space shape.

## Related issue number

Closes [#8600](https://github.com/ray-project/ray/issues/8600).

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
