### PR TITLE
Pin modin version to 0.12.1 and update two nightly test yaml files

### DIFF
--- a/python/requirements/ml/requirements_upstream.txt
+++ b/python/requirements/ml/requirements_upstream.txt
@@ -6,4 +6,4 @@ ray_lightning==0.2.0
 tune-sklearn==0.4.4
 xgboost_ray==0.1.10
 lightgbm_ray==0.1.5
-modin>=0.11.0; python_version >= '3.7'
+modin==0.12.1; python_version >= '3.7'

--- a/release/air_tests/air_benchmarks/xgboost_app_config.yaml
+++ b/release/air_tests/air_benchmarks/xgboost_app_config.yaml
@@ -5,6 +5,7 @@ debian_packages:
 python:
   pip_packages:
     - pytest
+    - modin==0.12.1
   conda_packages: []
 
 post_build_cmds:

--- a/release/xgboost_tests/app_config_gpu.yaml
+++ b/release/xgboost_tests/app_config_gpu.yaml
@@ -8,6 +8,7 @@ python:
     - pytest
     - xgboost_ray
     - petastorm
+    - modin==0.12.1
   conda_packages: []
 
 post_build_cmds:


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Debugging a release blocker ([issue](https://github.com/ray-project/ray/issues/29681)). Looks like modin dependency got updated from 0.12.1 to 0.16.1 between Oct 19 to Oct 20. The modin==0.16.1 not compatible with pandas=1.3.5, which caused nightly test `air_benchmark_xgboost_cpu_10 ` and `xgboost_train_gpu` failure with exception stack trace

```
Traceback (most recent call last):
  File "workloads/xgboost_benchmark.py", line 49, in run
    super(MyProcess, self).run()
  File "/home/ray/anaconda3/lib/python3.7/multiprocessing/process.py", line 99, in run
    self._target(*self._args, **self._kwargs)
  File "workloads/xgboost_benchmark.py", line 91, in run_xgboost_training
    result = trainer.fit()
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/train/base_trainer.py", line 360, in fit
    raise result.error
types.RayTaskError(ImportError): ray::_Inner.train() (pid=257, ip=172.31.113.249, repr=XGBoostTrainer)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/tune/trainable/trainable.py", line 361, in train
    raise skipped from exception_cause(skipped)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/tune/trainable/function_trainable.py", line 328, in entrypoint
    self._status_reporter.get_checkpoint(),
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/train/base_trainer.py", line 485, in _trainable_func
    super()._trainable_func(self._merged_config, reporter, checkpoint_dir)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/tune/trainable/function_trainable.py", line 642, in _trainable_func
    output = fn()
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/train/base_trainer.py", line 390, in train_func
    trainer.training_loop()
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/train/gbdt_trainer.py", line 224, in training_loop
    dmatrix_params=self.dmatrix_params,
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/train/gbdt_trainer.py", line 161, in _get_dmatrices
    for k, v in self.datasets.items()
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/train/gbdt_trainer.py", line 161, in <dictcomp>
    for k, v in self.datasets.items()
  File "/home/ray/anaconda3/lib/python3.7/site-packages/xgboost_ray/matrix.py", line 724, in __init__
    distributed = _detect_distributed(data)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/xgboost_ray/matrix.py", line 939, in _detect_distributed
    if not _can_load_distributed(source):
  File "/home/ray/anaconda3/lib/python3.7/site-packages/xgboost_ray/matrix.py", line 917, in _can_load_distributed
    elif Modin.is_data_type(source):
  File "/home/ray/anaconda3/lib/python3.7/site-packages/xgboost_ray/data_sources/modin.py", line 56, in is_data_type
    from modin.pandas import DataFrame as ModinDataFrame, \
  File "/home/ray/anaconda3/lib/python3.7/site-packages/modin/pandas/__init__.py", line 17, in <module>
    from modin._compat import PandasCompatVersion
  File "/home/ray/anaconda3/lib/python3.7/site-packages/modin/_compat/__init__.py", line 20, in <module>
    class PandasCompatVersion:
  File "/home/ray/anaconda3/lib/python3.7/site-packages/modin/_compat/__init__.py", line 31, in PandasCompatVersion
    raise ImportError(f"Unsupported pandas version: {pandas.__version__}")
ImportError: Unsupported pandas version: 1.3.5
```
## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/29681
## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
