### PR TITLE
Benchmarking Ray Data bulk ingest as input file size changes.

### DIFF
--- a/release/air_tests/air_benchmarks/mlperf-train/app_config.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/app_config.yaml
@@ -1,0 +1,14 @@
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_CPU"] | default("anyscale/ray-ml:2.0.1-py37-cpu") }}
+env_vars: {}
+debian_packages:
+  - curl
+
+python:
+  pip_packages:
+    - pytest
+  conda_packages: []
+
+post_build_cmds:
+  - pip3 uninstall ray -y || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 install -U tensorflow
+  - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/air_tests/air_benchmarks/mlperf-train/compute_cpu_16.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/compute_cpu_16.yaml
@@ -1,0 +1,10 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: m5.4xlarge
+
+worker_node_types: []

--- a/release/air_tests/air_benchmarks/mlperf-train/file_size_benchmark.sh
+++ b/release/air_tests/air_benchmarks/mlperf-train/file_size_benchmark.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Test Ray Data bulk ingestion performance as the size of input files change.
+
+set -x
+
+NUM_IMAGES_PER_FILE="32 512 2048"
+MIN_PARALLELISM=10
+NUM_EPOCHS=1
+BATCH_SIZE=64
+SHUFFLE_BUFFER_SIZE=0
+DATA_DIR=/home/ray/data
+
+MAX_IMAGES_PER_FILE=$( \
+    echo $NUM_IMAGES_PER_FILE \
+        | sed 's/ /\n/g' \
+        | python -c "import sys; print(max([int(line) for line in sys.stdin]))")
+NUM_IMAGES_PER_EPOCH=$((MIN_PARALLELISM * MAX_IMAGES_PER_FILE))
+
+SHARD_URL_PREFIX=https://air-example-data.s3.us-west-2.amazonaws.com/air-benchmarks
+
+for num_images_per_file in $NUM_IMAGES_PER_FILE; do
+    num_files=$(python -c "import math; print(math.ceil($NUM_IMAGES_PER_EPOCH/$num_images_per_file))")
+    
+    rm -rf $DATA_DIR
+    mkdir -p $DATA_DIR
+    python make_fake_dataset.py \
+        --num-shards $num_files \
+        --shard-url $SHARD_URL_PREFIX/single-image-repeated-$num_images_per_file-times \
+        --output-directory $DATA_DIR
+    
+    python resnet50_ray_air.py \
+        --num-images-per-input-file $num_images_per_file \
+        --num-epochs $NUM_EPOCHS \
+        --batch-size $BATCH_SIZE \
+        --shuffle-buffer-size $SHUFFLE_BUFFER_SIZE \
+        --num-images-per-epoch $NUM_IMAGES_PER_EPOCH \
+        --train-sleep-time-ms 0 \
+        --data-root $DATA_DIR \
+        --use-ray-data
+    sleep 5
+done

--- a/release/air_tests/air_benchmarks/mlperf-train/file_size_benchmark.sh
+++ b/release/air_tests/air_benchmarks/mlperf-train/file_size_benchmark.sh
@@ -11,7 +11,7 @@ SHUFFLE_BUFFER_SIZE=0
 DATA_DIR=/home/ray/data
 
 MAX_IMAGES_PER_FILE=$( \
-    echo $NUM_IMAGES_PER_FILE \
+    echo "$NUM_IMAGES_PER_FILE" \
         | sed 's/ /\n/g' \
         | python -c "import sys; print(max([int(line) for line in sys.stdin]))")
 NUM_IMAGES_PER_EPOCH=$((MIN_PARALLELISM * MAX_IMAGES_PER_FILE))
@@ -24,12 +24,12 @@ for num_images_per_file in $NUM_IMAGES_PER_FILE; do
     rm -rf $DATA_DIR
     mkdir -p $DATA_DIR
     python make_fake_dataset.py \
-        --num-shards $num_files \
-        --shard-url $SHARD_URL_PREFIX/single-image-repeated-$num_images_per_file-times \
+        --num-shards "$num_files" \
+        --shard-url "$SHARD_URL_PREFIX/single-image-repeated-$num_images_per_file-times" \
         --output-directory $DATA_DIR
     
     python resnet50_ray_air.py \
-        --num-images-per-input-file $num_images_per_file \
+        --num-images-per-input-file "$num_images_per_file" \
         --num-epochs $NUM_EPOCHS \
         --batch-size $BATCH_SIZE \
         --shuffle-buffer-size $SHUFFLE_BUFFER_SIZE \

