### PR TITLE
Use logger.info instead of print

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -733,11 +733,9 @@ cdef execute_task(
         # We need to handle this separately because `__repr__` may not be
         # runnable until after `__init__` (e.g., if it accesses fields
         # defined in the constructor).
-        actor_magic_token = "{}{}\n".format(
-            ray_constants.LOG_PREFIX_ACTOR_NAME, actor_class.__name__)
-        # Flush to both .out and .err
-        print(actor_magic_token, end="")
-        print(actor_magic_token, file=sys.stderr, end="")
+        logger.info(
+            f"{ray_constants.LOG_PREFIX_ACTOR_NAME}{actor_class.__name__}"
+        )
 
         # Initial eventloops for asyncio for this actor.
         if core_worker.current_actor_is_asyncio():
@@ -764,11 +762,10 @@ cdef execute_task(
         function_executor = execution_info.function
         # Record the task name via :task_name: magic token in the log file.
         # This is used for the prefix in driver logs `(task_name pid=123) ...`
-        task_name_magic_token = "{}{}\n".format(
-            ray_constants.LOG_PREFIX_TASK_NAME, task_name.replace("()", ""))
-        # Print on both .out and .err
-        print(task_name_magic_token, end="")
-        print(task_name_magic_token, file=sys.stderr, end="")
+        logger.info(
+            f"{ray_constants.LOG_PREFIX_TASK_NAME}"
+            f"{task_name.replace('()', '')}"
+        )
     else:
         actor = worker.actors[core_worker.get_actor_id()]
         class_name = actor.__class__.__name__
@@ -917,11 +914,9 @@ cdef execute_task(
                 if (hasattr(actor_class, "__ray_actor_class__") and
                         "__repr__" in
                         actor_class.__ray_actor_class__.__dict__):
-                    actor_magic_token = "{}{}\n".format(
-                        ray_constants.LOG_PREFIX_ACTOR_NAME, repr(actor))
-                    # Flush on both stdout and stderr.
-                    print(actor_magic_token, end="")
-                    print(actor_magic_token, file=sys.stderr, end="")
+                    logger.info(
+                        f"{ray_constants.LOG_PREFIX_ACTOR_NAME}{repr(actor)}"
+                    )
             # Check for a cancellation that was called when the function
             # was exiting and was raised after the except block.
             if not check_signals().ok():
@@ -1084,7 +1079,7 @@ cdef CRayStatus task_execution_handler(
                     f"Worker exits with an exit code {e.code}.")
             else:
                 msg = f"Worker exits with an exit code {e.code}."
-                # In K8s, SIGTERM likely means we hit memory limits, so print
+                # In K8s, SIGTERM likely means we hit memory limits, so log
                 # a more informative message there.
                 if "KUBERNETES_SERVICE_HOST" in os.environ:
                     msg += (


### PR DESCRIPTION
Signed-off-by: mattip <matti.picus@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In PR #18105, these print statements were added with [the exchange](https://github.com/ray-project/ray/pull/18105/files#r696302983):
> Do these show up on the console (@richardliaw)
> Nope, filtered out so you see just the PR description text. (@ericl)

But as evidenced in issue #21424, the prints __do__ show up on the console, and pollute various other workflows.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #21424
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
