### PR TITLE
[AIR - Datasets] Unrevert "Ragged tensor extension type. (#27625)"

### DIFF
--- a/doc/source/data/api/data_representations.rst
+++ b/doc/source/data/api/data_representations.rst
@@ -46,3 +46,9 @@ Tensor Column Extension API
 
 .. autoclass:: ray.data.extensions.tensor_extension.ArrowTensorArray
     :members:
+
+.. autoclass:: ray.data.extensions.tensor_extension.ArrowVariableShapedTensorType
+    :members:
+
+.. autoclass:: ray.data.extensions.tensor_extension.ArrowVariableShapedTensorArray
+    :members:

--- a/doc/source/data/dataset-tensor-support.rst
+++ b/doc/source/data/dataset-tensor-support.rst
@@ -3,18 +3,18 @@
 ML Tensor Support
 =================
 
-Tensor (multi-dimensional array) data is ubiquitous in ML workloads. However, popular data formats such as Pandas, Parquet, and Arrow don't natively support tensor data types. To bridge this gap, Datasets provides a unified tensor data type that can be used to represent and store tensor data:
+Tensor (multi-dimensional array) data is ubiquitous in ML workloads. However, popular data formats such as Pandas, Parquet, and Arrow don't natively support tensor data types. To bridge this gap, Datasets provides a unified tensor data type that can be used to represent, transform, and store tensor data:
 
 * For Pandas, Datasets will transparently convert ``List[np.ndarray]`` columns to and from the :class:`TensorDtype <ray.data.extensions.tensor_extension.TensorDtype>` extension type.
-* For Parquet, the Datasets Arrow extension :class:`ArrowTensorType <ray.data.extensions.tensor_extension.ArrowTensorType>` allows Tensors to be loaded and stored in Parquet format.
-* In addition, single-column Tensor datasets can be created from NumPy (.npy) files.
+* For Parquet, Datasets has an Arrow extension :class:`ArrowTensorType <ray.data.extensions.tensor_extension.ArrowTensorType>` that allows tensors to be loaded from and stored in the Parquet format.
+* In addition, single-column tensor datasets can be created from NumPy (.npy) files.
 
-Datasets automatically converts between the extension types/arrays above. This means you can just think of "Tensors" as a single first-class data type in Datasets.
+Datasets automatically converts between the extension types/arrays above. This means you can think of a ``Tensor`` as a first-class data type in Datasets.
 
 Creating Tensor Datasets
 ------------------------
 
-This section shows how to create single and multi-column Tensor datasets.
+This section shows how to create single and multi-column tensor datasets.
 
 .. tabbed:: Synthetic Data
 
@@ -48,7 +48,7 @@ This section shows how to create single and multi-column Tensor datasets.
 
 .. tabbed:: NumPy
 
-  Create from in-memory numpy data or from previously saved NumPy (.npy) files.
+  Create from in-memory NumPy data or from previously saved NumPy (.npy) files.
 
   **Single-column only**:
 
@@ -59,13 +59,13 @@ This section shows how to create single and multi-column Tensor datasets.
 
 .. tabbed:: Parquet
 
-  There are two ways to construct a parquet Tensor dataset: (1) loading a
-  previously-saved Tensor dataset, or (2) casting non-Tensor parquet columns to Tensor
+  There are two ways to construct a Parquet tensor dataset: (1) loading a
+  previously-saved tensor dataset, or (2) casting non-tensor Parquet columns to tensor
   type. When casting data, a tensor schema or deserialization
   :ref:`user-defined function <transform_datasets_writing_udfs>`  must be provided. The
   following are examples for each method.
 
-  **Previously-saved Tensor datasets**:
+  **Previously-saved tensor datasets**:
 
   .. literalinclude:: ./doc_code/tensor.py
     :language: python
@@ -74,7 +74,8 @@ This section shows how to create single and multi-column Tensor datasets.
 
   **Cast from data stored in C-contiguous format**:
 
-  For tensors stored as raw NumPy ndarray bytes in C-contiguous order (e.g., via ``ndarray.tobytes()``), all you need to specify is the tensor column schema. The following is an end-to-end example:
+  For tensors stored as raw NumPy ndarray bytes in C-contiguous order (e.g., via
+  `ndarray.tobytes() <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tobytes.html>`__), all you need to specify is the tensor column schema. The following is an end-to-end example:
 
   .. literalinclude:: ./doc_code/tensor.py
     :language: python
@@ -85,7 +86,7 @@ This section shows how to create single and multi-column Tensor datasets.
 
   For tensors stored in other formats (e.g., pickled), you can specify a deserializer
   :ref:`user-defined function <transform_datasets_writing_udfs>` that returns
-  TensorArray columns:
+  :class:`~ray.data.extensions.tensor_extensions.TensorArray` columns:
 
   .. literalinclude:: ./doc_code/tensor.py
     :language: python
@@ -94,7 +95,7 @@ This section shows how to create single and multi-column Tensor datasets.
 
 .. tabbed:: Images (experimental)
 
-  Load image data stored as individual files using :py:class:`~ray.data.datasource.ImageFolderDatasource`:
+  Load image data stored as individual files using :class:`~ray.data.datasource.ImageFolderDatasource`:
 
   **Image and label columns**:
 
@@ -105,8 +106,8 @@ This section shows how to create single and multi-column Tensor datasets.
 
 .. note::
 
-  By convention, single-column Tensor datasets are represented with a single ``__value__`` column.
-  This kind of dataset will be converted automatically to/from NumPy array format in all transformation and consumption APIs.
+  By convention, single-column tensor datasets are represented with a single ``__value__`` column.
+  This kind of dataset will be converted automatically to/from NumPy ndarray format in all transformation and consumption APIs.
 
 Transforming / Consuming Tensor Data
 ------------------------------------
@@ -180,7 +181,9 @@ Like any other Dataset, Datasets with tensor columns can be consumed / transform
 Saving Tensor Datasets
 ----------------------
 
-Because Tensor datasets rely on Datasets-specific extension types, they can only be saved in formats that preserve Arrow metadata (currently only Parquet). In addition, single-column Tensor datasets can be saved in NumPy format.
+Because tensor datasets rely on Datasets-specific extension types, they can only be
+saved in formats that preserve Arrow metadata (currently only Parquet). In addition,
+single-column tensor datasets can be saved in NumPy format.
 
 .. tabbed:: Parquet
 
@@ -196,13 +199,39 @@ Because Tensor datasets rely on Datasets-specific extension types, they can only
     :start-after: __write_2_begin_
     :end-before: __write_2_end__
 
+.. _ragged_tensor_support:
+
+Ragged Tensor Support
+---------------------
+
+`Ragged tensors <https://www.tensorflow.org/guide/ragged_tensor>`__, i.e. tensors with non-uniform dimensions, pop up in NLP
+(`textual sentences/documents of different lengths <https://towardsdatascience.com/using-tensorflow-ragged-tensors-2af07849a7bd>`__,
+`N-grams <https://www.tensorflow.org/guide/ragged_tensor#example_use_case>`__),
+computer vision (images of differing resolution,
+`ssd300_vgg16 detection outputs <https://pytorch.org/vision/main/models/generated/torchvision.models.detection.ssd300_vgg16.html>`__),
+and audio ML (differing durations). Datasets has basic support for ragged tensors,
+namely tensors that are a collection (batch) of variably-shaped subtensors, e.g. a batch
+of images of differing sizes or a batch of sentences of differing lengths.
+
+.. literalinclude:: ./doc_code/tensor.py
+  :language: python
+  :start-after: __create_variable_shaped_tensors_begin__
+  :end-before: __create_variable_shaped_tensors_end__
+
+These variable-shaped tensors can be exchanged with popular training frameworks that support ragged tensors, such as `TensorFlow <https://www.tensorflow.org/guide/ragged_tensor#setup>`__.
+
+.. literalinclude:: ./doc_code/tensor.py
+  :language: python
+  :start-after: __tf_variable_shaped_tensors_begin__
+  :end-before: __tf_variable_shaped_tensors_end__
+
 .. _disable_tensor_extension_casting:
 
 Disabling Tensor Extension Casting
 ----------------------------------
 
 To disable automatic casting of Pandas and Arrow arrays to
-:class:`TensorArray <ray.data.extensions.tensor_extension.TensorArray>`, run the code
+:class:`~ray.data.extensions.tensor_extension.TensorArray`, run the code
 below.
 
 .. code-block::
@@ -212,9 +241,10 @@ below.
     ctx = DatasetContext.get_current()
     ctx.enable_tensor_extension_casting = False
 
+
 Limitations
 -----------
 
-The following are current limitations of Tensor datasets.
+The following are current limitations of tensor datasets.
 
-* All tensors in a tensor column must have the same shape; see GitHub issue `#18316 <https://github.com/ray-project/ray/issues/18316>`__. An error will be raised in the ragged tensor case. Automatic casting can be disabled with ``ray.data.context.DatasetContext.get_current().enable_tensor_extension_cast = False`` in the ragged tensor scenario.
+* Arbitrarily `nested/ragged tensors <https://www.tensorflow.org/guide/ragged_tensor>`__ are not supported. Only tensors with all uniform dimensions (i.e. a fully well-defined shape) and tensors representing a collection of variable-shaped tensor elements (e.g. a collection of images with different shapes) are supported; arbitrary raggedness and nested ragged tensors is not supported.

--- a/doc/source/data/doc_code/tensor.py
+++ b/doc/source/data/doc_code/tensor.py
@@ -496,3 +496,35 @@ read_ds = ray.data.read_numpy("/tmp/some_path")
 print(read_ds.schema())
 # -> __value__: extension<arrow.py_extension_type<ArrowTensorType>>
 # __write_2_end__
