### PR TITLE
Change sort order of nodes list in dashboard to Headnode -> state -> node id

### DIFF
--- a/dashboard/client/src/pages/node/hook/useNodeList.ts
+++ b/dashboard/client/src/pages/node/hook/useNodeList.ts
@@ -54,6 +54,10 @@ export const useNodeList = () => {
     nodeList: nodeList
       .map((e) => ({ ...e, state: e.raylet.state }))
       .sort((a, b) => (a.raylet.nodeId > b.raylet.nodeId ? 1 : -1))
+      .sort((a, b) => (a.raylet.state > b.raylet.state ? 1 : -1))
+      .sort(
+        (a, b) => (a.raylet.isHeadNode ? 1 : 0) - (b.raylet.isHeadNode ? 1 : 0),
+      )
       .sort(sorterFunc)
       .filter((node) =>
         filter.every((f) => node[f.key] && node[f.key].includes(f.val)),

--- a/dashboard/client/src/pages/node/hook/useNodeList.ts
+++ b/dashboard/client/src/pages/node/hook/useNodeList.ts
@@ -56,7 +56,7 @@ export const useNodeList = () => {
       .sort((a, b) => (a.raylet.nodeId > b.raylet.nodeId ? 1 : -1))
       .sort((a, b) => (a.raylet.state > b.raylet.state ? 1 : -1))
       .sort(
-        (a, b) => (a.raylet.isHeadNode ? 1 : 0) - (b.raylet.isHeadNode ? 1 : 0),
+        (a, b) => (a.raylet.isHeadNode ? 0 : 1) - (b.raylet.isHeadNode ? 0 : 1),
       )
       .sort(sorterFunc)
       .filter((node) =>

--- a/dashboard/client/src/pages/node/hook/useNodeList.ts
+++ b/dashboard/client/src/pages/node/hook/useNodeList.ts
@@ -50,15 +50,31 @@ export const useNodeList = () => {
     };
   }, [getList]);
 
+  const finalSortFunc = (a: NodeDetail, b: NodeDetail) => {
+    const sortFuncs: ((a: NodeDetail, b: NodeDetail) => number)[] = [
+      // user override first
+      sorterFunc,
+      // Head node is always first
+      (a, b) => (a.raylet.isHeadNode ? 0 : 1) - (b.raylet.isHeadNode ? 0 : 1),
+      // Then sort by state
+      (a, b) => (a.raylet.state > b.raylet.state ? 1 : -1),
+      // Finally sort by nodeId
+      (a, b) => (a.raylet.nodeId > b.raylet.nodeId ? 1 : -1),
+    ];
+
+    for (const sortFunc of sortFuncs) {
+      const val = sortFunc(a, b);
+      if (val !== 0) {
+        return val;
+      }
+    }
+    return 0;
+  };
+
   return {
     nodeList: nodeList
       .map((e) => ({ ...e, state: e.raylet.state }))
-      .sort((a, b) => (a.raylet.nodeId > b.raylet.nodeId ? 1 : -1))
-      .sort((a, b) => (a.raylet.state > b.raylet.state ? 1 : -1))
-      .sort(
-        (a, b) => (a.raylet.isHeadNode ? 0 : 1) - (b.raylet.isHeadNode ? 0 : 1),
-      )
-      .sort(sorterFunc)
+      .sort(finalSortFunc)
       .filter((node) =>
         filter.every((f) => node[f.key] && node[f.key].includes(f.val)),
       ),

--- a/dashboard/client/src/type/raylet.d.ts
+++ b/dashboard/client/src/type/raylet.d.ts
@@ -27,4 +27,5 @@ export type Raylet = {
   terminateTime: number;
   objectStoreAvailableMemory: number;
   objectStoreUsedMemory: number;
+  isHeadNode: boolean;
 };

--- a/dashboard/datacenter.py
+++ b/dashboard/datacenter.py
@@ -178,9 +178,11 @@ class DataOrganizer:
         # Merge GcsNodeInfo to node physical stats
         node_info["raylet"].update(node)
         # Add "is_head_node" field
-        node_info["raylet"]["is_head_node"] = node_physical_stats.get(
-            "ip"
-        ) and cls.head_node_ip == node_physical_stats.get("ip")
+        node_info["raylet"]["is_head_node"] = (
+            cls.head_node_ip == node_physical_stats.get("ip")
+            if node_physical_stats.get("ip")
+            else False
+        )
         # Merge actors to node physical stats
         node_info["actors"] = DataSource.node_actors.get(node_id, {})
         # Update workers to node physical stats
@@ -212,9 +214,11 @@ class DataOrganizer:
         # Merge GcsNodeInfo to node physical stats
         node_summary["raylet"].update(node)
         # Add "is_head_node" field
-        node_summary["raylet"]["is_head_node"] = node_physical_stats.get(
-            "ip"
-        ) and cls.head_node_ip == node_physical_stats.get("ip")
+        node_summary["raylet"]["is_head_node"] = (
+            cls.head_node_ip == node_physical_stats.get("ip")
+            if node_physical_stats.get("ip")
+            else False
+        )
 
         await GlobalSignals.node_summary_fetched.send(node_summary)
 

--- a/dashboard/datacenter.py
+++ b/dashboard/datacenter.py
@@ -178,6 +178,7 @@ class DataOrganizer:
         # Merge GcsNodeInfo to node physical stats
         node_info["raylet"].update(node)
         # Add "is_head_node" field
+        # TODO(aguo): Grab head node information from a source of truth
         node_info["raylet"]["is_head_node"] = (
             cls.head_node_ip == node_physical_stats.get("ip")
             if node_physical_stats.get("ip")
@@ -214,6 +215,7 @@ class DataOrganizer:
         # Merge GcsNodeInfo to node physical stats
         node_summary["raylet"].update(node)
         # Add "is_head_node" field
+        # TODO(aguo): Grab head node information from a source of truth
         node_summary["raylet"]["is_head_node"] = (
             cls.head_node_ip == node_physical_stats.get("ip")
             if node_physical_stats.get("ip")

--- a/dashboard/datacenter.py
+++ b/dashboard/datacenter.py
@@ -178,7 +178,9 @@ class DataOrganizer:
         # Merge GcsNodeInfo to node physical stats
         node_info["raylet"].update(node)
         # Add "is_head_node" field
-        node_info["raylet"]["is_head_node"] = cls.head_node_ip == node_physical_stats["ip"]
+        node_info["raylet"]["is_head_node"] = node_physical_stats.get(
+            "ip"
+        ) and cls.head_node_ip == node_physical_stats.get("ip")
         # Merge actors to node physical stats
         node_info["actors"] = DataSource.node_actors.get(node_id, {})
         # Update workers to node physical stats
@@ -210,7 +212,9 @@ class DataOrganizer:
         # Merge GcsNodeInfo to node physical stats
         node_summary["raylet"].update(node)
         # Add "is_head_node" field
-        node_summary["raylet"]["is_head_node"] = cls.head_node_ip == node_physical_stats["ip"]
+        node_summary["raylet"]["is_head_node"] = node_physical_stats.get(
+            "ip"
+        ) and cls.head_node_ip == node_physical_stats.get("ip")
 
         await GlobalSignals.node_summary_fetched.send(node_summary)
 

--- a/dashboard/datacenter.py
+++ b/dashboard/datacenter.py
@@ -61,6 +61,8 @@ class DataSource:
 
 
 class DataOrganizer:
+    head_node_ip = None
+
     @staticmethod
     @async_loop_forever(dashboard_consts.PURGE_DATA_INTERVAL_SECONDS)
     async def purge():
@@ -175,6 +177,8 @@ class DataOrganizer:
 
         # Merge GcsNodeInfo to node physical stats
         node_info["raylet"].update(node)
+        # Add "is_head_node" field
+        node_info["raylet"]["is_head_node"] = cls.head_node_ip == node_physical_stats["ip"]
         # Merge actors to node physical stats
         node_info["actors"] = DataSource.node_actors.get(node_id, {})
         # Update workers to node physical stats
@@ -205,6 +209,8 @@ class DataOrganizer:
         node_summary["raylet"].update(ray_stats)
         # Merge GcsNodeInfo to node physical stats
         node_summary["raylet"].update(node)
+        # Add "is_head_node" field
+        node_summary["raylet"]["is_head_node"] = cls.head_node_ip == node_physical_stats["ip"]
 
         await GlobalSignals.node_summary_fetched.send(node_summary)
 

--- a/dashboard/head.py
+++ b/dashboard/head.py
@@ -108,6 +108,7 @@ class DashboardHead:
         self.gcs_error_subscriber = None
         self.gcs_log_subscriber = None
         self.ip = ray.util.get_node_ip_address()
+        DataOrganizer.head_node_ip = self.ip
         ip, port = gcs_address.split(":")
 
         self.server = aiogrpc.server(options=(("grpc.so_reuseport", 0),))

--- a/dashboard/modules/node/tests/test_node.py
+++ b/dashboard/modules/node/tests/test_node.py
@@ -104,6 +104,7 @@ def test_node_info(disable_aiohttp_cache, ray_start_with_dashboard):
             detail = detail["data"]["detail"]
             assert detail["hostname"] == hostname
             assert detail["raylet"]["state"] == "ALIVE"
+            assert detail["raylet"]["isHeadNode"] == True
             assert "raylet" in detail["cmdline"][0]
             assert len(detail["workers"]) >= 2
             assert len(detail["actors"]) == 2, detail["actors"]

--- a/dashboard/modules/node/tests/test_node.py
+++ b/dashboard/modules/node/tests/test_node.py
@@ -104,7 +104,7 @@ def test_node_info(disable_aiohttp_cache, ray_start_with_dashboard):
             detail = detail["data"]["detail"]
             assert detail["hostname"] == hostname
             assert detail["raylet"]["state"] == "ALIVE"
-            assert detail["raylet"]["isHeadNode"] == True
+            assert detail["raylet"]["isHeadNode"] is True
             assert "raylet" in detail["cmdline"][0]
             assert len(detail["workers"]) >= 2
             assert len(detail["actors"]) == 2, detail["actors"]


### PR DESCRIPTION
Signed-off-by: Alan Guo <aguo@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This sort order prevents dead nodes from showing up above alive nodes while still maintaining consistent ordering to prevent nodes jumping around.
<!-- Please give a short summary of the change and the problem this solves. -->

Currently this checks the head node by comparing the ip of the node to the ip of the machine the dashboard process is running on.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
