### PR TITLE
Optimize task metrics to avoid synchronous recording overhead.

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -626,6 +626,8 @@ void CoreWorker::Disconnect(
     const std::string &exit_detail,
     const std::shared_ptr<LocalMemoryBuffer> &creation_task_exception_pb_bytes) {
   // Force stats export before exiting the worker.
+  task_manager_->RecordMetrics();
+  task_counter_.RecordMetrics();
   opencensus::stats::StatsExporter::ExportNow();
   if (connected_) {
     RAY_LOG(INFO) << "Disconnecting to the raylet.";

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -826,6 +826,11 @@ void CoreWorker::InternalHeartbeat() {
   if (options_.worker_type == WorkerType::DRIVER && options_.interactive) {
     memory_store_->NotifyUnhandledErrors();
   }
+
+  // Record metrics for owned tasks.
+  task_manager_->RecordMetrics();
+  // Record metrics for executed tasks.
+  task_counter_.RecordMetrics();
 }
 
 std::unordered_map<ObjectID, std::pair<size_t, size_t>>

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -78,7 +78,7 @@ class TaskCounter {
     });
     // Track the sub-state of tasks running but blocked in ray.get().
     running_in_get_counter_.ForEachEntry(
-        [this](const std::string &func_name, int64_t value)
+        [](const std::string &func_name, int64_t value)
             EXCLUSIVE_LOCKS_REQUIRED(&mu_) mutable {
               ray::stats::STATS_tasks.Record(
                   value,
@@ -88,7 +88,7 @@ class TaskCounter {
             });
     // Track the sub-state of tasks running but blocked in ray.wait().
     running_in_wait_counter_.ForEachEntry(
-        [this](const std::string &func_name, int64_t value)
+        [](const std::string &func_name, int64_t value)
             EXCLUSIVE_LOCKS_REQUIRED(&mu_) mutable {
               ray::stats::STATS_tasks.Record(
                   value,

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -59,25 +59,24 @@ namespace core {
 
 JobID GetProcessJobID(const CoreWorkerOptions &options);
 
-/// Simple container for per function task counters. The counters will be
-/// keyed by the function name in task spec.
+/// Tracks stats for inbound tasks (tasks this worker is executing).
+/// The counters are keyed by the function name in task spec.
 class TaskCounter {
   /// A task can only be one of the following state. Received state in particular
   /// covers from the point of RPC call to beginning execution.
   enum TaskStatusType { kPending, kRunning, kFinished };
 
  public:
-  TaskCounter() {
+  void RecordMetrics() {
     // Track the number of running tasks per name.
-    counter_.SetOnChangeCallback(
-        [this](const std::pair<std::string, TaskStatusType> &key, int64_t value)
-            EXCLUSIVE_LOCKS_REQUIRED(&mu_) mutable {
-              if (key.second == kRunning) {
-                RefreshRunningMetric(key.first, value);
-              }
-            });
+    counter_.ForEachEntry([this](const std::pair<std::string, TaskStatusType> &key,
+                                 int64_t value) EXCLUSIVE_LOCKS_REQUIRED(&mu_) mutable {
+      if (key.second == kRunning) {
+        RefreshRunningMetric(key.first, value);
+      }
+    });
     // Track the sub-state of tasks running but blocked in ray.get().
-    running_in_get_counter_.SetOnChangeCallback(
+    running_in_get_counter_.ForEachEntry(
         [this](const std::string &func_name, int64_t value)
             EXCLUSIVE_LOCKS_REQUIRED(&mu_) mutable {
               ray::stats::STATS_tasks.Record(
@@ -85,10 +84,9 @@ class TaskCounter {
                   {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING_IN_RAY_GET)},
                    {"Name", func_name},
                    {"Source", "executor"}});
-              RefreshRunningMetric(func_name, counter_.Get({func_name, kRunning}));
             });
     // Track the sub-state of tasks running but blocked in ray.wait().
-    running_in_wait_counter_.SetOnChangeCallback(
+    running_in_wait_counter_.ForEachEntry(
         [this](const std::string &func_name, int64_t value)
             EXCLUSIVE_LOCKS_REQUIRED(&mu_) mutable {
               ray::stats::STATS_tasks.Record(
@@ -96,7 +94,6 @@ class TaskCounter {
                   {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING_IN_RAY_WAIT)},
                    {"Name", func_name},
                    {"Source", "executor"}});
-              RefreshRunningMetric(func_name, counter_.Get({func_name, kRunning}));
             });
   }
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -67,53 +67,50 @@ class TaskCounter {
   enum TaskStatusType { kPending, kRunning, kFinished };
 
  public:
-  void RecordMetrics() {
-    absl::MutexLock l(&mu_);
-    // Track the number of running tasks per name.
-    counter_.ForEachEntry([this](const std::pair<std::string, TaskStatusType> &key,
-                                 int64_t value) EXCLUSIVE_LOCKS_REQUIRED(&mu_) mutable {
-      if (key.second == kRunning) {
-        RefreshRunningMetric(key.first, value);
-      }
-    });
-    // Track the sub-state of tasks running but blocked in ray.get().
-    running_in_get_counter_.ForEachEntry(
-        [](const std::string &func_name, int64_t value)
+  TaskCounter() {
+    counter_.SetOnChangeCallback(
+        [this](const std::pair<std::string, TaskStatusType> &key, int64_t value)
             EXCLUSIVE_LOCKS_REQUIRED(&mu_) mutable {
-              ray::stats::STATS_tasks.Record(
-                  value,
-                  {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING_IN_RAY_GET)},
-                   {"Name", func_name},
-                   {"Source", "executor"}});
-            });
-    // Track the sub-state of tasks running but blocked in ray.wait().
-    running_in_wait_counter_.ForEachEntry(
-        [](const std::string &func_name, int64_t value)
-            EXCLUSIVE_LOCKS_REQUIRED(&mu_) mutable {
-              ray::stats::STATS_tasks.Record(
-                  value,
-                  {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING_IN_RAY_WAIT)},
-                   {"Name", func_name},
-                   {"Source", "executor"}});
+              if (key.second == kRunning) {
+                counter_changes_.insert(key);
+              }
             });
   }
 
-  void RefreshRunningMetric(const std::string func_name, int64_t running_total)
-      EXCLUSIVE_LOCKS_REQUIRED(&mu_) {
-    // RUNNING_IN_RAY_GET/WAIT are sub-states of RUNNING, so we need to subtract them
-    // out to avoid double-counting.
-    ray::stats::STATS_tasks.Record(
-        running_total - running_in_get_counter_.Get(func_name) -
-            running_in_wait_counter_.Get(func_name),
-        {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING)},
-         {"Name", func_name},
-         {"Source", "executor"}});
-    // Negate the metrics recorded from the submitter process for these tasks.
-    ray::stats::STATS_tasks.Record(
-        -running_total,
-        {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::SUBMITTED_TO_WORKER)},
-         {"Name", func_name},
-         {"Source", "executor"}});
+  void RecordMetrics() {
+    absl::MutexLock l(&mu_);
+    for (const auto &key : counter_changes_) {
+      auto func_name = key.first;
+      int64_t running_total = counter_.Get(key);
+      int64_t num_in_get = running_in_get_counter_.Get(func_name);
+      int64_t num_in_wait = running_in_wait_counter_.Get(func_name);
+      // RUNNING_IN_RAY_GET/WAIT are sub-states of RUNNING, so we need to subtract them
+      // out to avoid double-counting.
+      ray::stats::STATS_tasks.Record(
+          running_total - num_in_get - num_in_wait,
+          {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING)},
+           {"Name", func_name},
+           {"Source", "executor"}});
+      // Negate the metrics recorded from the submitter process for these tasks.
+      ray::stats::STATS_tasks.Record(
+          -running_total,
+          {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::SUBMITTED_TO_WORKER)},
+           {"Name", func_name},
+           {"Source", "executor"}});
+      // Record sub-state for get.
+      ray::stats::STATS_tasks.Record(
+          num_in_get,
+          {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING_IN_RAY_GET)},
+           {"Name", func_name},
+           {"Source", "executor"}});
+      // Record sub-state for wait.
+      ray::stats::STATS_tasks.Record(
+          num_in_wait,
+          {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING_IN_RAY_WAIT)},
+           {"Name", func_name},
+           {"Source", "executor"}});
+    }
+    counter_changes_.clear();
   }
 
   void IncPending(const std::string &func_name) {
@@ -184,6 +181,11 @@ class TaskCounter {
   // overlap with those of counter_.
   CounterMap<std::string> running_in_get_counter_ GUARDED_BY(&mu_);
   CounterMap<std::string> running_in_wait_counter_ GUARDED_BY(&mu_);
+
+  /// Tracks changes to the above counters that need to be flushed to OCL. We cannot
+  /// simply iterate over the counter since entries are deleted once they are zeroed.
+  absl::flat_hash_set<std::pair<std::string, TaskStatusType>> counter_changes_
+      GUARDED_BY(&mu_);
 };
 
 /// The root class that contains all the core and language-independent functionalities

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -68,6 +68,7 @@ class TaskCounter {
 
  public:
   void RecordMetrics() {
+    absl::MutexLock l(&mu_);
     // Track the number of running tasks per name.
     counter_.ForEachEntry([this](const std::pair<std::string, TaskStatusType> &key,
                                  int64_t value) EXCLUSIVE_LOCKS_REQUIRED(&mu_) mutable {

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -816,13 +816,13 @@ void TaskManager::FillTaskInfo(rpc::GetCoreWorkerStatsReply *reply,
 
 void TaskManager::RecordMetrics() {
   absl::MutexLock lock(&mu_);
-  task_counter_.ForEachEntry(
-      [](const std::pair<std::string, rpc::TaskStatus> key, int64_t value) {
-        ray::stats::STATS_tasks.Record(value,
-                                       {{"State", rpc::TaskStatus_Name(key.second)},
-                                        {"Name", key.first},
-                                        {"Source", "owner"}});
-      });
+  for (const auto &key : task_counter_changes_) {
+    ray::stats::STATS_tasks.Record(task_counter_.Get(key),
+                                   {{"State", rpc::TaskStatus_Name(key.second)},
+                                    {"Name", key.first},
+                                    {"Source", "owner"}});
+  }
+  task_counter_changes_.clear();
 }
 
 ObjectID TaskManager::TaskGeneratorId(const TaskID &task_id) const {

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -96,13 +96,6 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
         retry_task_callback_(retry_task_callback),
         push_error_callback_(push_error_callback),
         max_lineage_bytes_(max_lineage_bytes) {
-    task_counter_.SetOnChangeCallback(
-        [](const std::pair<std::string, rpc::TaskStatus> key, int64_t value) {
-          ray::stats::STATS_tasks.Record(value,
-                                         {{"State", rpc::TaskStatus_Name(key.second)},
-                                          {"Name", key.first},
-                                          {"Source", "owner"}});
-        });
     reference_counter_->SetReleaseLineageCallback(
         [this](const ObjectID &object_id, std::vector<ObjectID> *ids_to_release) {
           return RemoveLineageReference(object_id, ids_to_release);
@@ -290,6 +283,9 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// Returns the generator ID that contains the dynamically allocated
   /// ObjectRefs, if the task is dynamic. Else, returns Nil.
   ObjectID TaskGeneratorId(const TaskID &task_id) const;
+
+  /// Record OCL metrics.
+  void RecordMetrics();
 
  private:
   struct TaskEntry {

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -96,6 +96,9 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
         retry_task_callback_(retry_task_callback),
         push_error_callback_(push_error_callback),
         max_lineage_bytes_(max_lineage_bytes) {
+    task_counter_.SetOnChangeCallback(
+        [this](const std::pair<std::string, rpc::TaskStatus> key, int64_t value)
+            EXCLUSIVE_LOCKS_REQUIRED(&mu_) { task_counter_changes_.insert(key); });
     reference_counter_->SetReleaseLineageCallback(
         [this](const ObjectID &object_id, std::vector<ObjectID> *ids_to_release) {
           return RemoveLineageReference(object_id, ids_to_release);
@@ -441,6 +444,11 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
 
   /// Tracks per-task-state counters for metric purposes.
   TaskStatusCounter task_counter_ GUARDED_BY(mu_);
+
+  /// Tracks changes to the above counter that need to be flushed to OCL. We cannot
+  /// simply iterate over the counter since entries are deleted once they are zeroed.
+  absl::flat_hash_set<std::pair<std::string, rpc::TaskStatus>> task_counter_changes_
+      GUARDED_BY(mu_);
 
   /// This map contains one entry per task that may be submitted for
   /// execution. This includes both tasks that are currently pending execution


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Optimize metrics recording to avoid synchronous recording overhead. Microbenchmarks show about parity with previous speed (in principle there's still a slight overhead, but the expensive Record() calls no longer show in the traces).

## Related issue number

This is the followup for https://github.com/ray-project/ray/pull/29676