+
+# fmt: off
+# __create_variable_shaped_tensors_begin___
+# Create a Dataset of variable-shaped tensors.
+arr = np.array([np.ones((2, 2)), np.ones((3, 3))], dtype=object)
+ds = ray.data.from_numpy([arr, arr])
+# -> Dataset(num_blocks=2, num_rows=4,
+#            schema={__value__: ArrowVariableShapedTensorType(dtype=double)})
+
+ds.take(2)
+# -> [array([[1., 1.],
+#            [1., 1.]]),
+#     array([[1., 1., 1.],
+#            [1., 1., 1.],
+#            [1., 1., 1.]])]
+# __create_variable_shaped_tensors_end__
+
+# fmt: off
+# __tf_variable_shaped_tensors_begin___
+# Convert Ray Dataset to a TensorFlow Dataset.
+tf_ds = ds.to_tf(
+    batch_size=2,
+    output_signature=tf.RaggedTensorSpec(shape=(None, None, None), dtype=tf.float64),
+)
+# Iterate through the tf.RaggedTensors.
+for ragged_tensor in tf_ds:
+    print(ragged_tensor)
+# -> <tf.RaggedTensor [[[1.0, 1.0], [1.0, 1.0]],
+#     [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]]>
+#    <tf.RaggedTensor [[[1.0, 1.0], [1.0, 1.0]],
+#     [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]]>
+# __tf_variable_shaped_tensors_end__

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -66,12 +66,27 @@ def convert_pandas_to_tf_tensor(
         try:
             return tf.convert_to_tensor(series, dtype=dtype)
         except ValueError:
-            return tf.stack([tensorize(element) for element in series])
+            # This exception will be raised if series is of object dtype or otherwise
+            # cannot be made into a tensor directly. We assume it's a sequence in that
+            # case. This is more robust than checking for dtype.
+            tensors = [tensorize(element) for element in series]
+            try:
+                return tf.stack(tensors)
+            except Exception:
+                # Try to coerce the tensor to a ragged tensor, if possible.
+                # If this fails, the exception will be propagated up to the caller.
+                return tf.ragged.stack(tensors)
 
     tensors = []
     for column in df.columns:
         series = df[column]
-        tensor = tensorize(series)
+        try:
+            tensor = tensorize(series)
+        except Exception:
+            raise ValueError(
+                f"Failed to convert column {column} to a TensorFlow Tensor of dtype "
+                f"{dtype}. See above exception chain for the exact failure."
+            )
         tensors.append(tensor)
 
     if len(tensors) > 1:
@@ -79,7 +94,7 @@ def convert_pandas_to_tf_tensor(
 
     concatenated_tensor = tf.concat(tensors, axis=1)
 
-    if concatenated_tensor.ndim == 1:
+    if concatenated_tensor.shape.ndims == 1:
         return tf.expand_dims(concatenated_tensor, axis=1)
 
     return concatenated_tensor

--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -1,9 +1,233 @@
+import itertools
+
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 
-from ray.air.util.tensor_extensions.arrow import ArrowTensorArray
-from ray.air.util.tensor_extensions.pandas import TensorArray
+from ray.air.util.tensor_extensions.arrow import (
+    ArrowTensorArray,
+    ArrowVariableShapedTensorArray,
+    ArrowVariableShapedTensorType,
+)
+from ray.air.util.tensor_extensions.pandas import TensorArray, TensorDtype
+
+
+def test_tensor_array_validation():
+    # Test unknown input type raises TypeError.
+    with pytest.raises(TypeError):
+        TensorArray(object())
+
+    # Test non-primitive element raises TypeError.
+    with pytest.raises(TypeError):
+        TensorArray(np.array([object(), object()]))
+
+    with pytest.raises(TypeError):
+        TensorArray([object(), object()])
+
+
+def test_arrow_scalar_tensor_array_roundtrip():
+    arr = np.arange(10)
+    ata = ArrowTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, pa.DataType)
+    assert len(ata) == len(arr)
+    out = ata.to_numpy()
+    np.testing.assert_array_equal(out, arr)
+
+
+def test_arrow_scalar_tensor_array_roundtrip_boolean():
+    arr = np.array([True, False, False, True])
+    ata = ArrowTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, pa.DataType)
+    assert len(ata) == len(arr)
+    # Zero-copy is not possible since Arrow bitpacks boolean arrays while NumPy does
+    # not.
+    out = ata.to_numpy(zero_copy_only=False)
+    np.testing.assert_array_equal(out, arr)
+
+
+def test_scalar_tensor_array_roundtrip():
+    arr = np.arange(10)
+    ta = TensorArray(arr)
+    assert isinstance(ta.dtype, TensorDtype)
+    assert len(ta) == len(arr)
+    out = ta.to_numpy()
+    np.testing.assert_array_equal(out, arr)
+
+    # Check Arrow conversion.
+    ata = ta.__arrow_array__()
+    assert isinstance(ata.type, pa.DataType)
+    assert len(ata) == len(arr)
+    out = ata.to_numpy()
+    np.testing.assert_array_equal(out, arr)
+
+
+def test_arrow_variable_shaped_tensor_array_validation():
+    # Test homogeneous-typed tensor raises ValueError.
+    with pytest.raises(ValueError):
+        ArrowVariableShapedTensorArray.from_numpy(np.ones((3, 2, 2)))
+
+    # Test arbitrary object raises ValueError.
+    with pytest.raises(ValueError):
+        ArrowVariableShapedTensorArray.from_numpy(object())
+
+    # Test empty array raises ValueError.
+    with pytest.raises(ValueError):
+        ArrowVariableShapedTensorArray.from_numpy(np.array([]))
+
+    # Test deeply ragged tensor raises ValueError.
+    with pytest.raises(ValueError):
+        ArrowVariableShapedTensorArray.from_numpy(
+            np.array(
+                [
+                    np.array(
+                        [
+                            np.array([1, 2]),
+                            np.array([3, 4, 5]),
+                        ],
+                        dtype=object,
+                    ),
+                    np.array(
+                        [
+                            np.array([5, 6, 7, 8]),
+                        ],
+                        dtype=object,
+                    ),
+                    np.array(
+                        [
+                            np.array([5, 6, 7, 8]),
+                            np.array([5, 6, 7, 8]),
+                            np.array([5, 6, 7, 8]),
+                        ],
+                        dtype=object,
+                    ),
+                ],
+                dtype=object,
+            )
+        )
+
+
+def test_arrow_variable_shaped_tensor_array_roundtrip():
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    arr = np.array(arrs, dtype=object)
+    ata = ArrowVariableShapedTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, ArrowVariableShapedTensorType)
+    assert len(ata) == len(arr)
+    out = ata.to_numpy()
+    for o, a in zip(out, arr):
+        np.testing.assert_array_equal(o, a)
+
+
+def test_arrow_variable_shaped_tensor_array_roundtrip_boolean():
+    arr = np.array(
+        [[True, False], [False, False, True], [False], [True, True, False, True]],
+        dtype=object,
+    )
+    ata = ArrowVariableShapedTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, ArrowVariableShapedTensorType)
+    assert len(ata) == len(arr)
+    out = ata.to_numpy()
+    for o, a in zip(out, arr):
+        np.testing.assert_array_equal(o, a)
+
+
+def test_arrow_variable_shaped_tensor_array_roundtrip_contiguous_optimization():
+    # Test that a roundtrip on slices of an already-contiguous 1D base array does not
+    # create any unnecessary copies.
+    base = np.arange(6)
+    base_address = base.__array_interface__["data"][0]
+    arr = np.array([base[:2], base[2:]], dtype=object)
+    ata = ArrowVariableShapedTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, ArrowVariableShapedTensorType)
+    assert len(ata) == len(arr)
+    assert ata.storage.field("data").buffers()[3].address == base_address
+    out = ata.to_numpy()
+    for o, a in zip(out, arr):
+        assert o.base.address == base_address
+        np.testing.assert_array_equal(o, a)
+
+
+def test_arrow_variable_shaped_tensor_array_slice():
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    arr = np.array(arrs, dtype=object)
+    ata = ArrowVariableShapedTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, ArrowVariableShapedTensorType)
+    assert len(ata) == len(arr)
+    indices = [0, 1, 2]
+    for i in indices:
+        np.testing.assert_array_equal(ata[i], arr[i])
+    slices = [
+        slice(0, 1),
+        slice(1, 2),
+        slice(2, 3),
+        slice(0, 2),
+        slice(1, 3),
+        slice(0, 3),
+    ]
+    for slice_ in slices:
+        for o, e in zip(ata[slice_], arr[slice_]):
+            np.testing.assert_array_equal(o, e)
+
+
+def test_variable_shaped_tensor_array_roundtrip():
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    arr = np.array(arrs, dtype=object)
+    ta = TensorArray(arr)
+    assert isinstance(ta.dtype, TensorDtype)
+    assert len(ta) == len(arr)
+    out = ta.to_numpy()
+    for o, a in zip(out, arr):
+        np.testing.assert_array_equal(o, a)
+
+    # Check Arrow conversion.
+    ata = ta.__arrow_array__()
+    assert isinstance(ata.type, ArrowVariableShapedTensorType)
+    assert len(ata) == len(arr)
+    out = ata.to_numpy()
+    for o, a in zip(out, arr):
+        np.testing.assert_array_equal(o, a)
+
+
+def test_variable_shaped_tensor_array_slice():
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    arr = np.array(arrs, dtype=object)
+    ta = TensorArray(arr)
+    assert isinstance(ta.dtype, TensorDtype)
+    assert len(ta) == len(arr)
+    indices = [0, 1, 2]
+    for i in indices:
+        np.testing.assert_array_equal(ta[i], arr[i])
+    slices = [
+        slice(0, 1),
+        slice(1, 2),
+        slice(2, 3),
+        slice(0, 2),
+        slice(1, 3),
+        slice(0, 3),
+    ]
+    for slice_ in slices:
+        for o, e in zip(ta[slice_], arr[slice_]):
+            np.testing.assert_array_equal(o, e)
 
 
 def test_tensor_array_ops():
@@ -158,6 +382,31 @@ def test_arrow_tensor_array_slice(test_arr, dtype):
     slice2 = ata.slice(2, 2)
     np.testing.assert_array_equal(slice2.to_numpy(), arr[2:4])
     np.testing.assert_array_equal(slice2[1], arr[3])
+
+
+pytest_tensor_array_concat_shapes = [(1, 2, 2), (3, 2, 2), (2, 3, 3)]
+
+
+@pytest.mark.parametrize(
+    "shape1,shape2", list(itertools.combinations(pytest_tensor_array_concat_shapes, 2))
+)
+def test_tensor_array_concat(shape1, shape2):
+    a1 = np.arange(np.prod(shape1)).reshape(shape1)
+    a2 = np.arange(np.prod(shape2)).reshape(shape2)
+    ta1 = TensorArray(a1)
+    ta2 = TensorArray(a2)
+    ta = TensorArray._concat_same_type([ta1, ta2])
+    assert len(ta) == shape1[0] + shape2[0]
+    assert ta.dtype.element_dtype == ta1.dtype.element_dtype
+    if shape1[1:] == shape2[1:]:
+        assert ta.dtype.element_shape == shape1[1:]
+        np.testing.assert_array_equal(ta.to_numpy(), np.concatenate([a1, a2]))
+    else:
+        assert ta.dtype.element_shape is None
+        for arr, expected in zip(
+            ta.to_numpy(), np.array([e for a in [a1, a2] for e in a], dtype=object)
+        ):
+            np.testing.assert_array_equal(arr, expected)
 
 
 if __name__ == "__main__":

--- a/python/ray/air/util/data_batch_conversion.py
+++ b/python/ray/air/util/data_batch_conversion.py
@@ -205,18 +205,17 @@ def _cast_ndarray_columns_to_tensor_extension(df: pd.DataFrame) -> pd.DataFrame:
     """
     Cast all NumPy ndarray columns in df to our tensor extension type, TensorArray.
     """
-    from ray.air.util.tensor_extensions.pandas import TensorArray
+    from ray.air.util.tensor_extensions.pandas import (
+        TensorArray,
+        column_needs_tensor_extension,
+    )
 
     # Try to convert any ndarray columns to TensorArray columns.
     # TODO(Clark): Once Pandas supports registering extension types for type
     # inference on construction, implement as much for NumPy ndarrays and remove
     # this. See https://github.com/pandas-dev/pandas/issues/41848
     for col_name, col in df.items():
-        if (
-            col.dtype.type is np.object_
-            and not col.empty
-            and isinstance(col.iloc[0], np.ndarray)
-        ):
+        if column_needs_tensor_extension(col):
             try:
                 df.loc[:, col_name] = TensorArray(col)
             except Exception as e:

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -1,8 +1,10 @@
-from typing import Iterable, Optional, Tuple
+import itertools
+from typing import Iterable, Optional, Tuple, List, Union
 
 import numpy as np
 import pyarrow as pa
 
+from ray.air.util.tensor_extensions.utils import _is_ndarray_variable_shaped_tensor
 from ray.util.annotations import PublicAPI
 
 
@@ -114,25 +116,36 @@ class ArrowTensorArray(pa.ExtensionArray):
         return list(self)
 
     @classmethod
-    def from_numpy(cls, arr):
+    def from_numpy(
+        cls, arr: Union[np.ndarray, Iterable[np.ndarray]]
+    ) -> Union["ArrowTensorArray", "ArrowVariableShapedTensorArray"]:
         """
-        Convert an ndarray or an iterable of fixed-shape ndarrays to an array
-        of fixed-shape, homogeneous-typed tensors.
+        Convert an ndarray or an iterable of ndarrays to an array of homogeneous-typed
+        tensors. If given fixed-shape tensor elements, this will return an
+        ``ArrowTensorArray``; if given variable-shape tensor elements, this will return
+        an ``ArrowVariableShapedTensorArray``.
 
         Args:
-            arr: An ndarray or an iterable of fixed-shape ndarrays.
+            arr: An ndarray or an iterable of ndarrays.
 
         Returns:
-            An ArrowTensorArray containing len(arr) tensors of fixed shape.
+            - If fixed-shape tensor elements, an ``ArrowTensorArray`` containing
+              ``len(arr)`` tensors of fixed shape.
+            - If variable-shaped tensor elements, an ``ArrowVariableShapedTensorArray``
+              containing ``len(arr)`` tensors of variable shape.
+            - If scalar elements, a ``pyarrow.Array``.
         """
