### PR TITLE
[core] use hex instead of binary for file name in test

### DIFF
--- a/src/ray/common/test/memory_monitor_test.cc
+++ b/src/ray/common/test/memory_monitor_test.cc
@@ -185,7 +185,7 @@ TEST_F(MemoryMonitorTest, TestCgroupV1MemFileValidReturnsWorkingSet) {
 }
 
 TEST_F(MemoryMonitorTest, TestCgroupV1MemFileMissingFieldReturnskNull) {
-  std::string file_name = UniqueID::FromRandom().Binary();
+  std::string file_name = UniqueID::FromRandom().Hex();
 
   std::ofstream mem_file;
   mem_file.open(file_name);
@@ -205,7 +205,7 @@ TEST_F(MemoryMonitorTest, TestCgroupV1MemFileMissingFieldReturnskNull) {
 }
 
 TEST_F(MemoryMonitorTest, TestCgroupV1NonexistentMemFileReturnskNull) {
-  std::string file_name = UniqueID::FromRandom().Binary();
+  std::string file_name = UniqueID::FromRandom().Hex();
 
   int64_t used_bytes = MemoryMonitor::GetCGroupV1MemoryUsedBytes(file_name.c_str());
 


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

Address test flakiness

The random file name may contain weird character as a filename for the filesystem. Use only alphanumeric characters instead.

Example BK failure & error:

https://buildkite.com/ray-project/oss-ci-build-branch/builds/401#0183b0c0-11fd-410a-9b16-45442842e1fb

[ RUN      ] MemoryMonitorTest.TestCgroupV1MemFileValidReturnsWorkingSet
--
  | [2022-10-07 04:58:08,124 W 11533 11533] memory_monitor.cc:111:  file not found: �${�'�I+0�lzT/��:�������Z{
  | src/ray/common/test/memory_monitor_test.cc:184: Failure
  | Expected equality of these values:
  | used_bytes
  | Which is: -1
  | 8571 + 918757 - 821
  | Which is: 926507
  | [  FAILED  ] MemoryMonitorTest.TestCgroupV1MemFileValidReturnsWorkingSet (0 ms)
  | [ RUN      ] MemoryMonitorTest.TestCgroupV1MemFileMissingFieldReturnskNull
  | [2022-10-07 04:58:08,124 W 11533 11533] memory_monitor.cc:134: Failed to parse cgroup v1 mem stat. rss 8571 cache 918757 inactive -1
  | [       OK ] MemoryMonitorTest.TestCgroupV1MemFileMissingFieldReturnskNull (0 ms)

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
