### PR TITLE
[Datasets] Fix map_groups to work with different output type

### DIFF
--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -248,14 +248,23 @@ class GroupedDataset(Generic[T]):
 
         Examples:
             >>> # Return a single record per group (list of multiple records in,
-            >>> # list of a single record out). Note that median is not an
-            >>> # associative function so cannot be computed with aggregate().
+            >>> # list of a single record out).
             >>> import ray
             >>> import pandas as pd
             >>> import numpy as np
+            >>> # Get median per group. Note that median is not an associative
+            >>> # function so cannot be computed with aggregate().
             >>> ds = ray.data.range(100) # doctest: +SKIP
             >>> ds.groupby(lambda x: x % 3).map_groups( # doctest: +SKIP
             ...     lambda x: [np.median(x)])
+            >>> # Get first value per group.
+            >>> ds = ray.data.from_items([ # doctest: +SKIP
+            ...     {"group": 1, "value": 1},
+            ...     {"group": 1, "value": 2},
+            ...     {"group": 2, "value": 3},
+            ...     {"group": 2, "value": 4}])
+            >>> ds.groupby("group").map_groups( # doctest: +SKIP
+            ...     lambda g: [g["value"][0]])
 
             >>> # Return multiple records per group (dataframe in, dataframe out).
             >>> df = pd.DataFrame(

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Generic, List, Tuple, Union
 
 from ray.data._internal import sort
 from ray.data._internal.compute import CallableClass, ComputeStrategy
+from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.plan import AllToAllStage
 from ray.data._internal.shuffle import ShuffleOp, SimpleShufflePlan
 from ray.data._internal.push_based_shuffle import PushBasedShufflePlan
@@ -317,7 +318,7 @@ class GroupedDataset(Generic[T]):
                 boundaries = get_key_boundaries(block_accessor)
             else:
                 boundaries = [block_accessor.num_rows()]
-            builder = block_accessor.builder()
+            builder = DelegatingBlockBuilder()
             start = 0
             for end in boundaries:
                 group = block_accessor.slice(start, end, False)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -4332,10 +4332,6 @@ def test_groupby_map_groups_merging_invalid_result(ray_start_regular_shared):
     with pytest.raises(TypeError):
         grouped.map_groups(lambda x: None if x == [1] else x)
 
-    # The UDF returns a type that's different than the input type, which is invalid.
-    with pytest.raises(TypeError):
-        grouped.map_groups(lambda x: pd.DataFrame([1]) if x == [1] else x)
-
 
 @pytest.mark.parametrize("num_parts", [1, 2, 30])
 def test_groupby_map_groups_for_none_groupkey(ray_start_regular_shared, num_parts):

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -4435,6 +4435,24 @@ def test_groupby_map_groups_for_arrow(ray_start_regular_shared, num_parts):
     assert result.equals(expected)
 
 
+def test_groupby_map_groups_with_different_types(ray_start_regular_shared):
+    ds = ray.data.from_items(
+        [
+            {"group": 1, "value": 1},
+            {"group": 1, "value": 2},
+            {"group": 2, "value": 3},
+            {"group": 2, "value": 4},
+        ]
+    )
+
+    def func(group):
+        # Test output type is Python list, different from input type.
+        return [group["value"][0]]
+
+    ds = ds.groupby("group").map_groups(func)
+    assert sorted(ds.take()) == [1, 3]
+
+
 @pytest.mark.parametrize("num_parts", [1, 30])
 def test_groupby_simple_min(ray_start_regular_shared, num_parts):
     # Test built-in min aggregation


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is to fix https://github.com/ray-project/ray/issues/29175 where `map_groups` does not work with different output type. We should use `DelegatingBlockBuilder` to create block builder based on actual block type, but not based on input block type.
 
## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/29175

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
