### PR TITLE
[air][no_ci] update tune_torch_benchmark to report results before assertion

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
@@ -174,13 +174,13 @@ def main(
     factor = 1.2
     threshold = mean_train_time * factor
 
-    assert (
-        mean_tune_time <= threshold
-    ), f"{mean_tune_time:.2f} > {threshold:.2f} = {factor:.1f} * {mean_train_time:.2f}"
-
     test_output_json = os.environ.get("TEST_OUTPUT_JSON", "/tmp/result.json")
     with open(test_output_json, "wt") as f:
         json.dump(full_results, f)
+
+    assert (
+        mean_tune_time <= threshold
+    ), f"{mean_tune_time:.2f} > {threshold:.2f} = {factor:.1f} * {mean_train_time:.2f}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Matthew Deng <matt@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Moves the logic to write `full_results` to disk _before_ calling `assert`.

Without this, a failing job would raise an `AssertionError` and results will not be visible after the job has ended.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
