### PR TITLE
[Datasets] Add upper bound to pyarrow version check.

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1,6 +1,6 @@
 import importlib
 import logging
-from typing import Union, Optional, TYPE_CHECKING
+from typing import Union, Optional, Tuple, TYPE_CHECKING
 from types import ModuleType
 import sys
 
@@ -15,7 +15,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# NOTE: Make sure that these lower and upper bounds stay in sync with version
+# constraints given in python/setup.py.
+# Inclusive minimum pyarrow version.
 MIN_PYARROW_VERSION = (6, 0, 1)
+# Exclusive maximum pyarrow version.
+MAX_PYARROW_VERSION = (7, 0, 0)
 _VERSION_VALIDATED = False
 
 
@@ -35,30 +40,36 @@ def _lazy_import_pyarrow_dataset() -> LazyModule:
     return _pyarrow_dataset
 
 
+def _version_tuple_to_str(version: Tuple[int, int, int]) -> str:
+    """Convert version tuple to string."""
+    return ".".join(str(n) for n in version)
+
+
 def _check_pyarrow_version():
     global _VERSION_VALIDATED
+
     if not _VERSION_VALIDATED:
         import pkg_resources
+
+        min_version = _version_tuple_to_str(MIN_PYARROW_VERSION)
+        max_version = _version_tuple_to_str(MAX_PYARROW_VERSION)
 
         try:
             version_info = pkg_resources.require("pyarrow")
             version_str = version_info[0].version
             version = tuple(int(n) for n in version_str.split(".") if "dev" not in n)
-            if version < MIN_PYARROW_VERSION:
+            if version < MIN_PYARROW_VERSION or version >= MAX_PYARROW_VERSION:
                 raise ImportError(
-                    "Datasets requires pyarrow >= "
-                    f"{'.'.join(str(n) for n in MIN_PYARROW_VERSION)}, "
+                    f"Datasets requires pyarrow >= {min_version}, < {max_version}, "
                     f"but {version_str} is installed. Upgrade with "
-                    "`pip install -U pyarrow`."
+                    "`pip install -U pyarrow<{max_version}`."
                 )
         except pkg_resources.DistributionNotFound:
             logger.warning(
-                "You are using the 'pyarrow' module, but "
-                "the exact version is unknown (possibly carried as "
-                "an internal component by another module). Please "
-                "make sure you are using pyarrow >= "
-                f"{'.'.join(str(n) for n in MIN_PYARROW_VERSION)} "
-                "to ensure compatibility with Ray Datasets."
+                "You are using the 'pyarrow' module, but the exact version is unknown "
+                "(possibly carried as an internal component by another module). Please "
+                f"make sure you are using pyarrow >= {min_version}, < {max_version} to "
+                "ensure compatibility with Ray Datasets."
             )
         else:
             _VERSION_VALIDATED = True

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -66,6 +66,8 @@ def _check_pyarrow_version():
                     f"Datasets requires pyarrow >= {MIN_PYARROW_VERSION}, < "
                     f"{MAX_PYARROW_VERSION}, but {version} is installed. Upgrade with "
                     f"`pip install -U pyarrow<{MAX_PYARROW_VERSION}`."
+                    "If you want to disable this pyarrow version check, set the "
+                    f"environment variable {RAY_DISABLE_PYARROW_VERSION_CHECK}=1."
                 )
         except DistributionNotFound:
             logger.warning(
@@ -73,6 +75,8 @@ def _check_pyarrow_version():
                 "(possibly carried as an internal component by another module). Please "
                 f"make sure you are using pyarrow >= {MIN_PYARROW_VERSION}, < "
                 f"{MAX_PYARROW_VERSION} to ensure compatibility with Ray Datasets."
+                "If you want to disable this pyarrow version check, set the "
+                f"environment variable {RAY_DISABLE_PYARROW_VERSION_CHECK}=1."
             )
         else:
             _VERSION_VALIDATED = True

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -64,7 +64,7 @@ def _check_pyarrow_version():
                 "You are using the 'pyarrow' module, but the exact version is unknown "
                 "(possibly carried as an internal component by another module). Please "
                 f"make sure you are using pyarrow >= {MIN_PYARROW_VERSION}, < "
-                f"{MAX_PYARROW_VERSION} to ensure compatibility with Ray Datasets."
+                f"{MAX_PYARROW_VERSION} to ensure compatibility with Ray Datasets. "
                 "If you want to disable this pyarrow version check, set the "
                 f"environment variable {RAY_DISABLE_PYARROW_VERSION_CHECK}=1."
             )
