### PR TITLE
[Train] Deflake `test_torch_trainer::test_tune_torch_get_device_gpu` (#29190)

### DIFF
--- a/python/ray/train/tests/test_torch_trainer.py
+++ b/python/ray/train/tests/test_torch_trainer.py
@@ -1,3 +1,4 @@
+import contextlib
 import pytest
 from ray.air import session
 from ray.air.checkpoint import Checkpoint
@@ -25,11 +26,11 @@ def ray_start_4_cpus():
     ray.shutdown()
 
 
-@pytest.fixture
-def ray_2_node_2_gpu():
+@contextlib.contextmanager
+def ray_start_2_node_cluster(num_cpus_per_node: int, num_gpus_per_node: int):
     cluster = Cluster()
     for _ in range(2):
-        cluster.add_node(num_cpus=4, num_gpus=2)
+        cluster.add_node(num_cpus=num_cpus_per_node, num_gpus=num_gpus_per_node)
 
     ray.init(address=cluster.address)
 
@@ -131,52 +132,66 @@ def test_checkpoint_freq(ray_start_4_cpus):
 
 
 @pytest.mark.parametrize(
-    "num_gpus_per_worker, expected_local_rank", [(0.5, 0), (1, 0), (2, 0)]
+    "num_gpus_per_worker,expected_devices", [(0.5, [0]), (1, [0]), (2, [0, 1])]
 )
-def test_tune_torch_get_device_gpu(
-    ray_2_node_2_gpu, num_gpus_per_worker, expected_local_rank
-):
+def test_tune_torch_get_device_gpu(num_gpus_per_worker, expected_devices):
     """Tests if GPU ids are set correctly when running train concurrently in nested actors
     (for example when used with Tune).
     """
     from ray.air.config import ScalingConfig
     import time
 
-    num_samples = int(2 // num_gpus_per_worker)
+    num_samples = 2
     num_workers = 2
 
-    @patch("torch.cuda.is_available", lambda: True)
-    def train_fn():
-        # two workers are spread across two different nodes
-        # the device ids are always set to 0,
-        # for example, if `num_gpus_per_worker`` is 2,
-        # then each worker will have `ray.get_gpu_ids() == [0, 1]`
-        # and thus, the local rank is 0.
-        assert train.torch.get_device().index == expected_local_rank
+    # We should have exactly enough resources in the cluster to run both samples
+    # concurrently.
+    total_gpus_required = num_workers * num_gpus_per_worker * num_samples
+    # Divide by two because of a 2 node cluster.
+    gpus_per_node = total_gpus_required // 2
 
-    @ray.remote
-    class TrialActor:
-        def __init__(self, warmup_steps):
-            # adding warmup_steps to the config
-            # to avoid the error of checkpoint name conflict
-            time.sleep(2 * warmup_steps)
-            self.trainer = TorchTrainer(
-                train_fn,
-                torch_config=TorchConfig(backend="gloo"),
-                scaling_config=ScalingConfig(
-                    num_workers=num_workers,
-                    use_gpu=True,
-                    resources_per_worker={"GPU": num_gpus_per_worker},
-                    placement_strategy="SPREAD"
-                    # Each gpu worker will be spread onto separate nodes.
-                ),
-            )
+    # Use the same number of cpus per node as gpus per node.
+    with ray_start_2_node_cluster(
+        num_cpus_per_node=gpus_per_node, num_gpus_per_node=gpus_per_node
+    ):
 
-        def run(self):
-            return self.trainer.fit()
+        @patch("torch.cuda.is_available", lambda: True)
+        def train_fn():
+            # We use STRICT_SPREAD strategy to force multiple samples on the same node.
+            # For single or fractional GPU case, each worker has only 1 visible device (
+            # the other is taken by the other sample) so device index should be 0.
+            # For the multiple GPU case, each worker has 2 visible devices so device
+            # index should be either 0 or 1. It doesn't matter which.
+            assert train.torch.get_device().index in expected_devices
 
-    actors = [TrialActor.remote(_) for _ in range(num_samples)]
-    ray.get([actor.run.remote() for actor in actors])
+        @ray.remote(num_cpus=0)
+        class TrialActor:
+            def __init__(self, warmup_steps):
+                # adding warmup_steps to the config
+                # to avoid the error of checkpoint name conflict
+                time.sleep(2 * warmup_steps)
+                self.trainer = TorchTrainer(
+                    train_fn,
+                    torch_config=TorchConfig(backend="gloo"),
+                    scaling_config=ScalingConfig(
+                        num_workers=num_workers,
+                        use_gpu=True,
+                        resources_per_worker={"CPU": 1, "GPU": num_gpus_per_worker},
+                        # Need to specify 0 trainer resources so STRICT_SPREAD
+                        # will work.
+                        trainer_resources={"CPU": 0},
+                        placement_strategy="STRICT_SPREAD",
+                        # Each gpu worker will be spread onto separate nodes. This
+                        # forces different samples to run concurrently on the same
+                        # node.
+                    ),
+                )
+
+            def run(self):
+                return self.trainer.fit()
+
+        actors = [TrialActor.remote(1) for _ in range(num_samples)]
+        ray.get([actor.run.remote() for actor in actors])
 
 
 def test_torch_auto_unwrap(ray_start_4_cpus):


### PR DESCRIPTION


Signed-off-by: Amog Kamsetty amogkamsetty@yahoo.com

Deflakes test_torch_trainer::test_tune_torch_get_device_gpu test. The multi device test case was relying on a set being in a particular order which is not always the case.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
