### PR TITLE
[WIP] [docs] add glossary with term references

### DIFF
--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -326,6 +326,7 @@ parts:
   - caption: References
     chapters:
       - file: ray-references/api
+      - file: ray-references/glossary
       - file: cluster/usage-stats
 
   - caption: Developer Guides

--- a/doc/source/ray-references/glossary.rst
+++ b/doc/source/ray-references/glossary.rst
@@ -1,0 +1,306 @@
+Ray Glossary
+============
+
+On this page you find a list of important terminology used throughout the Ray 
+documentation.
+
+.. glossary::
+
+    Action space
+        TODO
+
+    Actor
+        TODO
+
+    Actor pool
+        TODO
+
+    Actor task
+        TODO
+
+    Agent
+        TODO
+
+    Algorithm
+        TODO
+
+    Asynchronous execution
+        TODO
+
+    Autoscaler / Autoscaling
+        TODO
+
+    Backend
+        TODO
+
+    Batch predictor
+        TODO
+
+    (Placement Group) Bundle
+        TODO
+
+    Checkpoint
+        TODO
+
+    (Ray) Client
+        TODO
+
+    (Ray) Cluster
+        TODO
+
+    Concurrency
+        TODO
+
+    DAG
+        TODO
+
+    (Ray) Dashboard
+        TODO
+
+    Data Shuffling
+        TODO
+
+    Datasets
+        TODO
+
+    Dataset pipeline
+        TODO
+
+    Deployment
+        TODO
+
+    Deployment pipeline
+        TODO
+
+    Deployment graph
+        TODO
+
+    Driver
+        TODO
+
+    (Ray) Ecosystem
+        TODO
+
+    Entrypoint
+        TODO
+
+    Environment
+        TODO
+
+    Episode
+        TODO
+
+    Executor
+        TODO
+
+    Experiment
+        TODO
+
+    Event
+        TODO
+
+    Fault tolerance
+        TODO
+
+    GCS / Global control store
+        TODO
+
+    Generator
+        TODO
+
+    Head node / head node pod
+        TODO
+
+    Host
+        TODO
+
+    HPO
+        TODO
+
+    (Ray) Integration
+        TODO
+
+    Job
+        TODO
+
+    Lineage
+        TODO
+
+    Logs
+        TODO
+
+    Namespace
+        TODO
+
+    Node
+        TODO
+
+    Object
+        TODO
+
+    Object ownership
+        TODO
+
+    Object reference
+        TODO
+
+    Object store / Plasma store
+        TODO
+
+    Object spilling
+        TODO
+
+    Observability
+        TODO
+
+    Observation
+        TODO
+
+    OOM / Out of memory
+        TODO
+
+    Parallelism
+        TODO
+
+    Pattern and anti-pattern
+        TODO
+
+    Pipeline/pipelining
+        TODO
+
+    Placement group
+        TODO
+
+    Policy
+        TODO
+
+    Policy evaluation
+        TODO
+
+    Predictor
+        TODO
+
+    Preprocessor
+        TODO
+
+    Process
+        TODO
+
+    Ray application
+        TODO
+
+    Ray Timeline
+        TODO
+
+    Raylet
+        TODO
+
+    Replica
+        TODO
+
+    Resource / logical resource / physical resources (CPU, GPU, etc.)
+        TODO
+
+    Reward
+        TODO
+
+    Rollout
+        TODO
+
+
+
+    Rollout Worker
+        .. START ROLLOUT WORKER
+
+        RolloutWorkers are used as ``@ray.remote`` actors to collect and return samples
+        from environments or offline files in parallel. An RLlib
+        :py:class:`~ray.rllib.algorithms.algorithm.Algorithm` usually has
+        ``num_workers`` :py:class:`~ray.rllib.evaluation.rollout_worker.RolloutWorker`s plus a
+        single "local" :py:class:`~ray.rllib.evaluation.rollout_worker.RolloutWorker` (not ``@ray.remote``) in
+        its :py:class:`~ray.rllib.evaluation.worker_set.WorkerSet` under ``self.workers``.
+
+        Depending on its evaluation config settings, an additional
+        :py:class:`~ray.rllib.evaluation.worker_set.WorkerSet` with
+        :py:class:`~ray.rllib.evaluation.rollout_worker.RolloutWorker`s for evaluation may be present in the
+        :py:class:`~ray.rllib.algorithms.algorithm.Algorithm`
+        under ``self.evaluation_workers``.
+
+        .. END ROLLOUT WORKER
+
+    Runtime
+        TODO
+
+    Runtime environment
+        TODO
+
+    (Ray) Scheduler
+        TODO
+
+    Search Space
+        TODO
+
+    Search algorithm
+        TODO
+
+    Serve application
+        TODO
+
+    ServeHandle
+        TODO
+
+    Session
+        TODO
+
+    State
+        TODO
+
+    Synchronous execution
+        TODO
+
+    Task
+        TODO
+
+    Trainable
+        TODO
+
+    Trainer
+        TODO
+
+    Trainer configuration
+        TODO
+
+    Training iteration
+        TODO
+
+    Training step
+        TODO
+
+    Trial
+        TODO
+
+    Trial scheduler
+        TODO
+
+    Tuner
+        TODO
+
+    Tunable
+        TODO
+
+    UDF
+        TODO
+
+    (Ray) Workflow
+        TODO
+
+    WorkerGroup
+        TODO
+
+    Worker heap
+        TODO
+
+    Worker node / worker node pod
+        TODO
+
+    Worker process / worker
+        TODO

