### PR TITLE
fixing deprecation warning for distutils

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -11,7 +11,7 @@ import urllib
 import urllib.parse
 import warnings
 from datetime import datetime
-from distutils.dir_util import copy_tree
+from shutil import copytree
 from typing import Optional, Set
 
 import click
@@ -2512,17 +2512,17 @@ def cpp(show_library_path, generate_bazel_project_template_to):
                 "The provided directory "
                 f"{generate_bazel_project_template_to} doesn't exist."
             )
-        copy_tree(cpp_templete_dir, generate_bazel_project_template_to)
+        copytree(cpp_templete_dir, generate_bazel_project_template_to)
         out_include_dir = os.path.join(
             generate_bazel_project_template_to, "thirdparty/include"
         )
         if not os.path.exists(out_include_dir):
             os.makedirs(out_include_dir)
-        copy_tree(include_dir, out_include_dir)
+        copytree(include_dir, out_include_dir)
         out_lib_dir = os.path.join(generate_bazel_project_template_to, "thirdparty/lib")
         if not os.path.exists(out_lib_dir):
             os.makedirs(out_lib_dir)
-        copy_tree(lib_dir, out_lib_dir)
+        copytree(lib_dir, out_lib_dir)
 
         cli_logger.print(
             "Project template generated to {}",


### PR DESCRIPTION
## Why are these changes needed?

I've noticed that when running `python -m pytest -v python/ray/tests/test_mini.py` a warning error was given by the use of distutils.copy_tree function within the ray/scripts/scripts.py file. The library will be removed in python 3.12 so I've replaced it with the alternative function from the shutil module (shutil.copytree). The shutil.copytree function is also used in other python files within the ray package. 

## Related issue number

Closes #29383

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've runned the test_mini.py again (now without deprecation errors)
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

For other testing strategies, I have not seen good documentation on this.