### PR TITLE
[Dashboard] Add a doc button. (#29315)

### DIFF
--- a/dashboard/client/src/pages/layout/index.tsx
+++ b/dashboard/client/src/pages/layout/index.tsx
@@ -5,7 +5,12 @@ import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
 import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
-import { NightsStay, VerticalAlignTop, WbSunny } from "@material-ui/icons";
+import {
+  Help,
+  NightsStay,
+  VerticalAlignTop,
+  WbSunny,
+} from "@material-ui/icons";
 import classnames from "classnames";
 import React, { PropsWithChildren, useContext } from "react";
 
@@ -170,6 +175,15 @@ const BasicLayout = (
             >
               <Tooltip title={`Theme - ${theme}`}>
                 {theme === "dark" ? <NightsStay /> : <WbSunny />}
+              </Tooltip>
+            </IconButton>
+            <IconButton
+              href="https://docs.ray.io/en/master/ray-core/ray-dashboard.html"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Tooltip title="Doc">
+                <Help />
               </Tooltip>
             </IconButton>
           </ListItem>


### PR DESCRIPTION
To help users understand dashboard, this adds a doc button to look at ray dashboard documentation. We can potentially add something similar to each pages (e.g., metrics page to the metrics setup doc)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add a doc button to the dashboard. This is a pretty low-risk change and IMO has a high ROI

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