-        if isinstance(arr, (list, tuple)):
-            if np.isscalar(arr[0]):
-                return pa.array(arr)
-            elif isinstance(arr[0], np.ndarray):
-                # Stack ndarrays and pass through to ndarray handling logic
-                # below.
-                arr = np.stack(arr, axis=0)
+        if isinstance(arr, (list, tuple)) and arr and isinstance(arr[0], np.ndarray):
+            # Stack ndarrays and pass through to ndarray handling logic below.
+            arr = np.stack(arr, axis=0)
         if isinstance(arr, np.ndarray):
+            if len(arr) > 0 and np.isscalar(arr[0]):
+                # Elements are scalar so a plain Arrow Array will suffice.
+                return pa.array(arr)
+            if _is_ndarray_variable_shaped_tensor(arr):
+                # Tensor elements have variable shape, so we delegate to
+                # ArrowVariableShapedTensorArray.
+                return ArrowVariableShapedTensorArray.from_numpy(arr)
             if not arr.flags.c_contiguous:
                 # We only natively support C-contiguous ndarrays.
                 arr = np.ascontiguousarray(arr)
@@ -270,3 +283,351 @@ class ArrowTensorArray(pa.ExtensionArray):
             A single ndarray representing the entire array of tensors.
         """
         return self._to_numpy(zero_copy_only=zero_copy_only)
+
+
+@PublicAPI(stability="alpha")
+class ArrowVariableShapedTensorType(pa.PyExtensionType):
+    """
+    Arrow ExtensionType for an array of heterogeneous-shaped, homogeneous-typed
+    tensors.
+
+    This is the Arrow side of TensorDtype for tensor elements with different shapes.
+    Note that this extension only supports non-ragged tensor elements; i.e., when
+    considering each tensor element in isolation, they must have a well-defined,
+    non-ragged shape.
+
+    See Arrow extension type docs:
+    https://arrow.apache.org/docs/python/extending_types.html#defining-extension-types-user-defined-types
+    """
+
+    def __init__(self, dtype: pa.DataType):
+        """
+        Construct the Arrow extension type for array of heterogeneous-shaped tensors.
+
+        Args:
+            dtype: pyarrow dtype of tensor elements.
+        """
+        super().__init__(
+            pa.struct([("data", pa.list_(dtype)), ("shape", pa.list_(pa.int64()))])
+        )
+
+    def to_pandas_dtype(self):
+        """
+        Convert Arrow extension type to corresponding Pandas dtype.
+
+        Returns:
+            An instance of pd.api.extensions.ExtensionDtype.
+        """
+        from ray.air.util.tensor_extensions.pandas import TensorDtype
+
+        return TensorDtype(
+            None,
+            self.storage_type["data"].type.value_type.to_pandas_dtype(),
+        )
+
+    def __reduce__(self):
+        return (
+            ArrowVariableShapedTensorType,
+            (self.storage_type["data"].type.value_type,),
+        )
+
+    def __arrow_ext_class__(self):
+        """
+        ExtensionArray subclass with custom logic for this array of tensors
+        type.
+
+        Returns:
+            A subclass of pd.api.extensions.ExtensionArray.
+        """
+        return ArrowVariableShapedTensorArray
+
+    def __str__(self) -> str:
+        dtype = self.storage_type["data"].type.value_type
+        return f"ArrowVariableShapedTensorType(dtype={dtype})"
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+@PublicAPI(stability="alpha")
+class ArrowVariableShapedTensorArray(pa.ExtensionArray):
+    """
+    An array of heterogeneous-shaped, homogeneous-typed tensors.
+
+    This is the Arrow side of TensorArray for tensor elements that have differing
+    shapes. Note that this extension only supports non-ragged tensor elements; i.e.,
+    when considering each tensor element in isolation, they must have a well-defined
+    shape.
+
+    See Arrow docs for customizing extension arrays:
+    https://arrow.apache.org/docs/python/extending_types.html#custom-extension-array-class
+    """
+
+    OFFSET_DTYPE = np.int32
+
+    def __getitem__(self, key):
+        # This __getitem__ hook allows us to support proper indexing when accessing a
+        # single tensor (a "scalar" item of the array). Without this hook for integer
+        # keys, the indexing will fail on all currently released pyarrow versions due
+        # to a lack of proper ExtensionScalar support. Support was added in
+        # https://github.com/apache/arrow/pull/10904, but hasn't been released at the
+        # time of this comment, and even with this support, the returned ndarray is a
+        # flat representation of the n-dimensional tensor.
+
+        # NOTE(Clark): We'd like to override the pa.Array.getitem() helper instead,
+        # which would obviate the need for overriding __iter__() below, but
+        # unfortunately overriding Cython cdef methods with normal Python methods isn't
+        # allowed.
+        if isinstance(key, slice):
+            sliced = super().__getitem__(key).to_numpy()
+            if sliced.dtype.type is not np.object_:
+                # Force ths slice to match NumPy semantics for unit (single-element)
+                # slices.
+                sliced = sliced[0:1]
+            return sliced
+        return self._to_numpy(key)
+
+    def __iter__(self):
+        # Override pa.Array.__iter__() in order to return an iterator of properly
+        # shaped tensors instead of an iterator of flattened tensors.
+        # See comment in above __getitem__ method.
+        for i in range(len(self)):
+            # Use overridden __getitem__ method.
+            yield self.__getitem__(i)
+
+    def to_pylist(self):
+        # Override pa.Array.to_pylist() due to a lack of ExtensionScalar support (see
+        # comment in __getitem__).
+        return list(self)
+
+    @classmethod
+    def from_numpy(
+        cls, arr: Union[np.ndarray, List[np.ndarray], Tuple[np.ndarray]]
+    ) -> "ArrowVariableShapedTensorArray":
+        """
+        Convert an ndarray or an iterable of heterogeneous-shaped ndarrays to an array
+        of heterogeneous-shaped, homogeneous-typed tensors.
+
+        Args:
+            arr: An ndarray or an iterable of heterogeneous-shaped ndarrays.
+
+        Returns:
+            An ArrowVariableShapedTensorArray containing len(arr) tensors of
+            heterogeneous shape.
+        """
+        # Implementation note - Arrow representation of ragged tensors:
+        #
+        # We represent an array of ragged tensors using a struct array containing two
+        # fields:
+        #  - data: a variable-sized list array, where each element in the array is a
+        #    tensor element stored in a 1D (raveled) variable-sized list of the
+        #    underlying scalar data type.
+        #  - shape: a variable-sized list array containing the shapes of each tensor
+        #    element.
+        if isinstance(arr, Iterable):
+            if isinstance(arr, np.ndarray) and arr.dtype.type is not np.object_:
+                raise ValueError(
+                    "ArrowVariableShapedTensorArray should only be used for "
+                    "heterogeneous-shaped tensor elements, i.e. of object dtype, but "
+                    f"got dtype: {arr.dtype}"
+                )
+            arr = list(arr)
+        elif not isinstance(arr, (list, tuple)):
+            raise ValueError(
+                "ArrowVariableShapedTensorArray can only be constructed from an "
+                f"ndarray or a list/tuple of ndarrays, but got: {type(arr)}"
+            )
+        if len(arr) == 0:
+            # Empty ragged tensor arrays are not supported.
+            raise ValueError("Creating empty ragged tensor arrays is not supported.")
+
+        # Whether all subndarrays are contiguous views of the same ndarray.
+        shapes, sizes, raveled = [], [], []
+        for a in arr:
+            a = np.asarray(a)
+            shapes.append(a.shape)
+            sizes.append(a.size)
+            # Convert to 1D array view; this should be zero-copy in the common case.
+            # NOTE: If array is not in C-contiguous order, this will convert it to
+            # C-contiguous order, incurring a copy.
+            a = np.ravel(a, order="C")
+            raveled.append(a)
+        # Get size offsets and total size.
+        sizes = np.array(sizes)
+        size_offsets = np.cumsum(sizes)
+        total_size = size_offsets[-1]
+        # Concatenate 1D views into a contiguous 1D array.
+        if all(_is_contiguous_view(curr, prev) for prev, curr in _pairwise(raveled)):
+            # An optimized zero-copy path if raveled tensor elements are already
+            # contiguous in memory, e.g. if this tensor array has already done a
+            # roundtrip through our Arrow representation.
+            np_data_buffer = raveled[-1].base
+        else:
+            np_data_buffer = np.concatenate(raveled)
+        dtype = np_data_buffer.dtype
+        if dtype.type is np.object_:
+            raise ValueError(
+                "ArrowVariableShapedTensorArray only supports heterogeneous-shaped "
+                "tensor collections, not arbitrarily nested ragged tensors. Got: "
+                f"{arr}"
+            )
+        pa_dtype = pa.from_numpy_dtype(dtype)
+        if dtype.type is np.bool_:
+            # NumPy doesn't represent boolean arrays as bit-packed, so we manually
+            # bit-pack the booleans before handing the buffer off to Arrow.
+            # NOTE: Arrow expects LSB bit-packed ordering.
+            # NOTE: This creates a copy.
+            np_data_buffer = np.packbits(np_data_buffer, bitorder="little")
+        data_buffer = pa.py_buffer(np_data_buffer)
+        # Construct underlying data array.
+        value_array = pa.Array.from_buffers(pa_dtype, total_size, [None, data_buffer])
+        # Construct array for offsets into the 1D data array, where each offset
+        # corresponds to a tensor element.
+        size_offsets = np.insert(size_offsets, 0, 0)
+        offset_array = pa.array(size_offsets)
+        data_array = pa.ListArray.from_arrays(offset_array, value_array)
+        # We store the tensor element shapes so we can reconstruct each tensor when
+        # converting back to NumPy ndarrays.
+        shape_array = pa.array(shapes)
+        # Build storage array containing tensor data and the tensor element shapes.
+        storage = pa.StructArray.from_arrays(
+            [data_array, shape_array],
+            ["data", "shape"],
+        )
+        type_ = ArrowVariableShapedTensorType(pa_dtype)
+        return pa.ExtensionArray.from_storage(type_, storage)
+
+    def _to_numpy(self, index: Optional[int] = None, zero_copy_only: bool = False):
+        """
+        Helper for getting either an element of the array of tensors as an ndarray, or
+        the entire array of tensors as a single ndarray.
+
+        Args:
+            index: The index of the tensor element that we wish to return as an
+                ndarray. If not given, the entire array of tensors is returned as an
+                ndarray.
+            zero_copy_only: If True, an exception will be raised if the conversion to a
+                NumPy array would require copying the underlying data (e.g. in presence
+                of nulls, or for non-primitive types). This argument is currently
+                ignored, so zero-copy isn't enforced even if this argument is true.
+
+        Returns:
+            The corresponding tensor element as an ndarray if an index was given, or
+            the entire array of tensors as an ndarray otherwise.
+        """
+        # TODO(Clark): Enforce zero_copy_only.
+        # TODO(Clark): Support strides?
+        if index is None:
+            # Get individual ndarrays for each tensor element.
+            arrs = [self._to_numpy(i, zero_copy_only) for i in range(len(self))]
+            # Return ragged NumPy ndarray in the ndarray of ndarray pointers
+            # representation.
+            return np.array(arrs, dtype=object)
+        data = self.storage.field("data")
+        shapes = self.storage.field("shape")
+        value_type = data.type.value_type
+        if pa.types.is_boolean(value_type):
+            # Arrow boolean array buffers are bit-packed, with 8 entries per byte,
+            # and are accessed via bit offsets.
+            buffer_item_width = value_type.bit_width
+        else:
+            # We assume all other array types are accessed via byte array
+            # offsets.
+            buffer_item_width = value_type.bit_width // 8
+        shape = shapes[index].as_py()
+        offset = data.offsets[index].as_py()
+        data_offset = buffer_item_width * offset
+        data_buffer = data.buffers()[3]
+        if not pa.types.is_boolean(value_type):
+            return np.ndarray(
+                shape,
+                dtype=value_type.to_pandas_dtype(),
+                buffer=data_buffer,
+                offset=data_offset,
+            )
+        # Special handling for boolean arrays, since Arrow bit-packs boolean arrays
+        # while NumPy does not.
+        # Cast as uint8 array and let NumPy unpack into a boolean view.
+        # Offset into uint8 array, where each element is a bucket for 8 booleans.
+        byte_bucket_offset = data_offset // 8
+        # Offset for a specific boolean, within a uint8 array element.
+        bool_offset = data_offset % 8
+        # The number of uint8 array elements (buckets) that our slice spans.
+        # Note that, due to the offset for a specific boolean, the slice can span byte
+        # boundaries even if it contains less than 8 booleans.
+        num_boolean_byte_buckets = 1 + ((bool_offset + np.prod(shape) - 1) // 8)
+        # Construct the uint8 array view on the buffer.
+        arr = np.ndarray(
+            (num_boolean_byte_buckets,),
+            dtype=np.uint8,
+            buffer=data_buffer,
+            offset=byte_bucket_offset,
+        )
+        # Unpack into a byte per boolean, using LSB bit-packed ordering.
+        arr = np.unpackbits(arr, bitorder="little")
+        # Interpret buffer as boolean array.
+        return np.ndarray(shape, dtype=np.bool_, buffer=arr, offset=bool_offset)
+
+    def to_numpy(self, zero_copy_only: bool = True):
+        """
+        Convert the entire array of tensors into a single ndarray.
+
+        Args:
+            zero_copy_only: If True, an exception will be raised if the conversion to a
+                NumPy array would require copying the underlying data (e.g. in presence
+                of nulls, or for non-primitive types). This argument is currently
+                ignored, so zero-copy isn't enforced even if this argument is true.
+
+        Returns:
+            A single ndarray representing the entire array of tensors.
+        """
+        return self._to_numpy(zero_copy_only=zero_copy_only)
+
+
+def _is_contiguous_view(curr: np.ndarray, prev: Optional[np.ndarray]) -> bool:
+    """Check if the provided tensor element is contiguous with the previous tensor
+    element.
+
+    Args:
+        curr: The tensor element whose contiguity that we wish to check.
+        prev: The previous tensor element in the tensor array.
+
+    Returns:
+        Whether the provided tensor element is contiguous with the previous tensor
+        element.
+    """
+    if (
+        curr.base is None
+        or not curr.data.c_contiguous
+        or (prev is not None and curr.base is not prev.base)
+    ):
+        # curr is either:
+        # - not a view,
+        # - not in C-contiguous order,
+        # - a view that does not share its base with the other subndarrays.
+        return False
+    else:
+        # curr is a C-contiguous view that shares the same base with the seen
+        # subndarrays, but we need to confirm that it is contiguous with the
+        # previous subndarray.
+        if prev is not None and (
+            _get_buffer_address(curr) - _get_buffer_address(prev)
+            != prev.base.dtype.itemsize * prev.size
+        ):
+            # This view is not contiguous with the previous view.
+            return False
+        else:
+            return True
+
+
+def _get_buffer_address(arr: np.ndarray) -> int:
+    """Get the address of the buffer underlying the provided NumPy ndarray."""
+    return arr.__array_interface__["data"][0]
+
+
+def _pairwise(iterable):
+    # pairwise('ABCDEFG') --> AB BC CD DE EF FG
+    # Backport of itertools.pairwise for Python < 3.10.
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return zip(a, b)

--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -27,9 +27,9 @@
 # - Added different (more vectorized) TensorArray.take() operation.
 # - Added support for more reducers (agg funcs) to TensorArray.
 # - Added support for logical operators to TensorArray(Element).
+# - Added support for heterogeneously-shaped tensors.
 # - Miscellaneous small bug fixes and optimizations.
 
-import itertools
 import numbers
 import os
 from packaging.version import Version
@@ -44,6 +44,7 @@ from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
 from pandas.core.indexers import check_array_indexer, validate_indices
 from pandas.io.formats.format import ExtensionArrayFormatter
 
+from ray.air.util.tensor_extensions.utils import _is_ndarray_variable_shaped_tensor
 from ray.util.annotations import PublicAPI
 
 try:
@@ -181,8 +182,11 @@ if os.getenv(_FORMATTER_ENABLED_ENV_VAR, "1") == "1":
 @pd.api.extensions.register_extension_dtype
 class TensorDtype(pd.api.extensions.ExtensionDtype):
     """
