### PR TITLE
[Serve][Doc] Split the scaling and resource allocation into two pages

### DIFF
--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -185,7 +185,8 @@ parts:
           - file: serve/user-guide
             sections:
               - file: serve/http-guide
-              - file: serve/scaling-and-resource-allocation
+              - file: serve/scaling
+              - file: serve/resource-allocation
               - file: serve/model_composition
               - file: serve/dev-workflow
               - file: serve/production-guide/index

--- a/doc/source/serve/index.md
+++ b/doc/source/serve/index.md
@@ -242,7 +242,7 @@ or head over to the {doc}`tutorials/index` to get started building your Ray Serv
 
     **User Guides**
     ^^^
-    Learn best practices for common patterns like :ref:`scaling and resource allocation <serve-scaling-and-resource-allocation>` and :ref:`model composition <serve-model-composition>`.
+    Learn best practices for common patterns like :ref:`scaling <serve-scaling>`, :ref:`resource allocation <serve-cpus-gpus>` and :ref:`model composition <serve-model-composition>`.
     Learn how to :ref:`develop Serve applications locally <serve-dev-workflow>` and :ref:`go to production <serve-in-production>`.
 
     +++

--- a/doc/source/serve/key-concepts.md
+++ b/doc/source/serve/key-concepts.md
@@ -121,7 +121,8 @@ Here's a simple example combining a preprocess function and model.
 
 ## What's Next?
 Now that you have learned the key concepts, you can dive into the [User Guide](user-guide):
-- [Scaling and allocating resources](scaling-and-resource-allocation)
+- [Serve Scaling](serve-scaling)
+- [CPU and GPU support and custom resource](serve-cpus-gpus)
 - [Configuring HTTP logic and integrating with FastAPI](http-guide)
 - [Development workflow for Serve applications](dev-workflow)
 - [Composing deployments to perform model composition](model_composition)

--- a/doc/source/serve/resource-allocation.md
+++ b/doc/source/serve/resource-allocation.md
@@ -1,0 +1,68 @@
+(serve-cpus-gpus)=
+
+# CPU & GPU support and Customized resource
+
+This guide helps you to:
+- allocate hardware resources for each deployment
+- allocate fractional CPU & GPU resources
+- allocate customized resources
+
+## Allocate resources
+
+You may want to specify a deployment's resource requirements to reserve cluster resources like GPUs.  To assign hardware resources per replica, you can pass resource requirements to
+`ray_actor_options`.
+By default, each replica reserves one CPU.
+To learn about options to pass in, take a look at the [Resources with Actors guide](actor-resource-guide).
+
+For example, to create a deployment where each replica uses a single GPU, you can do the
+following:
+
+```python
+@serve.deployment(ray_actor_options={"num_gpus": 1})
+def func(*args):
+    return do_something_with_my_gpu()
+```
+
+(serve-fractional-resources-guide)=
+
+## Fractional CPUs and Fractional GPUs
+
+Suppose you have two models and each doesn't fully saturate a GPU.  You might want to have them share a GPU by allocating 0.5 GPUs each.
+
+To do this, the resources specified in `ray_actor_options` can be *fractional*.
+For example, if you have two models and each doesn't fully saturate a GPU, you might want to have them share a GPU by allocating 0.5 GPUs each.
+
+```python
+@serve.deployment(ray_actor_options={"num_gpus": 0.5})
+def func_1(*args):
+    return do_something_with_my_gpu()
+
+@serve.deployment(ray_actor_options={"num_gpus": 0.5})
+def func_2(*args):
+    return do_something_with_my_gpu()
+```
+
+In this example, each replica of each deployment will be allocated 0.5 GPUs.  The same can be done to multiplex over CPUs, using `"num_cpus"`.
+
+## Custom Resources, Accelerator types, and more
+
+You can also specify {ref}`custom resources <cluster-resources>` in `ray_actor_options`, for example to ensure that a deployment is scheduled on a specific node.
+For example, if you have a deployment that requires 2 units of the `"custom_resource"` resource, you can specify it like this:
+
+```python
+@serve.deployment(ray_actor_options={"resources": {"custom_resource": 2}})
+def func(*args):
+    return do_something_with_my_custom_resource()
+```
+
+You can also specify {ref}`accelerator types <accelerator-types>` via the `accelerator_type` parameter in `ray_actor_options`.
+
+Below is the full list of supported options in `ray_actor_options`; please see the relevant Ray Core documentation for more details about each option:
+
+- `accelerator_type`
+- `memory`
+- `num_cpus`
+- `num_gpus`
+- `object_store_memory`
+- `resources`
+- `runtime_env`

--- a/doc/source/serve/resource-allocation.md
+++ b/doc/source/serve/resource-allocation.md
@@ -1,13 +1,13 @@
 (serve-cpus-gpus)=
 
-# CPU & GPU support and Customized resource
+# CPU and GPU support and custom resource
 
 This guide helps you to:
 - allocate hardware resources for each deployment
 - allocate fractional CPU & GPU resources
