### PR TITLE
[cherry-pick][ci] Fix the CI mac build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2708,7 +2708,6 @@ alias(
     name = "redis-server",
     actual = select({
         "@bazel_tools//src/conditions:windows": "@com_github_tporadowski_redis_bin//:redis-server.exe",
-        "@bazel_tools//src/conditions:darwin": "@com_github_antirez_redis//:redis-server-mac",
         "//conditions:default": "@com_github_antirez_redis//:redis-server",
     }),
     visibility = ["//visibility:public"],
@@ -2718,7 +2717,6 @@ alias(
     name = "redis-cli",
     actual = select({
         "@bazel_tools//src/conditions:windows": "@com_github_tporadowski_redis_bin//:redis-cli.exe",
-        "@bazel_tools//src/conditions:darwin": "@com_github_antirez_redis//:redis-cli-mac",
         "//conditions:default": "@com_github_antirez_redis//:redis-cli",
     }),
     visibility = ["//visibility:public"],

--- a/bazel/BUILD.redis
+++ b/bazel/BUILD.redis
@@ -40,31 +40,8 @@ make(
     ]
 )
 
-genrule(
-    name = "bin",
-    srcs = [":redis"],
-    outs = [
-        "redis-server",
-        "redis-cli",
-    ],
-    cmd = """
-        cp $(RULEDIR)/redis/bin/redis-server $(location redis-server)
-        cp $(RULEDIR)/redis/bin/redis-cli $(location redis-cli)
-    """,
-    visibility = ["//visibility:public"],
-    tags = ["local"],
-)
-
-# This is a build for mac without openssl.
-# rules_foreign_cc somehow pick the wrong toolchain in CI.
-genrule(
-    name = "bin-mac",
-    srcs = glob(["**"]),
-    outs = [
-        "redis-server-mac",
-        "redis-cli-mac",
-    ],
-    cmd = """
+genrule_cmd = select({
+    "@bazel_tools//src/conditions:darwin": """
         unset CC LDFLAGS CXX CXXFLAGS
         tmpdir="redis.tmp"
         p=$(location Makefile)
@@ -72,13 +49,32 @@ genrule(
         chmod +x "$${tmpdir}"/deps/jemalloc/configure
         parallel="$$(getconf _NPROCESSORS_ONLN || echo 1)"
         make -s -C "$${tmpdir}" -j"$${parallel}" V=0 CFLAGS="$${CFLAGS-} -DLUA_USE_MKSTEMP -Wno-pragmas -Wno-empty-body"
-        mv "$${tmpdir}"/src/redis-server $(location redis-server-mac)
-        chmod +x $(location redis-server-mac)
-        mv "$${tmpdir}"/src/redis-cli $(location redis-cli-mac)
-        chmod +x $(location redis-cli-mac)
+        mv "$${tmpdir}"/src/redis-server $(location redis-server)
+        chmod +x $(location redis-server)
+        mv "$${tmpdir}"/src/redis-cli $(location redis-cli)
+        chmod +x $(location redis-cli)
         rm -r -f -- "$${tmpdir}"
     """,
+    "//conditions:default": """
+        cp $(RULEDIR)/redis/bin/redis-server $(location redis-server)
+        cp $(RULEDIR)/redis/bin/redis-cli $(location redis-cli)
+    """
+})
+
+genrule_srcs = select({
+    "@bazel_tools//src/conditions:darwin": glob(["**"]),
+    "//conditions:default": [":redis"],
+})
+
+
+genrule(
+    name = "bin",
+    srcs = genrule_srcs,
+    outs = [
+        "redis-server",
+        "redis-cli",
+    ],
+    cmd = genrule_cmd,
     visibility = ["//visibility:public"],
     tags = ["local"],
 )
-


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The mac build in CI failed because it can't find redis-server. We rename the redis-server in mac to redis-server-mac but the setup is not updated which lead this error.

In this PR, we change the name of the redis-server-mac back to redis-server.

In the next release, we'll get rid of redis-server in ray pip pkgs.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