-    Pandas extension type for a column of fixed-shape, homogeneous-typed
-    tensors.
+    Pandas extension type for a column of homogeneous-typed tensors.
+
+    This extension supports tensors in which the elements have different shapes.
+    However, each tensor element must be non-ragged, i.e. each tensor element must have
+    a well-defined, non-ragged shape.
 
     See:
     https://github.com/pandas-dev/pandas/blob/master/pandas/core/dtypes/base.py
@@ -205,7 +209,7 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
         dtype: object
         >>> # Cast column to our TensorDtype extension type.
         >>> from ray.data.extensions import TensorDtype
-        >>> df["two"] = df["two"].astype(TensorDtype((3, 2, 2, 2), np.int64))
+        >>> df["two"] = df["two"].astype(TensorDtype(np.int64, (3, 2, 2, 2)))
         >>> # Note that the column dtype is now TensorDtype instead of
         >>> # np.object.
         >>> df.dtypes # doctest: +SKIP
@@ -279,7 +283,7 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
     # https://github.com/CODAIT/text-extensions-for-pandas/issues/166
     base = None
 
-    def __init__(self, shape: Tuple[int, ...], dtype: np.dtype):
+    def __init__(self, shape: Optional[Tuple[int, ...]], dtype: np.dtype):
         self._shape = shape
         self._dtype = dtype
 
@@ -293,6 +297,30 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
         instances of `type`.
         """
         return TensorArrayElement
+
+    @property
+    def element_dtype(self):
+        """
+        The dtype of the underlying tensor elements.
+        """
+        return self._dtype
+
+    @property
+    def element_shape(self):
+        """
+        The shape of the underlying tensor elements. This will be None if the
+        corresponding TensorArray for this TensorDtype holds variable-shaped tensor
+        elements.
+        """
+        return self._shape
+
+    @property
+    def is_variable_shaped(self):
+        """
+        Whether the corresponding TensorArray for this TensorDtype holds variable-shaped
+        tensor elements.
+        """
+        return self.shape is None
 
     @property
     def name(self) -> str:
@@ -356,7 +384,7 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
             )
         # Upstream code uses exceptions as part of its normal control flow and
         # will pass this method bogus class names.
-        regex = r"^TensorDtype\(shape=(\((?:\d+,?\s?)*\)), dtype=(\w+)\)$"
+        regex = r"^TensorDtype\(shape=((?:\((?:\d+,?\s?)*\))|(?:None)), dtype=(\w+)\)$"
         m = re.search(regex, string)
         err_msg = (
             f"Cannot construct a '{cls.__name__}' from '{string}'; expected a string "
@@ -584,8 +612,11 @@ class TensorArray(
 ):
     """
     Pandas `ExtensionArray` representing a tensor column, i.e. a column
-    consisting of ndarrays as elements. All tensors in a column must have the
-    same shape.
+    consisting of ndarrays as elements.
+
+    This extension supports tensors in which the elements have different shapes.
+    However, each tensor element must be non-ragged, i.e. each tensor element must have
+    a well-defined, non-ragged shape.
 
     Examples:
         >>> # Create a DataFrame with a list of ndarrays as a column.
@@ -677,7 +708,7 @@ class TensorArray(
         "var": np.var,
     }
 