-- allocate customized resources
+- allocate custom resources
 
-## Allocate resources
+## Allocating resources
 
 You may want to specify a deployment's resource requirements to reserve cluster resources like GPUs.  To assign hardware resources per replica, you can pass resource requirements to
 `ray_actor_options`.

--- a/doc/source/serve/scaling.md
+++ b/doc/source/serve/scaling.md
@@ -1,12 +1,12 @@
-(serve-scaling-and-resource-allocation)=
+(serve-scaling)=
 
-# Scaling and Resource Allocation
+# Scaling
 
 This guide helps you to:
 
 - scale your deployments horizontally by specifying a number of replicas
 - scale up and down automatically to react to changing traffic
-- allocate hardware resources (CPUs, GPUs, etc) for each deployment
+
 
 (scaling-out-a-deployment)=
 
@@ -84,67 +84,6 @@ Ray Serve Autoscaling allows the `min_replicas` to be 0 when starting your deplo
 
 **metrics_interval_s[default_value=10]**: This controls how often each replica sends metrics to the autoscaler. (Normally you don't need to change this config.)
 
-(serve-cpus-gpus)=
-
-## Resource Management (CPUs, GPUs)
-
-You may want to specify a deployment's resource requirements to reserve cluster resources like GPUs.  To assign hardware resources per replica, you can pass resource requirements to
-`ray_actor_options`.
-By default, each replica reserves one CPU.
-To learn about options to pass in, take a look at the [Resources with Actors guide](actor-resource-guide).
-
-For example, to create a deployment where each replica uses a single GPU, you can do the
-following:
-
-```python
-@serve.deployment(ray_actor_options={"num_gpus": 1})
-def func(*args):
-    return do_something_with_my_gpu()
-```
-
-(serve-fractional-resources-guide)=
-
-### Fractional CPUs and Fractional GPUs
-
-Suppose you have two models and each doesn't fully saturate a GPU.  You might want to have them share a GPU by allocating 0.5 GPUs each.
-
-To do this, the resources specified in `ray_actor_options` can be *fractional*.
-For example, if you have two models and each doesn't fully saturate a GPU, you might want to have them share a GPU by allocating 0.5 GPUs each.
-
-```python
-@serve.deployment(ray_actor_options={"num_gpus": 0.5})
-def func_1(*args):
-    return do_something_with_my_gpu()
-
-@serve.deployment(ray_actor_options={"num_gpus": 0.5})
-def func_2(*args):
-    return do_something_with_my_gpu()
-```
-
-In this example, each replica of each deployment will be allocated 0.5 GPUs.  The same can be done to multiplex over CPUs, using `"num_cpus"`.
-
-### Custom Resources, Accelerator types, and more
-
-You can also specify {ref}`custom resources <cluster-resources>` in `ray_actor_options`, for example to ensure that a deployment is scheduled on a specific node.
-For example, if you have a deployment that requires 2 units of the `"custom_resource"` resource, you can specify it like this:
-
-```python
-@serve.deployment(ray_actor_options={"resources": {"custom_resource": 2}})
-def func(*args):
-    return do_something_with_my_custom_resource()
-```
-
-You can also specify {ref}`accelerator types <accelerator-types>` via the `accelerator_type` parameter in `ray_actor_options`.
-
-Below is the full list of supported options in `ray_actor_options`; please see the relevant Ray Core documentation for more details about each option:
-
-- `accelerator_type`
-- `memory`
-- `num_cpus`
-- `num_gpus`
-- `object_store_memory`
-- `resources`
-- `runtime_env`
 
 (serve-omp-num-threads)=
 

--- a/doc/source/serve/user-guide.md
+++ b/doc/source/serve/user-guide.md
@@ -5,7 +5,8 @@ If you’re new to Ray Serve, we recommend starting with the [Ray Serve Quick St
 
 This user guide will help you navigate the Ray Serve project and show you how to achieve several key tasks:
 - [HTTP Handling](http-guide)
-- [Scaling and Resource Allocation](scaling-and-resource-allocation)
+- [Scaling](scaling)
+- [CPU & GPU support](serve-cpus-gpus)
 - [Model Composition](serve-model-composition)
 - [Development Workflow](dev-workflow)
 - [Production Guide](serve-in-production)

--- a/doc/source/serve/user-guide.md
+++ b/doc/source/serve/user-guide.md
@@ -6,7 +6,7 @@ If you’re new to Ray Serve, we recommend starting with the [Ray Serve Quick St
 This user guide will help you navigate the Ray Serve project and show you how to achieve several key tasks:
 - [HTTP Handling](http-guide)
 - [Scaling](scaling)
-- [CPU & GPU support](serve-cpus-gpus)
+- [CPU and GPU support](serve-cpus-gpus)
 - [Model Composition](serve-model-composition)
 - [Development Workflow](dev-workflow)
 - [Production Guide](serve-in-production)


### PR DESCRIPTION
Signed-off-by: Sihan Wang <sihanwang41@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Easy to find the gpu & cpu support in ray serve

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
