### PR TITLE
[Datasets] Check columns when adding rows to TableBlockBuilder

### DIFF
--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -27,8 +27,8 @@ class TableBlockBuilder(BlockBuilder[T]):
     def __init__(self, block_type):
         # The set of uncompacted Python values buffered.
         self._columns = collections.defaultdict(list)
-        # The sorted columns names of uncompacted Python values buffered.
-        self._sorted_columns_names = None
+        # The column names of uncompacted Python values buffered.
+        self._column_names = None
         # The set of compacted tables we have built so far.
         self._tables: List[Any] = []
         self._tables_size_bytes = 0
@@ -49,18 +49,18 @@ class TableBlockBuilder(BlockBuilder[T]):
                 "got {} (type {}).".format(item, type(item))
             )
 
-        item_columns_names = sorted(item.keys())
-        if self._sorted_columns_names:
+        item_column_names = item.keys()
+        if self._column_names is not None:
             # Check all added rows have same columns.
-            if item_columns_names != self._sorted_columns_names:
+            if item_column_names != self._column_names:
                 raise ValueError(
                     "Current row has different columns compared to previous rows. "
-                    f"Columns of current row: {item_columns_names}, "
-                    f"Columns of previous rows: {self._sorted_columns_names}."
+                    f"Columns of current row: {sorted(item_column_names)}, "
+                    f"Columns of previous rows: {sorted(self._column_names)}."
                 )
         else:
-            # Initialize columns names with the first added row.
-            self._sorted_columns_names = item_columns_names
+            # Initialize column names with the first added row.
+            self._column_names = item_column_names
 
         for key, value in item.items():
             self._columns[key].append(value)

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -49,7 +49,7 @@ class TableBlockBuilder(BlockBuilder[T]):
                 "got {} (type {}).".format(item, type(item))
             )
 
-        item_columns_names = sorted(list(item.keys()))
+        item_columns_names = sorted(item.keys())
         if self._sorted_columns_names:
             # Check all added rows have same columns.
             if item_columns_names != self._sorted_columns_names:


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to fix the bug in https://github.com/ray-project/ray/issues/28897. When adding rows into buffer of `TableBlockBuilder`, here we check the added row schema (columns names) to be same as previous added rows in buffer. Throw a clearer error message if columns are mismatch. Previously it produces misleading error message and outputs corrupted data. 

Added unit test and also ran the example in https://github.com/ray-project/ray/issues/28897, verified code failed with message:

```
(_map_block_nosplit pid=12925) 2022-10-03 15:24:33,955	INFO worker.py:755 -- Task failed with retryable exception: TaskID(71b133a11e1c461cffffffffffffffffffffffff01000000).
(_map_block_nosplit pid=12925) Traceback (most recent call last):
(_map_block_nosplit pid=12925)   File "python/ray/_raylet.pyx", line 733, in ray._raylet.execute_task
(_map_block_nosplit pid=12925)   File "python/ray/_raylet.pyx", line 737, in ray._raylet.execute_task
(_map_block_nosplit pid=12925)     if not (<int>task_type == <int>TASK_TYPE_ACTOR_TASK
(_map_block_nosplit pid=12925)   File "/Users/chengsu/ray/python/ray/data/_internal/compute.py", line 439, in _map_block_nosplit
(_map_block_nosplit pid=12925)     for new_block in block_fn(block, *fn_args, **fn_kwargs):
(_map_block_nosplit pid=12925)   File "/Users/chengsu/ray/python/ray/data/dataset.py", line 298, in transform
(_map_block_nosplit pid=12925)     output_buffer.add(fn(row))
(_map_block_nosplit pid=12925)   File "/Users/chengsu/ray/python/ray/data/_internal/output_buffer.py", line 45, in add
(_map_block_nosplit pid=12925)     self._buffer.add(item)
(_map_block_nosplit pid=12925)   File "/Users/chengsu/ray/python/ray/data/_internal/delegating_block_builder.py", line 36, in add
(_map_block_nosplit pid=12925)     self._builder.add(item)
(_map_block_nosplit pid=12925)   File "/Users/chengsu/ray/python/ray/data/_internal/table_block.py", line 56, in add
(_map_block_nosplit pid=12925)     raise ValueError(
(_map_block_nosplit pid=12925) ValueError: Current row has different columns compared to previous rows. Columns of current row: ['a'], Columns of previous rows: ['b'].
```

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/28897

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
