### PR TITLE
[workflow] Fix the object loss due to driver exit issues.

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -454,6 +454,7 @@ py_test_module_list(
     "test_basic_4.py",
     "test_basic_5.py",
     "test_asyncio.py",
+    "test_object_assign_owner.py",
     "test_multiprocessing.py",
     "test_list_actors.py",
     "test_list_actors_2.py",

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 # This version string is incremented to indicate breaking changes in the
 # protocol that require upgrading the client version.
-CURRENT_PROTOCOL_VERSION = "2022-07-24"
+CURRENT_PROTOCOL_VERSION = "2022-10-05"
 
 
 class _ClientContext:

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -65,6 +65,7 @@ def chunk_put(req: ray_client_pb2.DataRequest):
             chunk_id=chunk_id,
             total_chunks=total_chunks,
             total_size=total_size,
+            _owner_id=req.put._owner_id,
         )
         yield ray_client_pb2.DataRequest(req_id=req.req_id, put=chunk)
 

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -65,7 +65,7 @@ def chunk_put(req: ray_client_pb2.DataRequest):
             chunk_id=chunk_id,
             total_chunks=total_chunks,
             total_size=total_size,
-            _owner_id=req.put._owner_id,
+            owner_id=req.put.owner_id,
         )
         yield ray_client_pb2.DataRequest(req_id=req.req_id, put=chunk)
 

--- a/python/ray/util/client/server/dataservicer.py
+++ b/python/ray/util/client/server/dataservicer.py
@@ -231,6 +231,7 @@ class DataServicer(ray_client_pb2_grpc.RayletDataStreamerServicer):
                         self.put_request_chunk_collector.data,
                         req.put.client_ref_id,
                         client_id,
+                        req.put._owner_id,
                     )
                     self.put_request_chunk_collector.reset()
                     resp = ray_client_pb2.DataResponse(put=put_resp)

--- a/python/ray/util/client/server/dataservicer.py
+++ b/python/ray/util/client/server/dataservicer.py
@@ -231,7 +231,7 @@ class DataServicer(ray_client_pb2_grpc.RayletDataStreamerServicer):
                         self.put_request_chunk_collector.data,
                         req.put.client_ref_id,
                         client_id,
-                        req.put._owner_id,
+                        req.put.owner_id,
                     )
                     self.put_request_chunk_collector.reset()
                     resp = ray_client_pb2.DataResponse(put=put_resp)

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -507,13 +507,16 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
         self, request: ray_client_pb2.PutRequest, context=None
     ) -> ray_client_pb2.PutResponse:
         """gRPC entrypoint for unary PutObject"""
-        return self._put_object(request.data, request.client_ref_id, "", context)
+        return self._put_object(
+            request.data, request.client_ref_id, "", request._owner_id, context
+        )
 
     def _put_object(
         self,
         data: Union[bytes, bytearray],
         client_ref_id: bytes,
         client_id: str,
+        _owner_id: bytes,
         context=None,
     ):
         """Put an object in the cluster with ray.put() via gRPC.
@@ -524,12 +527,18 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
             client_ref_id: The id associated with this object on the client.
             client_id: The client who owns this data, for tracking when to
               delete this reference.
+            _owner_id: The owner id of the object.
             context: gRPC context.
         """
         try:
             obj = loads_from_client(data, self)
+
+            if _owner_id:
+                _owner = self.actor_refs[_owner_id]
+            else:
+                _owner = None
             with disable_client_hook():
-                objectref = ray.put(obj)
+                objectref = ray.put(obj, _owner=_owner)
         except Exception as e:
             logger.exception("Put failed:")
             return ray_client_pb2.PutResponse(

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -508,7 +508,7 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
     ) -> ray_client_pb2.PutResponse:
         """gRPC entrypoint for unary PutObject"""
         return self._put_object(
-            request.data, request.client_ref_id, "", request._owner_id, context
+            request.data, request.client_ref_id, "", request.owner_id, context
         )
 
     def _put_object(
@@ -516,7 +516,7 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
         data: Union[bytes, bytearray],
         client_ref_id: bytes,
         client_id: str,
-        _owner_id: bytes,
+        owner_id: bytes,
         context=None,
     ):
         """Put an object in the cluster with ray.put() via gRPC.
@@ -527,18 +527,18 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
             client_ref_id: The id associated with this object on the client.
             client_id: The client who owns this data, for tracking when to
               delete this reference.
-            _owner_id: The owner id of the object.
+            owner_id: The owner id of the object.
             context: gRPC context.
         """
         try:
             obj = loads_from_client(data, self)
 
