### PR TITLE
Revert "[Core] Allow to run memray against dashboard / agent"

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -67,17 +67,6 @@ RAY_JEMALLOC_LIB_PATH = "RAY_JEMALLOC_LIB_PATH"
 RAY_JEMALLOC_CONF = "RAY_JEMALLOC_CONF"
 RAY_JEMALLOC_PROFILE = "RAY_JEMALLOC_PROFILE"
 
-# Comma separated name of components that will run memory profiler.
-# Ray uses `memray` to memory profile internal components.
-# The name of the component must be one of ray_constants.PROCESS_TYPE*.
-RAY_MEMRAY_PROFILE_COMPONENT_ENV = "RAY_INTERNAL_MEM_PROFILE_COMPONENTS"
-# Options to specify for `memray run` command. See
-# `memray run --help` for more details.
-# Example:
-# RAY_INTERNAL_MEM_PROFILE_OPTIONS="--live,--live-port,3456,-q,"
-# -> `memray run --live --live-port 3456 -q`
-RAY_MEMRAY_PROFILE_OPTIONS_ENV = "RAY_INTERNAL_MEM_PROFILE_OPTIONS"
-
 # Logger for this module. It should be configured at the entry point
 # into the program using Ray. Ray provides a default configuration at
 # entry/init points.
@@ -96,52 +85,6 @@ ProcessInfo = collections.namedtuple(
         "use_tmux",
     ],
 )
-
-
-def _build_python_executable_command_memory_profileable(
-    component: str, session_dir: str, unbuffered: bool = True
-):
-    """Build the Python executable command.
-
-    It runs a memory profiler if env var is configured.
-
-    Args:
-        component: Name of the component. It must be one of
-            ray_constants.PROCESS_TYPE*.
-        session_dir: The directory name of the Ray session.
-        unbuffered: If true, Python executable is started with unbuffered option.
-            e.g., `-u`.
-            It means the logs are flushed immediately (good when there's a failure),
-            but writing to a log file can be slower.
-    """
-    command = [
-        sys.executable,
-    ]
-    if unbuffered:
-        command.append("-u")
-    components_to_memory_profile = os.getenv(RAY_MEMRAY_PROFILE_COMPONENT_ENV, "")
-    if not components_to_memory_profile:
-        return command
-
-    components_to_memory_profile = set(components_to_memory_profile.split(","))
-    try:
-        import memray  # noqa: F401
-    except ImportError:
-        raise ImportError(
-            "Memray is required to memory profiler on components "
-            f"{components_to_memory_profile}. Run `pip install memray`."
-        )
-    if component in components_to_memory_profile:
-        session_dir = Path(session_dir)
-        session_name = session_dir.name
-        profile_dir = session_dir / "profile"
-        profile_dir.mkdir(exist_ok=True)
-        output_file_path = profile_dir / f"{session_name}_memory_{component}.bin"
-        options = os.getenv(RAY_MEMRAY_PROFILE_OPTIONS_ENV, None)
-        options = options.split(",") if options else []
-        command.extend(["-m", "memray", "run", "-o", str(output_file_path), *options])
-
-    return command
 
 
 def _get_gcs_client_options(redis_address, redis_password, gcs_server_address):
