### PR TITLE
[Serve] Add `serve_deployment_replica_healthy` gauge to check whether deployment replicas are healthy

### DIFF
--- a/doc/source/serve/production-guide/monitoring.md
+++ b/doc/source/serve/production-guide/monitoring.md
@@ -248,6 +248,10 @@ The following metrics are exposed by Ray Serve:
      - The number of queries for this deployment waiting to be assigned to a replica.
    * - ``serve_num_deployment_http_error_requests`` [*]
      - The number of non-200 HTTP responses returned by each deployment.
+   * - ``serve_deployment_health_check_successes``
+     - The number of replica health checks that succeeded on this deployment.
+   * - ``serve_deployment_health_check_failures``
+     - The number of replica health checks that failed on this deployment.
 ```
 [*] - only available when using HTTP calls  
 [**] - only available when using Python `ServeHandle` calls

--- a/doc/source/serve/production-guide/monitoring.md
+++ b/doc/source/serve/production-guide/monitoring.md
@@ -232,6 +232,8 @@ The following metrics are exposed by Ray Serve:
      - The number of exceptions that have occurred in the deployment.
    * - ``serve_deployment_replica_starts`` [**]
      - The number of times this replica has been restarted due to failure.
+   * - ``serve_deployment_replica_healthy``
+     - Whether this deployment replica is healthy. 1 means healthy, 0 unhealthy.
    * - ``serve_deployment_processing_latency_ms`` [**]
      - The latency for queries to be processed.
    * - ``serve_replica_processing_queries`` [**]
@@ -248,10 +250,6 @@ The following metrics are exposed by Ray Serve:
      - The number of queries for this deployment waiting to be assigned to a replica.
    * - ``serve_num_deployment_http_error_requests`` [*]
      - The number of non-200 HTTP responses returned by each deployment.
-   * - ``serve_deployment_health_check_successes``
-     - The number of replica health checks that succeeded on this deployment.
-   * - ``serve_deployment_health_check_failures``
-     - The number of replica health checks that failed on this deployment.
 ```
 [*] - only available when using HTTP calls  
 [**] - only available when using Python `ServeHandle` calls

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -46,6 +46,7 @@ def test_serve_metrics_for_successful_connection(serve_instance):
             "serve_deployment_processing_latency_ms",
             # gauge
             "serve_replica_processing_queries",
+            "serve_deployment_replica_healthy",
             # handle
             "serve_handle_request_counter",
         ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The Serve controller periodically health checks deployment replicas and restarts them if they're unhealthy. However, this info is only exposed in the controller's logs, which makes it hard to observe.

This change adds a new gauge, `serve_deployment_replica_healthy`, to track whether deployment replicas are healthy. The gauge is 1 when the replica is healthy and 0 when unhealthy.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - `test_serve_metrics_for_successful_connection` in `test_metrics.py` is updated to check for the new `serve_deployment_replica_healthy` metric.
   - [X] Manual tests
     - This feature was also manually tested with this Serve app:

```python
from ray import serve

@serve.deployment(
    num_replicas=3,
    ray_actor_options={"num_cpus": 0},
    health_check_period_s=1,
    health_check_timeout_s=1,
)
class A:

    def __init__(self):
        self.tries = 5
    
    def __call__(self, *args):
        import os
        return os.getpid()
    
    def check_health(self):
        self.tries -= 1
        if self.tries < 0:
            raise RuntimeError("Failed!")

app = A.bind()
```