### PR TITLE
[ci][dep] Pin gradio version <3.6 for release 2.1 

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -45,7 +45,7 @@ uvicorn
 dataclasses; python_version < '3.7'
 starlette==0.18.0
 aiorwlock
-gradio; platform_system != "Windows"
+gradio<3.6; platform_system != "Windows"
 
 ## Requirements for running tests
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Similar to 9575c173204c2855bdd1dafbb285a3fc03c5d14c, this pins the gradio version for non windows systems. 
It doesn't pin 3.5 for mac but allows lower version since 3.5 is not yet release in the CI (2.1.0) 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #29617 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
