### PR TITLE
[Datasets] Fix construction of variable-shaped tensor column with uniform first dimension after batch dimension.

### DIFF
--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -409,6 +409,18 @@ def test_tensor_array_concat(shape1, shape2):
             np.testing.assert_array_equal(arr, expected)
 
 
+def test_variable_shaped_tensor_array_uniform_dim():
+    shape1 = (3, 2, 2)
+    shape2 = (3, 4, 4)
+    a1 = np.arange(np.prod(shape1)).reshape(shape1)
+    a2 = np.arange(np.prod(shape2)).reshape(shape2)
+    ta = TensorArray([a1, a2])
+    assert len(ta) == 2
+    assert ta.is_variable_shaped
+    for a, expected in zip(ta.to_numpy(), [a1, a2]):
+        np.testing.assert_array_equal(a, expected)
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
Constructing a ragged ndarray with uniform first dimension fails with a broadcast error; this PR works around this by falling back to a create-and-fill method.

## Related issue number

Closes https://github.com/ray-project/ray/issues/29493

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
