### PR TITLE
[AIR - Datasets] Cast tensor extension type to opaque object dtype in `.to_pandas()`, `.to_dask()`, etc.

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -189,7 +189,13 @@ class ArrowBlockAccessor(TableBlockAccessor):
         return self._table.schema
 
     def to_pandas(self) -> "pandas.DataFrame":
-        return self._table.to_pandas()
+        from ray.air.util.data_batch_conversion import _cast_tensor_columns_to_ndarrays
+
+        df = self._table.to_pandas()
+        ctx = DatasetContext.get_current()
+        if ctx.enable_tensor_extension_casting:
+            df = _cast_tensor_columns_to_ndarrays(df)
+        return df
 
     def to_numpy(
         self, columns: Optional[Union[str, List[str]]] = None

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2998,27 +2998,50 @@ class Dataset(Generic[T]):
 
         @dask.delayed
         def block_to_df(block: Block):
-            block = BlockAccessor.for_block(block)
             if isinstance(block, (ray.ObjectRef, ClientObjectRef)):
                 raise ValueError(
                     "Dataset.to_dask() must be used with Dask-on-Ray, please "
                     "set the Dask scheduler to ray_dask_get (located in "
                     "ray.util.dask)."
                 )
-            return block.to_pandas()
+            return _block_to_df(block)
 
         if meta is None:
+            from ray.data.extensions import TensorDtype
+
             # Infer Dask metadata from Datasets schema.
             schema = self.schema(fetch_if_missing=True)
             if isinstance(schema, PandasBlockSchema):
                 meta = pd.DataFrame(
                     {
-                        col: pd.Series(dtype=dtype)
+                        col: pd.Series(
+                            dtype=(
+                                dtype
+                                if not isinstance(dtype, TensorDtype)
+                                else np.object_
+                            )
+                        )
                         for col, dtype in zip(schema.names, schema.types)
                     }
                 )
             elif pa is not None and isinstance(schema, pa.Schema):
-                meta = schema.empty_table().to_pandas()
+                from ray.data.extensions import ArrowTensorType
+
+                if any(isinstance(type_, ArrowTensorType) for type_ in schema.types):
+                    meta = pd.DataFrame(
+                        {
+                            col: pd.Series(
+                                dtype=(
+                                    dtype.to_pandas_dtype()
+                                    if not isinstance(dtype, ArrowTensorType)
+                                    else np.object_
+                                )
+                            )
+                            for col, dtype in zip(schema.names, schema.types)
+                        }
+                    )
+                else:
+                    meta = schema.empty_table().to_pandas()
 
         ddf = dd.from_delayed(
             [block_to_df(block) for block in self.get_internal_block_refs()],
@@ -3112,7 +3135,6 @@ class Dataset(Generic[T]):
             A Pandas DataFrame created from this dataset, containing a limited
             number of records.
         """
-
         count = self.count()
         if count > limit:
             raise ValueError(
@@ -3125,7 +3147,8 @@ class Dataset(Generic[T]):
         output = DelegatingBlockBuilder()
         for block in blocks:
             output.add_block(ray.get(block))
-        return BlockAccessor.for_block(output.build()).to_pandas()
+        block = output.build()
+        return _block_to_df(block)
 
     def to_pandas_refs(self) -> List[ObjectRef["pandas.DataFrame"]]:
         """Convert this dataset into a distributed set of Pandas dataframes.
@@ -3985,8 +4008,14 @@ def _get_size_bytes(block: Block) -> int:
 
 
 def _block_to_df(block: Block):
+    from ray.air.util.data_batch_conversion import _cast_tensor_columns_to_ndarrays
+
     block = BlockAccessor.for_block(block)
-    return block.to_pandas()
+    df = block.to_pandas()
+    ctx = DatasetContext.get_current()
+    if ctx.enable_tensor_extension_casting:
+        df = _cast_tensor_columns_to_ndarrays(df)
+    return df
 
 
 def _block_to_ndarray(block: Block, column: Optional[str]):

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4008,14 +4008,8 @@ def _get_size_bytes(block: Block) -> int:
 
 
 def _block_to_df(block: Block):
-    from ray.air.util.data_batch_conversion import _cast_tensor_columns_to_ndarrays
-
     block = BlockAccessor.for_block(block)
-    df = block.to_pandas()
-    ctx = DatasetContext.get_current()
-    if ctx.enable_tensor_extension_casting:
-        df = _cast_tensor_columns_to_ndarrays(df)
-    return df
+    return block.to_pandas()
 
 
 def _block_to_ndarray(block: Block, column: Optional[str]):

--- a/python/ray/data/tests/test_batch_mapper.py
+++ b/python/ray/data/tests/test_batch_mapper.py
@@ -8,7 +8,6 @@ from pandas.testing import assert_frame_equal
 
 import ray
 from ray.data.preprocessors import BatchMapper
-from ray.data.extensions import TensorArray
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.arrow import ArrowTensorArray
 
@@ -183,9 +182,11 @@ def test_batch_mapper_pandas_data_format(ds_with_expected_pandas_numpy_df):
             ),
             pd.DataFrame(
                 {
-                    # Single column pandas automatically converts `TENSOR_COLUMN_NAME`
-                    # In UDFs
-                    TENSOR_COLUMN_NAME: TensorArray(np.arange(1, 13).reshape((3, 2, 2)))
+                    TENSOR_COLUMN_NAME: [
+                        [[1, 2], [3, 4]],
+                        [[5, 6], [7, 8]],
+                        [[9, 10], [11, 12]],
+                    ]
                 }
             ),
         ),