@@ -80,7 +80,7 @@ def _check_pyarrow_version():
                 raise ImportError(
                     f"Datasets requires pyarrow >= {MIN_PYARROW_VERSION}, < "
                     f"{MAX_PYARROW_VERSION}, but {version} is installed. Reinstall "
-                    f'with `pip install -U "pyarrow<{MAX_PYARROW_VERSION}"`.'
+                    f'with `pip install -U "pyarrow<{MAX_PYARROW_VERSION}"`. '
                     "If you want to disable this pyarrow version check, set the "
                     f"environment variable {RAY_DISABLE_PYARROW_VERSION_CHECK}=1."
                 )

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1,6 +1,7 @@
 import importlib
 import logging
-from typing import Union, Optional, Tuple, TYPE_CHECKING
+import os
+from typing import Union, Optional, TYPE_CHECKING
 from types import ModuleType
 import sys
 
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
 MIN_PYARROW_VERSION = "6.0.1"
 # Exclusive maximum pyarrow version.
 MAX_PYARROW_VERSION = "7.0.0"
+RAY_DISABLE_PYARROW_VERSION_CHECK = "RAY_DISABLE_PYARROW_VERSION_CHECK"
 _VERSION_VALIDATED = False
 
 
@@ -40,15 +42,14 @@ def _lazy_import_pyarrow_dataset() -> LazyModule:
     return _pyarrow_dataset
 
 
-def _version_tuple_to_str(version: Tuple[int, int, int]) -> str:
-    """Convert version tuple to string."""
-    return ".".join(str(n) for n in version)
-
-
 def _check_pyarrow_version():
     global _VERSION_VALIDATED
 
     if not _VERSION_VALIDATED:
+        if os.environ.get(RAY_DISABLE_PYARROW_VERSION_CHECK, "0") == "1":
+            _VERSION_VALIDATED = True
+            return
+
         from pkg_resources import require, packaging, DistributionNotFound
 
         try:

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -18,9 +18,9 @@ logger = logging.getLogger(__name__)
 # NOTE: Make sure that these lower and upper bounds stay in sync with version
 # constraints given in python/setup.py.
 # Inclusive minimum pyarrow version.
-MIN_PYARROW_VERSION = (6, 0, 1)
+MIN_PYARROW_VERSION = "6.0.1"
 # Exclusive maximum pyarrow version.
-MAX_PYARROW_VERSION = (7, 0, 0)
+MAX_PYARROW_VERSION = "7.0.0"
 _VERSION_VALIDATED = False
 
 
@@ -49,27 +49,29 @@ def _check_pyarrow_version():
     global _VERSION_VALIDATED
 
     if not _VERSION_VALIDATED:
-        import pkg_resources
-
-        min_version = _version_tuple_to_str(MIN_PYARROW_VERSION)
-        max_version = _version_tuple_to_str(MAX_PYARROW_VERSION)
+        from pkg_resources import require, packaging, DistributionNotFound
 
         try:
-            version_info = pkg_resources.require("pyarrow")
-            version_str = version_info[0].version
-            version = tuple(int(n) for n in version_str.split(".") if "dev" not in n)
-            if version < MIN_PYARROW_VERSION or version >= MAX_PYARROW_VERSION:
+            version_info = require("pyarrow")
+            version = version_info[0].version
+            if (
+                packaging.version.parse(version)
+                < packaging.version.parse(MIN_PYARROW_VERSION)
+            ) or (
+                packaging.version.parse(version)
+                >= packaging.version.parse(MAX_PYARROW_VERSION)
+            ):
                 raise ImportError(
-                    f"Datasets requires pyarrow >= {min_version}, < {max_version}, "
-                    f"but {version_str} is installed. Upgrade with "
-                    "`pip install -U pyarrow<{max_version}`."
+                    f"Datasets requires pyarrow >= {MIN_PYARROW_VERSION}, < "
+                    f"{MAX_PYARROW_VERSION}, but {version} is installed. Upgrade with "
+                    f"`pip install -U pyarrow<{MAX_PYARROW_VERSION}`."
                 )
-        except pkg_resources.DistributionNotFound:
+        except DistributionNotFound:
             logger.warning(
                 "You are using the 'pyarrow' module, but the exact version is unknown "
                 "(possibly carried as an internal component by another module). Please "
-                f"make sure you are using pyarrow >= {min_version}, < {max_version} to "
-                "ensure compatibility with Ray Datasets."
+                f"make sure you are using pyarrow >= {MIN_PYARROW_VERSION}, < "
+                f"{MAX_PYARROW_VERSION} to ensure compatibility with Ray Datasets."
             )
         else:
             _VERSION_VALIDATED = True

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -43,6 +43,7 @@ def _lazy_import_pyarrow_dataset() -> LazyModule:
 
 
 def _check_pyarrow_version():
