### PR TITLE
[ci] Obey constraints in installing build info dependencies

### DIFF
--- a/ci/build/upload_build_info.sh
+++ b/ci/build/upload_build_info.sh
@@ -35,6 +35,6 @@ if [[ -z "${BUILDKITE-}" ]]; then
     aws s3 cp --recursive /tmp/bazel_event_logs "${DST}"
 else
     # Codepath for Buildkite
-    pip install -q docker aws_requests_auth boto3
+    pip install -q -c "${RAY_DIR}/python/requirements.txt" -c "${RAY_DIR}/python/requirements_test.txt"  docker aws_requests_auth
     python .buildkite/copy_files.py --destination logs --path /tmp/bazel_event_logs
 fi

--- a/ci/build/upload_build_info.sh
+++ b/ci/build/upload_build_info.sh
@@ -35,6 +35,7 @@ if [[ -z "${BUILDKITE-}" ]]; then
     aws s3 cp --recursive /tmp/bazel_event_logs "${DST}"
 else
     # Codepath for Buildkite
-    pip install -q -c "${RAY_DIR}/python/requirements.txt" -c "${RAY_DIR}/python/requirements_test.txt"  docker aws_requests_auth
+    # Keep cryptography/openssl in sync with `requirements_test.txt`
+    pip install -q -c "${RAY_DIR}/python/requirements.txt" docker aws_requests_auth boto3 cryptography==38.0.1 PyOpenSSL==22.1.0
     python .buildkite/copy_files.py --destination logs --path /tmp/bazel_event_logs
 fi

--- a/python/requirements_test.txt
+++ b/python/requirements_test.txt
@@ -14,6 +14,7 @@ msrestazure==0.6.4
 boto3==1.23.10
 # Todo: investigate if we can get rid of this and exchange for ray.cloudpickle
 cloudpickle==2.2.0
+# Keep in sync with `ci/build/upload_build_info.sh`
 cryptography==38.0.1
 cython==0.29.32
 dataclasses; python_version < '3.7'
@@ -47,6 +48,7 @@ Pillow==9.2.0; platform_system != "Windows"
 proxy.py==2.4.3
 pyarrow==6.0.1
 pydantic==1.9.2
+# Keep in sync with `ci/build/upload_build_info.sh`
 PyOpenSSL==22.1.0
 pygame==2.1.2
 Pygments==2.13.0


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Minimal installs have to re-install boto3, and this sometimes installs an incompatible openssl version on top of the existing one. By pinning the version in `upload_build_info.sh` we should be able to resolve recent compatibility issues on the master branch.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
