### PR TITLE
[AIR] [Release] Fix air_benchmark_pytorch_training_e2e_gpu_1x1_20gb

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
+++ b/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
@@ -19,21 +19,6 @@ from ray.train.torch import TorchTrainer
 from ray.air.config import ScalingConfig
 
 
-def preprocess(batch: np.ndarray) -> pd.DataFrame:
-    """
-    User Pytorch code to transform user image.
-    """
-    preprocess = transforms.Compose(
-        [
-            transforms.ToTensor(),
-            transforms.Resize(256),
-            transforms.CenterCrop(224),
-            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-        ]
-    )
-    return pd.DataFrame({"image": [preprocess(image) for image in batch]})
-
-
 def preprocess_image_with_label(batch: np.ndarray) -> pd.DataFrame:
     """
     User Pytorch code to transform user image.

--- a/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
+++ b/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
@@ -103,7 +103,7 @@ def main(data_size_gb: int, num_epochs=2, num_workers=1):
     start = time.time()
     dataset = ray.data.read_images(data_url, size=(256, 256))
 
-    preprocessor = BatchMapper(preprocess_image_with_label)
+    preprocessor = BatchMapper(preprocess_image_with_label, batch_format="numpy")
 
     trainer = TorchTrainer(
         train_loop_per_worker=train_loop_per_worker,


### PR DESCRIPTION
Signed-off-by: Amog Kamsetty <amogkamsetty@yahoo.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Changes to the release test to fix breaking `read_images` changes

Closes https://github.com/ray-project/ray/issues/29240

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
