### PR TITLE
[Datasets] Fix `iter_batches` to not return empty batch

### DIFF
--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -67,12 +67,15 @@ class Batcher(BatcherInterface):
     def add(self, block: Block):
         """Add a block to the block buffer.
 
+        Note empty block is not added to buffer.
+
         Args:
             block: Block to add to the block buffer.
         """
-        assert self.can_add(block)
-        self._buffer.append(block)
-        self._buffer_size += BlockAccessor.for_block(block).num_rows()
+        if BlockAccessor.for_block(block).num_rows() > 0:
+            assert self.can_add(block)
+            self._buffer.append(block)
+            self._buffer_size += BlockAccessor.for_block(block).num_rows()
 
     def can_add(self, block: Block) -> bool:
         """Whether the block can be added to the buffer."""
@@ -84,7 +87,7 @@ class Batcher(BatcherInterface):
 
     def has_batch(self) -> bool:
         """Whether this Batcher has any full batches."""
-        return self._buffer and (
+        return self.has_any() and (
             self._batch_size is None or self._buffer_size >= self._batch_size
         )
 
@@ -220,11 +223,14 @@ class ShufflingBatcher(BatcherInterface):
     def add(self, block: Block):
         """Add a block to the shuffle buffer.
 
+        Note empty block is not added to buffer.
+
         Args:
             block: Block to add to the shuffle buffer.
         """
-        assert self.can_add(block)
-        self._builder.add_block(block)
+        if BlockAccessor.for_block(block).num_rows() > 0:
+            assert self.can_add(block)
+            self._builder.add_block(block)
 
     def can_add(self, block: Block) -> bool:
         """Whether the block can be added to the shuffle buffer.

--- a/python/ray/data/_internal/block_batching.py
+++ b/python/ray/data/_internal/block_batching.py
@@ -88,8 +88,7 @@ def batch_blocks(
             # NOTE: Since we add one block at a time and then immediately consume
             # batches, we don't need to check batcher.can_add() before adding the block;
             # it will always be True, and batcher.add() will assert this internally.
-            if BlockAccessor.for_block(block).num_rows() > 0:
-                batcher.add(block)
+            batcher.add(block)
         else:
             batcher.done_adding()
         while batcher.has_batch():

--- a/python/ray/data/_internal/block_batching.py
+++ b/python/ray/data/_internal/block_batching.py
@@ -88,7 +88,8 @@ def batch_blocks(
             # NOTE: Since we add one block at a time and then immediately consume
             # batches, we don't need to check batcher.can_add() before adding the block;
             # it will always be True, and batcher.add() will assert this internally.
-            batcher.add(block)
+            if BlockAccessor.for_block(block).num_rows() > 0:
+                batcher.add(block)
         else:
             batcher.done_adding()
         while batcher.has_batch():

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1881,6 +1881,12 @@ def test_iter_batches_basic(ray_start_regular_shared):
         assert batch.equals(df)
 
 
+def test_iter_batches_empty_block(ray_start_regular_shared):
+    ds = ray.data.range(1).repartition(10)
+    assert list(ds.iter_batches(batch_size=None)) == [[0]]
+    assert list(ds.iter_batches(batch_size=1, local_shuffle_buffer_size=1)) == [[0]]
+
+
 @pytest.mark.parametrize("pipelined", [False, True])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas", "simple"])
 def test_iter_batches_local_shuffle(shutdown_only, pipelined, ds_format):


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to fix `iter_batches()`, where it can produce unnecessary empty batch when some of blocks are empty.

```py
ds = ray.data.range(1).repartition(10)
for b in ds.iter_batches(batch_size=None):
  print(f"batch: {b}")

... 
batch: [0]
batch: []
batch: []
batch: []
batch: []
```

We should not return unnecessary empty batches to users.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
