### PR TITLE
[Train] Split test_gpu tests (#29297)

### DIFF
--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -163,7 +163,7 @@ py_test(
     size = "large",
     srcs = ["tests/test_examples.py"],
     tags = ["team:ml", "exclusive"],
-    deps = [":train_lib"]
+    deps = [":train_lib", ":conftest"]
 )
 
 py_test(
@@ -171,7 +171,7 @@ py_test(
     size = "large",
     srcs = ["tests/test_gpu.py"],
     tags = ["team:ml", "exclusive", "gpu_only"],
-    deps = [":train_lib"]
+    deps = [":train_lib", ":conftest"]
 )
 
 py_test(
@@ -179,7 +179,7 @@ py_test(
     size = "large",
     srcs = ["tests/test_gpu_auto_transfer.py"],
     tags = ["team:ml", "exclusive", "gpu_only"],
-    deps = [":train_lib"]
+    deps = [":train_lib", ":conftest"]
 )
 
 py_test(
@@ -187,7 +187,15 @@ py_test(
     size = "large",
     srcs = ["tests/test_gpu_examples.py"],
     tags = ["team:ml", "exclusive", "gpu_only"],
-    deps = [":train_lib"]
+    deps = [":train_lib", ":conftest"]
+)
+
+py_test(
+    name = "test_gpu_amp",
+    size = "large",
+    srcs = ["tests/test_gpu_amp.py"],
+    tags = ["team:ml", "exclusive", "gpu_only"],
+    deps = [":train_lib", ":conftest"]
 )
 
 py_test(

--- a/python/ray/train/tests/conftest.py
+++ b/python/ray/train/tests/conftest.py
@@ -5,6 +5,7 @@ from ray.tests.conftest import pytest_runtest_makereport  # noqa
 import pytest
 
 import ray
+from ray.cluster_utils import Cluster
 
 
 @pytest.fixture
@@ -24,3 +25,38 @@ def ray_start_runtime_env():
     yield address_info
     # The code after the yield will run as teardown code.
     ray.shutdown()
+
+
+@pytest.fixture
+def ray_start_1_cpu_1_gpu():
+    address_info = ray.init(num_cpus=1, num_gpus=1)
+    yield address_info
+    ray.shutdown()
+
+
+@pytest.fixture
+def ray_start_4_cpus_2_gpus():
+    address_info = ray.init(num_cpus=4, num_gpus=2)
+    yield address_info
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+
+
+@pytest.fixture
+def shutdown_only():
+    yield None
+    ray.shutdown()
+
+
+@pytest.fixture
+def ray_2_node_2_gpu():
+    cluster = Cluster()
+    for _ in range(2):
+        cluster.add_node(num_cpus=4, num_gpus=2)
+
+    ray.init(address=cluster.address)
+
+    yield
+
+    ray.shutdown()
+    cluster.shutdown()

--- a/python/ray/train/tests/test_examples.py
+++ b/python/ray/train/tests/test_examples.py
@@ -1,6 +1,5 @@
 import pytest
 
-import ray
 from ray.air.config import ScalingConfig
 from ray.train.constants import TRAINING_ITERATION
 
@@ -23,14 +22,6 @@ from ray.train.examples.torch_linear_example import train_func as linear_train_f
 from ray.train.horovod.horovod_trainer import HorovodTrainer
 from ray.train.tensorflow.tensorflow_trainer import TensorflowTrainer
 from ray.train.torch.torch_trainer import TorchTrainer
-
-
-@pytest.fixture
-def ray_start_4_cpus():
-    address_info = ray.init(num_cpus=4)
-    yield address_info
-    # The code after the yield will run as teardown code.
-    ray.shutdown()
 
 
 @pytest.mark.parametrize("num_workers", [1, 2])

--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -1,11 +1,8 @@
 import os
-from timeit import default_timer as timer
 from collections import Counter
 
 from unittest.mock import patch
 import pytest
-from ray.air.constants import MODEL_KEY
-from ray.train.torch.torch_checkpoint import TorchCheckpoint
 import torch
 import torchvision
 from torch.nn.parallel import DistributedDataParallel
@@ -13,7 +10,6 @@ from torch.utils.data import DataLoader, DistributedSampler
 
 import ray
 from ray.air import session
-from ray.cluster_utils import Cluster
 from ray import tune
 
 import ray.train as train
@@ -23,41 +19,6 @@ from ray.train.examples.torch_linear_example import LinearDataset
 from ray.train.torch.config import TorchConfig, _TorchBackend
 from ray.train.torch.torch_trainer import TorchTrainer
 from ray.train._internal.worker_group import WorkerGroup
-
-
-@pytest.fixture
-def ray_start_4_cpus_2_gpus():
-    address_info = ray.init(num_cpus=4, num_gpus=2)
-    yield address_info
-    # The code after the yield will run as teardown code.
-    ray.shutdown()
-
-
-@pytest.fixture
-def ray_start_1_cpu_1_gpu():
-    address_info = ray.init(num_cpus=1, num_gpus=1)
-    yield address_info
-    ray.shutdown()
-
-
-@pytest.fixture
-def shutdown_only():
-    yield None
-    ray.shutdown()
-
-
-@pytest.fixture
-def ray_2_node_2_gpu():
-    cluster = Cluster()
-    for _ in range(2):
-        cluster.add_node(num_cpus=4, num_gpus=2)
-
-    ray.init(address=cluster.address)
-
-    yield
-
-    ray.shutdown()
-    cluster.shutdown()
 
 
 class LinearDatasetDict(LinearDataset):
@@ -321,70 +282,6 @@ def test_enable_reproducibility(ray_start_4_cpus_2_gpus, use_gpu):
     assert result1.metrics["loss"] == result2.metrics["loss"]
 
 
-def test_torch_amp_performance(ray_start_4_cpus_2_gpus):
-    def train_func(config):
-        train.torch.accelerate(amp=config["amp"])
-
-        start_time = timer()
-        model = torchvision.models.resnet101()
-        model = train.torch.prepare_model(model)
-
-        dataset_length = 1000
-        dataset = torch.utils.data.TensorDataset(
-            torch.randn(dataset_length, 3, 224, 224),
-            torch.randint(low=0, high=1000, size=(dataset_length,)),
-        )
-        dataloader = torch.utils.data.DataLoader(dataset, batch_size=64)
-        dataloader = train.torch.prepare_data_loader(dataloader)
-
-        optimizer = torch.optim.SGD(model.parameters(), lr=0.001)
-        optimizer = train.torch.prepare_optimizer(optimizer)
-
-        model.train()
-        for epoch in range(1):
-            for images, targets in dataloader:
-                optimizer.zero_grad()
-
-                outputs = model(images)
-                loss = torch.nn.functional.cross_entropy(outputs, targets)
-
-                train.torch.backward(loss)
-                optimizer.step()
-        end_time = timer()
-        session.report({"latency": end_time - start_time})
-
-    def latency(amp: bool) -> float:
-        trainer = TorchTrainer(
-            train_func,
-            train_loop_config={"amp": amp},
-            scaling_config=ScalingConfig(num_workers=2, use_gpu=True),
-        )
-        results = trainer.fit()
-        return results.metrics["latency"]
-
-    # Training should be at least 5% faster with AMP.
-    assert 1.05 * latency(amp=True) < latency(amp=False)
-
-
-def test_checkpoint_torch_model_with_amp(ray_start_4_cpus_2_gpus):
-    """Test that model with AMP is serializable."""
-
-    def train_func():
-        train.torch.accelerate(amp=True)
-
-        model = torchvision.models.resnet101()
-        model = train.torch.prepare_model(model)
-
-        session.report({"model": model}, checkpoint=TorchCheckpoint.from_model(model))
-
-    trainer = TorchTrainer(
-        train_func, scaling_config=ScalingConfig(num_workers=2, use_gpu=True)
-    )
-    results = trainer.fit()
-    assert results.checkpoint
-    assert results.checkpoint.get_model()
-
-
 @pytest.mark.parametrize("nccl_socket_ifname", ["", "ens3"])
 def test_torch_backend_nccl_socket_ifname(ray_start_4_cpus_2_gpus, nccl_socket_ifname):
     worker_group = WorkerGroup(num_workers=2, num_gpus_per_worker=1)
@@ -404,67 +301,6 @@ def test_torch_backend_nccl_socket_ifname(ray_start_4_cpus_2_gpus, nccl_socket_i
     torch_backend.on_start(worker_group, backend_config=TorchConfig(backend="nccl"))
 
     worker_group.execute(assert_env_var_set)
-
-
-@patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": ""})
-def test_torch_auto_gpu_to_cpu(ray_start_4_cpus_2_gpus):
-    """Tests if GPU tensors are auto converted to CPU on driver."""
-    num_workers = 2
-    assert os.environ["CUDA_VISIBLE_DEVICES"] == ""
-
-    def train_func():
-        model = torch.nn.Linear(1, 1)
-
-        # Move to GPU device.
-        model = ray.train.torch.prepare_model(model)
-
-        assert next(model.parameters()).is_cuda
-
-        session.report({"model": model}, checkpoint=TorchCheckpoint.from_model(model))
-
-    trainer = TorchTrainer(
-        train_func, scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=True)
-    )
-    results = trainer.fit()
-
-    model_checkpoint = results.checkpoint.get_model()
-    model_report = results.metrics["model"]
-    assert not next(model_checkpoint.parameters()).is_cuda
-    assert not next(model_report.parameters()).is_cuda
-
-    # Test the same thing for state dict.
-
-    def train_func():
-        model = torch.nn.Linear(1, 1)
-
-        # Move to GPU device.
-        model = ray.train.torch.prepare_model(model)
-
-        assert next(model.parameters()).is_cuda
-
-        state_dict = model.state_dict()
-
-        for tensor in state_dict.values():
-            assert tensor.is_cuda
-
-        session.report(
-            {"state_dict": state_dict},
-            checkpoint=TorchCheckpoint.from_state_dict(state_dict),
-        )
-
-    trainer = TorchTrainer(
-        train_func, scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=True)
-    )
-    results = trainer.fit()
-
-    state_dict_checkpoint = results.checkpoint.to_dict()[MODEL_KEY]
-    state_dict_report = results.metrics["state_dict"]
-
-    for tensor in state_dict_report.values():
-        assert not tensor.is_cuda
-
-    for tensor in state_dict_checkpoint.values():
-        assert not tensor.is_cuda
 
 
 if __name__ == "__main__":

--- a/python/ray/train/tests/test_gpu_amp.py
+++ b/python/ray/train/tests/test_gpu_amp.py
@@ -1,0 +1,83 @@
+from timeit import default_timer as timer
+
+from ray.train.torch.torch_checkpoint import TorchCheckpoint
+import torch
+import torchvision
+
+from ray.air import session
+
+import ray.train as train
+from ray.air.config import ScalingConfig
+from ray.train.torch.torch_trainer import TorchTrainer
+
+
+def test_torch_amp_performance(ray_start_4_cpus_2_gpus):
+    def train_func(config):
+        train.torch.accelerate(amp=config["amp"])
+
+        start_time = timer()
+        model = torchvision.models.resnet101()
+        model = train.torch.prepare_model(model)
+
+        dataset_length = 1000
+        dataset = torch.utils.data.TensorDataset(
+            torch.randn(dataset_length, 3, 224, 224),
+            torch.randint(low=0, high=1000, size=(dataset_length,)),
+        )
+        dataloader = torch.utils.data.DataLoader(dataset, batch_size=64)
+        dataloader = train.torch.prepare_data_loader(dataloader)
+
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.001)
+        optimizer = train.torch.prepare_optimizer(optimizer)
+
+        model.train()
+        for epoch in range(1):
+            for images, targets in dataloader:
+                optimizer.zero_grad()
+
+                outputs = model(images)
+                loss = torch.nn.functional.cross_entropy(outputs, targets)
+
+                train.torch.backward(loss)
+                optimizer.step()
+        end_time = timer()
+        session.report({"latency": end_time - start_time})
+
+    def latency(amp: bool) -> float:
+        trainer = TorchTrainer(
+            train_func,
+            train_loop_config={"amp": amp},
+            scaling_config=ScalingConfig(num_workers=2, use_gpu=True),
+        )
+        results = trainer.fit()
+        return results.metrics["latency"]
+
+    # Training should be at least 5% faster with AMP.
+    assert 1.05 * latency(amp=True) < latency(amp=False)
+
+
+def test_checkpoint_torch_model_with_amp(ray_start_4_cpus_2_gpus):
+    """Test that model with AMP is serializable."""
+
+    def train_func():
+        train.torch.accelerate(amp=True)
+
+        model = torchvision.models.resnet101()
+        model = train.torch.prepare_model(model)
+
+        session.report({"model": model}, checkpoint=TorchCheckpoint.from_model(model))
+
+    trainer = TorchTrainer(
+        train_func, scaling_config=ScalingConfig(num_workers=2, use_gpu=True)
+    )
+    results = trainer.fit()
+    assert results.checkpoint
+    assert results.checkpoint.get_model()
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main(["-v", "-x", "-s", __file__]))

--- a/python/ray/train/tests/test_gpu_auto_transfer.py
+++ b/python/ray/train/tests/test_gpu_auto_transfer.py
@@ -1,23 +1,16 @@
+import os
+from unittest.mock import patch
 import pytest
+
 import torch
 
 import ray
+from ray.air import session
+from ray.air.constants import MODEL_KEY
+from ray.air.config import ScalingConfig
+from ray.train.torch.torch_checkpoint import TorchCheckpoint
+from ray.train.torch.torch_trainer import TorchTrainer
 import ray.train.torch.train_loop_utils
-
-
-@pytest.fixture
-def ray_start_1_cpu_1_gpu():
-    address_info = ray.init(num_cpus=1, num_gpus=1)
-    yield address_info
-    ray.shutdown()
-
-
-@pytest.fixture
-def ray_start_4_cpus_2_gpus():
-    address_info = ray.init(num_cpus=4, num_gpus=2)
-    yield address_info
-    # The code after the yield will run as teardown code.
-    ray.shutdown()
 
 
 @pytest.mark.parametrize(
@@ -97,6 +90,67 @@ def test_auto_transfer_correct_device(ray_start_4_cpus_2_gpus):
 
     # Verify GPU memory usage increases on the right cuda device
     assert end_gpu_memory > start_gpu_memory
+
+
+@patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": ""})
+def test_torch_auto_gpu_to_cpu(ray_start_4_cpus_2_gpus):
+    """Tests if GPU tensors are auto converted to CPU on driver."""
+    num_workers = 2
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == ""
+
+    def train_func():
+        model = torch.nn.Linear(1, 1)
+
+        # Move to GPU device.
+        model = ray.train.torch.prepare_model(model)
+
+        assert next(model.parameters()).is_cuda
+
+        session.report({"model": model}, checkpoint=TorchCheckpoint.from_model(model))
+
+    trainer = TorchTrainer(
+        train_func, scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=True)
+    )
+    results = trainer.fit()
+
+    model_checkpoint = results.checkpoint.get_model()
+    model_report = results.metrics["model"]
+    assert not next(model_checkpoint.parameters()).is_cuda
+    assert not next(model_report.parameters()).is_cuda
+
+    # Test the same thing for state dict.
+
+    def train_func():
+        model = torch.nn.Linear(1, 1)
+
+        # Move to GPU device.
+        model = ray.train.torch.prepare_model(model)
+
+        assert next(model.parameters()).is_cuda
+
+        state_dict = model.state_dict()
+
+        for tensor in state_dict.values():
+            assert tensor.is_cuda
+
+        session.report(
+            {"state_dict": state_dict},
+            checkpoint=TorchCheckpoint.from_state_dict(state_dict),
+        )
+
+    trainer = TorchTrainer(
+        train_func, scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=True)
+    )
+    results = trainer.fit()
+
+    state_dict_checkpoint = results.checkpoint.to_dict()[MODEL_KEY]
+    state_dict_report = results.metrics["state_dict"]
+
+    for tensor in state_dict_report.values():
+        assert not tensor.is_cuda
+
+    for tensor in state_dict_checkpoint.values():
+        assert not tensor.is_cuda
 
 
 if __name__ == "__main__":

--- a/python/ray/train/tests/test_gpu_examples.py
+++ b/python/ray/train/tests/test_gpu_examples.py
@@ -1,8 +1,6 @@
 import pytest
 import torch
 
-import ray
-from ray.cluster_utils import Cluster
 from ray.air import Checkpoint, session
 
 from ray.air.config import ScalingConfig
@@ -23,41 +21,6 @@ from ray.train.tests.test_tune import (
 )
 from ray.train.tensorflow.tensorflow_trainer import TensorflowTrainer
 from ray.train.torch.torch_trainer import TorchTrainer
-
-
-@pytest.fixture
-def ray_start_4_cpus_2_gpus():
-    address_info = ray.init(num_cpus=4, num_gpus=2)
-    yield address_info
-    # The code after the yield will run as teardown code.
-    ray.shutdown()
-
-
-@pytest.fixture
-def ray_start_1_cpu_1_gpu():
-    address_info = ray.init(num_cpus=1, num_gpus=1)
-    yield address_info
-    ray.shutdown()
-
-
-@pytest.fixture
-def shutdown_only():
-    yield None
-    ray.shutdown()
-
-
-@pytest.fixture
-def ray_2_node_2_gpu():
-    cluster = Cluster()
-    for _ in range(2):
-        cluster.add_node(num_cpus=4, num_gpus=2)
-
-    ray.init(address=cluster.address)
-
-    yield
-
-    ray.shutdown()
-    cluster.shutdown()
 
 
 def test_tensorflow_mnist_gpu(ray_start_4_cpus_2_gpus):


### PR DESCRIPTION
We had AMI changes that happened around same time test_gpu times out but for our ongoing work we should keep updated with latest pytorch and cuda 11.6.

Therefore this change split tests into two files so single buck target won't timeout.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
