### PR TITLE
[RLlib] Doc update. Remove the no-longer-supported record_env param.

### DIFF
--- a/doc/source/rllib/rllib-training.rst
+++ b/doc/source/rllib/rllib-training.rst
@@ -292,13 +292,6 @@ The following is a list of the common algorithm hyper-parameters:
     # a) handles window generation and rendering itself (returning True) or
     # b) returns a numpy uint8 image of shape [height x width x 3 (RGB)].
     "render_env": False,
-    # If True, stores videos in this relative directory inside the default
-    # output dir (~/ray_results/...). Alternatively, you can specify an
-    # absolute path (str), in which the env recordings should be
-    # stored instead.
-    # Set to False for not recording anything.
-    # Note: This setting replaces the deprecated `monitor` key.
-    "record_env": False,
     # Whether to clip rewards during Policy's postprocessing.
     # None (default): Clip for Atari only (r=sign(r)).
     # True: r=sign(r): Fixed rewards -1.0, 1.0, or 0.0.


### PR DESCRIPTION
Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

We no longer support Env Recorder.

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
