### PR TITLE
[metrics] Disable actor task metric tracking temporarily for performance

### DIFF
--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -231,6 +231,7 @@ ray.get(a)
     proc.kill()
 
 
+@pytest.mark.skipif(True, reason="actor metrics disabled temporarily")
 def test_actor_tasks_queued(shutdown_only):
     info = ray.init(num_cpus=2, **METRIC_CONFIG)
 
@@ -370,6 +371,7 @@ time.sleep(999)
     proc.kill()
 
 
+@pytest.mark.skipif(True, reason="actor metrics disabled temporarily")
 def test_concurrent_actor_tasks(shutdown_only):
     info = ray.init(num_cpus=2, **METRIC_CONFIG)
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1981,7 +1981,8 @@ std::optional<std::vector<rpc::ObjectReference>> CoreWorker::SubmitActorTask(
     returned_refs = ExecuteTaskLocalMode(task_spec, actor_id);
   } else {
     returned_refs = task_manager_->AddPendingTask(
-        rpc_address_, task_spec, CurrentCallSite(), actor_handle->MaxTaskRetries());
+        rpc_address_, task_spec, CurrentCallSite(), actor_handle->MaxTaskRetries(),
+        /*enable_metrics=*/false);
     RAY_CHECK_OK(direct_actor_submitter_->SubmitTask(task_spec));
   }
   return {std::move(returned_refs)};
@@ -2293,6 +2294,7 @@ Status CoreWorker::ExecuteTask(
     return_objects->pop_back();
     task_type = TaskType::ACTOR_CREATION_TASK;
     SetActorId(task_spec.ActorCreationId());
+    task_counter_.BecomeActor();
     {
       std::unique_ptr<ActorHandle> self_actor_handle(
           new ActorHandle(task_spec.GetSerializedActorHandle()));

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1980,9 +1980,11 @@ std::optional<std::vector<rpc::ObjectReference>> CoreWorker::SubmitActorTask(
     lock.Release();
     returned_refs = ExecuteTaskLocalMode(task_spec, actor_id);
   } else {
-    returned_refs = task_manager_->AddPendingTask(
-        rpc_address_, task_spec, CurrentCallSite(), actor_handle->MaxTaskRetries(),
-        /*enable_metrics=*/false);
+    returned_refs = task_manager_->AddPendingTask(rpc_address_,
+                                                  task_spec,
+                                                  CurrentCallSite(),
+                                                  actor_handle->MaxTaskRetries(),
+                                                  /*enable_metrics=*/false);
     RAY_CHECK_OK(direct_actor_submitter_->SubmitTask(task_spec));
   }
   return {std::move(returned_refs)};

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -32,7 +32,8 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
     const rpc::Address &caller_address,
     const TaskSpecification &spec,
     const std::string &call_site,
-    int max_retries) {
+    int max_retries,
+    bool enable_metrics) {
   int32_t max_oom_retries =
       (max_retries != 0) ? RayConfig::instance().task_oom_retries() : 0;
   RAY_LOG(DEBUG) << "Adding pending task " << spec.TaskId() << " with " << max_retries
@@ -99,8 +100,13 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
 
   {
     absl::MutexLock lock(&mu_);
-    auto inserted = submissible_tasks_.try_emplace(
-        spec.TaskId(), spec, max_retries, num_returns, task_counter_, max_oom_retries);
+    auto inserted = submissible_tasks_.try_emplace(spec.TaskId(),
+                                                   spec,
+                                                   max_retries,
+                                                   num_returns,
+                                                   task_counter_,
+                                                   max_oom_retries,
+                                                   enable_metrics);
     RAY_CHECK(inserted.second);
     num_pending_tasks_++;
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Synchronous metrics recording has a ~10% perf hit on actor microbenchmarks. Disable this for now. In 2.2, we can optimize this to batch record metrics asynchronously.