### PR TITLE
[tune] Add Tuner.get_results() to retrieve results after restore

### DIFF
--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -26,6 +26,7 @@ _TRAINABLE_PKL = "trainable.pkl"
 _TUNER_PKL = "tuner.pkl"
 _TRAINABLE_KEY = "_trainable"
 _PARAM_SPACE_KEY = "_param_space"
+_EXPERIMENT_ANALYSIS_KEY = "_experiment_analysis"
 
 
 class TunerInternal:
@@ -103,6 +104,8 @@ class TunerInternal:
         self._experiment_checkpoint_dir = self._setup_create_experiment_checkpoint_dir(
             self._run_config
         )
+
+        self._experiment_analysis = None
 
         # Not used for restored Tuner.
         self._param_space = param_space or {}
@@ -219,6 +222,8 @@ class TunerInternal:
             shutil.rmtree(experiment_checkpoint_path)
             self._experiment_checkpoint_dir = str(new_exp_path)
 
+        self._experiment_analysis = ExperimentAnalysis(self._experiment_checkpoint_dir)
+
     def _maybe_sync_down_tuner_state(self, restore_path: str) -> Tuple[bool, str]:
         """Sync down trainable state from remote storage.
 
@@ -284,7 +289,17 @@ class TunerInternal:
         else:
             analysis = self._fit_resume(trainable)
 
-        return ResultGrid(analysis)
+        self._experiment_analysis = analysis
+
+        return ResultGrid(self._experiment_analysis)
+
+    def get_results(self) -> ResultGrid:
+        if not self._experiment_analysis:
+            raise RuntimeError(
+                "Can't return results as experiment has not been run, yet. "
+                "Call `Tuner.fit()` to run the experiment first."
+            )
+        return ResultGrid(self._experiment_analysis)
 
     def _get_tune_run_arguments(self, trainable) -> Dict[str, Any]:
         """Get tune.run arguments common for both new and resumed runs."""
@@ -413,6 +428,7 @@ class TunerInternal:
         state = self.__dict__.copy()
         state.pop(_TRAINABLE_KEY, None)
         state.pop(_PARAM_SPACE_KEY, None)
+        state.pop(_EXPERIMENT_ANALYSIS_KEY, None)
         return state
 
     def __setstate__(self, state):

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -224,7 +224,9 @@ class TunerInternal:
 
         try:
             self._experiment_analysis = ExperimentAnalysis(
-                self._experiment_checkpoint_dir
+                self._experiment_checkpoint_dir,
+                default_metric=self._tune_config.metric,
+                default_mode=self._tune_config.mode,
             )
         except Exception:
             self._experiment_analysis = None

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -222,7 +222,12 @@ class TunerInternal:
             shutil.rmtree(experiment_checkpoint_path)
             self._experiment_checkpoint_dir = str(new_exp_path)
 
-        self._experiment_analysis = ExperimentAnalysis(self._experiment_checkpoint_dir)
+        try:
+            self._experiment_analysis = ExperimentAnalysis(
+                self._experiment_checkpoint_dir
+            )
+        except Exception:
+            self._experiment_analysis = None
 
     def _maybe_sync_down_tuner_state(self, restore_path: str) -> Tuple[bool, str]:
         """Sync down trainable state from remote storage.

--- a/python/ray/tune/tests/test_tuner_restore.py
+++ b/python/ray/tune/tests/test_tuner_restore.py
@@ -91,12 +91,14 @@ def test_tuner_restore_num_trials(ray_start_4_cpus, tmpdir):
     """Number of trials after restoring a finished run should be the same"""
     tuner = Tuner(
         lambda config: 1,
-        tune_config=TuneConfig(num_samples=4),
+        tune_config=TuneConfig(num_samples=4, metric="_metric", mode="max"),
         run_config=RunConfig(
             name="test_tuner_restore_num_trials", local_dir=str(tmpdir)
         ),
     )
-    tuner.fit()
+    results = tuner.fit()
+    assert len(results) == 4
+    assert results.get_best_result().metrics["_metric"] == 1
 
     del tuner
     tuner = Tuner.restore(str(tmpdir / "test_tuner_restore_num_trials"))
