### PR TITLE
[2.1] Revert "[Datasets] Bundle blocks smaller than batch size in `map_batches` tasks. (#28648)"

### DIFF
--- a/doc/source/ray-air/examples/convert_existing_pytorch_code_to_ray_air.ipynb
+++ b/doc/source/ray-air/examples/convert_existing_pytorch_code_to_ray_air.ipynb
@@ -1090,7 +1090,7 @@
    "source": [
     "import ray.data\n",
     "\n",
-    "ds = ray.data.from_items([x.numpy() for x, y in test_data], parallelism=8)"
+    "ds = ray.data.from_items([x.numpy() for x, y in test_data])"
    ]
   },
   {
@@ -1111,12 +1111,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Map Progress (2 actors 1 pending): 100%|██████████| 8/8 [00:02<00:00, 70.01it/s]\n"
+      "Map Progress (2 actors 1 pending): 100%|██████████| 200/200 [00:02<00:00, 70.01it/s]\n"
      ]
     }
    ],
    "source": [
-    "results = batch_predictor.predict(ds, batch_size=32, min_scoring_workers=2)"
+    "results = batch_predictor.predict(ds, min_scoring_workers=2)"
    ]
   },
   {
@@ -1222,14 +1222,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Map_Batches: 100%|██████████| 8/8 [00:02<00:00, 80.05it/s]\n"
+      "Map_Batches: 100%|██████████| 200/200 [00:02<00:00, 80.05it/s]\n"
      ]
     }
    ],
    "source": [
     "predicted_classes = results.map_batches(\n",
     "    lambda batch: [classes[pred.argmax(0)] for pred in batch[\"predictions\"]], \n",
-    "    batch_size=32,\n",
     "    batch_format=\"pandas\")"
    ]
   },
