### PR TITLE
Fixing flaky TestRemovingLeasingPlacementGroup caused by race condition

### DIFF
--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -346,8 +346,12 @@ TEST_F(GcsPlacementGroupManagerTest, TestRemovingLeasingPlacementGroup) {
   gcs_placement_group_manager_->OnPlacementGroupCreationFailed(
       placement_group, GetExpBackOff(), true);
 
+  // Sleep 1 second so that io_service_ can invoke SchedulePendingPlacementGroups.
+  // If we invoke it from this thread, then both threads race and cause use-after-free
+  // bugs.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
   // Make sure it is not rescheduled
-  gcs_placement_group_manager_->SchedulePendingPlacementGroups();
   ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_.size(), 0);
   mock_placement_group_scheduler_->placement_groups_.clear();
 


### PR DESCRIPTION
Signed-off-by: Cade Daniel <edacih@gmail.com>

## Description
This test became flaky recently when running with ASAN. It is caused by a race condition; the thread that runs the cpp test and an io_service thread both invoke SchedulePendingPlacementGroups, causing use-after-free when that function attempts to remove an element from a container.

See https://github.com/ray-project/ray/issues/29530#issuecomment-1286342816 for further details.

## Testing
To reproduce the failure, I built Ray with ASAN and ran `gcs_placement_group_manager_test` 100 times via `--gtest_repeat=100`. It failed after 16 iterations. With my changes, I can run `gcs_placement_group_manager_test` and it passes, even with `--gtest_repeat=100`.

## Issue
Closes https://github.com/ray-project/ray/issues/29530