### PR TITLE
[CI] Fix linkcheck with `JobSubmissionClient`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -183,7 +183,7 @@ linkcheck_ignore = [
     r"https://www.meetup.com/*",  # seems to be flaky
     r"https://www.pettingzoo.ml/*",  # seems to be flaky
     r"http://localhost[:/].*",  # Ignore localhost links
-    r"http:/",  # Ignore incomplete links
+    r"^http:/$",  # Ignore incomplete links
 ]
 
 # -- Options for HTML output ----------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -183,7 +183,7 @@ linkcheck_ignore = [
     r"https://www.meetup.com/*",  # seems to be flaky
     r"https://www.pettingzoo.ml/*",  # seems to be flaky
     r"http://localhost[:/].*",  # Ignore localhost links
-    r"http://<.*",  # Ignore docstrings examples, eg. http://<head-node-ip>:8265
+    r"http:/",  # Ignore incomplete links
 ]
 
 # -- Options for HTML output ----------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -183,6 +183,7 @@ linkcheck_ignore = [
     r"https://www.meetup.com/*",  # seems to be flaky
     r"https://www.pettingzoo.ml/*",  # seems to be flaky
     r"http://localhost[:/].*",  # Ignore localhost links
+    r"http://<.*",  # Ignore docstrings examples, eg. http://<head-node-ip>:8265
 ]
 
 # -- Options for HTML output ----------------------------------------------


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes linkcheck failure introduced in https://github.com/ray-project/ray/commit/1bd3f940db4db4d3e96f1498f0c2d4e4929694c5

The issue is that in the docstring of `JobSubmissionClient` linkcheck strips `"http://<head-node-ip>:8265"` to `http:/` and checks that (which obviously fails). The fix is to make linkcheck ignore `http:/`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
