### PR TITLE
[Nightly test] disable oom killer for chaos-dask-on-ray

### DIFF
--- a/release/nightly_tests/chaos_test/dask_on_ray_app_config_reconstruction.yaml
+++ b/release/nightly_tests/chaos_test/dask_on_ray_app_config_reconstruction.yaml
@@ -1,5 +1,6 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 env_vars: {"RAY_lineage_pinning_enabled": "1"}
+env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 debian_packages: []
 
 python:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It caused regression, and dask is not the first tier use cases for OOM killer. 
Failure case:
https://console.anyscale.com/o/anyscale-internal/projects/prj_FKRmeV5pA6X72aVscFALNC32/clusters/ses_paXtVfrbrefk5QDGNRFmUTyb?command-history-section=command_history

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
