### PR TITLE
[metric] Update object store metric record interval to not be coupled with event stats print interval

### DIFF
--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -119,7 +119,7 @@ PlasmaStore::PlasmaStore(instrumented_io_context &main_service,
   }
 
   if (RayConfig::instance().metrics_report_interval_ms() > 0) {
-    RecordMetrics();
+    ScheduleRecordMetrics();
   }
 }
 
@@ -555,13 +555,13 @@ void PlasmaStore::PrintAndRecordDebugDump() const {
       RayConfig::instance().event_stats_print_interval_ms());
 }
 
-void PlasmaStore::RecordMetrics() const {
+void PlasmaStore::ScheduleRecordMetrics() const {
   absl::MutexLock lock(&mutex_);
   object_lifecycle_mgr_.RecordMetrics();
 
   metric_timer_ = execute_after(
       io_context_,
-      [this]() { RecordMetrics(); },
+      [this]() { ScheduleRecordMetrics(); },
       // divide by 2 to make sure record happens before reporting
       // this also matches with  NodeManager::RecordMetrics interval
       RayConfig::instance().metrics_report_interval_ms() / 2);

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -117,6 +117,10 @@ PlasmaStore::PlasmaStore(instrumented_io_context &main_service,
       RayConfig::instance().event_stats()) {
     PrintAndRecordDebugDump();
   }
+
+  if (RayConfig::instance().metrics_report_interval_ms() > 0) {
+    RecordMetrics();
+  }
 }
 
 // TODO(pcm): Get rid of this destructor by using RAII to clean up data.
@@ -544,7 +548,6 @@ bool PlasmaStore::IsObjectSpillable(const ObjectID &object_id) {
 
 void PlasmaStore::PrintAndRecordDebugDump() const {
   absl::MutexLock lock(&mutex_);
-  RecordMetrics();
   RAY_LOG(INFO) << GetDebugDump();
   stats_timer_ = execute_after(
       io_context_,
@@ -552,7 +555,17 @@ void PlasmaStore::PrintAndRecordDebugDump() const {
       RayConfig::instance().event_stats_print_interval_ms());
 }
 
-void PlasmaStore::RecordMetrics() const { object_lifecycle_mgr_.RecordMetrics(); }
+void PlasmaStore::RecordMetrics() const {
+  absl::MutexLock lock(&mutex_);
+  object_lifecycle_mgr_.RecordMetrics();
+
+  metric_timer_ = execute_after(
+      io_context_,
+      [this]() { RecordMetrics(); },
+      // divide by 2 to make sure record happens before reporting
+      // this also matches with  NodeManager::RecordMetrics interval
+      RayConfig::instance().metrics_report_interval_ms() / 2);
+}
 
 std::string PlasmaStore::GetDebugDump() const {
   std::stringstream buffer;

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -222,14 +222,14 @@ class PlasmaStore {
   // Start listening for clients.
   void DoAccept();
 
-  void RecordMetrics() const LOCKS_EXCLUDED(mutex_);
-
   void PrintAndRecordDebugDump() const LOCKS_EXCLUDED(mutex_);
 
   std::string GetDebugDump() const EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
  private:
   friend class GetRequestQueue;
+
+  void ScheduleRecordMetrics() const LOCKS_EXCLUDED(mutex_);
 
   // A reference to the asio io context.
   instrumented_io_context &io_context_;

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -222,7 +222,7 @@ class PlasmaStore {
   // Start listening for clients.
   void DoAccept();
 
-  void RecordMetrics() const EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  void RecordMetrics() const LOCKS_EXCLUDED(mutex_);
 
   void PrintAndRecordDebugDump() const LOCKS_EXCLUDED(mutex_);
 
@@ -280,6 +280,9 @@ class PlasmaStore {
 
   /// Timer for printing debug information.
   mutable std::shared_ptr<boost::asio::deadline_timer> stats_timer_ GUARDED_BY(mutex_);
+
+  /// Timer for recording object store metrics.
+  mutable std::shared_ptr<boost::asio::deadline_timer> metric_timer_ GUARDED_BY(mutex_);
 
   /// Queue of object creation requests.
   CreateRequestQueue create_request_queue_ GUARDED_BY(mutex_);


### PR DESCRIPTION
…report interval rather than stats print interval

Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR makes recording of metric of `object_store_memory` to have the same interval as of those from node managers, ratther than the event status print interval. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
