### PR TITLE
[Test] Fix Pyopenssl dep issue

### DIFF
--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -317,7 +317,7 @@ install_pip_packages() {
     local status="0";
     local errmsg="";
     for _ in {1..3}; do
-      errmsg=$(CC=gcc pip install -c "${WORKSPACE_DIR}"/python/requirements.txt -r "${WORKSPACE_DIR}"/python/requirements_test.txt 2>&1) && break;
+      errmsg=$(CC=gcc pip install -c "${WORKSPACE_DIR}"/python/requirements.txt -U -r "${WORKSPACE_DIR}"/python/requirements_test.txt 2>&1) && break;
       status=$errmsg && echo "'pip install ...' failed, will retry after n seconds!" && sleep 30;
     done
     if [ "$status" != "0" ]; then

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2139,6 +2139,7 @@ def disconnect(exiting_interpreter=False):
         if hasattr(worker, "logger_thread"):
             worker.logger_thread.join()
         worker.threads_stopped.clear()
+
         worker._session_index += 1
 
         global_worker_stdstream_dispatcher.remove_handler("ray_print_logs")


### PR DESCRIPTION
Signed-off-by: SangBin Cho <rkooo567@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Looks like we are using PyOpenSSL < 22.0 which can cause issues with the newer version of cryptography module that causes `AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'` . Check https://github.com/boto/botocore/issues/2744
https://github.com/urllib3/urllib3/issues/2680
for more details. 

The problem was that when we call `install-dependencies`, it downloads `requirements.txt` and then `requirement_test.txt`. When we download `requirement_test.txt`, we don't have `-U` flag, and then this means some of dependencies are not upgraded as stated inside `requirement_test.txt`. I tried adding -U flag to the PR

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
