### PR TITLE
[ci/release] Return with correct exit code

### DIFF
--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -175,17 +175,21 @@ def run_release_test(
         autosuspend_mins = test["cluster"].get("autosuspend_mins", None)
         if autosuspend_mins:
             cluster_manager.autosuspend_minutes = autosuspend_mins
+            autosuspend_base = autosuspend_mins
         else:
             cluster_manager.autosuspend_minutes = min(
                 DEFAULT_AUTOSUSPEND_MINS, int(command_timeout / 60) + 10
             )
+            # Maximum uptime should be based on the command timeout, not the
+            # DEFAULT_AUTOSUSPEND_MINS
+            autosuspend_base = int(command_timeout / 60) + 10
 
         maximum_uptime_minutes = test["cluster"].get("maximum_uptime_minutes", None)
         if maximum_uptime_minutes:
             cluster_manager.maximum_uptime_minutes = maximum_uptime_minutes
         else:
             cluster_manager.maximum_uptime_minutes = (
-                cluster_manager.autosuspend_minutes + wait_timeout + 10
+                autosuspend_base + wait_timeout + 10
             )
 
         # Set cluster compute here. Note that this may use timeouts provided

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -161,7 +161,7 @@ def main(
         f"Release test pipeline for test {test['name']} completed. "
         f"Returning with exit code = {return_code}"
     )
-    sys.exit(result.return_code)
+    sys.exit(return_code)
 
 
 if __name__ == "__main__":

--- a/release/ray_release/util.py
+++ b/release/ray_release/util.py
@@ -132,8 +132,9 @@ def run_bash_script(bash_script: str) -> None:
 def reinstall_anyscale_dependencies() -> None:
     logger.info("Re-installing `anyscale` package")
 
+    # Copy anyscale pin to requirements.txt and requirements_buildkite.txt
     subprocess.check_output(
-        "pip install -U anyscale",
+        "pip install -U anyscale==0.5.51",
         shell=True,
         text=True,
     )

--- a/release/requirements.txt
+++ b/release/requirements.txt
@@ -1,5 +1,6 @@
+# Requirements to run release tests from the local machine (including client tests)
 click
-anyscale>0.5.0
+anyscale!=0.5.52
 slackclient
 boto3
 jinja2

--- a/release/requirements.txt
+++ b/release/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements to run release tests from the local machine (including client tests)
 click
-anyscale!=0.5.52
+anyscale==0.5.51
 slackclient
 boto3
 jinja2

--- a/release/requirements.txt
+++ b/release/requirements.txt
@@ -1,5 +1,6 @@
 # Requirements to run release tests from the local machine (including client tests)
 click
+# Copy anyscale pin to requirements_buildkite.txt and util.py
 anyscale==0.5.51
 slackclient
 boto3

--- a/release/requirements_buildkite.txt
+++ b/release/requirements_buildkite.txt
@@ -1,4 +1,5 @@
 # Requirements to run release tests from buildkite (client dependencies will be installed separately)
+# Copy anyscale pin to requirements.txt and util.py
 anyscale==0.5.51
 click
 boto3

--- a/release/requirements_buildkite.txt
+++ b/release/requirements_buildkite.txt
@@ -1,5 +1,5 @@
 # Requirements to run release tests from buildkite (client dependencies will be installed separately)
-anyscale!=0.5.52
+anyscale==0.5.51
 click
 boto3
 jinja2

--- a/release/requirements_buildkite.txt
+++ b/release/requirements_buildkite.txt
@@ -1,4 +1,5 @@
-anyscale
+# Requirements to run release tests from buildkite (client dependencies will be installed separately)
+anyscale!=0.5.52
 click
 boto3
 jinja2


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, we returned the wrong exit code on release test errors, leading to green builds even thlugh the test failed. Example: https://buildkite.com/ray-project/release-tests-pr/builds/18646#0183f621-b60a-4c3f-b626-23a58defa96a

This PR fixes the return code passing to the enclosing script, correctly propagating release test failures.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
