### PR TITLE
[Core] Fix placement group creation hangs when create pgs in parallel

### DIFF
--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
@@ -424,7 +424,7 @@ SchedulingResult BundleStrictPackSchedulingPolicy::Schedule(
           const auto &entry) {
         const auto &node_resources = entry.second->GetLocalView();
         auto allocatable =
-            (node_resources.IsAvailable(
+            (node_resources.IsFeasible(
                  aggregated_resource_request)         // If the resource is available
              && !AllocationWillExceedMaxCpuFraction(  // and allocating resources won't
                                                       // exceed max cpu fraction.


### PR DESCRIPTION
## Why are these changes needed?
Fix Placement group creation hangs when create pgs in parallel.

If this is IsAvailable, when this resource is not enough,   
PG will be added to the infeasible queue.   
If no new nodes have been added, even if the occupied resources are released, the PG will not be rescheduled.

## Related issue number
[Core] Placement group creation hangs when create pgs in parallel #28160 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
