### PR TITLE
[Metrics] Disable high cardinality operation metrics by default

### DIFF
--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -251,7 +251,6 @@ def test_metrics_export_end_to_end(_setup_cluster_for_test):
 
         # Make sure the gRPC stats are not reported from workers. We disabled
         # it there because it has too high cardinality.
-        print(metric_samples)
         grpc_metrics = [
             "ray_grpc_server_req_process_time_ms",
             "ray_grpc_server_req_new_total",

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -15,6 +15,7 @@ from ray._private.test_utils import (
     fetch_prometheus,
     get_log_batch,
     wait_for_condition,
+    raw_metrics,
 )
 from ray.autoscaler._private.constants import AUTOSCALER_METRIC_PORT
 from ray.dashboard.consts import DASHBOARD_METRIC_PORT
@@ -49,10 +50,6 @@ _METRICS = [
     "ray_internal_num_spilled_tasks",
     # "ray_unintentional_worker_failures_total",
     # "ray_node_failure_total",
-    "ray_operation_count",
-    "ray_operation_run_time_ms",
-    "ray_operation_queue_time_ms",
-    "ray_operation_active_count",
     "ray_grpc_server_req_process_time_ms",
     "ray_grpc_server_req_new_total",
     "ray_grpc_server_req_handling_total",
@@ -252,6 +249,20 @@ def test_metrics_export_end_to_end(_setup_cluster_for_test):
         assert hist_count == 1
         assert hist_sum == 1.5
 
+        # Make sure the gRPC stats are not reported from workers. We disabled
+        # it there because it has too high cardinality.
+        print(metric_samples)
+        grpc_metrics = [
+            "ray_grpc_server_req_process_time_ms",
+            "ray_grpc_server_req_new_total",
+            "ray_grpc_server_req_handling_total",
+            "ray_grpc_server_req_finished_total",
+        ]
+        for grpc_metric in grpc_metrics:
+            grpc_samples = [m for m in metric_samples if grpc_metric in m.name]
+            for grpc_sample in grpc_samples:
+                assert grpc_sample.labels["Component"] != "core_worker"
+
         # Autoscaler metrics
         _, autoscaler_metric_names, _ = fetch_prometheus([autoscaler_export_addr])
         for metric in _AUTOSCALER_METRICS:
@@ -286,6 +297,39 @@ def test_metrics_export_end_to_end(_setup_cluster_for_test):
     except RuntimeError:
         print(f"The components are {pformat(fetch_prometheus(prom_addresses))}")
         test_cases()  # Should fail assert
+
+
+def test_operation_stats(monkeypatch, shutdown_only):
+    # Test operation stats are available when flag is on.
+    operation_metrics = [
+        "ray_operation_count",
+        "ray_operation_run_time_ms",
+        "ray_operation_queue_time_ms",
+        "ray_operation_active_count",
+    ]
+    with monkeypatch.context() as m:
+        m.setenv("RAY_event_stats_metrics", "1")
+        addr = ray.init()
+
+        @ray.remote
+        def f():
+            pass
+
+        ray.get(f.remote())
+
+        def verify():
+            metrics = raw_metrics(addr)
+            metric_names = set(metrics.keys())
+            for op_metric in operation_metrics:
+                assert op_metric in metric_names
+                samples = metrics[op_metric]
+                components = set()
+                for sample in samples:
+                    components.add(sample.labels["Component"])
+            assert {"raylet", "gcs_server", "core_worker"} == components
+            return True
+
+        wait_for_condition(verify, timeout=30)
 
 
 def test_prometheus_file_based_service_discovery(ray_start_cluster):

--- a/src/ray/common/event_stats.cc
+++ b/src/ray/common/event_stats.cc
@@ -111,11 +111,11 @@ void EventTracker::RecordExecution(const std::function<void()> &fn,
   if (RayConfig::instance().event_stats_metrics()) {
     // Update event-specific stats.
     ray::stats::STATS_operation_run_time_ms.Record(execution_time_ns / 1000000,
-                                                  handle->event_name);
+                                                   handle->event_name);
     ray::stats::STATS_operation_active_count.Record(curr_count, handle->event_name);
     // Update global stats.
     ray::stats::STATS_operation_queue_time_ms.Record(queue_time_ns / 1000000,
-                                                    handle->event_name);
+                                                     handle->event_name);
   }
 
   {

--- a/src/ray/common/event_stats.cc
+++ b/src/ray/common/event_stats.cc
@@ -68,8 +68,12 @@ std::shared_ptr<StatsHandle> EventTracker::RecordStart(
     stats->stats.cum_count++;
     curr_count = ++stats->stats.curr_count;
   }
-  ray::stats::STATS_operation_count.Record(curr_count, name);
-  ray::stats::STATS_operation_active_count.Record(curr_count, name);
+
+  if (RayConfig::instance().event_stats_metrics()) {
+    ray::stats::STATS_operation_count.Record(curr_count, name);
+    ray::stats::STATS_operation_active_count.Record(curr_count, name);
+  }
+
   return std::make_shared<StatsHandle>(
       name,
       absl::GetCurrentTimeNanos() + expected_queueing_delay_ns,
@@ -91,9 +95,6 @@ void EventTracker::RecordExecution(const std::function<void()> &fn,
   int64_t end_execution = absl::GetCurrentTimeNanos();
   // Update execution time stats.
   const auto execution_time_ns = end_execution - start_execution;
-  // Update event-specific stats.
-  ray::stats::STATS_operation_run_time_ms.Record(execution_time_ns / 1000000,
-                                                 handle->event_name);
   int64_t curr_count;
   {
     auto &stats = handle->handler_stats;
@@ -105,11 +106,18 @@ void EventTracker::RecordExecution(const std::function<void()> &fn,
     // Event-specific running count.
     stats->stats.running_count--;
   }
-  ray::stats::STATS_operation_active_count.Record(curr_count, handle->event_name);
-  // Update global stats.
   const auto queue_time_ns = start_execution - handle->start_time;
-  ray::stats::STATS_operation_queue_time_ms.Record(queue_time_ns / 1000000,
-                                                   handle->event_name);
+
+  if (RayConfig::instance().event_stats_metrics()) {
+    // Update event-specific stats.
+    ray::stats::STATS_operation_run_time_ms.Record(execution_time_ns / 1000000,
+                                                  handle->event_name);
+    ray::stats::STATS_operation_active_count.Record(curr_count, handle->event_name);
+    // Update global stats.
+    ray::stats::STATS_operation_queue_time_ms.Record(queue_time_ns / 1000000,
+                                                    handle->event_name);
+  }
+
   {
     auto global_stats = handle->global_stats;
     absl::MutexLock lock(&(global_stats->mutex));

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -22,8 +22,12 @@
 RAY_CONFIG(uint64_t, debug_dump_period_milliseconds, 10000)
 
 /// Whether to enable Ray event stats collection.
-/// TODO(ekl) this seems to segfault Java unit tests when on by default?
 RAY_CONFIG(bool, event_stats, true)
+
+/// Whether to enbale Ray event stats metrics export.
+/// Note that enabling this adds high overhead to
+/// Ray metrics agent.
+RAY_CONFIG(bool, event_stats_metrics, false)
 
 /// Whether to enable Ray legacy scheduler warnings. These are replaced by
 /// autoscaler messages after https://github.com/ray-project/ray/pull/18724.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -489,7 +489,7 @@ RAY_CONFIG(int64_t, idle_worker_killing_time_threshold_ms, 1000)
 RAY_CONFIG(int64_t, num_workers_soft_limit, -1)
 
 // The interval where metrics are exported in milliseconds.
-RAY_CONFIG(uint64_t, metrics_report_interval_ms, 5000)
+RAY_CONFIG(uint64_t, metrics_report_interval_ms, 30000)
 
 /// Enable the task timeline. If this is enabled, certain events such as task
 /// execution are profiled and sent to the GCS.

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -132,12 +132,15 @@ class ServerCallImpl : public ServerCall {
   /// \param[in] service_handler The service handler that handles the request.
   /// \param[in] handle_request_function Pointer to the service handler function.
   /// \param[in] io_service The event loop.
+  /// \param[in] call_name The name of the RPC call.
+  /// \param[in] record_metrics If true, it records and exports the gRPC server metrics.
   ServerCallImpl(
       const ServerCallFactory &factory,
       ServiceHandler &service_handler,
       HandleRequestFunction<ServiceHandler, Request, Reply> handle_request_function,
       instrumented_io_context &io_service,
-      std::string call_name)
+      std::string call_name,
+      bool record_metrics)
       : state_(ServerCallState::PENDING),
         factory_(factory),
         service_handler_(service_handler),
@@ -145,11 +148,14 @@ class ServerCallImpl : public ServerCall {
         response_writer_(&context_),
         io_service_(io_service),
         call_name_(std::move(call_name)),
-        start_time_(0) {
+        start_time_(0),
+        record_metrics_(record_metrics) {
     reply_ = google::protobuf::Arena::CreateMessage<Reply>(&arena_);
     // TODO call_name_ sometimes get corrunpted due to memory issues.
     RAY_CHECK(!call_name_.empty()) << "Call name is empty";
-    ray::stats::STATS_grpc_server_req_new.Record(1.0, call_name_);
+    if (record_metrics_) {
+      ray::stats::STATS_grpc_server_req_new.Record(1.0, call_name_);
+    }
   }
 
   ~ServerCallImpl() override = default;
@@ -160,7 +166,9 @@ class ServerCallImpl : public ServerCall {
 
   void HandleRequest() override {
     start_time_ = absl::GetCurrentTimeNanos();
-    ray::stats::STATS_grpc_server_req_handling.Record(1.0, call_name_);
+    if (record_metrics_) {
+      ray::stats::STATS_grpc_server_req_handling.Record(1.0, call_name_);
+    }
     if (!io_service_.stopped()) {
       io_service_.post([this] { HandleRequestImpl(); }, call_name_);
     } else {
@@ -201,7 +209,9 @@ class ServerCallImpl : public ServerCall {
   }
 
   void OnReplySent() override {
-    ray::stats::STATS_grpc_server_req_finished.Record(1.0, call_name_);
+    if (record_metrics_) {
+      ray::stats::STATS_grpc_server_req_finished.Record(1.0, call_name_);
+    }
     if (send_reply_success_callback_ && !io_service_.stopped()) {
       auto callback = std::move(send_reply_success_callback_);
       io_service_.post([callback]() { callback(); }, call_name_ + ".success_callback");
@@ -210,7 +220,9 @@ class ServerCallImpl : public ServerCall {
   }
 
   void OnReplyFailed() override {
-    ray::stats::STATS_grpc_server_req_finished.Record(1.0, call_name_);
+    if (record_metrics_) {
+      ray::stats::STATS_grpc_server_req_finished.Record(1.0, call_name_);
+    }
     if (send_reply_failure_callback_ && !io_service_.stopped()) {
       auto callback = std::move(send_reply_failure_callback_);
       io_service_.post([callback]() { callback(); }, call_name_ + ".failure_callback");
@@ -224,8 +236,10 @@ class ServerCallImpl : public ServerCall {
   /// Log the duration this query used
   void LogProcessTime() {
     auto end_time = absl::GetCurrentTimeNanos();
-    ray::stats::STATS_grpc_server_req_process_time_ms.Record(
-        (end_time - start_time_) / 1000000.0, call_name_);
+    if (record_metrics_) {
+      ray::stats::STATS_grpc_server_req_process_time_ms.Record(
+          (end_time - start_time_) / 1000000.0, call_name_);
+    }
   }
   /// Tell gRPC to finish this request and send reply asynchronously.
   void SendReply(const Status &status) {
@@ -279,6 +293,9 @@ class ServerCallImpl : public ServerCall {
   /// The ts when the request created
   int64_t start_time_;
 
+  /// If true, the server call will generate gRPC server metrics.
+  bool record_metrics_;
+
   template <class T1, class T2, class T3, class T4>
   friend class ServerCallFactoryImpl;
 };
@@ -317,8 +334,10 @@ class ServerCallFactoryImpl : public ServerCallFactory {
   /// \param[in] handle_request_function Pointer to the service handler function.
   /// \param[in] cq The `CompletionQueue`.
   /// \param[in] io_service The event loop.
+  /// \param[in] call_name The name of the RPC call.
   /// \param[in] max_active_rpcs Maximum request number to handle at the same time. -1
   /// means no limit.
+  /// \param[in] record_metrics If true, it records and exports the gRPC server metrics.
   ServerCallFactoryImpl(
       AsyncService &service,
       RequestCallFunction<GrpcService, Request, Reply> request_call_function,
@@ -327,7 +346,8 @@ class ServerCallFactoryImpl : public ServerCallFactory {
       const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
       instrumented_io_context &io_service,
       std::string call_name,
-      int64_t max_active_rpcs)
+      int64_t max_active_rpcs,
+      bool record_metrics)
       : service_(service),
         request_call_function_(request_call_function),
         service_handler_(service_handler),
@@ -335,13 +355,19 @@ class ServerCallFactoryImpl : public ServerCallFactory {
         cq_(cq),
         io_service_(io_service),
         call_name_(std::move(call_name)),
-        max_active_rpcs_(max_active_rpcs) {}
+        max_active_rpcs_(max_active_rpcs),
+        record_metrics_(record_metrics) {}
 
   void CreateCall() const override {
     // Create a new `ServerCall`. This object will eventually be deleted by
     // `GrpcServer::PollEventsFromCompletionQueue`.
-    auto call = new ServerCallImpl<ServiceHandler, Request, Reply>(
-        *this, service_handler_, handle_request_function_, io_service_, call_name_);
+    auto call =
+        new ServerCallImpl<ServiceHandler, Request, Reply>(*this,
+                                                           service_handler_,
+                                                           handle_request_function_,
+                                                           io_service_,
+                                                           call_name_,
+                                                           record_metrics_);
     /// Request gRPC runtime to starting accepting this kind of request, using the call as
     /// the tag.
     (service_.*request_call_function_)(&call->context_,
@@ -379,6 +405,9 @@ class ServerCallFactoryImpl : public ServerCallFactory {
   /// Maximum request number to handle at the same time.
   /// -1 means no limit.
   uint64_t max_active_rpcs_;
+
+  /// If true, the server call will generate gRPC server metrics.
+  bool record_metrics_;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/worker/core_worker_server.h
+++ b/src/ray/rpc/worker/core_worker_server.h
@@ -27,27 +27,35 @@ class CoreWorker;
 namespace rpc {
 
 /// NOTE: See src/ray/core_worker/core_worker.h on how to add a new grpc handler.
-#define RAY_CORE_WORKER_RPC_HANDLERS                                         \
-  RPC_SERVICE_HANDLER(CoreWorkerService, PushTask, -1)                       \
-  RPC_SERVICE_HANDLER(CoreWorkerService, DirectActorCallArgWaitComplete, -1) \
-  RPC_SERVICE_HANDLER(CoreWorkerService, RayletNotifyGCSRestart, -1)         \
-  RPC_SERVICE_HANDLER(CoreWorkerService, GetObjectStatus, -1)                \
-  RPC_SERVICE_HANDLER(CoreWorkerService, WaitForActorOutOfScope, -1)         \
-  RPC_SERVICE_HANDLER(CoreWorkerService, PubsubLongPolling, -1)              \
-  RPC_SERVICE_HANDLER(CoreWorkerService, PubsubCommandBatch, -1)             \
-  RPC_SERVICE_HANDLER(CoreWorkerService, UpdateObjectLocationBatch, -1)      \
-  RPC_SERVICE_HANDLER(CoreWorkerService, GetObjectLocationsOwner, -1)        \
-  RPC_SERVICE_HANDLER(CoreWorkerService, KillActor, -1)                      \
-  RPC_SERVICE_HANDLER(CoreWorkerService, CancelTask, -1)                     \
-  RPC_SERVICE_HANDLER(CoreWorkerService, RemoteCancelTask, -1)               \
-  RPC_SERVICE_HANDLER(CoreWorkerService, GetCoreWorkerStats, -1)             \
-  RPC_SERVICE_HANDLER(CoreWorkerService, LocalGC, -1)                        \
-  RPC_SERVICE_HANDLER(CoreWorkerService, SpillObjects, -1)                   \
-  RPC_SERVICE_HANDLER(CoreWorkerService, RestoreSpilledObjects, -1)          \
-  RPC_SERVICE_HANDLER(CoreWorkerService, DeleteSpilledObjects, -1)           \
-  RPC_SERVICE_HANDLER(CoreWorkerService, PlasmaObjectReady, -1)              \
-  RPC_SERVICE_HANDLER(CoreWorkerService, Exit, -1)                           \
-  RPC_SERVICE_HANDLER(CoreWorkerService, AssignObjectOwner, -1)
+/// Disable gRPC server metrics since it incurs too high cardinality.
+#define RAY_CORE_WORKER_RPC_HANDLERS                                                     \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, PushTask, -1)           \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
+      CoreWorkerService, DirectActorCallArgWaitComplete, -1)                             \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
+      CoreWorkerService, RayletNotifyGCSRestart, -1)                                     \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, GetObjectStatus, -1)    \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
+      CoreWorkerService, WaitForActorOutOfScope, -1)                                     \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, PubsubLongPolling, -1)  \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, PubsubCommandBatch, -1) \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
+      CoreWorkerService, UpdateObjectLocationBatch, -1)                                  \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
+      CoreWorkerService, GetObjectLocationsOwner, -1)                                    \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, KillActor, -1)          \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, CancelTask, -1)         \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, RemoteCancelTask, -1)   \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, GetCoreWorkerStats, -1) \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, LocalGC, -1)            \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, SpillObjects, -1)       \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
+      CoreWorkerService, RestoreSpilledObjects, -1)                                      \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
+      CoreWorkerService, DeleteSpilledObjects, -1)                                       \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, PlasmaObjectReady, -1)  \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, Exit, -1)               \
+  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, AssignObjectOwner, -1)
 
 #define RAY_CORE_WORKER_DECLARE_RPC_HANDLERS                              \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(PushTask)                       \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Looks like the agent leaks the memory because it is highly overloaded, and the gRPC requests are queued up without being GC;ed,

This PR does 2 things for the short term mitigation
1. Increase the worker metrics export interval (recover to the original values)
2. Remove high cardinality metrics (operation + grpc) from worker metrics

## Related issue number

Closes https://github.com/ray-project/ray/issues/29199 (I already asked the user to try high worker metrics export interval)

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
