### PR TITLE
Revert "[Prototype] [Core] Make expensive subpackage imports dynamic. (#27658)"

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -1,7 +1,6 @@
 # isort: skip_file
 import logging
 import os
-import sys
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +115,7 @@ __version__ = "3.0.0.dev0"
 
 import ray._raylet  # noqa: E402
 
-from ray._raylet import (  # noqa: E402,F401
+from ray._raylet import (  # noqa: E402
     ActorClassID,
     ActorID,
     NodeID,
@@ -135,7 +134,7 @@ from ray._raylet import (  # noqa: E402,F401
 
 _config = _Config()
 
-from ray._private.state import (  # noqa: E402,F401
+from ray._private.state import (  # noqa: E402
     nodes,
     timeline,
     cluster_resources,
@@ -163,21 +162,23 @@ from ray._private.worker import (  # noqa: E402,F401
 # We import ray.actor because some code is run in actor.py which initializes
 # some functions in the worker.
 import ray.actor  # noqa: E402,F401
-from ray.actor import method  # noqa: E402,F401
+from ray.actor import method  # noqa: E402
 
 # TODO(qwang): We should remove this exporting in Ray2.0.
-from ray.cross_language import java_function, java_actor_class  # noqa: E402,F401
-from ray.runtime_context import get_runtime_context  # noqa: E402,F401
-from ray import autoscaler  # noqa: E402,F401
+from ray.cross_language import java_function, java_actor_class  # noqa: E402
+from ray.runtime_context import get_runtime_context  # noqa: E402
+from ray import autoscaler  # noqa:E402
+from ray import data  # noqa: E402,F401
 from ray import internal  # noqa: E402,F401
-from ray import util  # noqa: E402,F401
+from ray import util  # noqa: E402
 from ray import _private  # noqa: E402,F401
+from ray import workflow  # noqa: E402,F401
 
 # We import ClientBuilder so that modules can inherit from `ray.ClientBuilder`.
-from ray.client_builder import client, ClientBuilder  # noqa: E402,F401
+from ray.client_builder import client, ClientBuilder  # noqa: E402
 
 
-class _DeprecationWrapper:
+class _DeprecationWrapper(object):
     def __init__(self, name, real_worker):
         self._name = name
         self._real_worker = real_worker
@@ -200,23 +201,18 @@ ray_constants = _DeprecationWrapper("ray_constants", ray._private.ray_constants)
 serialization = _DeprecationWrapper("serialization", ray._private.serialization)
 state = _DeprecationWrapper("state", ray._private.state)
 
-
-_subpackages = [
-    "data",
-    "workflow",
-]
-
 __all__ = [
     "__version__",
     "_config",
     "get_runtime_context",
     "actor",
-    "autoscaler",
     "available_resources",
+    "autoscaler",
     "cancel",
     "client",
     "ClientBuilder",
     "cluster_resources",
+    "data",
     "get",
     "get_actor",
     "get_gpu_ids",
@@ -241,7 +237,7 @@ __all__ = [
     "LOCAL_MODE",
     "SCRIPT_MODE",
     "WORKER_MODE",
-] + _subpackages
+]
 
 # ID types
 __all__ += [
@@ -259,20 +255,6 @@ __all__ += [
     "PlacementGroupID",
 ]
 
-if sys.version_info < (3, 7):
-    # TODO(Clark): Remove this one we drop Python 3.6 support.
-    from ray import data  # noqa: F401
-    from ray import workflow  # noqa: F401
-else:
-    # Delay importing of expensive, isolated subpackages.
-    def __getattr__(name: str):
-        import importlib
-
-        if name in _subpackages:
-            return importlib.import_module("." + name, __name__)
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
 
 del os
 del logging
-del sys

--- a/python/ray/tests/test_runtime_env_working_dir_4.py
+++ b/python/ray/tests/test_runtime_env_working_dir_4.py
@@ -95,7 +95,7 @@ def test_default_large_cache(start_cluster, option: str, source: str):
                 # this delay will make worker start slow and time out
                 "testing_asio_delay_us": "InternalKVGcsService.grpc_server"
                 ".InternalKVGet=2000000:2000000",
-                "worker_register_timeout_seconds": 0.5,
+                "worker_register_timeout_seconds": 1,
             },
         },
         {
@@ -105,7 +105,7 @@ def test_default_large_cache(start_cluster, option: str, source: str):
                 # this delay will make worker start slow and time out
                 "testing_asio_delay_us": "InternalKVGcsService.grpc_server"
                 ".InternalKVGet=2000000:2000000",
-                "worker_register_timeout_seconds": 0.5,
+                "worker_register_timeout_seconds": 1,
             },
         },
     ],

--- a/python/ray/tests/test_top_level_api.py
+++ b/python/ray/tests/test_top_level_api.py
@@ -1,7 +1,4 @@
 from inspect import getmembers, isfunction, ismodule
-import sys
-
-import pytest
 
 import ray
 
@@ -39,56 +36,15 @@ def test_api_functions():
         "get_runtime_context",
     ]
 
-    IMPL_FUNCTIONS = ["__getattr__"]
-
     functions = getmembers(ray, isfunction)
     function_names = [f[0] for f in functions]
-    assert set(function_names) == set(
-        PYTHON_API + OTHER_ALLOWED_FUNCTIONS + IMPL_FUNCTIONS
-    )
+    assert set(function_names) == set(PYTHON_API + OTHER_ALLOWED_FUNCTIONS)
 
 
 def test_non_ray_modules():
     modules = getmembers(ray, ismodule)
     for name, mod in modules:
         assert "ray" in str(mod), f"Module {mod} should not be reachable via ray.{name}"
-
-
-def test_dynamic_subpackage_import():
-    # Test that subpackages are dynamically imported and properly cached.
-
-    # ray.data
-    assert "ray.data" not in sys.modules
-    ray.data
-    # Check that the package is cached.
-    assert "ray.data" in sys.modules
-
-    # ray.workflow
-    assert "ray.workflow" not in sys.modules
-    ray.workflow
-    # Check that the package is cached.
-    assert "ray.workflow" in sys.modules
-
-
-def test_dynamic_subpackage_missing():
-    # Test nonexistent subpackage dynamic attribute access and imports raise expected
-    # errors.
-
-    # Test that nonexistent subpackage attribute access raises an AttributeError.
-    with pytest.raises(AttributeError):
-        ray.foo  # noqa:F401
-
-    # Test that nonexistent subpackage import raises an ImportError.
-    with pytest.raises(ImportError):
-        from ray.foo import bar  # noqa:F401
-
-
-def test_dynamic_subpackage_fallback_only():
-    # Test that the __getattr__ dynamic
-    assert "ray.autoscaler" in sys.modules
-    assert ray.__getattribute__("autoscaler") is ray.autoscaler
-    with pytest.raises(AttributeError):
-        ray.__getattr__("autoscaler")
 
 
 def test_for_strings():
@@ -99,7 +55,9 @@ def test_for_strings():
 
 
 if __name__ == "__main__":
+    import pytest
     import os
+    import sys
 
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))


### PR DESCRIPTION
This reverts commit 241a02eba6f7b73ed47af0c61f4e7058d42c5664, reverting PR #27658. This PR was making some GCS tests flaky (somehow).

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