-    # See https://github.com/pandas-dev/pandas/blob/master/pandas/core/arrays/base.py  # noqa
+    # See https://github.com/pandas-dev/pandas/blob/master/pandas/core/arrays/base.py
     # for interface documentation and the subclassing contract.
     def __init__(
         self,
@@ -694,59 +725,50 @@ class TensorArray(
             values: A NumPy ndarray or sequence of NumPy ndarrays of equal
                 shape.
         """
+        # Try to convert some well-known objects to ndarrays before handing off to
+        # ndarray handling logic.
         if isinstance(values, ABCSeries):
-            # Convert series to ndarray and passthrough to ndarray handling
-            # logic.
-            values = values.to_numpy()
+            values = np.array(values, copy=False)
         elif isinstance(values, Sequence):
-            values = np.array([np.asarray(v) for v in values])
+            values = np.array(
+                [
+                    np.asarray(v) if isinstance(v, TensorArrayElement) else v
+                    for v in values
+                ],
+                copy=False,
+            )
+        elif isinstance(values, TensorArrayElement):
+            values = np.array([np.asarray(values)], copy=False)
 
         if isinstance(values, np.ndarray):
             if values.dtype.type is np.object_:
-                if len(values) == 0 or (
-                    not isinstance(values[0], str)
-                    and isinstance(
-                        values[0], (np.ndarray, TensorArrayElement, Sequence)
-                    )
+                if len(values) == 0:
+                    # Tensor is empty, pass through to create empty TensorArray.
+                    pass
+                elif all(
+                    isinstance(v, (np.ndarray, TensorArrayElement, Sequence))
+                    and not isinstance(v, str)
+                    for v in values
                 ):
-                    # Convert ndarrays of ndarrays/TensorArrayElements
-                    # with an opaque object type to a properly typed ndarray of
-                    # ndarrays.
-                    self._tensor = np.array([np.asarray(v) for v in values])
-                    if self._tensor.dtype.type is np.object_:
-                        subndarray_types = [
-                            v.dtype for v in itertools.islice(self._tensor, 5)
-                        ]
-                        raise TypeError(
-                            "Tried to convert an ndarray of ndarray pointers (object "
-                            "dtype) to a well-typed ndarray but this failed; convert "
-                            "the ndarray to a well-typed ndarray before casting it as "
-                            "a TensorArray, and note that ragged tensors are NOT "
-                            "supported by TensorArray. First 5 subndarray types: "
-                            f"{subndarray_types}"
-                        )
+                    # Try to convert ndarrays of ndarrays/TensorArrayElements with an
+                    # opaque object type to a properly typed ndarray of ndarrays.
+                    values = np.array([np.asarray(v) for v in values], copy=False)
                 else:
                     raise TypeError(
                         "Expected a well-typed ndarray or an object-typed ndarray of "
                         "ndarray pointers, but got an object-typed ndarray whose "
                         f"subndarrays are of type {type(values[0])}."
                     )
-            else:
-                # ndarray is well-typed, use it directly as the backing tensor.
-                self._tensor = values
-        elif isinstance(values, TensorArrayElement):
-            self._tensor = np.array([np.asarray(values)])
-        elif np.isscalar(values):
-            # `values` is a single element:
-            self._tensor = np.array([values])
         elif isinstance(values, TensorArray):
-            raise TypeError("Use the copy() method to create a copy of a TensorArray")
+            raise TypeError("Use the copy() method to create a copy of a TensorArray.")
         else:
             raise TypeError(
                 "Expected a numpy.ndarray or sequence of numpy.ndarray, "
-                f"but received {values} "
-                f"of type '{type(values)}' instead."
+                f"but received {values} of type {type(values).__name__} instead."
             )
+        assert isinstance(values, np.ndarray)
+        self._tensor = values
+        self._is_variable_shaped = None
 
     @classmethod
     def _from_sequence(
@@ -865,7 +887,24 @@ class TensorArray(
         """
         An instance of 'ExtensionDtype'.
         """
-        return TensorDtype(self.numpy_shape[1:], self.numpy_dtype)
+        if self.is_variable_shaped:
+            # A tensor is only considered variable-shaped if it's non-empty, so no
+            # non-empty check is needed here.
+            dtype = self._tensor[0].dtype
+            shape = None
+        else:
+            dtype = self.numpy_dtype
+            shape = self.numpy_shape[1:]
+        return TensorDtype(shape, dtype)
+
+    @property
+    def is_variable_shaped(self):
+        """
+        Whether this TensorArray holds variable-shaped tensor elements.
+        """
+        if self._is_variable_shaped is None:
+            self._is_variable_shaped = _is_ndarray_variable_shaped_tensor(self._tensor)
+        return self._is_variable_shaped
 
     @property
     def nbytes(self) -> int:
@@ -897,15 +936,15 @@ class TensorArray(
         if self._tensor.dtype.type is np.object_:
             # Avoid comparing with __eq__ because the elements of the tensor
             # may do something funny with that operation.
-            result_list = [self._tensor[i] is None for i in range(len(self))]
-            result = np.broadcast_to(
-                np.array(result_list, dtype=np.bool), self.numpy_shape
+            return np.array(
+                [self._tensor[i] is None for i in range(len(self))], dtype=bool
             )
         elif self._tensor.dtype.type is np.str_:
-            result = self._tensor == ""
+            return np.all(self._tensor == "", axis=tuple(range(1, self._tensor.ndim)))
         else:
-            result = np.isnan(self._tensor)
-        return TensorArray(result)
+            return np.all(
+                np.isnan(self._tensor), axis=tuple(range(1, self._tensor.ndim))
+            )
 
     def take(
         self, indices: Sequence[int], allow_fill: bool = False, fill_value: Any = None
@@ -1040,7 +1079,21 @@ class TensorArray(
         -------
         ExtensionArray
         """
-        return TensorArray(np.concatenate([a._tensor for a in to_concat]))
+        should_flatten = False
+        shape = None
+        for a in to_concat:
+            if shape is None:
+                shape = a.numpy_shape
+            if a.is_variable_shaped or a.numpy_shape != shape:
+                should_flatten = True
+                break
+        if should_flatten:
+            concated = TensorArray(
+                np.array([e for a in to_concat for e in a._tensor], dtype=object)
+            )
+        else:
+            concated = TensorArray(np.concatenate([a._tensor for a in to_concat]))
+        return concated
 
     def __setitem__(self, key: Union[int, np.ndarray], value: Any) -> None:
         """
@@ -1329,9 +1382,15 @@ class TensorArray(
         https://pandas.pydata.org/pandas-docs/stable/development/extending.html#compatibility-with-apache-arrow
         for more information.
         """
-        from ray.air.util.tensor_extensions.arrow import ArrowTensorArray
+        from ray.air.util.tensor_extensions.arrow import (
+            ArrowTensorArray,
+            ArrowVariableShapedTensorArray,
+        )
 
-        return ArrowTensorArray.from_numpy(self._tensor)
+        if self.is_variable_shaped:
+            return ArrowVariableShapedTensorArray.from_numpy(self._tensor)
+        else:
+            return ArrowTensorArray.from_numpy(self._tensor)
 
     @property
     def _is_boolean(self):
@@ -1361,3 +1420,22 @@ TensorArrayElement._add_logical_ops()
 TensorArray._add_arithmetic_ops()
 TensorArray._add_comparison_ops()
 TensorArray._add_logical_ops()
+
+
+@PublicAPI(stability="beta")
+def column_needs_tensor_extension(s: pd.Series) -> bool:
+    """Return whether the provided pandas Series column needs a tensor extension
+    representation. This tensor extension representation provides more efficient slicing
+    and interop with ML frameworks.
+
+    Args:
+        s: The pandas Series column that may need to be represented using the tensor
+            extension.
+
+    Returns:
+        Whether the provided Series needs a tensor extension representation.
+    """
+    # NOTE: This is an O(1) check.
+    return (
+        s.dtype.type is np.object_ and not s.empty and isinstance(s.iloc[0], np.ndarray)
+    )

--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -1083,8 +1083,8 @@ class TensorArray(
         shape = None
         for a in to_concat:
             if shape is None:
-                shape = a.numpy_shape
-            if a.is_variable_shaped or a.numpy_shape != shape:
+                shape = a.dtype.element_shape
+            if a.is_variable_shaped or a.dtype.element_shape != shape:
                 should_flatten = True
                 break
         if should_flatten:

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+
+def _is_ndarray_variable_shaped_tensor(arr: np.ndarray) -> bool:
+    """Return whether the provided NumPy ndarray is representing a variable-shaped
+    tensor.
+
+    NOTE: This is an O(rows) check.
+    """
+    if arr.dtype.type is not np.object_:
+        return False
+    if len(arr) == 0:
+        return False
+    if not isinstance(arr[0], np.ndarray):
+        return False
+    shape = arr[0].shape
+    for a in arr[1:]:
+        if not isinstance(a, np.ndarray):
+            return False
+        if a.shape != shape:
+            return True
+    return True

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -157,7 +157,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
         new_batch = {}
         for col_name, col in batch.items():
             # Use Arrow's native *List types for 1-dimensional ndarrays.
-            if col.ndim > 1:
+            if col.dtype.type is np.object_ or col.ndim > 1:
                 try:
                     col = ArrowTensorArray.from_numpy(col)
                 except pa.ArrowNotImplementedError as e:

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -4,6 +4,9 @@ from ray.data.extensions.tensor_extension import (
     TensorArrayElement,
     ArrowTensorType,
     ArrowTensorArray,
+    ArrowVariableShapedTensorType,
+    ArrowVariableShapedTensorArray,
+    column_needs_tensor_extension,
 )
 
 __all__ = [
@@ -13,4 +16,7 @@ __all__ = [
     "TensorArrayElement",
     "ArrowTensorType",
     "ArrowTensorArray",
+    "ArrowVariableShapedTensorType",
+    "ArrowVariableShapedTensorArray",
+    "column_needs_tensor_extension",
 ]

--- a/python/ray/data/extensions/tensor_extension.py
+++ b/python/ray/data/extensions/tensor_extension.py
@@ -2,8 +2,11 @@ from ray.air.util.tensor_extensions.pandas import (  # noqa: F401
     TensorDtype,
     TensorArray,
     TensorArrayElement,
+    column_needs_tensor_extension,
 )
 from ray.air.util.tensor_extensions.arrow import (  # noqa: F401
     ArrowTensorType,
     ArrowTensorArray,
+    ArrowVariableShapedTensorType,
+    ArrowVariableShapedTensorArray,
 )

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -26,6 +26,8 @@ from ray.data.datasource.csv_datasource import CSVDatasource
 from ray.data.extensions.tensor_extension import (
     ArrowTensorArray,
     ArrowTensorType,
+    ArrowVariableShapedTensorArray,
+    ArrowVariableShapedTensorType,
     TensorArray,
     TensorDtype,
 )
@@ -513,22 +515,216 @@ def test_tensor_array_validation():
     with pytest.raises(TypeError):
         TensorArray(object())
 
-    # Test ragged tensor raises TypeError.
-    with pytest.raises(TypeError):
-        TensorArray(np.array([np.ones((2, 2)), np.ones((3, 3))], dtype=object))
-
-    with pytest.raises(TypeError):
-        TensorArray([np.ones((2, 2)), np.ones((3, 3))])
-
-    with pytest.raises(TypeError):
-        TensorArray(pd.Series([np.ones((2, 2)), np.ones((3, 3))]))
-
     # Test non-primitive element raises TypeError.
     with pytest.raises(TypeError):
         TensorArray(np.array([object(), object()]))
 
     with pytest.raises(TypeError):
         TensorArray([object(), object()])
+
+
+def test_arrow_scalar_tensor_array_roundtrip():
+    arr = np.arange(10)
+    ata = ArrowTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, pa.DataType)
+    assert len(ata) == len(arr)
+    out = ata.to_numpy()
+    np.testing.assert_array_equal(out, arr)
+
+
+def test_arrow_scalar_tensor_array_roundtrip_boolean():
+    arr = np.array([True, False, False, True])
+    ata = ArrowTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, pa.DataType)
+    assert len(ata) == len(arr)
+    # Zero-copy is not possible since Arrow bitpacks boolean arrays while NumPy does
+    # not.
+    out = ata.to_numpy(zero_copy_only=False)
+    np.testing.assert_array_equal(out, arr)
+
+
+def test_scalar_tensor_array_roundtrip():
+    arr = np.arange(10)
+    ta = TensorArray(arr)
+    assert isinstance(ta.dtype, TensorDtype)
+    assert len(ta) == len(arr)
+    out = ta.to_numpy()
+    np.testing.assert_array_equal(out, arr)
+
+    # Check Arrow conversion.
+    ata = ta.__arrow_array__()
+    assert isinstance(ata.type, pa.DataType)
+    assert len(ata) == len(arr)
+    out = ata.to_numpy()
+    np.testing.assert_array_equal(out, arr)
+
+
+def test_arrow_variable_shaped_tensor_array_validation():
+    # Test homogeneous-typed tensor raises ValueError.
+    with pytest.raises(ValueError):
+        ArrowVariableShapedTensorArray.from_numpy(np.ones((3, 2, 2)))
+
+    # Test arbitrary object raises ValueError.
+    with pytest.raises(ValueError):
+        ArrowVariableShapedTensorArray.from_numpy(object())
+
+    # Test empty array raises ValueError.
+    with pytest.raises(ValueError):
+        ArrowVariableShapedTensorArray.from_numpy(np.array([]))
+
+    # Test deeply ragged tensor raises ValueError.
+    with pytest.raises(ValueError):
+        ArrowVariableShapedTensorArray.from_numpy(
+            np.array(
+                [
+                    np.array(
+                        [
+                            np.array([1, 2]),
+                            np.array([3, 4, 5]),
+                        ],
+                        dtype=object,
+                    ),
+                    np.array(
+                        [
+                            np.array([5, 6, 7, 8]),
+                        ],
+                        dtype=object,
+                    ),
+                    np.array(
+                        [
+                            np.array([5, 6, 7, 8]),
+                            np.array([5, 6, 7, 8]),
+                            np.array([5, 6, 7, 8]),
+                        ],
+                        dtype=object,
+                    ),
+                ],
+                dtype=object,
+            )
+        )
+
+
+def test_arrow_variable_shaped_tensor_array_roundtrip():
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    arr = np.array(arrs, dtype=object)
+    ata = ArrowVariableShapedTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, ArrowVariableShapedTensorType)
+    assert len(ata) == len(arr)
+    out = ata.to_numpy()
+    for o, a in zip(out, arr):
+        np.testing.assert_array_equal(o, a)
+
+
+def test_arrow_variable_shaped_tensor_array_roundtrip_boolean():
+    arr = np.array(
+        [[True, False], [False, False, True], [False], [True, True, False, True]],
+        dtype=object,
+    )
+    ata = ArrowVariableShapedTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, ArrowVariableShapedTensorType)
+    assert len(ata) == len(arr)
+    out = ata.to_numpy()
+    for o, a in zip(out, arr):
+        np.testing.assert_array_equal(o, a)
+
+
+def test_arrow_variable_shaped_tensor_array_roundtrip_contiguous_optimization():
+    # Test that a roundtrip on slices of an already-contiguous 1D base array does not
+    # create any unnecessary copies.
+    base = np.arange(6)
+    base_address = base.__array_interface__["data"][0]
+    arr = np.array([base[:2], base[2:]], dtype=object)
+    ata = ArrowVariableShapedTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, ArrowVariableShapedTensorType)
+    assert len(ata) == len(arr)
+    assert ata.storage.field("data").buffers()[3].address == base_address
+    out = ata.to_numpy()
+    for o, a in zip(out, arr):
+        assert o.base.address == base_address
+        np.testing.assert_array_equal(o, a)
+
+
+def test_arrow_variable_shaped_tensor_array_slice():
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    arr = np.array(arrs, dtype=object)
+    ata = ArrowVariableShapedTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, ArrowVariableShapedTensorType)
+    assert len(ata) == len(arr)
+    indices = [0, 1, 2]
+    for i in indices:
+        np.testing.assert_array_equal(ata[i], arr[i])
+    slices = [
+        slice(0, 1),
+        slice(1, 2),
+        slice(2, 3),
+        slice(0, 2),
+        slice(1, 3),
+        slice(0, 3),
+    ]
+    for slice_ in slices:
+        for o, e in zip(ata[slice_], arr[slice_]):
+            np.testing.assert_array_equal(o, e)
+
+
+def test_variable_shaped_tensor_array_roundtrip():
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    arr = np.array(arrs, dtype=object)
+    ta = TensorArray(arr)
+    assert isinstance(ta.dtype, TensorDtype)
+    assert len(ta) == len(arr)
+    out = ta.to_numpy()
+    for o, a in zip(out, arr):
+        np.testing.assert_array_equal(o, a)
+
+    # Check Arrow conversion.
+    ata = ta.__arrow_array__()
+    assert isinstance(ata.type, ArrowVariableShapedTensorType)
+    assert len(ata) == len(arr)
+    out = ata.to_numpy()
+    for o, a in zip(out, arr):
+        np.testing.assert_array_equal(o, a)
+
+
+def test_variable_shaped_tensor_array_slice():
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    arr = np.array(arrs, dtype=object)
+    ta = TensorArray(arr)
+    assert isinstance(ta.dtype, TensorDtype)
+    assert len(ta) == len(arr)
+    indices = [0, 1, 2]
+    for i in indices:
+        np.testing.assert_array_equal(ta[i], arr[i])
+    slices = [
+        slice(0, 1),
+        slice(1, 2),
+        slice(2, 3),
+        slice(0, 2),
+        slice(1, 3),
+        slice(0, 3),
+    ]
+    for slice_ in slices:
+        for o, e in zip(ta[slice_], arr[slice_]):
+            np.testing.assert_array_equal(o, e)
 
 
 def test_tensor_array_block_slice():
