### PR TITLE
[Test] Fix test_dashboard.py in Python 3.10 

### DIFF
--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -1013,6 +1013,22 @@ def test_dashboard_module_load(tmpdir):
     assert loaded_modules_actual == loaded_modules_expected
 
 
+@pytest.mark.skipif(
+    sys.version_info == (3, 10, 0),
+    reason=(
+        "six >= 1.16 and urllib3 >= 1.26.5 "
+        "(it has its own forked six internally that's verion 1.12) "
+        "are required to pass this test on Python 3.10. "
+        "It's because six < 1.16 doesn't have a `find_spec` API, "
+        "which is required from Python 3.10 "
+        "(otherwise, it warns that it fallbacks to use `find_modules` "
+        "that is deprecated from Python 3.10). "
+        "This test failure doesn't affect the user at all "
+        "and it is too much to introduce version restriction and new "
+        "dependencies requirement just for this test. "
+        "So instead of fixing it, we just skip it."
+    ),
+)
 def test_dashboard_module_no_warnings(enable_test_module):
     # Disable log_once so we will get all warnings
     from ray.util import debug


### PR DESCRIPTION
Signed-off-by: SangBin Cho <rkooo567@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```
        "six >= 1.16 and urllib3 >= 1.26.5 "
        "(it has its own forked six internally that's verion 1.12) "
        "are required to pass this test on Python 3.10. "
        "It's because six < 1.16 doesn't have a `find_spec` API, "
        "which is required from Python 3.10 "
        "(otherwise, it warns that it fallbacks to use `find_modules` "
        "that is deprecated from Python 3.10). "
        "This test failure doesn't affect the user at all "
        "and it is too much to introduce version restriction and new "
        "dependencies requirement just for this test. "
        "So instead of fixing it, we just skip it."
```

## Related issue number

Closes https://github.com/ray-project/ray/issues/29298

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
