### PR TITLE
[Datasets] [Arrow 7.0.0+ Support] [Mono-PR] Add support for Arrow 7+.

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -269,14 +269,65 @@
     # Dask tests and examples.
     - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-client python/ray/util/dask/...
 
-- label: "Dataset tests"
+- label: "Dataset tests (Arrow nightly)"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
   instance_size: medium
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - DATA_PROCESSING_TESTING=1 ./ci/env/install-dependencies.sh
+    - DATA_PROCESSING_TESTING=1 ARROW_VERSION=nightly ./ci/env/install-dependencies.sh
     - ./ci/env/env_info.sh
     - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/data/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=ray_data python/ray/air/...
+
+- label: "Dataset tests (Arrow 10)"
+  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
+  instance_size: medium
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+    - DATA_PROCESSING_TESTING=1 ARROW_VERSION=10.* ./ci/env/install-dependencies.sh
+    - ./ci/env/env_info.sh
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/data/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=ray_data python/ray/air/...
+
+- label: "Dataset tests (Arrow 9)"
+  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
+  instance_size: medium
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+    - DATA_PROCESSING_TESTING=1 ARROW_VERSION=9.* ./ci/env/install-dependencies.sh
+    - ./ci/env/env_info.sh
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/data/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=ray_data python/ray/air/...
+
+- label: "Dataset tests (Arrow 8)"
+  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
+  instance_size: medium
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+    - DATA_PROCESSING_TESTING=1 ARROW_VERSION=8.* ./ci/env/install-dependencies.sh
+    - ./ci/env/env_info.sh
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/data/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=ray_data python/ray/air/...
+
+- label: "Dataset tests (Arrow 7)"
+  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
+  instance_size: medium
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+    - DATA_PROCESSING_TESTING=1 ARROW_VERSION=7.* ./ci/env/install-dependencies.sh
+    - ./ci/env/env_info.sh
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/data/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=ray_data python/ray/air/...
+
+- label: "Dataset tests (Arrow 6)"
+  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
+  instance_size: medium
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+    - DATA_PROCESSING_TESTING=1 ARROW_VERSION=6.* ./ci/env/install-dependencies.sh
+    - ./ci/env/env_info.sh
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/data/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=ray_data python/ray/air/...
 
 - label: "Workflow tests"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_WORKFLOW_AFFECTED"]

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -399,6 +399,13 @@ install_pip_packages() {
   fi
   if [ "${DATA_PROCESSING_TESTING-}" = 1 ]; then
     pip install -U -c "${WORKSPACE_DIR}"/python/requirements.txt -r "${WORKSPACE_DIR}"/python/requirements/data_processing/requirements_dataset.txt
+    if [ -n "${ARROW_VERSION-}" ]; then
+      if [ "${ARROW_VERSION-}" = nightly ]; then
+        pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ --prefer-binary --pre pyarrow
+      else
+        pip install -U pyarrow=="${ARROW_VERSION}"
+      fi
+    fi
   fi
 
   # Remove this entire section once Serve dependencies are fixed.

--- a/python/ray/_private/storage.py
+++ b/python/ray/_private/storage.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
 from ray._private.client_mode_hook import client_mode_hook
+from ray._private.utils import _add_creatable_buckets_param_if_s3_uri
 
 if TYPE_CHECKING:
     import pyarrow.fs
@@ -368,6 +369,9 @@ def _init_filesystem(create_valid_file: bool = False, check_valid_file: bool = T
         fs_creator = _load_class(parsed_uri.netloc)
         _filesystem, _storage_prefix = fs_creator(parsed_uri.path)
     else:
+        # Arrow's S3FileSystem doesn't allow creating buckets by default, so we add a
+        # query arg enabling bucket creation if an S3 URI is provided.
+        _storage_uri = _add_creatable_buckets_param_if_s3_uri(_storage_uri)
         _filesystem, _storage_prefix = pyarrow.fs.FileSystem.from_uri(_storage_uri)
 
     if os.name == "nt":

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -4,6 +4,7 @@ import functools
 import hashlib
 import importlib
 import inspect
+import json
 import logging
 import multiprocessing
 import os
@@ -14,6 +15,7 @@ import sys
 import tempfile
 import threading
 import time
+from urllib.parse import urlencode, unquote, urlparse, parse_qsl, ParseResult
 import uuid
 import warnings
 from inspect import signature
@@ -61,6 +63,7 @@ win32_AssignProcessToJobObject = None
 
 
 ENV_DISABLE_DOCKER_CPU_WARNING = "RAY_DISABLE_DOCKER_CPU_WARNING" in os.environ
+_PYARROW_VERSION = None
 
 
 def get_user_temp_dir():
@@ -1578,3 +1581,101 @@ def split_address(address: str) -> Tuple[str, str]:
 
     module_string, inner_address = address.split("://", maxsplit=1)
     return (module_string, inner_address)
+
+
+def _add_url_query_params(
+    url: str, params: Dict[str, str], override: bool = False
+) -> str:
+    """Add params to the provided url as query parameters.
+
+    Args:
+        url: The URL to add query parameters to.
+        params: The query parameters to add.
+        override: Whether the provided params should override existing query parameters
+            in url: if True, the existing query parameters will be overwritten; if
+            False, the existing query parameters will take precedent. Default is False.
+
+    Returns:
+        URL with params added as query parameters.
+    """
+    # Unquoting URL first so we don't loose existing args.
+    url = unquote(url)
+    # Parse URL.
+    parsed_url = urlparse(url)
+    # Converting URL query string arguments to dict.
+    base_params = dict(parse_qsl(parsed_url.query))
+    if not override:
+        # If not overriding, treat params as base parameters and override with existing
+        # query string parameters.
+        base_params, params = params, base_params
+    # Merging URL query string arguments dict with new params.
+    base_params.update(params)
+    # bool and dict values should be converted to json-friendly values.
+    base_params.update(
+        {
+            k: json.dumps(v)
+            for k, v in base_params.items()
+            if isinstance(v, (bool, dict))
+        }
+    )
+
+    # Converting URL arguments to proper query string.
+    encoded_params = urlencode(base_params, doseq=True)
+    # Creating new parsed result object based on provided with new
+    # URL arguments. Same thing happens inside of urlparse.
+    new_url = ParseResult(
+        parsed_url.scheme,
+        parsed_url.netloc,
+        parsed_url.path,
+        parsed_url.params,
+        encoded_params,
+        parsed_url.fragment,
+    ).geturl()
+
+    return new_url
+
+
+def _add_creatable_buckets_param_if_s3_uri(uri: str) -> str:
+    """If the provided URI is an S3 URL, add allow_bucket_creation=true as a query
+    parameter. For pyarrow >= 9.0.0, this is required in order to allow
+    ``S3FileSystem.create_dir()`` to create S3 buckets.
+
+    If the provided URI is not an S3 URL or if pyarrow < 9.0.0 is installed, we return
+    the URI unchanged.
+
+    Args:
+        uri: The URI that we'll add the query parameter to, if it's an S3 URL.
+
+    Returns:
+        A URI with the added allow_bucket_creation=true query parameter, if the provided
+        URI is an S3 URL; uri will be returned unchanged otherwise.
+    """
+    from pkg_resources._vendor.packaging.version import parse as parse_version
+
+    pyarrow_version = _get_pyarrow_version()
+    if pyarrow_version is not None:
+        pyarrow_version = parse_version(pyarrow_version)
+    if pyarrow_version is not None and pyarrow_version < parse_version("9.0.0"):
+        # This bucket creation query parameter is not required for pyarrow < 9.0.0.
+        return uri
+    parsed_uri = urlparse(uri)
+    if parsed_uri.scheme == "s3":
+        uri = _add_url_query_params(uri, {"allow_bucket_creation": True})
+    return uri
+
+
+def _get_pyarrow_version() -> Optional[str]:
+    """Get the version of the installed pyarrow package, returned as a tuple of ints.
+    Returns None if the package is not found.
+    """
+    global _PYARROW_VERSION
+    if _PYARROW_VERSION is None:
+        try:
+            import pyarrow
+        except ModuleNotFoundError:
+            # pyarrow not installed, short-circuit.
+            pass
+        else:
+            if hasattr(pyarrow, "__version__"):
+                _PYARROW_VERSION = pyarrow.__version__
+    return _PYARROW_VERSION

--- a/python/ray/air/BUILD
+++ b/python/ray/air/BUILD
@@ -62,7 +62,7 @@ py_test(
     name = "test_data_batch_conversion",
     size = "small",
     srcs = ["tests/test_data_batch_conversion.py"],
-    tags = ["team:ml", "exclusive"],
+    tags = ["team:ml", "exclusive", "ray_data"],
     deps = [":ml_lib"]
 )
 
@@ -110,7 +110,7 @@ py_test(
     name = "test_tensor_extension",
     size = "small",
     srcs = ["tests/test_tensor_extension.py"],
-    tags = ["team:ml", "exclusive"],
+    tags = ["team:ml", "exclusive", "ray_data"],
     deps = [":ml_lib"]
 )
 

--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -2,6 +2,7 @@ import itertools
 
 import numpy as np
 import pandas as pd
+from pkg_resources._vendor.packaging.version import parse as parse_version
 import pyarrow as pa
 import pytest
 
@@ -12,6 +13,7 @@ from ray.air.util.tensor_extensions.arrow import (
     ArrowVariableShapedTensorType,
 )
 from ray.air.util.tensor_extensions.pandas import TensorArray, TensorDtype
+from ray._private.utils import _get_pyarrow_version
 
 
 def test_tensor_array_validation():
@@ -331,7 +333,8 @@ def test_tensor_array_reductions():
         np.testing.assert_equal(df["two"].agg(name), reducer(arr, axis=0, **np_kwargs))
 
 
-def test_arrow_tensor_array_getitem():
+@pytest.mark.parametrize("chunked", [False, True])
+def test_arrow_tensor_array_getitem(chunked):
     outer_dim = 3
     inner_shape = (2, 2, 2)
     shape = (outer_dim,) + inner_shape
@@ -339,9 +342,23 @@ def test_arrow_tensor_array_getitem():
     arr = np.arange(num_items).reshape(shape)
 
     t_arr = ArrowTensorArray.from_numpy(arr)
+    if chunked:
+        t_arr = pa.chunked_array(t_arr)
 
-    for idx in range(outer_dim):
-        np.testing.assert_array_equal(t_arr[idx], arr[idx])
+    pyarrow_version = parse_version(_get_pyarrow_version())
+    if (
+        chunked
+        and pyarrow_version >= parse_version("8.0.0")
+        and pyarrow_version < parse_version("9.0.0")
+    ):
+        for idx in range(outer_dim):
+            item = t_arr[idx]
+            assert isinstance(item, pa.ExtensionScalar)
+            item = item.type._extension_scalar_to_ndarray(item)
+            np.testing.assert_array_equal(item, arr[idx])
+    else:
+        for idx in range(outer_dim):
+            np.testing.assert_array_equal(t_arr[idx], arr[idx])
 
     # Test __iter__.
     for t_subarr, subarr in zip(t_arr, arr):
@@ -352,11 +369,101 @@ def test_arrow_tensor_array_getitem():
 
     # Test slicing and indexing.
     t_arr2 = t_arr[1:]
+    if chunked:
+        # For extension arrays, ChunkedArray.to_numpy() concatenates chunk storage
+        # arrays and calls to_numpy() on the resulting array, which returns the wrong
+        # ndarray.
+        # TODO(Clark): Fix this in Arrow by (1) providing an ExtensionArray hook for
+        # concatenation, and (2) using that + a to_numpy() call on the resulting
+        # ExtensionArray.
+        t_arr2_npy = t_arr2.chunk(0).to_numpy()
+    else:
+        t_arr2_npy = t_arr2.to_numpy()
 
-    np.testing.assert_array_equal(t_arr2.to_numpy(), arr[1:])
+    np.testing.assert_array_equal(t_arr2_npy, arr[1:])
 
-    for idx in range(1, outer_dim):
-        np.testing.assert_array_equal(t_arr2[idx - 1], arr[idx])
+    if (
+        chunked
+        and pyarrow_version >= parse_version("8.0.0")
+        and pyarrow_version < parse_version("9.0.0")
+    ):
+        for idx in range(1, outer_dim):
+            item = t_arr2[idx - 1]
+            assert isinstance(item, pa.ExtensionScalar)
+            item = item.type._extension_scalar_to_ndarray(item)
+            np.testing.assert_array_equal(item, arr[idx])
+    else:
+        for idx in range(1, outer_dim):
+            np.testing.assert_array_equal(t_arr2[idx - 1], arr[idx])
+
+
+@pytest.mark.parametrize("chunked", [False, True])
+def test_arrow_variable_shaped_tensor_array_getitem(chunked):
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    outer_dim = len(shapes)
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    arr = np.array(arrs, dtype=object)
+    t_arr = ArrowVariableShapedTensorArray.from_numpy(arr)
+
+    if chunked:
+        t_arr = pa.chunked_array(t_arr)
+
+    pyarrow_version = parse_version(_get_pyarrow_version())
+    if (
+        chunked
+        and pyarrow_version >= parse_version("8.0.0")
+        and pyarrow_version < parse_version("9.0.0")
+    ):
+        for idx in range(outer_dim):
+            item = t_arr[idx]
+            assert isinstance(item, pa.ExtensionScalar)
+            item = item.type._extension_scalar_to_ndarray(item)
+            np.testing.assert_array_equal(item, arr[idx])
+    else:
+        for idx in range(outer_dim):
+            np.testing.assert_array_equal(t_arr[idx], arr[idx])
+
+    # Test __iter__.
+    for t_subarr, subarr in zip(t_arr, arr):
+        np.testing.assert_array_equal(t_subarr, subarr)
+
+    # Test to_pylist.
+    for t_subarr, subarr in zip(t_arr.to_pylist(), list(arr)):
+        np.testing.assert_array_equal(t_subarr, subarr)
+
+    # Test slicing and indexing.
+    t_arr2 = t_arr[1:]
+    if chunked:
+        # For extension arrays, ChunkedArray.to_numpy() concatenates chunk storage
+        # arrays and calls to_numpy() on the resulting array, which returns the wrong
+        # ndarray.
+        # TODO(Clark): Fix this in Arrow by (1) providing an ExtensionArray hook for
+        # concatenation, and (2) using that + a to_numpy() call on the resulting
+        # ExtensionArray.
+        t_arr2_npy = t_arr2.chunk(0).to_numpy()
+    else:
+        t_arr2_npy = t_arr2.to_numpy()
+
+    for t_subarr, subarr in zip(t_arr2_npy, arr[1:]):
+        np.testing.assert_array_equal(t_subarr, subarr)
+
+    if (
+        chunked
+        and pyarrow_version >= parse_version("8.0.0")
+        and pyarrow_version < parse_version("9.0.0")
+    ):
+        for idx in range(1, outer_dim):
+            item = t_arr2[idx - 1]
+            assert isinstance(item, pa.ExtensionScalar)
+            item = item.type._extension_scalar_to_ndarray(item)
+            np.testing.assert_array_equal(item, arr[idx])
+    else:
+        for idx in range(1, outer_dim):
+            np.testing.assert_array_equal(t_arr2[idx - 1], arr[idx])
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -1,8 +1,3 @@
-import ray
-from ray.data._internal.arrow_serialization import (
-    _register_arrow_json_parseoptions_serializer,
-    _register_arrow_json_readoptions_serializer,
-)
 from ray.data._internal.compute import ActorPoolStrategy
 from ray.data._internal.progress_bar import set_progress_bars
 from ray.data.dataset import Dataset
@@ -37,15 +32,6 @@ from ray.data.read_api import (  # noqa: F401
     read_text,
     read_tfrecords,
 )
-
-# Register custom Arrow JSON ReadOptions and ParseOptions serializer after worker has
-# initialized.
-if ray.is_initialized():
-    _register_arrow_json_readoptions_serializer()
-    _register_arrow_json_parseoptions_serializer()
-else:
-    pass
-#    ray._internal.worker._post_init_hooks.append(_register_arrow_json_readoptions_serializer)
 
 __all__ = [
     "ActorPoolStrategy",

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
 
     from ray.data._internal.sort import SortKeyT
 
+
 T = TypeVar("T")
 
 
@@ -169,7 +170,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
     def _build_tensor_row(row: ArrowRow) -> np.ndarray:
         return row[VALUE_COL_NAME][0]
 
-    def slice(self, start: int, end: int, copy: bool) -> "pyarrow.Table":
+    def slice(self, start: int, end: int, copy: bool = False) -> "pyarrow.Table":
         view = self._table.slice(start, end - start)
         if copy:
             view = _copy_table(view)
@@ -212,10 +213,10 @@ class ArrowBlockAccessor(TableBlockAccessor):
         arrays = []
         for column in columns:
             array = self._table[column]
-            if array.num_chunks == 0:
-                array = pyarrow.array([], type=array.type)
-            elif _is_column_extension_type(array):
+            if _is_column_extension_type(array):
                 array = _concatenate_extension_column(array)
+            elif array.num_chunks == 0:
+                array = pyarrow.array([], type=array.type)
             else:
                 array = array.combine_chunks()
             arrays.append(array.to_numpy(zero_copy_only=False))
@@ -399,11 +400,9 @@ class ArrowBlockAccessor(TableBlockAccessor):
             bounds = np.searchsorted(table[col], boundaries)
         last_idx = 0
         for idx in bounds:
-            # Slices need to be copied to avoid including the base table
-            # during serialization.
-            partitions.append(_copy_table(table.slice(last_idx, idx - last_idx)))
+            partitions.append(table.slice(last_idx, idx - last_idx))
             last_idx = idx
-        partitions.append(_copy_table(table.slice(last_idx)))
+        partitions.append(table.slice(last_idx))
         return partitions
 
     def combine(self, key: KeyFn, aggs: Tuple[AggregateFn]) -> Block[ArrowRow]:
@@ -449,7 +448,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
                         except StopIteration:
                             next_row = None
                             break
-                    yield next_key, self.slice(start, end, copy=False)
+                    yield next_key, self.slice(start, end)
                     start = end
                 except StopIteration:
                     break

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -16,6 +16,7 @@ from typing import (
 
 import numpy as np
 
+from ray._private.utils import _get_pyarrow_version
 from ray.data._internal.arrow_ops import transform_polars, transform_pyarrow
 from ray.data._internal.table_block import (
     VALUE_COL_NAME,
@@ -71,6 +72,19 @@ class ArrowRow(TableRow):
     """
 
     def __getitem__(self, key: str) -> Any:
+        from ray.data.extensions.tensor_extension import (
+            ArrowTensorType,
+            ArrowVariableShapedTensorType,
+        )
+
+        schema = self._row.schema
+        if isinstance(
+            schema.field(schema.get_field_index(key)).type,
+            (ArrowTensorType, ArrowVariableShapedTensorType),
+        ):
+            # Build a tensor row.
+            return ArrowBlockAccessor._build_tensor_row(self._row, col_name=key)
+
         col = self._row[key]
         if len(col) == 0:
             return None
@@ -80,7 +94,7 @@ class ArrowRow(TableRow):
             return item.as_py()
         except AttributeError:
             # Assume that this row is an element of an extension array, and
-            # that it is bypassing pyarrow's scalar model.
+            # that it is bypassing pyarrow's scalar model for Arrow < 8.0.0.
             return item
 
     def __iter__(self) -> Iterator:
@@ -167,8 +181,30 @@ class ArrowBlockAccessor(TableBlockAccessor):
         return pa.Table.from_pydict(new_batch)
 
     @staticmethod
-    def _build_tensor_row(row: ArrowRow) -> np.ndarray:
-        return row[VALUE_COL_NAME][0]
+    def _build_tensor_row(row: ArrowRow, col_name: str = VALUE_COL_NAME) -> np.ndarray:
+        from pkg_resources._vendor.packaging.version import parse as parse_version
+
+        element = row[col_name][0]
+        # TODO(Clark): Reduce this to np.asarray(element) once we only support Arrow
+        # 9.0.0+.
+        pyarrow_version = _get_pyarrow_version()
+        if pyarrow_version is not None:
+            pyarrow_version = parse_version(pyarrow_version)
+        if pyarrow_version is None or pyarrow_version >= parse_version("8.0.0"):
+            assert isinstance(element, pyarrow.ExtensionScalar)
+            if pyarrow_version is None or pyarrow_version >= parse_version("9.0.0"):
+                # For Arrow 9.0.0+, accessing an element in a chunked tensor array
+                # produces an ArrowTensorScalar, which we convert to an ndarray using
+                # .as_py().
+                element = element.as_py()
+            else:
+                # For Arrow 8.*, accessing an element in a chunked tensor array produces
+                # an ExtensionScalar, which we convert to an ndarray using our custom
+                # method.
+                element = element.type._extension_scalar_to_ndarray(element)
+        # For Arrow < 8.0.0, accessing an element in a chunked tensor array produces an
+        # ndarray, which we return directly.
+        return element
 
     def slice(self, start: int, end: int, copy: bool = False) -> "pyarrow.Table":
         view = self._table.slice(start, end - start)

--- a/python/ray/data/_internal/arrow_ops/transform_polars.py
+++ b/python/ray/data/_internal/arrow_ops/transform_polars.py
@@ -7,7 +7,7 @@ except ImportError:
 
 
 if TYPE_CHECKING:
-    from ray.data.impl.sort import SortKeyT
+    from ray.data._internal.sort import SortKeyT
 
 pl = None
 

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -6,7 +6,7 @@ except ImportError:
     pyarrow = None
 
 if TYPE_CHECKING:
-    from ray.data.impl.sort import SortKeyT
+    from ray.data._internal.sort import SortKeyT
 
 
 def sort(table: "pyarrow.Table", key: "SortKeyT", descending: bool) -> "pyarrow.Table":

--- a/python/ray/data/_internal/arrow_serialization.py
+++ b/python/ray/data/_internal/arrow_serialization.py
@@ -1,13 +1,34 @@
+import functools
 import os
+from typing import List, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pyarrow
 
 RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION = (
     "RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION"
 )
+RAY_DISABLE_CUSTOM_ARROW_DATA_SERIALIZATION = (
+    "RAY_DISABLE_CUSTOM_ARROW_DATA_SERIALIZATION"
+)
 
 
-def _register_arrow_json_readoptions_serializer():
-    import ray
+def _register_custom_datasets_serializers(serialization_context):
+    try:
+        import pyarrow as pa  # noqa: F401
+    except ModuleNotFoundError:
+        # No pyarrow installed so not using Arrow, so no need for custom serializers.
+        return
 
+    # Register all custom serializers required by Datasets.
+    _register_arrow_data_serializer(serialization_context)
+    _register_arrow_json_readoptions_serializer(serialization_context)
+    _register_arrow_json_parseoptions_serializer(serialization_context)
+
+
+# Register custom Arrow JSON ReadOptions serializer to workaround it not being picklable
+# in Arrow < 8.0.0.
+def _register_arrow_json_readoptions_serializer(serialization_context):
     if (
         os.environ.get(
             RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION,
@@ -15,27 +36,18 @@ def _register_arrow_json_readoptions_serializer():
         )
         == "1"
     ):
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.info("Disabling custom Arrow JSON ReadOptions serialization.")
         return
 
-    try:
-        import pyarrow.json as pajson
-    except ModuleNotFoundError:
-        return
+    import pyarrow.json as pajson
 
-    ray.util.register_serializer(
+    serialization_context._register_cloudpickle_serializer(
         pajson.ReadOptions,
-        serializer=lambda opts: (opts.use_threads, opts.block_size),
-        deserializer=lambda args: pajson.ReadOptions(*args),
+        custom_serializer=lambda opts: (opts.use_threads, opts.block_size),
+        custom_deserializer=lambda args: pajson.ReadOptions(*args),
     )
 
 
-def _register_arrow_json_parseoptions_serializer():
-    import ray
-
+def _register_arrow_json_parseoptions_serializer(serialization_context):
     if (
         os.environ.get(
             RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION,
@@ -43,23 +55,188 @@ def _register_arrow_json_parseoptions_serializer():
         )
         == "1"
     ):
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.info("Disabling custom Arrow JSON ParseOptions serialization.")
         return
 
-    try:
-        import pyarrow.json as pajson
-    except ModuleNotFoundError:
-        return
+    import pyarrow.json as pajson
 
-    ray.util.register_serializer(
+    serialization_context._register_cloudpickle_serializer(
         pajson.ParseOptions,
-        serializer=lambda opts: (
+        custom_serializer=lambda opts: (
             opts.explicit_schema,
             opts.newlines_in_values,
             opts.unexpected_field_behavior,
         ),
-        deserializer=lambda args: pajson.ParseOptions(*args),
+        custom_deserializer=lambda args: pajson.ParseOptions(*args),
     )
+
+
+# Register custom Arrow data serializer to work around zero-copy slice pickling bug.
+# See https://issues.apache.org/jira/browse/ARROW-10739.
+def _register_arrow_data_serializer(serialization_context):
+    """Custom reducer for Arrow data that works around a zero-copy slicing pickling
+    bug by using the Arrow IPC format for the underlying serialization.
+
+    Background:
+        Arrow has both array-level slicing and buffer-level slicing; both are zero-copy,
+        but the former has a serialization bug where the entire buffer is serialized
+        instead of just the slice, while the latter's serialization works as expected
+        and only serializes the slice of the buffer. I.e., array-level slicing doesn't
+        propagate the slice down to the buffer when serializing the array.
+
+        All that these copy methods do is, at serialization time, take the array-level
+        slicing and translate them to buffer-level slicing, so only the buffer slice is
+        sent over the wire instead of the entire buffer.
+
+    See https://issues.apache.org/jira/browse/ARROW-10739.
+    """
+    import pyarrow as pa
+
+    if os.environ.get(RAY_DISABLE_CUSTOM_ARROW_DATA_SERIALIZATION, "0") == "1":
+        return
+
+    # Register custom reducer for Arrow Arrays.
+    array_types = _get_arrow_array_types()
+    for array_type in array_types:
+        serialization_context._register_cloudpickle_reducer(
+            array_type, _arrow_array_reduce
+        )
+    # Register custom reducer for Arrow ChunkedArrays.
+    serialization_context._register_cloudpickle_reducer(
+        pa.ChunkedArray, _arrow_chunkedarray_reduce
+    )
+    # Register custom reducer for Arrow RecordBatches.
+    serialization_context._register_cloudpickle_reducer(
+        pa.RecordBatch, _arrow_recordbatch_reduce
+    )
+    # Register custom reducer for Arrow Tables.
+    serialization_context._register_cloudpickle_reducer(pa.Table, _arrow_table_reduce)
+
+
+def _get_arrow_array_types() -> List[type]:
+    """Get all Arrow array types that we want to register a custom serializer for."""
+    import pyarrow as pa
+    from ray.data.extensions import ArrowTensorArray, ArrowVariableShapedTensorArray
+
+    array_types = [
+        pa.lib.NullArray,
+        pa.lib.BooleanArray,
+        pa.lib.UInt8Array,
+        pa.lib.UInt16Array,
+        pa.lib.UInt32Array,
+        pa.lib.UInt64Array,
+        pa.lib.Int8Array,
+        pa.lib.Int16Array,
+        pa.lib.Int32Array,
+        pa.lib.Int64Array,
+        pa.lib.Date32Array,
+        pa.lib.Date64Array,
+        pa.lib.TimestampArray,
+        pa.lib.Time32Array,
+        pa.lib.Time64Array,
+        pa.lib.DurationArray,
+        pa.lib.HalfFloatArray,
+        pa.lib.FloatArray,
+        pa.lib.DoubleArray,
+        pa.lib.ListArray,
+        pa.lib.LargeListArray,
+        pa.lib.MapArray,
+        pa.lib.FixedSizeListArray,
+        pa.lib.UnionArray,
+        pa.lib.BinaryArray,
+        pa.lib.StringArray,
+        pa.lib.LargeBinaryArray,
+        pa.lib.LargeStringArray,
+        pa.lib.DictionaryArray,
+        pa.lib.FixedSizeBinaryArray,
+        pa.lib.Decimal128Array,
+        pa.lib.Decimal256Array,
+        pa.lib.StructArray,
+        pa.lib.ExtensionArray,
+        ArrowTensorArray,
+        ArrowVariableShapedTensorArray,
+    ]
+    try:
+        array_types.append(pa.lib.MonthDayNanoIntervalArray)
+    except AttributeError:
+        # MonthDayNanoIntervalArray doesn't exist on older pyarrow versions.
+        pass
+    return array_types
+
+
+def _arrow_array_reduce(a: "pyarrow.Array"):
+    """Custom reducer for Arrow arrays that works around a zero-copy slicing pickling
+    bug by using the Arrow IPC format for the underlying serialization.
+    """
+    import pyarrow as pa
+
+    batch = pa.RecordBatch.from_arrays([a], [""])
+    restore_recordbatch, serialized = _arrow_recordbatch_reduce(batch)
+
+    return functools.partial(_restore_array, restore_recordbatch), serialized
+
+
+def _restore_array(
+    restore_recordbatch: Callable[[bytes], "pyarrow.RecordBatch"], buf: bytes
+) -> "pyarrow.Array":
+    """Restore a serialized Arrow Array."""
+    return restore_recordbatch(buf).column(0)
+
+
+def _arrow_chunkedarray_reduce(a: "pyarrow.ChunkedArray"):
+    """Custom reducer for Arrow ChunkedArrays that works around a zero-copy slicing
+    pickling bug by using the Arrow IPC format for the underlying serialization.
+    """
+    import pyarrow as pa
+
+    table = pa.Table.from_arrays([a], names=[""])
+    restore_table, serialized = _arrow_table_reduce(table)
+    return functools.partial(_restore_chunkedarray, restore_table), serialized
+
+
+def _restore_chunkedarray(
+    restore_table: Callable[[bytes], "pyarrow.Table"], buf: bytes
+) -> "pyarrow.ChunkedArray":
+    """Restore a serialized Arrow ChunkedArray."""
+    return restore_table(buf).column(0)
+
+
+def _arrow_recordbatch_reduce(batch: "pyarrow.RecordBatch"):
+    """Custom reducer for Arrow RecordBatch that works around a zero-copy slicing
+    pickling bug by using the Arrow IPC format for the underlying serialization.
+    """
+    from pyarrow.ipc import RecordBatchStreamWriter
+    from pyarrow.lib import BufferOutputStream
+
+    output_stream = BufferOutputStream()
+    with RecordBatchStreamWriter(output_stream, schema=batch.schema) as wr:
+        wr.write_batch(batch)
+    return _restore_recordbatch, (output_stream.getvalue(),)
+
+
+def _restore_recordbatch(buf: bytes) -> "pyarrow.RecordBatch":
+    """Restore a serialized Arrow RecordBatch."""
+    from pyarrow.ipc import RecordBatchStreamReader
+
+    with RecordBatchStreamReader(buf) as reader:
+        return reader.read_next_batch()
+
+
+def _arrow_table_reduce(table: "pyarrow.Table"):
+    """Custom reducer for Arrow Table that works around a zero-copy slicing pickling
+    bug by using the Arrow IPC format for the underlying serialization.
+    """
+    from pyarrow.ipc import RecordBatchStreamWriter
+    from pyarrow.lib import BufferOutputStream
+
+    output_stream = BufferOutputStream()
+    with RecordBatchStreamWriter(output_stream, schema=table.schema) as wr:
+        wr.write_table(table)
+    return _restore_table, (output_stream.getvalue(),)
+
+
+def _restore_table(buf: bytes) -> "pyarrow.Table":
+    """Restore a serialized Arrow Table."""
+    from pyarrow.ipc import RecordBatchStreamReader
+
+    with RecordBatchStreamReader(buf) as reader:
+        return reader.read_all()

--- a/python/ray/data/_internal/arrow_serialization.py
+++ b/python/ray/data/_internal/arrow_serialization.py
@@ -1,6 +1,5 @@
-import functools
 import os
-from typing import List, Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import pyarrow
@@ -94,131 +93,8 @@ def _register_arrow_data_serializer(serialization_context):
     if os.environ.get(RAY_DISABLE_CUSTOM_ARROW_DATA_SERIALIZATION, "0") == "1":
         return
 
-    # Register custom reducer for Arrow Arrays.
-    array_types = _get_arrow_array_types()
-    for array_type in array_types:
-        serialization_context._register_cloudpickle_reducer(
-            array_type, _arrow_array_reduce
-        )
-    # Register custom reducer for Arrow ChunkedArrays.
-    serialization_context._register_cloudpickle_reducer(
-        pa.ChunkedArray, _arrow_chunkedarray_reduce
-    )
-    # Register custom reducer for Arrow RecordBatches.
-    serialization_context._register_cloudpickle_reducer(
-        pa.RecordBatch, _arrow_recordbatch_reduce
-    )
     # Register custom reducer for Arrow Tables.
     serialization_context._register_cloudpickle_reducer(pa.Table, _arrow_table_reduce)
-
-
-def _get_arrow_array_types() -> List[type]:
-    """Get all Arrow array types that we want to register a custom serializer for."""
-    import pyarrow as pa
-    from ray.data.extensions import ArrowTensorArray, ArrowVariableShapedTensorArray
-
-    array_types = [
-        pa.lib.NullArray,
-        pa.lib.BooleanArray,
-        pa.lib.UInt8Array,
-        pa.lib.UInt16Array,
-        pa.lib.UInt32Array,
-        pa.lib.UInt64Array,
-        pa.lib.Int8Array,
-        pa.lib.Int16Array,
-        pa.lib.Int32Array,
-        pa.lib.Int64Array,
-        pa.lib.Date32Array,
-        pa.lib.Date64Array,
-        pa.lib.TimestampArray,
-        pa.lib.Time32Array,
-        pa.lib.Time64Array,
-        pa.lib.DurationArray,
-        pa.lib.HalfFloatArray,
-        pa.lib.FloatArray,
-        pa.lib.DoubleArray,
-        pa.lib.ListArray,
-        pa.lib.LargeListArray,
-        pa.lib.MapArray,
-        pa.lib.FixedSizeListArray,
-        pa.lib.UnionArray,
-        pa.lib.BinaryArray,
-        pa.lib.StringArray,
-        pa.lib.LargeBinaryArray,
-        pa.lib.LargeStringArray,
-        pa.lib.DictionaryArray,
-        pa.lib.FixedSizeBinaryArray,
-        pa.lib.Decimal128Array,
-        pa.lib.Decimal256Array,
-        pa.lib.StructArray,
-        pa.lib.ExtensionArray,
-        ArrowTensorArray,
-        ArrowVariableShapedTensorArray,
-    ]
-    try:
-        array_types.append(pa.lib.MonthDayNanoIntervalArray)
-    except AttributeError:
-        # MonthDayNanoIntervalArray doesn't exist on older pyarrow versions.
-        pass
-    return array_types
-
-
-def _arrow_array_reduce(a: "pyarrow.Array"):
-    """Custom reducer for Arrow arrays that works around a zero-copy slicing pickling
-    bug by using the Arrow IPC format for the underlying serialization.
-    """
-    import pyarrow as pa
-
-    batch = pa.RecordBatch.from_arrays([a], [""])
-    restore_recordbatch, serialized = _arrow_recordbatch_reduce(batch)
-
-    return functools.partial(_restore_array, restore_recordbatch), serialized
-
-
-def _restore_array(
-    restore_recordbatch: Callable[[bytes], "pyarrow.RecordBatch"], buf: bytes
-) -> "pyarrow.Array":
-    """Restore a serialized Arrow Array."""
-    return restore_recordbatch(buf).column(0)
-
-
-def _arrow_chunkedarray_reduce(a: "pyarrow.ChunkedArray"):
-    """Custom reducer for Arrow ChunkedArrays that works around a zero-copy slicing
-    pickling bug by using the Arrow IPC format for the underlying serialization.
-    """
-    import pyarrow as pa
-
-    table = pa.Table.from_arrays([a], names=[""])
-    restore_table, serialized = _arrow_table_reduce(table)
-    return functools.partial(_restore_chunkedarray, restore_table), serialized
-
-
-def _restore_chunkedarray(
-    restore_table: Callable[[bytes], "pyarrow.Table"], buf: bytes
-) -> "pyarrow.ChunkedArray":
-    """Restore a serialized Arrow ChunkedArray."""
-    return restore_table(buf).column(0)
-
-
-def _arrow_recordbatch_reduce(batch: "pyarrow.RecordBatch"):
-    """Custom reducer for Arrow RecordBatch that works around a zero-copy slicing
-    pickling bug by using the Arrow IPC format for the underlying serialization.
-    """
-    from pyarrow.ipc import RecordBatchStreamWriter
-    from pyarrow.lib import BufferOutputStream
-
-    output_stream = BufferOutputStream()
-    with RecordBatchStreamWriter(output_stream, schema=batch.schema) as wr:
-        wr.write_batch(batch)
-    return _restore_recordbatch, (output_stream.getvalue(),)
-
-
-def _restore_recordbatch(buf: bytes) -> "pyarrow.RecordBatch":
-    """Restore a serialized Arrow RecordBatch."""
-    from pyarrow.ipc import RecordBatchStreamReader
-
-    with RecordBatchStreamReader(buf) as reader:
-        return reader.read_next_batch()
 
 
 def _arrow_table_reduce(table: "pyarrow.Table"):

--- a/python/ray/data/_internal/delegating_block_builder.py
+++ b/python/ray/data/_internal/delegating_block_builder.py
@@ -59,6 +59,7 @@ class DelegatingBlockBuilder(BlockBuilder[T]):
         if self._builder is None:
             if self._empty_block is not None:
                 self._builder = BlockAccessor.for_block(self._empty_block).builder()
+                self._builder.add_block(self._empty_block)
             else:
                 self._builder = ArrowBlockBuilder()
         return self._builder.build()

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -143,7 +143,7 @@ class PandasBlockAccessor(TableBlockAccessor):
             tensor = tensor.to_numpy()
         return tensor
 
-    def slice(self, start: int, end: int, copy: bool) -> "pandas.DataFrame":
+    def slice(self, start: int, end: int, copy: bool = False) -> "pandas.DataFrame":
         view = self._table[start:end]
         view.reset_index(drop=True, inplace=True)
         if copy:

--- a/python/ray/data/_internal/shuffle_and_partition.py
+++ b/python/ray/data/_internal/shuffle_and_partition.py
@@ -56,7 +56,7 @@ class _ShufflePartitionOp(ShuffleOp):
         slice_sz = max(1, math.ceil(block.num_rows() / output_num_blocks))
         slices = []
         for i in range(output_num_blocks):
-            slices.append(block.slice(i * slice_sz, (i + 1) * slice_sz, copy=True))
+            slices.append(block.slice(i * slice_sz, (i + 1) * slice_sz))
 
         # Randomize the distribution order of the blocks (this prevents empty
         # outputs when input blocks are very small).

--- a/python/ray/data/_internal/simple_block.py
+++ b/python/ray/data/_internal/simple_block.py
@@ -67,7 +67,7 @@ class SimpleBlockAccessor(BlockAccessor):
     def iter_rows(self) -> Iterator[T]:
         return iter(self._items)
 
-    def slice(self, start: int, end: int, copy: bool) -> List[T]:
+    def slice(self, start: int, end: int, copy: bool = False) -> List[T]:
         view = self._items[start:end]
         if copy:
             view = view.copy()
@@ -333,7 +333,7 @@ class SimpleBlockAccessor(BlockAccessor):
                             has_next_row = False
                             next_row = None
                             break
-                    yield next_key, self.slice(start, end, copy=False)
+                    yield next_key, self.slice(start, end)
                     start = end
                 except StopIteration:
                     break

--- a/python/ray/data/_internal/split.py
+++ b/python/ray/data/_internal/split.py
@@ -118,7 +118,7 @@ def _split_single_block(
     for index in split_indices:
         logger.debug(f"slicing block {prev_index}:{index}")
         stats = BlockExecStats.builder()
-        split_block = block_accessor.slice(prev_index, index, copy=True)
+        split_block = block_accessor.slice(prev_index, index)
         accessor = BlockAccessor.for_block(split_block)
         _meta = BlockMetadata(
             num_rows=accessor.num_rows(),

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -9,6 +9,7 @@ import numpy as np
 
 import ray
 from ray.data.context import DatasetContext
+from ray._private.utils import _get_pyarrow_version
 
 if TYPE_CHECKING:
     from ray.data.datasource import Reader
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 # Inclusive minimum pyarrow version.
 MIN_PYARROW_VERSION = "6.0.1"
 # Exclusive maximum pyarrow version.
-MAX_PYARROW_VERSION = "7.0.0"
+MAX_PYARROW_VERSION = "11.0.0"
 RAY_DISABLE_PYARROW_VERSION_CHECK = "RAY_DISABLE_PYARROW_VERSION_CHECK"
 _VERSION_VALIDATED = False
 
@@ -51,31 +52,12 @@ def _check_pyarrow_version():
             _VERSION_VALIDATED = True
             return
 
-        try:
-            import pyarrow
-        except ModuleNotFoundError:
-            # pyarrow not installed, short-circuit.
-            return
+        version = _get_pyarrow_version()
+        if version is not None:
+            from pkg_resources._vendor.packaging.version import parse as parse_version
 
-        import pkg_resources
-
-        if not hasattr(pyarrow, "__version__"):
-            logger.warning(
-                "You are using the 'pyarrow' module, but the exact version is unknown "
-                "(possibly carried as an internal component by another module). Please "
-                f"make sure you are using pyarrow >= {MIN_PYARROW_VERSION}, < "
-                f"{MAX_PYARROW_VERSION} to ensure compatibility with Ray Datasets. "
-                "If you want to disable this pyarrow version check, set the "
-                f"environment variable {RAY_DISABLE_PYARROW_VERSION_CHECK}=1."
-            )
-        else:
-            version = pyarrow.__version__
-            if (
-                pkg_resources.packaging.version.parse(version)
-                < pkg_resources.packaging.version.parse(MIN_PYARROW_VERSION)
-            ) or (
-                pkg_resources.packaging.version.parse(version)
-                >= pkg_resources.packaging.version.parse(MAX_PYARROW_VERSION)
+            if (parse_version(version) < parse_version(MIN_PYARROW_VERSION)) or (
+                parse_version(version) >= parse_version(MAX_PYARROW_VERSION)
             ):
                 raise ImportError(
                     f"Datasets requires pyarrow >= {MIN_PYARROW_VERSION}, < "
@@ -84,6 +66,15 @@ def _check_pyarrow_version():
                     "If you want to disable this pyarrow version check, set the "
                     f"environment variable {RAY_DISABLE_PYARROW_VERSION_CHECK}=1."
                 )
+        else:
+            logger.warning(
+                "You are using the 'pyarrow' module, but the exact version is unknown "
+                "(possibly carried as an internal component by another module). Please "
+                f"make sure you are using pyarrow >= {MIN_PYARROW_VERSION}, < "
+                f"{MAX_PYARROW_VERSION} to ensure compatibility with Ray Datasets. "
+                "If you want to disable this pyarrow version check, set the "
+                f"environment variable {RAY_DISABLE_PYARROW_VERSION_CHECK}=1."
+            )
         _VERSION_VALIDATED = True
 
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -95,7 +95,7 @@ from ray.data.datasource import (
 )
 from ray.data.datasource.file_based_datasource import (
     _unwrap_arrow_serialization_workaround,
-    _wrap_and_register_arrow_serialization_workaround,
+    _wrap_arrow_serialization_workaround,
 )
 from ray.data.random_access_dataset import RandomAccessDataset
 from ray.data.row import TableRow
@@ -325,6 +325,7 @@ class Dataset(Generic[T]):
         batch_size: Optional[int] = DEFAULT_BATCH_SIZE,
         compute: Optional[Union[str, ComputeStrategy]] = None,
         batch_format: Literal["default", "pandas", "pyarrow", "numpy"] = "default",
+        allow_mutate_batch: bool = True,
         fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
         fn_constructor_args: Optional[Iterable[Any]] = None,
@@ -361,6 +362,10 @@ class Dataset(Generic[T]):
             If you have a small number of big blocks, it may limit parallelism. You may
             consider increase the number of blocks via ``.repartition()`` before
             applying the ``.map_batches()``.
+
+        .. note::
+            If ``fn`` mutates its input, you will need to ensure that the batch provided
+            to ``fn`` is writable. See the ``allow_mutate_batch`` parameter.
 
         .. note::
             The size of the batches provided to ``fn`` may be smaller than the provided
@@ -459,6 +464,14 @@ class Dataset(Generic[T]):
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
                 ``"numpy"`` to select ``numpy.ndarray`` for tensor datasets and
                 ``Dict[str, numpy.ndarray]`` for tabular datasets. Default is "default".
+            allow_mutate_batch: Whether the ``fn`` UDF needs to be able to mutate the
+                input batch. If this is ``True``, the batch will be writable, which may
+                require an extra copy. If this is ``False``, the batch may be a
+                zero-copy, read-only view on data in Ray's object store, which can
+                decrease memory utilization and improve performance. If ``fn`` mutates
+                its input, this will need to be ``True`` in order to avoid "assignment
+                destination is read-only" or "buffer source array is read-only" errors.
+                Default is ``True``.
             fn_args: Positional arguments to pass to ``fn`` after the first argument.
                 These arguments are top-level arguments to the underlying Ray task.
             fn_kwargs: Keyword arguments to pass to ``fn``. These arguments are
@@ -537,13 +550,33 @@ class Dataset(Generic[T]):
             DatasetContext._set_current(context)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
             # Ensure that zero-copy batch views are copied so mutating UDFs don't error.
-            batcher = Batcher(batch_size, ensure_copy=batch_size is not None)
+            batcher = Batcher(
+                batch_size, ensure_copy=allow_mutate_batch and batch_size is not None
+            )
 
             def process_next_batch(batch: Block) -> Iterator[Block]:
                 # Convert to batch format.
                 batch = BlockAccessor.for_block(batch).to_batch_format(batch_format)
                 # Apply UDF.
-                batch = batch_fn(batch, *fn_args, **fn_kwargs)
+                try:
+                    batch = batch_fn(batch, *fn_args, **fn_kwargs)
+                except ValueError as e:
+                    read_only_msgs = [
+                        "assignment destination is read-only",
+                        "buffer source array is read-only",
+                    ]
+                    err_msg = str(e)
+                    if any(msg in err_msg for msg in read_only_msgs):
+                        raise ValueError(
+                            f"Batch mapper function {fn.__name__} tried to mutate a "
+                            "zero-copy read-only batch. To be able to mutate the "
+                            "batch, pass allow_mutate_batch=True to map_batches(); "
+                            "this will copy the batch before giving it to fn. To elide "
+                            "this copy, modify your mapper function so it doesn't try "
+                            "to mutate its input."
+                        ) from e
+                    else:
+                        raise e from None
                 if not (
                     isinstance(batch, list)
                     or isinstance(batch, pa.Table)
@@ -644,7 +677,11 @@ class Dataset(Generic[T]):
             raise ValueError("`fn` must be callable, got {}".format(fn))
 
         return self.map_batches(
-            process_batch, batch_format="pandas", compute=compute, **ray_remote_args
+            process_batch,
+            batch_format="pandas",
+            compute=compute,
+            allow_mutate_batch=True,
+            **ray_remote_args,
         )
 
     def drop_columns(
@@ -2476,7 +2513,7 @@ class Dataset(Generic[T]):
                     blocks,
                     metadata,
                     ray_remote_args,
-                    _wrap_and_register_arrow_serialization_workaround(write_args),
+                    _wrap_arrow_serialization_workaround(write_args),
                 )
             )
 

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -16,10 +16,6 @@ from typing import (
 )
 
 from ray.data._internal.arrow_block import ArrowRow
-from ray.data._internal.arrow_serialization import (
-    _register_arrow_json_parseoptions_serializer,
-    _register_arrow_json_readoptions_serializer,
-)
 from ray.data._internal.block_list import BlockMetadata
 from ray.data._internal.output_buffer import BlockOutputBuffer
 from ray.data._internal.remote_fn import cached_remote_fn
@@ -410,15 +406,6 @@ class _FileBasedDatasourceReader(Reader):
         convert_block_to_tabular_block = self._delegate._convert_block_to_tabular_block
         column_name = reader_args.get("column_name", None)
         filesystem = _wrap_s3_serialization_workaround(self._filesystem)
-        read_options = reader_args.get("read_options")
-        parse_options = reader_args.get("parse_options")
-        if read_options is not None or parse_options is not None:
-            import pyarrow.json as pajson
-
-            if isinstance(read_options, pajson.ReadOptions):
-                _register_arrow_json_readoptions_serializer()
-            if isinstance(parse_options, pajson.ParseOptions):
-                _register_arrow_json_parseoptions_serializer()
 
         if open_stream_args is None:
             open_stream_args = {}
@@ -803,23 +790,9 @@ class _S3FileSystemWrapper:
         return _S3FileSystemWrapper._reconstruct, self._fs.__reduce__()
 
 
-def _wrap_and_register_arrow_serialization_workaround(kwargs: dict) -> dict:
+def _wrap_arrow_serialization_workaround(kwargs: dict) -> dict:
     if "filesystem" in kwargs:
         kwargs["filesystem"] = _wrap_s3_serialization_workaround(kwargs["filesystem"])
-
-    # TODO(Clark): Remove this serialization workaround once Datasets only supports
-    # pyarrow >= 8.0.0.
-    read_options = kwargs.get("read_options")
-    parse_options = kwargs.get("parse_options")
-    if read_options is not None or parse_options is not None:
-        import pyarrow.json as pajson
-
-        # Register a custom serializer instead of wrapping the options, since a
-        # custom reducer will suffice.
-        if isinstance(read_options, pajson.ReadOptions):
-            _register_arrow_json_readoptions_serializer()
-        if isinstance(parse_options, pajson.ParseOptions):
-            _register_arrow_json_parseoptions_serializer()
 
     return kwargs
 

--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -332,7 +332,15 @@ class DefaultParquetMetadataProvider(ParquetMetadataProvider):
 
 def _handle_read_os_error(error: OSError, paths: Union[str, List[str]]) -> str:
     # NOTE: this is not comprehensive yet, and should be extended as more errors arise.
-    aws_error_pattern = r"^(.*)AWS Error \[code \d+\]: No response body\.(.*)$"
+    # NOTE: The latter patterns are raised in Arrow 10+, while the former is raised in
+    # Arrow < 10.
+    aws_error_pattern = (
+        r"^(?:(.*)AWS Error \[code \d+\]: No response body\.(.*))|"
+        r"(?:(.*)AWS Error UNKNOWN \(HTTP status 400\) during HeadObject operation: "
+        r"No response body\.(.*))|"
+        r"(?:(.*)AWS Error ACCESS_DENIED during HeadObject operation: No response "
+        r"body\.(.*))$"
+    )
     if re.match(aws_error_pattern, str(error)):
         # Specially handle AWS error when reading files, to give a clearer error
         # message to avoid confusing users. The real issue is most likely that the AWS

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -444,15 +444,19 @@ def _sample_piece(
     # Use first batch in-memory size as ratio estimation.
     try:
         batch = next(batches)
-        in_memory_size = batch.nbytes / batch.num_rows
-        metadata = piece.metadata
-        total_size = 0
-        for idx in range(metadata.num_row_groups):
-            total_size += metadata.row_group(idx).total_byte_size
-        file_size = total_size / metadata.num_rows
-        ratio = in_memory_size / file_size
     except StopIteration:
         ratio = PARQUET_ENCODING_RATIO_ESTIMATE_LOWER_BOUND
+    else:
+        if batch.num_rows > 0:
+            in_memory_size = batch.nbytes / batch.num_rows
+            metadata = piece.metadata
+            total_size = 0
+            for idx in range(metadata.num_row_groups):
+                total_size += metadata.row_group(idx).total_byte_size
+            file_size = total_size / metadata.num_rows
+            ratio = in_memory_size / file_size
+        else:
+            ratio = PARQUET_ENCODING_RATIO_ESTIMATE_LOWER_BOUND
     logger.debug(
         f"Estimated Parquet encoding ratio is {ratio} for piece {piece} "
         f"with batch size {batch_size}."

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -335,7 +335,7 @@ class GroupedDataset(Generic[T]):
             builder = DelegatingBlockBuilder()
             start = 0
             for end in boundaries:
-                group = block_accessor.slice(start, end, False)
+                group = block_accessor.slice(start, end)
                 applied = fn(group)
                 builder.add_block(applied)
                 start = end

--- a/python/ray/data/random_access_dataset.py
+++ b/python/ray/data/random_access_dataset.py
@@ -225,7 +225,7 @@ class _RandomAccessWorker:
             col = block[self.key_field]
             indices = np.searchsorted(col, keys)
             acc = BlockAccessor.for_block(block)
-            result = [acc._get_row(i, copy=True) for i in indices]
+            result = [acc._get_row(i) for i in indices]
             # assert result == [self._get(i, k) for i, k in zip(block_indices, keys)]
         else:
             result = [self._get(i, k) for i, k in zip(block_indices, keys)]
@@ -254,7 +254,7 @@ class _RandomAccessWorker:
         if i is None:
             return None
         acc = BlockAccessor.for_block(block)
-        return acc._get_row(i, copy=True)
+        return acc._get_row(i)
 
 
 def _binary_search_find(column, x):

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -42,7 +42,7 @@ from ray.data.datasource import (
 )
 from ray.data.datasource.file_based_datasource import (
     _unwrap_arrow_serialization_workaround,
-    _wrap_and_register_arrow_serialization_workaround,
+    _wrap_arrow_serialization_workaround,
 )
 from ray.data.datasource.partitioning import Partitioning
 from ray.types import ObjectRef
@@ -276,7 +276,7 @@ def read_datasource(
                 ctx,
                 cur_pg,
                 parallelism,
-                _wrap_and_register_arrow_serialization_workaround(read_args),
+                _wrap_arrow_serialization_workaround(read_args),
             )
         )
 

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -95,10 +95,24 @@ def s3_fs_with_anonymous_crendential(
 
 
 def _s3_fs(aws_credentials, s3_server, s3_path):
+    import pkg_resources
     import urllib.parse
 
+    kwargs = aws_credentials
+
+    pyarrow_version_info = pkg_resources.require("pyarrow")
+    pyarrow_version_str = pyarrow_version_info[0].version
+    pyarrow_version = tuple(
+        int(n) for n in pyarrow_version_str.split(".") if "dev" not in n
+    )
+
+    if pyarrow_version >= (9, 0, 0):
+        kwargs["allow_bucket_creation"] = True
+
     fs = pa.fs.S3FileSystem(
-        region="us-west-2", endpoint_override=s3_server, **aws_credentials
+        region="us-west-2",
+        endpoint_override=s3_server,
+        **kwargs,
     )
     if s3_path.startswith("s3://"):
         if "@" in s3_path:

--- a/python/ray/data/tests/test_arrow_serialization.py
+++ b/python/ray/data/tests/test_arrow_serialization.py
@@ -1,0 +1,288 @@
+import itertools
+import os
+
+import pytest
+import pyarrow as pa
+import pyarrow.parquet as pq
+import numpy as np
+
+import ray
+import ray.cloudpickle as pickle
+from ray.tests.conftest import *  # noqa
+from ray.data._internal.arrow_serialization import _get_arrow_array_types
+from ray.data.extensions.tensor_extension import (
+    ArrowTensorArray,
+    ArrowVariableShapedTensorArray,
+)
+
+
+pytest_custom_serialization_arrays = [
+    # Null array
+    (pa.array([]), 1.0),
+    # Int array
+    (pa.array(list(range(1000))), 0.1),
+    # Array with nulls
+    (pa.array((list(range(9)) + [None]) * 100), 0.1),
+    # Float array
+    (pa.array([float(i) for i in range(1000)]), 0.1),
+    # Boolean array
+    # Due to bit-packing, most of the pickle bytes are metadata.
+    (pa.array([True, False] * 500), 0.8),
+    # String array
+    (pa.array(["foo", "bar", "bz", None, "quux"] * 200), 0.1),
+    # Binary array
+    (pa.array([b"foo", b"bar", b"bz", None, b"quux"] * 200), 0.1),
+    # List array with nulls
+    (pa.array(([None] + [list(range(9)) + [None]] * 9) * 100), 0.1),
+    # Large list array with nulls
+    (
+        pa.array(
+            ([None] + [list(range(9)) + [None]] * 9) * 100,
+            type=pa.large_list(pa.int64()),
+        ),
+        0.1,
+    ),
+    # Fixed size list array
+    (
+        pa.FixedSizeListArray.from_arrays(
+            pa.array((list(range(9)) + [None]) * 1000), 10
+        ),
+        0.1,
+    ),
+    # Map array
+    (
+        pa.array(
+            [
+                [(key, item) for key, item in zip("abcdefghij", range(10))]
+                for _ in range(1000)
+            ],
+            type=pa.map_(pa.string(), pa.int64()),
+        ),
+        0.1,
+    ),
+    # Struct array
+    (pa.array({"a": i} for i in range(1000)), 0.1),
+    # Union array (sparse)
+    (
+        pa.UnionArray.from_sparse(
+            pa.array([0, 1] * 500, type=pa.int8()),
+            [pa.array(list(range(1000))), pa.array([True, False] * 500)],
+        ),
+        0.1,
+    ),
+    # Union array (dense)
+    (
+        pa.UnionArray.from_dense(
+            pa.array([0, 1] * 500, type=pa.int8()),
+            pa.array(
+                [i if i % 2 == 0 else (i % 3) % 2 for i in range(1000)], type=pa.int32()
+            ),
+            [pa.array(list(range(1000))), pa.array([True, False])],
+        ),
+        0.1,
+    ),
+    # Dictionary array
+    (
+        pa.DictionaryArray.from_arrays(
+            pa.array((list(range(9)) + [None]) * 100),
+            pa.array(["a", "b", "c", "d", "e", "f", "g", "h", "i"]),
+        ),
+        0.1,
+    ),
+    # Tensor extension array
+    (
+        ArrowTensorArray.from_numpy(np.arange(1000 * 4 * 4).reshape((1000, 4, 4))),
+        0.1,
+    ),
+    # Boolean tensor extension array
+    (
+        ArrowTensorArray.from_numpy(
+            np.array(
+                [True, False, False, True, False, False, True, True] * 2 * 1000
+            ).reshape((1000, 4, 4))
+        ),
+        0.25,
+    ),
+    # Variable-shaped tensor extension array
+    (
+        ArrowVariableShapedTensorArray.from_numpy(
+            np.array(
+                [
+                    np.arange(4).reshape((2, 2)),
+                    np.arange(4, 13).reshape((3, 3)),
+                ]
+                * 500,
+                dtype=object,
+            ),
+        ),
+        0.1,
+    ),
+    # Boolean variable-shaped tensor extension array
+    (
+        ArrowVariableShapedTensorArray.from_numpy(
+            np.array(
+                [
+                    np.array([[True, False], [False, True]]),
+                    np.array(
+                        [
+                            [False, True, False],
+                            [True, True, False],
+                            [False, False, False],
+                        ],
+                    ),
+                ]
+                * 500,
+                dtype=object,
+            )
+        ),
+        0.25,
+    ),
+    # Complex nested array
+    (
+        pa.UnionArray.from_sparse(
+            pa.array([0, 1] * 500, type=pa.int8()),
+            [
+                pa.array(
+                    [
+                        {
+                            "a": i % 2 == 0,
+                            "b": i,
+                            "c": "bar",
+                        }
+                        for i in range(1000)
+                    ]
+                ),
+                pa.array(
+                    [
+                        [(key, item) for key, item in zip("abcdefghij", range(10))]
+                        for _ in range(1000)
+                    ],
+                    type=pa.map_(pa.string(), pa.int64()),
+                ),
+            ],
+        ),
+        0.1,
+    ),
+]
+
+pytest_custom_serialization_data = []
+for arr, cap in pytest_custom_serialization_arrays:
+    if len(arr) == 0:
+        pytest_custom_serialization_data.extend(
+            [
+                (arr, cap),
+                (pa.chunked_array([arr]), cap),
+                (
+                    pa.record_batch([arr], schema=pa.schema([pa.field("a", arr.type)])),
+                    cap,
+                ),
+                (pa.table({"a": []}), cap),
+            ]
+        )
+    else:
+        pytest_custom_serialization_data.extend(
+            zip(
+                [
+                    arr,
+                    pa.chunked_array(
+                        [
+                            arr.slice(i * (len(arr) // 10), (i + 1) * (len(arr) // 10))
+                            for i in range(10)
+                        ],
+                        type=arr.type,
+                    ),
+                    pa.record_batch(
+                        [arr, arr, pa.array(range(len(arr)), type=pa.int32())],
+                        schema=pa.schema(
+                            [
+                                pa.field("arr1", arr.type),
+                                pa.field("arr2", arr.type),
+                                pa.field("arr3", pa.int32()),
+                            ],
+                            metadata={b"foo": b"bar"},
+                        ),
+                    ),
+                    pa.Table.from_arrays(
+                        [arr, arr, pa.array(range(1000), type=pa.int32())],
+                        schema=pa.schema(
+                            [
+                                pa.field("arr1", arr.type),
+                                pa.field("arr2", arr.type),
+                                pa.field("arr3", pa.int32()),
+                            ],
+                            metadata={b"foo": b"bar"},
+                        ),
+                    ),
+                ],
+                itertools.repeat(cap),
+            )
+        )
+
+
+@pytest.mark.parametrize("data,cap_mult", pytest_custom_serialization_data)
+def test_custom_arrow_data_serializer(ray_start_regular_shared, data, cap_mult):
+    ray._private.worker.global_worker.get_serialization_context()
+    data.validate()
+    buf_size = data.get_total_buffer_size()
+    # Create a zero-copy slice view of data.
+    view = data.slice(10, 10)
+    s_arr = pickle.dumps(data)
+    s_view = pickle.dumps(view)
+    post_slice = pickle.loads(s_view)
+    post_slice.validate()
+    # Check for round-trip equality.
+    assert view.equals(post_slice), post_slice
+    # Check that the slice view was truncated upon serialization.
+    assert len(s_view) <= cap_mult * len(s_arr)
+    # Check that offset was reset on slice.
+    if isinstance(post_slice, pa.RecordBatch):
+        for column in post_slice.columns:
+            assert column.offset == 0
+    elif isinstance(post_slice, pa.Table):
+        for column in post_slice.columns:
+            if column.num_chunks > 0:
+                assert column.chunk(0).offset == 0
+    elif isinstance(post_slice, pa.ChunkedArray):
+        if post_slice.num_chunks > 0:
+            assert post_slice.chunk(0).offset == 0
+    else:
+        assert post_slice.offset == 0
+    # Check that slice buffer only contains slice data.
+    slice_buf_size = post_slice.get_total_buffer_size()
+    if buf_size > 0:
+        assert buf_size / slice_buf_size - len(data) / len(post_slice) < 100
+
+
+def test_custom_arrow_data_serializer_parquet_roundtrip(
+    ray_start_regular_shared, tmp_path
+):
+    ray._private.worker.global_worker.get_serialization_context()
+    t = pa.table({"a": list(range(10000000))})
+    pq.write_table(t, f"{tmp_path}/test.parquet")
+    t2 = pq.read_table(f"{tmp_path}/test.parquet")
+    s_t = pickle.dumps(t)
+    s_t2 = pickle.dumps(t2)
+    # Check that the post-Parquet slice view chunks don't cause a serialization blow-up.
+    assert len(s_t2) < 1.1 * len(s_t)
+    # Check for round-trip equality.
+    assert t2.equals(pickle.loads(s_t2))
+
+
+def test_custom_arrow_data_serializer_disable(shutdown_only):
+    ray.shutdown()
+    context = ray.worker.global_worker.get_serialization_context()
+    for array_type in _get_arrow_array_types():
+        context._unregister_cloudpickle_reducer(array_type)
+    # Disable custom Arrow array serialization.
+    os.environ["RAY_DISABLE_CUSTOM_ARROW_ARRAY_SERIALIZATION"] = "1"
+    ray.init()
+    # Create a zero-copy slice view of arr.
+    arr = pa.array(list(range(100)))
+    view = arr.slice(10, 10)
+    s_arr = pickle.dumps(arr)
+    s_view = pickle.dumps(view)
+    # Check that the slice view contains the full buffer of the underlying array.
+    d_view = pickle.loads(s_view)
+    assert d_view.buffers()[1].size == arr.buffers()[1].size
+    # Check that the serialized slice view is large
+    assert len(s_view) > 0.8 * len(s_arr)

--- a/python/ray/data/tests/test_arrow_serialization.py
+++ b/python/ray/data/tests/test_arrow_serialization.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 
 from pkg_resources._vendor.packaging.version import parse as parse_version
@@ -11,7 +10,6 @@ import ray
 import ray.cloudpickle as pickle
 from ray._private.utils import _get_pyarrow_version
 from ray.tests.conftest import *  # noqa
-from ray.data._internal.arrow_serialization import _get_arrow_array_types
 from ray.data.extensions.tensor_extension import (
     ArrowTensorArray,
     ArrowVariableShapedTensorArray,
@@ -170,53 +168,22 @@ pytest_custom_serialization_arrays = [
 pytest_custom_serialization_data = []
 for arr, cap in pytest_custom_serialization_arrays:
     if len(arr) == 0:
-        pytest_custom_serialization_data.extend(
-            [
-                (arr, cap),
-                (pa.chunked_array([arr]), cap),
-                (
-                    pa.record_batch([arr], schema=pa.schema([pa.field("a", arr.type)])),
-                    cap,
-                ),
-                (pa.table({"a": []}), cap),
-            ]
-        )
+        pytest_custom_serialization_data.append((pa.table({"a": []}), cap))
     else:
-        pytest_custom_serialization_data.extend(
-            zip(
-                [
-                    arr,
-                    pa.chunked_array(
+        pytest_custom_serialization_data.append(
+            (
+                pa.Table.from_arrays(
+                    [arr, arr, pa.array(range(1000), type=pa.int32())],
+                    schema=pa.schema(
                         [
-                            arr.slice(i * (len(arr) // 10), (i + 1) * (len(arr) // 10))
-                            for i in range(10)
+                            pa.field("arr1", arr.type),
+                            pa.field("arr2", arr.type),
+                            pa.field("arr3", pa.int32()),
                         ],
-                        type=arr.type,
+                        metadata={b"foo": b"bar"},
                     ),
-                    pa.record_batch(
-                        [arr, arr, pa.array(range(len(arr)), type=pa.int32())],
-                        schema=pa.schema(
-                            [
-                                pa.field("arr1", arr.type),
-                                pa.field("arr2", arr.type),
-                                pa.field("arr3", pa.int32()),
-                            ],
-                            metadata={b"foo": b"bar"},
-                        ),
-                    ),
-                    pa.Table.from_arrays(
-                        [arr, arr, pa.array(range(1000), type=pa.int32())],
-                        schema=pa.schema(
-                            [
-                                pa.field("arr1", arr.type),
-                                pa.field("arr2", arr.type),
-                                pa.field("arr3", pa.int32()),
-                            ],
-                            metadata={b"foo": b"bar"},
-                        ),
-                    ),
-                ],
-                itertools.repeat(cap),
+                ),
+                cap,
             )
         )
 
@@ -240,18 +207,9 @@ def test_custom_arrow_data_serializer(ray_start_regular_shared, data, cap_mult):
     # Check that the slice view was truncated upon serialization.
     assert len(s_view) <= cap_mult * len(s_arr)
     # Check that offset was reset on slice.
-    if isinstance(post_slice, pa.RecordBatch):
-        for column in post_slice.columns:
-            assert column.offset == 0
-    elif isinstance(post_slice, pa.Table):
-        for column in post_slice.columns:
-            if column.num_chunks > 0:
-                assert column.chunk(0).offset == 0
-    elif isinstance(post_slice, pa.ChunkedArray):
-        if post_slice.num_chunks > 0:
-            assert post_slice.chunk(0).offset == 0
-    else:
-        assert post_slice.offset == 0
+    for column in post_slice.columns:
+        if column.num_chunks > 0:
+            assert column.chunk(0).offset == 0
     if pyarrow_version >= parse_version("7.0.0"):
         # Check that slice buffer only contains slice data.
         slice_buf_size = post_slice.get_total_buffer_size()
@@ -277,18 +235,17 @@ def test_custom_arrow_data_serializer_parquet_roundtrip(
 def test_custom_arrow_data_serializer_disable(shutdown_only):
     ray.shutdown()
     context = ray.worker.global_worker.get_serialization_context()
-    for array_type in _get_arrow_array_types():
-        context._unregister_cloudpickle_reducer(array_type)
+    context._unregister_cloudpickle_reducer(pa.Table)
     # Disable custom Arrow array serialization.
     os.environ["RAY_DISABLE_CUSTOM_ARROW_ARRAY_SERIALIZATION"] = "1"
     ray.init()
-    # Create a zero-copy slice view of arr.
-    arr = pa.array(list(range(100)))
-    view = arr.slice(10, 10)
-    s_arr = pickle.dumps(arr)
+    # Create a zero-copy slice view of table.
+    t = pa.table({"a": list(range(10000000))})
+    view = t.slice(10, 10)
+    s_t = pickle.dumps(t)
     s_view = pickle.dumps(view)
     # Check that the slice view contains the full buffer of the underlying array.
     d_view = pickle.loads(s_view)
-    assert d_view.buffers()[1].size == arr.buffers()[1].size
+    assert d_view["a"].chunk(0).buffers()[1].size == t["a"].chunk(0).buffers()[1].size
     # Check that the serialized slice view is large
-    assert len(s_view) > 0.8 * len(s_arr)
+    assert len(s_view) > 0.8 * len(s_t)

--- a/python/ray/data/tests/test_batch_mapper.py
+++ b/python/ray/data/tests/test_batch_mapper.py
@@ -6,12 +6,13 @@ from pytest_lazyfixture import lazy_fixture
 from typing import Dict, Union
 from pandas.testing import assert_frame_equal
 
+import ray
 from ray.data.preprocessors import BatchMapper
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.tests.conftest import *  # noqa
 
 
-def test_batch_mapper_basic():
+def test_batch_mapper_basic(ray_start_regular_shared):
     """Tests batch mapper functionality."""
     old_column = [1, 2, 3, 4]
     to_be_modified = [1, -1, 1, -1]

--- a/python/ray/data/tests/test_batch_mapper.py
+++ b/python/ray/data/tests/test_batch_mapper.py
@@ -11,6 +11,36 @@ from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.tests.conftest import *  # noqa
 
 
+def test_batch_mapper_basic():
+    """Tests batch mapper functionality."""
+    old_column = [1, 2, 3, 4]
+    to_be_modified = [1, -1, 1, -1]
+    in_df = pd.DataFrame.from_dict(
+        {"old_column": old_column, "to_be_modified": to_be_modified}
+    )
+    ds = ray.data.from_pandas(in_df)
+
+    def add_and_modify_udf(df: "pd.DataFrame"):
+        df["new_col"] = df["old_column"] + 1
+        df["to_be_modified"] *= 2
+        return df
+
+    batch_mapper = BatchMapper(fn=add_and_modify_udf)
+    batch_mapper.fit(ds)
+    transformed = batch_mapper.transform(ds)
+    out_df = transformed.to_pandas()
+
+    expected_df = pd.DataFrame.from_dict(
+        {
+            "old_column": old_column,
+            "to_be_modified": [2, -2, 2, -2],
+            "new_col": [2, 3, 4, 5],
+        }
+    )
+
+    assert out_df.equals(expected_df)
+
+
 @pytest.mark.parametrize(
     "ds,expected_df,expected_numpy_df",
     [

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2596,6 +2596,34 @@ def test_map_batches_batch_mutation(
     assert [row["value"] for row in ds.iter_rows()] == list(range(1, num_rows + 1))
 
 
+@pytest.mark.parametrize(
+    "num_rows,num_blocks,batch_size",
+    [
+        (10, 5, 2),
+        (10, 1, 10),
+        (12, 3, 2),
+    ],
+)
+def test_map_batches_batch_zero_copy(
+    ray_start_regular_shared, num_rows, num_blocks, batch_size
+):
+    # Test that batches are zero-copy read-only views when allow_mutate_batch=False.
+    def mutate(df):
+        # Check that batch is read-only.
+        assert not df.values.flags.writeable
+        df["value"] += 1
+        return df
+
+    ds = ray.data.range_table(num_rows, parallelism=num_blocks).repartition(num_blocks)
+    # Convert to Pandas blocks.
+    ds = ds.map_batches(lambda df: df, batch_format="pandas", batch_size=None)
+
+    # Apply UDF that mutates the batches, which should fail since the batch is
+    # read-only.
+    with pytest.raises(ValueError, match="tried to mutate a zero-copy read-only batch"):
+        ds.map_batches(mutate, batch_size=batch_size, allow_mutate_batch=False)
+
+
 BLOCK_BUNDLING_TEST_CASES = [
     (block_size, batch_size)
     for batch_size in range(1, 8)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -4795,10 +4795,14 @@ def test_random_shuffle_check_random(shutdown_only):
             prev = x
 
 
-def test_unsupported_pyarrow_versions_check(shutdown_only, unsupported_pyarrow_version):
+def test_unsupported_pyarrow_versions_check(
+    shutdown_only, unsupported_pyarrow_version_that_exists
+):
     # Test that unsupported pyarrow versions cause an error to be raised upon the
     # initial pyarrow use.
-    ray.init(runtime_env={"pip": [f"pyarrow=={unsupported_pyarrow_version}"]})
+    ray.init(
+        runtime_env={"pip": [f"pyarrow=={unsupported_pyarrow_version_that_exists}"]}
+    )
 
     # Test Arrow-native creation APIs.
     # Test range_table.
@@ -4820,14 +4824,14 @@ def test_unsupported_pyarrow_versions_check(shutdown_only, unsupported_pyarrow_v
 
 def test_unsupported_pyarrow_versions_check_disabled(
     shutdown_only,
-    unsupported_pyarrow_version,
+    unsupported_pyarrow_version_that_exists,
     disable_pyarrow_version_check,
 ):
     # Test that unsupported pyarrow versions DO NOT cause an error to be raised upon the
     # initial pyarrow use when the version check is disabled.
     ray.init(
         runtime_env={
-            "pip": [f"pyarrow=={unsupported_pyarrow_version}"],
+            "pip": [f"pyarrow=={unsupported_pyarrow_version_that_exists}"],
             "env_vars": {"RAY_DISABLE_PYARROW_VERSION_CHECK": "1"},
         },
     )

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -343,25 +343,20 @@ def test_write_datasource_ray_remote_args(ray_start_cluster):
 def test_read_s3_file_error(ray_start_regular_shared, s3_path):
     dummy_path = s3_path + "_dummy"
     error_message = "Please check that file exists and has properly configured access."
-    with pytest.raises(OSError) as e:
+    with pytest.raises(OSError, match=error_message):
         ray.data.read_parquet(dummy_path)
-    assert error_message in str(e.value)
-    with pytest.raises(OSError) as e:
+    with pytest.raises(OSError, match=error_message):
         ray.data.read_binary_files(dummy_path)
-    assert error_message in str(e.value)
-    with pytest.raises(OSError) as e:
+    with pytest.raises(OSError, match=error_message):
         ray.data.read_csv(dummy_path)
-    assert error_message in str(e.value)
-    with pytest.raises(OSError) as e:
+    with pytest.raises(OSError, match=error_message):
         ray.data.read_json(dummy_path)
-    assert error_message in str(e.value)
-    with pytest.raises(OSError) as e:
+    with pytest.raises(OSError, match=error_message):
         error = OSError(
             f"Error creating dataset. Could not read schema from {dummy_path}: AWS "
             "Error [code 15]: No response body.. Is this a 'parquet' file?"
         )
         _handle_read_os_error(error, dummy_path)
-    assert error_message in str(e.value)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -3,12 +3,17 @@ import subprocess
 import urllib
 from pathlib import Path
 
+from pkg_resources._vendor.packaging.version import parse as parse_version
 import pyarrow.fs
 import pytest
 
 import ray
 import ray._private.storage as storage
 from ray._private.test_utils import simulate_storage
+from ray._private.utils import (
+    _add_creatable_buckets_param_if_s3_uri,
+    _get_pyarrow_version,
+)
 from ray.tests.conftest import *  # noqa
 
 
@@ -164,6 +169,39 @@ def test_connecting_to_cluster(shutdown_only, storage_type):
             assert _storage_uri == storage_uri
         finally:
             subprocess.check_call(["ray", "stop"])
+
+
+def test_add_creatable_buckets_param_if_s3_uri():
+    if parse_version(_get_pyarrow_version()) >= parse_version("9.0.0"):
+        # Test that the allow_bucket_creation=true query arg is added to an S3 URI.
+        uri = "s3://bucket/foo"
+        assert (
+            _add_creatable_buckets_param_if_s3_uri(uri)
+            == "s3://bucket/foo?allow_bucket_creation=true"
+        )
+
+        # Test that query args are merged (i.e. existing query args aren't dropped).
+        uri = "s3://bucket/foo?bar=baz"
+        assert (
+            _add_creatable_buckets_param_if_s3_uri(uri)
+            == "s3://bucket/foo?allow_bucket_creation=true&bar=baz"
+        )
+
+        # Test that existing allow_bucket_creation=false query arg isn't overridden.
+        uri = "s3://bucket/foo?allow_bucket_creation=false"
+        assert (
+            _add_creatable_buckets_param_if_s3_uri(uri)
+            == "s3://bucket/foo?allow_bucket_creation=false"
+        )
+    else:
+        # Test that the allow_bucket_creation=true query arg is not added to an S3 URI,
+        # since we're using Arrow < 9.
+        uri = "s3://bucket/foo"
+        assert _add_creatable_buckets_param_if_s3_uri(uri) == uri
+
+    # Test that non-S3 URI is unchanged.
+    uri = "gcs://bucket/foo"
+    assert _add_creatable_buckets_param_if_s3_uri(uri) == "gcs://bucket/foo"
 
 
 if __name__ == "__main__":

--- a/python/ray/util/serialization.py
+++ b/python/ray/util/serialization.py
@@ -39,6 +39,9 @@ class StandaloneSerializationContext:
     # use the SerializationContext because it requires Ray workers. Please
     # make sure to keep the API consistent.
 
+    def _register_cloudpickle_reducer(self, cls, reducer):
+        pickle.CloudPickler.dispatch[cls] = reducer
+
     def _unregister_cloudpickle_reducer(self, cls):
         pickle.CloudPickler.dispatch.pop(cls, None)
 

--- a/python/ray/util/serialization_addons.py
+++ b/python/ray/util/serialization_addons.py
@@ -55,3 +55,9 @@ def register_starlette_serializer(serialization_context):
 def apply(serialization_context):
     register_pydantic_serializer(serialization_context)
     register_starlette_serializer(serialization_context)
+
+    from ray.data._internal.arrow_serialization import (
+        _register_custom_datasets_serializers,
+    )
+
+    _register_custom_datasets_serializers(serialization_context)

--- a/python/ray/util/serialization_addons.py
+++ b/python/ray/util/serialization_addons.py
@@ -3,6 +3,8 @@ This module is intended for implementing internal serializers for some
 site packages.
 """
 
+import sys
+
 from ray.util.annotations import DeveloperAPI
 
 
@@ -56,8 +58,9 @@ def apply(serialization_context):
     register_pydantic_serializer(serialization_context)
     register_starlette_serializer(serialization_context)
 
-    from ray.data._internal.arrow_serialization import (
-        _register_custom_datasets_serializers,
-    )
+    if sys.platform != "win32":
+        from ray.data._internal.arrow_serialization import (
+            _register_custom_datasets_serializers,
+        )
 
-    _register_custom_datasets_serializers(serialization_context)
+        _register_custom_datasets_serializers(serialization_context)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -57,7 +57,7 @@ aiorwlock
 opentelemetry-exporter-otlp==1.1.0
 starlette
 typer
-pyarrow<7.0.0,>=6.0.1
+pyarrow>=6.0.1
 aiohttp_cors
 opentelemetry-api==1.1.0
 pyyaml

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -57,7 +57,8 @@ aiorwlock
 opentelemetry-exporter-otlp==1.1.0
 starlette
 typer
-pyarrow>=6.0.1
+pyarrow >= 6.0.1; python_version >= '3.7' and platform_system != "Windows"
+pyarrow >= 6.0.1, < 7.0.0; python_version < '3.7' or platform_system == "Windows"
 aiohttp_cors
 opentelemetry-api==1.1.0
 pyyaml

--- a/python/requirements/data_processing/requirements.txt
+++ b/python/requirements/data_processing/requirements.txt
@@ -11,6 +11,10 @@ s3fs
 modin>=0.8.3;  python_version < '3.7'
 modin>=0.11.0; python_version >= '3.7'
 pytest-repeat
-raydp-nightly==2022.6.30.dev1
+# Uncomment when RayDP:
+# - Makes MLDataset an optional dependency.
+# - Removes pyarrow < 7.0.0 upperbound.
+# raydp-nightly==2022.6.30.dev1
 responses==0.13.4
 pymars>=0.8.3
+polars

--- a/python/setup.py
+++ b/python/setup.py
@@ -216,13 +216,19 @@ if setup_spec.type == SetupType.RAY:
     else:
         # Pandas dropped python 3.6 support in 1.2.
         pandas_dep = "pandas >= 1.0.5"
-        # Numpy dropped python 3.6 support in 1.20.
+        # NumPy dropped python 3.6 support in 1.20.
         numpy_dep = "numpy >= 1.19"
+    if sys.version_info >= (3, 7) and sys.platform != "win32":
+        pyarrow_dep = "pyarrow >= 6.0.1"
+    else:
+        # pyarrow dropped python 3.6 support in 7.0.0.
+        # Serialization workaround for pyarrow 7.0.0+ doesn't work for Windows.
+        pyarrow_dep = "pyarrow >= 6.0.1, < 7.0.0"
     setup_spec.extras = {
         "data": [
             numpy_dep,
             pandas_dep,
-            "pyarrow >= 6.0.1",
+            pyarrow_dep,
             "fsspec",
         ],
         "default": [

--- a/python/setup.py
+++ b/python/setup.py
@@ -222,7 +222,7 @@ if setup_spec.type == SetupType.RAY:
         "data": [
             numpy_dep,
             pandas_dep,
-            "pyarrow >= 6.0.1, < 7.0.0",
+            "pyarrow >= 6.0.1",
             "fsspec",
         ],
         "default": [


### PR DESCRIPTION
This reverts commit 081ce2fe4e88ae5f36aa0a6b45fb7048c01947c7, and unreverts PR #29055.

This PR adds support for Arrow 9 while preserving support for Arrow 6, 7, 8; we duplicate the Datasets CI job for each of these Arrow major versions to ensure this support.

## Summary of major changes

- We change the Arrow version bounds to be `pyarrow >= 6.0.1` with no upper bound, except for Python 3.6 (Arrow dropped Python 3.6 support in Arrow 7) and Windows (Arrow has some blocker bugs in Arrow 7+) ([link](https://github.com/ray-project/ray/pull/29161/files#diff-eb8b42d9346d0a5d371facf21a8bfa2d16fb49e213ae7c21f03863accebe0fcf)).
- We duplicate the Datasets CI job for each major Arrow version we support: 6, 7, 8, and latest stable version (currently 9) ([link](https://github.com/ray-project/ray/pull/29161/files#diff-b7b70a2bd5baa32831cdfbc65f588be42b17d691193cf7094c889b76eecaa2f9)).
- For Arrow 9+, add `allow_bucket_creation=true` to S3 URIs for the Ray Core Storage API and for the Datasets S3 write API ([link 1](https://github.com/ray-project/ray/pull/29161/files#diff-e980526b049b705043d1375219344fde4b13b28aeafb56cd0ab3fa5c09281e98), [link 2](https://github.com/ray-project/ray/pull/29161/files#diff-3aadecf2fcf702efe84d3c56a05f74664069c40252351cc838dc96735c1e47bdR281)).
- For Arrow 9+, create an `ExtensionScalar` subclass for tensor extension types that returns an ndarray view from `.as_py()` ([link](https://github.com/ray-project/ray/pull/29161/files#diff-8d080ad52f83ccc0b591e9f62c481bc6d03a5b67dcc048d5f302f89e92f13f5dR74).
- For Arrow 8.*, we manually convert the `ExtensionScalar` to an ndarray for tensor extension types, since the `ExtensionScalar` type exists but isn't subclassable in Arrow 8 ([link 1](https://github.com/ray-project/ray/pull/29161/files#diff-a637aa9db5408fe440f8b335a480e66e6636d97e71dc4bad164c356ac43deafdR204), [link 2](https://github.com/ray-project/ray/pull/29161/files#diff-8d080ad52f83ccc0b591e9f62c481bc6d03a5b67dcc048d5f302f89e92f13f5dR83)).
- For Arrow 10+, we match on other potential error messages when encountering permission issues when interacting with S3.
- ~We override table concatenation and tensor extension array concatenation to ensure that concatenating tensor column chunks that each have homogeneous-shape but cumulatively have different shapes will result in a variable-shaped tensor column ([link 1](https://github.com/ray-project/ray/pull/29161/files#diff-28033e521e4161fe04351d940952e93a70bb9e0a0f1fdc71a56820f410a87679R66), [link 2](https://github.com/ray-project/ray/pull/29161/files#diff-8d080ad52f83ccc0b591e9f62c481bc6d03a5b67dcc048d5f302f89e92f13f5dR354), [link 3](https://github.com/ray-project/ray/pull/29161/files#diff-bf26e743f5dc78351cf2755d92da8f54a0e1d37baa8b809dc679e64ddce83840R34), [link 4](https://github.com/ray-project/ray/pull/29161/files#diff-8d080ad52f83ccc0b591e9f62c481bc6d03a5b67dcc048d5f302f89e92f13f5dR327)).~ Pulled out into separate [PR](https://github.com/ray-project/ray/pull/29479).
- Custom serialization hook for Arrow data types to work around Arrow serialization bug (pickling zero-copy views on Arrow data serializes the entire data buffer instead of truncating it) ([link](https://github.com/ray-project/ray/pull/29161/files#diff-0e6022a9213c5505fa07b9a1c1ddac565ba3a41e92928a8ce304c1349f0aaae1)).
- Adds batch mutation API to `ds.map_batches()`, which allows the user to opt in to zero-copy batching via `allow_mutate_batch=False` ([link](https://github.com/ray-project/ray/pull/29161/files#diff-5a812d24fc3efd599284bb40dcbd2c6627bbe324e1c89a6e623b4dccf8e5de44R326)).
- Fixes unhandled task cancellation when deserializing task arguments and storing task errors.

## TODOs

- [x] Ensure that relevant AIR-level tests run under Datasets CI jobs (e.g. extension type tests) that are running under all major Arrow versions.
- [x] Ensure that Core tests that are sensitive to worker startup times are passing.
- [x] Ensure that `pg_long_running_performance_test` release test passes.
- [x] Decompose PR into stacked PRs.
- [ ] (Post-merge) Open tracking issues for deprecating Arrow 6, 7, and 8.
- [ ] (Follow-up PR) Consolidate logic handling of Arrow-version-specific things to a `ray._private.arrow_compat` to share between the Storage API, Ray AIR, and Ray Datasets.

## Related Issue Number

Closes #29814, closes https://github.com/ray-project/ray/issues/29816, closes https://github.com/ray-project/ray/issues/29815, closes https://github.com/ray-project/ray/issues/29817, closes https://github.com/ray-project/ray/issues/29822

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
