### PR TITLE
[core] re-enable memory monitor in some of the nightly tests

### DIFF
--- a/release/air_tests/air_benchmarks/xgboost_app_config.yaml
+++ b/release/air_tests/air_benchmarks/xgboost_app_config.yaml
@@ -1,5 +1,4 @@
 base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
-env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 debian_packages:
   - curl
 

--- a/release/nightly_tests/chaos_test/dask_on_ray_app_config_reconstruction.yaml
+++ b/release/nightly_tests/chaos_test/dask_on_ray_app_config_reconstruction.yaml
@@ -1,6 +1,5 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 env_vars: {"RAY_lineage_pinning_enabled": "1"}
-env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
@@ -1,10 +1,5 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
-# Test fails due to excessive retry from memory monitor. Re-enable after https://github.com/ray-project/ray/pull/28714
-# Tests this would address:
-# dask_on_ray_1tb
-# dask_on_ray_100gb_sort
-env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 
 python:
   pip_packages: ["dask[complete]", tqdm, scipy, xarray, zarr, boto, s3fs, pyarrow, pytest]

--- a/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
@@ -1,10 +1,5 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
-# Test fails due to actor killed by memory monitor. Re-enable when we address non-retrieable task / actor.
-# Tests this would address:
-# dask_on_ray_large_scale_test_no_spilling
-# dask_on_ray_large_scale_test_spilling
-env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 
 python:
   pip_packages: ["dask[complete]", tqdm, scipy, xarray, zarr, boto, s3fs, pyarrow, pytest]

--- a/release/nightly_tests/decision_tree/decision_tree_app_config.yaml
+++ b/release/nightly_tests/decision_tree/decision_tree_app_config.yaml
@@ -1,9 +1,5 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
-# Test fails due to excessive retry from memory monitor. Re-enable after https://github.com/ray-project/ray/pull/28714
-# Tests this would address:
-# decision_tree_autoscaling_20_runs
-env_vars: {"RAY_memory_monitor_interval_ms": "0"}
 
 python:
   pip_packages:

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -55,11 +55,6 @@ class ClusterManager(abc.ABC):
             "RAY_memory_monitor_interval_ms"
         ] = self.cluster_env["env_vars"].get("RAY_memory_monitor_interval_ms", "250")
         self.cluster_env["env_vars"][
-            "RAY_memory_usage_threshold_fraction"
-        ] = self.cluster_env["env_vars"].get(
-            "RAY_memory_usage_threshold_fraction", "0.95"
-        )
-        self.cluster_env["env_vars"][
             "RAY_USAGE_STATS_EXTRA_TAGS"
         ] = f"test_name={self.test_name};smoke_test={self.smoke_test}"
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -80,7 +80,7 @@ RAY_CONFIG(uint64_t, raylet_check_gc_period_milliseconds, 100)
 /// memory_usage_threshold_fraction and free space is below the min_memory_free_bytes then
 /// it will start killing processes to free up the space.
 /// Ranging from [0, 1]
-RAY_CONFIG(float, memory_usage_threshold_fraction, 0.9)
+RAY_CONFIG(float, memory_usage_threshold_fraction, 0.98)
 
 /// The interval between runs of the memory usage monitor.
 /// Monitor is disabled when this value is 0.
@@ -93,7 +93,7 @@ RAY_CONFIG(uint64_t, memory_monitor_interval_ms, 0)
 /// This value is useful for larger host where the memory_usage_threshold_fraction could
 /// represent a large chunk of memory, e.g. a host with 64GB of memory and 0.9 threshold
 /// means 6.4 GB of the memory will not be usable.
-RAY_CONFIG(int64_t, min_memory_free_bytes, (int64_t)1 * 1024 * 1024 * 1024)
+RAY_CONFIG(int64_t, min_memory_free_bytes, (int64_t)512 * 1024 * 1024)
 
 /// The TTL for when the task failure entry is considered
 /// eligble for garbage colletion.


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>


## Why are these changes needed?
 
Re-enable memory monitor on the tests where it was failing previously to verify the fixes here are working.

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x]  I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(

release test results

https://buildkite.com/ray-project/release-tests-pr/builds/17501

https://buildkite.com/ray-project/release-tests-pr/builds/17626