### PR TITLE
[RLlib] Do not initialize PPO Algorithm in agent connector test.

### DIFF
--- a/rllib/connectors/tests/test_agent.py
+++ b/rllib/connectors/tests/test_agent.py
@@ -3,7 +3,6 @@ import numpy as np
 import unittest
 from gym.spaces import Box
 
-import ray
 from ray.rllib.algorithms.ppo.ppo import PPOConfig
 from ray.rllib.algorithms.ppo.ppo_torch_policy import PPOTorchPolicy
 from ray.rllib.connectors.agent.clip_reward import ClipRewardAgentConnector
@@ -207,9 +206,7 @@ class TestAgentConnector(unittest.TestCase):
                 )
 
             # Check if transformed observations are actually mean-std filtered
-            self.assertTrue(
-                np.isclose(np.mean(transformed_observations), 0, atol=0.1)
-            )
+            self.assertTrue(np.isclose(np.mean(transformed_observations), 0, atol=0.1))
             self.assertTrue(np.isclose(np.var(transformed_observations), 1, atol=0.1))
 
             # Check if filter parameters where frozen because we are not training
@@ -466,7 +463,7 @@ class TestViewRequirementAgentConnector(unittest.TestCase):
         policy = PPOTorchPolicy(
             observation_space=env.observation_space,
             action_space=env.action_space,
-            config=config.to_dict()
+            config=config.to_dict(),
         )
 
         # create a connector context

--- a/rllib/connectors/tests/test_agent.py
+++ b/rllib/connectors/tests/test_agent.py
@@ -3,7 +3,9 @@ import numpy as np
 import unittest
 from gym.spaces import Box
 
-from ray.rllib.algorithms.ppo.ppo import PPO, PPOConfig
+import ray
+from ray.rllib.algorithms.ppo.ppo import PPOConfig
+from ray.rllib.algorithms.ppo.ppo_torch_policy import PPOTorchPolicy
 from ray.rllib.connectors.agent.clip_reward import ClipRewardAgentConnector
 from ray.rllib.connectors.agent.lambdas import FlattenDataAgentConnector
 from ray.rllib.connectors.agent.obs_preproc import ObsPreprocessorConnector
@@ -160,6 +162,89 @@ class TestAgentConnector(unittest.TestCase):
         with_buffered = c([d])
         self.assertEqual(len(with_buffered), 1)
         self.assertEqual(with_buffered[0].data[SampleBatch.ACTIONS], [1, 2, 3])
+
+    def test_mean_std_observation_filter_connector(self):
+        for bounds in [
+            (-1, 1),  # normalized
+            (-2, 2),  # scaled
+            (0, 2),  # shifted
+            (0, 4),  # scaled and shifted
+        ]:
+            print("Testing uniform sampling with bounds: {}".format(bounds))
+
+            observation_space = Box(bounds[0], bounds[1], (3, 64, 64))
+            ctx = ConnectorContext(observation_space=observation_space)
+            filter_connector = MeanStdObservationFilterAgentConnector(ctx)
+
+            # Warm up Mean-Std filter
+            for i in range(1000):
+                obs = observation_space.sample()
+                sample_batch = {
+                    SampleBatch.NEXT_OBS: obs,
+                }
+                ac = AgentConnectorDataType(0, 0, sample_batch)
+                filter_connector.transform(ac)
+
+            # Create another connector to set state to
+            _, state = filter_connector.to_state()
+            another_filter_connector = (
+                MeanStdObservationFilterAgentConnector.from_state(ctx, state)
+            )
+
+            another_filter_connector.in_eval()
+
+            # Collect transformed observations
+            transformed_observations = []
+            for i in range(1000):
+                obs = observation_space.sample()
+                sample_batch = {
+                    SampleBatch.NEXT_OBS: obs,
+                }
+                ac = AgentConnectorDataType(0, 0, sample_batch)
+                connector_output = another_filter_connector.transform(ac)
+                transformed_observations.append(
+                    connector_output.data[SampleBatch.NEXT_OBS]
+                )
+
+            # Check if transformed observations are actually mean-std filtered
+            self.assertTrue(
+                np.isclose(np.mean(transformed_observations), 0, atol=0.1)
+            )
+            self.assertTrue(np.isclose(np.var(transformed_observations), 1, atol=0.1))
+
+            # Check if filter parameters where frozen because we are not training
+            self.assertTrue(
+                filter_connector.filter.running_stats.num_pushes
+                == another_filter_connector.filter.running_stats.num_pushes,
+            )
+            self.assertTrue(
+                np.all(
+                    filter_connector.filter.running_stats.mean_array
+                    == another_filter_connector.filter.running_stats.mean_array,
+                )
+            )
+            self.assertTrue(
+                np.all(
+                    filter_connector.filter.running_stats.std_array
+                    == another_filter_connector.filter.running_stats.std_array,
+                )
+            )
+            self.assertTrue(
+                filter_connector.filter.buffer.num_pushes
+                == another_filter_connector.filter.buffer.num_pushes,
+            )
+            self.assertTrue(
+                np.all(
+                    filter_connector.filter.buffer.mean_array
+                    == another_filter_connector.filter.buffer.mean_array,
+                )
+            )
+            self.assertTrue(
+                np.all(
+                    filter_connector.filter.buffer.std_array
+                    == another_filter_connector.filter.buffer.std_array,
+                )
+            )
 
 
 class TestViewRequirementAgentConnector(unittest.TestCase):
