### PR TITLE
[core][CI] Add wait_for_nodes stage for stress_test_dead_actors

### DIFF
--- a/release/nightly_tests/stress_tests/test_dead_actors.py
+++ b/release/nightly_tests/stress_tests/test_dead_actors.py
@@ -70,12 +70,10 @@ if __name__ == "__main__":
     death_probability = args.death_probability
 
     # Wait until the expected number of nodes have joined the cluster.
-    while True:
-        num_nodes = len(ray.nodes())
-        logger.info("Waiting for nodes {}/{}".format(num_nodes, num_remote_nodes + 1))
-        if num_nodes >= num_remote_nodes + 1:
-            break
-        time.sleep(5)
+    num_nodes = len(ray.nodes())
+    assert (
+        num_nodes >= num_remote_nodes + 1
+    ), f"Expect {num_remote_nodes+1}, but only {num_nodes} joined."
     logger.info(
         "Nodes have all joined. There are %s resources.", ray.cluster_resources()
     )

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3689,6 +3689,9 @@
 
   run:
     timeout: 7200
+    wait_for_nodes:
+      num_nodes: 101
+
     script: python stress_tests/test_dead_actors.py
     type: sdk_command
     file_manager: sdk
@@ -3701,6 +3704,8 @@
 
     run:
       timeout: 3600
+      wait_for_nodes:
+        num_nodes: 5
       script: python stress_tests/test_dead_actors.py --num-nodes=4 --num-parents=3
         --num-children=3
 


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Such that infra errors (not enough nodes) will be reported as infra errors rather than command errors. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
