### PR TITLE
[release/rllib] Fix long running impala disk size

### DIFF
--- a/release/long_running_tests/tpl_cpu_1_large.yaml
+++ b/release/long_running_tests/tpl_cpu_1_large.yaml
@@ -26,5 +26,5 @@ aws:
   BlockDeviceMappings:
     - DeviceName: /dev/sda1
       Ebs:
-        VolumeSize: 202
+        VolumeSize: 300
         DeleteOnTermination: true

--- a/release/tune_tests/scalability_tests/tpl_1x32_hd.yaml
+++ b/release/tune_tests/scalability_tests/tpl_1x32_hd.yaml
@@ -26,4 +26,4 @@ aws:
 #  BlockDeviceMappings:
 #    - DeviceName: /dev/sda1
 #      Ebs:
-#        VolumeSize: 202
+#        VolumeSize: 300


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See e.g. https://github.com/ray-project/ray/pull/28156

Anyscale uses snapshots with 300GB disk size, but it does not automatically increase requested disks to this size. Thus, if we try to allocate a smaller volume, we run into an error message:

```
Volume of size 202GB is smaller than snapshot 'snap-015ea2bc47d946da2', expect size >= 300GB
```

This PR adjusts the size of the long running impala test to 300GB.

## Related issue number

Closes #29023

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
