### PR TITLE
[ci] Bump MacOS CI tests to Python 3.7

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -2,7 +2,7 @@ common: &common
   env:
     BUILDKITE: "true"
     CI: "true"
-    PYTHON: "3.6"
+    PYTHON: "3.7"
     RAY_USE_RANDOM_PORTS: "1"
     RAY_DEFAULT_BUILD: "1"
     LC_ALL: en_US.UTF-8

--- a/python/requirements_test.txt
+++ b/python/requirements_test.txt
@@ -26,8 +26,7 @@ feather-format==0.4.1
 flask==2.1.3
 google-api-python-client==2.65.0
 google-cloud-storage==2.5.0
-gradio==3.5; platform_system == "Linux"
-gradio==3.0.12; platform_system == "Darwin"
+gradio==3.5; platform_system != "Windows"
 gym-minigrid==1.0.3
 kubernetes==24.2.0
 # higher version of llvmlite breaks windows


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We are running Linux tests on Python 3.7 already. To upgrade to later dependencies we should move the Mac runners, too.

We assert compatibility of certain workloads with Python 3.6 in our legacy testing.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
