### PR TITLE
Cherry-pick 2.1.0: Fix metrics exporter exporting metrics in incorrect format

### DIFF
--- a/python/ray/_private/prometheus_exporter.py
+++ b/python/ray/_private/prometheus_exporter.py
@@ -8,7 +8,6 @@ import re
 from prometheus_client import start_http_server
 from prometheus_client.core import (
     REGISTRY,
-    CollectorRegistry,
     CounterMetricFamily,
     GaugeMetricFamily,
     HistogramMetricFamily,
@@ -39,9 +38,7 @@ class Options(object):
     :param registry: A Prometheus collector registry instance.
     """
 
-    def __init__(
-        self, namespace="", port=8000, address="", registry=CollectorRegistry()
-    ):
+    def __init__(self, namespace="", port=8000, address="", registry=REGISTRY):
         self._namespace = namespace
         self._registry = registry
         self._port = int(port)
@@ -115,7 +112,6 @@ class Collector(object):
                 "units": view.measure.unit,
             }
             self.registered_views[v_name] = desc
-            self.registry.register(self)
 
     def add_view_data(self, view_data):
         """Add view data object to be sent to server"""
@@ -124,7 +120,7 @@ class Collector(object):
         self.view_name_to_data_map[v_name] = view_data
 
     # TODO: add start and end timestamp
-    def to_metric(self, desc, tag_values, agg_data):
+    def to_metric(self, desc, tag_values, agg_data, metrics_map):
         """to_metric translate the data that OpenCensus create
         to Prometheus format, using Prometheus Metric object
         :type desc: dict
@@ -154,12 +150,15 @@ class Collector(object):
         tag_values = [tv if tv else "" for tv in tag_values]
 
         if isinstance(agg_data, aggregation_data_module.CountAggregationData):
-            metric = CounterMetricFamily(
-                name=metric_name,
-                documentation=metric_description,
-                unit=metric_units,
-                labels=label_keys,
-            )
+            metric = metrics_map.get(metric_name)
+            if not metric:
+                metric = CounterMetricFamily(
+                    name=metric_name,
+                    documentation=metric_description,
+                    unit=metric_units,
+                    labels=label_keys,
+                )
+                metrics_map[metric_name] = metric
             metric.add_metric(labels=tag_values, value=agg_data.count_data)
             return metric
 
@@ -179,9 +178,14 @@ class Collector(object):
             # In OpenCensus we don't have +Inf in the bucket bonds so need to
             # append it here.
             buckets.append(["+Inf", agg_data.count_data])
-            metric = HistogramMetricFamily(
-                name=metric_name, documentation=metric_description, labels=label_keys
-            )
+            metric = metrics_map.get(metric_name)
+            if not metric:
+                metric = HistogramMetricFamily(
+                    name=metric_name,
+                    documentation=metric_description,
+                    labels=label_keys,
+                )
+                metrics_map[metric_name] = metric
             metric.add_metric(
                 labels=tag_values,
                 buckets=buckets,
@@ -190,16 +194,26 @@ class Collector(object):
             return metric
 
         elif isinstance(agg_data, aggregation_data_module.SumAggregationData):
-            metric = UnknownMetricFamily(
-                name=metric_name, documentation=metric_description, labels=label_keys
-            )
+            metric = metrics_map.get(metric_name)
+            if not metric:
+                metric = UnknownMetricFamily(
+                    name=metric_name,
+                    documentation=metric_description,
+                    labels=label_keys,
+                )
+                metrics_map[metric_name] = metric
             metric.add_metric(labels=tag_values, value=agg_data.sum_data)
             return metric
 
         elif isinstance(agg_data, aggregation_data_module.LastValueAggregationData):
-            metric = GaugeMetricFamily(
-                name=metric_name, documentation=metric_description, labels=label_keys
-            )
+            metric = metrics_map.get(metric_name)
+            if not metric:
+                metric = GaugeMetricFamily(
+                    name=metric_name,
+                    documentation=metric_description,
+                    labels=label_keys,
+                )
+                metrics_map[metric_name] = metric
             metric.add_metric(labels=tag_values, value=agg_data.value)
             return metric
 
@@ -214,14 +228,17 @@ class Collector(object):
         """
         # Make a shallow copy of self._view_name_to_data_map, to avoid seeing
         # concurrent modifications when iterating through the dictionary.
+        metrics_map = {}
         for v_name, view_data in self._view_name_to_data_map.copy().items():
             if v_name not in self.registered_views:
                 continue
             desc = self.registered_views[v_name]
             for tag_values in view_data.tag_value_aggregation_data_map:
                 agg_data = view_data.tag_value_aggregation_data_map[tag_values]
-                metric = self.to_metric(desc, tag_values, agg_data)
-                yield metric
+                metric = self.to_metric(desc, tag_values, agg_data, metrics_map)
+
+        for metric in metrics_map.values():
+            yield metric
 
 
 class PrometheusStatsExporter(base_exporter.StatsExporter):

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -796,22 +796,29 @@ def object_memory_usage() -> bool:
     return total - avail
 
 
-def fetch_prometheus(prom_addresses):
+def fetch_raw_prometheus(prom_addresses):
     # Local import so minimal dependency tests can run without requests
     import requests
 
-    components_dict = {}
-    metric_names = set()
-    metric_samples = []
     for address in prom_addresses:
-        if address not in components_dict:
-            components_dict[address] = set()
         try:
             response = requests.get(f"http://{address}/metrics")
+            yield address, response.text
         except requests.exceptions.ConnectionError:
             continue
 
-        for line in response.text.split("\n"):
+
+def fetch_prometheus(prom_addresses):
+    components_dict = {}
+    metric_names = set()
+    metric_samples = []
+
+    for address in prom_addresses:
+        if address not in components_dict:
+            components_dict[address] = set()
+
+    for address, response in fetch_raw_prometheus(prom_addresses):
+        for line in response.split("\n"):
             for family in text_string_to_metric_families(line):
                 for sample in family.samples:
                     metric_names.add(sample.name)

--- a/python/ray/tests/test_metrics_agent_2.py
+++ b/python/ray/tests/test_metrics_agent_2.py
@@ -24,7 +24,11 @@ from ray.core.generated.metrics_pb2 import (
 )
 from ray._raylet import WorkerID
 
-from ray._private.test_utils import fetch_prometheus_metrics, wait_for_condition
+from ray._private.test_utils import (
+    fetch_prometheus_metrics,
+    fetch_raw_prometheus,
+    wait_for_condition,
+)
 
 
 def raw_metrics(export_port):
@@ -139,15 +143,34 @@ def test_metrics_agent_record_and_export(get_agent):
     assert samples[0].value == 4
     assert samples[0].labels == {"tag": "a"}
 
+    # Record the same gauge with different ag.
+    record_d = Record(
+        gauge=test_gauge,
+        value=6,
+        tags={"tag": "aa"},
+    )
+    agent.record_and_export(
+        [
+            record_d,
+        ]
+    )
+    name, samples = get_metric(get_prom_metric_name(namespace, metric_name), agent_port)
+    assert name == get_prom_metric_name(namespace, metric_name)
+    assert len(samples) == 2
+    assert samples[0].value == 4
+    assert samples[0].labels == {"tag": "a"}
+    assert samples[1].value == 6
+    assert samples[1].labels == {"tag": "aa"}
+
     # Record more than 1 gauge.
     metric_name_2 = "test2"
     test_gauge_2 = Gauge(metric_name_2, "desc", "unit", ["tag"])
-    record_c = Record(
+    record_e = Record(
         gauge=test_gauge_2,
         value=1,
         tags={"tag": "b"},
     )
-    agent.record_and_export([record_c])
+    agent.record_and_export([record_e])
     name, samples = get_metric(
         get_prom_metric_name(namespace, metric_name_2), agent_port
     )
@@ -159,9 +182,11 @@ def test_metrics_agent_record_and_export(get_agent):
     # Make sure the previous record is still there.
     name, samples = get_metric(get_prom_metric_name(namespace, metric_name), agent_port)
     assert name == get_prom_metric_name(namespace, metric_name)
-    assert len(samples) == 1
+    assert len(samples) == 2
     assert samples[0].value == 4
     assert samples[0].labels == {"tag": "a"}
+    assert samples[1].value == 6
+    assert samples[1].labels == {"tag": "aa"}
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
@@ -327,6 +352,73 @@ def test_metrics_agent_proxy_record_and_export_from_workers_delay(get_agent):  #
 
     wait_for_condition(verify)
     assert time.time() - start > DELAY
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
+def test_metrics_agent_export_format_correct(get_agent):
+    """
+    Verifies that there is one metric per metric name and not one
+    per metric name + tag combination.
+    Also verifies that the prometheus output is in the right format.
+    """
+    namespace = "test"
+    agent, agent_port = get_agent
+
+    # Record a new gauge.
+    metric_name = "test"
+    test_gauge = Gauge(metric_name, "desc", "unit", ["tag"])
+    record_a = Record(
+        gauge=test_gauge,
+        value=3,
+        tags={"tag": "a"},
+    )
+    agent.record_and_export([record_a])
+
+    # Record a different tag.
+    record_b = Record(
+        gauge=test_gauge,
+        value=4,
+        tags={"tag": "b"},
+    )
+    agent.record_and_export([record_b])
+
+    # Record more than 1 gauge.
+    metric_name_2 = "test2"
+    test_gauge_2 = Gauge(metric_name_2, "desc", "unit", ["tag"])
+    record_c = Record(
+        gauge=test_gauge_2,
+        value=1,
+        tags={"tag": "c"},
+    )
+    agent.record_and_export([record_c])
+
+    # Basic assertions
+    name, samples = get_metric(
+        get_prom_metric_name(namespace, metric_name_2), agent_port
+    )
+    assert name == get_prom_metric_name(namespace, metric_name_2)
+    assert len(samples) == 1
+    assert samples[0].value == 1
+    assert samples[0].labels == {"tag": "c"}
+
+    name, samples = get_metric(get_prom_metric_name(namespace, metric_name), agent_port)
+    assert name == get_prom_metric_name(namespace, metric_name)
+    assert len(samples) == 2
+    assert samples[0].value == 3
+    assert samples[0].labels == {"tag": "a"}
+    assert samples[1].value == 4
+    assert samples[1].labels == {"tag": "b"}
+
+    # Assert there is not multiple HELP text per metric
+    # Need to manually parse the prometheus output because the official
+    # `prometheus_client.parser` is more lenient than the actual
+    # specification and ignores the multiple HELP / TYPE comments.
+    metrics_page = "localhost:{}".format(agent_port)
+    _, response = list(fetch_raw_prometheus([metrics_page]))[0]
+    assert response.count("# HELP test_test desc") == 1
+    assert response.count("# TYPE test_test gauge") == 1
+    assert response.count("# HELP test_test2 desc") == 1
+    assert response.count("# TYPE test_test2 gauge") == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Alan Guo aguo@anyscale.com

Cherry-pick of #29488

Ray was using prometheus client wrong a few ways:

We were registering the Collector to the RegistryCollector multiple times The collector was exporting a new "metric" for each tag combination instead of using a single Metric with multiple samples. We were creating a new RegistryCollector that was unused instead of re-using the "REGISTRY" singleton

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
