### PR TITLE
[AIR] Ensure that driver `DatasetContext` is propagated to the `Trainer` actor.

### DIFF
--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -369,7 +369,6 @@ class BaseTrainer(abc.ABC):
             A Trainable class to use for training.
         """
 
-        from ray.data.context import DatasetContext
         from ray.tune.execution.placement_groups import PlacementGroupFactory
         from ray.tune.trainable import wrap_function
 
@@ -397,7 +396,12 @@ class BaseTrainer(abc.ABC):
 
         trainable_cls = wrap_function(train_func, warn=False)
         has_base_dataset = bool(self.datasets)
-        dataset_context = DatasetContext.get_current()
+        if has_base_dataset:
+            from ray.data.context import DatasetContext
+
+            dataset_context = DatasetContext.get_current()
+        else:
+            dataset_context = None
 
         class TrainTrainable(trainable_cls):
             """Add default resources to the Trainable."""
@@ -436,9 +440,10 @@ class BaseTrainer(abc.ABC):
                 ] = self._reconcile_scaling_config_with_trial_resources(
                     merged_scaling_config
                 )
-                # Set the DatasetContext on the Trainer actor to the DatasetContext
-                # specified on the driver.
-                DatasetContext._set_current(dataset_context)
+                if self.has_base_dataset():
+                    # Set the DatasetContext on the Trainer actor to the DatasetContext
+                    # specified on the driver.
+                    DatasetContext._set_current(dataset_context)
                 super(TrainTrainable, self).setup(config)
 
             def _reconcile_scaling_config_with_trial_resources(

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -369,6 +369,7 @@ class BaseTrainer(abc.ABC):
             A Trainable class to use for training.
         """
 
+        from ray.data.context import DatasetContext
         from ray.tune.execution.placement_groups import PlacementGroupFactory
         from ray.tune.trainable import wrap_function
 
@@ -396,6 +397,7 @@ class BaseTrainer(abc.ABC):
 
         trainable_cls = wrap_function(train_func, warn=False)
         has_base_dataset = bool(self.datasets)
+        dataset_context = DatasetContext.get_current()
 
         class TrainTrainable(trainable_cls):
             """Add default resources to the Trainable."""
@@ -434,6 +436,9 @@ class BaseTrainer(abc.ABC):
                 ] = self._reconcile_scaling_config_with_trial_resources(
                     merged_scaling_config
                 )
+                # Set the DatasetContext on the Trainer actor to the DatasetContext
+                # specified on the driver.
+                DatasetContext._set_current(dataset_context)
                 super(TrainTrainable, self).setup(config)
 
             def _reconcile_scaling_config_with_trial_resources(

--- a/python/ray/train/tests/test_base_trainer.py
+++ b/python/ray/train/tests/test_base_trainer.py
@@ -409,6 +409,9 @@ def test_preprocess_datasets_context(ray_start_4_cpus):
 
     preprocessor = BatchMapper(map_fn)
 
+    ctx = ray.data.context.DatasetContext.get_current()
+    ctx.target_max_block_size = target_max_block_size
+
     datasets = {"my_dataset": ray.data.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))}
     trainer = DummyTrainer(training_loop, datasets=datasets, preprocessor=preprocessor)
     result = trainer.fit()

--- a/python/ray/train/tests/test_base_trainer.py
+++ b/python/ray/train/tests/test_base_trainer.py
@@ -5,6 +5,7 @@ import time
 from contextlib import redirect_stderr
 from unittest.mock import patch
 
+import pandas as pd
 import numpy as np
 import pytest
 
@@ -396,7 +397,7 @@ def test_preprocess_datasets_context(ray_start_4_cpus):
     """Tests if DatasetContext is propagated to preprocessors."""
 
     def training_loop(self):
-        assert self.datasets["my_dataset"].take() == [2, 3, 4]
+        assert self.datasets["my_dataset"].take() == [{"a": i} for i in range(2, 5)]
         session.report(dict(my_metric=1))
 
     target_max_block_size = 100
@@ -408,7 +409,7 @@ def test_preprocess_datasets_context(ray_start_4_cpus):
 
     preprocessor = BatchMapper(map_fn)
 
-    datasets = {"my_dataset": ray.data.from_items([1, 2, 3])}
+    datasets = {"my_dataset": ray.data.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))}
     trainer = DummyTrainer(training_loop, datasets=datasets, preprocessor=preprocessor)
     result = trainer.fit()
     assert result.metrics["my_metric"] == 1


### PR DESCRIPTION
DatasetContext allows setting Datasets config values like the target max block size. Normally these are propagated from the driver to all tasks in the Dataset.

However, when using the AIR trainer, context changes made by the driver don't get propagated to the training dataset preprocessor. I think this is likely because the BatchMapper doesn't save the context, so when we pass the BatchMapper to the worker that actually creates the final Dataset, the driver's context values are lost.

## Related issue number

Closes https://github.com/ray-project/ray/issues/29160

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
