### PR TITLE
[metrics] Refactor CounterMap to be easier to use for deferred batch recording of metrics

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2273,6 +2273,7 @@ cc_library(
         "@boost//:asio",
         "@com_github_spdlog//:spdlog",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/debugging:failure_signal_handler",
         "@com_google_absl//absl/debugging:stacktrace",
         "@com_google_absl//absl/debugging:symbolize",

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -69,48 +69,46 @@ class TaskCounter {
  public:
   TaskCounter() {
     counter_.SetOnChangeCallback(
-        [this](const std::pair<std::string, TaskStatusType> &key, int64_t value)
+        [this](const std::pair<std::string, TaskStatusType> &key)
             EXCLUSIVE_LOCKS_REQUIRED(&mu_) mutable {
-              if (key.second == kRunning) {
-                counter_changes_.insert(key);
+              if (key.second != kRunning) {
+                return;
               }
+              auto func_name = key.first;
+              int64_t running_total = counter_.Get(key);
+              int64_t num_in_get = running_in_get_counter_.Get(func_name);
+              int64_t num_in_wait = running_in_wait_counter_.Get(func_name);
+              // RUNNING_IN_RAY_GET/WAIT are sub-states of RUNNING, so we need to subtract
+              // them out to avoid double-counting.
+              ray::stats::STATS_tasks.Record(
+                  running_total - num_in_get - num_in_wait,
+                  {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING)},
+                   {"Name", func_name},
+                   {"Source", "executor"}});
+              // Negate the metrics recorded from the submitter process for these tasks.
+              ray::stats::STATS_tasks.Record(
+                  -running_total,
+                  {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::SUBMITTED_TO_WORKER)},
+                   {"Name", func_name},
+                   {"Source", "executor"}});
+              // Record sub-state for get.
+              ray::stats::STATS_tasks.Record(
+                  num_in_get,
+                  {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING_IN_RAY_GET)},
+                   {"Name", func_name},
+                   {"Source", "executor"}});
+              // Record sub-state for wait.
+              ray::stats::STATS_tasks.Record(
+                  num_in_wait,
+                  {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING_IN_RAY_WAIT)},
+                   {"Name", func_name},
+                   {"Source", "executor"}});
             });
   }
 
   void RecordMetrics() {
     absl::MutexLock l(&mu_);
-    for (const auto &key : counter_changes_) {
-      auto func_name = key.first;
-      int64_t running_total = counter_.Get(key);
-      int64_t num_in_get = running_in_get_counter_.Get(func_name);
-      int64_t num_in_wait = running_in_wait_counter_.Get(func_name);
-      // RUNNING_IN_RAY_GET/WAIT are sub-states of RUNNING, so we need to subtract them
-      // out to avoid double-counting.
-      ray::stats::STATS_tasks.Record(
-          running_total - num_in_get - num_in_wait,
-          {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING)},
-           {"Name", func_name},
-           {"Source", "executor"}});
-      // Negate the metrics recorded from the submitter process for these tasks.
-      ray::stats::STATS_tasks.Record(
-          -running_total,
-          {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::SUBMITTED_TO_WORKER)},
-           {"Name", func_name},
-           {"Source", "executor"}});
-      // Record sub-state for get.
-      ray::stats::STATS_tasks.Record(
-          num_in_get,
-          {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING_IN_RAY_GET)},
-           {"Name", func_name},
-           {"Source", "executor"}});
-      // Record sub-state for wait.
-      ray::stats::STATS_tasks.Record(
-          num_in_wait,
-          {{"State", rpc::TaskStatus_Name(rpc::TaskStatus::RUNNING_IN_RAY_WAIT)},
-           {"Name", func_name},
-           {"Source", "executor"}});
-    }
-    counter_changes_.clear();
+    counter_.FlushOnChangeCallbacks();
   }
 
   void IncPending(const std::string &func_name) {
@@ -181,11 +179,6 @@ class TaskCounter {
   // overlap with those of counter_.
   CounterMap<std::string> running_in_get_counter_ GUARDED_BY(&mu_);
   CounterMap<std::string> running_in_wait_counter_ GUARDED_BY(&mu_);
-
-  /// Tracks changes to the above counters that need to be flushed to OCL. We cannot
-  /// simply iterate over the counter since entries are deleted once they are zeroed.
-  absl::flat_hash_set<std::pair<std::string, TaskStatusType>> counter_changes_
-      GUARDED_BY(&mu_);
 };
 
 /// The root class that contains all the core and language-independent functionalities

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -816,13 +816,7 @@ void TaskManager::FillTaskInfo(rpc::GetCoreWorkerStatsReply *reply,
 
 void TaskManager::RecordMetrics() {
   absl::MutexLock lock(&mu_);
-  for (const auto &key : task_counter_changes_) {
-    ray::stats::STATS_tasks.Record(task_counter_.Get(key),
-                                   {{"State", rpc::TaskStatus_Name(key.second)},
-                                    {"Name", key.first},
-                                    {"Source", "owner"}});
-  }
-  task_counter_changes_.clear();
+  task_counter_.FlushOnChangeCallbacks();
 }
 
 ObjectID TaskManager::TaskGeneratorId(const TaskID &task_id) const {

--- a/src/ray/raylet/dependency_manager.cc
+++ b/src/ray/raylet/dependency_manager.cc
@@ -325,6 +325,10 @@ std::string DependencyManager::DebugString() const {
   return result.str();
 }
 
+void DependencyManager::RecordMetrics() {
+  waiting_tasks_counter_.FlushOnChangeCallbacks();
+}
+
 }  // namespace raylet
 
 }  // namespace ray

--- a/src/ray/raylet/dependency_manager.h
+++ b/src/ray/raylet/dependency_manager.h
@@ -53,8 +53,8 @@ class DependencyManager : public TaskDependencyManagerInterface {
   /// Create a task dependency manager.
   DependencyManager(ObjectManagerInterface &object_manager)
       : object_manager_(object_manager) {
-    waiting_tasks_counter_.SetOnChangeCallback([this](std::string task_name,
-                                                      int64_t num_total) mutable {
+    waiting_tasks_counter_.SetOnChangeCallback([this](std::string task_name) mutable {
+      int64_t num_total = waiting_tasks_counter_.Get(task_name);
       // Of the waiting tasks of this name, some fraction may be inactive (blocked on
       // object store memory availability). Get this breakdown by querying the pull
       // manager.
@@ -189,6 +189,9 @@ class DependencyManager : public TaskDependencyManagerInterface {
   ///
   /// \return string.
   std::string DebugString() const;
+
+  /// Record time-series metrics.
+  void RecordMetrics();
 
  private:
   /// Metadata for an object that is needed by at least one executing worker

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2823,7 +2823,7 @@ void NodeManager::RecordMetrics() {
   uint64_t duration_ms = current_time - last_metrics_recorded_at_ms_;
   last_metrics_recorded_at_ms_ = current_time;
   object_directory_->RecordMetrics(duration_ms);
-  dependency_manager_->RecordMetrics();
+  dependency_manager_.RecordMetrics();
 }
 
 void NodeManager::ConsumeSyncMessage(

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2823,6 +2823,7 @@ void NodeManager::RecordMetrics() {
   uint64_t duration_ms = current_time - last_metrics_recorded_at_ms_;
   last_metrics_recorded_at_ms_ = current_time;
   object_directory_->RecordMetrics(duration_ms);
+  dependency_manager_->RecordMetrics();
 }
 
 void NodeManager::ConsumeSyncMessage(

--- a/src/ray/util/counter_map.h
+++ b/src/ray/util/counter_map.h
@@ -17,6 +17,7 @@
 #include <list>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "ray/util/logging.h"
 
 /// \class CounterMap
@@ -107,6 +108,9 @@ class CounterMap {
   /// Return the total count across all keys in this counter.
   size_t Total() const { return total_; }
 
+  /// For testing, return the number of pending change callbacks.
+  size_t NumPendingCallbacks() const { return pending_changes_.size(); }
+
   /// Run the given function `f((key, count))` for every tracked entry.
   void ForEachEntry(std::function<void(const K &, int64_t)> callback) const {
     for (const auto &it : counters_) {
@@ -117,6 +121,6 @@ class CounterMap {
  private:
   absl::flat_hash_map<K, int64_t> counters_;
   absl::flat_hash_set<K> pending_changes_;
-  std::function<void(const K &, int64_t)> on_change_;
+  std::function<void(const K &)> on_change_;
   size_t total_ = 0;
 };

--- a/src/ray/util/counter_test.cc
+++ b/src/ray/util/counter_test.cc
@@ -50,33 +50,41 @@ TEST_F(CounterMapTest, TestCallback) {
   int num_calls = 0;
   std::string last_call_key;
   int64_t last_call_value;
-  c.SetOnChangeCallback([&](const std::string &key, int64_t value) mutable {
+  c.SetOnChangeCallback([&](const std::string &key) mutable {
     num_calls += 1;
     last_call_key = key;
-    last_call_value = value;
+    last_call_value = c.Get(key);
   });
 
   c.Increment("k1");
+  EXPECT_EQ(num_calls, 0);
+  EXPECT_EQ(c.NumPendingCallbacks(), 1);
+  c.FlushOnChangeCallbacks();
+  EXPECT_EQ(c.NumPendingCallbacks(), 0);
   EXPECT_EQ(num_calls, 1);
   EXPECT_EQ(last_call_key, "k1");
   EXPECT_EQ(last_call_value, 1);
 
   c.Increment("k1");
+  c.FlushOnChangeCallbacks();
   EXPECT_EQ(num_calls, 2);
   EXPECT_EQ(last_call_key, "k1");
   EXPECT_EQ(last_call_value, 2);
 
   c.Increment("k2");
+  c.FlushOnChangeCallbacks();
   EXPECT_EQ(num_calls, 3);
   EXPECT_EQ(last_call_key, "k2");
   EXPECT_EQ(last_call_value, 1);
 
   c.Swap("k1", "k2");
+  EXPECT_EQ(c.NumPendingCallbacks(), 2);
+  c.FlushOnChangeCallbacks();
+  EXPECT_EQ(c.NumPendingCallbacks(), 0);
   EXPECT_EQ(num_calls, 5);
-  EXPECT_EQ(last_call_key, "k2");
-  EXPECT_EQ(last_call_value, 2);
 
   c.Decrement("k1");
+  c.FlushOnChangeCallbacks();
   EXPECT_EQ(num_calls, 6);
   EXPECT_EQ(last_call_key, "k1");
   EXPECT_EQ(last_call_value, 0);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Make the default callback mode async instead of sync, since Record() has significant overhead if called synchronously in the critical path of Ray operations.