### PR TITLE
[Core] fix test_object_directory_failure flakiness 

### DIFF
--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -664,12 +664,12 @@ def test_object_directory_failure(ray_start_cluster):
     def task(x):
         pass
 
+    cluster.remove_node(node_to_kill, allow_graceful=False)
     tasks = []
     repeat = 3
     for i in range(num_nodes):
         for _ in range(repeat):
             tasks.append(task.options(resources={str(i): 1}).remote(obj))
-    cluster.remove_node(node_to_kill, allow_graceful=False)
 
     for t in tasks:
         with pytest.raises(ray.exceptions.RayTaskError):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There could be a race that the task finished execution before owner is killed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