+    """Check that pyarrow's version is within the supported bounds."""
     global _VERSION_VALIDATED
 
     if not _VERSION_VALIDATED:
@@ -78,8 +79,8 @@ def _check_pyarrow_version():
             ):
                 raise ImportError(
                     f"Datasets requires pyarrow >= {MIN_PYARROW_VERSION}, < "
-                    f"{MAX_PYARROW_VERSION}, but {version} is installed. Upgrade with "
-                    f"`pip install -U pyarrow<{MAX_PYARROW_VERSION}`."
+                    f"{MAX_PYARROW_VERSION}, but {version} is installed. Reinstall "
+                    f'with `pip install -U "pyarrow<{MAX_PYARROW_VERSION}"`.'
                     "If you want to disable this pyarrow version check, set the "
                     f"environment variable {RAY_DISABLE_PYARROW_VERSION_CHECK}=1."
                 )

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -270,3 +270,10 @@ def unsupported_pyarrow_version(request):
     pa.__version__ = request.param
     yield request.param
     pa.__version__ = orig_version
+
+
+@pytest.fixture
+def disable_pyarrow_version_check():
+    os.environ["RAY_DISABLE_PYARROW_VERSION_CHECK"] = "1"
+    yield
+    del os.environ["RAY_DISABLE_PYARROW_VERSION_CHECK"]

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -262,3 +262,11 @@ def enable_automatic_tensor_extension_cast(request):
     ctx.enable_tensor_extension_casting = request.param
     yield request.param
     ctx.enable_tensor_extension_casting = original
+
+
+@pytest.fixture(params=["5.0.0", "7.0.0"])
+def unsupported_pyarrow_version(request):
+    orig_version = pa.__version__
+    pa.__version__ = request.param
+    yield request.param
+    pa.__version__ = orig_version

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -4655,69 +4655,6 @@ def test_random_block_order(ray_start_regular_shared):
 # tests should only be carefully reordered to retain this invariant!
 
 
-def test_unsupported_pyarrow_versions_check(shutdown_only, unsupported_pyarrow_version):
-    # Test that unsupported pyarrow versions cause an error to be raised upon the
-    # initial pyarrow use.
-    ray.init(runtime_env={"pip": [f"pyarrow=={unsupported_pyarrow_version}"]})
-
-    # Test Arrow-native creation APIs.
-    # Test range_table.
-    with pytest.raises(ImportError):
-        ray.data.range_table(10).take_all()
-
-    # Test from_arrow.
-    with pytest.raises(ImportError):
-        ray.data.from_arrow(pa.table({"a": [1, 2]}))
-
-    # Test read_parquet.
-    with pytest.raises(ImportError):
-        ray.data.read_parquet("example://iris.parquet").take_all()
-
-    # Test from_numpy (we use Arrow for representing the tensors).
-    with pytest.raises(ImportError):
-        ray.data.from_numpy(np.arange(12).reshape((3, 2, 2)))
-
-
-def test_unsupported_pyarrow_versions_check_disabled(
-    shutdown_only,
-    unsupported_pyarrow_version,
-    disable_pyarrow_version_check,
-):
-    # Test that unsupported pyarrow versions DO NOT cause an error to be raised upon the
-    # initial pyarrow use when the version check is disabled.
-    ray.init(
-        runtime_env={
-            "pip": [f"pyarrow=={unsupported_pyarrow_version}"],
-            "env_vars": {"RAY_DISABLE_PYARROW_VERSION_CHECK": "1"},
-        },
-    )
-
-    # Test Arrow-native creation APIs.
-    # Test range_table.
-    try:
-        ray.data.range_table(10).take_all()
-    except ImportError as e:
-        pytest.fail(f"_check_pyarrow_version failed unexpectedly: {e}")
-
-    # Test from_arrow.
-    try:
-        ray.data.from_arrow(pa.table({"a": [1, 2]}))
-    except ImportError as e:
-        pytest.fail(f"_check_pyarrow_version failed unexpectedly: {e}")
-
-    # Test read_parquet.
-    try:
-        ray.data.read_parquet("example://iris.parquet").take_all()
-    except ImportError as e:
-        pytest.fail(f"_check_pyarrow_version failed unexpectedly: {e}")
-
-    # Test from_numpy (we use Arrow for representing the tensors).
-    try:
-        ray.data.from_numpy(np.arange(12).reshape((3, 2, 2)))
-    except ImportError as e:
-        pytest.fail(f"_check_pyarrow_version failed unexpectedly: {e}")
-
-
 @pytest.mark.parametrize("pipelined", [False, True])
 def test_random_shuffle(shutdown_only, pipelined, use_push_based_shuffle):
     def range(n, parallelism=200):
