### PR TITLE
[tune/release] Fix half-synced checkpoint loading in tune cloud tests

### DIFF
--- a/release/tune_tests/cloud_tests/workloads/run_cloud_test.py
+++ b/release/tune_tests/cloud_tests/workloads/run_cloud_test.py
@@ -640,14 +640,19 @@ def load_trial_checkpoint_data(
             continue
 
         json_path = os.path.join(cp_full_dir, "checkpoint.json")
+        meta_path = os.path.join(cp_full_dir, ".tune_metadata")
+
         if os.path.exists(json_path):
             with open(json_path, "rt") as f:
                 checkpoint_data = json.load(f)
-        else:
-            meta_path = os.path.join(cp_full_dir, ".tune_metadata")
+        elif os.path.exists(meta_path):
             with open(meta_path, "rb") as f:
                 checkpoint_meta = pickle.load(f)
                 checkpoint_data = {"internal_iter": checkpoint_meta["iteration"]}
+        else:
+            # If neither file exists, this means the checkpoint got only synced half,
+            # so we should skip it
+            continue
         checkpoints.append((cp_dir, checkpoint_data))
 
     return TrialCheckpointData(


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In the cloud test, we interrupt and resume training. The interrupt can stochastically happen during checkpoint upload, in which case the checkpoint is not fully synced to cloud. In that case, the test script currently errors, but it should gracefully skip the checkpoint instead.

## Related issue number

Closes #29094

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
