### PR TITLE
Finish cleaning up any lingering references to an old bucket

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -144,10 +144,8 @@ build:ci --show_task_finish
 build:ci --ui_actions_shown=1024
 build:ci --show_timestamps
 build:ci-travis --disk_cache=~/ray-bazel-cache
-build:ci-travis --remote_cache="https://storage.googleapis.com/ray-bazel-cache"
 build:ci-github --experimental_repository_cache_hardlinks # GitHub Actions has low disk space, so prefer hardlinks there.
 build:ci-github --disk_cache=~/ray-bazel-cache
-build:ci-github --remote_cache="https://storage.googleapis.com/ray-bazel-cache"
 test:ci --flaky_test_attempts=3
 # Disable test result caching because py_test under Bazel can import from outside of sandbox, but Bazel only looks at
 # declared dependencies to determine if a result should be cached. More details at:

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -8,7 +8,6 @@ ADD git-rev /ray/git-rev
 RUN sudo apt-get update && sudo apt-get install -y curl unzip cmake gcc g++ && sudo apt-get clean
 RUN sudo chown -R ray:users /ray && cd /ray && git init && ./ci/env/install-bazel.sh --system
 ENV PATH=$PATH:/home/ray/bin
-RUN echo 'build --remote_cache="https://storage.googleapis.com/ray-bazel-cache"' >> $HOME/.bazelrc 
 RUN echo 'build --remote_upload_local_results=false' >> $HOME/.bazelrc 
 WORKDIR /ray/
 # The result of bazel build is reused in pip install. It if run first to allow


### PR DESCRIPTION
## Why are these changes needed?

We had a few code references left over to our old google storage bazel cache bucket. We haven't had anything that actually uses this in the last year, so lets just finish our clean up.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