@@ -4823,6 +4760,69 @@ def test_random_shuffle_check_random(shutdown_only):
                 ), f"{part} contains non-shuffled rows from input blocks"
                 num_increasing = 0
             prev = x
+
+
+def test_unsupported_pyarrow_versions_check(shutdown_only, unsupported_pyarrow_version):
+    # Test that unsupported pyarrow versions cause an error to be raised upon the
+    # initial pyarrow use.
+    ray.init(runtime_env={"pip": [f"pyarrow=={unsupported_pyarrow_version}"]})
+
+    # Test Arrow-native creation APIs.
+    # Test range_table.
+    with pytest.raises(ImportError):
+        ray.data.range_table(10).take_all()
+
+    # Test from_arrow.
+    with pytest.raises(ImportError):
+        ray.data.from_arrow(pa.table({"a": [1, 2]}))
+
+    # Test read_parquet.
+    with pytest.raises(ImportError):
+        ray.data.read_parquet("example://iris.parquet").take_all()
+
+    # Test from_numpy (we use Arrow for representing the tensors).
+    with pytest.raises(ImportError):
+        ray.data.from_numpy(np.arange(12).reshape((3, 2, 2)))
+
+
+def test_unsupported_pyarrow_versions_check_disabled(
+    shutdown_only,
+    unsupported_pyarrow_version,
+    disable_pyarrow_version_check,
+):
+    # Test that unsupported pyarrow versions DO NOT cause an error to be raised upon the
+    # initial pyarrow use when the version check is disabled.
+    ray.init(
+        runtime_env={
+            "pip": [f"pyarrow=={unsupported_pyarrow_version}"],
+            "env_vars": {"RAY_DISABLE_PYARROW_VERSION_CHECK": "1"},
+        },
+    )
+
+    # Test Arrow-native creation APIs.
+    # Test range_table.
+    try:
+        ray.data.range_table(10).take_all()
+    except ImportError as e:
+        pytest.fail(f"_check_pyarrow_version failed unexpectedly: {e}")
+
+    # Test from_arrow.
+    try:
+        ray.data.from_arrow(pa.table({"a": [1, 2]}))
+    except ImportError as e:
+        pytest.fail(f"_check_pyarrow_version failed unexpectedly: {e}")
+
+    # Test read_parquet.
+    try:
+        ray.data.read_parquet("example://iris.parquet").take_all()
+    except ImportError as e:
+        pytest.fail(f"_check_pyarrow_version failed unexpectedly: {e}")
+
+    # Test from_numpy (we use Arrow for representing the tensors).
+    try:
+        ray.data.from_numpy(np.arange(12).reshape((3, 2, 2)))
+    except ImportError as e:
+        pytest.fail(f"_check_pyarrow_version failed unexpectedly: {e}")
 
 
 def test_random_shuffle_with_custom_resource(ray_start_cluster):

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -1,0 +1,22 @@
+import pytest
+
+from ray.data._internal.util import _check_pyarrow_version
+from ray.data.tests.conftest import *  # noqa: F401, F403
+
+
+def test_check_pyarrow_version_bounds(unsupported_pyarrow_version):
+    with pytest.raises(ImportError):
+        _check_pyarrow_version()
+
+
+def test_check_pyarrow_version_supported():
+    try:
+        _check_pyarrow_version()
+    except ImportError as e:
+        pytest.fail(f"_check_pyarrow_version failed unexpectedly: {e}")
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -5,11 +5,29 @@ from ray.data.tests.conftest import *  # noqa: F401, F403
 
 
 def test_check_pyarrow_version_bounds(unsupported_pyarrow_version):
+    # Test that pyarrow versions outside of the defined bounds cause an ImportError to
+    # be raised.
     with pytest.raises(ImportError):
         _check_pyarrow_version()
 
 
+def test_check_pyarrow_version_bounds_disabled(
+    unsupported_pyarrow_version,
+    disable_pyarrow_version_check,
+):
+    # Test that pyarrow versions outside of the defined bounds DO NOT cause an
+    # ImportError to be raised if the environment variable disabling the check is set.
+
+    # Confirm that ImportError is not raised.
+    try:
+        _check_pyarrow_version()
+    except ImportError as e:
+        pytest.fail(f"_check_pyarrow_version failed unexpectedly: {e}")
+
+
 def test_check_pyarrow_version_supported():
+    # Test that the pyarrow installed in this testing environment satisfies the pyarrow
+    # version bounds.
     try:
         _check_pyarrow_version()
     except ImportError as e:


### PR DESCRIPTION
We previously weren't checking that the 7.0.0 pyarrow upper bound was being respected. This PR adds this upper bound check.

## TODOs

- [x] Add test coverage?

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #29673 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