@@ -1086,9 +1029,8 @@ def start_api_server(
         dashboard_filepath = os.path.join(RAY_PATH, dashboard_dir, "dashboard.py")
 
         command = [
-            *_build_python_executable_command_memory_profileable(
-                ray_constants.PROCESS_TYPE_DASHBOARD, session_dir
-            ),
+            sys.executable,
+            "-u",
             dashboard_filepath,
             f"--host={host}",
             f"--port={port}",
@@ -1460,9 +1402,8 @@ def start_raylet(
         max_worker_port = 0
 
     agent_command = [
-        *_build_python_executable_command_memory_profileable(
-            ray_constants.PROCESS_TYPE_DASHBOARD_AGENT, session_dir
-        ),
+        sys.executable,
+        "-u",
         os.path.join(RAY_PATH, "dashboard", "agent.py"),
         f"--node-ip-address={node_ip_address}",
         f"--metrics-export-port={metrics_export_port}",

--- a/python/ray/tests/test_debug_tools.py
+++ b/python/ray/tests/test_debug_tools.py
@@ -3,14 +3,8 @@ import subprocess
 import sys
 
 import pytest
-from pathlib import Path
 
 import ray
-
-import ray._private.services as services
-import ray._private.ray_constants as ray_constants
-
-from ray._private.test_utils import wait_for_condition
 
 
 @pytest.fixture
@@ -50,84 +44,6 @@ def test_raylet_gdb(ray_gdb_start):
         stderr=subprocess.PIPE,
     )
     assert pgrep_command.communicate()[0]
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="memray not supported in win32")
-def test_memory_profiler_command_builder(monkeypatch, tmp_path):
-    session_dir = tmp_path
-    # When there's no env var, command should be just a regular python command.
-    command = services._build_python_executable_command_memory_profileable(
-        ray_constants.PROCESS_TYPE_DASHBOARD, session_dir
-    )
-    assert command == [sys.executable, "-u"]
-
-    with monkeypatch.context() as m:
-        m.setenv(services.RAY_MEMRAY_PROFILE_COMPONENT_ENV, "dashboard")
-        m.setenv(services.RAY_MEMRAY_PROFILE_OPTIONS_ENV, "-q")
-        command = services._build_python_executable_command_memory_profileable(
-            ray_constants.PROCESS_TYPE_DASHBOARD, session_dir
-        )
-
-        assert command == [
-            sys.executable,
-            "-u",
-            "-m",
-            "memray",
-            "run",
-            "-o",
-            str(
-                Path(tmp_path)
-                / "profile"
-                / f"{Path(tmp_path).name}_memory_dashboard.bin"
-            ),  # noqa
-            "-q",
-        ]
-        m.delenv(services.RAY_MEMRAY_PROFILE_COMPONENT_ENV)
-        m.delenv(services.RAY_MEMRAY_PROFILE_OPTIONS_ENV)
-        m.setenv(services.RAY_MEMRAY_PROFILE_COMPONENT_ENV, "dashboard,dashboard_agent")
-        m.setenv(services.RAY_MEMRAY_PROFILE_OPTIONS_ENV, "-q,--live,--live-port,1234")
-        command = services._build_python_executable_command_memory_profileable(
-            ray_constants.PROCESS_TYPE_DASHBOARD_AGENT, session_dir
-        )
-        assert command == [
-            sys.executable,
-            "-u",
-            "-m",
-            "memray",
-            "run",
-            "-o",
-            str(
-                Path(tmp_path)
-                / "profile"
-                / f"{Path(tmp_path).name}_memory_dashboard_agent.bin"
-            ),  # noqa
-            "-q",
-            "--live",
-            "--live-port",
-            "1234",
-        ]
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="memray not supported in win32")
-def test_memory_profile_dashboard_and_agent(monkeypatch, shutdown_only):
-    with monkeypatch.context() as m:
-        m.setenv(services.RAY_MEMRAY_PROFILE_COMPONENT_ENV, "dashboard,dashboard_agent")
-        m.setenv(services.RAY_MEMRAY_PROFILE_OPTIONS_ENV, "-q")
-        addr = ray.init()
-
-        def verify():
-            session_dir = Path(addr["session_dir"])
-            profile_dir = session_dir / "profile"
-            assert profile_dir.exists()
-            files = []
-            for f in profile_dir.iterdir():
-                files.append(f.name)
-            assert len(files) == 2
-            assert f"{session_dir.name}_memory_dashboard.bin" in files
-            assert f"{session_dir.name}_memory_dashboard_agent.bin" in files
-            return True
-
-        wait_for_condition(verify)
 
 
 if __name__ == "__main__":

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -103,7 +103,6 @@ tqdm
 testfixtures
 werkzeug<2.2.0
 xlrd
-memray; platform_system != "Windows"
 
 # For doc tests
 myst-parser==0.15.2


### PR DESCRIPTION
Reverts ray-project/ray#29366

Break mac builds.

<img width="447" alt="image" src="https://user-images.githubusercontent.com/74173148/196560470-c4ea805e-2b72-4674-bfab-cf0b69fc8546.png">
