### PR TITLE
[RLlib] Include replay buffer API test

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -3354,6 +3354,7 @@ py_test(
 
 py_test(
     name = "examples/replay_buffer_api",
+    main = "examples/replay_buffer_api.py",
     tags = ["team:rllib", "examples"],
     size = "large",
     srcs = ["examples/replay_buffer_api.py"],

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -3354,8 +3354,7 @@ py_test(
 
 py_test(
     name = "examples/replay_buffer_api",
-    main = "examples/replay_buffer_api.py",
-    tags = ["team:rllib", "examples"],
+    tags = ["team:rllib", "examples", "examples_R"],
     size = "large",
     srcs = ["examples/replay_buffer_api.py"],
     args = ["--as-test", "--stop-reward=70"]

--- a/rllib/examples/replay_buffer_api.py
+++ b/rllib/examples/replay_buffer_api.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
         .environment(env="CartPole-v0")
         .training(model=dict(use_lstm=True, lstm_cell_size=64, max_seq_len=20))
         .framework(framework=args.framework)
-        .rollouts(num_workers=4)
+        .rollouts(num_rollout_workers=4)
     )
 
     stop_config = {


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Replay Buffer API test broke a while ago and is not included in tests.

## Related issue number

Closes #29367 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
