### PR TITLE
[Datasets][test] Increase stream_window_size for datasets_ingest_400G nightly test

### DIFF
--- a/release/nightly_tests/dataset/ray_sgd_runner.py
+++ b/release/nightly_tests/dataset/ray_sgd_runner.py
@@ -280,8 +280,9 @@ if __name__ == "__main__":
     num_gpus = 1 if use_gpu else 0
     num_cpus = 0 if use_gpu else 1
 
-    # each file is 2GBs
-    stream_window_size = 2 * 1024 * 1024 * 1024
+    # Each file is around 4GB after reading into memory.
+    # Read 4 files in each window.
+    stream_window_size = 16 * 1024 * 1024 * 1024
 
     trainer = TorchTrainer(
         train_func,


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The current nightly test datasets_ingest_400G run very slowly and cannot suceed within 2 hours. Before the change https://github.com/ray-project/ray/pull/29015, the test is [having 64 windows on 200 files](https://github.com/ray-project/ray/blob/75a0c491e8ee4009e8828081059cfc98543c4d51/release/nightly_tests/dataset/ray_sgd_runner.py#L256), so 3-4 files per dataset pipeline window. After the change, the window byte size is 2GB (while each file is around 4GB when reading into memory), so each window ended up with only reading 1 file. So we have 3-4x more windows and slowness.

Increase the stream window size here to have similar behavior as before.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/29098

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [] Release tests
   - [ ] This PR is not tested :(
