### PR TITLE
[CI] Reduce cost of golden notebook release test

### DIFF
--- a/release/golden_notebook_tests/gpu_tpl.yaml
+++ b/release/golden_notebook_tests/gpu_tpl.yaml
@@ -1,15 +1,15 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
-max_workers: 3
+max_workers: 2
 
 head_node_type:
     name: head_node
-    instance_type: m5.4xlarge
+    instance_type: m5.xlarge
 
 worker_node_types:
     - name: worker_node
       instance_type: g3.8xlarge
-      min_workers: 3
-      max_workers: 3
-      use_spot: false
+      min_workers: 2
+      max_workers: 2
+      use_spot: true

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1747,7 +1747,7 @@
     test_name: torch_tune_serve_test
     test_suite: golden_notebook_tests
 
-  frequency: nightly
+  frequency: nightly-3x
   team: ml
   env: staging
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1756,7 +1756,7 @@
     cluster_compute: gpu_tpl.yaml
 
   run:
-    timeout: 1800
+    timeout: 600
     script: python workloads/torch_tune_serve_test.py
     type: client
 


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The golden notebook release test was only using 2 of the 3 GPU nodes assigned. Removed one, switched to use spot instances (as the test is very short) and reduced the size of the head instance. Also set it to run as nightly-3x instead of nightly.

https://buildkite.com/ray-project/release-tests-pr/builds/18943

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
