### PR TITLE
[Datasets] Hard upgrade to pyarrow 9.0.0.

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -83,7 +83,7 @@ opentelemetry-exporter-otlp==1.1.0
 pexpect
 Pillow; platform_system != "Windows"
 proxy.py
-pyarrow >= 6.0.1
+pyarrow >= 9.0.0
 pygments
 pyspark==3.1.2
 pytest==7.0.1

--- a/python/setup.py
+++ b/python/setup.py
@@ -223,7 +223,7 @@ if setup_spec.type == SetupType.RAY:
         "data": [
             numpy_dep,
             pandas_dep,
-            "pyarrow >= 6.0.1",
+            "pyarrow >= 9.0.0",
             "fsspec",
         ],
         "default": [


### PR DESCRIPTION
Make pyarrow 9.0.0 the minimum supported version. This may be a generically good move, but I'm currently doing this to see if things break in CI.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
