### PR TITLE
[docs] Update local_mode pydoc to say it's deprecated

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1116,8 +1116,7 @@ def init(
         object_store_memory: The amount of memory (in bytes) to start the
             object store with. By default, this is automatically set based on
             available system memory.
-        local_mode: If true, the code will be executed serially. This
-            is useful for debugging.
+        local_mode: Deprecated: consider using the Ray Debugger instead.
         ignore_reinit_error: If true, Ray suppresses errors from calling
             ray.init() a second time. Ray won't be restarted.
         include_dashboard: Boolean flag indicating whether or not to start the


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Per https://github.com/ray-project/ray/pull/29211, we currently log a deprecation warning, but it's not marked as deprecated in the pydoc.