### PR TITLE
[docs] fix deprecation warnings (in Tune)

### DIFF
--- a/doc/source/tune/api_docs/internals.rst
+++ b/doc/source/tune/api_docs/internals.rst
@@ -6,7 +6,7 @@ Tune Internals
 RayTrialExecutor
 ----------------
 
-.. autoclass:: ray.tune.ray_trial_executor.RayTrialExecutor
+.. autoclass:: ray.tune.execution.ray_trial_executor.RayTrialExecutor
     :members:
 
 .. _trialrunner-docstring:
@@ -14,14 +14,14 @@ RayTrialExecutor
 TrialRunner
 -----------
 
-.. autoclass:: ray.tune.trial_runner.TrialRunner
+.. autoclass:: ray.tune.execution.trial_runner.TrialRunner
 
 .. _trial-docstring:
 
 Trial
 -----
 
-.. autoclass:: ray.tune.trial.Trial
+.. autoclass:: ray.tune.experiment.trial.Trial
 
 .. _tune-callbacks-docs:
 

--- a/doc/source/tune/tutorials/tune-lifecycle.rst
+++ b/doc/source/tune/tutorials/tune-lifecycle.rst
@@ -128,7 +128,7 @@ This is an illustration of the high-level training flow and how some of the comp
 
 TrialRunner
 ~~~~~~~~~~~
-[`source code <https://github.com/ray-project/ray/blob/master/python/ray/tune/trial_runner.py>`__]
+[`source code <https://github.com/ray-project/ray/blob/master/python/ray/tune/execution/trial_runner.py>`__]
 This is the main driver of the training loop. This component
 uses the TrialScheduler to prioritize and execute trials,
 queries the SearchAlgorithm for new
@@ -148,7 +148,7 @@ See the docstring at :ref:`trialrunner-docstring`.
 
 Trial objects
 ~~~~~~~~~~~~~
-[`source code <https://github.com/ray-project/ray/blob/master/python/ray/tune/trial.py>`__]
+[`source code <https://github.com/ray-project/ray/blob/master/python/ray/tune/experiment/trial.py>`__]
 This is an internal data structure that contains metadata about each training run. Each Trial
 object is mapped one-to-one with a Trainable object but are not themselves
 distributed/remote. Trial objects transition among
@@ -159,7 +159,7 @@ See the docstring at :ref:`trial-docstring`.
 
 RayTrialExecutor
 ~~~~~~~~~~~~~~~~
-[`source code <https://github.com/ray-project/ray/blob/master/python/ray/tune/ray_trial_executor.py>`__]
+[`source code <https://github.com/ray-project/ray/blob/master/python/ray/tune/execution/ray_trial_executor.py>`__]
 The RayTrialExecutor is a component that interacts with the underlying execution framework.
 It also manages resources to ensure the cluster isn't overloaded.
 


### PR DESCRIPTION
Removes previously seen warnings (soon to be errors):

![Screenshot 2022-10-21 at 14 50 52](https://user-images.githubusercontent.com/3462566/197203203-5efc7914-2d7b-4a59-8266-0f1580f33daf.png)
