### PR TITLE
revert "[core] update cgroup v1 memory usage calculation to ignore inactive"

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -618,28 +618,6 @@ def get_num_cpus(
     return cpu_count
 
 
-# TODO(clarng): merge code with c++
-def get_cgroupv1_used_memory(filename):
-    with open(filename, "r") as f:
-        lines = f.readlines()
-        cache_bytes = -1
-        rss_bytes = -1
-        inactive_file_bytes = -1
-        working_set = -1
-        for line in lines:
-            if "total_rss " in line:
-                rss_bytes = int(line.split()[1])
-            elif "cache " in line:
-                cache_bytes = int(line.split()[1])
-            elif "inactive_file" in line:
-                inactive_file_bytes = int(line.split()[1])
-        if cache_bytes >= 0 and rss_bytes >= 0 and inactive_file_bytes >= 0:
-            working_set = rss_bytes + cache_bytes - inactive_file_bytes
-            assert working_set >= 0
-            return working_set
-        return None
-
-
 def get_used_memory():
     """Return the currently used system memory in bytes
 
@@ -650,18 +628,25 @@ def get_used_memory():
     # container.
     docker_usage = None
     # For cgroups v1:
-    memory_usage_filename = "/sys/fs/cgroup/memory/memory.stat"
+    memory_usage_filename = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
     # For cgroups v2:
     memory_usage_filename_v2 = "/sys/fs/cgroup/memory.current"
     if os.path.exists(memory_usage_filename):
-        docker_usage = get_cgroupv1_used_memory(memory_usage_filename)
+        with open(memory_usage_filename, "r") as f:
+            docker_usage = int(f.read())
     elif os.path.exists(memory_usage_filename_v2):
         with open(memory_usage_filename_v2, "r") as f:
             docker_usage = int(f.read())
 
+    # Use psutil if it is available.
+    psutil_memory_in_bytes = psutil.virtual_memory().used
+
     if docker_usage is not None:
-        return docker_usage
-    return psutil.virtual_memory().used
+        # We take the min because the cgroup limit is very large if we aren't
+        # in Docker.
+        return min(docker_usage, psutil_memory_in_bytes)
+
+    return psutil_memory_in_bytes
 
 
 def estimate_available_memory():

--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -2,15 +2,12 @@ from math import ceil
 import sys
 import time
 
+import psutil
 import pytest
 
 import ray
 from ray._private import test_utils
 from ray._private.test_utils import get_node_stats, wait_for_condition
-
-import numpy as np
-from ray._private.utils import get_system_memory
-from ray._private.utils import get_used_memory
 
 
 memory_usage_threshold_fraction = 0.65
@@ -93,10 +90,10 @@ class Leaker:
         return ray._private.worker.global_worker.core_worker.get_actor_id().hex()
 
 
-def get_additional_bytes_to_reach_memory_usage_pct(pct: float) -> int:
-    used = get_used_memory()
-    total = get_system_memory()
-    bytes_needed = int(total * pct) - used
+def get_additional_bytes_to_reach_memory_usage_pct(pct: float) -> None:
+    node_mem = psutil.virtual_memory()
+    used = node_mem.total - node_mem.available
+    bytes_needed = node_mem.total * pct - used
     assert bytes_needed > 0, "node has less memory than what is requested"
     return bytes_needed
 
@@ -400,41 +397,6 @@ def test_newer_task_not_retriable_kill_older_retriable_task_first(
     ray.get(non_retriable_actor_ref)
     with pytest.raises(ray.exceptions.OutOfMemoryError) as _:
         ray.get(retriable_task_ref)
-
-
-@pytest.mark.skipif(
-    sys.platform != "linux" and sys.platform != "linux2",
-    reason="memory monitor only on linux currently",
-)
-def test_put_object_task_usage_slightly_below_limit_does_not_crash():
-    with ray.init(
-        num_cpus=1,
-        object_store_memory=2 << 30,
-        _system_config={
-            "memory_monitor_interval_ms": 0,
-        },
-    ):
-        bytes_to_alloc = get_additional_bytes_to_reach_memory_usage_pct(0.97)
-        print(bytes_to_alloc)
-        ray.get(
-            allocate_memory.options(max_retries=0).remote(
-                allocate_bytes=bytes_to_alloc,
-            ),
-            timeout=90,
-        )
-
-        entries = int((1 << 30) / 8)
-        obj_ref = ray.put(np.random.rand(entries))
-        ray.get(obj_ref)
-
-        bytes_to_alloc = get_additional_bytes_to_reach_memory_usage_pct(0.97)
-        print(bytes_to_alloc)
-        ray.get(
-            allocate_memory.options(max_retries=0).remote(
-                allocate_bytes=bytes_to_alloc,
-            ),
-            timeout=90,
-        )
 
 
 if __name__ == "__main__":

--- a/src/ray/common/memory_monitor.cc
+++ b/src/ray/common/memory_monitor.cc
@@ -105,44 +105,6 @@ std::tuple<int64_t, int64_t> MemoryMonitor::GetMemoryBytes() {
   return std::tuple(system_used_bytes, system_total_bytes);
 }
 
-int64_t MemoryMonitor::GetCGroupV1MemoryUsedBytes(const char *path) {
-  std::ifstream memstat_ifs(path, std::ios::in | std::ios::binary);
-  if (!memstat_ifs.is_open()) {
-    RAY_LOG_EVERY_MS(WARNING, kLogIntervalMs) << " file not found: " << path;
-    return kNull;
-  }
-
-  std::string line;
-  std::string title;
-  int64_t value;
-
-  int64_t rss_bytes = kNull;
-  int64_t cache_bytes = kNull;
-  int64_t inactive_file_bytes = kNull;
-  while (std::getline(memstat_ifs, line)) {
-    std::istringstream iss(line);
-    iss >> title >> value;
-    if (title == "total_rss") {
-      rss_bytes = value;
-    } else if (title == "total_cache") {
-      cache_bytes = value;
-    } else if (title == "total_inactive_file") {
-      inactive_file_bytes = value;
-    }
-  }
-  if (rss_bytes == kNull || cache_bytes == kNull || inactive_file_bytes == kNull) {
-    RAY_LOG_EVERY_MS(WARNING, kLogIntervalMs)
-        << "Failed to parse cgroup v1 mem stat. rss " << rss_bytes << " cache "
-        << cache_bytes << " inactive " << inactive_file_bytes;
-    return kNull;
-  }
-  // Working set, used by cadvisor for cgroup oom killing, is calculcated as (usage -
-  // inactive files)
-  // https://medium.com/@eng.mohamed.m.saeed/memory-working-set-vs-memory-rss-in-kubernetes-which-one-you-should-monitor-8ef77bf0acee
-  int64_t used = rss_bytes + cache_bytes - inactive_file_bytes;
-  return used;
-}
-
 std::tuple<int64_t, int64_t> MemoryMonitor::GetCGroupMemoryBytes() {
   int64_t total_bytes = kNull;
   if (std::filesystem::exists(kCgroupsV2MemoryMaxPath)) {
@@ -157,10 +119,10 @@ std::tuple<int64_t, int64_t> MemoryMonitor::GetCGroupMemoryBytes() {
   if (std::filesystem::exists(kCgroupsV2MemoryUsagePath)) {
     std::ifstream mem_file(kCgroupsV2MemoryUsagePath, std::ios::in | std::ios::binary);
     mem_file >> used_bytes;
-  } else if (std::filesystem::exists(kCgroupsV1MemoryStatPath)) {
-    used_bytes = GetCGroupV1MemoryUsedBytes(kCgroupsV1MemoryStatPath);
+  } else if (std::filesystem::exists(kCgroupsV1MemoryUsagePath)) {
+    std::ifstream mem_file(kCgroupsV1MemoryUsagePath, std::ios::in | std::ios::binary);
+    mem_file >> used_bytes;
   }
-
   /// This can be zero if the memory limit is not set for cgroup v2.
   if (total_bytes == 0) {
     total_bytes = kNull;
@@ -190,7 +152,7 @@ std::tuple<int64_t, int64_t> MemoryMonitor::GetLinuxMemoryBytes() {
   std::string meminfo_path = "/proc/meminfo";
   std::ifstream meminfo_ifs(meminfo_path, std::ios::in | std::ios::binary);
   if (!meminfo_ifs.is_open()) {
-    RAY_LOG_EVERY_MS(WARNING, kLogIntervalMs) << " file not found: " << meminfo_path;
+    RAY_LOG_EVERY_MS(ERROR, kLogIntervalMs) << " file not found: " << meminfo_path;
     return {kNull, kNull};
   }
   std::string line;
@@ -222,7 +184,7 @@ std::tuple<int64_t, int64_t> MemoryMonitor::GetLinuxMemoryBytes() {
     }
   }
   if (mem_total_bytes == kNull) {
-    RAY_LOG_EVERY_MS(WARNING, kLogIntervalMs)
+    RAY_LOG_EVERY_MS(ERROR, kLogIntervalMs)
         << "Unable to determine total bytes . Will return null";
     return {kNull, kNull};
   }

--- a/src/ray/common/memory_monitor.h
+++ b/src/ray/common/memory_monitor.h
@@ -73,7 +73,6 @@ class MemoryMonitor {
       "/sys/fs/cgroup/memory/memory.limit_in_bytes";
   static constexpr char kCgroupsV1MemoryUsagePath[] =
       "/sys/fs/cgroup/memory/memory.usage_in_bytes";
-  static constexpr char kCgroupsV1MemoryStatPath[] = "/sys/fs/cgroup/memory/memory.stat";
   static constexpr char kCgroupsV2MemoryMaxPath[] = "/sys/fs/cgroup/memory.max";
   static constexpr char kCgroupsV2MemoryUsagePath[] = "/sys/fs/cgroup/memory.current";
   /// The logging frequency. Decoupled from how often the monitor runs.
@@ -92,16 +91,10 @@ class MemoryMonitor {
   /// \return the used and total memory in bytes from Cgroup.
   std::tuple<int64_t, int64_t> GetCGroupMemoryBytes();
 
-  /// \param path file path to the memory stat file.
-  ///
-  /// \return the used memory for cgroup v1.
-  static int64_t GetCGroupV1MemoryUsedBytes(const char *path);
-
   /// \return the used and total memory in bytes for linux OS.
   std::tuple<int64_t, int64_t> GetLinuxMemoryBytes();
 
   /// \param smap_path file path to the smap file
-  ///
   /// \return the used memory in bytes from the given smap file or kNull if the file does
   /// not exist or if it fails to read a valid value.
   static int64_t GetLinuxProcessMemoryBytesFromSmap(const std::string smap_path);
@@ -130,9 +123,6 @@ class MemoryMonitor {
   FRIEND_TEST(MemoryMonitorTest, TestUsageAtThresholdReportsFalse);
   FRIEND_TEST(MemoryMonitorTest, TestGetNodeAvailableMemoryAlwaysPositive);
   FRIEND_TEST(MemoryMonitorTest, TestGetNodeTotalMemoryEqualsFreeOrCGroup);
-  FRIEND_TEST(MemoryMonitorTest, TestCgroupV1MemFileValidReturnsWorkingSet);
-  FRIEND_TEST(MemoryMonitorTest, TestCgroupV1MemFileMissingFieldReturnskNull);
-  FRIEND_TEST(MemoryMonitorTest, TestCgroupV1NonexistentMemFileReturnskNull);
   FRIEND_TEST(MemoryMonitorTest, TestMonitorPeriodSetCallbackExecuted);
   FRIEND_TEST(MemoryMonitorTest, TestGetMemoryThresholdTakeGreaterOfTheTwoValues);
 

--- a/src/ray/common/test/memory_monitor_test.cc
+++ b/src/ray/common/test/memory_monitor_test.cc
@@ -16,11 +16,8 @@
 
 #include <sys/sysinfo.h>
 
-#include <fstream>
-
 #include "gtest/gtest.h"
 #include "ray/common/asio/instrumented_io_context.h"
-#include "ray/common/id.h"
 #include "ray/util/process.h"
 
 namespace ray {
@@ -160,56 +157,6 @@ TEST_F(MemoryMonitorTest, TestMonitorMinFreeZeroThresholdIsOne) {
                         });
   std::unique_lock<std::mutex> callback_ran_mutex_lock(callback_ran_mutex);
   callback_ran.wait(callback_ran_mutex_lock);
-}
-
-TEST_F(MemoryMonitorTest, TestCgroupV1MemFileValidReturnsWorkingSet) {
-  std::string file_name = UniqueID::FromRandom().Binary();
-
-  std::ofstream mem_file;
-  mem_file.open(file_name);
-  mem_file << "total_cache "
-           << "918757" << std::endl;
-  mem_file << "unknown "
-           << "9" << std::endl;
-  mem_file << "total_rss "
-           << "8571" << std::endl;
-  mem_file << "total_inactive_file "
-           << "821" << std::endl;
-  mem_file.close();
-
-  int64_t used_bytes = MemoryMonitor::GetCGroupV1MemoryUsedBytes(file_name.c_str());
-
-  std::remove(file_name.c_str());
-
-  ASSERT_EQ(used_bytes, 8571 + 918757 - 821);
-}
-
-TEST_F(MemoryMonitorTest, TestCgroupV1MemFileMissingFieldReturnskNull) {
-  std::string file_name = UniqueID::FromRandom().Hex();
-
-  std::ofstream mem_file;
-  mem_file.open(file_name);
-  mem_file << "total_cache "
-           << "918757" << std::endl;
-  mem_file << "unknown "
-           << "9" << std::endl;
-  mem_file << "total_rss "
-           << "8571" << std::endl;
-  mem_file.close();
-
-  int64_t used_bytes = MemoryMonitor::GetCGroupV1MemoryUsedBytes(file_name.c_str());
-
-  std::remove(file_name.c_str());
-
-  ASSERT_EQ(used_bytes, MemoryMonitor::kNull);
-}
-
-TEST_F(MemoryMonitorTest, TestCgroupV1NonexistentMemFileReturnskNull) {
-  std::string file_name = UniqueID::FromRandom().Hex();
-
-  int64_t used_bytes = MemoryMonitor::GetCGroupV1MemoryUsedBytes(file_name.c_str());
-
-  ASSERT_EQ(used_bytes, MemoryMonitor::kNull);
 }
 
 TEST_F(MemoryMonitorTest, TestGetMemoryThresholdTakeGreaterOfTheTwoValues) {


### PR DESCRIPTION
## Why are these changes needed?

After release test bisection in https://docs.google.com/document/d/1SfbHV5AFZe3P_VA_snDve6yeCh8cobVAydn7MRqRSIE/edit#

This PR introduces ~15GB memory regression for both training and prediction stage. See details in the doc.

## Related issue number

Closes #28974

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
