### PR TITLE
[Tune] Remove deprecated `checkpoint_dir` function checkpointing warning

### DIFF
--- a/python/ray/tune/trainable/function_trainable.py
+++ b/python/ray/tune/trainable/function_trainable.py
@@ -581,15 +581,6 @@ def wrap_function(
             "Found: {}".format(func_args)
         )
 
-    if use_config_single and not use_checkpoint:
-        if log_once("tune_function_checkpoint") and warn:
-            logger.warning(
-                "Function checkpointing is disabled. This may result in "
-                "unexpected behavior when using checkpointing features or "
-                "certain schedulers. To enable, set the train function "
-                "arguments to be `func(config, checkpoint_dir=None)`."
-            )
-
     if use_checkpoint:
         if log_once("tune_checkpoint_dir_deprecation") and warn:
             with warnings.catch_warnings():


### PR DESCRIPTION
Signed-off-by: Justin Yu <justinvyu@berkeley.edu>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Function checkpointing with `def train_func(config, checkpoint_dir=None)` has been deprecated in favor of `session.report(..., checkpoint=checkpoint)`.

Tune was giving a warning that function checkpointing was disabled if the `checkpoint_dir` argument is missing, and it was also giving a deprecation warning if `checkpoint_dir` was used. This PR removes the first warning. 

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/29216

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
