### PR TITLE
[cherry-pick][core] Change the API to support rediss:// (#29188)

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -95,7 +95,7 @@ class Node:
             # instance provided.
             if len(external_redis) == 1:
                 external_redis.append(external_redis[0])
-            [primary_redis_ip, port] = external_redis[0].split(":")
+            [primary_redis_ip, port] = external_redis[0].rsplit(":", 1)
             ray_params.external_addresses = external_redis
             ray_params.num_redis_shards = len(external_redis) - 1
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1058,6 +1058,7 @@ def _start_redis_instance(
     fate_share: Optional[bool] = None,
     port_denylist: Optional[List[int]] = None,
     listen_to_localhost_only: bool = False,
+    enable_tls: bool = False,
 ):
     """Start a single Redis server.
 
@@ -1089,6 +1090,7 @@ def _start_redis_instance(
         listen_to_localhost_only: Redis server only listens to
             localhost (127.0.0.1) if it's true,
             otherwise it listens to all network interfaces.
+        enable_tls: Enable the TLS/SSL in Redis or not
 
     Returns:
         A tuple of the port used by Redis and ProcessInfo for the process that
@@ -1108,9 +1110,7 @@ def _start_redis_instance(
             raise ValueError("Spaces not permitted in redis password.")
         command += ["--requirepass", password]
 
-    if not Config.REDIS_ENABLE_SSL():
-        command += ["--port", str(port), "--loglevel", "warning"]
-    else:
+    if enable_tls:
         import socket
 
         with socket.socket() as s:
@@ -1124,12 +1124,14 @@ def _start_redis_instance(
             "--port",
             str(free_port),
         ]
+    else:
+        command += ["--port", str(port), "--loglevel", "warning"]
 
     if listen_to_localhost_only:
         command += ["--bind", "127.0.0.1"]
     pidfile = os.path.join(session_dir_path, "redis-" + uuid.uuid4().hex + ".pid")
     command += ["--pidfile", pidfile]
-    if Config.REDIS_ENABLE_SSL():
+    if enable_tls:
         if Config.REDIS_CA_CERT():
             command += ["--tls-ca-cert-file", Config.REDIS_CA_CERT()]
         if Config.REDIS_CLIENT_CERT():
@@ -1447,10 +1449,21 @@ def start_gcs_server(
         f"--node-ip-address={node_ip_address}",
     ]
     if redis_address:
-        redis_ip_address, redis_port = redis_address.rsplit(":")
+        parts = redis_address.split("://", 1)
+        enable_redis_ssl = "false"
+        if len(parts) == 1:
+            redis_ip_address, redis_port = parts[0].rsplit(":", 1)
+        else:
+            if len(parts) != 2 or parts[0] not in ("redis", "rediss"):
+                raise ValueError(f"Invalid redis address {redis_address}")
+            redis_ip_address, redis_port = parts[1].rsplit(":", 1)
+            if parts[0] == "rediss":
+                enable_redis_ssl = "true"
+
         command += [
             f"--redis_address={redis_ip_address}",
             f"--redis_port={redis_port}",
+            f"--redis_enable_ssl={enable_redis_ssl}",
         ]
     if redis_password:
         command += [f"--redis_password={redis_password}"]

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -71,8 +71,6 @@ cdef extern from "ray/common/ray_config.h" nogil:
 
         c_bool use_ray_syncer() const
 
-        c_bool REDIS_ENABLE_SSL() const
-
         c_string REDIS_CA_CERT() const
 
         c_string REDIS_CA_PATH() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -118,10 +118,6 @@ cdef class Config:
         return RayConfig.instance().use_ray_syncer()
 
     @staticmethod
-    def REDIS_ENABLE_SSL():
-        return RayConfig.instance().REDIS_ENABLE_SSL()
-
-    @staticmethod
     def REDIS_CA_CERT():
         return RayConfig.instance().REDIS_CA_CERT()
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -152,6 +152,7 @@ def _setup_redis(request):
     else:
         del param["external_redis_ports"]
     processes = []
+    enable_tls = "RAY_REDIS_CA_CERT" in os.environ
     for port in external_redis_ports:
         temp_dir = ray._private.utils.get_ray_temp_dir()
         port, proc = _start_redis_instance(
@@ -159,10 +160,13 @@ def _setup_redis(request):
             temp_dir,
             port,
             password=ray_constants.REDIS_DEFAULT_PASSWORD,
+            enable_tls=enable_tls,
         )
         processes.append(proc)
-    address_str = ",".join(map(lambda x: f"127.0.0.1:{x}", external_redis_ports))
-    import os
+    scheme = "rediss://" if enable_tls else ""
+    address_str = ",".join(
+        map(lambda x: f"{scheme}127.0.0.1:{x}", external_redis_ports)
+    )
 
     old_addr = os.environ.get("RAY_REDIS_ADDRESS")
     os.environ["RAY_REDIS_ADDRESS"] = address_str

--- a/python/ray/tests/test_redis_tls.py
+++ b/python/ray/tests/test_redis_tls.py
@@ -39,9 +39,7 @@ openssl dhparam -out {str(tmp_path)}/tls/redis.dh 2048
     ca.crt  ca.key  ca.txt  redis.crt  redis.dh  redis.key
     """
 
-    monkeypatch.setenv("RAY_REDIS_ENABLE_SSL", "true")
     monkeypatch.setenv("RAY_REDIS_CA_CERT", f"{str(tmp_path)}/tls/ca.crt")
