### PR TITLE
[all_tests] fix `test_dashboard_module_no_warnings` to only run in RAY_DEFAULT

### DIFF
--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -956,8 +956,8 @@ def test_agent_port_conflict():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") != "1",
-    reason="This test only works for minimal installation.",
+    os.environ.get("RAY_DEFAULT") != "1",
+    reason="This test only works for default installation.",
 )
 def test_dashboard_requests_fail_on_missing_deps(ray_start_with_dashboard):
     """Check that requests from client fail with minimal installation"""
@@ -1013,6 +1013,10 @@ def test_dashboard_module_load(tmpdir):
     assert loaded_modules_actual == loaded_modules_expected
 
 
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test only works for non-minimal installation.",
+)
 def test_dashboard_module_no_warnings(enable_test_module):
     # Disable log_once so we will get all warnings
     from ray.util import debug

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -1014,8 +1014,8 @@ def test_dashboard_module_load(tmpdir):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_DEFAULT") != "1",
-    reason="This test only works for default installation.",
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test currently fails with minimal install.",
 )
 def test_dashboard_module_no_warnings(enable_test_module):
     # Disable log_once so we will get all warnings

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -956,8 +956,8 @@ def test_agent_port_conflict():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_DEFAULT") != "1",
-    reason="This test only works for default installation.",
+    os.environ.get("RAY_MINIMAL") != "1",
+    reason="This test only works for minimal installation.",
 )
 def test_dashboard_requests_fail_on_missing_deps(ray_start_with_dashboard):
     """Check that requests from client fail with minimal installation"""
@@ -1014,8 +1014,8 @@ def test_dashboard_module_load(tmpdir):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1",
-    reason="This test only works for non-minimal installation.",
+    os.environ.get("RAY_DEFAULT") != "1",
+    reason="This test only works for default installation.",
 )
 def test_dashboard_module_no_warnings(enable_test_module):
     # Disable log_once so we will get all warnings


### PR DESCRIPTION


Signed-off-by: Alan Guo <aguo@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Should help with #29298 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
