### PR TITLE
[RLlib] Fix policy restore. Avoid keyward params. (#29227)

### DIFF
--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -289,9 +289,12 @@ class Policy(metaclass=ABCMeta):
 
         # Create the new policy.
         new_policy = pol_spec.policy_class(
-            observation_space=pol_spec.observation_space,
-            action_space=pol_spec.action_space,
-            config=pol_spec.config,
+            # Note(jungong) : we are intentionally not using keyward arguments here
+            # because some policies name the observation space parameter obs_space,
+            # and some others name it observation_space.
+            pol_spec.observation_space,
+            pol_spec.action_space,
+            pol_spec.config,
         )
 
         # Set the new policy's state (weights, optimizer vars, exploration state,


### PR DESCRIPTION
Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

Cherry pick a fix for the broken policy checkpoint loading functionality.

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
