### PR TITLE
[Datasets] Change `map_batches` to fetch input blocks on-demand

### DIFF
--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -95,10 +95,6 @@ class Batcher(BatcherInterface):
         """Whether this Batcher has any data."""
         return self._buffer_size > 0
 
-    def buffer_size(self) -> int:
-        """The number of buffered rows in this Batcher"""
-        return self._buffer_size
-
     def next_batch(self) -> Block:
         """Get the next batch from the block buffer.
 

--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -95,6 +95,10 @@ class Batcher(BatcherInterface):
         """Whether this Batcher has any data."""
         return self._buffer_size > 0
 
+    def buffer_size(self) -> int:
+        """The number of buffered rows in this Batcher"""
+        return self._buffer_size
+
     def next_batch(self) -> Block:
         """Get the next batch from the block buffer.
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -532,25 +532,12 @@ class Dataset(Generic[T]):
             *fn_args,
             **fn_kwargs,
         ) -> Iterable[Block]:
-
-            # Fetch next available input blocks for the batch.
-            # Only fetch required number of blocks but not all blocks.
-            # This avoids over-buffering in current node's memory.
-            blocks_iter = iter(blocks)
-            def _fetch_next_blocks(batcher: Batcher, batch_size: Optional[int]):
-                for block in blocks_iter:
-                    batcher.add(block)
-                    if batch_size is None or batcher.buffer_size() >= batch_size:
-                        break
-
             DatasetContext._set_current(context)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
             # Ensure that zero-copy batch views are copied so mutating UDFs don't error.
             batcher = Batcher(batch_size, ensure_copy=batch_size is not None)
 
-            # Fetch blocks for the first batch.
-            _fetch_next_blocks(batcher, batch_size)
-            while batcher.has_any():
+            def process_next_batch() -> Iterator[Block]:
                 batch = batcher.next_batch()
                 # Convert to batch format.
                 batch = BlockAccessor.for_block(batch).to_batch_format(batch_format)
@@ -577,10 +564,18 @@ class Dataset(Generic[T]):
                 if output_buffer.has_next():
                     yield output_buffer.next()
 
-                # Fetch blocks for the next batch if needed.
-                if batch_size is None or batcher.buffer_size() < batch_size:
-                    _fetch_next_blocks(batcher, batch_size)
+            # Process batches for each block.
+            for block in blocks:
+                batcher.add(block)
+                while batcher.has_batch():
+                    yield from process_next_batch()
 
+            # Process any last remainder batch.
+            batcher.done_adding()
+            if batcher.has_any():
+                yield from process_next_batch()
+
+            # Yield remainder block from output buffer.
             output_buffer.finalize()
             if output_buffer.has_next():
                 yield output_buffer.next()

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -536,8 +536,9 @@ class Dataset(Generic[T]):
             # Fetch next available input blocks for the batch.
             # Only fetch required number of blocks but not all blocks.
             # This avoids over-buffering in current node's memory.
+            blocks_iter = iter(blocks)
             def _fetch_next_blocks(batcher: Batcher, batch_size: Optional[int]):
-                for block in blocks:
+                for block in blocks_iter:
                     batcher.add(block)
                     if batch_size is None or batcher.buffer_size() >= batch_size:
                         break

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import ray
+from ray.data.block import BlockMetadata
+from ray.data.datasource import Datasource
+from ray.data.datasource.datasource import ReadTask
+
+from ray.tests.conftest import *  # noqa
+
+
+def test_read_large_data(ray_start_cluster):
+    # Test 20G input with single task
+    num_batch = 20
+    ctx = ray.data.context.DatasetContext.get_current()
+    block_splitting_enabled = ctx.block_splitting_enabled
+    ctx.block_splitting_enabled = True
+
+    try:
+        cluster = ray_start_cluster
+        cluster.add_node(num_cpus=1)
+
+        ray.init(cluster.address)
+
+        # Data source generates multiple 1G random bytes data
+        class LargeBytesDatasource(Datasource):
+            def prepare_read(self, parallelism):
+                def _1g_batches_generator():
+                    for _ in range(num_batch):
+                        yield pd.DataFrame({"one": [np.random.bytes(1_000_000_000)]})
+
+                return parallelism * [
+                    ReadTask(
+                        lambda: _1g_batches_generator(),
+                        BlockMetadata(
+                            num_rows=None,
+                            size_bytes=None,
+                            schema=None,
+                            input_files=None,
+                            exec_stats=None,
+                        ),
+                    )
+                ]
+
+        def foo(batch):
+            return pd.DataFrame({"one": [1]})
+
+        ds = ray.data.read_datasource(
+            LargeBytesDatasource(),
+            parallelism=1,
+        )
+
+        ds = ds.map_batches(foo, batch_size=None)
+        assert ds.count() == num_batch
+    finally:
+        ctx.block_splitting_enabled = block_splitting_enabled
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is the fix the issue we found during AIR benchmark. When the map_batches have multiple input blocks (it can happen when dynamic block splitting is enabled by default, or multiple input blocks are coalesced together), previously we always fetch and buffer all input blocks before producing first batch. This is bad especially for dynamic block splitting, because it essentially buffers all split blocks again in memory. So in this PR, change `map_batches` to fetch and buffer input blocks on-demand, i.e. only fetch blocks when needed to construct the next required batch. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x]  I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
