### PR TITLE
[CI] Increase latency threshold in `tune_torch_benchmark`

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
@@ -171,7 +171,9 @@ def main(
 
     print("Full results:", full_results)
 
-    factor = 1.2
+    # NOTE: The value of `factor` is mostly arbitrary. It was previously `1.2`, but 
+    # that value turned out to be too low. For more context, see #29682.
+    factor = 1.35
     threshold = mean_train_time * factor
 
     assert (

--- a/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
@@ -171,7 +171,7 @@ def main(
 
     print("Full results:", full_results)
 
-    # NOTE: The value of `factor` is mostly arbitrary. It was previously `1.2`, but 
+    # NOTE: The value of `factor` is mostly arbitrary. It was previously `1.2`, but
     # that value turned out to be too low. For more context, see #29682.
     factor = 1.35
     threshold = mean_train_time * factor


### PR DESCRIPTION
Signed-off-by: Balaji <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

With the current threshold, the `air_benchmark_tune_torch_mnist` release test failed due to random variance. Since the threshold was arbitrary to begin with, I've increased the threshold to prevent the chance of random failures in the future.

## Related issue number

<!-- For example: "Closes #1234" -->

See #29682 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
