### PR TITLE
refactor: Use GP3 EBS volumes for 100tb_shuffle

### DIFF
--- a/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
@@ -7,10 +7,12 @@ aws:
           Ebs:
             DeleteOnTermination: true
             VolumeSize: 2000
+            VolumeType: gp3
         - DeviceName: /dev/sda2
           Ebs:
             DeleteOnTermination: true
             VolumeSize: 2000
+            VolumeType: gp3
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances.yaml
+++ b/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances.yaml
@@ -7,6 +7,7 @@ aws:
           Ebs:
             DeleteOnTermination: true
             VolumeSize: 1000
+            VolumeType: gp3
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/shuffle_compute_autoscaling.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_autoscaling.yaml
@@ -7,6 +7,7 @@ aws:
           Ebs:
             DeleteOnTermination: true
             VolumeSize: 500
+            VolumeType: gp3
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
@@ -7,6 +7,7 @@ aws:
           Ebs:
             DeleteOnTermination: true
             VolumeSize: 500
+            VolumeType: gp3
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/shuffle_compute_multi.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_multi.yaml
@@ -9,6 +9,7 @@ aws:
           Ebs:
             DeleteOnTermination: true
             VolumeSize: 500
+            VolumeType: gp3
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/shuffle_compute_single.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_single.yaml
@@ -9,6 +9,7 @@ aws:
           Ebs:
             DeleteOnTermination: true
             VolumeSize: 500
+            VolumeType: gp3
 
 head_node_type:
     name: head_node


### PR DESCRIPTION
- Increases theoretical throughput max from 250 to 1000 MiB/s
- Decreases IOPS from 6000 to 3000 (but can be set if desired)
- Reduces cost for 400TB of volumes by ~20%

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Saves money and likely increases performance of a large test. 100 TB shuffle is the most expensive release test to run, so is a prime target to switch to GP3 EBS volumes first.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