--- a/release/air_tests/air_benchmarks/mlperf-train/make_fake_dataset.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/make_fake_dataset.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Download or generate a fake dataset for training resnet50 in TensorFlow.
+"""
+
+from typing import Union, Iterable, Tuple, Optional
+import io
+import os
+import requests
+import shutil
+import sys
+import tensorflow.compat.v1 as tf
+
+DEFAULT_IMAGE_URL = "https://air-example-data-2.s3.us-west-2.amazonaws.com/1G-image-data-synthetic-raw/dog.jpg"
+
+def parse_args() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Download or generate a fake dataset for training resnet50 in TensorFlow."
+    )
+    parser.add_argument(
+        "--num-shards",
+        type=int,
+        default=32,
+        help="The number of files to create in the output directory.",
+    )
+    parser.add_argument(
+        "--output-directory",
+        type=str,
+        required=True,
+        help="The directory in which to place the fake dataset files.",
+    )
+
+    parser.add_argument(
+        "--single-image-url",
+        type=str,
+        default=DEFAULT_IMAGE_URL,
+        help="If --shard-url is not provided, use the image found at this URL to generate a fake dataset.",
+    )
+
+    input_data_group = parser.add_mutually_exclusive_group(required=True)
+    input_data_group.add_argument(
+        "--shard-url",
+        type=str,
+        default=None,
+        help="Download this shard and copy it --num-shards times.",
+    )
+    input_data_group.add_argument(
+        "--num-images-per-shard",
+        type=int,
+        help="Copy the image at --single-image-url this many times and store in each tfrecord shard.",
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+def main(
+    num_shards: int,
+    num_images_per_shard: Optional[int],
+    shard_url: Optional[str],
+    image_url: str,
+    output_directory: str,
+) -> None:
+    print(
+        f"Creating a tfrecord dataset with {num_shards} shards, {num_images_per_shard} images per shard, in the output directory {output_directory}"
+    )
+
+    gen_filename = lambda i, total: os.path.join(
+        output_directory, f"single-image-repeated-{i:05d}-of-{total:05d}"
+    )
+
+    filenames = [gen_filename(i, num_shards) for i in range(num_shards)]
+
+    if num_images_per_shard:
+        single_example = create_single_example(image_url).SerializeToString()
+        write_shard(filenames[0], single_example, num_images_per_shard)
+    elif shard_url:
+        download_single_shard(shard_url, filenames[0])
+
+    bcast_single_shard(filenames[0], filenames[1:])
+
+
+def bcast_single_shard(src_filename: str, dst_filenames: Iterable[str]) -> None:
+    print(f"Copying {src_filename} {len(dst_filenames)} times")
+
+    # TODO(swang): Mark the file path with the number of images contained and
+    # don't write again if not needed.
+    for dst in dst_filenames:
+        print(f"Copying {src_filename} to {dst}")
+        shutil.copyfile(src_filename, dst)
+
+
+def download_single_shard(
+    shard_url: str, dst_filename: str, chunk_size_mb: int = 512
+) -> None:
+
+    print(f"Downloading single shard from {shard_url} to {dst_filename}")
+    with requests.get(shard_url, stream=True) as request:
+        assert request.ok, "Downloading shard failed"
+        with open(dst_filename, "wb") as dst:
+            for chunk in request.iter_content(chunk_size=chunk_size_mb * 1 << 20):
+                bytes_written = dst.write(chunk)
+                print(f"Wrote {bytes_written / (1 << 20):0.02f} MB to {dst_filename}")
+
+
+def write_shard(
+    output_filename: str, single_record: str, num_images_per_shard: int
+) -> None:
+    # TODO(swang): Make sure it works in cluster setting. Need to either sync
+    # all data files to worker nodes using VM launcher's file_mounts or run
+    # data script on each node.
+    with tf.python_io.TFRecordWriter(output_filename) as writer:
+        for _ in range(num_images_per_shard):
+            writer.write(single_record)
+    print(f"Done writing {output_filename}", file=sys.stderr)
+
+
+class ImageCoder(object):
+    """Helper class that provides TensorFlow image coding utilities."""
+
+    def __init__(self):
+        tf.disable_v2_behavior()
+
+        # Create a single Session to run all image coding calls.
+        self._sess = tf.Session()
+
+        # Initializes function that converts PNG to JPEG data.
+        self._png_data = tf.placeholder(dtype=tf.string)
+        image = tf.image.decode_png(self._png_data, channels=3)
+        self._png_to_jpeg = tf.image.encode_jpeg(image, format="rgb", quality=100)
+
+        # Initializes function that converts CMYK JPEG data to RGB JPEG data.
+        self._cmyk_data = tf.placeholder(dtype=tf.string)
+        image = tf.image.decode_jpeg(self._cmyk_data, channels=0)
+        self._cmyk_to_rgb = tf.image.encode_jpeg(image, format="rgb", quality=100)
+
+        # Initializes function that decodes RGB JPEG data.
+        self._decode_jpeg_data = tf.placeholder(dtype=tf.string)
+        self._decode_jpeg = tf.image.decode_jpeg(self._decode_jpeg_data, channels=3)
+
+    def png_to_jpeg(self, image_data: bytes) -> tf.Tensor:
+        """Converts a PNG compressed image to a JPEG Tensor."""
+        return self._sess.run(self._png_to_jpeg, feed_dict={self._png_data: image_data})
+
+    def cmyk_to_rgb(self, image_data: bytes) -> tf.Tensor:
+        """Converts a CMYK image to RGB Tensor."""
+        return self._sess.run(
+            self._cmyk_to_rgb, feed_dict={self._cmyk_data: image_data}
+        )
+
+    def decode_jpeg(self, image_data: bytes) -> tf.Tensor:
+        """Decodes a JPEG image."""
+        image = self._sess.run(
+            self._decode_jpeg, feed_dict={self._decode_jpeg_data: image_data}
+        )
+        assert len(image.shape) == 3
+        assert image.shape[2] == 3
+        return image
+
+def get_single_image(image_url: str) -> bytes:
+    r = requests.get(image_url)
+    assert r.ok, "Downloading image failed"
+    return r.content
+
+def parse_single_image(image_url: str) -> Tuple[bytes, int, int]:
+    image_buffer = get_single_image(image_url)
+
+    coder = ImageCoder()
+    image = coder.decode_jpeg(image_buffer)
+    height, width, _ = image.shape
+
+    return image_buffer, height, width
+
+
+def create_single_example(image_url: str) -> tf.train.Example:
+    image_buffer, height, width = parse_single_image(image_url)
+
+    colorspace = "RGB"
+    channels = 3
+    image_format = "JPEG"
+    label = 0
+    synset = "dummy-synset"
+    filename = "dummy-filename"
+
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                "image/height": _int64_feature(height),
+                "image/width": _int64_feature(width),
+                "image/colorspace": _bytes_feature(colorspace),
+                "image/channels": _int64_feature(channels),
+                "image/class/label": _int64_feature(label),
+                "image/class/synset": _bytes_feature(synset),
+                "image/format": _bytes_feature(image_format),
+                "image/filename": _bytes_feature(os.path.basename(filename)),
+                "image/encoded": _bytes_feature(image_buffer),
+            }
+        )
+    )
+
+    return example
+
+
+def _int64_feature(value: Union[int, Iterable[int]]) -> tf.train.Feature:
+    """Inserts int64 features into Example proto."""
+    if not isinstance(value, list):
+        value = [value]
+    return tf.train.Feature(int64_list=tf.train.Int64List(value=value))
+
+
+def _bytes_feature(value: Union[bytes, str]) -> tf.train.Feature:
+    """Inserts bytes features into Example proto."""
+    if isinstance(value, str):
+        value = bytes(value, "utf-8")
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    sys.exit(
+        main(
+            args.num_shards,
+            args.num_images_per_shard,
+            args.shard_url,
+            args.single_image_url,
+            args.output_directory,
+        )
+    )

--- a/release/air_tests/air_benchmarks/mlperf-train/make_fake_dataset.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/make_fake_dataset.py
@@ -10,14 +10,14 @@ import shutil
 import sys
 import tensorflow.compat.v1 as tf
 
-DEFAULT_IMAGE_URL = "https://air-example-data-2.s3.us-west-2.amazonaws.com/1G-image-data-synthetic-raw/dog.jpg"
+DEFAULT_IMAGE_URL = "https://air-example-data-2.s3.us-west-2.amazonaws.com/1G-image-data-synthetic-raw/dog.jpg"  # noqa: E501
 
 
 def parse_args() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Download or generate a fake dataset for training resnet50 in TensorFlow."
+        description="Download or generate a fake dataset for training resnet50 in TensorFlow."  # noqa: E501
     )
     parser.add_argument(
         "--num-shards",
@@ -36,7 +36,7 @@ def parse_args() -> None:
         "--single-image-url",
         type=str,
         default=DEFAULT_IMAGE_URL,
-        help="If --shard-url is not provided, use the image found at this URL to generate a fake dataset.",
+        help="If --shard-url is not provided, use the image found at this URL to generate a fake dataset.",  # noqa: E501
     )
 
     input_data_group = parser.add_mutually_exclusive_group(required=True)
@@ -49,7 +49,7 @@ def parse_args() -> None:
     input_data_group.add_argument(
         "--num-images-per-shard",
         type=int,
-        help="Copy the image at --single-image-url this many times and store in each tfrecord shard.",
+        help="Copy the image at --single-image-url this many times and store in each tfrecord shard.",  # noqa: E501
     )
 
     args = parser.parse_args()
@@ -64,12 +64,13 @@ def main(
     output_directory: str,
 ) -> None:
     print(
-        f"Creating a tfrecord dataset with {num_shards} shards, {num_images_per_shard} images per shard, in the output directory {output_directory}"
+        f"Creating a tfrecord dataset with {num_shards} shards, {num_images_per_shard} images per shard, in the output directory {output_directory}"  # noqa: E501
     )
 
-    gen_filename = lambda i, total: os.path.join(
-        output_directory, f"single-image-repeated-{i:05d}-of-{total:05d}"
-    )
+    def gen_filename(i: int, total: int) -> str:
+        return os.path.join(
+            output_directory, f"single-image-repeated-{i:05d}-of-{total:05d}"
+        )
 
     filenames = [gen_filename(i, num_shards) for i in range(num_shards)]
 

--- a/release/air_tests/air_benchmarks/mlperf-train/make_fake_dataset.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/make_fake_dataset.py
@@ -4,7 +4,6 @@ Download or generate a fake dataset for training resnet50 in TensorFlow.
 """
 
 from typing import Union, Iterable, Tuple, Optional
-import io
 import os
 import requests
 import shutil
@@ -12,6 +11,7 @@ import sys
 import tensorflow.compat.v1 as tf
 
 DEFAULT_IMAGE_URL = "https://air-example-data-2.s3.us-west-2.amazonaws.com/1G-image-data-synthetic-raw/dog.jpg"
+
 
 def parse_args() -> None:
     import argparse
@@ -159,10 +159,12 @@ class ImageCoder(object):
         assert image.shape[2] == 3
         return image
 
+
 def get_single_image(image_url: str) -> bytes:
     r = requests.get(image_url)
     assert r.ok, "Downloading image failed"
     return r.content
+
 
 def parse_single_image(image_url: str) -> Tuple[bytes, int, int]:
     image_buffer = get_single_image(image_url)

