### PR TITLE
fix missing APIs in gloo kvstore

### DIFF
--- a/python/ray/util/collective/collective_group/gloo_util.py
+++ b/python/ray/util/collective/collective_group/gloo_util.py
@@ -1,6 +1,7 @@
 """Code to wrap some GLOO API calls."""
 import asyncio
 import time
+from typing import List
 
 import numpy
 
@@ -285,7 +286,18 @@ class RayInternalKvStore:
         ret = internal_kv._internal_kv_get(key)
         return ret
 
-    def wait(self, keys: list):
+    def delete(self, key: str) -> None:
+        key = self.__concat_key_with_prefixes(key)
+        ret = internal_kv._internal_kv_del(key)
+        return ret
+
+    def del_keys(self, keys: List[str]):
+        results = []
+        for key in keys:
+            results.append(self.delete(key))
+        return results
+
+    def wait(self, keys: List[str]):
         while True:
             all_exist = True
             for key in keys:

--- a/python/ray/util/collective/collective_group/gloo_util.py
+++ b/python/ray/util/collective/collective_group/gloo_util.py
@@ -286,12 +286,12 @@ class RayInternalKvStore:
         ret = internal_kv._internal_kv_get(key)
         return ret
 
-    def delete(self, key: str) -> None:
+    def delete(self, key: str) -> int:
         key = self.__concat_key_with_prefixes(key)
         ret = internal_kv._internal_kv_del(key)
         return ret
 
-    def del_keys(self, keys: List[str]):
+    def del_keys(self, keys: List[str]) -> List[int]:
         results = []
         for key in keys:
             results.append(self.delete(key))


### PR DESCRIPTION
## Why are these changes needed?

In [#23633)](https://sourcegraph.com/github.com/ray-project/ray/-/commit/42b4cc4e72a2b3b7980ca60cb3abb5a6f26b951d) we added ray internal kv store as a backend for metadata but it doesn't have corresponding `del_keys` API, thus fails.

This PR adds it. 

Running user scripts with GLOO now correctly return

```python
import numpy as np

import ray
import ray.util.collective as col
from ray.util.collective.types import Backend, ReduceOp

ray.init(log_to_driver=True)

@ray.remote(num_cpus=4)
class Worker:
    def __init__(self):
        self.buffer = None
        self.list_buffer = None

    def init_tensors(self):
        self.buffer = np.ones((10,), dtype=np.float32)
        self.list_buffer = [np.ones((10,), dtype=np.float32) for _ in range(2)]
        return True

    def init_group(self, world_size, rank, backend=Backend.NCCL, group_name="default"):
        col.init_collective_group(world_size, rank, backend, group_name)
        return True

    def do_allreduce(self, group_name="default", op=ReduceOp.SUM):
        col.allreduce(self.buffer, group_name, op)
        return self.buffer



def create_collective_workers(num_workers=2, group_name="default", backend="nccl"):
    actors = [None] * num_workers
    for i in range(num_workers):
        actor = Worker.remote()
        ray.get([actor.init_tensors.remote()])
        actors[i] = actor
    world_size = num_workers
    init_results = ray.get(
        [
            actor.init_group.remote(world_size, i, backend, group_name)
            for i, actor in enumerate(actors)
        ]
    )
    return actors, init_results

world_size=2
group_name="default"
actors, _ = create_collective_workers(
    num_workers=world_size, group_name=group_name, backend=Backend.GLOO
)
results = ray.get([a.do_allreduce.remote(group_name) for a in actors])
print(results)
```

 ```
[array([2., 2., 2., 2., 2., 2., 2., 2., 2., 2.], dtype=float32), array([2., 2., 2., 2., 2., 2., 2., 2., 2., 2.], dtype=float32)]
```

## Related issue number

Closes #29036

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
