### PR TITLE
[Nighly-test] fix get cpu resource in test_scheduling

### DIFF
--- a/release/benchmarks/distributed/test_scheduling.py
+++ b/release/benchmarks/distributed/test_scheduling.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
 
     ray.init(address="auto")
 
-    total_cpus_per_node = [node["Resources"]["CPU"] for node in ray.nodes()]
+    total_cpus_per_node = [node["Resources"].get("CPU", 0) for node in ray.nodes()]
     num_nodes = len(total_cpus_per_node)
     total_cpus = sum(total_cpus_per_node)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

CPU could be empty on Raylet initialization.

## Related issue number

Closes #29290

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