-
     monkeypatch.setenv("RAY_REDIS_CLIENT_CERT", f"{str(tmp_path)}/tls/redis.crt")
     monkeypatch.setenv("RAY_REDIS_CLIENT_KEY", f"{str(tmp_path)}/tls/redis.key")
     ray._raylet.Config.initialize("")

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -682,7 +682,6 @@ RAY_CONFIG(std::string, TLS_CA_CERT, "")
 
 /// Location of Redis TLS credentials
 /// https://github.com/redis/hiredis/blob/c78d0926bf169670d15cfc1214e4f5d21673396b/README.md#hiredis-openssl-wrappers
-RAY_CONFIG(bool, REDIS_ENABLE_SSL, false)
 RAY_CONFIG(std::string, REDIS_CA_CERT, "")
 RAY_CONFIG(std::string, REDIS_CA_PATH, "")
 

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -111,7 +111,8 @@ RedisClientOptions GcsServer::GetRedisClientOptions() const {
   return RedisClientOptions(config_.redis_address,
                             config_.redis_port,
                             config_.redis_password,
-                            config_.enable_sharding_conn);
+                            config_.enable_sharding_conn,
+                            config_.enable_redis_ssl);
 }
 
 void GcsServer::Start() {

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -47,6 +47,7 @@ struct GcsServerConfig {
   std::string redis_password;
   std::string redis_address;
   uint16_t redis_port = 6379;
+  bool enable_redis_ssl = false;
   bool retry_redis = true;
   bool enable_sharding_conn = false;
   std::string node_ip_address;

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -24,6 +24,7 @@
 #include "src/ray/protobuf/gcs_service.pb.h"
 
 DEFINE_string(redis_address, "", "The ip address of redis.");
+DEFINE_bool(redis_enable_ssl, false, "Use tls/ssl in redis connection.");
 DEFINE_int32(redis_port, -1, "The port of redis.");
 DEFINE_string(log_dir, "", "The path of the dir where log files are created.");
 DEFINE_int32(gcs_server_port, 0, "The port of gcs server.");
@@ -87,6 +88,7 @@ int main(int argc, char *argv[]) {
       RayConfig::instance().gcs_server_rpc_server_thread_num();
   gcs_server_config.redis_address = redis_address;
   gcs_server_config.redis_port = redis_port;
+  gcs_server_config.enable_redis_ssl = FLAGS_redis_enable_ssl;
   gcs_server_config.redis_password = redis_password;
   gcs_server_config.retry_redis = retry_redis;
   gcs_server_config.node_ip_address = node_ip_address;

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -142,7 +142,8 @@ Status RedisClient::Connect(std::vector<instrumented_io_context *> io_services) 
   RAY_CHECK_OK(primary_context_->Connect(options_.server_ip_,
                                          options_.server_port_,
                                          /*sharding=*/options_.enable_sharding_conn_,
-                                         /*password=*/options_.password_));
+                                         /*password=*/options_.password_,
+                                         /*enable_ssl=*/options_.enable_ssl_));
 
   if (options_.enable_sharding_conn_) {
     // Moving sharding into constructor defaultly means that sharding = true.
@@ -165,7 +166,8 @@ Status RedisClient::Connect(std::vector<instrumented_io_context *> io_services) 
       RAY_CHECK_OK(shard_contexts_[i]->Connect(addresses[i],
                                                ports[i],
                                                /*sharding=*/true,
-                                               /*password=*/options_.password_));
+                                               /*password=*/options_.password_,
+                                               /*enable_ssl=*/options_.enable_ssl_));
     }
   } else {
     shard_contexts_.push_back(std::make_shared<RedisContext>(*io_services[0]));
@@ -173,7 +175,8 @@ Status RedisClient::Connect(std::vector<instrumented_io_context *> io_services) 
     RAY_CHECK_OK(shard_contexts_[0]->Connect(options_.server_ip_,
                                              options_.server_port_,
                                              /*sharding=*/true,
-                                             /*password=*/options_.password_));
+                                             /*password=*/options_.password_,
+                                             /*enable_ssl=*/options_.enable_ssl_));
   }
 
   Attach();

--- a/src/ray/gcs/redis_client.h
+++ b/src/ray/gcs/redis_client.h
@@ -33,11 +33,13 @@ class RedisClientOptions {
   RedisClientOptions(const std::string &ip,
                      int port,
                      const std::string &password,
-                     bool enable_sharding_conn = false)
+                     bool enable_sharding_conn = false,
+                     bool enable_ssl = false)
       : server_ip_(ip),
         server_port_(port),
         password_(password),
-        enable_sharding_conn_(enable_sharding_conn) {}
+        enable_sharding_conn_(enable_sharding_conn),
+        enable_ssl_(enable_ssl) {}
 
   // Redis server address
   std::string server_ip_;
@@ -48,6 +50,9 @@ class RedisClientOptions {
 
   // Whether we enable sharding for accessing data.
   bool enable_sharding_conn_ = false;
+
+  // Whether to use tls/ssl for redis connection
+  bool enable_ssl_ = false;
 };
 
 /// \class RedisClient

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -186,7 +186,8 @@ class RedisContext {
   Status Connect(const std::string &address,
                  int port,
                  bool sharding,
-                 const std::string &password);
+                 const std::string &password,
+                 bool enable_ssl = false);
 
   /// Run an arbitrary Redis command synchronously.
   ///


### PR DESCRIPTION
The current API is to use RAY_ENABLE_REDIS_SSL as the os env. The updated API asks to pass rediss:// as the redis address.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
