### PR TITLE
[Test] Fix MacOS `test_actors_and_tasks_with_gpus`. 

### DIFF
--- a/python/ray/tests/test_actor_resources.py
+++ b/python/ray/tests/test_actor_resources.py
@@ -349,9 +349,9 @@ def test_actors_and_tasks_with_gpus(ray_start_cluster):
 
     @ray.remote(num_gpus=1)
     def f1():
-        t1 = time.monotonic()
+        t1 = time.time()
         time.sleep(0.1)
-        t2 = time.monotonic()
+        t2 = time.time()
         gpu_ids = ray.get_gpu_ids()
         assert len(gpu_ids) == 1
         assert gpu_ids[0] in range(num_gpus_per_raylet)
@@ -363,9 +363,9 @@ def test_actors_and_tasks_with_gpus(ray_start_cluster):
 
     @ray.remote(num_gpus=2)
     def f2():
-        t1 = time.monotonic()
+        t1 = time.time()
         time.sleep(0.1)
-        t2 = time.monotonic()
+        t2 = time.time()
         gpu_ids = ray.get_gpu_ids()
         assert len(gpu_ids) == 2
         assert gpu_ids[0] in range(num_gpus_per_raylet)


### PR DESCRIPTION
Signed-off-by: SangBin Cho <rkooo567@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test verifies that the same GPU is not used by more than 1 task with num_gpus=1 or 2 at a time. It compares the interval that the task is occupying GPU and make sure there's no overlap.

At this time, the test uses time.monotonic to compare "cross-process" interval. This seems to be a bad approach because as you can read from the `time.monotonic` documentation, the returned value is undefined, but only the interval between two results are valid. I used time.time instead and verified it fixes the issue. 

https://docs.python.org/3/library/time.html#time.monotonic

```
The reference point of the returned value is undefined, so that only the difference between the results of two calls is valid.
```

Not sure how it passed before. Maybe some systems guarantee the return value if valid across processes, and some are not. And for some reasons, the new Mac tests start using the system that has undefined behavior

## Related issue number

Closes https://github.com/ray-project/ray/issues/29549

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
