### PR TITLE
[tests] Skip bad ray memory call in shuffle nightly tests if it fails

### DIFF
--- a/release/nightly_tests/dataset/sort.py
+++ b/release/nightly_tests/dataset/sort.py
@@ -3,6 +3,7 @@ import os
 import resource
 import time
 from typing import List
+import traceback
 
 import numpy as np
 import psutil
@@ -134,7 +135,11 @@ if __name__ == "__main__":
     rss = int(process.memory_info().rss)
     print(f"rss: {rss / 1e9}/GB")
 
-    print(memory_summary(stats_only=True))
+    try:
+        print(memory_summary(stats_only=True))
+    except Exception:
+        print("Failed to retrieve memory summary")
+        print(traceback.format_exc())
     print("")
 
     print(ds.stats())


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`ray memory` sometimes fails if the cluster is under load. It's only used in the nightly test for debugging, so skip it if it fails.

## Related issue number

Closes #28242.
