### PR TITLE
[runtime env] [jobs] [Ray Client] Bump pinned URI timeout for uploading local working_dir for jobs and Client

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -69,8 +69,10 @@ RAY_RUNTIME_ENV_ENVIRONMENT_VARIABLE = "RAY_RUNTIME_ENV"
 RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_ENV_VAR = (
     "RAY_RUNTIME_ENV_TEMPORARY_REFERENCE_EXPIRATION_S"
 )
-# Defaults to 30 seconds. This should be enough time for the job to start.
-RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_DEFAULT = 30
+# Defaults to 10 minutes. This should be longer than the total time it takes for
+# the local working_dir and py_modules to be uploaded, or these files might get
+# garbage collected before the job starts.
+RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_DEFAULT = 10 * 60
 RAY_STORAGE_ENVIRONMENT_VARIABLE = "RAY_STORAGE"
 # Hook for running a user-specified runtime-env hook. This hook will be called
 # unconditionally given the runtime_env dict passed for ray.init. It must return

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -649,8 +649,8 @@ async def download_and_unpack_package(
                         "long upload time or a problem with Ray. Try setting the "
                         "environment variable "
                         f"{RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_ENV_VAR} "
-                        " to a value larger than the upload time in seconds (default 30). "
-                        "If this fails, try re-running "
+                        " to a value larger than the upload time in seconds "
+                        "(the default is 30). If this fails, try re-running "
                         "after making any change to a file in the file package."
                     )
                 code = code or b""

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -646,8 +646,12 @@ async def download_and_unpack_package(
                         f"Failed to download runtime_env file package {pkg_uri} "
                         "from the GCS to the Ray worker node. The package may "
                         "have prematurely been deleted from the GCS due to a "
-                        "problem with Ray. Try re-running the statement or "
-                        "restarting the Ray cluster."
+                        "long upload time or a problem with Ray. Try setting the "
+                        "environment variable "
+                        f"{RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_ENV_VAR} "
+                        " to a value larger than the upload time in seconds (default 30). "
+                        "If this fails, try re-running "
+                        "after making any change to a file in the file package."
                     )
                 code = code or b""
                 pkg_file.write_bytes(code)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Debugged with @tchordia and @wuisawesome.

We have a temporary reference serving as a lease to prevent an uploaded local working_dir/py_modules from being garbage collected from the GCS before the job starts (in Ray Job Submission) or before the driver starts (in the case of Ray Client) See https://github.com/ray-project/ray/pull/24719 for more context about this.

However, the upload time can be longer than the default 30s lifetime of the temporary reference.  This leads to the following scenario, which was already noticed by @iycheng in the previous PR and which we recently witnessed for a user:

1. Job is submitted
2. Check if working_dir already exists on cluster.  It doesn't exist. 
3. Add a temporary reference
4. Begin to upload a large working_dir
5. Before the upload is complete, the reference expires, causing the working_dir to be deleted from the GCS
6.  On the cluster, the job driver starts and tries to pull the working_dir from the GCS, but it doesn't exist.

This PR mitigates the issue by bumping the default timeout from 30s to 10 minutes.  The PR also improves the error message for this scenario by including the name of the environment variable which configures the timeout.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
