### PR TITLE
[RLlib] Quick fix for MultiAgentEnv.observation_space_contains

### DIFF
--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -145,7 +145,7 @@ class MultiAgentEnv(gym.Env):
             for key, agent_obs in x.items():
                 if not self.observation_space[key].contains(agent_obs):
                     return False
-            if not all(k in self.observation_space for k in x):
+            if not all(k in self.observation_space.spaces for k in x):
                 if log_once("possibly_bad_multi_agent_dict_missing_agent_observations"):
                     logger.warning(
                         "You environment returns observations that are "


### PR DESCRIPTION
Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

Dict gym space doesn't work like dict. We shouldn't use ``in`` to check membership.

## Related issue number

Closes #28667

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
