### PR TITLE
[ci] Fetch base branch before git diff in determine_tests_to_run.py

### DIFF
--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -24,6 +24,10 @@ def list_changed_files(commit_range):
     Returns:
         list: List of changed files within the commit range
     """
+    base_branch = os.environ.get("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
+    if base_branch:
+        pull_command = ["git", "fetch", "origin", base_branch]
+        subprocess.check_call(pull_command)
 
     command = ["git", "diff", "--name-only", commit_range, "--"]
     out = subprocess.check_output(command)


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some PRs (e.g. https://github.com/ray-project/ray/pull/29064) only change a single file but trigger the full test suite. The reason is likely that we have a stale master head ref. By fetching the latest head, we should be able to see more accurate results here and avoid running too many tests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
