### PR TITLE
[AIR] Fix wandb callback failing with RLLib

### DIFF
--- a/python/ray/air/callbacks/wandb.py
+++ b/python/ray/air/callbacks/wandb.py
@@ -16,11 +16,14 @@ from ray.tune.experiment import Trial
 
 try:
     import wandb
-    import wandb.util as wandb_util
 except ImportError:
     logger.error("pip install 'wandb' to use WandbLoggerCallback/WandbTrainableMixin.")
     wandb = None
-    wandb_util = None
+
+if wandb:
+    from wandb.util import json_dumps_safer
+else:
+    json_dumps_safer = None
 
 WANDB_ENV_VAR = "WANDB_API_KEY"
 WANDB_PROJECT_ENV_VAR = "WANDB_PROJECT_NAME"
@@ -91,7 +94,7 @@ def _clean_log(obj: Any):
     try:
         # This is what wandb uses internally. If we cannot dump
         # an object using this method, wandb will raise an exception.
-        wandb_util.json_dumps_safer(obj)
+        json_dumps_safer(obj)
 
         # This is probably unnecessary, but left here to be extra sure.
         pickle.dumps(obj)


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The logic in `WandbLoggerCallback` responsible for cleaning the object passed to `wandb` wasn't foolproof - namely, it allowed sets which are not JSON seriallizable to sneak through when passed to `wandb.init`, causing a JSON encoding error in `wandb`. This PR changes our serializability check to use the actual wandb JSON encoder, automatically converts sets to lists and adds testing.

## Related issue number

Closes https://github.com/ray-project/ray/issues/28541

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
