### PR TITLE
Make sure random shuffle can run with custom resources and remote args

### DIFF
--- a/python/ray/data/_internal/stage_impl.py
+++ b/python/ray/data/_internal/stage_impl.py
@@ -1,4 +1,4 @@
-from typing import Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
 import ray
 from ray.data._internal.fast_repartition import fast_repartition
@@ -89,7 +89,10 @@ class RandomShuffleStage(AllToAllStage):
     """Implementation of `Dataset.random_shuffle()`."""
 
     def __init__(
-        self, seed: Optional[int], output_num_blocks: Optional[int], **ray_remote_args
+        self,
+        seed: Optional[int],
+        output_num_blocks: Optional[int],
+        remote_args: Optional[Dict[str, Any]] = None,
     ):
         def do_shuffle(block_list, clear_input_blocks: bool, block_udf, remote_args):
             num_blocks = block_list.executed_num_blocks()  # Blocking.
@@ -125,7 +128,7 @@ class RandomShuffleStage(AllToAllStage):
             output_num_blocks,
             do_shuffle,
             supports_block_udf=True,
-            remote_args=ray_remote_args,
+            remote_args=remote_args,
         )
 
 

--- a/python/ray/data/_internal/stage_impl.py
+++ b/python/ray/data/_internal/stage_impl.py
@@ -88,7 +88,9 @@ class RandomizeBlocksStage(AllToAllStage):
 class RandomShuffleStage(AllToAllStage):
     """Implementation of `Dataset.random_shuffle()`."""
 
-    def __init__(self, seed: Optional[int], output_num_blocks: Optional[int]):
+    def __init__(
+        self, seed: Optional[int], output_num_blocks: Optional[int], **ray_remote_args
+    ):
         def do_shuffle(block_list, clear_input_blocks: bool, block_udf, remote_args):
             num_blocks = block_list.executed_num_blocks()  # Blocking.
             if num_blocks == 0:
@@ -119,7 +121,11 @@ class RandomShuffleStage(AllToAllStage):
             )
 
         super().__init__(
-            "random_shuffle", output_num_blocks, do_shuffle, supports_block_udf=True
+            "random_shuffle",
+            output_num_blocks,
+            do_shuffle,
+            supports_block_udf=True,
+            remote_args=ray_remote_args,
         )
 
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -855,7 +855,7 @@ class Dataset(Generic[T]):
         """
 
         plan = self._plan.with_stage(
-            RandomShuffleStage(seed, num_blocks, **ray_remote_args)
+            RandomShuffleStage(seed, num_blocks, ray_remote_args)
         )
         return Dataset(plan, self._epoch, self._lazy)
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -826,6 +826,7 @@ class Dataset(Generic[T]):
         *,
         seed: Optional[int] = None,
         num_blocks: Optional[int] = None,
+        **ray_remote_args,
     ) -> "Dataset[T]":
         """Randomly shuffle the elements of this dataset.
 
@@ -853,7 +854,9 @@ class Dataset(Generic[T]):
             The shuffled dataset.
         """
 
-        plan = self._plan.with_stage(RandomShuffleStage(seed, num_blocks))
+        plan = self._plan.with_stage(
+            RandomShuffleStage(seed, num_blocks, **ray_remote_args)
+        )
         return Dataset(plan, self._epoch, self._lazy)
 
     def randomize_block_order(


### PR DESCRIPTION
Signed-off-by: jianoaix <iamjianxiao@gmail.com>

## Why are these changes needed?
The random_shuffle cannot run according to custom resources, which is needed for users who use heterogeneous cluster.

This adds ray_remote_args to random_shuffle().

Additionally, we can have a control in DatasetContext that adds a custom resource requirement for all APIs (each API can still add additional custom resource requirements), which will make heterogeneous cluster support easier. But it's legitimate for random_shuffle() to have ray_remote_args, so we start with it.

## Related issue number
#29273

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