-            if _owner_id:
-                _owner = self.actor_refs[_owner_id]
+            if owner_id:
+                owner = self.actor_refs[owner_id]
             else:
-                _owner = None
+                owner = None
             with disable_client_hook():
-                objectref = ray.put(obj, _owner=_owner)
+                objectref = ray.put(obj, _owner=owner)
         except Exception as e:
             logger.exception("Put failed:")
             return ray_client_pb2.PutResponse(

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -496,13 +496,13 @@ class Worker:
         return self._put_pickled(data, client_ref_id, _owner)
 
     def _put_pickled(
-        self, data, client_ref_id: bytes, _owner: Optional[ClientActorHandle] = None
+        self, data, client_ref_id: bytes, owner: Optional[ClientActorHandle] = None
     ):
         req = ray_client_pb2.PutRequest(data=data)
         if client_ref_id is not None:
             req.client_ref_id = client_ref_id
-        if _owner is not None:
-            req._owner_id = _owner.actor_ref.id
+        if owner is not None:
+            req.owner_id = owner.actor_ref.id
 
         resp = self.data_client.PutObject(req)
         if not resp.valid:

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -477,7 +477,13 @@ class Worker:
             raise decode_exception(e)
         return loads_from_server(data)
 
-    def put(self, val, *, client_ref_id: bytes = None):
+    def put(
+        self,
+        val,
+        *,
+        client_ref_id: bytes = None,
+        _owner: Optional[ClientActorHandle] = None,
+    ):
         if isinstance(val, ClientObjectRef):
             raise TypeError(
                 "Calling 'put' on an ObjectRef is not allowed "
@@ -487,12 +493,17 @@ class Worker:
                 "call 'put' on it (or return it)."
             )
         data = dumps_from_client(val, self._client_id)
-        return self._put_pickled(data, client_ref_id)
+        return self._put_pickled(data, client_ref_id, _owner)
 
-    def _put_pickled(self, data, client_ref_id: bytes):
+    def _put_pickled(
+        self, data, client_ref_id: bytes, _owner: Optional[ClientActorHandle] = None
+    ):
         req = ray_client_pb2.PutRequest(data=data)
         if client_ref_id is not None:
             req.client_ref_id = client_ref_id
+        if _owner is not None:
+            req._owner_id = _owner.actor_ref.id
+
         resp = self.data_client.PutObject(req)
         if not resp.valid:
             try:

--- a/python/ray/workflow/tests/conftest.py
+++ b/python/ray/workflow/tests/conftest.py
@@ -39,13 +39,13 @@ def _workflow_start(storage_url, shared, use_ray_client, **kwargs):
     assert use_ray_client in {"no_ray_client", "ray_client"}
     with _init_cluster(storage_url, **kwargs) as cluster:
         if use_ray_client == "ray_client":
-            address_info = ray.init(
-                address=f"ray://{cluster.address.split(':')[0]}:10001"
-            )
+            address = f"ray://{cluster.address.split(':')[0]}:10001"
         else:
-            address_info = ray.init(address=cluster.address)
+            address = cluster.address
 
-        yield address_info
+        ray.init(address=address)
+
+        yield address
 
 
 @pytest.fixture(scope="function")

--- a/python/ray/workflow/tests/test_basic_workflows_4.py
+++ b/python/ray/workflow/tests/test_basic_workflows_4.py
@@ -69,7 +69,7 @@ def test_no_init_api(shutdown_only):
     workflow.list_all()
 
 
-def test_object_valid(workflow_start_cluster):
+def test_object_valid(workflow_start_regular):
     # Test the async api and make sure the object live
     # across the lifetime of the job.
     import uuid
@@ -80,7 +80,7 @@ import ray
 from ray import workflow
 from typing import List
 
-ray.init(address="auto")
+ray.init(address="{workflow_start_regular}")
 
 @ray.remote
 def echo(data, sleep_s=0, others=None):
@@ -94,7 +94,7 @@ e2 = echo.bind(a, 0, e1)
 workflow.run_async(e2, workflow_id="{workflow_id}")
 """
     run_string_as_driver(script)
-    ray.init("auto")
+
     print(ray.get(workflow.get_output_async(workflow_id=workflow_id)))
 
 

--- a/python/ray/workflow/tests/test_basic_workflows_4.py
+++ b/python/ray/workflow/tests/test_basic_workflows_4.py
@@ -1,6 +1,7 @@
 """Basic tests isolated from other tests for shared fixtures."""
 import os
 import pytest
+from ray._private.test_utils import run_string_as_driver
 
 import ray
 from ray import workflow
@@ -66,6 +67,35 @@ def test_no_init_run(shutdown_only):
 
 def test_no_init_api(shutdown_only):
     workflow.list_all()
+
+
+def test_object_valid(workflow_start_cluster):
+    # Test the async api and make sure the object live
+    # across the lifetime of the job.
+    import uuid
+
+    workflow_id = str(uuid.uuid4())
+    script = f"""
+import ray
+from ray import workflow
+from typing import List
+
+ray.init(address="auto")
+
+@ray.remote
+def echo(data, sleep_s=0, others=None):
+    from time import sleep
+    sleep(sleep_s)
+    print(data)
+
+a = {{"abc": "def"}}
+e1 = echo.bind(a, 5)
+e2 = echo.bind(a, 0, e1)
+workflow.run_async(e2, workflow_id="{workflow_id}")
+"""
+    run_string_as_driver(script)
+    ray.init("auto")
+    print(ray.get(workflow.get_output_async(workflow_id=workflow_id)))
 
 
 if __name__ == "__main__":

--- a/python/ray/workflow/workflow_state_from_dag.py
+++ b/python/ray/workflow/workflow_state_from_dag.py
@@ -168,10 +168,7 @@ def workflow_state_from_dag(
                     flattened_args = _SerializationContextPreservingWrapper(
                         flattened_args
                     )
-                workflow_manager = workflow_access.get_management_actor()
-                input_placeholder: ray.ObjectRef = ray.put(
-                    flattened_args, _owner=workflow_manager
-                )
+                input_placeholder: ray.ObjectRef = ray.put(flattened_args, _owner=mgr)
 
             orig_task_id = workflow_options.get("task_id", None)
             if orig_task_id is None:

--- a/python/ray/workflow/workflow_state_from_dag.py
+++ b/python/ray/workflow/workflow_state_from_dag.py
@@ -4,7 +4,6 @@ import unicodedata
 
 import ray
 from ray.workflow.common import WORKFLOW_OPTIONS
-from ray.workflow import workflow_access
 from ray.dag import DAGNode, FunctionNode, InputNode
 from ray.dag.input_node import InputAttributeNode, DAGInputData
 from ray import cloudpickle

--- a/python/ray/workflow/workflow_state_from_dag.py
+++ b/python/ray/workflow/workflow_state_from_dag.py
@@ -167,6 +167,8 @@ def workflow_state_from_dag(
                     flattened_args = _SerializationContextPreservingWrapper(
                         flattened_args
                     )
+                # Set the owner of the objects to the actor so that even the driver
+                # exits, these objects are still available.
                 input_placeholder: ray.ObjectRef = ray.put(flattened_args, _owner=mgr)
 
             orig_task_id = workflow_options.get("task_id", None)

--- a/python/ray/workflow/workflow_state_from_dag.py
+++ b/python/ray/workflow/workflow_state_from_dag.py
@@ -4,7 +4,7 @@ import unicodedata
 
 import ray
 from ray.workflow.common import WORKFLOW_OPTIONS
-
+from ray.workflow import workflow_access
 from ray.dag import DAGNode, FunctionNode, InputNode
 from ray.dag.input_node import InputAttributeNode, DAGInputData
 from ray import cloudpickle
@@ -168,7 +168,10 @@ def workflow_state_from_dag(
                     flattened_args = _SerializationContextPreservingWrapper(
                         flattened_args
                     )
-                input_placeholder: ray.ObjectRef = ray.put(flattened_args)
+                workflow_manager = workflow_access.get_management_actor()
+                input_placeholder: ray.ObjectRef = ray.put(
+                    flattened_args, _owner=workflow_manager
+                )
 
             orig_task_id = workflow_options.get("task_id", None)
             if orig_task_id is None:

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -114,6 +114,8 @@ message PutRequest {
   int32 total_chunks = 4;
   // Total size in bytes of the data being put
   int64 total_size = 5;
+  // The owner of the put
+  bytes _owner_id = 6;
 }
 
 message PutResponse {

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -115,7 +115,7 @@ message PutRequest {
   // Total size in bytes of the data being put
   int64 total_size = 5;
   // The owner of the put
-  bytes _owner_id = 6;
+  bytes owner_id = 6;
 }
 
 message PutResponse {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
When the workflow runs in driver mode, the owner of the object ref is the driver. So when the driver exits, the objects are no longer available. This happens when we run with `run_async`.

This PR fixed this by passing the manager actor as the owner of the objects.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
