### PR TITLE
[Dashboard] Fix the issue middleware is crashed due to unhandled CancelledError

### DIFF
--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -121,7 +121,7 @@ class HttpServerDashboardHead:
             response = await handler(request)
             status_tag = f"{floor(response.status / 100)}xx"
             return response
-        except Exception:
+        except (Exception, asyncio.CancelledError):
             status_tag = "5xx"
             raise
         finally:

--- a/dashboard/modules/state/state_head.py
+++ b/dashboard/modules/state/state_head.py
@@ -380,6 +380,11 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
                 await response.write(bytes(logs_to_stream))
             await response.write_eof()
             return response
+        except asyncio.CancelledError:
+            # This happens when the client side closes the connection.
+            # Fofce close the connection and do no-op.
+            response.force_close()
+            raise
         except Exception as e:
             logger.exception(e)
             error_msg = bytearray(b"0")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

except Except cannot catch the `asyncio.CancelledError` because it is based on `BaseException`. This causes the middleware to throw an exception because the handler doesn't return value & error is not handled. This fixes the issue by handling `CancelledError` better. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
