### PR TITLE
[ci/release] Update docker plugin version to 5.2.0

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -85,7 +85,7 @@ def get_step(
     else:
         python_version = DEFAULT_PYTHON_VERSION
 
-    step["plugins"][0]["docker#v3.9.0"][
+    step["plugins"][0]["docker#v5.2.0"][
         "image"
     ] = f"rayproject/ray:nightly-py{python_version_str(python_version)}"
 

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -32,7 +32,7 @@ DEFAULT_STEP_TEMPLATE: Dict[str, Any] = {
     "agents": {"queue": "runner_queue_branch"},
     "plugins": [
         {
-            "docker#v3.9.0": {
+            "docker#v5.2.0": {
                 "image": "rayproject/ray",
                 "propagate-environment": True,
                 "volumes": [


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The latest release of the docker buildkite plugin implements needed features like propagating exit codes, which can be used on our end in order to retry failing tests automatically.

See e.g. https://github.com/buildkite-plugins/docker-buildkite-plugin/pull/213

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