@@ -376,10 +461,13 @@ class TestViewRequirementAgentConnector(unittest.TestCase):
             .environment(env="CartPole-v0")
             .rollouts(create_env_on_local_worker=True)
         )
-        algo = PPO(config)
-        rollout_worker = algo.workers.local_worker()
-        policy = rollout_worker.get_policy()
-        env = rollout_worker.env
+
+        env = gym.make("CartPole-v0")
+        policy = PPOTorchPolicy(
+            observation_space=env.observation_space,
+            action_space=env.action_space,
+            config=config.to_dict()
+        )
 
         # create a connector context
         ctx = ConnectorContext(
@@ -476,89 +564,6 @@ class TestViewRequirementAgentConnector(unittest.TestCase):
         self.assertEqual(len(obs_data), 1)
         # Data matches the latest timestep.
         self.assertTrue(np.array_equal(obs_data[0], np.array([4, 5, 6, 7])))
-
-    def test_mean_std_observation_filter_connector(self):
-        for bounds in [
-            (-1, 1),  # normalized
-            (-2, 2),  # scaled
-            (0, 2),  # shifted
-            (0, 4),  # scaled and shifted
-        ]:
-            print("Testing uniform sampling with bounds: {}".format(bounds))
-
-            observation_space = Box(bounds[0], bounds[1], (3, 64, 64))
-            ctx = ConnectorContext(observation_space=observation_space)
-            filter_connector = MeanStdObservationFilterAgentConnector(ctx)
-
-            # Warm up Mean-Std filter
-            for i in range(1000):
-                obs = observation_space.sample()
-                sample_batch = {
-                    SampleBatch.NEXT_OBS: obs,
-                }
-                ac = AgentConnectorDataType(0, 0, sample_batch)
-                filter_connector.transform(ac)
-
-            # Create another connector to set state to
-            _, state = filter_connector.to_state()
-            another_filter_connector = (
-                MeanStdObservationFilterAgentConnector.from_state(ctx, state)
-            )
-
-            another_filter_connector.in_eval()
-
-            # Collector transformed observations
-            transformed_observations = []
-            for i in range(1000):
-                obs = observation_space.sample()
-                sample_batch = {
-                    SampleBatch.NEXT_OBS: obs,
-                }
-                ac = AgentConnectorDataType(0, 0, sample_batch)
-                connector_output = another_filter_connector.transform(ac)
-                transformed_observations.append(
-                    connector_output.data[SampleBatch.NEXT_OBS]
-                )
-
-            # Check if transformed observations are actually mean-std filtered
-            self.assertTrue(
-                np.isclose(np.mean(transformed_observations), 0, atol=0.001)
-            )
-            self.assertTrue(np.isclose(np.var(transformed_observations), 1, atol=0.01))
-
-            # Check if filter parameters where frozen because we are not training
-            self.assertTrue(
-                filter_connector.filter.running_stats.num_pushes
-                == another_filter_connector.filter.running_stats.num_pushes,
-            )
-            self.assertTrue(
-                np.all(
-                    filter_connector.filter.running_stats.mean_array
-                    == another_filter_connector.filter.running_stats.mean_array,
-                )
-            )
-            self.assertTrue(
-                np.all(
-                    filter_connector.filter.running_stats.std_array
-                    == another_filter_connector.filter.running_stats.std_array,
-                )
-            )
-            self.assertTrue(
-                filter_connector.filter.buffer.num_pushes
-                == another_filter_connector.filter.buffer.num_pushes,
-            )
-            self.assertTrue(
-                np.all(
-                    filter_connector.filter.buffer.mean_array
-                    == another_filter_connector.filter.buffer.mean_array,
-                )
-            )
-            self.assertTrue(
-                np.all(
-                    filter_connector.filter.buffer.std_array
-                    == another_filter_connector.filter.buffer.std_array,
-                )
-            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This makes things more unit-test-like, and avoids timing out issue when there is random left-over ray cluster in the testing env.

Also make mean_std filter test a bit more reliable.

Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

Stablize test.

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