@@ -104,9 +106,11 @@ def test_tuner_restore_num_trials(ray_start_4_cpus, tmpdir):
     # Check restored results
     results = tuner.get_results()
     assert len(results) == 4
+    assert results.get_best_result().metrics["_metric"] == 1
 
     results = tuner.fit()
     assert len(results) == 4
+    assert results.get_best_result().metrics["_metric"] == 1
 
 
 def test_tuner_restore_resume_errored(ray_start_4_cpus, tmpdir):

--- a/python/ray/tune/tests/test_tuner_restore.py
+++ b/python/ray/tune/tests/test_tuner_restore.py
@@ -100,6 +100,11 @@ def test_tuner_restore_num_trials(ray_start_4_cpus, tmpdir):
 
     del tuner
     tuner = Tuner.restore(str(tmpdir / "test_tuner_restore_num_trials"))
+
+    # Check restored results
+    results = tuner.get_results()
+    assert len(results) == 4
+
     results = tuner.fit()
     assert len(results) == 4
 
@@ -137,7 +142,17 @@ def test_tuner_restore_resume_errored(ray_start_4_cpus, tmpdir):
     tuner = Tuner.restore(
         str(tmpdir / "test_tuner_restore_resume_errored"), resume_errored=True
     )
+
+    # Check restored results
+    results = tuner.get_results()
+    assert len(results) == 4
+    assert len(results.errors) == 2
+    # Second and third trial are at iter 1 because they failed after first report
+    assert [r.metrics["it"] for r in results] == [2, 1, 2, 1]
+
+    # Get new results
     results = tuner.fit()
+
     assert len(results) == 4
     assert len(results.errors) == 0
     # Since the errored trials are being resumed from previous state and then report
@@ -176,6 +191,14 @@ def test_tuner_restore_restart_errored(ray_start_4_cpus, tmpdir):
     tuner = Tuner.restore(
         str(tmpdir / "test_tuner_restore_restart_errored"), restart_errored=True
     )
+
+    # Check restored results
+    results = tuner.get_results()
+    assert len(results) == 4
+    assert len(results.errors) == 2
+    assert [r.metrics["it"] for r in results] == [2, 1, 2, 1]
+
+    # Get new results
     results = tuner.fit()
     assert len(results) == 4
     assert len(results.errors) == 0

--- a/python/ray/tune/tuner.py
+++ b/python/ray/tune/tuner.py
@@ -261,8 +261,9 @@ class Tuner:
     def get_results(self) -> ResultGrid:
         """Get results of a hyperparameter tuning run.
 
-        This method returns the same results as :meth:`fit` and can be used
-        to retrieve the results after restoring a tuner.
+        This method returns the same results as :meth:`fit() <ray.tune.tuner.Tuner.fit>`
+        and can be used to retrieve the results after restoring a tuner without
+        calling ``fit()`` again.
 
         If the tuner has not been fit before, an error will be raised.
 

--- a/python/ray/tune/tuner.py
+++ b/python/ray/tune/tuner.py
@@ -257,3 +257,27 @@ class Tuner:
                 raise TuneError(
                     _TUNER_FAILED_MSG.format(path=experiment_checkpoint_dir)
                 ) from e
+
+    def get_results(self) -> ResultGrid:
+        """Get results of a hyperparameter tuning run.
+
+        This method returns the same results as :meth:`fit` and can be used
+        to retrieve the results after restoring a tuner.
+
+        If the tuner has not been fit before, an error will be raised.
+
+        .. code-block:: python
+
+            from ray.tune import Tuner
+
+            tuner = Tuner.restore("/path/to/experiment')
+            results = tuner.get_results()
+
+        Returns:
+            Result grid of a previously fitted tuning run.
+
+        """
+        if not self._is_ray_client:
+            return self._local_tuner.get_results()
+        else:
+            return ray.get(self._remote_tuner.fit.remote())


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

At the moment, we need to call `tuner.fit()` to retrieve results. This PR adds a method `Tuner.get_results()` that will return the results again after fitting. It can also be used after restoring a run to get results without calling `fit()` (and potentially resuming failed trials).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