@@ -628,44 +824,52 @@ def test_tensor_array_block_slice():
             9,
             12,
         ),
+        # Variable-shaped tensors.
+        (
+            [[False, True], [True, False, True], [False], [False, False, True, True]],
+            1,
+            3,
+        ),
     ],
 )
 @pytest.mark.parametrize("init_with_pandas", [True, False])
 def test_tensor_array_boolean_slice_pandas_roundtrip(init_with_pandas, test_data, a, b):
+    is_variable_shaped = len({len(elem) for elem in test_data}) > 1
     n = len(test_data)
     test_arr = np.array(test_data)
     df = pd.DataFrame({"one": TensorArray(test_arr), "two": ["a"] * n})
     if init_with_pandas:
         table = pa.Table.from_pandas(df)
     else:
-        pa_dtype = pa.bool_()
-        flat = [w for v in test_data for w in v]
-        data_array = pa.array(flat, pa_dtype)
-        inner_len = len(test_data[0])
-        offsets = list(range(0, len(flat) + 1, inner_len))
-        offset_buffer = pa.py_buffer(np.int32(offsets))
-        storage = pa.Array.from_buffers(
-            pa.list_(pa_dtype),
-            len(test_data),
-            [None, offset_buffer],
-            children=[data_array],
-        )
-        t_arr = pa.ExtensionArray.from_storage(
-            ArrowTensorType((inner_len,), pa.bool_()), storage
-        )
-        table = pa.table({"one": t_arr, "two": ["a"] * n})
+        if is_variable_shaped:
+            col = ArrowVariableShapedTensorArray.from_numpy(test_arr)
+        else:
+            col = ArrowTensorArray.from_numpy(test_arr)
+        table = pa.table({"one": col, "two": ["a"] * n})
     block_accessor = BlockAccessor.for_block(table)
 
     # Test without copy.
     table2 = block_accessor.slice(a, b, False)
-    np.testing.assert_array_equal(table2["one"].chunk(0).to_numpy(), test_arr[a:b, :])
+    out = table2["one"].chunk(0).to_numpy()
+    expected = test_arr[a:b]
+    if is_variable_shaped:
+        for o, e in zip(out, expected):
+            np.testing.assert_array_equal(o, e)
+    else:
+        np.testing.assert_array_equal(out, expected)
     pd.testing.assert_frame_equal(
         table2.to_pandas().reset_index(drop=True), df[a:b].reset_index(drop=True)
     )
 
     # Test with copy.
     table2 = block_accessor.slice(a, b, True)
-    np.testing.assert_array_equal(table2["one"].chunk(0).to_numpy(), test_arr[a:b, :])
+    out = table2["one"].chunk(0).to_numpy()
+    expected = test_arr[a:b]
+    if is_variable_shaped:
+        for o, e in zip(out, expected):
+            np.testing.assert_array_equal(o, e)
+    else:
+        np.testing.assert_array_equal(out, expected)
     pd.testing.assert_frame_equal(
         table2.to_pandas().reset_index(drop=True), df[a:b].reset_index(drop=True)
     )
@@ -898,26 +1102,14 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
         "schema={a: TensorDtype(shape=(4, 4), dtype=float64)})"
     )
 
-    # Test map_batches ragged ndarray column fails by default.
-    with pytest.raises(ValueError):
-        ds = ray.data.range(16, parallelism=4).map_batches(
-            lambda _: pd.DataFrame({"a": [np.ones((2, 2)), np.ones((3, 3))]}),
-            batch_size=2,
-        )
-
-    # Test map_batches ragged ndarray column uses opaque object-typed column if
-    # automatic tensor extension type casting is disabled.
-    ctx = DatasetContext.get_current()
-    old_config = ctx.enable_tensor_extension_casting
-    ctx.enable_tensor_extension_casting = False
-    try:
-        ds = ray.data.range(16, parallelism=4).map_batches(
-            lambda _: pd.DataFrame({"a": [np.ones((2, 2)), np.ones((3, 3))]}),
-            batch_size=2,
-        )
-        assert str(ds) == ("Dataset(num_blocks=4, num_rows=16, schema={a: object})")
-    finally:
-        ctx.enable_tensor_extension_casting = old_config
+    ds = ray.data.range(16, parallelism=4).map_batches(
+        lambda _: pd.DataFrame({"a": [np.ones((2, 2)), np.ones((3, 3))]}),
+        batch_size=2,
+    )
+    assert str(ds) == (
+        "Dataset(num_blocks=4, num_rows=16, "
+        "schema={a: TensorDtype(shape=None, dtype=float64)})"
+    )
 
 
 def test_tensors_in_tables_from_pandas(ray_start_regular_shared):
@@ -936,6 +1128,24 @@ def test_tensors_in_tables_from_pandas(ray_start_regular_shared):
         np.testing.assert_equal(v, e)
 
 