@@ -257,7 +258,7 @@ def test_batch_mapper_arrow_data_format(ds_with_expected_pandas_numpy_df):
 
 
 @pytest.mark.parametrize(
-    "ds_with_expected_pandas_numpy_df",
+    "ds,expected_df",
     [
         (
             ds_numpy_single_column_tensor_format(),
@@ -270,13 +271,6 @@ def test_batch_mapper_arrow_data_format(ds_with_expected_pandas_numpy_df):
                         [[5, 6], [7, 8]],
                         [[9, 10], [11, 12]],
                     ]
-                }
-            ),
-            pd.DataFrame(
-                {
-                    # Single column pandas automatically converts `TENSOR_COLUMN_NAME`
-                    # In UDFs
-                    TENSOR_COLUMN_NAME: TensorArray(np.arange(1, 13).reshape((3, 2, 2)))
                 }
             ),
         ),
@@ -296,24 +290,16 @@ def test_batch_mapper_arrow_data_format(ds_with_expected_pandas_numpy_df):
                     ]
                 }
             ),
-            pd.DataFrame(
-                {
-                    # Single column pandas automatically converts `TENSOR_COLUMN_NAME`
-                    # In UDFs
-                    TENSOR_COLUMN_NAME: TensorArray(np.arange(1, 25).reshape((6, 2, 2)))
-                }
-            ),
         ),
     ],
 )
-def test_batch_mapper_numpy_data_format(ds_with_expected_pandas_numpy_df):
+def test_batch_mapper_numpy_data_format(ds, expected_df):
     """Tests batch mapper functionality for numpy data format.
 
     Note:
         For single column pandas dataframes, we automatically convert it to
         single column tensor with column name as `__value__`.
     """
-    ds, expected_df, expected_numpy_df = ds_with_expected_pandas_numpy_df
 
     def add_and_modify_udf_pandas(df: "pd.DataFrame"):
         col_name = list(df.columns)[0]
@@ -331,7 +317,7 @@ def test_batch_mapper_numpy_data_format(ds_with_expected_pandas_numpy_df):
 
     transformed_ds = ds.map_batches(add_and_modify_udf_numpy, batch_format="numpy")
     out_df_map_batches = transformed_ds.to_pandas()
-    assert_frame_equal(out_df_map_batches, expected_numpy_df)
+    assert_frame_equal(out_df_map_batches, expected_df)
 
     # Test BatchMapper
     batch_mapper = BatchMapper(fn=add_and_modify_udf_pandas, batch_format="pandas")
@@ -344,7 +330,7 @@ def test_batch_mapper_numpy_data_format(ds_with_expected_pandas_numpy_df):
     batch_mapper.fit(ds)
     transformed_ds = batch_mapper.transform(ds)
     out_df = transformed_ds.to_pandas()
-    assert_frame_equal(out_df, expected_numpy_df)
+    assert_frame_equal(out_df, expected_df)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_dataset_image.py
+++ b/python/ray/data/tests/test_dataset_image.py
@@ -93,7 +93,10 @@ class TestReadImages:
 
         df = ds.to_pandas()
         assert sorted(df["label"]) == ["cat", "cat", "dog"]
-        assert all(tensor.numpy_shape == (32, 32, 3) for tensor in df["image"])
+        if enable_automatic_tensor_extension_cast:
+            assert all(tensor.shape == (32, 32, 3) for tensor in df["image"])
+        else:
+            assert all(tensor.numpy_shape == (32, 32, 3) for tensor in df["image"])
 
     def test_e2e_prediction(self, ray_start_regular_shared):
         from ray.train.torch import TorchCheckpoint, TorchPredictor


### PR DESCRIPTION
Cast tensor columns in Pandas views of Datasets to an opaque object dtype, to match the semantics of our batch UDFs and iterators.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/29490

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
