### PR TITLE
[AIR] Hard deprecate train.report, warn on air.session misuse

### DIFF
--- a/doc/source/ray-air/doc_code/air_ingest.py
+++ b/doc/source/ray-air/doc_code/air_ingest.py
@@ -163,14 +163,14 @@ my_trainer.fit()
 
 # __global_shuffling_start__
 import ray
-from ray import train
+from ray.air import session
 from ray.data import Dataset
 from ray.train.torch import TorchTrainer
 from ray.air.config import DatasetConfig, ScalingConfig
 
 
 def train_loop_per_worker():
-    data_shard: Dataset = train.get_dataset_shard("train")
+    data_shard: Dataset = session.get_dataset_shard("train")
 
     # Iterate over 10 epochs of data.
     for epoch in range(10):
@@ -196,14 +196,14 @@ my_trainer.fit()
 
 # __local_shuffling_start__
 import ray
-from ray import train
+from ray.air import session
 from ray.data import Dataset
 from ray.train.torch import TorchTrainer
 from ray.air.config import DatasetConfig, ScalingConfig
 
 
 def train_loop_per_worker():
-    data_shard: Dataset = train.get_dataset_shard("train")
+    data_shard: Dataset = session.get_dataset_shard("train")
 
     # Iterate over 10 epochs of data.
     for epoch in range(10):

