### PR TITLE
[Nightly Test] Handle query memory info failure gracefully in large scale dask test

### DIFF
--- a/release/nightly_tests/dask_on_ray/large_scale_test.py
+++ b/release/nightly_tests/dask_on_ray/large_scale_test.py
@@ -275,7 +275,7 @@ class TransformRoutines:
         )
 
         spectrogram = np.abs(spectrogram)
-        spectrogram = 10 * np.log10(spectrogram ** 2)
+        spectrogram = 10 * np.log10(spectrogram**2)
         return spectrogram
 
     @staticmethod
@@ -462,7 +462,10 @@ def main():
     used_gb, usage = ray.get(monitor_actor.get_peak_memory_info.remote())
     print(f"Peak memory usage: {round(used_gb, 2)}GB")
     print(f"Peak memory usage per processes:\n {usage}")
-    print(ray._private.internal_api.memory_summary(stats_only=True))
+    try:
+        print(ray._private.internal_api.memory_summary(stats_only=True))
+    except Exception as e:
+        print(f"Warning: query memory summary failed: {e}")
     with open(os.environ["TEST_OUTPUT_JSON"], "w") as f:
         f.write(
             json.dumps(

--- a/release/nightly_tests/dask_on_ray/large_scale_test.py
+++ b/release/nightly_tests/dask_on_ray/large_scale_test.py
@@ -275,7 +275,7 @@ class TransformRoutines:
         )
 
         spectrogram = np.abs(spectrogram)
-        spectrogram = 10 * np.log10(spectrogram**2)
+        spectrogram = 10 * np.log10(spectrogram ** 2)
         return spectrogram
 
     @staticmethod


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`ray._private.internal_api.memory_summary` has a high chance failure running in [dask related test](https://console.anyscale.com/o/anyscale-internal/projects/prj_FKRmeV5pA6X72aVscFALNC32/clusters/ses_scEfAyHMUNEfyyMtHkqhFfhp?command-history-section=command_history). We shouldn't fail the test since `ray._private.internal_api.memory_summary` is not designed to scale.

## Related issue number

```
Traceback (most recent call last):
  File "dask_on_ray/large_scale_test.py", line 479, in <module>
    main()
  File "dask_on_ray/large_scale_test.py", line 465, in main
    print(ray._private.internal_api.memory_summary(stats_only=True))
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/internal_api.py", line 39, in memory_summary
    return get_store_stats(state)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/internal_api.py", line 77, in get_store_stats
    timeout=60.0,
  File "/home/ray/anaconda3/lib/python3.7/site-packages/grpc/_channel.py", line 946, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/grpc/_channel.py", line 849, in _end_unary_response_blocking
    raise _InactiveRpcError(state)
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.DEADLINE_EXCEEDED
        details = "Deadline Exceeded"
        debug_error_string = "UNKNOWN:Deadline Exceeded {created_time:"2022-10-11T15:47:32.195935064-07:00", grpc_status:4}"
```

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
