### PR TITLE
[Tune] Keep resource specifications when nesting `with_resources` in `with_parameters`

### DIFF
--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -1551,8 +1551,7 @@ def test_with_resources_and_parameters_fn(ray_start_2_cpus_2_gpus, num_gpus):
 
     # The other order of nesting should work the same.
     trainable = tune.with_parameters(
-        tune.with_resources(train_fn, {"gpu": num_gpus}),
-        extra_param="extra"
+        tune.with_resources(train_fn, {"gpu": num_gpus}), extra_param="extra"
     )
     tuner = tune.Tuner(trainable)
     results = tuner.fit()

--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -1530,6 +1530,35 @@ def test_with_resources_class_method(ray_start_2_cpus_2_gpus, num_gpus):
     assert trial.last_result["_metric"] == num_gpus
 
 
+@pytest.mark.parametrize("num_gpus", [1, 2])
+def test_with_resources_and_parameters_fn(ray_start_2_cpus_2_gpus, num_gpus):
+    def train_fn(config, extra_param=None):
+        assert extra_param is not None, "Missing extra parameter."
+        print(ray.get_runtime_context().get_assigned_resources())
+        return {"num_gpus": len(ray.get_gpu_ids())}
+
+    # Nesting `tune.with_parameters` and `tune.with_resources` should respect
+    # the resource specifications.
+    trainable = tune.with_resources(
+        tune.with_parameters(train_fn, extra_param="extra"),
+        {"gpu": num_gpus},
+    )
+
+    tuner = tune.Tuner(trainable)
+    results = tuner.fit()
+    print(results[0].metrics)
+    assert results[0].metrics["num_gpus"] == num_gpus
+
+    # The other order of nesting should work the same.
+    trainable = tune.with_parameters(
+        tune.with_resources(train_fn, {"gpu": num_gpus}),
+        extra_param="extra"
+    )
+    tuner = tune.Tuner(trainable)
+    results = tuner.fit()
+    assert results[0].metrics["num_gpus"] == num_gpus
+
+
 class SerializabilityTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/python/ray/tune/trainable/util.py
+++ b/python/ray/tune/trainable/util.py
@@ -362,7 +362,7 @@ def with_parameters(trainable: Union[Type["Trainable"], Callable], **kwargs):
 
             for k in keys:
                 fn_kwargs[k] = parameter_registry.get(prefix + k)
-            trainable(config, **fn_kwargs)
+            return trainable(config, **fn_kwargs)
 
         inner.__name__ = trainable_name
 
@@ -376,7 +376,7 @@ def with_parameters(trainable: Union[Type["Trainable"], Callable], **kwargs):
         if not use_checkpoint:
 
             def _inner(config):
-                inner(config, checkpoint_dir=None)
+                return inner(config, checkpoint_dir=None)
 
             _inner.__name__ = trainable_name
 

--- a/python/ray/tune/trainable/util.py
+++ b/python/ray/tune/trainable/util.py
@@ -366,6 +366,11 @@ def with_parameters(trainable: Union[Type["Trainable"], Callable], **kwargs):
 
         inner.__name__ = trainable_name
 
+        # If the trainable has been wrapped with `tune.with_resources`, we should
+        # keep the `_resources` attribute around
+        if hasattr(trainable, "_resources"):
+            inner._resources = trainable._resources
+
         # Use correct function signature if no `checkpoint_dir` parameter
         # is set
         if not use_checkpoint:
@@ -374,6 +379,10 @@ def with_parameters(trainable: Union[Type["Trainable"], Callable], **kwargs):
                 inner(config, checkpoint_dir=None)
 
             _inner.__name__ = trainable_name
+
+            # Again, pass along the resource specification if it exists
+            if hasattr(inner, "_resources"):
+                _inner._resources = inner._resources
 
             if hasattr(trainable, "__mixins__"):
                 _inner.__mixins__ = trainable.__mixins__


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
### Order of nesting matters

The order of nesting matters when using `tune.with_parameters` and `tune.with_resources` together. When `tune.with_resources` is nested inside a `tune.with_parameters`, the resource specification is dropped and not considered when launching the trials.

```python
def train_func(config, extra_data=None):
    pass

# This works (resources assigned correctly)
trainable = tune.with_resources(
    tune.with_parameters(train_func, extra_data=1),
    {"cpu": 1.0, "gpu": 1.0}
)
results = Tuner(trainable).fit()

# This doesn't work!
trainable = tune.with_parameters(
    tune.with_resources(train_func, {"cpu": 1.0, "gpu": 1.0}),
    extra_data=1
)
results = Tuner(trainable).fit()
```

This PR introduces a fix for both cases above to work.

### `tune.with_parameters` on a training function with a return value

Another issue addressed in this PR (let me know if this should be its own PR) is allowing `tune.with_parameters` to work with custom training functions that return a value.

```python
def train_func(config, extra_data=None):
    return {"metric": 1}  # train function returns a "final result"

# The return value gets dropped after wrapping with `tune.with_parameters`
trainable = tune.with_parameters(train_func, extra_data=1)
```

This PR returns the original training function's return value instead of dropping it.

### Open questions

1. If we introduce any more trainable wrapper utils, we will need to maintain compatibility by passing around the `_resource` attribute. Is there a better way to keep the resource specification information around?

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/29235

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
