### PR TITLE
Remove dead redis_address and redis_password parameters

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -224,10 +224,8 @@ class Node:
                 # Get the address info of the processes to connect to
                 # from Redis or GCS.
                 node_info = ray._private.services.get_node_to_connect_for_driver(
-                    self.redis_address,
                     self.gcs_address,
                     self._raylet_ip_address,
-                    redis_password=self.redis_password,
                 )
                 self._plasma_store_socket_name = node_info.object_store_socket_name
                 self._raylet_socket_name = node_info.raylet_socket_name
@@ -310,10 +308,8 @@ class Node:
             # we should update the address info after the node has been started
             try:
                 ray._private.services.wait_for_node(
-                    self.redis_address,
                     self.gcs_address,
                     self._plasma_store_socket_name,
-                    self.redis_password,
                 )
             except TimeoutError:
                 raise Exception(
@@ -322,10 +318,8 @@ class Node:
                     "the Ray processes failed to startup."
                 )
             node_info = ray._private.services.get_node_to_connect_for_driver(
-                self.redis_address,
                 self.gcs_address,
                 self._raylet_ip_address,
-                redis_password=self.redis_password,
             )
             if self._ray_params.node_manager_port == 0:
                 self._ray_params.node_manager_port = node_info.node_manager_port

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -144,7 +144,7 @@ def _build_python_executable_command_memory_profileable(
     return command
 
 
-def _get_gcs_client_options(redis_address, redis_password, gcs_server_address):
+def _get_gcs_client_options(gcs_server_address):
     return GcsClientOptions.from_gcs_address(gcs_server_address)
 
 
@@ -401,20 +401,16 @@ def get_ray_address_from_environment(addr: str, temp_dir: Optional[str]):
 
 
 def wait_for_node(
-    redis_address: str,
     gcs_address: str,
     node_plasma_store_socket_name: str,
-    redis_password: Optional[str] = None,
     timeout: int = _timeout,
 ):
     """Wait until this node has appeared in the client table.
 
     Args:
-        redis_address: The redis address.
         gcs_address: The gcs address
         node_plasma_store_socket_name: The
             plasma_store_socket_name for the given node which we wait for.
-        redis_password: the redis password.
         timeout: The amount of time in seconds to wait before raising an
             exception.
 
@@ -438,12 +434,10 @@ def wait_for_node(
     raise TimeoutError("Timed out while waiting for node to startup.")
 
 
-def get_node_to_connect_for_driver(
-    redis_address, gcs_address, node_ip_address, redis_password=None
-):
+def get_node_to_connect_for_driver(gcs_address, node_ip_address):
     # Get node table from global state accessor.
     global_state = ray._private.state.GlobalState()
-    gcs_options = _get_gcs_client_options(redis_address, redis_password, gcs_address)
+    gcs_options = _get_gcs_client_options(gcs_address)
     global_state._initialize_global_state(gcs_options)
     return global_state.get_node_to_connect_for_driver(node_ip_address)
 

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -286,10 +286,8 @@ class Cluster:
                 the node appears in the client table.
         """
         ray._private.services.wait_for_node(
-            self.redis_address,
             node.gcs_address,
             node.plasma_store_socket_name,
-            self.redis_password,
             timeout,
         )
 

--- a/python/ray/tests/test_component_failures_2.py
+++ b/python/ray/tests/test_component_failures_2.py
@@ -120,10 +120,8 @@ def test_get_node_info_after_raylet_died(ray_start_cluster_head):
 
     def get_node_info():
         return ray._private.services.get_node_to_connect_for_driver(
-            cluster.redis_address,
             cluster.gcs_address,
             cluster.head_node.node_ip_address,
-            redis_password=cluster.redis_password,
         )
 
     assert get_node_info().raylet_socket_name == cluster.head_node.raylet_socket_name

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -247,7 +247,7 @@ def test_ray_init_from_workers(ray_start_cluster):
     assert info["node_ip_address"] == "127.0.0.3"
 
     node_info = ray._private.services.get_node_to_connect_for_driver(
-        address, cluster.gcs_address, "127.0.0.3", redis_password=password
+        cluster.gcs_address, "127.0.0.3"
     )
     assert node_info.node_manager_port == node2.node_manager_port
 


### PR DESCRIPTION
Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In some functions, redis_address and redis_password are no longer in use.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
