### PR TITLE
[RLlib] fix test_backward_compat.py on instances running py3.7.

### DIFF
--- a/rllib/tests/backward_compat/test_backward_compat.py
+++ b/rllib/tests/backward_compat/test_backward_compat.py
@@ -55,9 +55,10 @@ class TestBackwardCompatibility(unittest.TestCase):
                         state = pickle.load(f)
                     worker_state = pickle.loads(state["worker"])
                     algo = PPO(config=worker_state["policy_config"])
-                    # Note, we can not use restore() here because the testing checkpoints
-                    # are created with Algorithm.save in checkpoints/create_checkpoints.py,
-                    # i.e, the Tune checkpoint metadata is missing.
+                    # Note, we can not use restore() here because the testing
+                    # checkpoints are created with Algorithm.save() by
+                    # checkpoints/create_checkpoints.py. I.e, they are missing
+                    # all the Tune checkpoint metadata.
                     algo.load_checkpoint(path_to_checkpoint)
                 # > v0.1: Simply use new `Algorithm.from_checkpoint()` staticmethod.
                 else:

--- a/rllib/tests/backward_compat/test_backward_compat.py
+++ b/rllib/tests/backward_compat/test_backward_compat.py
@@ -55,7 +55,10 @@ class TestBackwardCompatibility(unittest.TestCase):
                         state = pickle.load(f)
                     worker_state = pickle.loads(state["worker"])
                     algo = PPO(config=worker_state["policy_config"])
-                    algo.restore(path_to_checkpoint)
+                    # Note, we can not use restore() here because the testing checkpoints
+                    # are created with Algorithm.save in checkpoints/create_checkpoints.py,
+                    # i.e, the Tune checkpoint metadata is missing.
+                    algo.load_checkpoint(path_to_checkpoint)
                 # > v0.1: Simply use new `Algorithm.from_checkpoint()` staticmethod.
                 else:
                     algo = Algorithm.from_checkpoint(path_to_checkpoint)


### PR DESCRIPTION
Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

This test is broken on CI instances that run python3.7

## Related issue number

#29302

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
