### PR TITLE
[Metrics] Skip flaky tests on Windows.

### DIFF
--- a/python/ray/tests/test_metrics_agent_2.py
+++ b/python/ray/tests/test_metrics_agent_2.py
@@ -1,5 +1,6 @@
 import os
 import time
+import sys
 
 import pytest
 

--- a/python/ray/tests/test_metrics_agent_2.py
+++ b/python/ray/tests/test_metrics_agent_2.py
@@ -100,6 +100,7 @@ def get_agent(request, monkeypatch):
         execution_context.set_measure_to_view_map({})
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 def test_metrics_agent_record_and_export(get_agent):
     namespace = "test"
     agent, agent_port = get_agent
@@ -162,6 +163,7 @@ def test_metrics_agent_record_and_export(get_agent):
     assert samples[0].labels == {"tag": "a"}
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 def test_metrics_agent_proxy_record_and_export_basic(get_agent):
     """Test the case the metrics are exported without worker_id."""
     namespace = "test"
@@ -207,6 +209,7 @@ def test_metrics_agent_proxy_record_and_export_basic(get_agent):
     assert samples[1].value == 5
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 def test_metrics_agent_proxy_record_and_export_from_workers(get_agent):
     """
     Test the basic worker death case.
@@ -233,6 +236,7 @@ def test_metrics_agent_proxy_record_and_export_from_workers(get_agent):
     assert get_metric(f"{namespace}_test", agent_port) is None
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 def test_metrics_agent_proxy_record_and_export_from_workers_complicated(
     get_agent,
 ):  # noqa
@@ -298,6 +302,7 @@ def test_metrics_agent_proxy_record_and_export_from_workers_complicated(
 DELAY = 3
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 @pytest.mark.parametrize("get_agent", [DELAY], indirect=True)
 def test_metrics_agent_proxy_record_and_export_from_workers_delay(get_agent):  # noqa
     """

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -472,6 +472,7 @@ ray.get([f.remote(x) for x in buf])"""
     proc.kill()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 def test_stale_view_cleanup_when_job_exits(monkeypatch, shutdown_only):
     with monkeypatch.context() as m:
         m.setenv(RAY_WORKER_TIMEOUT_S, 5)
@@ -508,6 +509,7 @@ ray.get(g.remote())
         )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 def test_stale_view_cleanup_when_worker_exits_complicated(monkeypatch, shutdown_only):
     with monkeypatch.context() as m:
         m.setenv(RAY_WORKER_TIMEOUT_S, 5)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Metrics cleanup seems to be not working in Windows now. Will temporarily skip the test

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
