### PR TITLE
[core] add min memory free bytes to cap the amount of free space for oom killer

### DIFF
--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -29,6 +29,7 @@ def ray_with_memory_monitor(shutdown_only):
             "metrics_report_interval_ms": 100,
             "task_failure_entry_ttl_ms": 2 * 60 * 1000,
             "task_oom_retries": task_oom_retries,
+            "min_memory_free_bytes": -1,
         },
     ):
         yield
@@ -45,6 +46,7 @@ def ray_with_memory_monitor_no_oom_retry(shutdown_only):
             "metrics_report_interval_ms": 100,
             "task_failure_entry_ttl_ms": 2 * 60 * 1000,
             "task_oom_retries": 0,
+            "min_memory_free_bytes": -1,
         },
     ):
         yield

--- a/src/ray/common/memory_monitor.cc
+++ b/src/ray/common/memory_monitor.cc
@@ -25,9 +25,11 @@ namespace ray {
 
 MemoryMonitor::MemoryMonitor(instrumented_io_context &io_service,
                              float usage_threshold,
+                             int64_t min_memory_free_bytes,
                              uint64_t monitor_interval_ms,
                              MemoryUsageRefreshCallback monitor_callback)
     : usage_threshold_(usage_threshold),
+      min_memory_free_bytes_(min_memory_free_bytes),
       monitor_callback_(monitor_callback),
       runner_(io_service) {
   RAY_CHECK(monitor_callback_ != nullptr);
@@ -42,8 +44,13 @@ MemoryMonitor::MemoryMonitor(instrumented_io_context &io_service,
           system_memory.used_bytes = used_memory_bytes;
           system_memory.total_bytes = total_memory_bytes;
 
-          bool is_usage_above_threshold = IsUsageAboveThreshold(system_memory);
-          monitor_callback_(is_usage_above_threshold, system_memory, usage_threshold_);
+          // TODO(clarng): compute this once only.
+          int64_t threshold_bytes = GetMemoryThreshold(system_memory.total_bytes, usage_threshold_, min_memory_free_bytes_);
+
+          bool is_usage_above_threshold = IsUsageAboveThreshold(system_memory, threshold_bytes);
+
+          float threshold_fraction = (float)threshold_bytes / system_memory.total_bytes;
+          monitor_callback_(is_usage_above_threshold, system_memory, threshold_fraction);
         },
         monitor_interval_ms,
         "MemoryMonitor.CheckIsMemoryUsageAboveThreshold");
@@ -58,7 +65,7 @@ MemoryMonitor::MemoryMonitor(instrumented_io_context &io_service,
   }
 }
 
