### PR TITLE
[CI] Adjust Serve test sizes to bazel suggestions

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -163,7 +163,7 @@ py_test(
 
 py_test(
     name = "test_deployment_state",
-    size = "medium",
+    size = "small",
     srcs = serve_tests_srcs,
     tags = ["exclusive", "team:serve"],
     deps = [":serve_lib"],
@@ -257,7 +257,7 @@ py_test(
 
 py_test(
     name = "test_schema",
-    size = "medium",
+    size = "small",
     srcs = serve_tests_srcs,
     tags = ["exclusive", "team:serve"],
     deps = [":serve_lib"],
@@ -347,7 +347,7 @@ py_test(
 
 py_test(
     name = "test_cross_language",
-    size = "medium",
+    size = "small",
     srcs = serve_tests_srcs,
     tags = ["exclusive", "team:serve"],
     deps = [":serve_lib"],
@@ -363,7 +363,7 @@ py_test(
 
 py_test(
     name = "test_air_integrations_gpu",
-    size = "medium",
+    size = "small",
     srcs = serve_tests_srcs,
     tags = ["exclusive", "team:serve", "gpu"],
     deps = [":serve_lib"],
@@ -379,7 +379,7 @@ py_test(
 
 py_test(
     name = "test_deployment_graph_driver",
-    size = "medium",
+    size = "small",
     srcs = serve_tests_srcs,
     tags = ["exclusive", "team:serve"],
     deps = [":serve_lib"],
@@ -489,7 +489,7 @@ py_test(
 
 py_test(
     name = "test_deployment_node",
-    size = "medium",
+    size = "small",
     srcs = serve_tests_srcs,
     tags = ["exclusive", "team:serve"],
     deps = [":serve_lib"],


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adjust timeouts of Serve unit tests to match bazel suggestions. This allows to take better advantage of the new automatic sharding algorithm that takes test sizes into account.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
