### PR TITLE
[docs] Remove backpressure from batch training nb

### DIFF
--- a/doc/source/ray-core/examples/batch_training.ipynb
+++ b/doc/source/ray-core/examples/batch_training.ipynb
@@ -292,7 +292,7 @@
    "source": [
     "The `task` Ray task contains all logic necessary to load a data batch, transform it and fit and evaluate models on it.\n",
     "\n",
-    "You may notice that we have previously defined `fit_and_score_sklearn` as a Ray task as well and set it to be executed from inside `task`. This allows us to dynamically create a {doc}`tree of tasks </ray-core/tasks/patterns/tree-of-tasks>`, ensuring that the cluster resources are fully utillized. Without this pattern, each `task` would need to be assigned several CPU cores for the model fitting, meaning that if certain models finish faster, then those CPU cores would stil stay occupied. Thankfully, Ray is able to deal with nested parallelism in tasks without the need for any extra logic, allowing us to simplify the code."
+    "You may notice that we have previously defined `fit_and_score_sklearn` as a Ray task as well and set it to be executed from inside `task`. This allows us to dynamically create a [tree of tasks](task-pattern-tree-of-tasks), ensuring that the cluster resources are fully utillized. Without this pattern, each `task` would need to be assigned several CPU cores for the model fitting, meaning that if certain models finish faster, then those CPU cores would stil stay occupied. Thankfully, Ray is able to deal with nested parallelism in tasks without the need for any extra logic, allowing us to simplify the code."
    ]
   },
   {
@@ -359,7 +359,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, the `run` driver function generates tasks for each Parquet file it recieves (with each file corresponding to one month). We define the function to take in a list of models, so that we can evaluate them all and choose the best one for each batch. In order to not overload cluster and cause OOM, we use `ray.wait()` to limit the number of in-flight tasks - see details about this design pattern in {doc}`/ray-core/patterns/limit-tasks`."
+    "Finally, the `run` driver function generates tasks for each Parquet file it recieves (with each file corresponding to one month). We define the function to take in a list of models, so that we can evaluate them all and choose the best one for each batch. The function blocks when it reaches `ray.get()` and waits for tasks to return their results."
    ]
   },
   {
@@ -372,31 +372,8 @@
     "    print(\"Starting run...\")\n",
     "    start = time.time()\n",
     "\n",
-    "    # NOTE: This should be set to a number that's large enough (e.g. at least\n",
-    "    # the number of CPUs in the cluster, usually can be even larger) to enable good\n",
-    "    # parallelization. In practice you can start with sys.maxsize (i.e. no limit),\n",
-    "    # and scale down if you have massive number of tasks causing overload/OOM the node.\n",
-    "    import sys\n",
-    "\n",
-    "    max_in_flight_tasks = sys.maxsize\n",
-    "    result_refs = []\n",
-    "    results = []\n",
-    "\n",
-    "    # Launch all training tasks.\n",
-    "    for ref in task_generator(files, models):\n",
-    "        # Apply backpressure: when there are more than max_in_flight_tasks tasks pending,\n",
-    "        # we wait with ray.wait() untill one of the object ref is ready.\n",
-    "        if len(result_refs) > max_in_flight_tasks:\n",
-    "            num_ready = len(result_refs) - max_in_flight_tasks\n",
-    "            newly_completed, result_refs = ray.wait(result_refs, num_returns=num_ready)\n",
-    "            for completed_ref in newly_completed:\n",
-    "                results.append(ray.get(completed_ref))\n",
-    "\n",
-    "        result_refs.append(ref)\n",
-    "\n",
-    "    # Wait the remaining pending tasks to complete.\n",
-    "    newly_completed, result_refs = ray.wait(result_refs, num_returns=len(result_refs))\n",
-    "    results.extend(ray.get(newly_completed))\n",
+    "    task_refs = list(task_generator(files, models))\n",
+    "    results = ray.get(task_refs)\n",
     "\n",
     "    taken = time.time() - start\n",
     "    count = len(results)\n",
@@ -520,7 +497,7 @@
     "\n",
     "In order to ensure that the data can always fit in memory, each task reads the files independently and extracts the desired data batch. This, however, negatively impacts the runtime. If we have sufficient memory in our Ray cluster, we can instead load each partition once, extract the batches, and save them in the [Ray object store](objects-in-ray), reducing time required dramatically at a cost of higher memory usage.\n",
     "\n",
-    "Notice we do not call `ray.get()` on the references of the `read_into_object_store`. Instead, we pass the reference itself as the argument to the `task.remote` dispatch, {doc}`allowing for the data to stay in the object store until it is actually needed </ray-core/patterns/pass-large-arg-by-value>`. This avoids a situation where all the data would be loaded into the memory of the process calling `ray.get()`.\n",
+    "Notice we do not call `ray.get()` on the references of the `read_into_object_store`. Instead, we pass the reference itself as the argument to the `task.remote` dispatch, [allowing for the data to stay in the object store until it is actually needed](ray-pass-large-arg-by-value). This avoids a situation where all the data would be loaded into the memory of the process calling `ray.get()`.\n",
     "\n",
     "You can use the Ray Dashboard to compare the memory usage between the previous approach and this one."
    ]

--- a/doc/source/ray-core/patterns/pass-large-arg-by-value.rst
+++ b/doc/source/ray-core/patterns/pass-large-arg-by-value.rst
@@ -1,3 +1,5 @@
+.. _ray-pass-large-arg-by-value:
+
 Anti-pattern: Passing the same large argument by value repeatedly harms performance
 ===================================================================================
 

--- a/doc/source/ray-core/tasks/patterns/tree-of-tasks.rst
+++ b/doc/source/ray-core/tasks/patterns/tree-of-tasks.rst
@@ -1,3 +1,5 @@
+.. _task-pattern-tree-of-tasks:
+
 Pattern: Tree of tasks
 ======================
 


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Removes backpressure from the batch training with core example after offline discussion. Also adds refs instead of linking to docs.


Context: the number of running tasks should be limited via resources not `ray.wait()`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
