### PR TITLE
[Datasets] Fuse AllToAllStage and OneToOneStage with compatible remote args

### DIFF
--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -715,7 +715,7 @@ class AllToAllStage(Stage):
             return False
         if not is_task_compute(prev.compute):
             return False
-        if any(k not in INHERITABLE_REMOTE_ARGS for k in prev.ray_remote_args):
+        if not _are_remote_args_compatible(prev.ray_remote_args, self.ray_remote_args):
             return False
         return True
 

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -435,6 +435,22 @@ def test_optimize_equivalent_remote_args(ray_start_regular_shared):
                 ],
             )
 
+    for kwa in equivalent_kwargs:
+        for kwb in equivalent_kwargs:
+            print("CHECKING", kwa, kwb)
+            pipe = ray.data.range(3).repeat(2)
+            pipe = pipe.map_batches(lambda x: x, compute="tasks", **kwa)
+            pipe = pipe.random_shuffle_each_window(**kwb)
+            pipe.take()
+            expect_stages(
+                pipe,
+                1,
+                [
+                    "read->map_batches->random_shuffle_map",
+                    "random_shuffle_reduce",
+                ],
+            )
+
 
 def test_optimize_incompatible_stages(ray_start_regular_shared):
     context = DatasetContext.get_current()


### PR DESCRIPTION
Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently random_shuffle_map cannot be fused with pervious OneToOneStage even though they have compatible remote args.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