+def test_tensors_in_tables_from_pandas_variable_shaped(ray_start_regular_shared):
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    outer_dim = len(arrs)
+    df = pd.DataFrame({"one": list(range(outer_dim)), "two": arrs})
+    # Cast column to tensor extension dtype.
+    df["two"] = df["two"].astype(TensorDtype(None, np.int64))
+    ds = ray.data.from_pandas(df)
+    values = [[s["one"], s["two"]] for s in ds.take()]
+    expected = list(zip(range(outer_dim), arrs))
+    for v, e in zip(sorted(values), expected):
+        np.testing.assert_equal(v, e)
+
+
 def test_tensors_in_tables_pandas_roundtrip(
     ray_start_regular_shared,
     enable_automatic_tensor_extension_cast,
@@ -946,9 +1156,31 @@ def test_tensors_in_tables_pandas_roundtrip(
     num_items = np.prod(np.array(shape))
     arr = np.arange(num_items).reshape(shape)
     df = pd.DataFrame({"one": list(range(outer_dim)), "two": TensorArray(arr)})
-    ds = ray.data.from_pandas([df])
+    ds = ray.data.from_pandas(df)
+    ds = ds.map_batches(lambda df: df + 1, batch_size=2)
     ds_df = ds.to_pandas()
-    expected_df = df
+    expected_df = df + 1
+    if enable_automatic_tensor_extension_cast:
+        expected_df.loc[:, "two"] = list(expected_df["two"].to_numpy())
+    pd.testing.assert_frame_equal(ds_df, expected_df)
+
+
+def test_tensors_in_tables_pandas_roundtrip_variable_shaped(
+    ray_start_regular_shared,
+    enable_automatic_tensor_extension_cast,
+):
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    outer_dim = len(arrs)
+    df = pd.DataFrame({"one": list(range(outer_dim)), "two": TensorArray(arrs)})
+    ds = ray.data.from_pandas(df)
+    ds = ds.map_batches(lambda df: df + 1, batch_size=2)
+    ds_df = ds.to_pandas()
+    expected_df = df + 1
     if enable_automatic_tensor_extension_cast:
         expected_df.loc[:, "two"] = list(expected_df["two"].to_numpy())
     pd.testing.assert_frame_equal(ds_df, expected_df)
@@ -961,11 +1193,33 @@ def test_tensors_in_tables_parquet_roundtrip(ray_start_regular_shared, tmp_path)
     num_items = np.prod(np.array(shape))
     arr = np.arange(num_items).reshape(shape)
     df = pd.DataFrame({"one": list(range(outer_dim)), "two": TensorArray(arr)})
-    ds = ray.data.from_pandas([df])
+    ds = ray.data.from_pandas(df)
+    ds = ds.map_batches(lambda df: df + 1, batch_size=2)
     ds.write_parquet(str(tmp_path))
     ds = ray.data.read_parquet(str(tmp_path))
     values = [[s["one"], s["two"]] for s in ds.take()]
-    expected = list(zip(list(range(outer_dim)), arr))
+    expected = list(zip(list(range(1, outer_dim + 1)), arr + 1))
+    for v, e in zip(sorted(values), expected):
+        np.testing.assert_equal(v, e)
+
+
+def test_tensors_in_tables_parquet_roundtrip_variable_shaped(
+    ray_start_regular_shared, tmp_path
+):
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    outer_dim = len(arrs)
+    df = pd.DataFrame({"one": list(range(outer_dim)), "two": TensorArray(arrs)})
+    ds = ray.data.from_pandas(df)
+    ds = ds.map_batches(lambda df: df + 1, batch_size=2)
+    ds.write_parquet(str(tmp_path))
+    ds = ray.data.read_parquet(str(tmp_path))
+    values = [[s["one"], s["two"]] for s in ds.take()]
+    expected = list(zip(list(range(1, outer_dim + 1)), [arr + 1 for arr in arrs]))
     for v, e in zip(sorted(values), expected):
         np.testing.assert_equal(v, e)
 
@@ -1306,6 +1560,59 @@ def test_tensors_in_tables_to_torch_mix(ray_start_regular_shared, pipelined):
         np.testing.assert_array_equal(labels, np.sort(df["label"].to_numpy()))
 
 
+@pytest.mark.skip(
+    reason=(
+        "Waiting for Torch to support unsqueezing and concatenating nested tensors."
+    )
+)
+@pytest.mark.parametrize("pipelined", [False, True])
+def test_tensors_in_tables_to_torch_variable_shaped(
+    ray_start_regular_shared, pipelined
+):
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs1 = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    df1 = pd.DataFrame(
+        {
+            "one": TensorArray(arrs1),
+            "two": TensorArray([a + 1 for a in arrs1]),
+            "label": [1.0, 2.0, 3.0],
+        }
+    )
+    base = cumsum_sizes[-1]
+    arrs2 = [
+        np.arange(base + offset, base + offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    df2 = pd.DataFrame(
+        {
+            "one": TensorArray(arrs2),
+            "two": TensorArray([a + 1 for a in arrs2]),
+            "label": [4.0, 5.0, 6.0],
+        }
+    )
+    df = pd.concat([df1, df2])
+    ds = ray.data.from_pandas([df1, df2])
+    ds = maybe_pipeline(ds, pipelined)
+    torchd = ds.to_torch(
+        label_column="label", batch_size=2, unsqueeze_label_tensor=False
+    )
+
+    num_epochs = 1 if pipelined else 2
+    for _ in range(num_epochs):
+        features, labels = [], []
+        for batch in iter(torchd):
+            features.append(batch[0].numpy())
+            labels.append(batch[1].numpy())
+        features, labels = np.concatenate(features), np.concatenate(labels)
+        values = np.stack([df["one"].to_numpy(), df["two"].to_numpy()], axis=1)
+        np.testing.assert_array_equal(values, features)
+        np.testing.assert_array_equal(df["label"].to_numpy(), labels)
+
+
 @pytest.mark.parametrize("pipelined", [False, True])
 def test_tensors_in_tables_to_tf(ray_start_regular_shared, pipelined):
     import tensorflow as tf
@@ -1401,6 +1708,66 @@ def test_tensors_in_tables_to_tf_mix(ray_start_regular_shared, pipelined):
     np.testing.assert_array_equal(col1, np.sort(df["one"].to_numpy()))
     np.testing.assert_array_equal(col2, np.sort(df["two"].to_numpy()))
     np.testing.assert_array_equal(labels, np.sort(df["label"].to_numpy()))
+
+
+@pytest.mark.parametrize("pipelined", [False, True])
+def test_tensors_in_tables_to_tf_variable_shaped(ray_start_regular_shared, pipelined):
+    import tensorflow as tf
+
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs1 = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    df1 = pd.DataFrame(
+        {
+            "one": TensorArray(arrs1),
+            "two": TensorArray([a + 1 for a in arrs1]),
+            "label": [1.0, 2.0, 3.0],
+        }
+    )
+    base = cumsum_sizes[-1]
+    arrs2 = [
+        np.arange(base + offset, base + offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    df2 = pd.DataFrame(
+        {
+            "one": TensorArray(arrs2),
+            "two": TensorArray([a + 1 for a in arrs2]),
+            "label": [4.0, 5.0, 6.0],
+        }
+    )
+    df = pd.concat([df1, df2])
+    ds = ray.data.from_pandas([df1, df2])
+    ds = maybe_pipeline(ds, pipelined)
+    tfd = ds.to_tf(
+        label_column="label",
+        output_signature=(
+            tf.RaggedTensorSpec(shape=(None, 2, None, None), dtype=tf.int64),
+            tf.TensorSpec(shape=(None,), dtype=tf.float64),
+        ),
+        batch_size=2,
+    )
+    features, labels = [], []
+    # TODO(Clark): Use tf.data.Dataset.as_numpy_iterator() once it supports
+    # RaggedTensors: https://github.com/tensorflow/tensorflow/issues/53149
+    for features_, labels_ in tfd:
+        features.append(features_.numpy())
+        labels.append(labels_.numpy())
+    features, labels = np.concatenate(features), np.concatenate(labels)
+    values = np.stack([df["one"].to_numpy(), df["two"].to_numpy()], axis=1)
+
+    def recursive_to_list(a):
+        if not isinstance(a, (list, np.ndarray)):
+            return a
+        return [recursive_to_list(e) for e in a]
+
+    # Convert to a nested Python list in order to circumvent failed comparisons on
+    # ndarray raggedness.
+    np.testing.assert_equal(recursive_to_list(values), recursive_to_list(features))
+    np.testing.assert_array_equal(df["label"].to_numpy(), labels)
 
 
 def test_empty_shuffle(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -27,7 +27,6 @@ from ray.data.extensions.tensor_extension import (
     ArrowTensorArray,
     ArrowTensorType,
     ArrowVariableShapedTensorArray,
-    ArrowVariableShapedTensorType,
     TensorArray,
     TensorDtype,
 )
@@ -510,371 +509,6 @@ def test_range_table(ray_start_regular_shared):
     assert ds.take() == [{"value": i} for i in range(10)]
 
 
-def test_tensor_array_validation():
-    # Test unknown input type raises TypeError.
-    with pytest.raises(TypeError):
-        TensorArray(object())
-
-    # Test non-primitive element raises TypeError.
-    with pytest.raises(TypeError):
-        TensorArray(np.array([object(), object()]))
-
-    with pytest.raises(TypeError):
-        TensorArray([object(), object()])
-
-
-def test_arrow_scalar_tensor_array_roundtrip():
-    arr = np.arange(10)
-    ata = ArrowTensorArray.from_numpy(arr)
-    assert isinstance(ata.type, pa.DataType)
-    assert len(ata) == len(arr)
-    out = ata.to_numpy()
-    np.testing.assert_array_equal(out, arr)
-
-
-def test_arrow_scalar_tensor_array_roundtrip_boolean():
-    arr = np.array([True, False, False, True])
-    ata = ArrowTensorArray.from_numpy(arr)
-    assert isinstance(ata.type, pa.DataType)
-    assert len(ata) == len(arr)
-    # Zero-copy is not possible since Arrow bitpacks boolean arrays while NumPy does
-    # not.
-    out = ata.to_numpy(zero_copy_only=False)
-    np.testing.assert_array_equal(out, arr)
-
-
-def test_scalar_tensor_array_roundtrip():
-    arr = np.arange(10)
-    ta = TensorArray(arr)
-    assert isinstance(ta.dtype, TensorDtype)
-    assert len(ta) == len(arr)
-    out = ta.to_numpy()
-    np.testing.assert_array_equal(out, arr)
-
-    # Check Arrow conversion.
-    ata = ta.__arrow_array__()
-    assert isinstance(ata.type, pa.DataType)
-    assert len(ata) == len(arr)
-    out = ata.to_numpy()
-    np.testing.assert_array_equal(out, arr)
-
-
-def test_arrow_variable_shaped_tensor_array_validation():
-    # Test homogeneous-typed tensor raises ValueError.
-    with pytest.raises(ValueError):
-        ArrowVariableShapedTensorArray.from_numpy(np.ones((3, 2, 2)))
-
-    # Test arbitrary object raises ValueError.
-    with pytest.raises(ValueError):
-        ArrowVariableShapedTensorArray.from_numpy(object())
-
-    # Test empty array raises ValueError.
-    with pytest.raises(ValueError):
-        ArrowVariableShapedTensorArray.from_numpy(np.array([]))
-
-    # Test deeply ragged tensor raises ValueError.
-    with pytest.raises(ValueError):
-        ArrowVariableShapedTensorArray.from_numpy(
-            np.array(
-                [
-                    np.array(
-                        [
-                            np.array([1, 2]),
-                            np.array([3, 4, 5]),
-                        ],
-                        dtype=object,
-                    ),
-                    np.array(
-                        [
-                            np.array([5, 6, 7, 8]),
-                        ],
-                        dtype=object,
-                    ),
-                    np.array(
-                        [
-                            np.array([5, 6, 7, 8]),
-                            np.array([5, 6, 7, 8]),
-                            np.array([5, 6, 7, 8]),
-                        ],
-                        dtype=object,
-                    ),
-                ],
-                dtype=object,
-            )
-        )
-
-
-def test_arrow_variable_shaped_tensor_array_roundtrip():
-    shapes = [(2, 2), (3, 3), (4, 4)]
-    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
-    arrs = [
-        np.arange(offset, offset + np.prod(shape)).reshape(shape)
-        for offset, shape in zip(cumsum_sizes, shapes)
-    ]
-    arr = np.array(arrs, dtype=object)
-    ata = ArrowVariableShapedTensorArray.from_numpy(arr)
-    assert isinstance(ata.type, ArrowVariableShapedTensorType)
-    assert len(ata) == len(arr)
-    out = ata.to_numpy()
-    for o, a in zip(out, arr):
-        np.testing.assert_array_equal(o, a)
-
-
-def test_arrow_variable_shaped_tensor_array_roundtrip_boolean():
-    arr = np.array(
-        [[True, False], [False, False, True], [False], [True, True, False, True]],
-        dtype=object,
-    )
-    ata = ArrowVariableShapedTensorArray.from_numpy(arr)
-    assert isinstance(ata.type, ArrowVariableShapedTensorType)
-    assert len(ata) == len(arr)
-    out = ata.to_numpy()
-    for o, a in zip(out, arr):
-        np.testing.assert_array_equal(o, a)
-
-
-def test_arrow_variable_shaped_tensor_array_roundtrip_contiguous_optimization():
-    # Test that a roundtrip on slices of an already-contiguous 1D base array does not
-    # create any unnecessary copies.
-    base = np.arange(6)
-    base_address = base.__array_interface__["data"][0]
-    arr = np.array([base[:2], base[2:]], dtype=object)
-    ata = ArrowVariableShapedTensorArray.from_numpy(arr)
-    assert isinstance(ata.type, ArrowVariableShapedTensorType)
-    assert len(ata) == len(arr)
-    assert ata.storage.field("data").buffers()[3].address == base_address
-    out = ata.to_numpy()
-    for o, a in zip(out, arr):
-        assert o.base.address == base_address
-        np.testing.assert_array_equal(o, a)
-
-
-def test_arrow_variable_shaped_tensor_array_slice():
-    shapes = [(2, 2), (3, 3), (4, 4)]
-    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
-    arrs = [
-        np.arange(offset, offset + np.prod(shape)).reshape(shape)
-        for offset, shape in zip(cumsum_sizes, shapes)
-    ]
-    arr = np.array(arrs, dtype=object)
-    ata = ArrowVariableShapedTensorArray.from_numpy(arr)
-    assert isinstance(ata.type, ArrowVariableShapedTensorType)
-    assert len(ata) == len(arr)
-    indices = [0, 1, 2]
-    for i in indices:
-        np.testing.assert_array_equal(ata[i], arr[i])
-    slices = [
-        slice(0, 1),
-        slice(1, 2),
-        slice(2, 3),
-        slice(0, 2),
-        slice(1, 3),
-        slice(0, 3),
-    ]
-    for slice_ in slices:
-        for o, e in zip(ata[slice_], arr[slice_]):
-            np.testing.assert_array_equal(o, e)
-
-
-def test_variable_shaped_tensor_array_roundtrip():
-    shapes = [(2, 2), (3, 3), (4, 4)]
-    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
-    arrs = [
-        np.arange(offset, offset + np.prod(shape)).reshape(shape)
-        for offset, shape in zip(cumsum_sizes, shapes)
-    ]
-    arr = np.array(arrs, dtype=object)
-    ta = TensorArray(arr)
-    assert isinstance(ta.dtype, TensorDtype)
-    assert len(ta) == len(arr)
-    out = ta.to_numpy()
-    for o, a in zip(out, arr):
-        np.testing.assert_array_equal(o, a)
-
-    # Check Arrow conversion.
-    ata = ta.__arrow_array__()
-    assert isinstance(ata.type, ArrowVariableShapedTensorType)
-    assert len(ata) == len(arr)
-    out = ata.to_numpy()
-    for o, a in zip(out, arr):
-        np.testing.assert_array_equal(o, a)
-
-
-def test_variable_shaped_tensor_array_slice():
-    shapes = [(2, 2), (3, 3), (4, 4)]
-    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
-    arrs = [
-        np.arange(offset, offset + np.prod(shape)).reshape(shape)
-        for offset, shape in zip(cumsum_sizes, shapes)
-    ]
-    arr = np.array(arrs, dtype=object)
-    ta = TensorArray(arr)
-    assert isinstance(ta.dtype, TensorDtype)
-    assert len(ta) == len(arr)
-    indices = [0, 1, 2]
-    for i in indices:
-        np.testing.assert_array_equal(ta[i], arr[i])
-    slices = [
-        slice(0, 1),
-        slice(1, 2),
-        slice(2, 3),
-        slice(0, 2),
-        slice(1, 3),
-        slice(0, 3),
-    ]
-    for slice_ in slices:
-        for o, e in zip(ta[slice_], arr[slice_]):
-            np.testing.assert_array_equal(o, e)
-
-
-def test_tensor_array_block_slice():
-    # Test that ArrowBlock slicing works with tensor column extension type.
-    def check_for_copy(table1, table2, a, b, is_copy):
-        expected_slice = table1.slice(a, b - a)
-        assert table2.equals(expected_slice)
-        assert table2.schema == table1.schema
-        assert table1.num_columns == table2.num_columns
-        for col1, col2 in zip(table1.columns, table2.columns):
-            assert col1.num_chunks == col2.num_chunks
-            for chunk1, chunk2 in zip(col1.chunks, col2.chunks):
-                bufs1 = chunk1.buffers()
-                bufs2 = chunk2.buffers()
-                expected_offset = 0 if is_copy else a
-                assert chunk2.offset == expected_offset
-                assert len(chunk2) == b - a
-                if is_copy:
-                    assert bufs2[1].address != bufs1[1].address
-                else:
-                    assert bufs2[1].address == bufs1[1].address
-
-    n = 20
-    one_arr = np.arange(4 * n).reshape(n, 2, 2)
-    df = pd.DataFrame({"one": TensorArray(one_arr), "two": ["a"] * n})
-    table = pa.Table.from_pandas(df)
-    a, b = 5, 10
-    block_accessor = BlockAccessor.for_block(table)
-
-    # Test with copy.
-    table2 = block_accessor.slice(a, b, True)
-    np.testing.assert_array_equal(table2["one"].chunk(0).to_numpy(), one_arr[a:b, :, :])
-    check_for_copy(table, table2, a, b, is_copy=True)
-
-    # Test without copy.
-    table2 = block_accessor.slice(a, b, False)
-    np.testing.assert_array_equal(table2["one"].chunk(0).to_numpy(), one_arr[a:b, :, :])
-    check_for_copy(table, table2, a, b, is_copy=False)
-
-
-@pytest.mark.parametrize(
-    "test_data,a,b",
-    [
-        ([[False, True], [True, False], [True, True], [False, False]], 1, 3),
-        ([[False, True], [True, False], [True, True], [False, False]], 0, 1),
-        (
-            [
-                [False, True],
-                [True, False],
-                [True, True],
-                [False, False],
-                [True, False],
-                [False, False],
-                [False, True],
-                [True, True],
-                [False, False],
-                [True, True],
-                [False, True],
-                [True, False],
-            ],
-            3,
-            6,
-        ),
-        (
-            [
-                [False, True],
-                [True, False],
-                [True, True],
-                [False, False],
-                [True, False],
-                [False, False],
-                [False, True],
-                [True, True],
-                [False, False],
-                [True, True],
-                [False, True],
-                [True, False],
-            ],
-            7,
-            11,
-        ),
-        (
-            [
-                [False, True],
-                [True, False],
-                [True, True],
-                [False, False],
-                [True, False],
-                [False, False],
-                [False, True],
-                [True, True],
-                [False, False],
-                [True, True],
-                [False, True],
-                [True, False],
-            ],
-            9,
-            12,
-        ),
-        # Variable-shaped tensors.
-        (
-            [[False, True], [True, False, True], [False], [False, False, True, True]],
-            1,
-            3,
-        ),
-    ],
-)
-@pytest.mark.parametrize("init_with_pandas", [True, False])
-def test_tensor_array_boolean_slice_pandas_roundtrip(init_with_pandas, test_data, a, b):
-    is_variable_shaped = len({len(elem) for elem in test_data}) > 1
-    n = len(test_data)
-    test_arr = np.array(test_data)
-    df = pd.DataFrame({"one": TensorArray(test_arr), "two": ["a"] * n})
-    if init_with_pandas:
-        table = pa.Table.from_pandas(df)
-    else:
-        if is_variable_shaped:
-            col = ArrowVariableShapedTensorArray.from_numpy(test_arr)
-        else:
-            col = ArrowTensorArray.from_numpy(test_arr)
-        table = pa.table({"one": col, "two": ["a"] * n})
-    block_accessor = BlockAccessor.for_block(table)
-
-    # Test without copy.
-    table2 = block_accessor.slice(a, b, False)
-    out = table2["one"].chunk(0).to_numpy()
-    expected = test_arr[a:b]
-    if is_variable_shaped:
-        for o, e in zip(out, expected):
-            np.testing.assert_array_equal(o, e)
-    else:
-        np.testing.assert_array_equal(out, expected)
-    pd.testing.assert_frame_equal(
-        table2.to_pandas().reset_index(drop=True), df[a:b].reset_index(drop=True)
-    )
-
-    # Test with copy.
-    table2 = block_accessor.slice(a, b, True)
-    out = table2["one"].chunk(0).to_numpy()
-    expected = test_arr[a:b]
-    if is_variable_shaped:
-        for o, e in zip(out, expected):
-            np.testing.assert_array_equal(o, e)
-    else:
-        np.testing.assert_array_equal(out, expected)
-    pd.testing.assert_frame_equal(
-        table2.to_pandas().reset_index(drop=True), df[a:b].reset_index(drop=True)
-    )
-
-
 def test_tensors_basic(ray_start_regular_shared):
     # Create directly.
     tensor_shape = (3, 5)
@@ -1109,6 +743,154 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     assert str(ds) == (
         "Dataset(num_blocks=4, num_rows=16, "
         "schema={a: TensorDtype(shape=None, dtype=float64)})"
+    )
+
+
+def test_tensor_array_block_slice():
+    # Test that ArrowBlock slicing works with tensor column extension type.
+    def check_for_copy(table1, table2, a, b, is_copy):
+        expected_slice = table1.slice(a, b - a)
+        assert table2.equals(expected_slice)
+        assert table2.schema == table1.schema
+        assert table1.num_columns == table2.num_columns
+        for col1, col2 in zip(table1.columns, table2.columns):
+            assert col1.num_chunks == col2.num_chunks
+            for chunk1, chunk2 in zip(col1.chunks, col2.chunks):
+                bufs1 = chunk1.buffers()
+                bufs2 = chunk2.buffers()
+                expected_offset = 0 if is_copy else a
+                assert chunk2.offset == expected_offset
+                assert len(chunk2) == b - a
+                if is_copy:
+                    assert bufs2[1].address != bufs1[1].address
+                else:
+                    assert bufs2[1].address == bufs1[1].address
+
+    n = 20
+    one_arr = np.arange(4 * n).reshape(n, 2, 2)
+    df = pd.DataFrame({"one": TensorArray(one_arr), "two": ["a"] * n})
+    table = pa.Table.from_pandas(df)
+    a, b = 5, 10
+    block_accessor = BlockAccessor.for_block(table)
+
+    # Test with copy.
+    table2 = block_accessor.slice(a, b, True)
+    np.testing.assert_array_equal(table2["one"].chunk(0).to_numpy(), one_arr[a:b, :, :])
+    check_for_copy(table, table2, a, b, is_copy=True)
+
+    # Test without copy.
+    table2 = block_accessor.slice(a, b, False)
+    np.testing.assert_array_equal(table2["one"].chunk(0).to_numpy(), one_arr[a:b, :, :])
+    check_for_copy(table, table2, a, b, is_copy=False)
+
+
+@pytest.mark.parametrize(
+    "test_data,a,b",
+    [
+        ([[False, True], [True, False], [True, True], [False, False]], 1, 3),
+        ([[False, True], [True, False], [True, True], [False, False]], 0, 1),
+        (
+            [
+                [False, True],
+                [True, False],
+                [True, True],
+                [False, False],
+                [True, False],
+                [False, False],
+                [False, True],
+                [True, True],
+                [False, False],
+                [True, True],
+                [False, True],
+                [True, False],
+            ],
+            3,
+            6,
+        ),
+        (
+            [
+                [False, True],
+                [True, False],
+                [True, True],
+                [False, False],
+                [True, False],
+                [False, False],
+                [False, True],
+                [True, True],
+                [False, False],
+                [True, True],
+                [False, True],
+                [True, False],
+            ],
+            7,
+            11,
+        ),
+        (
+            [
+                [False, True],
+                [True, False],
+                [True, True],
+                [False, False],
+                [True, False],
+                [False, False],
+                [False, True],
+                [True, True],
+                [False, False],
+                [True, True],
+                [False, True],
+                [True, False],
+            ],
+            9,
+            12,
+        ),
+        # Variable-shaped tensors.
+        (
+            [[False, True], [True, False, True], [False], [False, False, True, True]],
+            1,
+            3,
+        ),
+    ],
+)
+@pytest.mark.parametrize("init_with_pandas", [True, False])
+def test_tensor_array_boolean_slice_pandas_roundtrip(init_with_pandas, test_data, a, b):
+    is_variable_shaped = len({len(elem) for elem in test_data}) > 1
+    n = len(test_data)
+    test_arr = np.array(test_data)
+    df = pd.DataFrame({"one": TensorArray(test_arr), "two": ["a"] * n})
+    if init_with_pandas:
+        table = pa.Table.from_pandas(df)
+    else:
+        if is_variable_shaped:
+            col = ArrowVariableShapedTensorArray.from_numpy(test_arr)
+        else:
+            col = ArrowTensorArray.from_numpy(test_arr)
+        table = pa.table({"one": col, "two": ["a"] * n})
+    block_accessor = BlockAccessor.for_block(table)
+
+    # Test without copy.
+    table2 = block_accessor.slice(a, b, False)
+    out = table2["one"].chunk(0).to_numpy()
+    expected = test_arr[a:b]
+    if is_variable_shaped:
+        for o, e in zip(out, expected):
+            np.testing.assert_array_equal(o, e)
+    else:
+        np.testing.assert_array_equal(out, expected)
+    pd.testing.assert_frame_equal(
+        table2.to_pandas().reset_index(drop=True), df[a:b].reset_index(drop=True)
+    )
+
+    # Test with copy.
+    table2 = block_accessor.slice(a, b, True)
+    out = table2["one"].chunk(0).to_numpy()
+    expected = test_arr[a:b]
+    if is_variable_shaped:
+        for o, e in zip(out, expected):
+            np.testing.assert_array_equal(o, e)
+    else:
+        np.testing.assert_array_equal(out, expected)
+    pd.testing.assert_frame_equal(
+        table2.to_pandas().reset_index(drop=True), df[a:b].reset_index(drop=True)
     )
 
 

--- a/python/ray/data/tests/test_dataset_numpy.py
+++ b/python/ray/data/tests/test_dataset_numpy.py
@@ -59,6 +59,21 @@ def test_from_numpy(ray_start_regular_shared, from_ref):
     assert "from_numpy_refs" in ds.stats()
 
 
+def test_from_numpy_variable_shaped(ray_start_regular_shared):
+    arr = np.array([np.ones((2, 2)), np.ones((3, 3))], dtype=object)
+    ds = ray.data.from_numpy(arr)
+    values = np.array(ds.take(2), dtype=object)
+
+    def recursive_to_list(a):
+        if not isinstance(a, (list, np.ndarray)):
+            return a
+        return [recursive_to_list(e) for e in a]
+
+    # Convert to a nested Python list in order to circumvent failed comparisons on
+    # ndarray raggedness.
+    np.testing.assert_equal(recursive_to_list(values), recursive_to_list(arr))
+
+
 def test_to_numpy_refs(ray_start_regular_shared):
     # Simple Dataset
     ds = ray.data.range(10)


### PR DESCRIPTION
This reverts commit c1c09455e05f0c14af234faa1c442eadfcfbac5b, and unreverts #27625.

This was failing due to a failing nightly test: https://buildkite.com/ray-project/release-tests-branch/builds/1087#01839c28-e9c8-43f3-859e-6dc3a6289f6e

## TODOs

- [x] Nightly test is passing

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