--- a/release/air_tests/air_benchmarks/mlperf-train/metric_utils.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/metric_utils.py
@@ -1,0 +1,133 @@
+import threading
+import time
+
+
+def get_ray_spilled_and_restored_mb():
+    import ray._private.internal_api as internal_api
+    import re
+
+    summary_str = internal_api.memory_summary(stats_only=True)
+
+    match = re.search("Spilled (\d+) MiB", summary_str)
+    spilled_mb = int(match.group(1)) if match else 0
+
+    match = re.search("Restored (\d+) MiB", summary_str)
+    restored_mb = int(match.group(1)) if match else 0
+
+    return spilled_mb, restored_mb
+
+
+class MaxMemoryUtilizationTracker:
+    """
+    Class that enables tracking of the maximum memory utilization on a
+    system.
+
+    This creates a thread which samples the available memory every sample_interval_s
+    seconds. The "available" memory is reported directly from psutil.
+    See https://psutil.readthedocs.io/en/latest/#psutil.virtual_memory for more
+    information.
+    """
+
+    def __init__(self, sample_interval_s: float):
+        self._results = {}
+        self._stop_event = threading.Event()
+        self._print_updates = False
+
+        self._thread = threading.Thread(
+            target=self._track_memory_utilization,
+            args=(
+                sample_interval_s,
+                self._print_updates,
+                self._results,
+                self._stop_event,
+            ),
+        )
+
+    @staticmethod
+    def _track_memory_utilization(
+        sample_interval_s: float,
+        print_updates: bool,
+        output_dict: dict,
+        stop_event: threading.Event,
+    ):
+        import psutil
+
+        min_available = float("inf")
+
+        while not stop_event.is_set():
+            memory_stats = psutil.virtual_memory()
+
+            if memory_stats.available < min_available:
+                if print_updates:
+                    print(
+                        f"{min_available / (1 << 30):.02f} -> {memory_stats.available / (1 << 30):.02f}"
+                    )
+                min_available = memory_stats.available
+
+            time.sleep(sample_interval_s)
+
+        output_dict["min_available_bytes"] = min_available
+
+    def start(self) -> None:
+        assert (
+            not self._stop_event.is_set()
+        ), "Can't start a thread that has been stopped."
+        self._thread.start()
+
+    def stop(self) -> int:
+        assert (
+            not self._stop_event.is_set()
+        ), "Can't stop a thread that has been stopped."
+        self._stop_event.set()
+        self._thread.join()
+        return self._results["min_available_bytes"]
+
+
+def determine_if_memory_monitor_is_enabled_in_latest_session():
+    """
+    Grep session_latest raylet logs to see if the memory monitor is enabled.
+    This is really only helpful when you're interested in session_latest, use with care.
+    """
+    import subprocess
+
+    completed_proc = subprocess.run(
+        [
+            "grep",
+            "-q",
+            "MemoryMonitor initialized",
+            "/tmp/ray/session_latest/logs/raylet.out",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert completed_proc.returncode in [
+        0,
+        1,
+    ], f"Unexpected returncode {completed_proc.returncode}"
+    assert not completed_proc.stdout, f"Unexpected stdout {completed_proc.stdout}"
+    assert not completed_proc.stderr, f"Unexpected stderr {completed_proc.stderr}"
+
+    return completed_proc.returncode == 0
+
+
+def test_max_mem_util_tracker():
+    max_mem_tracker = MaxMemoryUtilizationTracker(sample_interval_s=1)
+    max_mem_tracker.start()
+
+    import numpy as np
+
+    time.sleep(4)
+    print("create numpy")
+    large_tensor = np.random.randint(10, size=1 << 30, dtype=np.uint8)
+    large_tensor += 1
+    print("done create numpy")
+    time.sleep(2)
+
+    results = max_mem_tracker.stop()
+    min_available_gb = results["min_available_bytes"] / (1 << 30)
+    print(f"{min_available_gb:.02f}")
+
+
+if __name__ == "__main__":
+    test_max_mem_util_tracker()

--- a/release/air_tests/air_benchmarks/mlperf-train/metric_utils.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/metric_utils.py
@@ -60,7 +60,10 @@ class MaxMemoryUtilizationTracker:
             if memory_stats.available < min_available:
                 if print_updates:
                     print(
-                        f"{min_available / (1 << 30):.02f} -> {memory_stats.available / (1 << 30):.02f}"
+                        "{before:.02f} -> {after:.02f}".format(
+                            before=min_available / (1 << 30),
+                            after=memory_stats.available / (1 << 30),
+                        )
                     )
                 min_available = memory_stats.available
 

--- a/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
@@ -346,7 +346,15 @@ def append_to_test_output_json(path, metrics):
             output_json = json.load(existing_test_output_file)
     except FileNotFoundError:
         pass
+    
+    #start_time = output_json.get("start_time")
 
+    # Set success to be previous_success && current_success.
+    success = output_json.get("success", "1")
+    success = "1" if (success == "1") and (metrics["tput_images_per_s"] != -1) else "0"
+    output_json["success"] = success
+
+    # Append all metrics to an array of runs.
     runs = output_json.get("runs", [])
     runs.append(metrics)
     output_json["runs"] = runs
@@ -354,6 +362,7 @@ def append_to_test_output_json(path, metrics):
     num_images_per_file = metrics["num_images_per_input_file"]
     data_loader = metrics["data_loader"]
 
+    # Append select performance metrics to perf_metrics.
     perf_metrics = output_json.get("perf_metrics", [])
     perf_metrics.append({
         "perf_metric_name": f"{data_loader}_{num_images_per_file}-images-per-file_throughput-img-per-second",
@@ -470,6 +479,7 @@ if __name__ == "__main__":
         result = result.metrics
     except Exception as e:
         exc = e
+
     if exc is not None:
         result["tput_images_per_s"] = -1
         result["time_total_s"] = time.perf_counter() - start_time_s

--- a/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
@@ -1,0 +1,484 @@
+import tensorflow as tf
+import numpy as np
+import os
+import pandas as pd
+import time
+import logging
+import csv
+import json
+
+import ray
+from ray.air import session
+from ray.train.tensorflow import prepare_dataset_shard, TensorflowTrainer
+from ray.air.config import ScalingConfig
+from ray.data.preprocessors import BatchMapper
+
+from tf_utils import (
+    DEFAULT_IMAGE_SIZE,
+    NUM_CHANNELS,
+    preprocess_image,
+    build_tf_dataset,
+)
+
+from metric_utils import (
+    determine_if_memory_monitor_is_enabled_in_latest_session,
+    get_ray_spilled_and_restored_mb,
+    MaxMemoryUtilizationTracker
+)
+
+IMAGE_DIMS = (None, DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE, NUM_CHANNELS)
+
+ONE_HOT = False
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Data loader options.
+# Use tf.data preprocessor provided by MLPerf reference implementation.
+TF_DATA = "tf.data"
+# Use a single empty data batch, repeated.
+SYNTHETIC = "synthetic"
+# Use Ray Datasets.
+RAY_DATA = "ray.data"
+
+
+def build_model():
+    return tf.keras.applications.resnet50.ResNet50(
+        weights=None,
+        # input_tensor=None,
+        # input_shape=None,
+        # pooling=None,
+        # classes=1000,
+    )
+
+
+def print_dataset_stats(ds):
+    print("")
+    print("====Dataset stats====")
+    print(f"num_rows: {ds.count()}")
+    print(f"num_partitions: {ds.num_blocks()}")
+    print(f"size: {ds.size_bytes() // 1e9}GB")
+    print(ds.stats())
+    print("")
+
+def train_loop_for_worker(config):
+    if config["train_sleep_time_ms"] >= 0:
+        model = None
+    else:
+        strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy()
+        with strategy.scope():
+            model = build_model()
+            # model.compile(optimizer="rmsprop", loss="sparse_categorical_crossentropy")
+            model.compile(optimizer="Adam", loss="mean_squared_error", metrics=["mse"])
+
+    dataset_shard = session.get_dataset_shard("train")
+    _tf_dataset = None
+    synthetic_dataset = None
+    if config["data_loader"] == TF_DATA:
+        assert dataset_shard is None
+        logger.info("Building tf.dataset...")
+        filenames = get_tfrecords_filenames(
+                config["data_root"],
+                config["num_images_per_epoch"],
+                config["num_images_per_input_file"])
+        _tf_dataset = build_tf_dataset(
+                filenames,
+                config["batch_size"],
+                config["num_images_per_epoch"],
+                config["num_epochs"],
+                config["online_processing"],
+                shuffle_buffer=config["shuffle_buffer_size"])
+    elif config["data_loader"] == SYNTHETIC:
+        # Build an empty batch and repeat it.
+        synthetic_dataset = build_synthetic_dataset(config["batch_size"])
+
+    def ray_dataset_to_tf_dataset(dataset, batch_size, num_steps_per_epoch, online_processing):
+        if online_processing:
+            # Apply online preprocessing on the decoded images, cropping and
+            # flipping.
+            dataset = dataset.map_batches(crop_and_flip_image_batch)
+
+        def to_tensor_iterator():
+            num_steps = 0
+            # TODO(swang): Should also set a local shuffle buffer size here and
+            # pass the same one to build_tf_dataset to match the tf.data
+            # implementation.
+            for batch in dataset.iter_tf_batches(
+                batch_size=batch_size, dtypes=tf.float32,
+                local_shuffle_buffer_size=config["shuffle_buffer_size"],
+            ):
+                yield batch["image"], batch["label"]
+                num_steps += 1
+            assert num_steps == num_steps_per_epoch, f"expected {num_steps} to equal {num_steps_per_epoch}"
+            print_dataset_stats(dataset)
+
+        output_signature = (
+            tf.TensorSpec(shape=IMAGE_DIMS, dtype=tf.uint8),
+            tf.TensorSpec(shape=(None, ), dtype=tf.int32),
+        )
+        tf_dataset = tf.data.Dataset.from_generator(
+            to_tensor_iterator, output_signature=output_signature
+        )
+        return prepare_dataset_shard(tf_dataset)
+
+    def build_synthetic_tf_dataset(dataset, batch_size, num_steps_per_epoch):
+        batch = list(dataset.iter_tf_batches(
+            batch_size=batch_size, dtypes=tf.float32
+        ))[0]
+        batch = (batch["image"], batch["label"])
+
+        # TODO(swang): Might generate a few more records than expected if
+        # batches don't divide evenly into num_images_per_epoch.
+        def to_tensor_iterator():
+            for _ in range(num_steps_per_epoch):
+                yield batch
+
+        output_signature = (
+            tf.TensorSpec(shape=IMAGE_DIMS, dtype=tf.uint8),
+            tf.TensorSpec(shape=(None, ), dtype=tf.int32),
+        )
+        tf_dataset = tf.data.Dataset.from_generator(
+            to_tensor_iterator, output_signature=output_signature
+        )
+        return prepare_dataset_shard(tf_dataset)
+
+    num_steps_per_epoch = config["num_images_per_epoch"] // config["batch_size"]
+    if config["num_images_per_epoch"] % config["batch_size"]:
+        # Assuming batches will respect epoch boundaries.
+        num_steps_per_epoch += 1
+    for epoch in range(config["num_epochs"]):
+        epoch_start_time_s = time.perf_counter()
+
+        tf_dataset = None
+        if config["data_loader"] == TF_DATA:
+            assert _tf_dataset is not None
+            tf_dataset = _tf_dataset
+        elif config["data_loader"] == RAY_DATA:
+            assert dataset_shard is not None
+            tf_dataset = ray_dataset_to_tf_dataset(
+                    dataset=dataset_shard,
+                    batch_size=config["batch_size"],
+                    num_steps_per_epoch=num_steps_per_epoch,
+                    online_processing=config["online_processing"])
+        elif config["data_loader"] == SYNTHETIC:
+            tf_dataset = build_synthetic_tf_dataset(
+                    synthetic_dataset,
+                    batch_size=config["batch_size"],
+                    num_steps_per_epoch=num_steps_per_epoch)
+
+        if model:
+            model.fit(tf_dataset, steps_per_epoch=num_steps_per_epoch)
+        else:
+            for i, row in enumerate(tf_dataset):
+                if i == num_steps_per_epoch:
+                    break
+                time.sleep(config["train_sleep_time_ms"] / 1000)
+                if i % 10 == 0:
+                    print("Step", i)
+
+        epoch_time_s = time.perf_counter() - epoch_start_time_s
+        logger.info(f"Epoch time: {epoch_time_s}s, images/s: {config['num_images_per_epoch'] / epoch_time_s}")
+
+        # You can also use ray.air.callbacks.keras.Callback
+        # for reporting and checkpointing instead of reporting manually.
+        session.report({
+            # f"epoch_{epoch}_time_s": epoch_time_s,
+            })
+
+
+def crop_and_flip_image_batch(image_batch):
+    image_batch["image"] = [preprocess_image(
+        image_buffer=image_buffer,
+        output_height=DEFAULT_IMAGE_SIZE,
+        output_width=DEFAULT_IMAGE_SIZE,
+        num_channels=NUM_CHANNELS,
+        # TODO(swang): Also load validation set.
+        is_training=True,
+    ).numpy() for image_buffer in image_batch["image"]]
+    return image_batch
+
+
+def decode_tf_record_batch(tf_record_batch):
+    def process_images():
+        for image_buffer in tf_record_batch["image/encoded"]:
+            image_buffer = tf.reshape(image_buffer, shape=[])
+            image_buffer = tf.io.decode_jpeg(image_buffer, channels=NUM_CHANNELS)
+            yield image_buffer
+
+    # Subtract one so that labels are in [0, 1000), and cast to float32 for
+    # Keras model.
+    # TODO(swang): Do we need to support one-hot encoding?
+    labels = (tf_record_batch["image/class/label"] - 1).astype("float32")
+    df = pd.DataFrame.from_dict(
+        {
+            "image": process_images(),
+            "label": labels,
+        }
+    )
+
+    return df
+
+
+def decode_crop_and_flip_tf_record_batch(tf_record_batch):
+    """
+    This version of the preprocessor fuses the load step with the crop and flip
+    step, which should have better performance (at the cost of re-executing the
+    load step on each epoch):
+    - the reference tf.data implementation can use the fused decode_and_crop op
+    - ray.data doesn't have to materialize the intermediate decoded batch.
+    """
+    def process_images():
+        for image_buffer in tf_record_batch["image/encoded"]:
+            yield preprocess_image(
+                image_buffer=image_buffer,
+                output_height=DEFAULT_IMAGE_SIZE,
+                output_width=DEFAULT_IMAGE_SIZE,
+                num_channels=NUM_CHANNELS,
+                # TODO(swang): Also load validation set.
+                is_training=True,
+            ).numpy()
+
+    # Subtract one so that labels are in [0, 1000), and cast to float32 for
+    # Keras model.
+    # TODO(swang): Do we need to support one-hot encoding?
+    labels = (tf_record_batch["image/class/label"] - 1).astype("float32")
+    df = pd.DataFrame.from_dict(
+        {
+            "image": process_images(),
+            "label": labels,
+        }
+    )
+
+    return df
+
+
+def build_synthetic_dataset(batch_size):
+    image_dims = IMAGE_DIMS[1:]
+    empty = np.empty(image_dims, dtype=np.uint8)
+    ds = ray.data.from_items(
+        [
+            {
+                "image": empty,
+                "label": 1,
+            }
+            for _ in range(int(batch_size))
+        ], parallelism=1
+    )
+    return ds
+
+
+def get_tfrecords_filenames(data_root, num_images_per_epoch, num_images_per_input_file):
+    num_files = num_images_per_epoch // num_images_per_input_file
+    if num_images_per_epoch % num_images_per_input_file:
+        num_files += 1
+    filenames = [
+        os.path.join(data_root, filename)
+        for filename in os.listdir(data_root)
+    ][:num_files]
+    assert len(filenames) == num_files, (f"Need {num_files} input files, only found {len(filenames)}")
+    return filenames
+
+def build_dataset(data_root, num_images_per_epoch, num_images_per_input_file):
+    filenames = get_tfrecords_filenames(data_root, num_images_per_epoch, num_images_per_input_file)
+    ds = ray.data.read_tfrecords(filenames)
+    # TODO(swang): If we are reading the actual dataset and we only want to read
+    # a fraction of images, then we should actually call .limit(), but right now
+    # this materializes all data to the object store. For now, we can just skip
+    # the call since we're generating all the data files to have the right
+    # number of images anyway.
+    # See https://github.com/ray-project/ray/issues/29122.
+    # ds = ray.data.read_tfrecords(filenames).limit(num_images_per_epoch)
+    return ds
+
+
+FIELDS = [
+        "data_loader",
+        "train_sleep_time_ms",
+        "num_epochs",
+        "num_images_per_epoch",
+        "num_images_per_input_file",
+        "batch_size",
+        "shuffle_buffer_size",
+        "ray_mem_monitor_enabled",
+        "ray_spilled_mb",
+        "ray_restored_mb",
+        "min_available_mb",
+        "time_total_s",
+        "tput_images_per_s",
+    ]
+
+def write_metrics(data_loader, command_args, metrics, output_file):
+    row = {key: val for key, val in metrics.items() if key in FIELDS}
+    row["data_loader"] = data_loader
+    for field in FIELDS:
+        val = getattr(command_args, field, None)
+        if val is not None:
+            row[field] = val
+
+    if "tput_images_per_s" in metrics:
+        row["tput_images_per_s"] = metrics["tput_images_per_s"]
+    else:
+        row["tput_images_per_s"] = args.num_images_per_epoch * args.num_epochs / metrics["time_total_s"]
+
+    for field in FIELDS:
+        print(f"{field}: {row[field]}")
+
+    write_header = not os.path.exists(output_file)
+    with open(output_file, 'a+', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=FIELDS)
+        if write_header:
+            writer.writeheader()
+        writer.writerow(row)
+
+    test_output_json_envvar = "TEST_OUTPUT_JSON"
+    test_output_json_path = os.environ.get(test_output_json_envvar)
+    if not test_output_json_path:
+        print(f"Environment variable {test_output_json_envvar} not set, will not write test output json.")
+    else:
+        print(f"Environment variable {test_output_json_envvar} set to '{test_output_json_path}'. Will write test output json.")
+        append_to_test_output_json(test_output_json_path, row)
+
+def append_to_test_output_json(path, metrics):
+    
+    output_json = {}
+    try:
+        with open(path, 'r') as existing_test_output_file:
+            output_json = json.load(existing_test_output_file)
+    except FileNotFoundError:
+        pass
+
+    runs = output_json.get("runs", [])
+    runs.append(metrics)
+    output_json["runs"] = runs
+    
+    num_images_per_file = metrics["num_images_per_input_file"]
+    data_loader = metrics["data_loader"]
+
+    perf_metrics = output_json.get("perf_metrics", [])
+    perf_metrics.append({
+        "perf_metric_name": f"{data_loader}_{num_images_per_file}-images-per-file_throughput-img-per-second",
+        "perf_metric_value": metrics["tput_images_per_s"],
+        "perf_metric_type": "THROUGHPUT",
+    })
+    output_json["perf_metrics"] = perf_metrics
+    
+    with open(path, 'w') as test_output_file:
+        json.dump(output_json, test_output_file)
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    
+    parser.add_argument(
+        "--data-root",
+        default=None,
+        type=str,
+        help='Directory path with TFRecords. Filenames should start with "train".',
+    )
+
+    data_ingest_group = parser.add_mutually_exclusive_group(required=True)
+    data_ingest_group.add_argument("--use-tf-data", action="store_true")
+    data_ingest_group.add_argument("--use-ray-data", action="store_true")
+    data_ingest_group.add_argument('--synthetic-data', action='store_true')
+
+    parser.add_argument(
+        "--num-images-per-input-file",
+        default=98,
+        type=int,
+        help=(
+            "Estimated number of images per input TFRecord file. "
+            "Used to determine how many files to load."
+            "If you receive an error about too few rows, lower this value."
+        ),
+    )
+    parser.add_argument("--num-images-per-epoch", default=100, type=int)
+    parser.add_argument("--num-epochs", default=2, type=int)
+    parser.add_argument("--batch-size", default=1, type=int)
+    parser.add_argument(
+        "--train-sleep-time-ms",
+        default=-1,
+        type=int,
+        help="If set to >= 0, use an empty trainer that sleeps this many ms per batch.",
+    )
+    parser.add_argument(
+        "--shuffle-buffer-size",
+        default=0,
+        type=int,
+        help=(
+            "Size of each Train worker's local shuffle buffer. "
+            "Default value taken from MLPerf reference implementation."
+        ),
+    )
+    parser.add_argument("--output-file", default="out.csv", type=str)
+    parser.add_argument("--use-gpu", action="store_true")
+    parser.add_argument("--online-processing", action="store_true")
+    args = parser.parse_args()
+
+    if args.use_tf_data or args.use_ray_data:
+        assert args.data_root is not None, "Both --use-tf-data and --use-ray-data require a --data-root directory for TFRecord files"
+    elif args.synthetic_data:
+        assert args.data_root is None, "--synthetic-data doesn't use --data-root"
+
+    memory_utilization_tracker = MaxMemoryUtilizationTracker(sample_interval_s=1)
+    memory_utilization_tracker.start()
+
+    datasets = {}
+    train_loop_config = {
+            "num_epochs": args.num_epochs,
+            "batch_size": args.batch_size,
+            "train_sleep_time_ms": args.train_sleep_time_ms,
+            "data_root": args.data_root,
+            "num_images_per_epoch": args.num_images_per_epoch,
+            "num_images_per_input_file": args.num_images_per_input_file,
+            "shuffle_buffer_size": None if args.shuffle_buffer_size == 0 else args.shuffle_buffer_size,
+            "online_processing": args.online_processing,
+            }
+    if args.synthetic_data:
+        logger.info("Using synthetic data loader...")
+        preprocessor = None
+        train_loop_config["data_loader"] = SYNTHETIC
+    else:
+        if args.use_tf_data:
+            logger.info("Using tf.data loader")
+            preprocessor = None
+            train_loop_config["data_loader"] = TF_DATA
+        else:
+            logger.info("Using Ray Datasets loader")
+            datasets["train"] = build_dataset(
+                args.data_root, args.num_images_per_epoch, args.num_images_per_input_file
+            )
+            if args.online_processing:
+                preprocessor = BatchMapper(decode_tf_record_batch)
+            else:
+                preprocessor = BatchMapper(decode_crop_and_flip_tf_record_batch)
+            train_loop_config["data_loader"] = RAY_DATA
+
+    trainer = TensorflowTrainer(
+        train_loop_for_worker,
+        scaling_config=ScalingConfig(num_workers=1, use_gpu=args.use_gpu),
+        datasets=datasets,
+        preprocessor=preprocessor,
+        train_loop_config=train_loop_config,
+    )
+    result = {}
+    exc = None
+    start_time_s = time.perf_counter()
+    ray_spill_stats_start = get_ray_spilled_and_restored_mb()
+    try:
+        result = trainer.fit()
+        result = result.metrics
+    except Exception as e:
+        exc = e
+    if exc is not None:
+        result["tput_images_per_s"] = -1
+        result["time_total_s"] = time.perf_counter() - start_time_s
+
+    result['ray_spilled_mb'], result['ray_restored_mb'] = tuple(end - start for start, end in zip(ray_spill_stats_start, get_ray_spilled_and_restored_mb()))
+    result['min_available_mb'] = memory_utilization_tracker.stop() / (1 << 20)
+    result['ray_mem_monitor_enabled'] = determine_if_memory_monitor_is_enabled_in_latest_session()
+
+    write_metrics(train_loop_config["data_loader"], args, result, args.output_file)
+
+    if exc is not None:
+        raise exc

--- a/release/air_tests/air_benchmarks/mlperf-train/tf_utils.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/tf_utils.py
@@ -5,6 +5,7 @@ https://github.com/mlcommons/training/blob/master/image_classification/tensorflo
 """
 import tensorflow as tf
 import functools
+import logging
 
 DEFAULT_IMAGE_SIZE = 224
 NUM_CHANNELS = 3
@@ -38,25 +39,25 @@ def process_record_dataset(
 ):
     """Given a Dataset with raw records, return an iterator over the records.
 
-  Args:
-    dataset: A Dataset representing raw records
-    is_training: A boolean denoting whether the input is for training.
-    batch_size: The number of samples per batch.
-    shuffle_buffer: The buffer size to use when shuffling records. A larger
-      value results in better randomness, but smaller values reduce startup
-      time and use less memory.
-    dtype: Data type to use for images/features.
-    datasets_num_private_threads: Number of threads for a private
-      threadpool created for all datasets computation.
-    drop_remainder: A boolean indicates whether to drop the remainder of the
-      batches. If True, the batch dimension will be static.
-    tf_data_experimental_slack: Whether to enable tf.data's
-      `experimental_slack` option.
-    prefetch_batchs: The number of batchs to prefetch.
+    Args:
+      dataset: A Dataset representing raw records
+      is_training: A boolean denoting whether the input is for training.
+      batch_size: The number of samples per batch.
+      shuffle_buffer: The buffer size to use when shuffling records. A larger
+        value results in better randomness, but smaller values reduce startup
+        time and use less memory.
+      dtype: Data type to use for images/features.
+      datasets_num_private_threads: Number of threads for a private
+        threadpool created for all datasets computation.
+      drop_remainder: A boolean indicates whether to drop the remainder of the
+        batches. If True, the batch dimension will be static.
+      tf_data_experimental_slack: Whether to enable tf.data's
+        `experimental_slack` option.
+      prefetch_batchs: The number of batchs to prefetch.
 
-  Returns:
-    Dataset of (image, label) pairs ready for iteration.
-  """
+    Returns:
+      Dataset of (image, label) pairs ready for iteration.
+    """
     # Defines a specific size thread pool for tf.data operations.
     if datasets_num_private_threads:
         options = tf.data.Options()
@@ -112,37 +113,37 @@ def process_record_dataset(
 def _parse_example_proto(example_serialized):
     """Parses an Example proto containing a training example of an image.
 
-  The output of the build_image_data.py image preprocessing script is a dataset
-  containing serialized Example protocol buffers. Each Example proto contains
-  the following fields (values are included as examples):
+    The output of the build_image_data.py image preprocessing script is a dataset
+    containing serialized Example protocol buffers. Each Example proto contains
+    the following fields (values are included as examples):
 
-    image/height: 462
-    image/width: 581
-    image/colorspace: 'RGB'
-    image/channels: 3
-    image/class/label: 615
-    image/class/synset: 'n03623198'
-    image/class/text: 'knee pad'
-    image/object/bbox/xmin: 0.1
-    image/object/bbox/xmax: 0.9
-    image/object/bbox/ymin: 0.2
-    image/object/bbox/ymax: 0.6
-    image/object/bbox/label: 615
-    image/format: 'JPEG'
-    image/filename: 'ILSVRC2012_val_00041207.JPEG'
-    image/encoded: <JPEG encoded string>
+      image/height: 462
+      image/width: 581
+      image/colorspace: 'RGB'
+      image/channels: 3
+      image/class/label: 615
+      image/class/synset: 'n03623198'
+      image/class/text: 'knee pad'
+      image/object/bbox/xmin: 0.1
+      image/object/bbox/xmax: 0.9
+      image/object/bbox/ymin: 0.2
+      image/object/bbox/ymax: 0.6
+      image/object/bbox/label: 615
+      image/format: 'JPEG'
+      image/filename: 'ILSVRC2012_val_00041207.JPEG'
+      image/encoded: <JPEG encoded string>
 
-  Args:
-    example_serialized: scalar Tensor tf.string containing a serialized
-      Example protocol buffer.
+    Args:
+      example_serialized: scalar Tensor tf.string containing a serialized
+        Example protocol buffer.
 
-  Returns:
-    image_buffer: Tensor tf.string containing the contents of a JPEG file.
-    label: Tensor tf.int32 containing the label.
-    bbox: 3-D float Tensor of bounding boxes arranged [1, num_boxes, coords]
-      where each coordinate is [0, 1) and the coordinates are arranged as
-      [ymin, xmin, ymax, xmax].
-  """
+    Returns:
+      image_buffer: Tensor tf.string containing the contents of a JPEG file.
+      label: Tensor tf.int32 containing the label.
+      bbox: 3-D float Tensor of bounding boxes arranged [1, num_boxes, coords]
+        where each coordinate is [0, 1) and the coordinates are arranged as
+        [ymin, xmin, ymax, xmax].
+    """
     # Dense features in Example proto.
     feature_map = {
         "image/encoded": tf.io.FixedLenFeature([], dtype=tf.string, default_value=""),
@@ -255,27 +256,27 @@ def build_tf_dataset(
 ):
     """Input function which provides batches for train or eval.
 
-  Args:
-    is_training: A boolean denoting whether the input is for training.
-    data_dir: The directory containing the input data.
-    batch_size: The number of samples per batch.
-    dtype: Data type to use for images/features
-    datasets_num_private_threads: Number of private threads for tf.data.
-    input_context: A `tf.distribute.InputContext` object passed in by
-      `tf.distribute.Strategy`.
-    drop_remainder: A boolean indicates whether to drop the remainder of the
-      batches. If True, the batch dimension will be static.
-    tf_data_experimental_slack: Whether to enable tf.data's
-      `experimental_slack` option.
-    dataset_cache: Whether to cache the dataset on workers.
-       Typically used to improve training performance when training data is in
-       remote storage and can fit into worker memory.
-    filenames: Optional field for providing the file names of the TFRecords.
-    prefetch_batchs: The number of batchs to prefetch.
+    Args:
+      is_training: A boolean denoting whether the input is for training.
+      data_dir: The directory containing the input data.
+      batch_size: The number of samples per batch.
+      dtype: Data type to use for images/features
+      datasets_num_private_threads: Number of private threads for tf.data.
+      input_context: A `tf.distribute.InputContext` object passed in by
+        `tf.distribute.Strategy`.
+      drop_remainder: A boolean indicates whether to drop the remainder of the
+        batches. If True, the batch dimension will be static.
+      tf_data_experimental_slack: Whether to enable tf.data's
+        `experimental_slack` option.
+      dataset_cache: Whether to cache the dataset on workers.
+         Typically used to improve training performance when training data is in
+         remote storage and can fit into worker memory.
+      filenames: Optional field for providing the file names of the TFRecords.
+      prefetch_batchs: The number of batchs to prefetch.
 
-  Returns:
-    A dataset that can be used for iteration.
-  """
+    Returns:
+      A dataset that can be used for iteration.
+    """
     dataset = tf.data.Dataset.from_tensor_slices(filenames)
 
     if input_context:

--- a/release/air_tests/air_benchmarks/mlperf-train/tf_utils.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/tf_utils.py
@@ -1,0 +1,568 @@
+"""
+Utils for converting a TFRecord -> decoded image buffer for training pipeline.
+Adapted from MLPerf reference implementation.
+https://github.com/mlcommons/training/blob/master/image_classification/tensorflow2/imagenet_preprocessing.py
+"""
+import tensorflow as tf
+import functools
+
+DEFAULT_IMAGE_SIZE = 224
+NUM_CHANNELS = 3
+
+_R_MEAN = 123.68
+_G_MEAN = 116.78
+_B_MEAN = 103.94
+CHANNEL_MEANS = [_R_MEAN, _G_MEAN, _B_MEAN]
+
+# The lower bound for the smallest side of the image for aspect-preserving
+# resizing. For example, if an image is 500 x 1000, it will be resized to
+# _RESIZE_MIN x (_RESIZE_MIN * 2).
+_RESIZE_MIN = 256
+
+# TODO(swang): Set num_classes from main script?
+NUM_CLASSES = 1000
+
+def process_record_dataset(dataset,
+                           is_training,
+                           batch_size,
+                           num_epochs,
+                           online_processing,
+                           shuffle_buffer=None,
+                           dtype=tf.float32,
+                           datasets_num_private_threads=None,
+                           drop_remainder=False,
+                           tf_data_experimental_slack=False,
+                           prefetch_batchs=tf.data.experimental.AUTOTUNE):
+  """Given a Dataset with raw records, return an iterator over the records.
+
+  Args:
+    dataset: A Dataset representing raw records
+    is_training: A boolean denoting whether the input is for training.
+    batch_size: The number of samples per batch.
+    shuffle_buffer: The buffer size to use when shuffling records. A larger
+      value results in better randomness, but smaller values reduce startup
+      time and use less memory.
+    dtype: Data type to use for images/features.
+    datasets_num_private_threads: Number of threads for a private
+      threadpool created for all datasets computation.
+    drop_remainder: A boolean indicates whether to drop the remainder of the
+      batches. If True, the batch dimension will be static.
+    tf_data_experimental_slack: Whether to enable tf.data's
+      `experimental_slack` option.
+    prefetch_batchs: The number of batchs to prefetch.
+
+  Returns:
+    Dataset of (image, label) pairs ready for iteration.
+  """
+  # Defines a specific size thread pool for tf.data operations.
+  if datasets_num_private_threads:
+    options = tf.data.Options()
+    options.experimental_threading.private_threadpool_size = (
+        datasets_num_private_threads)
+    dataset = dataset.with_options(options)
+    logging.info(
+        'datasets_num_private_threads: %s', datasets_num_private_threads)
+
+  if is_training:
+    # Shuffles records before repeating to respect epoch boundaries.
+    if shuffle_buffer is not None:
+        dataset = dataset.shuffle(buffer_size=shuffle_buffer)
+    # Repeats the dataset for the number of epochs to train.
+    dataset = dataset.repeat(num_epochs)
+
+  one_hot = False
+  # TODO(swang): Support one-hot encoding?
+  #num_classes = FLAGS.num_classes
+  #if FLAGS.label_smoothing and FLAGS.label_smoothing > 0:
+  #  one_hot = True
+
+  num_classes = NUM_CLASSES
+
+  if online_processing:
+    map_fn = functools.partial(
+        preprocess_parsed_example,
+        is_training=is_training,
+        dtype=dtype,
+        num_classes=num_classes,
+        one_hot=one_hot)
+
+    # Parses the raw records into images and labels.
+    dataset = dataset.map(
+        map_fn,
+        num_parallel_calls=tf.data.experimental.AUTOTUNE)
+  dataset = dataset.batch(batch_size, drop_remainder=drop_remainder)
+
+  # Operations between the final prefetch and the get_next call to the iterator
+  # will happen synchronously during run time. We prefetch here again to
+  # background all of the above processing work and keep it out of the
+  # critical training path. Setting buffer_size to tf.data.experimental.AUTOTUNE
+  # allows DistributionStrategies to adjust how many batches to fetch based
+  # on how many devices are present.
+  dataset = dataset.prefetch(buffer_size=prefetch_batchs)
+
+  options = tf.data.Options()
+  options.experimental_slack = tf_data_experimental_slack
+  dataset = dataset.with_options(options)
+
+  return dataset
+
+
+def _parse_example_proto(example_serialized):
+  """Parses an Example proto containing a training example of an image.
+
+  The output of the build_image_data.py image preprocessing script is a dataset
+  containing serialized Example protocol buffers. Each Example proto contains
+  the following fields (values are included as examples):
+
+    image/height: 462
+    image/width: 581
+    image/colorspace: 'RGB'
+    image/channels: 3
+    image/class/label: 615
+    image/class/synset: 'n03623198'
+    image/class/text: 'knee pad'
+    image/object/bbox/xmin: 0.1
+    image/object/bbox/xmax: 0.9
+    image/object/bbox/ymin: 0.2
+    image/object/bbox/ymax: 0.6
+    image/object/bbox/label: 615
+    image/format: 'JPEG'
+    image/filename: 'ILSVRC2012_val_00041207.JPEG'
+    image/encoded: <JPEG encoded string>
+
+  Args:
+    example_serialized: scalar Tensor tf.string containing a serialized
+      Example protocol buffer.
+
+  Returns:
+    image_buffer: Tensor tf.string containing the contents of a JPEG file.
+    label: Tensor tf.int32 containing the label.
+    bbox: 3-D float Tensor of bounding boxes arranged [1, num_boxes, coords]
+      where each coordinate is [0, 1) and the coordinates are arranged as
+      [ymin, xmin, ymax, xmax].
+  """
+  # Dense features in Example proto.
+  feature_map = {
+      'image/encoded': tf.io.FixedLenFeature([], dtype=tf.string,
+                                          default_value=''),
+      'image/class/label': tf.io.FixedLenFeature([], dtype=tf.int64,
+                                              default_value=-1),
+      'image/class/text': tf.io.FixedLenFeature([], dtype=tf.string,
+                                             default_value=''),
+  }
+  # NOTE(swang): bbox from dataset is not actually used by the reference
+  # implementation.
+  # https://github.com/mlcommons/training/pull/170
+  # sparse_float32 = tf.VarLenFeature(dtype=tf.float32)
+  # # Sparse features in Example proto.
+  # feature_map.update(
+  #     {k: sparse_float32 for k in ['image/object/bbox/xmin',
+  #                                  'image/object/bbox/ymin',
+  #                                  'image/object/bbox/xmax',
+  #                                  'image/object/bbox/ymax']})
+
+  features = tf.io.parse_single_example(example_serialized, feature_map)
+  label = tf.cast(features['image/class/label'], dtype=tf.int32)
+
+  return features['image/encoded'], label
+
+
+def parse_example_proto_and_decode(example_serialized):
+  """Parses an example and decodes the image to prepare for caching."""
+  image_buffer, label = _parse_example_proto(example_serialized)
+  image_buffer = tf.reshape(image_buffer, shape=[])
+  image_buffer = tf.io.decode_jpeg(image_buffer, channels=NUM_CHANNELS)
+  return image_buffer, label
+
+
+def preprocess_parsed_example(
+    image_buffer, label, is_training, dtype, num_classes, one_hot=False):
+  """Applies preprocessing steps to the input parsed example."""
+  image = preprocess_image(
+      image_buffer=image_buffer,
+      output_height=DEFAULT_IMAGE_SIZE,
+      output_width=DEFAULT_IMAGE_SIZE,
+      num_channels=NUM_CHANNELS,
+      is_training=is_training)
+  image = tf.cast(image, dtype)
+
+  # Subtract one so that labels are in [0, 1000), and cast to float32 for
+  # Keras model.
+  label = tf.reshape(label, shape=[1])
+  label = tf.cast(label, tf.int32)
+  label -= 1
+
+  if one_hot:
+    label = tf.one_hot(label, num_classes)
+    label = tf.reshape(label, [num_classes])
+  else:
+    label = tf.cast(label, tf.float32)
+
+  return image, label
+
+
+def preprocess_example(
+    example_serialized, is_training, dtype, num_classes, one_hot=False):
+  """Applies preprocessing steps to the input parsed example."""
+  image, label = parse_example_proto_and_decode(example_serialized)
+  image = preprocess_image(
+      image_buffer=image,
+      output_height=DEFAULT_IMAGE_SIZE,
+      output_width=DEFAULT_IMAGE_SIZE,
+      num_channels=NUM_CHANNELS,
+      is_training=is_training)
+  image = tf.cast(image, dtype)
+
+  # Subtract one so that labels are in [0, 1000), and cast to float32 for
+  # Keras model.
+  label = tf.reshape(label, shape=[1])
+  label = tf.cast(label, tf.int32)
+  label -= 1
+
+  if one_hot:
+    label = tf.one_hot(label, num_classes)
+    label = tf.reshape(label, [num_classes])
+  else:
+    label = tf.cast(label, tf.float32)
+
+  return image, label
+
+
+def build_tf_dataset(
+             filenames,
+             batch_size,
+             num_images_per_epoch,
+             num_epochs,
+             online_processing,
+             shuffle_buffer=None,
+             is_training=True,
+             dtype=tf.float32,
+             datasets_num_private_threads=None,
+             input_context=None,
+             drop_remainder=False,
+             tf_data_experimental_slack=False,
+             # NOTE(swang): MLPerf sets this to False by default, but we should
+             # cache decoded images for parity with AIR bulk ingest.
+             dataset_cache=True,
+             prefetch_batchs=tf.data.experimental.AUTOTUNE):
+  """Input function which provides batches for train or eval.
+
+  Args:
+    is_training: A boolean denoting whether the input is for training.
+    data_dir: The directory containing the input data.
+    batch_size: The number of samples per batch.
+    dtype: Data type to use for images/features
+    datasets_num_private_threads: Number of private threads for tf.data.
+    input_context: A `tf.distribute.InputContext` object passed in by
+      `tf.distribute.Strategy`.
+    drop_remainder: A boolean indicates whether to drop the remainder of the
+      batches. If True, the batch dimension will be static.
+    tf_data_experimental_slack: Whether to enable tf.data's
+      `experimental_slack` option.
+    dataset_cache: Whether to cache the dataset on workers.
+       Typically used to improve training performance when training data is in
+       remote storage and can fit into worker memory.
+    filenames: Optional field for providing the file names of the TFRecords.
+    prefetch_batchs: The number of batchs to prefetch.
+
+  Returns:
+    A dataset that can be used for iteration.
+  """
+  dataset = tf.data.Dataset.from_tensor_slices(filenames)
+
+  if input_context:
+    # TODO(swang): Shard and set shard index based on TF session.
+    logging.info(
+        'Sharding the dataset: input_pipeline_id=%d num_input_pipelines=%d',
+        input_context.input_pipeline_id, input_context.num_input_pipelines)
+    dataset = dataset.shard(input_context.num_input_pipelines,
+                            input_context.input_pipeline_id)
+
+  if is_training:
+    # Shuffle the input files
+    dataset = dataset.shuffle(buffer_size=len(filenames))
+
+  # Convert to individual records.
+  # cycle_length = 10 means that up to 10 files will be read and deserialized in
+  # parallel. You may want to increase this number if you have a large number of
+  # CPU cores.
+  dataset = dataset.interleave(
+      tf.data.TFRecordDataset,
+      cycle_length=10,
+      num_parallel_calls=tf.data.experimental.AUTOTUNE)
+
+  if is_training:
+    if online_processing:
+        dataset = dataset.map(
+            parse_example_proto_and_decode,
+            num_parallel_calls=tf.data.experimental.AUTOTUNE)
+    else:
+        # We're just applying random transforms a single time and loading these
+        # all into memory. NOTE(swang): this doesn't follow the reference
+        # implementation and should only be used for debugging purposes.
+        map_fn = functools.partial(
+            preprocess_example,
+            is_training=is_training,
+            dtype=dtype,
+            num_classes=NUM_CLASSES)
+
+        dataset = dataset.map(
+            map_fn,
+            num_parallel_calls=tf.data.experimental.AUTOTUNE)
+  dataset = dataset.take(num_images_per_epoch)
+  if dataset_cache:
+    # Improve training / eval performance when data is in remote storage and
+    # can fit into worker memory.
+    dataset = dataset.cache()
+
+  return process_record_dataset(
+      dataset=dataset,
+      is_training=is_training,
+      batch_size=batch_size,
+      num_epochs=num_epochs,
+      online_processing=online_processing,
+      shuffle_buffer=shuffle_buffer,
+      dtype=dtype,
+      datasets_num_private_threads=datasets_num_private_threads,
+      drop_remainder=drop_remainder,
+      tf_data_experimental_slack=tf_data_experimental_slack,
+      prefetch_batchs=prefetch_batchs,
+  )
+
+
+def _decode_crop_and_flip(image_buffer, num_channels):
+    """Crops the given image to a random part of the image, and randomly flips.
+
+    We use the fused decode_and_crop op, which performs better than the two ops
+    used separately in series, but note that this requires that the image be
+    passed in as an un-decoded string Tensor.
+
+    Args:
+        image_buffer: scalar string Tensor representing the raw JPEG image buffer.
+        bbox: 3-D float Tensor of bounding boxes arranged [1, num_boxes, coords]
+            where each coordinate is [0, 1) and the coordinates are arranged as
+            [ymin, xmin, ymax, xmax].
+        num_channels: Integer depth of the image buffer for decoding.
+
+    Returns:
+        3-D tensor with cropped image.
+
+    """
+    # A large fraction of image datasets contain a human-annotated bounding box
+    # delineating the region of the image containing the object of interest.    We
+    # choose to create a new bounding box for the object which is a randomly
+    # distorted version of the human-annotated bounding box that obeys an
+    # allowed range of aspect ratios, sizes and overlap with the human-annotated
+    # bounding box. If no box is supplied, then we assume the bounding box is
+    # the entire image.
+    decoded = not isinstance(image_buffer, bytes)
+    shape = (
+        tf.shape(image_buffer)
+        if decoded
+        else tf.image.extract_jpeg_shape(image_buffer)
+    )
+    bbox = tf.constant([0.0, 0.0, 1.0, 1.0],
+                       dtype=tf.float32, shape=[1, 1, 4])   #From the entire image
+    sample_distorted_bounding_box = tf.image.sample_distorted_bounding_box(
+        shape,
+        bounding_boxes=bbox,
+        min_object_covered=0.1,
+        aspect_ratio_range=[0.75, 1.33],
+        area_range=[0.05, 1.0],
+        max_attempts=100,
+        use_image_if_no_bounding_boxes=True,
+    )
+    bbox_begin, bbox_size, _ = sample_distorted_bounding_box
+
+    # Reassemble the bounding box in the format the crop op requires.
+    offset_y, offset_x, _ = tf.unstack(bbox_begin)
+    target_height, target_width, _ = tf.unstack(bbox_size)
+    crop_window = tf.stack([offset_y, offset_x, target_height, target_width])
+
+    if decoded:
+        image_buffer = tf.image.crop_to_bounding_box(
+            image_buffer,
+            offset_height=offset_y,
+            offset_width=offset_x,
+            target_height=target_height,
+            target_width=target_width,
+        )
+    else:
+        # Use the fused decode and crop op here, which is faster than sequential.
+        image_buffer = tf.image.decode_and_crop_jpeg(
+            image_buffer, crop_window, channels=num_channels
+        )
+    # Flip to add a little more random distortion in.
+    image_buffer = tf.image.random_flip_left_right(image_buffer)
+    return image_buffer
+
+
+def _central_crop(image, crop_height, crop_width):
+    """Performs central crops of the given image list.
+
+    Args:
+        image: a 3-D image tensor
+        crop_height: the height of the image following the crop.
+        crop_width: the width of the image following the crop.
+
+    Returns:
+        3-D tensor with cropped image.
+    """
+    shape = tf.shape(input=image)
+    height, width = shape[0], shape[1]
+
+    amount_to_be_cropped_h = height - crop_height
+    crop_top = amount_to_be_cropped_h // 2
+    amount_to_be_cropped_w = width - crop_width
+    crop_left = amount_to_be_cropped_w // 2
+    return tf.slice(image, [crop_top, crop_left, 0], [crop_height, crop_width, -1])
+
+
+def _mean_image_subtraction(image, means, num_channels):
+    """Subtracts the given means from each image channel.
+
+    For example:
+        means = [123.68, 116.779, 103.939]
+        image = _mean_image_subtraction(image, means)
+
+    Note that the rank of `image` must be known.
+
+    Args:
+        image: a tensor of size [height, width, C].
+        means: a C-vector of values to subtract from each channel.
+        num_channels: number of color channels in the image that will be distorted.
+
+    Returns:
+        the centered image.
+
+    Raises:
+        ValueError: If the rank of `image` is unknown, if `image` has a rank other
+            than three or if the number of channels in `image` doesn't match the
+            number of values in `means`.
+    """
+    if image.get_shape().ndims != 3:
+        raise ValueError("Input must be of size [height, width, C>0]")
+
+    if len(means) != num_channels:
+        raise ValueError("len(means) must match the number of channels")
+
+    # We have a 1-D tensor of means; convert to 3-D.
+    # Note(b/130245863): we explicitly call `broadcast` instead of simply
+    # expanding dimensions for better performance.
+    means = tf.broadcast_to(means, tf.shape(image))
+
+    return image - means
+
+
+def _smallest_size_at_least(height, width, resize_min):
+    """Computes new shape with the smallest side equal to `smallest_side`.
+
+    Computes new shape with the smallest side equal to `smallest_side` while
+    preserving the original aspect ratio.
+
+    Args:
+        height: an int32 scalar tensor indicating the current height.
+        width: an int32 scalar tensor indicating the current width.
+        resize_min: A python integer or scalar `Tensor` indicating the size of
+            the smallest side after resize.
+
+    Returns:
+        new_height: an int32 scalar tensor indicating the new height.
+        new_width: an int32 scalar tensor indicating the new width.
+    """
+    resize_min = tf.cast(resize_min, tf.float32)
+
+    # Convert to floats to make subsequent calculations go smoothly.
+    height, width = tf.cast(height, tf.float32), tf.cast(width, tf.float32)
+
+    smaller_dim = tf.minimum(height, width)
+    scale_ratio = resize_min / smaller_dim
+
+    # Convert back to ints to make heights and widths that TF ops will accept.
+    new_height = tf.cast(height * scale_ratio, tf.int32)
+    new_width = tf.cast(width * scale_ratio, tf.int32)
+
+    return new_height, new_width
+
+
+def _aspect_preserving_resize(image, resize_min):
+    """Resize images preserving the original aspect ratio.
+
+    Args:
+        image: A 3-D image `Tensor`.
+        resize_min: A python integer or scalar `Tensor` indicating the size of
+            the smallest side after resize.
+
+    Returns:
+        resized_image: A 3-D tensor containing the resized image.
+    """
+    shape = tf.shape(input=image)
+    height, width = shape[0], shape[1]
+
+    new_height, new_width = _smallest_size_at_least(height, width, resize_min)
+
+    return _resize_image(image, new_height, new_width)
+
+
+def _resize_image(image, height, width):
+    """Simple wrapper around tf.resize_images.
+
+    This is primarily to make sure we use the same `ResizeMethod` and other
+    details each time.
+
+    Args:
+        image: A 3-D image `Tensor`.
+        height: The target height for the resized image.
+        width: The target width for the resized image.
+
+    Returns:
+        resized_image: A 3-D tensor containing the resized image. The first two
+            dimensions have the shape [height, width].
+    """
+    return tf.compat.v1.image.resize(
+        image,
+        [height, width],
+        method=tf.image.ResizeMethod.BILINEAR,
+        align_corners=False,
+    )
+
+
+def preprocess_image(
+    image_buffer, output_height, output_width, num_channels, is_training=False
+):
+    """Preprocesses the given image.
+
+    Preprocessing includes decoding, cropping, and resizing for both training
+    and eval images. Training preprocessing, however, introduces some random
+    distortion of the image to improve accuracy.
+
+    Args:
+        image_buffer: scalar string Tensor representing the raw JPEG image buffer.
+        bbox: 3-D float Tensor of bounding boxes arranged [1, num_boxes, coords]
+            where each coordinate is [0, 1) and the coordinates are arranged as
+            [ymin, xmin, ymax, xmax].
+        output_height: The height of the image after preprocessing.
+        output_width: The width of the image after preprocessing.
+        num_channels: Integer depth of the image buffer for decoding.
+        is_training: `True` if we're preprocessing the image for training and
+            `False` otherwise.
+
+    Returns:
+        A preprocessed image.
+    """
+    if is_training:
+        # For training, we want to randomize some of the distortions.
+        image = _decode_crop_and_flip(image_buffer, num_channels)
+        image = _resize_image(image, output_height, output_width)
+    else:
+        # For validation, we want to decode, resize, then just crop the middle.
+        if isinstance(image_buffer, bytes):
+            image = tf.image.decode_jpeg(image_buffer, channels=num_channels)
+        else:
+            image = image_buffer
+        image = _aspect_preserving_resize(image, _RESIZE_MIN)
+        image = _central_crop(image, output_height, output_width)
+
+    image.set_shape([output_height, output_width, num_channels])
+
+    return _mean_image_subtraction(image, CHANNEL_MEANS, num_channels)

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -600,6 +600,25 @@
 
   alert: default
 
+- name: ray-data-bulk-ingest-file-size-benchmark
+  group: AIR tests
+  working_dir: air_tests/air_benchmarks/mlperf-train
+
+  stable: true
+  env: staging
+
+  frequency: nightly
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: compute_cpu_16.yaml
+
+  run:
+    timeout: 900
+    script: bash file_size_benchmark.sh
+    type: sdk_command
+    file_manager: sdk
+
 #######################
 # XGBoost release tests
 #######################


### PR DESCRIPTION
This PR adds a benchmark which takes work from https://github.com/anyscale/air-benchmarks and makes it run as a release test.

Full metrics are stored in Databricks:
```
[
    {
        "time_total_s": 66.81319880485535,
        "ray_spilled_mb": 0,
        "ray_restored_mb": 0,
        "min_available_mb": 34939.1328125,
        "ray_mem_monitor_enabled": "True",
        "data_loader": "ray.data",
        "train_sleep_time_ms": 0,
        "num_epochs": 1,
        "num_images_per_epoch": 20480,
        "num_images_per_input_file": 32,
        "batch_size": 64,
        "shuffle_buffer_size": 0,
        "tput_images_per_s": 306.5262607739671
    },
    {
        "time_total_s": 63.11659026145935,
        "ray_spilled_mb": 0,
        "ray_restored_mb": 0,
        "min_available_mb": 26121.12109375,
        "ray_mem_monitor_enabled": "True",
        "data_loader": "ray.data",
        "train_sleep_time_ms": 0,
        "num_epochs": 1,
        "num_images_per_epoch": 20480,
        "num_images_per_input_file": 512,
        "batch_size": 64,
        "shuffle_buffer_size": 0,
        "tput_images_per_s": 324.4788718015654
    },
    {
        "time_total_s": 117.54973983764648,
        "ray_spilled_mb": 0,
        "ray_restored_mb": 0,
        "min_available_mb": 5155.19921875,
        "ray_mem_monitor_enabled": "True",
        "data_loader": "ray.data",
        "train_sleep_time_ms": 0,
        "num_epochs": 1,
        "num_images_per_epoch": 20480,
        "num_images_per_input_file": 2048,
        "batch_size": 64,
        "shuffle_buffer_size": 0,
        "tput_images_per_s": 174.22412017488
    }
]
```

Performance metrics are exported:
```
[
    {
        "perf_metric_name": "ray.data_32-images-per-file_throughput-img-per-second",
        "perf_metric_value": 306.5262607739671,
        "perf_metric_type": "THROUGHPUT"
    },
    {
        "perf_metric_name": "ray.data_512-images-per-file_throughput-img-per-second",
        "perf_metric_value": 324.4788718015654,
        "perf_metric_type": "THROUGHPUT"
    },
    {
        "perf_metric_name": "ray.data_2048-images-per-file_throughput-img-per-second",
        "perf_metric_value": 174.22412017488,
        "perf_metric_type": "THROUGHPUT"
    }
]
```

## Testing
I ran the release test from BK: https://buildkite.com/ray-project/release-tests-pr/builds/18592

Locally, I tested via the following command:
```
ANYSCALE_HOST=https://console.anyscale-staging.com \
  ANYSCALE_CLI_TOKEN=xyz \
  PYTHONPATH=$PYTHONPATH:$(pwd) \
  python3 ray_release/scripts/run_release_test.py ray-data-bulk-ingest-file-size-benchmark \
  --ray-wheels master \
  --no-terminate \
```

## Dashboard screenshots
<img width="1383" alt="Screen Shot 2022-10-19 at 3 23 35 PM" src="https://user-images.githubusercontent.com/950914/196816021-1bfc4fa2-3e97-4dee-b594-2c7caf7e86ca.png">
<img width="1388" alt="Screen Shot 2022-10-19 at 3 23 42 PM" src="https://user-images.githubusercontent.com/950914/196816033-1b2fd898-9a2c-4555-a3e2-59dc076ff8ea.png">