-bool MemoryMonitor::IsUsageAboveThreshold(MemorySnapshot system_memory) {
+bool MemoryMonitor::IsUsageAboveThreshold(MemorySnapshot system_memory, int64_t threshold_bytes) {
   int64_t used_memory_bytes = system_memory.used_bytes;
   int64_t total_memory_bytes = system_memory.total_bytes;
   if (total_memory_bytes == kNull || used_memory_bytes == kNull) {
@@ -67,13 +74,13 @@ bool MemoryMonitor::IsUsageAboveThreshold(MemorySnapshot system_memory) {
         << "to detect memory usage above threshold.";
     return false;
   }
-  float usage_fraction = static_cast<float>(used_memory_bytes) / total_memory_bytes;
-  bool is_usage_above_threshold = usage_fraction >= usage_threshold_;
+  bool is_usage_above_threshold = used_memory_bytes > threshold_bytes;
   if (is_usage_above_threshold) {
     RAY_LOG_EVERY_MS(INFO, kLogIntervalMs)
         << "Node memory usage above threshold, used: " << used_memory_bytes
-        << ", total: " << total_memory_bytes << ", usage fraction: " << usage_fraction
-        << ", threshold: " << usage_threshold_;
+        << ", threshold_bytes: " << threshold_bytes
+        << ", total bytes: " << total_memory_bytes
+        << ", threshold fraction: " << float(threshold_bytes) / total_memory_bytes;
   }
   return is_usage_above_threshold;
 }
@@ -260,6 +267,25 @@ int64_t MemoryMonitor::NullableMin(int64_t left, int64_t right) {
     return left;
   } else {
     return std::min(left, right);
+  }
+}
+
+int64_t MemoryMonitor::GetMemoryThreshold(int64_t total_memory_bytes,
+                                          float usage_threshold,
+                                          int64_t min_memory_free_bytes) {
+  RAY_CHECK_GE(total_memory_bytes, kNull);
+  RAY_CHECK_GE(min_memory_free_bytes, kNull);
+  RAY_CHECK_GE(usage_threshold, 0);
+  RAY_CHECK_LE(usage_threshold, 1);
+
+  int64_t threshold_fraction = (int64_t)(total_memory_bytes * usage_threshold);
+
+  if (min_memory_free_bytes > kNull) {
+    int64_t threshold_absolute = total_memory_bytes - min_memory_free_bytes;
+    RAY_CHECK_GE(threshold_absolute, 0);
+    return std::max(threshold_fraction, threshold_absolute);
+  } else {
+    return threshold_fraction;
   }
 }
 

--- a/src/ray/common/memory_monitor.cc
+++ b/src/ray/common/memory_monitor.cc
@@ -45,9 +45,11 @@ MemoryMonitor::MemoryMonitor(instrumented_io_context &io_service,
           system_memory.total_bytes = total_memory_bytes;
 
           // TODO(clarng): compute this once only.
-          int64_t threshold_bytes = GetMemoryThreshold(system_memory.total_bytes, usage_threshold_, min_memory_free_bytes_);
+          int64_t threshold_bytes = GetMemoryThreshold(
+              system_memory.total_bytes, usage_threshold_, min_memory_free_bytes_);
 
-          bool is_usage_above_threshold = IsUsageAboveThreshold(system_memory, threshold_bytes);
+          bool is_usage_above_threshold =
+              IsUsageAboveThreshold(system_memory, threshold_bytes);
 
           float threshold_fraction = (float)threshold_bytes / system_memory.total_bytes;
           monitor_callback_(is_usage_above_threshold, system_memory, threshold_fraction);
@@ -65,7 +67,8 @@ MemoryMonitor::MemoryMonitor(instrumented_io_context &io_service,
   }
 }
 
-bool MemoryMonitor::IsUsageAboveThreshold(MemorySnapshot system_memory, int64_t threshold_bytes) {
+bool MemoryMonitor::IsUsageAboveThreshold(MemorySnapshot system_memory,
+                                          int64_t threshold_bytes) {
   int64_t used_memory_bytes = system_memory.used_bytes;
   int64_t total_memory_bytes = system_memory.total_bytes;
   if (total_memory_bytes == kNull || used_memory_bytes == kNull) {

--- a/src/ray/common/memory_monitor.h
+++ b/src/ray/common/memory_monitor.h
@@ -51,11 +51,11 @@ class MemoryMonitor {
   ///
   /// \param io_service the event loop.
   /// \param usage_threshold a value in [0-1] to indicate the max usage.
-  /// \param min_memory_free_bytes to indicate the minimum amount of free space before it becomes over the threshold.
-  /// \param monitor_interval_ms the frequency to update the usage. 0 disables the
-  /// the monitor and callbacks won't fire.
-  /// \param monitor_callback function to execute on a dedicated thread owned by this
-  /// monitor when the usage is refreshed.
+  /// \param min_memory_free_bytes to indicate the minimum amount of free space before it
+  /// becomes over the threshold. \param monitor_interval_ms the frequency to update the
+  /// usage. 0 disables the the monitor and callbacks won't fire. \param monitor_callback
+  /// function to execute on a dedicated thread owned by this monitor when the usage is
+  /// refreshed.
   MemoryMonitor(instrumented_io_context &io_service,
                 float usage_threshold,
                 int64_t min_memory_free_bytes,
@@ -81,7 +81,8 @@ class MemoryMonitor {
   /// \param system_memory snapshot of system memory information.
   /// \param threshold_bytes usage threshold in bytes.
   /// \return true if the memory usage of this node is above the threshold.
-  static bool IsUsageAboveThreshold(MemorySnapshot system_memory, int64_t threshold_bytes);
+  static bool IsUsageAboveThreshold(MemorySnapshot system_memory,
+                                    int64_t threshold_bytes);
 
   /// \return the used and total memory in bytes.
   std::tuple<int64_t, int64_t> GetMemoryBytes();
@@ -104,14 +105,17 @@ class MemoryMonitor {
   /// Computes the memory threshold, where
   /// Memory usage threshold = max(total_memory * usage_threshold_, total_memory -
   /// min_memory_free_bytes)
+  ///
   /// \param total_memory_bytes the total amount of memory available in the system.
   /// \param usage_threshold a value in [0-1] to indicate the max usage.
-  /// \param min_memory_free_bytes the min amount of free space before it starts killing to free up space.
+  /// \param min_memory_free_bytes the min amount of free space to maintain before it is
+  /// exceeding the threshold.
   ///
   /// \return the memory threshold.
   static int64_t GetMemoryThreshold(int64_t total_memory_bytes,
                                     float usage_threshold,
                                     int64_t min_memory_free_bytes);
+
  private:
   FRIEND_TEST(MemoryMonitorTest, TestThresholdZeroMonitorAlwaysAboveThreshold);
   FRIEND_TEST(MemoryMonitorTest, TestThresholdOneMonitorAlwaysBelowThreshold);

--- a/src/ray/common/memory_monitor.h
+++ b/src/ray/common/memory_monitor.h
@@ -52,10 +52,11 @@ class MemoryMonitor {
   /// \param io_service the event loop.
   /// \param usage_threshold a value in [0-1] to indicate the max usage.
   /// \param min_memory_free_bytes to indicate the minimum amount of free space before it
-  /// becomes over the threshold. \param monitor_interval_ms the frequency to update the
-  /// usage. 0 disables the the monitor and callbacks won't fire. \param monitor_callback
-  /// function to execute on a dedicated thread owned by this monitor when the usage is
-  /// refreshed.
+  /// becomes over the threshold.
+  /// \param monitor_interval_ms the frequency to update the usage. 0 disables the the
+  /// monitor and callbacks won't fire.
+  /// \param monitor_callback function to execute on a dedicated thread owned by this
+  /// monitor when the usage is refreshed.
   MemoryMonitor(instrumented_io_context &io_service,
                 float usage_threshold,
                 int64_t min_memory_free_bytes,

--- a/src/ray/common/memory_monitor.h
+++ b/src/ray/common/memory_monitor.h
@@ -51,12 +51,14 @@ class MemoryMonitor {
   ///
   /// \param io_service the event loop.
   /// \param usage_threshold a value in [0-1] to indicate the max usage.
+  /// \param min_memory_free_bytes to indicate the minimum amount of free space before it becomes over the threshold.
   /// \param monitor_interval_ms the frequency to update the usage. 0 disables the
   /// the monitor and callbacks won't fire.
   /// \param monitor_callback function to execute on a dedicated thread owned by this
   /// monitor when the usage is refreshed.
   MemoryMonitor(instrumented_io_context &io_service,
                 float usage_threshold,
+                int64_t min_memory_free_bytes,
                 uint64_t monitor_interval_ms,
                 MemoryUsageRefreshCallback monitor_callback);
 
@@ -77,8 +79,9 @@ class MemoryMonitor {
   static constexpr int64_t kNull = -1;
 
   /// \param system_memory snapshot of system memory information.
+  /// \param threshold_bytes usage threshold in bytes.
   /// \return true if the memory usage of this node is above the threshold.
-  bool IsUsageAboveThreshold(MemorySnapshot system_memory);
+  static bool IsUsageAboveThreshold(MemorySnapshot system_memory, int64_t threshold_bytes);
 
   /// \return the used and total memory in bytes.
   std::tuple<int64_t, int64_t> GetMemoryBytes();
@@ -98,15 +101,32 @@ class MemoryMonitor {
   /// or one of the values if the other is kNull.
   static int64_t NullableMin(int64_t left, int64_t right);
 
+  /// Computes the memory threshold, where
+  /// Memory usage threshold = max(total_memory * usage_threshold_, total_memory -
+  /// min_memory_free_bytes)
+  /// \param total_memory_bytes the total amount of memory available in the system.
+  /// \param usage_threshold a value in [0-1] to indicate the max usage.
+  /// \param min_memory_free_bytes the min amount of free space before it starts killing to free up space.
+  ///
+  /// \return the memory threshold.
+  static int64_t GetMemoryThreshold(int64_t total_memory_bytes,
+                                    float usage_threshold,
+                                    int64_t min_memory_free_bytes);
  private:
   FRIEND_TEST(MemoryMonitorTest, TestThresholdZeroMonitorAlwaysAboveThreshold);
   FRIEND_TEST(MemoryMonitorTest, TestThresholdOneMonitorAlwaysBelowThreshold);
-  FRIEND_TEST(MemoryMonitorTest, TestUsageAtThresholdReportsTrue);
+  FRIEND_TEST(MemoryMonitorTest, TestUsageAtThresholdReportsFalse);
   FRIEND_TEST(MemoryMonitorTest, TestGetNodeAvailableMemoryAlwaysPositive);
   FRIEND_TEST(MemoryMonitorTest, TestGetNodeTotalMemoryEqualsFreeOrCGroup);
+  FRIEND_TEST(MemoryMonitorTest, TestMonitorPeriodSetCallbackExecuted);
+  FRIEND_TEST(MemoryMonitorTest, TestGetMemoryThresholdTakeGreaterOfTheTwoValues);
 
   /// Memory usage fraction between [0, 1]
   const double usage_threshold_;
+
+  /// Indicates the minimum amount of free space to retain before it considers
+  /// the usage as above threshold.
+  const int64_t min_memory_free_bytes_;
   /// Callback function that executes at each monitoring interval,
   /// on a dedicated thread managed by this class.
   const MemoryUsageRefreshCallback monitor_callback_;

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -76,7 +76,9 @@ RAY_CONFIG(uint64_t, raylet_report_resources_period_milliseconds, 100)
 /// The duration between raylet check memory pressure and send gc request
 RAY_CONFIG(uint64_t, raylet_check_gc_period_milliseconds, 100)
 
-/// Threshold when the node is beyond the memory capacity.
+/// Threshold when the node is beyond the memory capacity. If the memory is above the
+/// memory_usage_threshold_fraction and free space is below the min_memory_free_bytes then
+/// it will start killing processes to free up the space.
 /// Ranging from [0, 1]
 RAY_CONFIG(float, memory_usage_threshold_fraction, 0.9)
 
@@ -84,13 +86,14 @@ RAY_CONFIG(float, memory_usage_threshold_fraction, 0.9)
 /// Monitor is disabled when this value is 0.
 RAY_CONFIG(uint64_t, memory_monitor_interval_ms, 0)
 
-/// The minimum amount of free space. If it goes below this value,
-/// start killing process to free up space. Disabled if it is -1.
+/// The minimum amount of free space. If the memory is above the
+/// memory_usage_threshold_fraction and free space is below min_memory_free_bytes then it
+/// will start killing processes to free up the space. Disabled if it is -1.
 ///
-/// The memory threshold is calculcated as
-/// Threshold = max(node_memory * memory_usage_threshold_fraction, node_memory -
-/// min_memory_free_bytes)
-RAY_CONFIG(int64_t, min_memory_free_bytes, (int64_t) 1 * 1024 * 1024 * 1024)
+/// This value is useful for larger host where the memory_usage_threshold_fraction could
+/// represent a large chunk of memory, e.g. a host with 64GB of memory and 0.9 threshold
+/// means 6.4 GB of the memory will not be usable.
+RAY_CONFIG(int64_t, min_memory_free_bytes, (int64_t)1 * 1024 * 1024 * 1024)
 
 /// The TTL for when the task failure entry is considered
 /// eligble for garbage colletion.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -84,6 +84,14 @@ RAY_CONFIG(float, memory_usage_threshold_fraction, 0.9)
 /// Monitor is disabled when this value is 0.
 RAY_CONFIG(uint64_t, memory_monitor_interval_ms, 0)
 
+/// The minimum amount of free space. If it goes below this value,
+/// start killing process to free up space. Disabled if it is -1.
+///
+/// The memory threshold is calculcated as
+/// Threshold = max(node_memory * memory_usage_threshold_fraction, node_memory -
+/// min_memory_free_bytes)
+RAY_CONFIG(int64_t, min_memory_free_bytes, (int64_t) 1024 * 1024 * 1024)
+
 /// The TTL for when the task failure entry is considered
 /// eligble for garbage colletion.
 RAY_CONFIG(uint64_t, task_failure_entry_ttl_ms, 15 * 60 * 1000)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -90,7 +90,7 @@ RAY_CONFIG(uint64_t, memory_monitor_interval_ms, 0)
 /// The memory threshold is calculcated as
 /// Threshold = max(node_memory * memory_usage_threshold_fraction, node_memory -
 /// min_memory_free_bytes)
-RAY_CONFIG(int64_t, min_memory_free_bytes, (int64_t)1.5 * 1024 * 1024 * 1024)
+RAY_CONFIG(int64_t, min_memory_free_bytes, (int64_t) 1 * 1024 * 1024 * 1024)
 
 /// The TTL for when the task failure entry is considered
 /// eligble for garbage colletion.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -90,7 +90,7 @@ RAY_CONFIG(uint64_t, memory_monitor_interval_ms, 0)
 /// The memory threshold is calculcated as
 /// Threshold = max(node_memory * memory_usage_threshold_fraction, node_memory -
 /// min_memory_free_bytes)
-RAY_CONFIG(int64_t, min_memory_free_bytes, (int64_t) 1024 * 1024 * 1024)
+RAY_CONFIG(int64_t, min_memory_free_bytes, (int64_t)1.5 * 1024 * 1024 * 1024)
 
 /// The TTL for when the task failure entry is considered
 /// eligble for garbage colletion.

--- a/src/ray/common/test/memory_monitor_test.cc
+++ b/src/ray/common/test/memory_monitor_test.cc
@@ -137,7 +137,6 @@ TEST_F(MemoryMonitorTest, TestMonitorPeriodSetCallbackExecuted) {
     std::unique_lock<std::mutex> callback_ran_mutex_lock(callback_ran_mutex);
     callback_ran.wait(callback_ran_mutex_lock);
   }
- 
 }
 
 TEST_F(MemoryMonitorTest, TestMonitorMinFreeZeroThresholdIsOne) {

--- a/src/ray/common/test/memory_monitor_test.cc
+++ b/src/ray/common/test/memory_monitor_test.cc
@@ -38,38 +38,17 @@ class MemoryMonitorTest : public ::testing::Test {
 };
 
 TEST_F(MemoryMonitorTest, TestThresholdZeroMonitorAlwaysAboveThreshold) {
-  MemoryMonitor monitor(
-      MemoryMonitorTest::io_context_,
-      0 /*usage_threshold*/,
-      0 /*refresh_interval_ms*/,
-      [](bool is_usage_above_threshold,
-         MemorySnapshot system_memory,
-         float usage_threshold) { FAIL() << "Expected monitor to not run"; });
-  ASSERT_TRUE(monitor.IsUsageAboveThreshold({1, 10}));
+  ASSERT_TRUE(MemoryMonitor::IsUsageAboveThreshold({1, 10}, 0));
 }
 
 TEST_F(MemoryMonitorTest, TestThresholdOneMonitorAlwaysBelowThreshold) {
-  MemoryMonitor monitor(
-      MemoryMonitorTest::io_context_,
-      1 /*usage_threshold*/,
-      0 /*refresh_interval_ms*/,
-      [](bool is_usage_above_threshold,
-         MemorySnapshot system_memory,
-         float usage_threshold) { FAIL() << "Expected monitor to not run"; });
-  ASSERT_FALSE(monitor.IsUsageAboveThreshold({9, 10}));
+  ASSERT_FALSE(MemoryMonitor::IsUsageAboveThreshold({9, 10}, 10));
 }
 
-TEST_F(MemoryMonitorTest, TestUsageAtThresholdReportsTrue) {
-  MemoryMonitor monitor(
-      MemoryMonitorTest::io_context_,
-      0.5 /*usage_threshold*/,
-      0 /*refresh_interval_ms*/,
-      [](bool is_usage_above_threshold,
-         MemorySnapshot system_memory,
-         float usage_threshold) { FAIL() << "Expected monitor to not run"; });
-  ASSERT_FALSE(monitor.IsUsageAboveThreshold({4, 10}));
-  ASSERT_TRUE(monitor.IsUsageAboveThreshold({5, 10}));
-  ASSERT_TRUE(monitor.IsUsageAboveThreshold({6, 10}));
+TEST_F(MemoryMonitorTest, TestUsageAtThresholdReportsFalse) {
+  ASSERT_FALSE(MemoryMonitor::IsUsageAboveThreshold({4, 10}, 5));
+  ASSERT_FALSE(MemoryMonitor::IsUsageAboveThreshold({5, 10}, 5));
+  ASSERT_TRUE(MemoryMonitor::IsUsageAboveThreshold({6, 10}, 5));
 }
 
 TEST_F(MemoryMonitorTest, TestGetNodeAvailableMemoryAlwaysPositive) {
@@ -77,6 +56,7 @@ TEST_F(MemoryMonitorTest, TestGetNodeAvailableMemoryAlwaysPositive) {
     MemoryMonitor monitor(
         MemoryMonitorTest::io_context_,
         0 /*usage_threshold*/,
+        -1 /*min_memory_free_bytes*/,
         0 /*refresh_interval_ms*/,
         [](bool is_usage_above_threshold,
            MemorySnapshot system_memory,
@@ -92,6 +72,7 @@ TEST_F(MemoryMonitorTest, TestGetNodeTotalMemoryEqualsFreeOrCGroup) {
     MemoryMonitor monitor(
         MemoryMonitorTest::io_context_,
         0 /*usage_threshold*/,
+        -1 /*min_memory_free_bytes*/,
         0 /*refresh_interval_ms*/,
         [](bool is_usage_above_threshold,
            MemorySnapshot system_memory,
@@ -123,8 +104,49 @@ TEST_F(MemoryMonitorTest, TestMonitorPeriodSetCallbackExecuted) {
   std::condition_variable callback_ran;
   std::mutex callback_ran_mutex;
 
+  {
+    MemoryMonitor monitor(MemoryMonitorTest::io_context_,
+                          1 /*usage_threshold*/,
+                          -1 /*min_memory_free_bytes*/,
+                          1 /*refresh_interval_ms*/,
+                          [&callback_ran](bool is_usage_above_threshold,
+                                          MemorySnapshot system_memory,
+                                          float usage_threshold) {
+                            ASSERT_EQ(1.0f, usage_threshold);
+                            ASSERT_GT(system_memory.total_bytes, 0);
+                            ASSERT_GT(system_memory.used_bytes, 0);
+                            callback_ran.notify_all();
+                          });
+    std::unique_lock<std::mutex> callback_ran_mutex_lock(callback_ran_mutex);
+    callback_ran.wait(callback_ran_mutex_lock);
+  }
+
+  {
+    MemoryMonitor monitor(MemoryMonitorTest::io_context_,
+                          0.4 /*usage_threshold*/,
+                          -1 /*min_memory_free_bytes*/,
+                          1 /*refresh_interval_ms*/,
+                          [&callback_ran](bool is_usage_above_threshold,
+                                          MemorySnapshot system_memory,
+                                          float usage_threshold) {
+                            ASSERT_EQ(0.4f, usage_threshold);
+                            ASSERT_GT(system_memory.total_bytes, 0);
+                            ASSERT_GT(system_memory.used_bytes, 0);
+                            callback_ran.notify_all();
+                          });
+    std::unique_lock<std::mutex> callback_ran_mutex_lock(callback_ran_mutex);
+    callback_ran.wait(callback_ran_mutex_lock);
+  }
+ 
+}
+
+TEST_F(MemoryMonitorTest, TestMonitorMinFreeZeroThresholdIsOne) {
+  std::condition_variable callback_ran;
+  std::mutex callback_ran_mutex;
+
   MemoryMonitor monitor(MemoryMonitorTest::io_context_,
-                        1 /*usage_threshold*/,
+                        0.4 /*usage_threshold*/,
+                        0 /*min_memory_free_bytes*/,
                         1 /*refresh_interval_ms*/,
                         [&callback_ran](bool is_usage_above_threshold,
                                         MemorySnapshot system_memory,
@@ -136,6 +158,22 @@ TEST_F(MemoryMonitorTest, TestMonitorPeriodSetCallbackExecuted) {
                         });
   std::unique_lock<std::mutex> callback_ran_mutex_lock(callback_ran_mutex);
   callback_ran.wait(callback_ran_mutex_lock);
+}
+
+TEST_F(MemoryMonitorTest, TestGetMemoryThresholdTakeGreaterOfTheTwoValues) {
+  ASSERT_EQ(MemoryMonitor::GetMemoryThreshold(100, 0.5, 0), 100);
+  ASSERT_EQ(MemoryMonitor::GetMemoryThreshold(100, 0.5, 60), 50);
+
+  ASSERT_EQ(MemoryMonitor::GetMemoryThreshold(100, 1, 10), 100);
+  ASSERT_EQ(MemoryMonitor::GetMemoryThreshold(100, 1, 100), 100);
+
+  ASSERT_EQ(MemoryMonitor::GetMemoryThreshold(100, 0.1, 100), 10);
+  ASSERT_EQ(MemoryMonitor::GetMemoryThreshold(100, 0, 10), 90);
+  ASSERT_EQ(MemoryMonitor::GetMemoryThreshold(100, 0, 100), 0);
+
+  ASSERT_EQ(MemoryMonitor::GetMemoryThreshold(100, 0, MemoryMonitor::kNull), 0);
+  ASSERT_EQ(MemoryMonitor::GetMemoryThreshold(100, 0.5, MemoryMonitor::kNull), 50);
+  ASSERT_EQ(MemoryMonitor::GetMemoryThreshold(100, 1, MemoryMonitor::kNull), 100);
 }
 
 }  // namespace ray

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -337,6 +337,7 @@ NodeManager::NodeManager(instrumented_io_context &io_service,
       memory_monitor_(std::make_unique<MemoryMonitor>(
           io_service,
           RayConfig::instance().memory_usage_threshold_fraction(),
+          RayConfig::instance().min_memory_free_bytes(),
           RayConfig::instance().memory_monitor_interval_ms(),
           CreateMemoryUsageRefreshCallback())) {
   RAY_LOG(INFO) << "Initializing NodeManager with ID " << self_node_id_;

--- a/src/ray/raylet/worker_killing_policy_test.cc
+++ b/src/ray/raylet/worker_killing_policy_test.cc
@@ -30,6 +30,7 @@ class WorkerKillerTest : public ::testing::Test {
   MemoryMonitor memory_monitor_ = {
       io_context_,
       0 /*usage_threshold*/,
+      -1 /*min_memory_free_bytes*/,
       0 /*refresh_interval_ms*/,
       [](bool is_usage_above_threshold,
          MemorySnapshot system_memory,


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

We add an absolute threshold to cap the amount of ram that we leave unused. The existing memory threshold, which is a %, is a little extremely for large nodes that leads to wasted memory and prevents existing workloads from completing. For a 64GB host at 0.9 threshold we start killing processes when there is still 6.4GB ram left. With this change we cap the free memory to 1GB regardless of the size of the host.

## Related issue number


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [] Release tests
   - [ ] This PR is not tested :(

