### PR TITLE
Make the time series metrics in dashboard auto-refresh

### DIFF
--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -40,15 +40,15 @@ const useStyles = makeStyles((theme) =>
 );
 
 enum TimeRangeOptions {
-  FIVE_MINS = "5 minutes",
-  THIRTY_MINS = "30 minutes",
-  ONE_HOUR = "1 hour",
-  THREE_HOURS = "3 hours",
-  SIX_HOURS = "6 hours",
-  TWELVE_HOURS = "12 hours",
-  ONE_DAY = "1 day",
-  TWO_DAYS = "2 days",
-  SEVEN_DAYS = "7 days",
+  FIVE_MINS = "Last 5 minutes",
+  THIRTY_MINS = "Last 30 minutes",
+  ONE_HOUR = "Last 1 hour",
+  THREE_HOURS = "Last 3 hours",
+  SIX_HOURS = "Last 6 hours",
+  TWELVE_HOURS = "Last 12 hours",
+  ONE_DAY = "Last 1 day",
+  TWO_DAYS = "Last 2 days",
+  SEVEN_DAYS = "Last 7 days",
 }
 
 const TIME_RANGE_TO_FROM_VALUE: Record<TimeRangeOptions, string> = {

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -51,16 +51,16 @@ enum TimeRangeOptions {
   SEVEN_DAYS = "7 days",
 }
 
-const TIME_RANGE_DURATIONS_MS: Record<TimeRangeOptions, number> = {
-  [TimeRangeOptions.FIVE_MINS]: 1000 * 60 * 5,
-  [TimeRangeOptions.THIRTY_MINS]: 1000 * 60 * 30,
-  [TimeRangeOptions.ONE_HOUR]: 1000 * 60 * 60 * 1,
-  [TimeRangeOptions.THREE_HOURS]: 1000 * 60 * 60 * 3,
-  [TimeRangeOptions.SIX_HOURS]: 1000 * 60 * 60 * 6,
-  [TimeRangeOptions.TWELVE_HOURS]: 1000 * 60 * 60 * 12,
-  [TimeRangeOptions.ONE_DAY]: 1000 * 60 * 60 * 24 * 1,
-  [TimeRangeOptions.TWO_DAYS]: 1000 * 60 * 60 * 24 * 2,
-  [TimeRangeOptions.SEVEN_DAYS]: 1000 * 60 * 60 * 24 * 7,
+const TIME_RANGE_TO_FROM_VALUE: Record<TimeRangeOptions, string> = {
+  [TimeRangeOptions.FIVE_MINS]: "now-5m",
+  [TimeRangeOptions.THIRTY_MINS]: "now-30m",
+  [TimeRangeOptions.ONE_HOUR]: "now-1h",
+  [TimeRangeOptions.THREE_HOURS]: "now-3h",
+  [TimeRangeOptions.SIX_HOURS]: "now-6h",
+  [TimeRangeOptions.TWELVE_HOURS]: "now-12h",
+  [TimeRangeOptions.ONE_DAY]: "now-1d",
+  [TimeRangeOptions.TWO_DAYS]: "now-2d",
+  [TimeRangeOptions.SEVEN_DAYS]: "now-7d",
 };
 
 const METRICS_CONFIG = [
@@ -105,15 +105,13 @@ export const Metrics = () => {
   const [timeRangeOption, setTimeRangeOption] = useState<TimeRangeOptions>(
     TimeRangeOptions.ONE_HOUR,
   );
-  const [[from, to], setTimeRange] = useState<[number | null, number | null]>([
+  const [[from, to], setTimeRange] = useState<[string | null, string | null]>([
     null,
     null,
   ]);
   useEffect(() => {
-    const now = new Date().getTime();
-    const duration = TIME_RANGE_DURATIONS_MS[timeRangeOption];
-    const from = now - duration;
-    setTimeRange([from, now]);
+    const from = TIME_RANGE_TO_FROM_VALUE[timeRangeOption];
+    setTimeRange([from, "now"]);
   }, [timeRangeOption]);
 
   const fromParam = from !== null ? `&from=${from}` : "";
@@ -173,7 +171,7 @@ export const Metrics = () => {
                 key={title}
                 className={classes.grafanaEmbed}
                 title={title}
-                src={`${grafanaHost}${path}${timeRangeParams}`}
+                src={`${grafanaHost}${path}&refresh${timeRangeParams}`}
                 width="450"
                 height="400"
                 frameBorder="0"


### PR DESCRIPTION
Signed-off-by: Alan Guo <aguo@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Before, the grafana embeds would show a static time range and the page had to be manually refreshed to see the latest data.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