--- a/doc/source/ray-air/examples/pytorch_tabular_starter.py
+++ b/doc/source/ray-air/examples/pytorch_tabular_starter.py
@@ -30,7 +30,6 @@ preprocessor = Chain(
 # __air_pytorch_train_start__
 import torch
 import torch.nn as nn
-from torch.nn.modules.utils import consume_prefix_in_state_dict_if_present
 
 from ray import train
 from ray.air import session
@@ -57,7 +56,7 @@ def train_loop_per_worker(config):
 
     # Get the Ray Dataset shard for this data parallel worker,
     # and convert it to a PyTorch Dataset.
-    train_data = train.get_dataset_shard("train")
+    train_data = session.get_dataset_shard("train")
     # Create model.
     model = create_model(num_features)
     model = train.torch.prepare_model(model)

--- a/doc/source/ray-air/examples/tf_tabular_starter.py
+++ b/doc/source/ray-air/examples/tf_tabular_starter.py
@@ -82,7 +82,7 @@ def train_loop_per_worker(config):
 
     # Get the Ray Dataset shard for this data parallel worker,
     # and convert it to a Tensorflow Dataset.
-    train_data = train.get_dataset_shard("train")
+    train_data = session.get_dataset_shard("train")
 
     strategy = tf.distribute.MultiWorkerMirroredStrategy()
     with strategy.scope():

--- a/python/ray/air/constants.py
+++ b/python/ray/air/constants.py
@@ -31,3 +31,7 @@ _RESULT_FETCH_TIMEOUT = 0.2
 
 # Timeout for fetching exceptions raised by the training function.
 _ERROR_FETCH_TIMEOUT = 1
+
+# The key used to identify whether we have already warned about ray.air.session
+# functions being used outside of the session
+SESSION_MISUSE_LOG_ONCE_KEY = "air_warn_session_misuse"

--- a/python/ray/air/session.py
+++ b/python/ray/air/session.py
@@ -27,7 +27,7 @@ def _warn_session_misuse(default_value: Any = None):
                     warnings.warn(
                         f"`{fn_name}` is meant to only be "
                         "called inside a function that is executed by a Tuner"
-                        " or Trainer."
+                        f" or Trainer. Returning `{default_value}`."
                     )
                 return default_value
             return fn(*args, **kwargs)

--- a/python/ray/air/session.py
+++ b/python/ray/air/session.py
@@ -1,14 +1,43 @@
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
+import warnings
+import functools
 
 from ray.air._internal.session import _get_session
 from ray.air.checkpoint import Checkpoint
+from ray.air.constants import SESSION_MISUSE_LOG_ONCE_KEY
 from ray.train.session import _TrainSessionImpl
+from ray.util import log_once
 
 if TYPE_CHECKING:
     from ray.data import Dataset, DatasetPipeline
     from ray.tune.execution.placement_groups import PlacementGroupFactory
 
 
+def _warn_session_misuse(default_value: Any = None):
+    """Warns if fn is being used outside of session and returns ``default_value``."""
+
+    def inner(fn: Callable):
+        fn_name = fn.__name__
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            session = _get_session()
+            if not session:
+                if log_once(f"{SESSION_MISUSE_LOG_ONCE_KEY}-{fn_name}"):
+                    warnings.warn(
+                        f"`{fn_name}` is meant to only be "
+                        "called inside a function that is executed by a Tuner"
+                        " or Trainer."
+                    )
+                return default_value
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return inner
+
+
+@_warn_session_misuse()
 def report(metrics: Dict, *, checkpoint: Optional[Checkpoint] = None) -> None:
     """Report metrics and optionally save a checkpoint.
 
@@ -61,6 +90,7 @@ def report(metrics: Dict, *, checkpoint: Optional[Checkpoint] = None) -> None:
     _get_session().report(metrics, checkpoint=checkpoint)
 
 
+@_warn_session_misuse()
 def get_checkpoint() -> Optional[Checkpoint]:
     """Access the session's last checkpoint to resume from if applicable.
 
@@ -110,21 +140,25 @@ def get_checkpoint() -> Optional[Checkpoint]:
     return _get_session().loaded_checkpoint
 
 
+@_warn_session_misuse()
 def get_trial_name() -> str:
     """Trial name for the corresponding trial."""
     return _get_session().trial_name
 
 
+@_warn_session_misuse()
 def get_trial_id() -> str:
     """Trial id for the corresponding trial."""
     return _get_session().trial_id
 
 
+@_warn_session_misuse()
 def get_trial_resources() -> "PlacementGroupFactory":
     """Trial resources for the corresponding trial."""
     return _get_session().trial_resources
 
 
+@_warn_session_misuse()
 def get_trial_dir() -> str:
     """Log directory corresponding to the trial directory for a Tune session.
     If calling from a Train session, this will give the trial directory of its parent
@@ -146,6 +180,7 @@ def get_trial_dir() -> str:
     return _get_session().trial_dir
 
 
+@_warn_session_misuse(default_value=1)
 def get_world_size() -> int:
     """Get the current world size (i.e. total number of workers) for this run.
 
@@ -175,6 +210,7 @@ def get_world_size() -> int:
     return session.world_size
 
 
+@_warn_session_misuse(default_value=0)
 def get_world_rank() -> int:
     """Get the world rank of this worker.
 
@@ -207,6 +243,7 @@ def get_world_rank() -> int:
     return session.world_rank
 
 
+@_warn_session_misuse(default_value=0)
 def get_local_rank() -> int:
     """Get the local rank of this worker (rank of the worker on its node).
 
@@ -238,6 +275,7 @@ def get_local_rank() -> int:
     return session.local_rank
 
 
+@_warn_session_misuse()
 def get_dataset_shard(
     dataset_name: Optional[str] = None,
 ) -> Optional[Union["Dataset", "DatasetPipeline"]]:

--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -299,7 +299,7 @@ py_test(
     size = "small",
     srcs = ["tests/test_session.py"],
     tags = ["team:ml", "exclusive"],
-    deps = [":train_lib"]
+    deps = [":train_lib", ":conftest"]
 )
 
 py_test(

--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -396,10 +396,8 @@ class BackendExecutor:
                 raise RuntimeError(
                     "Some workers returned results while "
                     "others didn't. Make sure that "
-                    "`session.report()` (legacy API:"
-                    "`train.report()` and `train.save_checkpoint()`) "
-                    "are called the same number of times on all "
-                    "workers."
+                    "`session.report()` are called the "
+                    "same number of times on all workers."
                 )
             else:
                 # Return None if all results are None.
@@ -410,15 +408,13 @@ class BackendExecutor:
             raise RuntimeError(
                 "Some workers returned results with "
                 "different types. Make sure that "
-                "`session.report()` (legacy API:"
-                "`train.report()` and `train.save_checkpoint()`) "
-                "are called the same number of times on all "
-                "workers."
+                "`session.report()` are called the "
+                "same number of times on all workers."
             )
         return results
 
     def pause_reporting(self):
-        """Disable workers from enqueuing results from `train.report()`.
+        """Disable workers from enqueuing results from ``session.report()``.
 
         Note: Already reported results may still be enqueued at this point,
               and should be handled appropriately.

--- a/python/ray/train/_internal/session.py
+++ b/python/ray/train/_internal/session.py
@@ -324,7 +324,9 @@ def get_session() -> Optional[_TrainSession]:
 def shutdown_session():
     """Shuts down the initialized session."""
     global _session
+    global _session_v2
     _session = None
+    _session_v2 = None
 
 
 def _raise_accelerator_session_misuse():

--- a/python/ray/train/constants.py
+++ b/python/ray/train/constants.py
@@ -62,10 +62,6 @@ TRAIN_PLACEMENT_GROUP_TIMEOUT_S_ENV = "TRAIN_PLACEMENT_GROUP_TIMEOUT_S"
 # PACK to SPREAD. 1 for True, 0 for False.
 TRAIN_ENABLE_WORKER_SPREAD_ENV = "TRAIN_ENABLE_WORKER_SPREAD"
 
-# The key used to identify whether we have already warned about ray.train
-# functions being used outside of the session
-SESSION_MISUSE_LOG_ONCE_KEY = "train_warn_session_misuse"
-
 # Default NCCL_SOCKET_IFNAME.
 # Use ethernet when possible.
 # NCCL_SOCKET_IFNAME does a prefix match so "ens3" or "ens5" will match with

--- a/python/ray/train/examples/transformers/transformers_example.py
+++ b/python/ray/train/examples/transformers/transformers_example.py
@@ -43,6 +43,7 @@ from transformers import (
 from transformers.utils.versions import require_version
 
 import ray
+from ray.air import session
 from ray.train.torch import TorchTrainer
 from ray.air.config import ScalingConfig
 
@@ -231,8 +232,8 @@ def parse_args():
 
 def train_func(config: Dict[str, Any]):
     # Accelerator reads from this environment variable for GPU placement.
-    os.environ["LOCAL_RANK"] = str(ray.train.local_rank())
-    os.environ["WORLD_SIZE"] = str(ray.train.world_size())
+    os.environ["LOCAL_RANK"] = str(session.get_local_rank())
+    os.environ["WORLD_SIZE"] = str(session.get_world_size())
 
     args = config["args"]
     # Initialize the accelerator. We will let the accelerator handle device

--- a/python/ray/train/tensorflow/train_loop_utils.py
+++ b/python/ray/train/tensorflow/train_loop_utils.py
@@ -9,8 +9,8 @@ def prepare_dataset_shard(tf_dataset_shard: tf.data.Dataset):
 
     This should be used on a TensorFlow ``Dataset`` created by calling
     ``iter_tf_batches()`` on a ``ray.data.Dataset`` returned by
-    ``ray.train.get_dataset_shard()`` since the dataset has already been sharded
-    across the workers.
+    ``ray.air.session.get_dataset_shard()`` since the dataset has already
+    been sharded across the workers.
 
     Args:
         tf_dataset_shard (tf.data.Dataset): A TensorFlow Dataset.

--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -174,12 +174,12 @@ def test_torch_prepare_model_uses_device(ray_start_4_cpus_2_gpus):
     @patch.object(
         ray.train.torch.train_loop_utils._TorchAccelerator,
         "get_device",
-        lambda self: torch.device(f"cuda:{1 - train.local_rank()}"),
+        lambda self: torch.device(f"cuda:{1 - session.get_local_rank()}"),
     )
     def train_func():
         # These assert statements must hold for prepare_model to wrap with DDP.
         assert torch.cuda.is_available()
-        assert train.world_size() > 1
+        assert session.get_world_size() > 1
         model = torch.nn.Linear(1, 1)
         data = torch.ones(1)
         data = data.to(train.torch.get_device())

--- a/python/ray/train/tests/test_session.py
+++ b/python/ray/train/tests/test_session.py
@@ -5,8 +5,9 @@ import pytest
 
 import ray
 from ray.air._internal.util import StartTraceback
+from ray.air.checkpoint import Checkpoint
 from ray.train._internal.accelerator import Accelerator
-from ray.train.constants import SESSION_MISUSE_LOG_ONCE_KEY
+from ray.air.constants import SESSION_MISUSE_LOG_ONCE_KEY
 from ray.train._internal.session import (
     init_session,
     shutdown_session,
@@ -15,14 +16,13 @@ from ray.train._internal.session import (
     get_accelerator,
     set_accelerator,
 )
-from ray.train.train_loop_utils import (
-    world_rank,
-    local_rank,
+from ray.air.session import (
+    get_checkpoint,
+    get_world_rank,
+    get_local_rank,
     report,
-    save_checkpoint,
-    load_checkpoint,
     get_dataset_shard,
-    world_size,
+    get_world_size,
 )
 from ray.train.error import SessionMisuseError
 
@@ -48,24 +48,24 @@ def test_shutdown(session):
 
 
 def test_world_rank(session):
-    assert world_rank() == 0
+    assert get_world_rank() == 0
     shutdown_session()
     # Make sure default to 0.
-    assert world_rank() == 0
+    assert get_world_rank() == 0
 
 
 def test_local_rank(session):
-    assert local_rank() == 0
+    assert get_local_rank() == 0
     shutdown_session()
     # Make sure default to 0.
-    assert local_rank() == 0
+    assert get_local_rank() == 0
 
 
 def test_world_size(session):
-    assert world_size() == 1
+    assert get_world_size() == 1
     shutdown_session()
     # Make sure default to 1.
-    assert world_size() == 1
+    assert get_world_size() == 1
 
 
 def test_train(session):
@@ -74,7 +74,7 @@ def test_train(session):
     assert output == 1
 
 
-def test_get_dataset_shard():
+def test_get_dataset_shard(shutdown_only):
     dataset = ray.data.from_items([1, 2, 3])
     init_session(
         training_func=lambda: 1,
@@ -90,7 +90,7 @@ def test_get_dataset_shard():
 def test_report():
     def train_func():
         for i in range(2):
-            report(loss=i)
+            report(dict(loss=i))
 
     init_session(training_func=train_func, world_rank=0, local_rank=0, world_size=1)
     session = get_session()
@@ -119,19 +119,21 @@ def test_report_after_finish(session):
     session.pause_reporting()
     session.finish()
     for _ in range(2):
-        report(loss=1)
+        report(dict(loss=1))
     assert session.get_next() is None
+    shutdown_session()
 
 
 def test_no_start(session):
     with pytest.raises(RuntimeError):
         session.get_next()
+    shutdown_session()
 
 
 def test_checkpoint():
     def train_func():
         for i in range(2):
-            save_checkpoint(epoch=i)
+            report({}, checkpoint=Checkpoint.from_dict(dict(epoch=i)))
 
     def validate_zero(expected):
         next = session.get_next()
@@ -143,7 +145,9 @@ def test_checkpoint():
     session = get_session()
     session.start()
     validate_zero(0)
+    session.get_next()  # handle report
     validate_zero(1)
+    session.get_next()
     session.finish()
     shutdown_session()
 
@@ -157,15 +161,16 @@ def test_checkpoint():
     session = get_session()
     session.start()
     validate_nonzero()
+    session.get_next()  # handle report
     validate_nonzero()
+    session.get_next()
     session.finish()
     shutdown_session()
 
 
 def test_encode_data():
     def train_func():
-        save_checkpoint(epoch=0)
-        report(epoch=1)
+        report(dict(epoch=0), checkpoint=Checkpoint.from_dict(dict(epoch=0)))
 
     def encode_checkpoint(checkpoint):
         checkpoint.update({"encoded": True})
@@ -197,9 +202,9 @@ def test_encode_data():
 def test_load_checkpoint_after_save():
     def train_func():
         for i in range(2):
-            save_checkpoint(epoch=i)
-            checkpoint = load_checkpoint()
-            assert checkpoint["epoch"] == i
+            report(dict(epoch=i), checkpoint=Checkpoint.from_dict(dict(epoch=i)))
+            checkpoint = get_checkpoint()
+            assert checkpoint.to_dict()["epoch"] == i
 
     init_session(training_func=train_func, world_rank=0, local_rank=0, world_size=1)
     session = get_session()
@@ -226,7 +231,7 @@ def test_locking():
 
     def train_2():
         for i in range(2):
-            report(loss=i)
+            report(dict(loss=i))
         train_1()
 
     init_session(training_func=train_2, world_rank=0, local_rank=0, world_size=1)
@@ -250,16 +255,29 @@ def reset_log_once_with_str(str_to_append=None):
     ray.util.debug.reset_log_once(key)
 
 
-@pytest.mark.parametrize(
-    "fn", [load_checkpoint, save_checkpoint, report, get_dataset_shard]
-)
+@pytest.mark.parametrize("fn", [get_checkpoint, get_dataset_shard])
 def test_warn(fn):
-    """Checks if calling train functions outside of session raises warning."""
+    """Checks if calling session functions outside of session raises warning."""
 
     with warnings.catch_warnings(record=True) as record:
         # Ignore Deprecation warnings.
         warnings.filterwarnings("ignore", category=DeprecationWarning)
-        fn()
+        assert not fn()
+
+    assert fn.__name__ in record[0].message.args[0]
+
+    reset_log_once_with_str(fn.__name__)
+
+
+def test_warn_report():
+    """Checks if calling session.report function outside of session raises warning."""
+
+    fn = report
+
+    with warnings.catch_warnings(record=True) as record:
+        # Ignore Deprecation warnings.
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        assert not fn(dict())
 
     assert fn.__name__ in record[0].message.args[0]
 
@@ -272,15 +290,15 @@ def test_warn_once():
     with warnings.catch_warnings(record=True) as record:
         # Ignore Deprecation warnings.
         warnings.filterwarnings("ignore", category=DeprecationWarning)
-        assert not load_checkpoint()
-        assert not load_checkpoint()
-        assert not save_checkpoint(x=2)
-        assert not report(x=2)
-        assert not report(x=3)
+        assert not get_checkpoint()
+        assert not get_checkpoint()
+        assert not report(dict(x=2))
+        assert not report(dict(x=2))
+        assert not get_dataset_shard()
         assert not get_dataset_shard()
 
     # Should only warn once.
-    assert len(record) == 4
+    assert len(record) == 3
 
 
 class FakeAccelerator(Accelerator):

--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -9,7 +9,6 @@ from distutils.version import LooseVersion
 from typing import Any, Dict, Optional
 
 import ray
-from ray import train
 from ray.air import session
 from ray.train._internal.accelerator import Accelerator
 from torch.optim import Optimizer
@@ -282,12 +281,7 @@ class _TorchAccelerator(Accelerator):
         """
         parallel_strategy_kwargs = parallel_strategy_kwargs or {}
 
-        # Backwards compatibility
-        try:
-            rank = session.get_local_rank()
-        except Exception:
-            rank = train.local_rank()
-
+        rank = session.get_local_rank()
         device = self.get_device()
 
         if torch.cuda.is_available():
@@ -334,11 +328,7 @@ class _TorchAccelerator(Accelerator):
             # See https://stackoverflow.com/questions/972/adding-a-method-to-an-existing-object-instance.  # noqa: E501
             model.__getstate__ = types.MethodType(model_get_state, model)
 
-        # Backwards compatibility
-        try:
-            world_size = session.get_world_size()
-        except Exception:
-            world_size = train.world_size()
+        world_size = session.get_world_size()
 
         if parallel_strategy and world_size > 1:
             if parallel_strategy == "ddp":
@@ -393,13 +383,8 @@ class _TorchAccelerator(Accelerator):
                 if ``move_to_device`` is False.
         """
 
-        # Backwards compatibility
-        try:
-            world_size = session.get_world_size()
-            world_rank = session.get_world_rank()
-        except Exception:
-            world_size = train.world_size()
-            world_rank = train.world_rank()
+        world_size = session.get_world_size()
+        world_rank = session.get_world_rank()
 
         # Only add Distributed Sampler if the following conditions hold:
         # 1. More than one training worker is being used.

--- a/python/ray/train/train_loop_utils.py
+++ b/python/ray/train/train_loop_utils.py
@@ -1,8 +1,5 @@
-import warnings
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
-from ray.train.constants import SESSION_MISUSE_LOG_ONCE_KEY
-from ray.util import log_once
 from ray.util.annotations import Deprecated
 
 if TYPE_CHECKING:
@@ -27,22 +24,6 @@ def _get_deprecation_msg(is_docstring: bool, fn_name: Optional[str] = None):
         "but in a unified manner across Ray Train and Ray Tune."
     )
     return deprecation_msg
-
-
-def _warn_session_misuse(fn_name: str):
-    """Logs warning message on provided fn being used outside of session.
-
-    Args:
-        fn_name: The name of the function to warn about.
-    """
-
-    if log_once(f"{SESSION_MISUSE_LOG_ONCE_KEY}-{fn_name}"):
-        warnings.warn(
-            f"`train.{fn_name}()` is meant to only be "
-            f"called "
-            "inside a training function that is executed by "
-            "`Trainer.run`. Returning None."
-        )
 
 
 @Deprecated(message=_get_deprecation_msg(is_docstring=True))

--- a/python/ray/train/train_loop_utils.py
+++ b/python/ray/train/train_loop_utils.py
@@ -1,7 +1,6 @@
 import warnings
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
-from ray.train._internal.session import get_session
 from ray.train.constants import SESSION_MISUSE_LOG_ONCE_KEY
 from ray.util import log_once
 from ray.util.annotations import Deprecated
@@ -86,32 +85,9 @@ def get_dataset_shard(
         The ``Dataset`` or ``DatasetPipeline`` shard to use for this worker.
         If no dataset is passed into Trainer, then return None.
     """
-    warnings.warn(
+    raise DeprecationWarning(
         _get_deprecation_msg(is_docstring=False, fn_name=get_dataset_shard.__name__),
-        DeprecationWarning,
-        stacklevel=2,
     )
-    session = get_session()
-    if session is None:
-        _warn_session_misuse(get_dataset_shard.__name__)
-        return
-    shard = session.dataset_shard
-    if shard is None:
-        warnings.warn(
-            "No dataset passed in. Returning None. Make sure to "
-            "pass in a Ray Dataset to Trainer.run to use this "
-            "function."
-        )
-    elif isinstance(shard, dict):
-        if not dataset_name:
-            raise RuntimeError(
-                "Multiple datasets were passed into ``Trainer``, "
-                "but no ``dataset_name`` is passed into "
-                "``get_dataset_shard``. Please specify which "
-                "dataset shard to retrieve."
-            )
-        return shard.get(dataset_name)
-    return shard
 
 
 @Deprecated(message=_get_deprecation_msg(is_docstring=True))
@@ -138,16 +114,9 @@ def report(**kwargs) -> None:
             If callbacks are provided, they are executed on these
             intermediate results.
     """
-    warnings.warn(
+    raise DeprecationWarning(
         _get_deprecation_msg(is_docstring=False, fn_name=report.__name__),
-        DeprecationWarning,
-        stacklevel=2,
     )
-    session = get_session()
-    if session is None:
-        _warn_session_misuse(report.__name__)
-        return
-    session._report_legacy(**kwargs)
 
 
 @Deprecated(message=_get_deprecation_msg(is_docstring=True))
@@ -171,15 +140,9 @@ def world_rank() -> int:
         trainer.shutdown()
 
     """
-    warnings.warn(
+    raise DeprecationWarning(
         _get_deprecation_msg(is_docstring=False, fn_name=world_rank.__name__),
-        DeprecationWarning,
-        stacklevel=2,
     )
-    session = get_session()
-    if session is None:
-        return 0
-    return session.world_rank
 
 
 @Deprecated(message=_get_deprecation_msg(is_docstring=True))
@@ -202,15 +165,9 @@ def local_rank() -> int:
         trainer.shutdown()
 
     """
-    warnings.warn(
+    raise DeprecationWarning(
         _get_deprecation_msg(is_docstring=False, fn_name=local_rank.__name__),
-        DeprecationWarning,
-        stacklevel=2,
     )
-    session = get_session()
-    if session is None:
-        return 0
-    return session.local_rank
 
 
 @Deprecated(message=_get_deprecation_msg(is_docstring=True))
@@ -240,16 +197,9 @@ def load_checkpoint() -> Optional[Dict]:
         has been called. Otherwise, the checkpoint that the session was
         originally initialized with. ``None`` if neither exist.
     """
-    warnings.warn(
+    raise DeprecationWarning(
         _get_deprecation_msg(is_docstring=False, fn_name=load_checkpoint.__name__),
-        DeprecationWarning,
-        stacklevel=2,
     )
-    session = get_session()
-    if session is None:
-        _warn_session_misuse(load_checkpoint.__name__)
-        return
-    return session.loaded_checkpoint
 
 
 @Deprecated(message=_get_deprecation_msg(is_docstring=True))
@@ -274,16 +224,9 @@ def save_checkpoint(**kwargs) -> None:
     Args:
         **kwargs: Any key value pair to be checkpointed by Train.
     """
-    warnings.warn(
+    raise DeprecationWarning(
         _get_deprecation_msg(is_docstring=False, fn_name=save_checkpoint.__name__),
-        DeprecationWarning,
-        stacklevel=2,
     )
-    session = get_session()
-    if session is None:
-        _warn_session_misuse(save_checkpoint.__name__)
-        return
-    session.checkpoint(**kwargs)
 
 
 @Deprecated(message=_get_deprecation_msg(is_docstring=True))
@@ -303,12 +246,6 @@ def world_size() -> int:
         trainer.run(train_func)
         trainer.shutdown()
     """
-    warnings.warn(
+    raise DeprecationWarning(
         _get_deprecation_msg(is_docstring=False, fn_name=world_size.__name__),
-        DeprecationWarning,
-        stacklevel=2,
     )
-    session = get_session()
-    if session is None:
-        return 1
-    return session.world_size

--- a/python/ray/train/trainer.py
+++ b/python/ray/train/trainer.py
@@ -242,12 +242,12 @@ class TrainingIterator:
             raise
 
     def _fetch_next_result(self) -> Optional[List[Dict]]:
-        """Fetch next results produced by ``train.report()`` from each worker.
+        """Fetch next results produced by ``session.report()`` from each worker.
 
         Assumes ``start_training`` has already been called.
 
         Returns:
-            A list of dictionaries of values passed to ``train.report()`` from
+            A list of dictionaries of values passed to ``session.report()`` from
                 each worker. Each item corresponds to an intermediate result
                 a single worker. If there are no more items to fetch,
                 returns None.


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Hard deprecates `ray.train.report` and other session functions and ensures that the user is informed when using `ray.air.session` if they are not in session for consistency with the old functions.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
