### PR TITLE
[ci/release] Nightly long running should be smoke tests, fix nightly-3x

### DIFF
--- a/release/ray_release/buildkite/settings.py
+++ b/release/ray_release/buildkite/settings.py
@@ -23,7 +23,7 @@ frequency_str_to_enum = {
     "any-smoke": Frequency.ANY,
     "multi": Frequency.MULTI,
     "nightly": Frequency.NIGHTLY,
-    "nightly-3x": Frequency.NIGHTLY,
+    "nightly-3x": Frequency.NIGHTLY_3x,
     "weekly": Frequency.WEEKLY,
 }
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -149,7 +149,7 @@
     frequency: disabled
 
     run:
-      timeout: 1800
+      timeout: 3600
 
   alert: default
 
@@ -1755,7 +1755,7 @@
     test_name: actor_deaths
     test_suite: long_running_tests
 
-  frequency: nightly
+  frequency: weekly
   team: core
   cluster:
     cluster_env: app_config.yaml
@@ -1770,7 +1770,7 @@
     file_manager: sdk
 
   smoke_test:
-    frequency: disabled
+    frequency: nightly
 
     run:
       timeout: 3600
@@ -1784,7 +1784,7 @@
     test_name: apex
     test_suite: long_running_tests
 
-  frequency: nightly
+  frequency: weekly
   team: ml
   env: staging
   cluster:
@@ -1802,7 +1802,7 @@
     file_manager: sdk
 
   smoke_test:
-    frequency: disabled
+    frequency: nightly
 
     run:
       timeout: 3600
@@ -1816,7 +1816,7 @@
     test_name: impala
     test_suite: long_running_tests
 
-  frequency: nightly
+  frequency: weekly
   team: ml
   env: staging
   cluster:
@@ -1831,7 +1831,7 @@
     file_manager: sdk
 
   smoke_test:
-    frequency: disabled
+    frequency: nightly
 
     run:
       timeout: 3600
@@ -1845,7 +1845,7 @@
     test_name: many_actor_tasks
     test_suite: long_running_tests
 
-  frequency: nightly
+  frequency: weekly
   team: core
   cluster:
     cluster_env: app_config.yaml
@@ -1860,7 +1860,7 @@
     file_manager: sdk
 
   smoke_test:
-    frequency: disabled
+    frequency: nightly
 
     run:
       timeout: 3600
@@ -1874,7 +1874,7 @@
     test_name: many_drivers
     test_suite: long_running_tests
 
-  frequency: nightly
+  frequency: weekly
   team: core
   cluster:
     cluster_env: app_config.yaml
@@ -1889,7 +1889,7 @@
     file_manager: sdk
 
   smoke_test:
-    frequency: disabled
+    frequency: nightly
 
     run:
       timeout: 3600
@@ -1905,7 +1905,7 @@
 
   stable: false
 
-  frequency: nightly
+  frequency: weekly
   team: ml
   env: staging
   cluster:
@@ -1923,7 +1923,7 @@
     file_manager: sdk
 
   smoke_test:
-    frequency: disabled
+    frequency: nightly
 
     run:
       timeout: 3600
@@ -1937,7 +1937,7 @@
     test_name: many_tasks
     test_suite: long_running_tests
 
-  frequency: nightly
+  frequency: weekly
   team: core
   cluster:
     cluster_env: app_config.yaml
@@ -1952,7 +1952,7 @@
     file_manager: sdk
 
   smoke_test:
-    frequency: disabled
+    frequency: nightly
 
     run:
       timeout: 3600
@@ -1966,7 +1966,7 @@
     test_name: many_tasks_serialized_ids
     test_suite: long_running_tests
 
-  frequency: nightly
+  frequency: weekly
   team: core
   cluster:
     cluster_env: app_config.yaml
@@ -1981,7 +1981,7 @@
     file_manager: sdk
 
   smoke_test:
-    frequency: disabled
+    frequency: nightly
 
     run:
       timeout: 3600
@@ -1995,7 +1995,7 @@
     test_name: node_failures
     test_suite: long_running_tests
 
-  frequency: nightly
+  frequency: weekly
   team: core
   cluster:
     cluster_env: app_config.yaml
@@ -2010,7 +2010,7 @@
     file_manager: sdk
 
   smoke_test:
-    frequency: disabled
+    frequency: nightly
 
     run:
       timeout: 3600
@@ -2024,7 +2024,7 @@
     test_name: pbt
     test_suite: long_running_tests
 
-  frequency: nightly
+  frequency: weekly
   team: ml
   env: staging
   cluster:
@@ -2040,7 +2040,7 @@
     file_manager: sdk
 
   smoke_test:
-    frequency: disabled
+    frequency: nightly
 
     run:
       timeout: 3600
@@ -2054,7 +2054,7 @@
     test_name: serve
     test_suite: long_running_tests
 
-  frequency: nightly
+  frequency: weekly
   team: serve
   cluster:
     cluster_env: app_config.yaml
@@ -2069,7 +2069,7 @@
     file_manager: job
 
   smoke_test:
-    frequency: disabled
+    frequency: nightly
 
     run:
       timeout: 3600
@@ -2086,7 +2086,7 @@
     test_name: serve_failure
     test_suite: long_running_tests
 
-  frequency: nightly
+  frequency: weekly
   team: serve
   cluster:
     cluster_env: app_config.yaml
@@ -2101,7 +2101,7 @@
     file_manager: job
 
   smoke_test:
-    frequency: disabled
+    frequency: nightly
 
     run:
       timeout: 600


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

First, this fixes a bug where the `nightly-3x` string was parsed incorrectly, which effectively started nightly tests and not the nightly-3x tests.

Second, this activates smoke tests for the long running tests for nightly tests, and moves the full tests to a weekly schedule. This is to avoid occupying too many instances during the week and save costs. Also, most failures happen earlier in the run, so it is sufficient to test a 24h workload once a week.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