--- a/doc/source/rllib/core-concepts.rst
+++ b/doc/source/rllib/core-concepts.rst
@@ -32,7 +32,7 @@ An environment in RL is the agent's world, it is a simulation of the problem to 
 
 An RLlib environment consists of: 
 
-1. all possible actions (**action space**)
+1. all possible actions (:term:`Action space`)
 2. a complete description of the environment, nothing hidden (**state space**)
 3. an observation by the agent of certain parts of the state (**observation space**)
 4. **reward**, which is the only feedback the agent receives per action.

--- a/doc/source/rllib/package_ref/evaluation/rollout_worker.rst
+++ b/doc/source/rllib/package_ref/evaluation/rollout_worker.rst
@@ -3,15 +3,10 @@
 RolloutWorker
 =============
 
-RolloutWorkers are used as ``@ray.remote`` actors to collect and return samples
-from environments or offline files in parallel. An RLlib :py:class:`~ray.rllib.algorithms.algorithm.Algorithm` usually has
-``num_workers`` :py:class:`~ray.rllib.evaluation.rollout_worker.RolloutWorker`s plus a
-single "local" :py:class:`~ray.rllib.evaluation.rollout_worker.RolloutWorker` (not ``@ray.remote``) in
-its :py:class:`~ray.rllib.evaluation.worker_set.WorkerSet` under ``self.workers``.
+.. include:: /ray-references/glossary.rst
+    :start-after: START ROLLOUT WORKER
+    :end-before: END ROLLOUT WORKER
 
-Depending on its evaluation config settings, an additional :py:class:`~ray.rllib.evaluation.worker_set.WorkerSet` with
-:py:class:`~ray.rllib.evaluation.rollout_worker.RolloutWorker`s for evaluation may be present in the :py:class:`~ray.rllib.algorithms.algorithm.Algorithm`
-under ``self.evaluation_workers``.
 
 .. autoclass:: ray.rllib.evaluation.rollout_worker.RolloutWorker
     :special-members: __init__


### PR DESCRIPTION
To make the [glossary initiative](https://docs.google.com/document/d/1tKZEmP11wS0OjZ2cUIjo_TFO9ZwcbJ_iA82t8YQczh0/edit#) immediately useful to users, here's an implementation of a glossary for our docs.

We build up a main `glossary.rst` (to be completed) and place it under references. Here's one such item (probably _way_ too specific for this general doc):

![Screenshot 2022-10-24 at 15 42 10](https://user-images.githubusercontent.com/3462566/197540196-bcf52d9c-1ae8-4b5c-b794-9835e0a4fb31.png)

Not only can we reference back to these glossary terms (shown in PR), we can also use these definitions in several places, so that we don't repeat ourselves (taken from the RLlib API docs, actual example from this PR):

![Screenshot 2022-10-24 at 15 42 17](https://user-images.githubusercontent.com/3462566/197540481-94c9222c-298a-4251-8cfe-c727b25fb65c.png)
