### PR TITLE
Revert "Revert "Revert "Revert "[core] Support encrypted redis connection." (#28991)"""

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -89,9 +89,9 @@ build:llvm --action_env=BAZEL_LINKOPTS=-lm:-pthread
 build:llvm --define force_libcpp=enabled
 
 # Thread sanitizer configuration:
+build:tsan --per_file_copt="-bazel-ray/external/com_github_antirez_redis/.*$@-fsanitize=thread"
+build:tsan --per_file_copt="-bazel-ray/external/com_github_antirez_redis/.*$@-DTHREAD_SANITIZER"
 build:tsan --strip=never
-build:tsan --copt -fsanitize=thread
-build:tsan --copt -DTHREAD_SANITIZER
 build:tsan --copt -O2
 build:tsan --copt -g
 build:tsan --copt -fno-omit-frame-pointer

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2708,6 +2708,7 @@ alias(
     name = "redis-server",
     actual = select({
         "@bazel_tools//src/conditions:windows": "@com_github_tporadowski_redis_bin//:redis-server.exe",
+        "@bazel_tools//src/conditions:darwin": "@com_github_antirez_redis//:redis-server-mac",
         "//conditions:default": "@com_github_antirez_redis//:redis-server",
     }),
     visibility = ["//visibility:public"],
@@ -2717,6 +2718,7 @@ alias(
     name = "redis-cli",
     actual = select({
         "@bazel_tools//src/conditions:windows": "@com_github_tporadowski_redis_bin//:redis-cli.exe",
+        "@bazel_tools//src/conditions:darwin": "@com_github_antirez_redis//:redis-cli-mac",
         "//conditions:default": "@com_github_antirez_redis//:redis-cli",
     }),
     visibility = ["//visibility:public"],

--- a/bazel/BUILD.hiredis
+++ b/bazel/BUILD.hiredis
@@ -1,6 +1,8 @@
-COPTS = [] + select({
+COPTS = ["-DUSE_SSL=1"] + select({
     "@bazel_tools//src/conditions:windows": [
         "-D_CRT_DECLARE_NONSTDC_NAMES=0",  # don't define off_t, to avoid conflicts
+        "-DWIN32",
+        "-DWIN32_LEAN_AND_MEAN"
     ],
     "//conditions:default": [
     ],
@@ -32,7 +34,6 @@ cc_library(
         ],
         exclude =
         [
-            "ssl.c",
             "test.c",
         ],
     ),
@@ -44,6 +45,8 @@ cc_library(
     include_prefix = "hiredis",
     deps = [
         ":_hiredis",
+        "@boringssl//:ssl",
+        "@boringssl//:crypto"
     ],
     visibility = ["//visibility:public"],
 )

--- a/bazel/BUILD.redis
+++ b/bazel/BUILD.redis
@@ -1,3 +1,5 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "make")
+
 exports_files(
     [
         "redis-server.exe",
@@ -6,62 +8,53 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "all_srcs",
+    srcs = glob(
+        include = ["**"],
+        exclude = ["*.bazel"],
+    ),
+)
+    
+
+make(
+    name = "redis",
+    args = [
+        "BUILD_TLS=yes",
+        "-s",
+    ],
+    copts = [
+        "-DLUA_USE_MKSTEMP",
+        "-Wno-pragmas",
+        "-Wno-empty-body",
+        "-fPIC",
+    ],
+    visibility = ["//visibility:public"],
+    lib_source = ":all_srcs",
+    deps = [
+        "@openssl//:openssl",
+    ],
+    out_binaries = [
+        "redis-server",
+        "redis-cli"
+    ]
+)
+
 genrule(
     name = "bin",
-    srcs = glob(["**"]),
+    srcs = [":redis"],
     outs = [
         "redis-server",
         "redis-cli",
     ],
     cmd = """
-        unset CC LDFLAGS CXX CXXFLAGS
-        tmpdir="redis.tmp"
-        p=$(location Makefile)
-        cp -p -L -R -- "$${p%/*}" "$${tmpdir}"
-        chmod +x "$${tmpdir}"/deps/jemalloc/configure
-        parallel="$$(getconf _NPROCESSORS_ONLN || echo 1)"
-        make -s -C "$${tmpdir}" -j"$${parallel}" V=0 CFLAGS="$${CFLAGS-} -DLUA_USE_MKSTEMP -Wno-pragmas -Wno-empty-body"
-        mv "$${tmpdir}"/src/redis-server $(location redis-server)
-        chmod +x $(location redis-server)
-        mv "$${tmpdir}"/src/redis-cli $(location redis-cli)
-        chmod +x $(location redis-cli)
-        rm -r -f -- "$${tmpdir}"
+    mkdir tmp-redis-bin
+    cp -rf $(locations :redis) ./tmp-redis-bin/
+    cp tmp-redis-bin/redis-server $(location redis-server)
+    chmod +x $(location redis-server)
+    cp tmp-redis-bin/redis-cli $(location redis-cli)
+    chmod +x $(location redis-cli)
+    rm -rf tmp-redis-bin
     """,
-    visibility = ["//visibility:public"],
-    tags = ["local"],
-)
-
-# This library is for internal hiredis use, because hiredis assumes a
-# different include prefix for itself than external libraries do.
-cc_library(
-    name = "_hiredis",
-    hdrs = [
-        "deps/hiredis/dict.c",
-        "deps/hiredis/dict.h",
-        "deps/hiredis/fmacros.h",
-    ],
-    strip_include_prefix = "deps/hiredis",
-)
-
-cc_library(
-    name = "hiredis",
-    srcs = glob(
-        [
-            "deps/hiredis/*.c",
-            "deps/hiredis/*.h",
-        ],
-        exclude =
-        [
-            "deps/hiredis/test.c",
-        ],
-    ),
-    hdrs = glob([
-        "deps/hiredis/*.h",
-        "deps/hiredis/adapters/*.h",
-    ]),
-    strip_include_prefix = "deps",
-    deps = [
-        ":_hiredis",
-    ],
     visibility = ["//visibility:public"],
 )

--- a/bazel/BUILD.redis
+++ b/bazel/BUILD.redis
@@ -57,4 +57,33 @@ genrule(
     rm -rf tmp-redis-bin
     """,
     visibility = ["//visibility:public"],
+    tags = ["local"],
 )
+
+# This is a build for mac without openssl.
+# rules_foreign_cc somehow pick the wrong toolchain in CI.
+genrule(
+    name = "bin-mac",
+    srcs = glob(["**"]),
+    outs = [
+        "redis-server-mac",
+        "redis-cli-mac",
+    ],
+    cmd = """
+        unset CC LDFLAGS CXX CXXFLAGS
+        tmpdir="redis.tmp"
+        p=$(location Makefile)
+        cp -p -L -R -- "$${p%/*}" "$${tmpdir}"
+        chmod +x "$${tmpdir}"/deps/jemalloc/configure
+        parallel="$$(getconf _NPROCESSORS_ONLN || echo 1)"
+        make -s -C "$${tmpdir}" -j"$${parallel}" V=0 CFLAGS="$${CFLAGS-} -DLUA_USE_MKSTEMP -Wno-pragmas -Wno-empty-body"
+        mv "$${tmpdir}"/src/redis-server $(location redis-server-mac)
+        chmod +x $(location redis-server-mac)
+        mv "$${tmpdir}"/src/redis-cli $(location redis-cli-mac)
+        chmod +x $(location redis-cli-mac)
+        rm -r -f -- "$${tmpdir}"
+    """,
+    visibility = ["//visibility:public"],
+    tags = ["local"],
+)
+

--- a/bazel/ray_deps_build_all.bzl
+++ b/bazel/ray_deps_build_all.bzl
@@ -6,6 +6,9 @@ load("@com_github_grpc_grpc//third_party/py:python_configure.bzl", "python_confi
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_toolchains")
 load("@com_github_johnynek_bazel_jar_jar//:jar_jar.bzl", "jar_jar_repositories")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+load("@rules_foreign_cc_thirdparty//openssl:openssl_setup.bzl", "openssl_setup")
+
 
 
 def ray_deps_build_all():
@@ -17,3 +20,5 @@ def ray_deps_build_all():
   grpc_deps()
   rules_proto_grpc_toolchains()
   jar_jar_repositories()
+  rules_foreign_cc_dependencies()
+  openssl_setup()

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -98,6 +98,7 @@ def ray_deps_setup():
     auto_http_archive(
         name = "com_github_antirez_redis",
         build_file = "@com_github_ray_project_ray//bazel:BUILD.redis",
+        patch_args = ["-p1"],
         url = "https://github.com/redis/redis/archive/refs/tags/7.0.5.tar.gz",
         sha256 = "40827fcaf188456ad9b3be8e27a4f403c43672b6bb6201192dc15756af6f1eae",
         patches = [
@@ -242,6 +243,36 @@ def ray_deps_setup():
             "@com_github_ray_project_ray//thirdparty/patches:grpc-cython-copts.patch",
             "@com_github_ray_project_ray//thirdparty/patches:grpc-python.patch",
         ],
+    )
+    
+    http_archive(
+        name = "openssl",
+        strip_prefix = "openssl-1.1.1f",
+        sha256 = "186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35",
+        urls = [
+            "https://www.openssl.org/source/openssl-1.1.1f.tar.gz",
+        ],
+        build_file = "@rules_foreign_cc_thirdparty//openssl:BUILD.openssl.bazel",
+    )
+    
+    http_archive(
+        name = "rules_foreign_cc",
+        sha256 = "2a4d07cd64b0719b39a7c12218a3e507672b82a97b98c6a89d38565894cf7c51",
+        strip_prefix = "rules_foreign_cc-0.9.0",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz",
+    )
+
+    git_repository(
+        name = "rules_perl",
+        remote = "https://github.com/bazelbuild/rules_perl.git",
+        commit = "022b8daf2bb4836ac7a50e4a1d8ea056a3e1e403",
+    )
+
+    http_archive(
+        name = "rules_foreign_cc_thirdparty",
+        sha256 = "2a4d07cd64b0719b39a7c12218a3e507672b82a97b98c6a89d38565894cf7c51",
+        strip_prefix = "rules_foreign_cc-0.9.0/examples/third_party",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz",
     )
 
     http_archive(

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -104,6 +104,7 @@ def ray_deps_setup():
         patches = [
             "@com_github_ray_project_ray//thirdparty/patches:redis-quiet.patch",
         ],
+        workspace_file_content = 'workspace(name = "com_github_antirez_redis")'
     )
 
     auto_http_archive(

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -25,7 +25,7 @@ import psutil
 import ray
 import ray._private.ray_constants as ray_constants
 from ray._private.gcs_utils import GcsClient
-from ray._raylet import GcsClientOptions
+from ray._raylet import GcsClientOptions, Config
 from ray.core.generated.common_pb2 import Language
 
 resource = None
@@ -1107,11 +1107,36 @@ def _start_redis_instance(
         if " " in password:
             raise ValueError("Spaces not permitted in redis password.")
         command += ["--requirepass", password]
-    command += ["--port", str(port), "--loglevel", "warning"]
+
+    if not Config.REDIS_ENABLE_SSL():
+        command += ["--port", str(port), "--loglevel", "warning"]
+    else:
+        import socket
+
+        with socket.socket() as s:
+            s.bind(("", 0))
+            free_port = s.getsockname()[1]
+        command += [
+            "--tls-port",
+            str(port),
+            "--loglevel",
+            "warning",
+            "--port",
+            str(free_port),
+        ]
+
     if listen_to_localhost_only:
         command += ["--bind", "127.0.0.1"]
     pidfile = os.path.join(session_dir_path, "redis-" + uuid.uuid4().hex + ".pid")
     command += ["--pidfile", pidfile]
+    if Config.REDIS_ENABLE_SSL():
+        if Config.REDIS_CA_CERT():
+            command += ["--tls-ca-cert-file", Config.REDIS_CA_CERT()]
+        if Config.REDIS_CLIENT_CERT():
+            command += ["--tls-cert-file", Config.REDIS_CLIENT_CERT()]
+        if Config.REDIS_CLIENT_KEY():
+            command += ["--tls-key-file", Config.REDIS_CLIENT_KEY()]
+        command += ["--tls-replication", "yes"]
     if sys.platform != "win32":
         command += ["--save", "", "--appendonly", "no"]
     process_info = start_ray_process(

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -70,3 +70,15 @@ cdef extern from "ray/common/ray_config.h" nogil:
         c_bool start_python_importer_thread() const
 
         c_bool use_ray_syncer() const
+
+        c_bool REDIS_ENABLE_SSL() const
+
+        c_string REDIS_CA_CERT() const
+
+        c_string REDIS_CA_PATH() const
+
+        c_string REDIS_CLIENT_CERT() const
+
+        c_string REDIS_CLIENT_KEY() const
+
+        c_string REDIS_SERVER_NAME() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -116,3 +116,27 @@ cdef class Config:
     @staticmethod
     def use_ray_syncer():
         return RayConfig.instance().use_ray_syncer()
+
+    @staticmethod
+    def REDIS_ENABLE_SSL():
+        return RayConfig.instance().REDIS_ENABLE_SSL()
+
+    @staticmethod
+    def REDIS_CA_CERT():
+        return RayConfig.instance().REDIS_CA_CERT()
+
+    @staticmethod
+    def REDIS_CA_PATH():
+        return RayConfig.instance().REDIS_CA_PATH()
+
+    @staticmethod
+    def REDIS_CLIENT_CERT():
+        return RayConfig.instance().REDIS_CLIENT_CERT()
+
+    @staticmethod
+    def REDIS_CLIENT_KEY():
+        return RayConfig.instance().REDIS_CLIENT_KEY()
+
+    @staticmethod
+    def REDIS_SERVER_NAME():
+        return RayConfig.instance().REDIS_SERVER_NAME()

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -186,6 +186,7 @@ py_test_module_list(
     "test_raylet_output.py",
     "test_scheduling_performance.py",
     "test_get_or_create_actor.py",
+    "test_redis_tls.py",
   ],
   size = "small",
   tags = ["exclusive", "small_size_python_tests", "team:core"],

--- a/python/ray/tests/test_redis_tls.py
+++ b/python/ray/tests/test_redis_tls.py
@@ -1,0 +1,62 @@
+import pytest
+import subprocess
+import sys
+import ray
+from ray._private.test_utils import enable_external_redis
+
+
+@pytest.fixture
+def setup_tls(tmp_path, monkeypatch):
+    shell_scripts = f"""
+mkdir -p {str(tmp_path)}/tls
+openssl genrsa -out {str(tmp_path)}/tls/ca.key 4096
+openssl req \
+    -x509 -new -nodes -sha256 \
+    -key {str(tmp_path)}/tls/ca.key \
+    -days 3650 \
+    -subj '/O=Redis Test/CN=Certificate Authority' \
+    -out {str(tmp_path)}/tls/ca.crt
+openssl genrsa -out {str(tmp_path)}/tls/redis.key 2048
+openssl req \
+    -new -sha256 \
+    -key {str(tmp_path)}/tls/redis.key \
+    -subj '/O=Redis Test/CN=Server' | \
+    openssl x509 \
+        -req -sha256 \
+        -CA {str(tmp_path)}/tls/ca.crt \
+        -CAkey {str(tmp_path)}/tls/ca.key \
+        -CAserial {str(tmp_path)}/tls/ca.txt \
+        -CAcreateserial \
+        -days 365 \
+        -out {str(tmp_path)}/tls/redis.crt
+openssl dhparam -out {str(tmp_path)}/tls/redis.dh 2048
+"""
+    (tmp_path / "gen-test-certs.sh").write_text(shell_scripts)
+
+    print(subprocess.check_output(["bash", f"{tmp_path}/gen-test-certs.sh"]))
+    """
+    ls {tmp_path}/tls/
+    ca.crt  ca.key  ca.txt  redis.crt  redis.dh  redis.key
+    """
+
+    monkeypatch.setenv("RAY_REDIS_ENABLE_SSL", "true")
+    monkeypatch.setenv("RAY_REDIS_CA_CERT", f"{str(tmp_path)}/tls/ca.crt")
+
+    monkeypatch.setenv("RAY_REDIS_CLIENT_CERT", f"{str(tmp_path)}/tls/redis.crt")
+    monkeypatch.setenv("RAY_REDIS_CLIENT_KEY", f"{str(tmp_path)}/tls/redis.key")
+    ray._raylet.Config.initialize("")
+    yield tmp_path
+
+
+@pytest.mark.skipif(not enable_external_redis(), reason="Only work for redis mode")
+@pytest.mark.skipif(sys.platform != "linux", reason="Only work in linux")
+def test_redis_tls(setup_tls, ray_start_cluster_head):
+    @ray.remote
+    def hello():
+        return "world"
+
+    assert ray.get(hello.remote()) == "world"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -669,6 +669,16 @@ RAY_CONFIG(std::string, TLS_SERVER_CERT, "")
 RAY_CONFIG(std::string, TLS_SERVER_KEY, "")
 RAY_CONFIG(std::string, TLS_CA_CERT, "")
 
+/// Location of Redis TLS credentials
+/// https://github.com/redis/hiredis/blob/c78d0926bf169670d15cfc1214e4f5d21673396b/README.md#hiredis-openssl-wrappers
+RAY_CONFIG(bool, REDIS_ENABLE_SSL, false)
+RAY_CONFIG(std::string, REDIS_CA_CERT, "")
+RAY_CONFIG(std::string, REDIS_CA_PATH, "")
+
+RAY_CONFIG(std::string, REDIS_CLIENT_CERT, "")
+RAY_CONFIG(std::string, REDIS_CLIENT_KEY, "")
+RAY_CONFIG(std::string, REDIS_SERVER_NAME, "")
+
 /// grpc delay testing flags
 ///  To use this, simply do
 ///      export RAY_testing_asio_delay_us="method1=min_val:max_val,method2=20:100"

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -30,6 +30,7 @@
 
 struct redisContext;
 struct redisAsyncContext;
+struct redisSSLContext;
 
 namespace ray {
 
@@ -171,8 +172,7 @@ class RedisCallbackManager {
 
 class RedisContext {
  public:
-  RedisContext(instrumented_io_context &io_service)
-      : io_service_(io_service), context_(nullptr) {}
+  RedisContext(instrumented_io_context &io_service);
 
   ~RedisContext();
 
@@ -284,6 +284,7 @@ class RedisContext {
 
   instrumented_io_context &io_service_;
   redisContext *context_;
+  redisSSLContext *ssl_context_;
   std::unique_ptr<RedisAsyncContext> redis_async_context_;
   std::unique_ptr<RedisAsyncContext> async_redis_subscribe_context_;
 };

--- a/thirdparty/patches/redis-quiet.patch
+++ b/thirdparty/patches/redis-quiet.patch
@@ -1,7 +1,7 @@
 diff --git a/deps/Makefile b/deps/Makefile
 index 8592e17..0c13eea 100644
---- deps/Makefile
-+++ deps/Makefile
+--- a/deps/Makefile
++++ b/deps/Makefile
 @@ -49,19 +49,19 @@ ifeq ($(BUILD_TLS),yes)
  endif
  
@@ -45,8 +45,8 @@ index 8592e17..0c13eea 100644
  
 diff --git a/deps/jemalloc/Makefile.in b/deps/jemalloc/Makefile.in
 index 7128b00..da8e429 100644
---- deps/jemalloc/Makefile.in
-+++ deps/jemalloc/Makefile.in
+--- a/deps/jemalloc/Makefile.in
++++ b/deps/jemalloc/Makefile.in
 @@ -406,7 +406,7 @@ $(objroot)include/jemalloc/internal/private_namespace_jet.gen.h: $(C_JET_SYMS)
  	$(SHELL) $(srcroot)include/jemalloc/internal/private_namespace.sh $^ > $@
  
@@ -57,9 +57,18 @@ index 7128b00..da8e429 100644
  $(CPP_OBJS) $(CPP_PIC_OBJS) $(TESTS_CPP_OBJS): %.$(O):
  	@mkdir -p $(@D)
 diff --git a/src/Makefile b/src/Makefile
-index e4f7d90..218543f 100644
---- src/Makefile
-+++ src/Makefile
+index e4f7d90..704d4b4 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -115,7 +115,7 @@ endif
+ # Override default settings if possible
+ -include .make-settings
+ 
+-FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
++FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS) $(CPPFLAGS)
+ FINAL_LDFLAGS=$(LDFLAGS) $(REDIS_LDFLAGS) $(DEBUG)
+ FINAL_LIBS=-lm
+ DEBUG=-g -ggdb
 @@ -326,9 +326,9 @@ REDIS_CHECK_AOF_NAME=redis-check-aof$(PROG_SUFFIX)
  ALL_SOURCES=$(sort $(patsubst %.o,%.c,$(REDIS_SERVER_OBJ) $(REDIS_CLI_OBJ) $(REDIS_BENCHMARK_OBJ)))
  


### PR DESCRIPTION
Reverts ray-project/ray#29078

There are two issues: tsan fail and mac build fail.

For TSAN, if we build redis + openssl with tsan the redis will segfault. So we exclude the redis target from the tsan build.

For mac failure, the root cause is that in the CI somehow the toolchain picked in rules_foreign_cc is wrong. Failed to find any useful solution within a day. So just use the old build for mac and pick in the runtime.

Since redis is only used for testing, win/mac/linux both support rediss.