### PR TITLE
[Train] Make `prepare_model` always use the correct device

### DIFF
--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -177,6 +177,32 @@ def test_torch_prepare_model(ray_start_4_cpus_2_gpus):
     trainer.shutdown()
 
 
+def test_torch_prepare_model_uses_device(ray_start_4_cpus_2_gpus):
+    """Tests if `prepare_model` uses the train.torch.get_device even if it does not
+    match with the local rank."""
+    # The below test should pass without errors.
+
+    @patch.object(
+        ray.train.torch.train_loop_utils._TorchAccelerator,
+        "get_device",
+        lambda self: torch.device(f"cuda:{1 - train.local_rank()}"),
+    )
+    def train_func():
+        # These assert statements must hold for prepare_model to wrap with DDP.
+        assert torch.cuda.is_available()
+        assert train.world_size() > 1
+        model = torch.nn.Linear(1, 1)
+        data = torch.ones(1)
+        data = data.to(train.torch.get_device())
+        model = train.torch.prepare_model(model)
+        model(data)
+
+    trainer = TorchTrainer(
+        train_func, scaling_config=ScalingConfig(num_workers=2, use_gpu=True)
+    )
+    trainer.fit()
+
+
 # TODO: Refactor as a backend test.
 @pytest.mark.parametrize(
     "dataset", (LinearDataset, LinearDatasetDict, NonTensorDataset)

--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -401,8 +401,8 @@ class _TorchAccelerator(Accelerator):
                 DataParallel = DistributedDataParallel
                 if torch.cuda.is_available():
                     parallel_strategy_kwargs = {
-                        "device_ids": [rank],
-                        "output_device": rank,
+                        "device_ids": [device],
+                        "output_device": device,
                         **parallel_strategy_kwargs,
                     }
             else:


### PR DESCRIPTION
Signed-off-by: Amog Kamsetty <amogkamsetty@yahoo.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Previously, `prepare_model` would use the local rank as the device even though local rank may not be the same as the actual device index. This mismatch can happen when CUDA_VISIBLE_DEVICES is set for example, which we do by default in Ray Train.

We should always use `train.torch.get_device()` as the device values for wrapping in DDP.

Closes https://github.com/ray-project/ray/issues/28996

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
