### PR TITLE
[core] Fix test failure when there is a zombie in Mac

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1552,3 +1552,18 @@ def external_ray_cluster_activity_hook5():
             "timestamp": datetime.now().timestamp(),
         }
     }
+
+
+def get_gcs_memory_used():
+    import psutil
+
+    m = {
+        process.name(): process.memory_info().rss
+        for process in psutil.process_iter()
+        if (
+            process.status() not in (psutil.STATUS_ZOMBIE, psutil.STATUS_DEAD)
+            and process.name() in ("gcs_server", "redis-server")
+        )
+    }
+    assert "gcs_server" in m
+    return sum(m.values())

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -189,7 +189,8 @@ def get_gcs_memory_used():
         [
             process.memory_info().rss
             for process in psutil.process_iter()
-            if process.name() in ("gcs_server", "redis-server")
+            if (process.status() not in (psutil.STATUS_ZOMBIE, psutil.STATUS_DEAD)
+                and process.name() in ("gcs_server", "redis-server"))
         ]
     )
     return m

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -185,17 +185,16 @@ def test_local_mode_deadlock(shutdown_only_with_initialization_check):
 def get_gcs_memory_used():
     import psutil
 
-    m = sum(
-        [
-            process.memory_info().rss
+    m = {
+        process.name(): process.memory_info().rss
             for process in psutil.process_iter()
             if (
-                process.status() not in (psutil.STATUS_ZOMBIE, psutil.STATUS_DEAD)
-                and process.name() in ("gcs_server", "redis-server")
+                    process.status() not in (psutil.STATUS_ZOMBIE, psutil.STATUS_DEAD)
+                    and process.name() in ("gcs_server", "redis-server")
             )
-        ]
-    )
-    return m
+    }
+    assert "gcs_server" in m
+    return sum(m.values())
 
 
 def function_entry_num(job_id):

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -6,7 +6,12 @@ import pytest
 
 import ray
 from ray._private.gcs_utils import check_health
-from ray._private.test_utils import Semaphore, client_test_enabled, wait_for_condition
+from ray._private.test_utils import (
+    Semaphore,
+    client_test_enabled,
+    wait_for_condition,
+    get_gcs_memory_used,
+)
 from ray.experimental.internal_kv import _internal_kv_list
 
 
@@ -180,21 +185,6 @@ def test_local_mode_deadlock(shutdown_only_with_initialization_check):
     bar = Bar.remote()
     # Expect ping_actor call returns normally without deadlock.
     assert ray.get(foo.ping_actor.remote(bar)) == 3
-
-
-def get_gcs_memory_used():
-    import psutil
-
-    m = {
-        process.name(): process.memory_info().rss
-        for process in psutil.process_iter()
-        if (
-            process.status() not in (psutil.STATUS_ZOMBIE, psutil.STATUS_DEAD)
-            and process.name() in ("gcs_server", "redis-server")
-        )
-    }
-    assert "gcs_server" in m
-    return sum(m.values())
 
 
 def function_entry_num(job_id):

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -189,8 +189,10 @@ def get_gcs_memory_used():
         [
             process.memory_info().rss
             for process in psutil.process_iter()
-            if (process.status() not in (psutil.STATUS_ZOMBIE, psutil.STATUS_DEAD)
-                and process.name() in ("gcs_server", "redis-server"))
+            if (
+                process.status() not in (psutil.STATUS_ZOMBIE, psutil.STATUS_DEAD)
+                and process.name() in ("gcs_server", "redis-server")
+            )
         ]
     )
     return m

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -187,11 +187,11 @@ def get_gcs_memory_used():
 
     m = {
         process.name(): process.memory_info().rss
-            for process in psutil.process_iter()
-            if (
-                    process.status() not in (psutil.STATUS_ZOMBIE, psutil.STATUS_DEAD)
-                    and process.name() in ("gcs_server", "redis-server")
-            )
+        for process in psutil.process_iter()
+        if (
+            process.status() not in (psutil.STATUS_ZOMBIE, psutil.STATUS_DEAD)
+            and process.name() in ("gcs_server", "redis-server")
+        )
     }
     assert "gcs_server" in m
     return sum(m.values())

--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -9,6 +9,7 @@ from ray._private.test_utils import (
     client_test_enabled,
     run_string_as_driver,
     wait_for_condition,
+    get_gcs_memory_used,
 )
 from ray.experimental.internal_kv import _internal_kv_list
 from ray.tests.conftest import call_ray_start
@@ -80,19 +81,6 @@ def test_local_mode_deadlock(shutdown_only_with_initialization_check):
     bar = Bar.remote()
     # Expect ping_actor call returns normally without deadlock.
     assert ray.get(foo.ping_actor.remote(bar)) == 3
-
-
-def get_gcs_memory_used():
-    import psutil
-
-    m = sum(
-        [
-            process.memory_info().rss
-            for process in psutil.process_iter()
-            if process.name() in ("gcs_server", "redis-server")
-        ]
-    )
-    return m
 
 
 def function_entry_num(job_id):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Some API to psutil on a zombie process will cause an exception which breaks the mac build. This test fixed this.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #28893 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
