### PR TITLE
Resolve xgboost benchmark failure

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -102,7 +102,12 @@ def run_xgboost_prediction(model_path: str, data_path: str):
     ds = data.read_parquet(data_path)
     ckpt = XGBoostCheckpoint.from_model(booster=model)
     batch_predictor = BatchPredictor.from_checkpoint(ckpt, XGBoostPredictor)
-    result = batch_predictor.predict(ds.drop_columns(["labels"]), batch_size=8192)
+    result = batch_predictor.predict(
+        ds.drop_columns(["labels"]),
+        # Improve prediction throughput for xgboost with larger
+        # batch size than default 4096
+        batch_size=8192,
+    )
     return result
 
 

--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -102,7 +102,7 @@ def run_xgboost_prediction(model_path: str, data_path: str):
     ds = data.read_parquet(data_path)
     ckpt = XGBoostCheckpoint.from_model(booster=model)
     batch_predictor = BatchPredictor.from_checkpoint(ckpt, XGBoostPredictor)
-    result = batch_predictor.predict(ds.drop_columns(["labels"]))
+    result = batch_predictor.predict(ds.drop_columns(["labels"]), batch_size=8192)
     return result
 
 


### PR DESCRIPTION
## Why are these changes needed?

After batch_size in predictor is applied correctly, we can reduce flakiness of our release test by using larger batch size for xgboost, since default 4096 is too small. This reduces runtime from ~310secs to ~200secs.

Full context and debugging history see attached issue.

## Test plan

Run it with new batch size on our release tool

<img width="1285" alt="Screen Shot 2022-10-14 at 10 46 57 AM" src="https://user-images.githubusercontent.com/6372689/195909310-bc2dff3f-75af-491e-8fde-edf4e1ee27eb.png">


## Related issue number

#28974

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
