### PR TITLE
[ci][release] Change max worker count for `stress_test_many_tasks` and move it to prod

### DIFF
--- a/release/nightly_tests/stress_tests/stress_tests_compute.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_compute.yaml
@@ -1,7 +1,7 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
-max_workers: 900
+max_workers: 100
 
 aws:
     BlockDeviceMappings:
@@ -19,8 +19,8 @@ head_node_type:
 worker_node_types:
    - name: worker_node
      instance_type: m4.large
-     min_workers: 110
-     max_workers: 110
+     min_workers: 100
+     max_workers: 100
      use_spot: false
      resources:
       cpu: 2

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3666,7 +3666,6 @@
 
   frequency: nightly
   team: core
-  env: staging
   cluster:
     cluster_env: stress_tests/stress_tests_app_config.yaml
     cluster_compute: stress_tests/stress_tests_compute.yaml


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This reverts part of the PR https://github.com/ray-project/ray/pull/28851/files, changing the number of actual worker nodes current introduce two issues:
1. Some test runs [fail](https://console.anyscale-staging.com/o/anyscale-internal/projects/prj_qC3ZfndQWYYjx2cz8KWGNUL4/clusters/ses_Q947bx3TG163vdM5jBwVnBwt) with assertion of 100 worker nodes (it could be removed as an alternative, but see point 2 for why not so) 
2. It changes the resources available for each run, thus making the stress test resources not consistent across runs (impact unknown though) 

Alternative: 
- We could remove the assertion in the test logic to allow variable number of nodes (100 - 105?) 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
