### PR TITLE
[AIR - Datasets] [Hotfix] Tensor extension column concatenation fixes.

### DIFF
--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -7,6 +7,7 @@ import pytest
 
 from ray.air.util.tensor_extensions.arrow import (
     ArrowTensorArray,
+    ArrowTensorType,
     ArrowVariableShapedTensorArray,
     ArrowVariableShapedTensorType,
 )
@@ -381,24 +382,51 @@ def test_arrow_tensor_array_slice(test_arr, dtype):
 
 
 pytest_tensor_array_concat_shapes = [(1, 2, 2), (3, 2, 2), (2, 3, 3)]
-
-
-@pytest.mark.parametrize(
-    "shape1,shape2", list(itertools.combinations(pytest_tensor_array_concat_shapes, 2))
+pytest_tensor_array_concat_arrs = [
+    np.arange(np.prod(shape)).reshape(shape)
+    for shape in pytest_tensor_array_concat_shapes
+]
+pytest_tensor_array_concat_arrs += [
+    np.array([np.arange(4).reshape((2, 2)), np.arange(4, 13).reshape((3, 3))])
+]
+pytest_tensor_array_concat_arr_combinations = list(
+    itertools.combinations(pytest_tensor_array_concat_arrs, 2)
 )
-def test_tensor_array_concat(shape1, shape2):
-    a1 = np.arange(np.prod(shape1)).reshape(shape1)
-    a2 = np.arange(np.prod(shape2)).reshape(shape2)
+
+
+@pytest.mark.parametrize("a1,a2", pytest_tensor_array_concat_arr_combinations)
+def test_tensor_array_concat(a1, a2):
     ta1 = TensorArray(a1)
     ta2 = TensorArray(a2)
     ta = TensorArray._concat_same_type([ta1, ta2])
-    assert len(ta) == shape1[0] + shape2[0]
+    assert len(ta) == a1.shape[0] + a2.shape[0]
     assert ta.dtype.element_dtype == ta1.dtype.element_dtype
-    if shape1[1:] == shape2[1:]:
-        assert ta.dtype.element_shape == shape1[1:]
+    if a1.shape[1:] == a2.shape[1:]:
+        assert ta.dtype.element_shape == a1.shape[1:]
         np.testing.assert_array_equal(ta.to_numpy(), np.concatenate([a1, a2]))
     else:
         assert ta.dtype.element_shape is None
+        for arr, expected in zip(
+            ta.to_numpy(), np.array([e for a in [a1, a2] for e in a], dtype=object)
+        ):
+            np.testing.assert_array_equal(arr, expected)
+
+
+@pytest.mark.parametrize("a1,a2", pytest_tensor_array_concat_arr_combinations)
+def test_arrow_tensor_array_concat(a1, a2):
+    ta1 = ArrowTensorArray.from_numpy(a1)
+    ta2 = ArrowTensorArray.from_numpy(a2)
+    ta = ArrowTensorArray._concat_same_type([ta1, ta2])
+    assert len(ta) == a1.shape[0] + a2.shape[0]
+    if a1.shape[1:] == a2.shape[1:]:
+        assert isinstance(ta.type, ArrowTensorType)
+        assert ta.type.storage_type == ta1.type.storage_type
+        assert ta.type.storage_type == ta2.type.storage_type
+        assert ta.type.shape == a1.shape[1:]
+        np.testing.assert_array_equal(ta.to_numpy(), np.concatenate([a1, a2]))
+    else:
+        assert isinstance(ta.type, ArrowVariableShapedTensorType)
+        assert pa.types.is_struct(ta.type.storage_type)
         for arr, expected in zip(
             ta.to_numpy(), np.array([e for a in [a1, a2] for e in a], dtype=object)
         ):

--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -63,10 +63,6 @@ def test_scalar_tensor_array_roundtrip():
 
 
 def test_arrow_variable_shaped_tensor_array_validation():
-    # Test homogeneous-typed tensor raises ValueError.
-    with pytest.raises(ValueError):
-        ArrowVariableShapedTensorArray.from_numpy(np.ones((3, 2, 2)))
-
     # Test arbitrary object raises ValueError.
     with pytest.raises(ValueError):
         ArrowVariableShapedTensorArray.from_numpy(object())

--- a/python/ray/air/util/transform_pyarrow.py
+++ b/python/ray/air/util/transform_pyarrow.py
@@ -18,14 +18,21 @@ def _concatenate_extension_column(ca: "pyarrow.ChunkedArray") -> "pyarrow.Array"
     extension arrays.
     See https://issues.apache.org/jira/browse/ARROW-16503.
     """
+    from ray.air.util.tensor_extensions.arrow import (
+        ArrowTensorArray,
+        ArrowTensorType,
+        ArrowVariableShapedTensorType,
+    )
+
     if not _is_column_extension_type(ca):
         raise ValueError("Chunked array isn't an extension array: {ca}")
 
     if ca.num_chunks == 0:
-        # No-op for no-chunk chunked arrays, since there's nothing to concatenate.
-        return ca
+        # Create empty storage array.
+        storage = pyarrow.array([], type=ca.type.storage_type)
+    elif isinstance(ca.type, (ArrowTensorType, ArrowVariableShapedTensorType)):
+        return ArrowTensorArray._concat_same_type(ca.chunks)
+    else:
+        storage = pyarrow.concat_arrays([c.storage for c in ca.chunks])
 
-    chunk = ca.chunk(0)
-    return type(chunk).from_storage(
-        chunk.type, pyarrow.concat_arrays([c.storage for c in ca.chunks])
-    )
+    return ca.type.__arrow_ext_class__().from_storage(ca.type, storage)

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -100,7 +100,8 @@ class ArrowBlockBuilder(TableBlockBuilder[T]):
             raise ImportError("Run `pip install pyarrow` for Arrow support")
         super().__init__(pyarrow.Table)
 
-    def _table_from_pydict(self, columns: Dict[str, List[Any]]) -> Block:
+    @staticmethod
+    def _table_from_pydict(columns: Dict[str, List[Any]]) -> Block:
         for col_name, col in columns.items():
             if col_name == VALUE_COL_NAME or isinstance(
                 next(iter(col), None), np.ndarray
@@ -110,11 +111,9 @@ class ArrowBlockBuilder(TableBlockBuilder[T]):
                 columns[col_name] = ArrowTensorArray.from_numpy(col)
         return pyarrow.Table.from_pydict(columns)
 
-    def _concat_tables(self, tables: List[Block]) -> Block:
-        if len(tables) > 1:
-            return transform_pyarrow.concat(tables)
-        else:
-            return tables[0]
+    @staticmethod
+    def _concat_tables(tables: List[Block]) -> Block:
+        return transform_pyarrow.concat(tables)
 
     @staticmethod
     def _empty_table() -> "pyarrow.Table":

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -112,7 +112,7 @@ class ArrowBlockBuilder(TableBlockBuilder[T]):
 
     def _concat_tables(self, tables: List[Block]) -> Block:
         if len(tables) > 1:
-            return pyarrow.concat_tables(tables, promote=True)
+            return transform_pyarrow.concat(tables)
         else:
             return tables[0]
 

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -49,6 +49,11 @@ def _concatenate_chunked_arrays(arrs: "pyarrow.ChunkedArray") -> "pyarrow.Chunke
     """
     Concatenate provided chunked arrays into a single chunked array.
     """
+    from ray.data.extensions import (
+        ArrowTensorType,
+        ArrowVariableShapedTensorType,
+    )
+
     # Single flat list of chunks across all chunked arrays.
     chunks = []
     type_ = None
@@ -56,6 +61,11 @@ def _concatenate_chunked_arrays(arrs: "pyarrow.ChunkedArray") -> "pyarrow.Chunke
         if type_ is None:
             type_ = arr.type
         else:
+            if isinstance(type_, (ArrowTensorType, ArrowVariableShapedTensorType)):
+                raise ValueError(
+                    "_concatenate_chunked_arrays should only be used on non-tensor "
+                    f"extension types, but got a chunked array of type {type_}."
+                )
             assert type_ == arr.type
         # Add chunks for this chunked array to flat chunk list.
         chunks.extend(arr.chunks)

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -45,9 +45,80 @@ def take_table(
     return table
 
 
+def _concatenate_chunked_arrays(arrs: "pyarrow.ChunkedArray") -> "pyarrow.ChunkedArray":
+    """
+    Concatenate provided chunked arrays into a single chunked array.
+    """
+    # Single flat list of chunks across all chunked arrays.
+    chunks = []
+    type_ = None
+    for arr in arrs:
+        if type_ is None:
+            type_ = arr.type
+        else:
+            assert type_ == arr.type
+        # Add chunks for this chunked array to flat chunk list.
+        chunks.extend(arr.chunks)
+    # Construct chunked array on flat list of chunks.
+    return pyarrow.chunked_array(chunks, type=type_)
+
+
+def concat(blocks: List["pyarrow.Table"]) -> "pyarrow.Table":
+    """Concatenate provided Arrow Tables into a single Arrow Table. This has special
+    handling for extension types that pyarrow.concat_tables does not yet support.
+    """
+    from ray.data.extensions import (
+        ArrowTensorArray,
+        ArrowTensorType,
+        ArrowVariableShapedTensorType,
+    )
+
+    if not blocks:
+        # Short-circuit on empty list of blocks.
+        return blocks
+
+    schema = blocks[0].schema
+    if any(isinstance(type_, pyarrow.ExtensionType) for type_ in schema.types):
+        schema = pyarrow.unify_schemas([block.schema for block in blocks])
+        # Custom handling for extension array columns.
+        cols = []
+        for col_name in schema.names:
+            col_chunked_arrays = []
+            for block in blocks:
+                col_chunked_arrays.append(block.column(col_name))
+            if isinstance(
+                schema.field(col_name).type,
+                (ArrowTensorType, ArrowVariableShapedTensorType),
+            ):
+                # For our tensor extension types, manually construct a chunked array
+                # containing chunks from all blocks. This is to handle
+                # homogeneous-shaped block columns having different shapes across
+                # blocks: if tensor element shapes differ across blocks, a
+                # variable-shaped tensor array will be returned.
+                col = ArrowTensorArray._chunk_tensor_arrays(
+                    [chunk for ca in col_chunked_arrays for chunk in ca.chunks]
+                )
+                if schema.field(col_name).type != col.type:
+                    # Ensure that the field's type is properly updated in the schema if
+                    # a collection of homogeneous-shaped columns resulted in a
+                    # variable-shaped tensor column once concatenated.
+                    new_field = schema.field(col_name).with_type(col.type)
+                    schema = schema.set(schema.get_field_index(col_name), new_field)
+            else:
+                col = _concatenate_chunked_arrays(col_chunked_arrays)
+            cols.append(col)
+        table = pyarrow.Table.from_arrays(cols, schema=schema)
+        # Validate table schema (this is a cheap check by default).
+        table.validate()
+    else:
+        # No extension array columns, so use built-in pyarrow.concat_tables.
+        table = pyarrow.concat_tables(blocks, promote=True)
+    return table
+
+
 def concat_and_sort(
     blocks: List["pyarrow.Table"], key: "SortKeyT", descending: bool
 ) -> "pyarrow.Table":
-    ret = pyarrow.concat_tables(blocks, promote=True)
+    ret = concat(blocks)
     indices = pyarrow.compute.sort_indices(ret, sort_keys=key)
     return take_table(ret, indices)

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -83,7 +83,8 @@ class PandasBlockBuilder(TableBlockBuilder[T]):
         pandas = lazy_import_pandas()
         super().__init__(pandas.DataFrame)
 
-    def _table_from_pydict(self, columns: Dict[str, List[Any]]) -> "pandas.DataFrame":
+    @staticmethod
+    def _table_from_pydict(columns: Dict[str, List[Any]]) -> "pandas.DataFrame":
         pandas = lazy_import_pandas()
         for key, value in columns.items():
             if key == VALUE_COL_NAME or isinstance(next(iter(value), None), np.ndarray):
@@ -94,7 +95,8 @@ class PandasBlockBuilder(TableBlockBuilder[T]):
                 columns[key] = TensorArray(value)
         return pandas.DataFrame(columns)
 
-    def _concat_tables(self, tables: List["pandas.DataFrame"]) -> "pandas.DataFrame":
+    @staticmethod
+    def _concat_tables(tables: List["pandas.DataFrame"]) -> "pandas.DataFrame":
         pandas = lazy_import_pandas()
         from ray.air.util.data_batch_conversion import (
             _cast_ndarray_columns_to_tensor_extension,

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -81,10 +81,12 @@ class TableBlockBuilder(BlockBuilder[T]):
         self._tables_size_bytes += accessor.size_bytes()
         self._num_rows += accessor.num_rows()
 
-    def _table_from_pydict(self, columns: Dict[str, List[Any]]) -> Block:
+    @staticmethod
+    def _table_from_pydict(columns: Dict[str, List[Any]]) -> Block:
         raise NotImplementedError
 
-    def _concat_tables(self, tables: List[Block]) -> Block:
+    @staticmethod
+    def _concat_tables(tables: List[Block]) -> Block:
         raise NotImplementedError
 
     @staticmethod

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -1,0 +1,172 @@
+import numpy as np
+import pyarrow as pa
+
+from ray.data.extensions import (
+    ArrowTensorArray,
+    ArrowTensorType,
+    ArrowVariableShapedTensorType,
+)
+from ray.data._internal.arrow_ops.transform_pyarrow import concat
+
+
+def test_arrow_concat_empty():
+    # Test empty.
+    assert concat([]) == []
+
+
+def test_arrow_concat_single_block():
+    # Test single block:
+    t = pa.table({"a": [1, 2]})
+    out = concat([t])
+    assert len(out) == 2
+    assert out == t
+
+
+def test_arrow_concat_basic():
+    # Test two basic tables.
+    t1 = pa.table({"a": [1, 2], "b": [5, 6]})
+    t2 = pa.table({"a": [3, 4], "b": [7, 8]})
+    ts = [t1, t2]
+    out = concat(ts)
+    # Check length.
+    assert len(out) == 4
+    # Check schema.
+    assert out.column_names == ["a", "b"]
+    assert out.schema.types == [pa.int64(), pa.int64()]
+    # Confirm that concatenation is zero-copy (i.e. it didn't trigger chunk
+    # consolidation).
+    assert out["a"].num_chunks == 2
+    assert out["b"].num_chunks == 2
+    # Check content.
+    assert out["a"].to_pylist() == [1, 2, 3, 4]
+    assert out["b"].to_pylist() == [5, 6, 7, 8]
+    # Check equivalence.
+    expected = pa.concat_tables(ts)
+    assert out == expected
+
+
+def test_arrow_concat_null_promotion():
+    # Test null column --> well-typed column promotion.
+    t1 = pa.table({"a": [None, None], "b": [5, 6]})
+    t2 = pa.table({"a": [3, 4], "b": [None, None]})
+    ts = [t1, t2]
+    out = concat(ts)
+    # Check length.
+    assert len(out) == 4
+    # Check schema.
+    assert out.column_names == ["a", "b"]
+    assert out.schema.types == [pa.int64(), pa.int64()]
+    # Confirm that concatenation is zero-copy (i.e. it didn't trigger chunk
+    # consolidation).
+    assert out["a"].num_chunks == 2
+    assert out["b"].num_chunks == 2
+    # Check content.
+    assert out["a"].to_pylist() == [None, None, 3, 4]
+    assert out["b"].to_pylist() == [5, 6, None, None]
+    # Check equivalence.
+    expected = pa.concat_tables(ts, promote=True)
+    assert out == expected
+
+
+def test_arrow_concat_tensor_extension_uniform():
+    # Test tensor column concatenation.
+    a1 = np.arange(12).reshape((3, 2, 2))
+    t1 = pa.table({"a": ArrowTensorArray.from_numpy(a1)})
+    a2 = np.arange(12, 24).reshape((3, 2, 2))
+    t2 = pa.table({"a": ArrowTensorArray.from_numpy(a2)})
+    ts = [t1, t2]
+    out = concat(ts)
+    # Check length.
+    assert len(out) == 6
+    # Check schema.
+    assert out.column_names == ["a"]
+    assert out.schema.types == [ArrowTensorType((2, 2), pa.int64())]
+    # Confirm that concatenation is zero-copy (i.e. it didn't trigger chunk
+    # consolidation).
+    assert out["a"].num_chunks == 2
+    # Check content.
+    np.testing.assert_array_equal(out["a"].chunk(0).to_numpy(), a1)
+    np.testing.assert_array_equal(out["a"].chunk(1).to_numpy(), a2)
+    # Check equivalence.
+    expected = pa.concat_tables(ts, promote=True)
+    assert out == expected
+
+
+def test_arrow_concat_tensor_extension_variable_shaped():
+    # Test variable_shaped tensor column concatenation.
+    a1 = np.array(
+        [np.arange(4).reshape((2, 2)), np.arange(4, 13).reshape((3, 3))], dtype=object
+    )
+    t1 = pa.table({"a": ArrowTensorArray.from_numpy(a1)})
+    a2 = np.array(
+        [np.arange(4).reshape((2, 2)), np.arange(4, 13).reshape((3, 3))], dtype=object
+    )
+    t2 = pa.table({"a": ArrowTensorArray.from_numpy(a2)})
+    ts = [t1, t2]
+    out = concat(ts)
+    # Check length.
+    assert len(out) == 4
+    # Check schema.
+    assert out.column_names == ["a"]
+    assert out.schema.types == [ArrowVariableShapedTensorType(pa.int64())]
+    # Confirm that concatenation is zero-copy (i.e. it didn't trigger chunk
+    # consolidation).
+    assert out["a"].num_chunks == 2
+    # Check content.
+    for o, e in zip(out["a"].chunk(0).to_numpy(), a1):
+        np.testing.assert_array_equal(o, e)
+    for o, e in zip(out["a"].chunk(1).to_numpy(), a2):
+        np.testing.assert_array_equal(o, e)
+    # NOTE: We don't check equivalence with pyarrow.concat_tables since it currently
+    # fails for this case.
+
+
+def test_arrow_concat_tensor_extension_uniform_and_variable_shaped():
+    # Test concatenating a homogeneous-shaped tensor column with a variable-shaped
+    # tensor column.
+    a1 = np.arange(12).reshape((3, 2, 2))
+    t1 = pa.table({"a": ArrowTensorArray.from_numpy(a1)})
+    a2 = np.array(
+        [np.arange(4).reshape((2, 2)), np.arange(4, 13).reshape((3, 3))], dtype=object
+    )
+    t2 = pa.table({"a": ArrowTensorArray.from_numpy(a2)})
+    ts = [t1, t2]
+    out = concat(ts)
+    # Check length.
+    assert len(out) == 5
+    # Check schema.
+    assert out.column_names == ["a"]
+    assert out.schema.types == [ArrowVariableShapedTensorType(pa.int64())]
+    # Confirm that concatenation is zero-copy (i.e. it didn't trigger chunk
+    # consolidation).
+    assert out["a"].num_chunks == 2
+    # Check content.
+    np.testing.assert_array_equal(out["a"].chunk(0).to_numpy(), a1)
+    for o, e in zip(out["a"].chunk(1).to_numpy(), a2):
+        np.testing.assert_array_equal(o, e)
+    # NOTE: We don't check equivalence with pyarrow.concat_tables since it currently
+    # fails for this case.
+
+
+def test_arrow_concat_tensor_extension_uniform_but_different():
+    # Test concatenating two homogeneous-shaped tensor columns with differing shapes
+    # between them.
+    a1 = np.arange(12).reshape((3, 2, 2))
+    t1 = pa.table({"a": ArrowTensorArray.from_numpy(a1)})
+    a2 = np.arange(12, 39).reshape((3, 3, 3))
+    t2 = pa.table({"a": ArrowTensorArray.from_numpy(a2)})
+    ts = [t1, t2]
+    out = concat(ts)
+    # Check length.
+    assert len(out) == 6
+    # Check schema.
+    assert out.column_names == ["a"]
+    assert out.schema.types == [ArrowVariableShapedTensorType(pa.int64())]
+    # Confirm that concatenation is zero-copy (i.e. it didn't trigger chunk
+    # consolidation).
+    assert out["a"].num_chunks == 2
+    # Check content.
+    np.testing.assert_array_equal(out["a"].chunk(0).to_numpy(), a1)
+    np.testing.assert_array_equal(out["a"].chunk(1).to_numpy(), a2)
+    # NOTE: We don't check equivalence with pyarrow.concat_tables since it currently
+    # fails for this case.


### PR DESCRIPTION
Fixes the concatenation of tensor columns (and extension types in general). Previously, concatenating tensor columns may produce a variable-shaped tensor but would be represented with a broken homogeneous-shaped tensor. This PR ensures that the correct tensor extension type is produced post-concatenation.

## Issue Details

The core issue is that we weren’t accounting for homogeneous-shaped tensor column concatenation resulting in a heterogeneous-shaped tensor column. In master, this currently fails silently until accessing the data fails somewhere downstream of the concatenation.

E.g., if you have 5 images of shape (32, 32) in one block, and 5 images of shape (64, 64) in another block, the image column in each individual block is homogeneous-shaped. But if you concatenate those blocks, you have 10 images, half with shape (32, 32) and half with shape (64, 64), which needs our heterogeneous-shaped (variable-shaped) tensor column representation.

## Issue

Closes https://github.com/ray-project/ray/issues/29489

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
