### PR TITLE
[Datasets] Add feature guide section for configuring ``batch_size`` in ``.map_batches()``

### DIFF
--- a/doc/source/data/doc_code/transforming_datasets.py
+++ b/doc/source/data/doc_code/transforming_datasets.py
@@ -570,6 +570,35 @@ ds.show(2)
 # fmt: on
 
 # fmt: off
+# __configuring_batch_size_begin__
+import ray
+import pandas as pd
+
+# Load dataset.
+ds = ray.data.read_csv("example://iris.csv")
+
+# UDF as a function on Pandas DataFrame batches.
+def pandas_transform(df: pd.DataFrame) -> pd.DataFrame:
+    # Filter rows.
+    df = df[df["variety"] == "Versicolor"]
+    # Add derived column.
+    df.loc[:, "normalized.sepal.length"] = df["sepal.length"] / df["sepal.length"].max()
+    # Drop column.
+    df = df.drop(columns=["sepal.length"])
+    return df
+
+# Have each batch that pandas_transform receives contain 10 rows.
+ds = ds.map_batches(pandas_transform, batch_size=10)
+
+ds.show(2)
+# -> {'sepal.width': 3.2, 'petal.length': 4.7, 'petal.width': 1.4,
+#     'variety': 'Versicolor', 'normalized.sepal.length': 1.0}
+# -> {'sepal.width': 3.2, 'petal.length': 4.5, 'petal.width': 1.5,
+#     'variety': 'Versicolor', 'normalized.sepal.length': 0.9142857142857144}
+# __configuring_batch_size_end__
+# fmt: on
+
+# fmt: off
 # __dataset_compute_strategy_begin__
 import ray
 import pandas

--- a/doc/source/data/transforming-datasets.rst
+++ b/doc/source/data/transforming-datasets.rst
@@ -346,6 +346,8 @@ The following output types are allowed for per-row UDFs (e.g.,
     :start-after: __writing_simple_out_row_udfs_begin__
     :end-before: __writing_simple_out_row_udfs_end__
 
+.. _transform_datasets_configuring_batch_size:
+
 ----------------------
 Configuring Batch Size
 ----------------------
@@ -354,7 +356,7 @@ Configuring Batch Size
 transformation API for Datasets: it launches parallel tasks over the underlying Datasets
 blocks and maps UDFs over batches of data within those tasks, allowing the UDF to
 implement vectorized operations on batches. An important parameter to
-set is ``batch_size``, which controls the size of batches provided to the UDF.
+set is ``batch_size``, which controls the size of the batches provided to the UDF.
 
 .. literalinclude:: ./doc_code/transforming_datasets.py
   :language: python
@@ -362,7 +364,7 @@ set is ``batch_size``, which controls the size of batches provided to the UDF.
   :end-before: __configuring_batch_size_end__
 
 Increasing ``batch_size`` can result in faster execution by better leveraging SIMD
-hardware, reducing batch slicing overhead, and overall saturating CPUs/GPUs, but will
+hardware, reducing batch slicing overhead, and overall saturating of CPUs/GPUs, but will
 also result in higher memory utilization, which can lead to out-of-memory failures.
 If encountering OOMs, decreasing your ``batch_size`` may help.
 
@@ -370,15 +372,22 @@ If encountering OOMs, decreasing your ``batch_size`` may help.
   The default ``batch_size`` of ``4096`` may be too large for datasets with large rows
   (e.g. tables with many columns or a collection of large images).
 
-Datasets will also bundle multiple blocks together for a single mapper task in order
-to better satisfy ``batch_size``, so if ``batch_size`` is a lot larger than your Dataset
-blocks (e.g. if your dataset was created with too large of a ``parallelism`` and/or the
-``batch_size`` is set to too large of a value), the number of parallel mapper tasks may
-be less than expected and you may be leaving some throughput on the table.
+If you specify a ``batch_size`` that's larger than your ``Dataset`` blocks, Datasets
+will bundle multiple blocks together for a single mapper task in order to better satisfy
+``batch_size``. If ``batch_size`` is a lot larger than your ``Dataset`` blocks (e.g. if
+your dataset was created with too large of a ``parallelism`` and/or the ``batch_size``
+is set to too large of a value for your dataset), the number of parallel mapper tasks
+may be less than expected and you may be leaving some throughput on the table.
+
+If your ``Dataset`` blocks are smaller than your ``batch_size`` and you want to increase
+transformation parallelism, decrease your ``batch_size`` to prevent this block bundling.
+If you think that your ``Dataset`` blocks are too small, try decreasing ``parallelism``
+during the read to create larger blocks.
 
 .. note::
-  The size of the batches provided to the UDF may be smaller than the provided ``batch_size``
-  if ``batch_size`` doesn't evenly divide the block(s) sent to a given map task.
+  The size of the batches provided to the UDF may be smaller than the provided
+  ``batch_size`` if ``batch_size`` doesn't evenly divide the block(s) sent to a given
+  map task.
 
 .. _transform_datasets_compute_strategy:
 

--- a/doc/source/data/transforming-datasets.rst
+++ b/doc/source/data/transforming-datasets.rst
@@ -354,7 +354,7 @@ Configuring Batch Size
 transformation API for Datasets: it launches parallel tasks over the underlying Datasets
 blocks and maps UDFs over batches of data within those tasks, allowing the UDF to
 implement vectorized operations on batches. An important parameter to
-set is the ``batch_size``, which controls the size of batches provided to the UDF.
+set is ``batch_size``, which controls the size of batches provided to the UDF.
 
 .. literalinclude:: ./doc_code/transforming_datasets.py
   :language: python
@@ -367,8 +367,8 @@ also result in higher memory utilization, which can lead to out-of-memory failur
 If encountering OOMs, decreasing your ``batch_size`` may help.
 
 .. note::
-  The default ``batch_size`` of ``4096`` may be too large for wide tables (many columns)
-  or datasets containing large images.
+  The default ``batch_size`` of ``4096`` may be too large for datasets with large rows
+  (e.g. tables with many columns or a collection of large images).
 
 Datasets will also bundle multiple blocks together for a single mapper task in order
 to better satisfy ``batch_size``, so if ``batch_size`` is a lot larger than your Dataset


### PR DESCRIPTION
Users may need guidance on configuring `batch_size` for `ds.map_batches()`, since the hardcoded default of 4096 will be suboptimal for wide tables and datasets containing large images, and the semantics of parallelism vs. batch size got more complicated with the block bundling PR. This PR adds a section for configuring ``batch_size`` to the "Transforming Datasets" feature guide.

## TODOs

- [ ] (Follow-up, after batch size is configurable for preprocessors) Add code example showing parallelism vs. batch size, where batch size is tweaked?

## Related issue number

Closes #29116

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
