### PR TITLE
[tune/release] Use STRICT_PACK in air_benchmark_tune_torch_mnist

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
@@ -36,6 +36,13 @@ def get_trainer(num_workers: int = 4, use_gpu: bool = False):
     def train_loop(config):
         train_func(use_ray=True, config=config)
 
+    # We are using STRICT_PACK here to do an apples to apples comparison.
+    # PyTorch defaults to using multithreading, so if the workers are spread,
+    # they are able to utilize more resources. We would effectively be comparing
+    # X tune runs with 2 CPUs per worker vs. 1 tune run with up to 8 CPUs per
+    # worker. Using STRICT_PACK avoids this by forcing all workers to be
+    # co-located.
+
     trainer = TorchTrainer(
         train_loop_per_worker=train_loop,
         train_loop_config=CONFIG,
@@ -44,6 +51,7 @@ def get_trainer(num_workers: int = 4, use_gpu: bool = False):
             resources_per_worker={"CPU": 2},
             trainer_resources={"CPU": 0},
             use_gpu=use_gpu,
+            placement_strategy="STRICT_PACK",
         ),
     )
     return trainer


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We are using STRICT_PACK here to do an apples to apples comparison. PyTorch defaults to using multithreading, so if the workers are spread, they are able to utilize more resources. We would effectively be comparing X tune runs with 2 CPUs per worker vs. 1 tune run with up to 8 CPUs per worker. Using STRICT_PACK avoids this by forcing all workers to be co-located.

## Related issue number

Closes #28975

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
