### PR TITLE
[CI] Pin Gradio to 3.5

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -45,7 +45,7 @@ uvicorn
 dataclasses; python_version < '3.7'
 starlette==0.18.0
 aiorwlock
-gradio; platform_system != "Windows"
+gradio==3.5; platform_system != "Windows"
 
 ## Requirements for running tests
 


### PR DESCRIPTION
Latest 3.6 release broke tests

<img width="417" alt="image" src="https://user-images.githubusercontent.com/21118851/196767936-79d8fffd-2ae3-4072-9d7b-5d450393ddbd.png">


Signed-off-by: simon-mo <simon.mo@hey.com>](https://buildkite.com/ray-project/oss-ci-build-branch/builds/592#0183eecf-733c-409f-8c3c-b259fb51bfdc/1063-1494)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
