### PR TITLE
[metric] Separate fallback allocated  from the in memory accounting 

### DIFF
--- a/src/ray/object_manager/plasma/common.h
+++ b/src/ray/object_manager/plasma/common.h
@@ -60,6 +60,8 @@ struct Allocation {
   int device_num;
   /// the total size of this mapped memory.
   int64_t mmap_size;
+  /// if it was fallback allocated.
+  bool fallback_allocated;
 
   // only allow moves.
   RAY_DISALLOW_COPY_AND_ASSIGN(Allocation);
@@ -73,17 +75,25 @@ struct Allocation {
              MEMFD_TYPE fd,
              ptrdiff_t offset,
              int device_num,
-             int64_t mmap_size)
+             int64_t mmap_size,
+             bool fallback_allocated)
       : address(address),
         size(size),
         fd(std::move(fd)),
         offset(offset),
         device_num(device_num),
-        mmap_size(mmap_size) {}
+        mmap_size(mmap_size),
+        fallback_allocated(fallback_allocated) {}
 
   // Test only
   Allocation()
-      : address(nullptr), size(0), fd(), offset(0), device_num(0), mmap_size(0) {}
+      : address(nullptr),
+        size(0),
+        fd(),
+        offset(0),
+        device_num(0),
+        mmap_size(0),
+        fallback_allocated(false) {}
 
   friend class PlasmaAllocator;
   friend class DummyAllocator;

--- a/src/ray/object_manager/plasma/plasma_allocator.h
+++ b/src/ray/object_manager/plasma/plasma_allocator.h
@@ -84,7 +84,9 @@ class PlasmaAllocator : public IAllocator {
   int64_t FallbackAllocated() const override;
 
  private:
-  absl::optional<Allocation> BuildAllocation(void *addr, size_t size);
+  absl::optional<Allocation> BuildAllocation(void *addr,
+                                             size_t size,
+                                             bool is_fallback_allocated);
 
  private:
   const int64_t kFootprintLimit;

--- a/src/ray/object_manager/plasma/stats_collector.h
+++ b/src/ray/object_manager/plasma/stats_collector.h
@@ -62,6 +62,8 @@ class ObjectStatsCollector {
 
   int64_t GetNumBytesCreatedCurrent() const;
 
+  int64_t num_bytes_on_fallback_ = 0;
+
   int64_t num_objects_spillable_ = 0;
   int64_t num_bytes_spillable_ = 0;
   int64_t num_objects_unsealed_ = 0;

--- a/src/ray/object_manager/plasma/test/fallback_allocator_test.cc
+++ b/src/ray/object_manager/plasma/test/fallback_allocator_test.cc
@@ -44,9 +44,11 @@ TEST(FallbackPlasmaAllocatorTest, FallbackPassThroughTest) {
   {
     auto allocation_1 = allocator.Allocate(object_size);
     EXPECT_TRUE(allocation_1.has_value());
+    EXPECT_FALSE(allocation_1->fallback_allocated);
 
     auto allocation_2 = allocator.Allocate(object_size);
     EXPECT_TRUE(allocation_2.has_value());
+    EXPECT_FALSE(allocation_2->fallback_allocated);
 
     EXPECT_EQ(2 * object_size, allocator.Allocated());
 
@@ -69,6 +71,7 @@ TEST(FallbackPlasmaAllocatorTest, FallbackPassThroughTest) {
     auto allocation = allocator.Allocate(kMB);
     expect_allocated += kMB;
     EXPECT_TRUE(allocation.has_value());
+    EXPECT_FALSE(allocation->fallback_allocated);
     EXPECT_EQ(expect_allocated, allocator.Allocated());
     EXPECT_EQ(0, allocator.FallbackAllocated());
     allocations.push_back(std::move(allocation.value()));
@@ -90,6 +93,7 @@ TEST(FallbackPlasmaAllocatorTest, FallbackPassThroughTest) {
       expect_allocated += kMB;
       expect_fallback_allocated += kMB;
       EXPECT_TRUE(allocation.has_value());
+      EXPECT_TRUE(allocation->fallback_allocated);
       EXPECT_EQ(expect_allocated, allocator.Allocated());
       EXPECT_EQ(expect_fallback_allocated, allocator.FallbackAllocated());
       fallback_allocations.push_back(std::move(allocation.value()));

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -51,3 +51,4 @@ extern const TagKeyType LocationKey;
 constexpr char kObjectLocInMemory[] = "IN_MEMORY";
 constexpr char kObjectLocSpilled[] = "SPILLED";
 constexpr char kObjectLocUnsealed[] = "UNSEALED";
+constexpr char kObjectLocFallback[] = "FALLBACK";


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This adds the fallback category for object store memory location. 

In order to track the fallback allocated memory, this PR also adds a meta data field in the `Allocation` struct to surface the allocation kind. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
