### PR TITLE
[DO NOT MERGE] Upgrade tensorflow

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -43,7 +43,7 @@ tabulate
 tensorboardX >= 1.9
 uvicorn
 dataclasses; python_version < '3.7'
-starlette==0.18.0
+starlette
 aiorwlock
 gradio; platform_system != "Windows"
 
@@ -63,10 +63,7 @@ boto3
 cryptography>=3.0.0
 cython >= 0.29.26
 dataclasses; python_version < '3.7'
-# 0.85.0 of fastapi is breaking the ci because
-# requires newer starlette -> newer version typing-extensions
-# conflicting with tensorflow 2.6
-fastapi <= 0.84.0
+fastapi
 feather-format
 google-api-python-client
 google-cloud-storage

--- a/python/requirements/ml/requirements_dl.txt
+++ b/python/requirements/ml/requirements_dl.txt
@@ -1,7 +1,8 @@
 # These requirements are used for the CI and CPU-only Docker images so we install CPU only versions of torch.
 # For GPU Docker images, you should install requirements_ml_docker.txt afterwards.
 
-tensorflow==2.6.2
+tensorflow==2.6.2;python_version < '3.7'
+tensorflow==2.6.3;python_version >= '3.7'
 tensorflow-probability==0.14.1
 
 # If you make changes to the torch versions below, please also make the corresponding changes to `requirements_ml_docker.txt`!

--- a/python/requirements/ml/requirements_rllib.txt
+++ b/python/requirements/ml/requirements_rllib.txt
@@ -34,7 +34,7 @@ higher==0.2.1
 pyglet==1.5.15
 imageio-ffmpeg==0.4.5
 # Ray Serve example
-starlette==0.18.0
+starlette
 # ONNX
 onnx==1.9.0
 onnxruntime==1.9.0

--- a/release/serve_tests/gpu_app_config.yaml
+++ b/release/serve_tests/gpu_app_config.yaml
@@ -7,10 +7,6 @@ debian_packages:
 python:
   pip_packages:
     - "validators"
-    # ray-ml image is not able to reflect the requirements.txt
-    # So install the starlette here temporary.
-    # https://github.com/ray-project/ray/issues/29396
-    - starlette==0.20.4
   conda_packages: []
 
 post_build_cmds:


### PR DESCRIPTION
Signed-off-by: Sihan Wang <sihanwang41@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

tensorflow 2.6.2 has a restricted version control for the type_extensions which cause the issue to upgrade fast api (require different version of type_extensions)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
