### PR TITLE
[build] Fix redis build in linux.

### DIFF
--- a/bazel/BUILD.redis
+++ b/bazel/BUILD.redis
@@ -48,13 +48,8 @@ genrule(
         "redis-cli",
     ],
     cmd = """
-    mkdir tmp-redis-bin
-    cp -rf $(locations :redis) ./tmp-redis-bin/
-    cp tmp-redis-bin/redis-server $(location redis-server)
-    chmod +x $(location redis-server)
-    cp tmp-redis-bin/redis-cli $(location redis-cli)
-    chmod +x $(location redis-cli)
-    rm -rf tmp-redis-bin
+        cp $(RULEDIR)/redis/bin/redis-server $(location redis-server)
+        cp $(RULEDIR)/redis/bin/redis-cli $(location redis-cli)
     """,
     visibility = ["//visibility:public"],
     tags = ["local"],


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The current build in some platform will show errors:

```
    Execution platform: @local_config_platform//:host
    rm: cannot remove 'tmp-redis-bin/redis/bin/redis-cli': Permission denied
    rm: cannot remove 'tmp-redis-bin/redis/bin/redis-benchmark': Permission denied
    rm: cannot remove 'tmp-redis-bin/redis/bin/redis-check-rdb': Permission denied
    rm: cannot remove 'tmp-redis-bin/redis/bin/redis-sentinel': Permission denied
    rm: cannot remove 'tmp-redis-bin/redis/bin/redis-server': Permission denied
    rm: cannot remove 'tmp-redis-bin/redis/bin/redis-check-aof': Permission denied
    rm: cannot remove 'tmp-redis-bin/redis/include': Permission denied
```

This PR fixed this by avoiding creating tmp dir.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
