### PR TITLE
[Metrics] Fix the default dashboard GPU utilization.

### DIFF
--- a/dashboard/modules/metrics/export/grafana/dashboards/default_grafana_dashboard.json
+++ b/dashboard/modules/metrics/export/grafana/dashboards/default_grafana_dashboard.json
@@ -697,7 +697,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "ray_node_gpus_utilization{instance=~\"$Instance\",cluster_id=\"$cluster_id\"} * ray_node_gpus_available{instance=~\"$Instance\",cluster_id=\"$cluster_id\"} / 100",
+          "expr": "ray_node_gpus_utilization{instance=~\"$Instance\",cluster_id=\"$cluster_id\"} / 100",
           "interval": "",
           "legendFormat": "GPU Usage: {{instance}}",
           "queryType": "randomWalk",


### PR DESCRIPTION
Signed-off-by: SangBin Cho <rkooo567@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

GPU utilization is already calculated based on all GPUs, so it is unnecessary to multiply num available GPUs. 

https://github.com/ray-project/ray/blob/398300252611547acc4d47b2f645e580e828965b/dashboard/modules/reporter/reporter_agent.py#L346

## Related issue number

Closes https://github.com/ray-project/ray/issues/29630

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
