### PR TITLE
[tune] Fix TrialTerminationReporter in docs

### DIFF
--- a/doc/source/tune/api_docs/reporters.rst
+++ b/doc/source/tune/api_docs/reporters.rst
@@ -52,9 +52,11 @@ Extending ``CLIReporter`` lets you control reporting frequency. For example:
 
     tuner = tune.Tuner(my_trainable, run_config=air.RunConfig(progress_reporter=ExperimentTerminationReporter()))
     results = tuner.fit()
-
+    
+    from ray.tune.trial import Trial
     class TrialTerminationReporter(CLIReporter):
         def __init__(self):
+            super(TrialTerminationReporter, self).__init__()
             self.num_terminated = 0
 
         def should_report(self, trials, done=False):

--- a/doc/source/tune/api_docs/reporters.rst
+++ b/doc/source/tune/api_docs/reporters.rst
@@ -53,7 +53,7 @@ Extending ``CLIReporter`` lets you control reporting frequency. For example:
     tuner = tune.Tuner(my_trainable, run_config=air.RunConfig(progress_reporter=ExperimentTerminationReporter()))
     results = tuner.fit()
     
-    from ray.tune.trial import Trial
+    from ray.tune.experiment.trial import Trial
     class TrialTerminationReporter(CLIReporter):
         def __init__(self):
             super(TrialTerminationReporter, self).__init__()

--- a/doc/source/tune/api_docs/reporters.rst
+++ b/doc/source/tune/api_docs/reporters.rst
@@ -45,6 +45,8 @@ Extending ``CLIReporter`` lets you control reporting frequency. For example:
 
 .. code-block:: python
 
+    from ray.tune.experiment.trial import Trial
+
     class ExperimentTerminationReporter(CLIReporter):
         def should_report(self, trials, done=False):
             """Reports only on experiment termination."""
@@ -52,8 +54,7 @@ Extending ``CLIReporter`` lets you control reporting frequency. For example:
 
     tuner = tune.Tuner(my_trainable, run_config=air.RunConfig(progress_reporter=ExperimentTerminationReporter()))
     results = tuner.fit()
-    
-    from ray.tune.experiment.trial import Trial
+
     class TrialTerminationReporter(CLIReporter):
         def __init__(self):
             super(TrialTerminationReporter, self).__init__()


### PR DESCRIPTION
Signed-off-by: linusbiostat <102326615+linusbiostat@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
To make the documentation code work.

<!-- Please give a short summary of the change and the problem this solves. -->
TrialTerminationReporter has an init function. Because extending the CliReporter, it's need to take the same init parameters. I've added these with the super() function.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
