### PR TITLE
[Kubernetes][Doc] State intent to remove legacy Ray Operator

### DIFF
--- a/doc/source/cluster/kubernetes/index.md
+++ b/doc/source/cluster/kubernetes/index.md
@@ -91,6 +91,8 @@ and discussion of new and upcoming features.
 
 ```{note}
 The KubeRay operator replaces the older Ray operator hosted in the [Ray repository](https://github.com/ray-project/ray/tree/master/python/ray/ray_operator).
+The legacy Ray operator will be compatible with Ray versions up to Ray 2.1.0.
+However, **the legacy Ray operator will be removed in Ray 2.2.0.**
 Check the linked README for migration notes.
 
 If you have used the legacy Ray operator in the past,

--- a/python/ray/ray_operator/README.md
+++ b/python/ray/ray_operator/README.md
@@ -6,12 +6,21 @@ Using the [KubeRay operator](https://ray-project.github.io/kuberay/components/op
 is the preferred way to deploy Ray on Kubernetes. Refer to the latest [Ray documentation](https://docs.ray.io/en/latest/)
 for up-to-date guides on Ray's Kubernetes support.
 
-As of Ray 2.0.0, the legacy Ray Operator is in maintenance mode.
-This operator will be deprecated and removed in a future Ray release.
 For documentation on the legacy Ray Operator,
 refer to the [Ray 1.13.0 documentation](https://docs.ray.io/en/releases-1.13.0/cluster/kubernetes.html#deploying-on-kubernetes).
 
-The rest of this page
+## Deprecation timeline
+
+This section outlines the deprecation timeline for the legacy Ray Operator.
+
+- As of Ray 2.0.0, the legacy Ray Operator is in maintenance mode.
+- The operator will still be compatible with Ray 2.1.0.
+- **The legacy Ray Operator will be removed in Ray 2.2.0.**
+
+_In other words, it will not be possible to use the legacy Ray Operator with Ray versions
+2.2.0 or greater._
+
+The rest of this document
 - Compares the KubeRay operator to the legacy Ray Operator hosted in the Ray repo.
 - Provides migration notes for users switching to the KubeRay operator.
 


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR documents the intent to remove the legacy Ray operator in Ray 2.2.0.

Here's the timeline of our posture:

- In Ray 2.0.0, we documented KubeRay as the preferred deployment method and stated the intent to deprecate
the legacy operator in the future.
- In the Ray 2.1.0 release, we state that it is still possible to use the operator but give an explicit end-of-life at Ray 2.2.0.
- In the Ray 2.2.0, we remove the operator code and documentation. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
