### PR TITLE
[RLlib] add config whitelist for `extra_python_environs_for_driver`

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -186,6 +186,7 @@ class Algorithm(Trainable):
         "exploration_config",
         "replay_buffer_config",
         "extra_python_environs_for_worker",
+        "extra_python_environs_for_driver",
         "input_config",
         "output_config",
     ]


### PR DESCRIPTION
Signed-off-by: zaber <20830726+ZaberKo@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When passing the `extra_python_environs_for_driver` to the config:
```
config = SACConfig().python_environment(
    extra_python_environs_for_driver={"OMP_NUM_THREADS": str(8)}
)
```
this will cause an error in `deep_update()`. Adding this entry to the `Algorithm._allow_unknown_subkeys` will fix it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(