@@ -1238,13 +1237,32 @@
    "id": "cb7040db",
    "metadata": {},
    "source": [
-    "To see how well our prediction did, let's zip the predicted labels together with some of the actual labels to compare them:"
+    "To compare this with the actual labels, let's create a Ray dataset for these and zip it together with the predicted classes:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 30,
    "id": "207e13b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "real_classes = ray.data.from_items([classes[y] for x, y in test_data])\n",
+    "merged = predicted_classes.zip(real_classes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18b1012c",
+   "metadata": {},
+   "source": [
+    "Let's examine our results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "2b2decc6",
    "metadata": {},
    "outputs": [
     {
@@ -1275,9 +1293,7 @@
     }
    ],
    "source": [
-    "real_classes = [classes[y] for x, y in test_data]\n",
-    "for predicted, real in zip(predicted_classes.take(), real_classes):\n",
-    "    print((predicted, real))"
+    "merged.show()"
    ]
   },
   {

--- a/doc/source/ray-air/examples/torch_image_batch_pretrained.py
+++ b/doc/source/ray-air/examples/torch_image_batch_pretrained.py
@@ -36,4 +36,4 @@ preprocessor = BatchMapper(preprocess, batch_format="numpy")
 ckpt = TorchCheckpoint.from_model(model=model, preprocessor=preprocessor)
 
 predictor = BatchPredictor.from_checkpoint(ckpt, TorchPredictor)
-predictor.predict(dataset, batch_size=80)
+predictor.predict(dataset)

--- a/python/ray/air/tests/test_dataset_config.py
+++ b/python/ray/air/tests/test_dataset_config.py
@@ -255,13 +255,13 @@ def test_stream_inf_window_cache_prep(ray_start_4_cpus):
         assert results[0] == results[1], results
         stats = shard.stats()
         assert str(shard) == "DatasetPipeline(num_windows=inf, num_stages=1)", shard
-        assert "Stage 1 read->map_batches: 1/1 blocks executed " in stats, stats
+        assert "Stage 1 read->map_batches: 5/5 blocks executed " in stats, stats
 
     def rand(x):
         return [random.random() for _ in range(len(x))]
 
     prep = BatchMapper(rand)
-    ds = ray.data.range_table(5, parallelism=1)
+    ds = ray.data.range_table(5)
     test = TestStream(
         checker,
         preprocessor=prep,
@@ -287,7 +287,7 @@ def test_stream_finite_window_nocache_prep(ray_start_4_cpus):
         stats = shard.stats()
         assert str(shard) == "DatasetPipeline(num_windows=inf, num_stages=1)", shard
         assert (
-            "Stage 1 read->randomize_block_order->map_batches: 1/1 blocks executed "
+            "Stage 1 read->randomize_block_order->map_batches: 5/5 blocks executed "
             in stats
         ), stats
 

--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -49,20 +49,11 @@ class Batcher(BatcherInterface):
     # zero-copy views, we sacrifice what should be a small performance hit for better
     # readability.
 
-    def __init__(self, batch_size: Optional[int], ensure_copy: bool = False):
-        """
-        Construct a batcher that yields batches of batch_sizes rows.
-
-        Args:
-            batch_size: The size of batches to yield.
-            ensure_copy: Whether batches are always copied from the underlying base
-                blocks (not zero-copy views).
-        """
+    def __init__(self, batch_size: Optional[int]):
         self._batch_size = batch_size
         self._buffer = []
         self._buffer_size = 0
         self._done_adding = False
-        self._ensure_copy = ensure_copy
 
     def add(self, block: Block):
         """Add a block to the block buffer.
@@ -103,10 +94,6 @@ class Batcher(BatcherInterface):
         if self._batch_size is None:
             assert len(self._buffer) == 1
             block = self._buffer[0]
-            if self._ensure_copy:
-                # Copy block if needing to ensure fresh batch copy.
-                block = BlockAccessor.for_block(block)
-                block = block.slice(0, block.num_rows(), copy=True)
             self._buffer = []
             self._buffer_size = 0
             return block
@@ -123,28 +110,20 @@ class Batcher(BatcherInterface):
                 # We need this entire block to fill out a batch.
                 # We need to call `accessor.slice()` to ensure
                 # the subsequent block's type are the same.
-                output.add_block(accessor.slice(0, accessor.num_rows(), copy=False))
+                output.add_block(accessor.slice(0, accessor.num_rows()))
                 needed -= accessor.num_rows()
             else:
                 # We only need part of the block to fill out a batch.
-                output.add_block(accessor.slice(0, needed, copy=False))
+                output.add_block(accessor.slice(0, needed))
                 # Add the rest of the block to the leftovers.
-                leftover.append(accessor.slice(needed, accessor.num_rows(), copy=False))
+                leftover.append(accessor.slice(needed, accessor.num_rows()))
                 needed = 0
 
         # Move the leftovers into the block buffer so they're the first
         # blocks consumed on the next batch extraction.
         self._buffer = leftover
         self._buffer_size -= self._batch_size
-        batch = output.build()
-        if self._ensure_copy:
-            # Need to ensure that the batch is a fresh copy.
-            batch = BlockAccessor.for_block(batch)
-            # TOOD(Clark): This copy will often be unnecessary, e.g. for pandas
-            # DataFrame batches that have required concatenation to construct, which
-            # always requires a copy. We should elide this copy in those cases.
-            batch = batch.slice(0, batch.num_rows(), copy=True)
-        return batch
+        return output.build()
 
 
 class ShufflingBatcher(BatcherInterface):

--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -110,13 +110,13 @@ class Batcher(BatcherInterface):
                 # We need this entire block to fill out a batch.
                 # We need to call `accessor.slice()` to ensure
                 # the subsequent block's type are the same.
-                output.add_block(accessor.slice(0, accessor.num_rows()))
+                output.add_block(accessor.slice(0, accessor.num_rows(), copy=False))
                 needed -= accessor.num_rows()
             else:
                 # We only need part of the block to fill out a batch.
-                output.add_block(accessor.slice(0, needed))
+                output.add_block(accessor.slice(0, needed, copy=False))
                 # Add the rest of the block to the leftovers.
-                leftover.append(accessor.slice(needed, accessor.num_rows()))
+                leftover.append(accessor.slice(needed, accessor.num_rows(), copy=False))
                 needed = 0
 
         # Move the leftovers into the block buffer so they're the first

--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -1,6 +1,5 @@
 import collections
 import logging
-import math
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
 
 import ray
@@ -19,7 +18,6 @@ from ray.data.block import (
     RowUDF,
 )
 from ray.data.context import DEFAULT_SCHEDULING_STRATEGY, DatasetContext
-from ray.types import ObjectRef
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
 logger = logging.getLogger(__name__)
@@ -33,8 +31,8 @@ BlockTransform = Union[
     # transform type.
     # Callable[[Block, ...], Iterable[Block]]
     # Callable[[Block, BatchUDF, ...], Iterable[Block]],
-    Callable[[Iterable[Block]], Iterable[Block]],
-    Callable[[Iterable[Block], Union[BatchUDF, RowUDF]], Iterable[Block]],
+    Callable[[Block], Iterable[Block]],
+    Callable[[Block, Union[BatchUDF, RowUDF]], Iterable[Block]],
     Callable[..., Iterable[Block]],
 ]
 
@@ -63,7 +61,6 @@ class TaskPoolStrategy(ComputeStrategy):
         block_list: BlockList,
         clear_input_blocks: bool,
         name: Optional[str] = None,
-        target_block_size: Optional[int] = None,
         fn: Optional[UDF] = None,
         fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
@@ -82,55 +79,35 @@ class TaskPoolStrategy(ComputeStrategy):
         if block_list.initial_num_blocks() == 0:
             return block_list
 
+        blocks = block_list.get_blocks_with_metadata()
         if name is None:
             name = "map"
-        blocks = block_list.get_blocks_with_metadata()
-        # Bin blocks by target block size.
-        if target_block_size is not None:
-            _check_batch_size(blocks, target_block_size, name)
-            block_bundles = _bundle_blocks_up_to_size(blocks, target_block_size, name)
-        else:
-            block_bundles = [((b,), (m,)) for b, m in blocks]
-        del blocks
         name = name.title()
-        map_bar = ProgressBar(name, total=len(block_bundles))
+        map_bar = ProgressBar(name, total=len(blocks))
 
         if context.block_splitting_enabled:
             map_block = cached_remote_fn(_map_block_split).options(
                 num_returns="dynamic", **remote_args
             )
             refs = [
-                map_block.remote(
-                    block_fn,
-                    [f for m in ms for f in m.input_files],
-                    fn,
-                    len(bs),
-                    *(bs + fn_args),
-                    **fn_kwargs,
-                )
-                for bs, ms in block_bundles
+                map_block.remote(b, block_fn, m.input_files, fn, *fn_args, **fn_kwargs)
+                for b, m in blocks
             ]
         else:
             map_block = cached_remote_fn(_map_block_nosplit).options(
                 **dict(remote_args, num_returns=2)
             )
             all_refs = [
-                map_block.remote(
-                    block_fn,
-                    [f for m in ms for f in m.input_files],
-                    fn,
-                    len(bs),
-                    *(bs + fn_args),
-                    **fn_kwargs,
-                )
-                for bs, ms in block_bundles
+                map_block.remote(b, block_fn, m.input_files, fn, *fn_args, **fn_kwargs)
+                for b, m in blocks
             ]
-            data_refs, refs = map(list, zip(*all_refs))
+            data_refs = [r[0] for r in all_refs]
+            refs = [r[1] for r in all_refs]
 
         in_block_owned_by_consumer = block_list._owned_by_consumer
         # Release input block references.
         if clear_input_blocks:
-            del block_bundles
+            del blocks
             block_list.clear()
 
         # Common wait for non-data refs.
@@ -226,7 +203,6 @@ class ActorPoolStrategy(ComputeStrategy):
         block_list: BlockList,
         clear_input_blocks: bool,
         name: Optional[str] = None,
-        target_block_size: Optional[int] = None,
         fn: Optional[UDF] = None,
         fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
@@ -243,26 +219,17 @@ class ActorPoolStrategy(ComputeStrategy):
         if fn_constructor_kwargs is None:
             fn_constructor_kwargs = {}
 
-        if name is None:
-            name = "map"
         blocks_in = block_list.get_blocks_with_metadata()
-        # Bin blocks by target block size.
-        if target_block_size is not None:
-            _check_batch_size(blocks_in, target_block_size, name)
-            block_bundles = _bundle_blocks_up_to_size(
-                blocks_in, target_block_size, name
-            )
-        else:
-            block_bundles = [((b,), (m,)) for b, m in blocks_in]
-        del blocks_in
         owned_by_consumer = block_list._owned_by_consumer
 
         # Early release block references.
         if clear_input_blocks:
             block_list.clear()
 
-        orig_num_blocks = len(block_bundles)
+        orig_num_blocks = len(blocks_in)
         results = []
+        if name is None:
+            name = "map"
         name = name.title()
         map_bar = ProgressBar(name, total=orig_num_blocks)
 
@@ -287,35 +254,25 @@ class ActorPoolStrategy(ComputeStrategy):
 
             def map_block_split(
                 self,
+                block: Block,
                 input_files: List[str],
-                num_blocks: int,
-                *blocks_and_fn_args,
+                *fn_args,
                 **fn_kwargs,
             ) -> BlockPartition:
                 return _map_block_split(
-                    block_fn,
-                    input_files,
-                    self.fn,
-                    num_blocks,
-                    *blocks_and_fn_args,
-                    **fn_kwargs,
+                    block, block_fn, input_files, self.fn, *fn_args, **fn_kwargs
                 )
 
             @ray.method(num_returns=2)
             def map_block_nosplit(
                 self,
+                block: Block,
                 input_files: List[str],
-                num_blocks: int,
-                *blocks_and_fn_args,
+                *fn_args,
                 **fn_kwargs,
             ) -> Tuple[Block, BlockMetadata]:
                 return _map_block_nosplit(
-                    block_fn,
-                    input_files,
-                    self.fn,
-                    num_blocks,
-                    *blocks_and_fn_args,
-                    **fn_kwargs,
+                    block, block_fn, input_files, self.fn, *fn_args, **fn_kwargs
                 )
 
         if "num_cpus" not in remote_args:
@@ -381,20 +338,20 @@ class ActorPoolStrategy(ComputeStrategy):
 
                 # Schedule a new task.
                 while (
-                    block_bundles
+                    blocks_in
                     and tasks_in_flight[worker] < self.max_tasks_in_flight_per_actor
                 ):
-                    blocks, metas = block_bundles.pop()
+                    block, meta = blocks_in.pop()
                     # TODO(swang): Support block splitting for compute="actors".
                     ref, meta_ref = worker.map_block_nosplit.remote(
-                        [f for meta in metas for f in meta.input_files],
-                        len(blocks),
-                        *(blocks + fn_args),
+                        block,
+                        meta.input_files,
+                        *fn_args,
                         **fn_kwargs,
                     )
                     metadata_mapping[ref] = meta_ref
                     tasks[ref] = worker
-                    block_indices[ref] = len(block_bundles)
+                    block_indices[ref] = len(blocks_in)
                     tasks_in_flight[worker] += 1
 
             map_bar.close()
@@ -441,19 +398,18 @@ def is_task_compute(compute_spec: Union[str, ComputeStrategy]) -> bool:
 
 
 def _map_block_split(
+    block: Block,
     block_fn: BlockTransform,
     input_files: List[str],
     fn: Optional[UDF],
-    num_blocks: int,
-    *blocks_and_fn_args: Union[Block, Any],
+    *fn_args,
     **fn_kwargs,
 ) -> BlockPartition:
     stats = BlockExecStats.builder()
-    blocks, fn_args = blocks_and_fn_args[:num_blocks], blocks_and_fn_args[num_blocks:]
     if fn is not None:
         fn_args = (fn,) + fn_args
     new_metas = []
-    for new_block in block_fn(blocks, *fn_args, **fn_kwargs):
+    for new_block in block_fn(block, *fn_args, **fn_kwargs):
         accessor = BlockAccessor.for_block(new_block)
         new_meta = BlockMetadata(
             num_rows=accessor.num_rows(),
@@ -469,86 +425,21 @@ def _map_block_split(
 
 
 def _map_block_nosplit(
+    block: Block,
     block_fn: BlockTransform,
     input_files: List[str],
     fn: Optional[UDF],
-    num_blocks: int,
-    *blocks_and_fn_args: Union[Block, Any],
+    *fn_args,
     **fn_kwargs,
 ) -> Tuple[Block, BlockMetadata]:
     stats = BlockExecStats.builder()
     builder = DelegatingBlockBuilder()
-    blocks, fn_args = blocks_and_fn_args[:num_blocks], blocks_and_fn_args[num_blocks:]
     if fn is not None:
         fn_args = (fn,) + fn_args
-    for new_block in block_fn(blocks, *fn_args, **fn_kwargs):
+    for new_block in block_fn(block, *fn_args, **fn_kwargs):
         builder.add_block(new_block)
     new_block = builder.build()
     accessor = BlockAccessor.for_block(new_block)
     return new_block, accessor.get_metadata(
         input_files=input_files, exec_stats=stats.build()
     )
-
-
-def _bundle_blocks_up_to_size(
-    blocks: List[Tuple[ObjectRef[Block], BlockMetadata]],
-    target_size: int,
-    name: str,
-) -> List[Tuple[List[ObjectRef[Block]], List[BlockMetadata]]]:
-    """Group blocks into bundles that are up to (but not exceeding) the provided target
-    size.
-    """
-    block_bundles = []
-    curr_bundle = []
-    curr_bundle_size = 0
-    for b, m in blocks:
-        num_rows = m.num_rows
-        if num_rows is None:
-            num_rows = float("inf")
-        if curr_bundle_size > 0 and curr_bundle_size + num_rows > target_size:
-            block_bundles.append(curr_bundle)
-            curr_bundle = []
-            curr_bundle_size = 0
-        curr_bundle.append((b, m))
-        curr_bundle_size += num_rows
-    if curr_bundle:
-        block_bundles.append(curr_bundle)
-    if len(blocks) / len(block_bundles) >= 10:
-        logger.warning(
-            f"Having to send 10 or more blocks to a single {name} task to create a "
-            f"batch of size {target_size}, which may result in less transformation "
-            "parallelism than expected. This may indicate that your blocks are too "
-            "small and/or your batch size is too large, and you may want to decrease "
-            "your read parallelism and/or decrease your batch size."
-        )
-    return [tuple(zip(*block_bundle)) for block_bundle in block_bundles]
-
-
-def _check_batch_size(
-    blocks_and_meta: List[Tuple[ObjectRef[Block], BlockMetadata]],
-    batch_size: int,
-    name: str,
-):
-    """Log a warning if the provided batch size exceeds the configured target max block
-    size.
-    """
-    batch_size_bytes = None
-    for _, meta in blocks_and_meta:
-        if meta.num_rows and meta.size_bytes:
-            batch_size_bytes = math.ceil(batch_size * (meta.size_bytes / meta.num_rows))
-            break
-    context = DatasetContext.get_current()
-    if (
-        batch_size_bytes is not None
-        and batch_size_bytes > context.target_max_block_size
-    ):
-        logger.warning(
-            f"Requested batch size {batch_size} results in batches of "
-            f"{batch_size_bytes} bytes for {name} tasks, which is larger than the "
-            f"configured target max block size {context.target_max_block_size}. This "
-            "may result in out-of-memory errors for certain workloads, and you may "
-            "want to decrease your batch size or increase the configured target max "
-            "block size, e.g.: "
-            "from ray.data.context import DatasetContext; "
-            "DatasetContext.get_current().target_max_block_size = 4_000_000_000"
-        )

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -1,5 +1,4 @@
 import copy
-import functools
 import itertools
 import uuid
 from typing import (
@@ -534,7 +533,6 @@ class OneToOneStage(Stage):
         block_fn: BlockTransform,
         compute: Union[str, ComputeStrategy],
         ray_remote_args: dict,
-        target_block_size: Optional[int] = None,
         fn: Optional[UDF] = None,
         fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
@@ -545,7 +543,6 @@ class OneToOneStage(Stage):
         self.block_fn = block_fn
         self.compute = compute or "tasks"
         self.ray_remote_args = ray_remote_args or {}
-        self.target_block_size = target_block_size
         self.fn = fn
         self.fn_args = fn_args
         self.fn_kwargs = fn_kwargs
@@ -613,15 +610,9 @@ class OneToOneStage(Stage):
 
         block_fn1 = prev.block_fn
         block_fn2 = self.block_fn
-        if prev.target_block_size is not None and self.target_block_size is not None:
-            target_block_size = max(prev.target_block_size, self.target_block_size)
-        elif prev.target_block_size is not None:
-            target_block_size = prev.target_block_size
-        else:
-            target_block_size = self.target_block_size
 
         def block_fn(
-            blocks: Iterable[Block],
+            block: Block,
             fn: UDF,
             *fn_args,
             **fn_kwargs,
@@ -639,15 +630,15 @@ class OneToOneStage(Stage):
             prev_fn_args = (
                 prev_fn_args if prev_fn_ is None else (prev_fn_,) + prev_fn_args
             )
-            blocks = block_fn1(blocks, *prev_fn_args, **prev_fn_kwargs)
-            return block_fn2(blocks, *self_fn_args, **self_fn_kwargs)
+            for tmp1 in block_fn1(block, *prev_fn_args, **prev_fn_kwargs):
+                for tmp2 in block_fn2(tmp1, *self_fn_args, **self_fn_kwargs):
+                    yield tmp2
 
         return OneToOneStage(
             name,
             block_fn,
             self.compute,
             prev.ray_remote_args,
-            target_block_size=target_block_size,
             fn=self.fn,
             fn_args=fn_args,
             fn_kwargs={},
@@ -674,7 +665,6 @@ class OneToOneStage(Stage):
             blocks,
             clear_input_blocks,
             name=self.name,
-            target_block_size=self.target_block_size,
             fn=self.fn,
             fn_args=self.fn_args,
             fn_kwargs=self.fn_kwargs,
@@ -733,19 +723,20 @@ class AllToAllStage(Stage):
         prev_block_fn = prev.block_fn
         if self.block_udf is None:
 
-            def block_udf(blocks: Iterable[Block]) -> Iterable[Block]:
-                yield from prev_block_fn(blocks, *prev_fn_args, **prev_fn_kwargs)
+            def block_udf(block: Block) -> Iterable[Block]:
+                yield from prev_block_fn(block, *prev_fn_args, **prev_fn_kwargs)
 
         else:
             self_block_udf = self.block_udf
 
-            def block_udf(blocks: Iterable[Block]) -> Iterable[Block]:
-                blocks = prev_block_fn(
-                    blocks,
+            def block_udf(block: Block) -> Iterable[Block]:
+                for tmp1 in prev_block_fn(
+                    block,
                     *prev_fn_args,
                     **prev_fn_kwargs,
-                )
-                yield from self_block_udf(blocks)
+                ):
+                    for tmp2 in self_block_udf(tmp1):
+                        yield tmp2
 
         return AllToAllStage(
             name, self.num_blocks, self.fn, True, block_udf, prev.ray_remote_args
@@ -820,7 +811,6 @@ def _rewrite_read_stage(
         blocks, metadata, owned_by_consumer=in_blocks._owned_by_consumer
     )
 
-    @_adapt_for_multiple_blocks
     def block_fn(read_fn: Callable[[], Iterator[Block]]) -> Iterator[Block]:
         for block in read_fn():
             yield block
@@ -934,14 +924,3 @@ def _canonicalize(remote_args: dict) -> dict:
 def _is_lazy(blocks: BlockList) -> bool:
     """Whether the provided block list is lazy."""
     return isinstance(blocks, LazyBlockList)
-
-
-def _adapt_for_multiple_blocks(
-    fn: Callable[..., Iterable[Block]],
-) -> Callable[..., Iterable[Block]]:
-    @functools.wraps(fn)
-    def wrapper(blocks: Iterable[Block], *args, **kwargs):
-        for block in blocks:
-            yield from fn(block, *args, **kwargs)
-
-    return wrapper

--- a/python/ray/data/_internal/shuffle_and_partition.py
+++ b/python/ray/data/_internal/shuffle_and_partition.py
@@ -37,7 +37,7 @@ class _ShufflePartitionOp(ShuffleOp):
         stats = BlockExecStats.builder()
         if block_udf:
             # TODO(ekl) note that this effectively disables block splitting.
-            blocks = list(block_udf([block]))
+            blocks = list(block_udf(block))
             if len(blocks) > 1:
                 builder = BlockAccessor.for_block(blocks[0]).builder()
                 for b in blocks:

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -4,8 +4,6 @@ from typing import Union, Optional, TYPE_CHECKING
 from types import ModuleType
 import sys
 
-import numpy as np
-
 import ray
 from ray.data.context import DatasetContext
 
@@ -98,7 +96,7 @@ def _autodetect_parallelism(
     max_reasonable_parallelism = sys.maxsize
     if reader:
         mem_size = reader.estimate_inmemory_data_size()
-        if mem_size is not None and not np.isnan(mem_size):
+        if mem_size is not None:
             min_safe_parallelism = max(1, int(mem_size / ctx.target_max_block_size))
             max_reasonable_parallelism = max(
                 1, int(mem_size / ctx.target_min_block_size)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -27,7 +27,6 @@ import numpy as np
 import ray
 import ray.cloudpickle as pickle
 from ray._private.usage import usage_lib
-from ray.data._internal.batcher import Batcher
 from ray.data._internal.block_batching import BatchType, batch_blocks
 from ray.data._internal.block_list import BlockList
 from ray.data._internal.compute import (
@@ -45,7 +44,6 @@ from ray.data._internal.pandas_block import PandasBlockSchema
 from ray.data._internal.plan import (
     ExecutionPlan,
     OneToOneStage,
-    _adapt_for_multiple_blocks,
 )
 from ray.data._internal.stage_impl import (
     RandomizeBlocksStage,
@@ -292,7 +290,6 @@ class Dataset(Generic[T]):
         self._warn_slow()
         context = DatasetContext.get_current()
 
-        @_adapt_for_multiple_blocks
         def transform(block: Block, fn: RowUDF[T, U]) -> Iterable[Block]:
             DatasetContext._set_current(context)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
@@ -349,14 +346,6 @@ class Dataset(Generic[T]):
             For some standard operations like imputing, encoding or normalization,
             one may find directly using :py:class:`~ray.data.preprocessors.Preprocessor` to be
             more convenient.
-
-        .. note::
-            The size of the batches provided to ``fn`` may be smaller than the provided
-            ``batch_size`` if ``batch_size`` doesn't evenly divide the block(s) sent to
-            a given map task. Each map task will be sent a single block if the block is
-            equal to or larger than ``batch_size``, and will be sent a bundle of blocks
-            up to (but not exceeding) ``batch_size`` if blocks are smaller than
-            ``batch_size``.
 
         Examples:
 
@@ -430,17 +419,16 @@ class Dataset(Generic[T]):
             fn: The function to apply to each record batch, or a class type
                 that can be instantiated to create such a callable. Callable classes are
                 only supported for the actor compute strategy.
-            batch_size: The desired number of rows in each batch, or None to use entire
-                blocks as batches (blocks may contain different number of rows).
-                The actual size of the batch provided to ``fn`` may be smaller than
-                ``batch_size`` if ``batch_size`` doesn't evenly divide the block(s) sent
-                to a given map task. Defaults to 4096.
+            batch_size: The number of rows in each batch, or ``None`` to use entire
+                blocks as batches. Blocks can contain different number of rows, and
+                the last batch can include fewer than ``batch_size`` rows. Defaults to
+                ``4096``.
             compute: The compute strategy, either ``"tasks"`` (default) to use Ray
                 tasks, or ``"actors"`` to use an autoscaling actor pool. If you want to
                 configure the size of the autoscaling actor pool, provide an
                 :class:`ActorPoolStrategy <ray.data.ActorPoolStrategy>` instance.
                 If you're passing callable type to ``fn``, you must pass an
-                :class:`ActorPoolStrategy <ray.data.ActorPoolStrategy>` or ``"actors"``.
+                :class:`ActorPoolStrategy <ray.data.ActorPoolStrategy>`.
             batch_format: Specify ``"default"`` to use the default block format
                 (promotes tables to Pandas and tensors to NumPy), ``"pandas"`` to select
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
@@ -516,42 +504,46 @@ class Dataset(Generic[T]):
         context = DatasetContext.get_current()
 
         def transform(
-            blocks: Iterable[Block],
+            block: Block,
             batch_fn: BatchUDF,
             *fn_args,
             **fn_kwargs,
         ) -> Iterable[Block]:
             DatasetContext._set_current(context)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
-            # Ensure that zero-copy batch views are copied so mutating UDFs don't error.
-            batcher = Batcher(batch_size, ensure_copy=batch_size is not None)
-            for block in blocks:
-                batcher.add(block)
-            batcher.done_adding()
-            while batcher.has_any():
-                batch = batcher.next_batch()
+            block = BlockAccessor.for_block(block)
+            total_rows = block.num_rows()
+            max_batch_size = batch_size
+            if max_batch_size is None:
+                max_batch_size = max(total_rows, 1)
+
+            for start in range(0, total_rows, max_batch_size):
+                # Build a block for each batch.
+                end = min(total_rows, start + max_batch_size)
+                # Make sure to copy if slicing to avoid the Arrow serialization
+                # bug where we include the entire base view on serialization.
+                view = block.slice(start, end, copy=batch_size is not None)
                 # Convert to batch format.
-                batch = BlockAccessor.for_block(batch).to_batch_format(batch_format)
-                # Apply UDF.
-                batch = batch_fn(batch, *fn_args, **fn_kwargs)
+                view = BlockAccessor.for_block(view).to_batch_format(batch_format)
+
+                applied = batch_fn(view, *fn_args, **fn_kwargs)
                 if not (
-                    isinstance(batch, list)
-                    or isinstance(batch, pa.Table)
-                    or isinstance(batch, np.ndarray)
+                    isinstance(applied, list)
+                    or isinstance(applied, pa.Table)
+                    or isinstance(applied, np.ndarray)
                     or (
-                        isinstance(batch, dict)
-                        and all(isinstance(col, np.ndarray) for col in batch.values())
+                        isinstance(applied, dict)
+                        and all(isinstance(col, np.ndarray) for col in applied.values())
                     )
-                    or isinstance(batch, pd.core.frame.DataFrame)
+                    or isinstance(applied, pd.core.frame.DataFrame)
                 ):
                     raise ValueError(
                         "The map batches UDF returned the value "
-                        f"{batch} of type {type(batch)}, "
+                        f"{applied} of type {type(applied)}, "
                         "which is not allowed. "
                         f"The return type must be one of: {BatchType}"
                     )
-                # Add output batch to output buffer.
-                output_buffer.add_batch(batch)
+                output_buffer.add_batch(applied)
                 if output_buffer.has_next():
                     yield output_buffer.next()
 
@@ -565,8 +557,6 @@ class Dataset(Generic[T]):
                 transform,
                 compute,
                 ray_remote_args,
-                # TODO(Clark): Add a strict cap here.
-                target_block_size=batch_size,
                 fn=fn,
                 fn_args=fn_args,
                 fn_kwargs=fn_kwargs,
@@ -708,7 +698,6 @@ class Dataset(Generic[T]):
         self._warn_slow()
         context = DatasetContext.get_current()
 
-        @_adapt_for_multiple_blocks
         def transform(block: Block, fn: RowUDF[T, U]) -> Iterable[Block]:
             DatasetContext._set_current(context)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
@@ -776,7 +765,6 @@ class Dataset(Generic[T]):
         self._warn_slow()
         context = DatasetContext.get_current()
 
-        @_adapt_for_multiple_blocks
         def transform(block: Block, fn: RowUDF[T, U]) -> Iterable[Block]:
             DatasetContext._set_current(context)
             block = BlockAccessor.for_block(block)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1,4 +1,3 @@
-import itertools
 import math
 import os
 import random
@@ -206,7 +205,7 @@ def test_callable_classes(shutdown_only):
     assert sorted(actor_reuse) == list(range(10)), actor_reuse
 
     # map batches
-    actor_reuse = ds.map_batches(StatefulFn, batch_size=1, compute="actors").take()
+    actor_reuse = ds.map_batches(StatefulFn, compute="actors").take()
     assert sorted(actor_reuse) == list(range(10)), actor_reuse
 
     class StatefulFn:
@@ -2253,7 +2252,7 @@ def test_map_batches_basic(ray_start_regular_shared, tmp_path):
     ds = ray.data.range(size)
     ds2 = ds.map_batches(lambda df: df + 1, batch_size=17, batch_format="pandas")
     assert ds2._dataset_format() == "pandas"
-    ds_list = ds2.take_all()
+    ds_list = ds2.take(limit=size)
     for i in range(size):
         # The pandas column is "value", and it originally has rows from 0~299.
         # After the map batch, it should have 1~300.
@@ -2303,8 +2302,8 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
         ds.map_batches(Foo, compute="tasks")
 
     with pytest.raises(ValueError):
-        # fn_constructor_args and fn_constructor_kwargs only supported for actor
-        # compute strategy.
+        # fn_constructor_args and fn_constructor_kwargs only supported for actor compute
+        # strategy.
         ds.map_batches(
             lambda x: x,
             compute="tasks",
@@ -2528,138 +2527,6 @@ def test_map_batches_actors_preserves_order(ray_start_regular_shared):
     # Test that actor compute model preserves block order.
     ds = ray.data.range(10, parallelism=5)
     assert ds.map_batches(lambda x: x, compute="actors").take() == list(range(10))
-
-
-@pytest.mark.parametrize(
-    "num_rows,num_blocks,batch_size",
-    [
-        (10, 5, 2),
-        (10, 1, 10),
-        (12, 3, 2),
-    ],
-)
-def test_map_batches_batch_mutation(
-    ray_start_regular_shared, num_rows, num_blocks, batch_size
-):
-    # Test that batch mutation works without encountering a read-only error (e.g. if the
-    # batch is a zero-copy view on data in the object store).
-    def mutate(df):
-        df["value"] += 1
-        return df
-
-    ds = ray.data.range_table(num_rows, parallelism=num_blocks).repartition(num_blocks)
-    # Convert to Pandas blocks.
-    ds = ds.map_batches(lambda df: df, batch_format="pandas", batch_size=None)
-
-    # Apply UDF that mutates the batches.
-    ds = ds.map_batches(mutate, batch_size=batch_size)
-    assert [row["value"] for row in ds.iter_rows()] == list(range(1, num_rows + 1))
-
-
-BLOCK_BUNDLING_TEST_CASES = [
-    (block_size, batch_size)
-    for batch_size in range(1, 8)
-    for block_size in range(1, 2 * batch_size + 1)
-]
-
-
-@pytest.mark.parametrize("block_size,batch_size", BLOCK_BUNDLING_TEST_CASES)
-def test_map_batches_block_bundling_auto(
-    ray_start_regular_shared, block_size, batch_size
-):
-    # Ensure that we test at least 2 batches worth of blocks.
-    num_blocks = max(10, 2 * batch_size // block_size)
-    ds = ray.data.range(num_blocks * block_size, parallelism=num_blocks)
-    # Confirm that we have the expected number of initial blocks.
-    assert ds.num_blocks() == num_blocks
-    ds = ds.map_batches(lambda x: x, batch_size=batch_size)
-    # Blocks should be bundled up to the batch size.
-    assert ds.num_blocks() == math.ceil(num_blocks / max(batch_size // block_size, 1))
-
-
-@pytest.mark.parametrize(
-    "block_sizes,batch_size,expected_num_blocks",
-    [
-        ([1, 2], 3, 1),
-        ([2, 2, 1], 3, 2),
-        ([1, 2, 3, 4], 4, 3),
-        ([3, 1, 1, 3], 4, 2),
-        ([2, 4, 1, 8], 4, 4),
-        ([1, 1, 1, 1], 4, 1),
-        ([1, 0, 3, 2], 4, 2),
-        ([4, 4, 4, 4], 4, 4),
-    ],
-)
-def test_map_batches_block_bundling_skewed_manual(
-    ray_start_regular_shared, block_sizes, batch_size, expected_num_blocks
-):
-    num_blocks = len(block_sizes)
-    ds = ray.data.from_pandas(
-        [pd.DataFrame({"a": [1] * block_size}) for block_size in block_sizes]
-    )
-    # Confirm that we have the expected number of initial blocks.
-    assert ds.num_blocks() == num_blocks
-    ds = ds.map_batches(lambda x: x, batch_size=batch_size)
-
-    # Blocks should be bundled up to the batch size.
-    assert ds.num_blocks() == expected_num_blocks
-
-
-BLOCK_BUNDLING_SKEWED_TEST_CASES = [
-    (block_sizes, batch_size)
-    for batch_size in range(1, 4)
-    for num_blocks in range(1, batch_size + 1)
-    for block_sizes in itertools.product(
-        range(1, 2 * batch_size + 1), repeat=num_blocks
-    )
-]
-
-
-@pytest.mark.parametrize("block_sizes,batch_size", BLOCK_BUNDLING_SKEWED_TEST_CASES)
-def test_map_batches_block_bundling_skewed_auto(
-    ray_start_regular_shared, block_sizes, batch_size
-):
-    num_blocks = len(block_sizes)
-    ds = ray.data.from_pandas(
-        [pd.DataFrame({"a": [1] * block_size}) for block_size in block_sizes]
-    )
-    # Confirm that we have the expected number of initial blocks.
-    assert ds.num_blocks() == num_blocks
-    ds = ds.map_batches(lambda x: x, batch_size=batch_size)
-    curr = 0
-    num_out_blocks = 0
-    for block_size in block_sizes:
-        if curr > 0 and curr + block_size > batch_size:
-            num_out_blocks += 1
-            curr = 0
-        curr += block_size
-    if curr > 0:
-        num_out_blocks += 1
-
-    # Blocks should be bundled up to the batch size.
-    assert ds.num_blocks() == num_out_blocks
-
-
-def test_map_with_mismatched_columns(ray_start_regular_shared):
-    def bad_fn(row):
-        if row > 5:
-            return {"a": "hello1"}
-        else:
-            return {"b": "hello1"}
-
-    def good_fn(row):
-        if row > 5:
-            return {"a": "hello1", "b": "hello2"}
-        else:
-            return {"b": "hello2", "a": "hello1"}
-
-    ds = ray.data.range(10, parallelism=1)
-    error_message = "Current row has different columns compared to previous rows."
-    with pytest.raises(ValueError) as e:
-        ds.map(bad_fn)
-    assert error_message in str(e.value)
-    ds_map = ds.map(good_fn)
-    assert ds_map.take() == [{"a": "hello1", "b": "hello2"} for _ in range(10)]
 
 
 def test_union(ray_start_regular_shared):
@@ -3973,13 +3840,8 @@ def test_map_batches_combine_empty_blocks(ray_start_regular_shared):
     assert ds1._block_num_rows() == [100]
 
     # ds2 has 30 blocks, but only 3 of them are non-empty
-    ds2 = (
-        ray.data.from_items(xs)
-        .repartition(30)
-        .sort()
-        .map_batches(lambda x: x, batch_size=1)
-    )
-    assert len(ds2._block_num_rows()) == 3
+    ds2 = ray.data.from_items(xs).repartition(30).sort().map_batches(lambda x: x)
+    assert len(ds2._block_num_rows()) == 30
     count = sum(1 for x in ds2._block_num_rows() if x > 0)
     assert count == 3
 
@@ -4958,9 +4820,7 @@ def test_actor_pool_strategy_default_num_actors(shutdown_only):
     num_cpus = 5
     ray.init(num_cpus=num_cpus)
     compute_strategy = ray.data.ActorPoolStrategy()
-    ray.data.range(10, parallelism=10).map_batches(
-        f, batch_size=1, compute=compute_strategy
-    )
+    ray.data.range(10, parallelism=10).map_batches(f, compute=compute_strategy)
     expected_max_num_workers = math.ceil(
         num_cpus * (1 / compute_strategy.ready_to_total_workers_ratio)
     )

--- a/python/ray/data/tests/test_object_gc.py
+++ b/python/ray/data/tests/test_object_gc.py
@@ -66,8 +66,8 @@ def test_iter_batches_no_spilling_upon_post_transformation(shutdown_only):
     ds = ray.data.range_tensor(500, shape=(80, 80, 4), parallelism=100)
 
     # Repeat, with transformation post the pipeline creation.
-    check_no_spill(ctx, ds.repeat().map_batches(lambda x: x, batch_size=5))
-    check_no_spill(ctx, ds.repeat().map_batches(lambda x: x, batch_size=5), 5)
+    check_no_spill(ctx, ds.repeat().map_batches(lambda x: x))
+    check_no_spill(ctx, ds.repeat().map_batches(lambda x: x), 5)
 
     # Window, with transformation post the pipeline creation.
     check_no_spill(ctx, ds.window(blocks_per_window=20).map_batches(lambda x: x))
@@ -81,18 +81,9 @@ def test_iter_batches_no_spilling_upon_transformations(shutdown_only):
     ds = ray.data.range_tensor(500, shape=(80, 80, 4), parallelism=100)
 
     # Repeat, with transformation before and post the pipeline.
+    check_no_spill(ctx, ds.map_batches(lambda x: x).repeat().map_batches(lambda x: x))
     check_no_spill(
-        ctx,
-        ds.map_batches(lambda x: x, batch_size=5)
-        .repeat()
-        .map_batches(lambda x: x, batch_size=5),
-    )
-    check_no_spill(
-        ctx,
-        ds.map_batches(lambda x: x, batch_size=5)
-        .repeat()
-        .map_batches(lambda x: x, batch_size=5),
-        5,
+        ctx, ds.map_batches(lambda x: x).repeat().map_batches(lambda x: x), 5
     )
 
     # Window, with transformation before and post the pipeline.

--- a/python/ray/train/tests/test_torch_trainer.py
+++ b/python/ray/train/tests/test_torch_trainer.py
@@ -61,7 +61,7 @@ def test_torch_linear(ray_start_4_cpus, num_workers):
 
 def test_torch_e2e(ray_start_4_cpus):
     def train_func():
-        model = torch.nn.Linear(3, 1)
+        model = torch.nn.Linear(1, 1)
         session.report({}, checkpoint=Checkpoint.from_dict(dict(model=model)))
 
     scaling_config = ScalingConfig(num_workers=2)
@@ -70,7 +70,7 @@ def test_torch_e2e(ray_start_4_cpus):
     )
     result = trainer.fit()
 
-    predict_dataset = ray.data.range(9)
+    predict_dataset = ray.data.range(3)
 
     class TorchScorer:
         def __init__(self):
@@ -80,14 +80,14 @@ def test_torch_e2e(ray_start_4_cpus):
             return self.pred.predict(x, dtype=torch.float)
 
     predictions = predict_dataset.map_batches(
-        TorchScorer, batch_size=3, batch_format="pandas", compute="actors"
+        TorchScorer, batch_format="pandas", compute="actors"
     )
     assert predictions.count() == 3
 
 
 def test_torch_e2e_state_dict(ray_start_4_cpus):
     def train_func():
-        model = torch.nn.Linear(3, 1).state_dict()
+        model = torch.nn.Linear(1, 1).state_dict()
         session.report({}, checkpoint=Checkpoint.from_dict(dict(model=model)))
 
     scaling_config = ScalingConfig(num_workers=2)
@@ -103,15 +103,15 @@ def test_torch_e2e_state_dict(ray_start_4_cpus):
     class TorchScorer:
         def __init__(self):
             self.pred = TorchPredictor.from_checkpoint(
-                result.checkpoint, model=torch.nn.Linear(3, 1)
+                result.checkpoint, model=torch.nn.Linear(1, 1)
             )
 
         def __call__(self, x):
             return self.pred.predict(x, dtype=torch.float)
 
-    predict_dataset = ray.data.range(9)
+    predict_dataset = ray.data.range(3)
     predictions = predict_dataset.map_batches(
-        TorchScorer, batch_size=3, batch_format="pandas", compute="actors"
+        TorchScorer, batch_format="pandas", compute="actors"
     )
     assert predictions.count() == 3
 


### PR DESCRIPTION


This reverts commit b5687a1aaa3dc72dfde9758e730607a4ab22afe4.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
To avoid benchmark regression in release 2.1.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
