### PR TITLE
[nightly-test][tune] fix tune test failures due to protobuf version change.

### DIFF
--- a/release/tune_tests/cloud_tests/app_config.yaml
+++ b/release/tune_tests/cloud_tests/app_config.yaml
@@ -11,6 +11,7 @@ python:
     - gym>=0.21.0,<0.24.1
     - gcsfs<=2022.7.1
     - pyarrow>=6.0.1,<7.0.0
+    - tensorboardX
   conda_packages: []
 
 post_build_cmds:

--- a/release/tune_tests/cloud_tests/app_config.yaml
+++ b/release/tune_tests/cloud_tests/app_config.yaml
@@ -12,6 +12,7 @@ python:
     - gcsfs<=2022.7.1
     - pyarrow>=6.0.1,<7.0.0
     - tensorboardX
+    - grpcio-tools
   conda_packages: []
 
 post_build_cmds:

--- a/release/tune_tests/cloud_tests/app_config.yaml
+++ b/release/tune_tests/cloud_tests/app_config.yaml
@@ -12,7 +12,6 @@ python:
     - gcsfs<=2022.7.1
     - pyarrow>=6.0.1,<7.0.0
     - tensorboardX
-    - grpcio-tools
   conda_packages: []
 
 post_build_cmds:

--- a/release/tune_tests/cloud_tests/app_config_ml.yaml
+++ b/release/tune_tests/cloud_tests/app_config_ml.yaml
@@ -11,6 +11,7 @@ python:
     - gym>=0.21.0,<0.24.1
     - gcsfs<=2022.7.1
     - pyarrow>=6.0.1,<7.0.0
+    - tensorboardX
   conda_packages: []
 
 post_build_cmds:

--- a/release/tune_tests/cloud_tests/app_config_ml.yaml
+++ b/release/tune_tests/cloud_tests/app_config_ml.yaml
@@ -12,6 +12,7 @@ python:
     - gcsfs<=2022.7.1
     - pyarrow>=6.0.1,<7.0.0
     - tensorboardX
+    - grpcio-tools
   conda_packages: []
 
 post_build_cmds:

--- a/release/tune_tests/cloud_tests/app_config_ml.yaml
+++ b/release/tune_tests/cloud_tests/app_config_ml.yaml
@@ -12,7 +12,6 @@ python:
     - gcsfs<=2022.7.1
     - pyarrow>=6.0.1,<7.0.0
     - tensorboardX
-    - grpcio-tools
   conda_packages: []
 
 post_build_cmds:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

the tune related nightly tests[ began to fail ](https://buildkite.com/ray-project/release-tests-branch/builds/1129#0183e820-cb4c-4193-b7da-666f95c0c220)after we loose the upper bound limit for protobuf. Reading the log it looks the tensorboardX we installed is not compatible with latest protobuf. We need to explicit install tensorboardX so pip can recognize the dependency constraints of tensorboardX.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests https://console.anyscale-staging.com/o/anyscale-internal/projects/prj_qC3ZfndQWYYjx2cz8KWGNUL4/clusters/ses_dtVeARQRSF1kENi7VTzV6riA?command-history-section=head_start_up_log
   - [ ] This PR is not tested :(
