### PR TITLE
[Datasets] read_csv not filter out files by default

### DIFF
--- a/python/ray/data/datasource/csv_datasource.py
+++ b/python/ray/data/datasource/csv_datasource.py
@@ -29,7 +29,7 @@ class CSVDatasource(FileBasedDatasource):
     def _read_stream(
         self, f: "pyarrow.NativeFile", path: str, **reader_args
     ) -> Iterator[Block]:
-        import pyarrow
+        import pyarrow as pa
         from pyarrow import csv
 
         read_options = reader_args.pop(
@@ -48,18 +48,18 @@ class CSVDatasource(FileBasedDatasource):
             while True:
                 try:
                     batch = reader.read_next_batch()
-                    table = pyarrow.Table.from_batches([batch], schema=schema)
+                    table = pa.Table.from_batches([batch], schema=schema)
                     if schema is None:
                         schema = table.schema
                     yield table
                 except StopIteration:
                     return
-        except Exception as e:
-            raise type(e)(
+        except pa.lib.ArrowInvalid as e:
+            raise pa.lib.ArrowInvalid(
                 f"{e}. Failed to read CSV file: {path}. "
-                "Please check the file has correct format, or filter out file with "
-                "'partition_filter' field. See read_csv() documentation for more "
-                "details."
+                "Please check the CSV file has correct format, or filter out non-CSV "
+                "file with 'partition_filter' field. See read_csv() documentation for "
+                "more details."
             )
 
     def _write_block(

--- a/python/ray/data/datasource/csv_datasource.py
+++ b/python/ray/data/datasource/csv_datasource.py
@@ -55,12 +55,12 @@ class CSVDatasource(FileBasedDatasource):
                 except StopIteration:
                     return
         except pa.lib.ArrowInvalid as e:
-            raise pa.lib.ArrowInvalid(
-                f"{e}. Failed to read CSV file: {path}. "
+            raise ValueError(
+                f"Failed to read CSV file: {path}. "
                 "Please check the CSV file has correct format, or filter out non-CSV "
                 "file with 'partition_filter' field. See read_csv() documentation for "
                 "more details."
-            )
+            ) from e
 
     def _write_block(
         self,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -646,7 +646,7 @@ def read_csv(
             with a custom callback to read only selected partitions of a dataset.
             By default, this does not filter out any files.
             If wishing to filter out all file paths except those whose file extension
-            matches e.g. "*.csv", a ``FileExtensionFilter("csv")`` can be provided.
+            matches e.g. "*.csv*", a ``FileExtensionFilter("csv")`` can be provided.
         partitioning: A :class:`~ray.data.datasource.partitioning.Partitioning` object
             that describes how paths are organized. By default, this function parses
             `Hive-style partitions <https://athena.guide/articles/hive-style-partitioning/>`_.

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -625,7 +625,7 @@ def read_csv(
         By default, ``read_csv`` reads all files from file paths. If you want to filter
         files by file extensions, set the ``partition_filter`` parameter.
 
-        >>> # Read only "*.csv" files from multiple directories.
+        >>> # Read only *.csv files from multiple directories.
         >>> from ray.data.datasource import FileExtensionFilter
         >>> ray.data.read_csv( # doctest: +SKIP
         ...     ["s3://bucket/path1", "s3://bucket/path2"],

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -577,9 +577,7 @@ def read_csv(
     ray_remote_args: Dict[str, Any] = None,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
     meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
-    partition_filter: Optional[
-        PathPartitionFilter
-    ] = CSVDatasource.file_extension_filter(),
+    partition_filter: Optional[PathPartitionFilter] = None,
     partitioning: Partitioning = Partitioning("hive"),
     **arrow_csv_args,
 ) -> Dataset[ArrowRow]:
@@ -597,15 +595,13 @@ def read_csv(
         >>> ray.data.read_csv( # doctest: +SKIP
         ...     ["s3://bucket/path1", "s3://bucket/path2"])
 
-        >>> # Read files that use a different delimiter. The partition_filter=None is needed here
-        >>> # because by default read_csv only reads .csv files. For more uses of ParseOptions see
+        >>> # Read files that use a different delimiter. For more uses of ParseOptions see
         >>> # https://arrow.apache.org/docs/python/generated/pyarrow.csv.ParseOptions.html  # noqa: #501
         >>> from pyarrow import csv
         >>> parse_options = csv.ParseOptions(delimiter="\t")
         >>> ray.data.read_csv( # doctest: +SKIP
         ...     "example://iris.tsv",
-        ...     parse_options=parse_options,
-        ...     partition_filter=None)
+        ...     parse_options=parse_options)
 
         >>> # Convert a date column with a custom format from a CSV file.
         >>> # For more uses of ConvertOptions see
@@ -626,6 +622,15 @@ def read_csv(
         >>> ds.take(1)  # doctest: + SKIP
         [{'order_number': 10107, 'quantity': 30, 'year': '2022', 'month': '09'}
 
+        By default, ``read_csv`` reads all files from file paths. If you want to filter
+        files by file extensions, set the ``partition_filter`` parameter.
+
+        >>> # Read only "*.csv" files from multiple directories.
+        >>> from ray.data.datasource import FileExtensionFilter
+        >>> ray.data.read_csv( # doctest: +SKIP
+        ...     ["s3://bucket/path1", "s3://bucket/path2"],
+        ...     partition_filter=FileExtensionFilter("csv"))
+
     Args:
         paths: A single file/directory path or a list of file/directory paths.
             A list of paths can contain both files and directories.
@@ -639,8 +644,9 @@ def read_csv(
             be able to resolve file metadata more quickly and/or accurately.
         partition_filter: Path-based partition filter, if any. Can be used
             with a custom callback to read only selected partitions of a dataset.
-            By default, this filters out any file paths whose file extension does not
-            match "*.csv*".
+            By default, this does not filter out any files.
+            If wishing to filter out all file paths except those whose file extension
+            matches e.g. "*.csv", a ``FileExtensionFilter("csv")`` can be provided.
         partitioning: A :class:`~ray.data.datasource.partitioning.Partitioning` object
             that describes how paths are organized. By default, this function parses
             `Hive-style partitions <https://athena.guide/articles/hive-style-partitioning/>`_.

--- a/python/ray/data/tests/test_dataset_csv.py
+++ b/python/ray/data/tests/test_dataset_csv.py
@@ -23,7 +23,10 @@ from ray.data.datasource import (
     PathPartitionEncoder,
     PathPartitionFilter,
 )
-from ray.data.datasource.file_based_datasource import _unwrap_protocol
+from ray.data.datasource.file_based_datasource import (
+    FileExtensionFilter,
+    _unwrap_protocol,
+)
 
 
 def df_to_csv(dataframe, path, **kwargs):
@@ -196,7 +199,12 @@ def test_csv_read(ray_start_regular_shared, fs, data_path, endpoint_url):
         storage_options=storage_options,
     )
 
-    ds = ray.data.read_csv(path, filesystem=fs, partitioning=None)
+    ds = ray.data.read_csv(
+        path,
+        filesystem=fs,
+        partition_filter=FileExtensionFilter("csv"),
+        partitioning=None,
+    )
     assert ds.num_blocks() == 2
     df = pd.concat([df1, df2], ignore_index=True)
     dsdf = ds.to_pandas()
@@ -669,7 +677,7 @@ def test_csv_read_filter_no_file(shutdown_only, tmp_path):
 
     error_message = "No input files found to read"
     with pytest.raises(ValueError, match=error_message):
-        ray.data.read_csv(path)
+        ray.data.read_csv(path, partition_filter=FileExtensionFilter("csv"))
 
 
 @pytest.mark.skipif(

--- a/python/ray/data/tests/test_dataset_csv.py
+++ b/python/ray/data/tests/test_dataset_csv.py
@@ -669,15 +669,49 @@ def test_csv_read_with_column_type_specified(shutdown_only, tmp_path):
     assert ds.to_pandas().equals(expected_df)
 
 
-def test_csv_read_filter_no_file(shutdown_only, tmp_path):
+def test_csv_read_filter_non_csv_file(shutdown_only, tmp_path):
     df = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
-    table = pa.Table.from_pandas(df)
-    path = os.path.join(str(tmp_path), "test.parquet")
-    pq.write_table(table, path)
 
+    # Non-CSV file in Parquet format.
+    table = pa.Table.from_pandas(df)
+    path1 = os.path.join(tmp_path, "test1.parquet")
+    pq.write_table(table, path1)
+
+    # CSV file with .csv extension.
+    path2 = os.path.join(tmp_path, "test2.csv")
+    df.to_csv(path2, index=False)
+
+    # CSV file without .csv extension.
+    path3 = os.path.join(tmp_path, "test3")
+    df.to_csv(path3, index=False)
+
+    # Single non-CSV file.
+    error_message = "Failed to read CSV file"
+    with pytest.raises(pa.lib.ArrowInvalid, match=error_message):
+        ray.data.read_csv(path1)
+
+    # Single non-CSV file with filter.
     error_message = "No input files found to read"
     with pytest.raises(ValueError, match=error_message):
-        ray.data.read_csv(path, partition_filter=FileExtensionFilter("csv"))
+        ray.data.read_csv(path1, partition_filter=FileExtensionFilter("csv"))
+
+    # Single CSV file without extension.
+    ds = ray.data.read_csv(path3)
+    assert ds.to_pandas().equals(df)
+
+    # Single CSV file without extension with filter.
+    error_message = "No input files found to read"
+    with pytest.raises(ValueError, match=error_message):
+        ray.data.read_csv(path3, partition_filter=FileExtensionFilter("csv"))
+
+    # Directory of CSV and non-CSV files.
+    error_message = "Failed to read CSV file"
+    with pytest.raises(pa.lib.ArrowInvalid, match=error_message):
+        ray.data.read_csv(tmp_path)
+
+    # Directory of CSV and non-CSV files with filter.
+    ds = ray.data.read_csv(tmp_path, partition_filter=FileExtensionFilter("csv"))
+    assert ds.to_pandas().equals(df)
 
 
 @pytest.mark.skipif(

--- a/python/ray/data/tests/test_dataset_csv.py
+++ b/python/ray/data/tests/test_dataset_csv.py
@@ -650,7 +650,7 @@ def test_csv_read_with_column_type_specified(shutdown_only, tmp_path):
 
     # Incorrect to parse scientific notation in int64 as PyArrow represents
     # it as double.
-    with pytest.raises(pa.lib.ArrowInvalid):
+    with pytest.raises(ValueError):
         ray.data.read_csv(
             file_path,
             convert_options=csv.ConvertOptions(
@@ -691,7 +691,7 @@ def test_csv_read_filter_non_csv_file(shutdown_only, tmp_path):
 
     # Single non-CSV file.
     error_message = "Failed to read CSV file"
-    with pytest.raises(pa.lib.ArrowInvalid, match=error_message):
+    with pytest.raises(ValueError, match=error_message):
         ray.data.read_csv(path3)
 
     # Single non-CSV file with filter.
@@ -710,7 +710,7 @@ def test_csv_read_filter_non_csv_file(shutdown_only, tmp_path):
 
     # Directory of CSV and non-CSV files.
     error_message = "Failed to read CSV file"
-    with pytest.raises(pa.lib.ArrowInvalid, match=error_message):
+    with pytest.raises(ValueError, match=error_message):
         ray.data.read_csv(tmp_path)
 
     # Directory of CSV and non-CSV files with filter.


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently `read_csv` filters out files without `.csv` extension when reading. This behavior seems to be surprising to users, and reported to be bad user experience in 3+ user reports (https://github.com/ray-project/ray/issues/26605). We should change to NOT filter files by default.

Verified Arrow (https://arrow.apache.org/docs/python/csv.html) and Spark (https://spark.apache.org/docs/latest/sql-data-sources-csv.html) does not filter out CSV files by default. I don't see a strong reason why we want to do it in a different way in Ray.

Added documentation in case users want to use `partition_filter` to filter out files, and gave an example to filter out files with `.csv` extension.

Also improve the error message when reading CSV file:

```
>>> 2022-10-03 23:20:02,578	ERROR worker.py:400 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): ray::_execute_read_task() (pid=47372, ip=127.0.0.1)
  File "pyarrow/_csv.pyx", line 942, in pyarrow._csv.open_csv
  File "pyarrow/_csv.pyx", line 834, in pyarrow._csv.CSVStreamingReader._open
  File "pyarrow/error.pxi", line 143, in pyarrow.lib.pyarrow_internal_check_status
  File "pyarrow/error.pxi", line 99, in pyarrow.lib.check_status
pyarrow.lib.ArrowInvalid: CSV parse error: Row #2: Expected 4 columns, got 5: {"a": [3, 4, 5], "b": {"c": false, "d": "2019-04-01"}}

During handling of the above exception, another exception occurred:

ray::_execute_read_task() (pid=47372, ip=127.0.0.1)
  File "/Users/chengsu/ray/python/ray/data/_internal/lazy_block_list.py", line 580, in _execute_read_task
    block = task()
  File "/Users/chengsu/ray/python/ray/data/datasource/datasource.py", line 202, in __call__
    for block in result:
  File "/Users/chengsu/ray/python/ray/data/datasource/file_based_datasource.py", line 475, in read_files
    for data in read_stream(f, read_path, **reader_args):
  File "/Users/chengsu/ray/python/ray/data/datasource/csv_datasource.py", line 58, in _read_stream
    raise type(e)(f"{e}. Failed to read CSV file: {path}. "
pyarrow.lib.ArrowInvalid: CSV parse error: Row #2: Expected 4 columns, got 5: {"a": [3, 4, 5], "b": {"c": false, "d": "2019-04-01"}}. Failed to read CSV file: /Users/chengsu/try/json/test. Please check the file has correct format, or filter out file with 'partition_filter' field. See read_csv() documentation for more details.
```

## Related issue number
Closes https://github.com/ray-project/ray/issues/26605

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
