### PR TITLE
Revert "[RLlib] Fix policy restore. Avoid keyward params. (#29227)"

### DIFF
--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -289,12 +289,9 @@ class Policy(metaclass=ABCMeta):
 
         # Create the new policy.
         new_policy = pol_spec.policy_class(
-            # Note(jungong) : we are intentionally not using keyward arguments here
-            # because some policies name the observation space parameter obs_space,
-            # and some others name it observation_space.
-            pol_spec.observation_space,
-            pol_spec.action_space,
-            pol_spec.config,
+            observation_space=pol_spec.observation_space,
+            action_space=pol_spec.action_space,
+            config=pol_spec.config,
         )
 
         # Set the new policy's state (weights, optimizer vars, exploration state,


### PR DESCRIPTION
This reverts commit 75e9722a4d9c0d8d5cb0c37eb6316553f9e0789e.

Revert offending PR that leads to master test failure

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
