### PR TITLE
[RLlib] Handle TF2 policies when using TargetNetworkMixin (#29218)

### DIFF
--- a/rllib/policy/tf_mixins.py
+++ b/rllib/policy/tf_mixins.py
@@ -5,6 +5,8 @@ import numpy as np
 
 
 from ray.rllib.models.modelv2 import ModelV2
+from ray.rllib.policy.eager_tf_policy import EagerTFPolicy
+from ray.rllib.policy.eager_tf_policy_v2 import EagerTFPolicyV2
 from ray.rllib.policy.policy import Policy, PolicyState
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.policy.tf_policy import TFPolicy
@@ -18,6 +20,7 @@ from ray.rllib.utils.typing import (
     ModelGradients,
     TensorType,
 )
+
 
 logger = logging.getLogger(__name__)
 tf1, tf, tfv = try_import_tf()
@@ -252,9 +255,13 @@ class TargetNetworkMixin:
     def variables(self) -> List[TensorType]:
         return self.model.variables()
 
-    @override(TFPolicy)
     def set_weights(self, weights):
-        TFPolicy.set_weights(self, weights)
+        if isinstance(self, TFPolicy):
+            TFPolicy.set_weights(self, weights)
+        elif isinstance(self, EagerTFPolicyV2):  # Handle TF2V2 policies.
+            EagerTFPolicyV2.set_weights(self, weights)
+        elif isinstance(self, EagerTFPolicy):  # Handle TF2 policies.
+            EagerTFPolicy.set_weights(self, weights)
         self.update_target(self.config.get("tau", 1.0))
 
 


### PR DESCRIPTION
Handle TF2 policies when using TargetNetworkMixin

Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

Cherry pick a fix for broken TF2 APPO algorithm.

## Related issue number

Closes #29301

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
