### PR TITLE
[ci] Relax protobuf upper bound in CI

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -12,8 +12,7 @@ click<=8.0.4,>=7.0
 filelock
 jsonschema
 msgpack<2.0.0,>=1.0.0
-protobuf<4.0.0,>=3.15.35; platform_system != "Windows"
-protobuf>= 3.15.3, != 3.19.55; platform_system == "Windows"
+protobuf>= 3.15.3, != 3.19.55
 pyyaml
 aiosignal
 frozenlist


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#29224 removed the protobuf upper bound but #29375 was oroginally created on an older requirements file and accidentally reverted the update for unix builds.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
