### PR TITLE
[cherry-pick][core] Fix the redis issue with TLS/SSL in AWS Redis (#29244)

### DIFF
--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -428,13 +428,7 @@ Status RedisContext::Connect(const std::string &address,
     RAY_CHECK(redisInitiateSSLWithContext(context_, ssl_context_) == REDIS_OK)
         << "Failed to setup encrypted redis: " << context_->errstr;
   }
-
   RAY_CHECK_OK(AuthenticateRedis(context_, password));
-
-  redisReply *reply = reinterpret_cast<redisReply *>(
-      redisCommand(context_, "CONFIG SET notify-keyspace-events Kl"));
-  REDIS_CHECK_ERROR(context_, reply);
-  freeReplyObject(reply);
 
   // Connect to async context
   redisAsyncContext *async_context = nullptr;


### PR DESCRIPTION
When connecting to secured redis sometimes config is not allowed (https://redis.io/docs/manual/security/) by default for security reasons by the vendor.

In Ray, Redis used to be used for pubsub, but not anymore. This PR just deletes this config setup so that it can be used with vendor's redis.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
