### PR TITLE
[Tune] Deflake `testVerboseReporting`

### DIFF
--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -243,9 +243,9 @@ VERBOSE_TRIAL_NORM_1 = (
     "with parameters={'do': 'complete'}. This trial completed.\n"
 )
 
-# NOTE: We use Regex for `VERBOSE_TRIAL_NORM_2` to make the test deterministic. 
+# NOTE: We use Regex for `VERBOSE_TRIAL_NORM_2` to make the test deterministic.
 # `"Trial train_xxxxx_00001 reported..."` and `"Trial train_xxxxx_00001 completed..."`
-# are printed in separate calls. Sometimes, a status update is printed between the 
+# are printed in separate calls. Sometimes, a status update is printed between the
 # calls. For more information, see #29693.
 VERBOSE_TRIAL_NORM_2_PATTERN = (
     r"Trial train_xxxxx_00001 reported _metric=6 with parameters=\{'do': 'once'\}\."
@@ -254,8 +254,7 @@ VERBOSE_TRIAL_NORM_2_PATTERN = (
 )
 
 VERBOSE_TRIAL_NORM_3 = (
-    "Trial train_xxxxx_00002 reported acc=7 "
-    "with parameters={'do': 'twice'}.\n"
+    "Trial train_xxxxx_00002 reported acc=7 " "with parameters={'do': 'twice'}.\n"
 )
 
 VERBOSE_TRIAL_NORM_4 = (

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -248,9 +248,9 @@ VERBOSE_TRIAL_NORM_1 = (
 # are printed in separate calls. Sometimes, a status update is printed between the
 # calls. For more information, see #29693.
 VERBOSE_TRIAL_NORM_2_PATTERN = (
-    r"Trial train_xxxxx_00001 reported _metric=6 with parameters=\{'do': 'once'\}\."
+    r"Trial train_xxxxx_00001 reported _metric=6 with parameters=\{'do': 'once'\}\.\n"
     r"(?s).*"
-    r"Trial train_xxxxx_00001 completed\. Last result: _metric=6"
+    r"Trial train_xxxxx_00001 completed\. Last result: _metric=6\n"
 )
 
 VERBOSE_TRIAL_NORM_3 = (

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -254,7 +254,7 @@ VERBOSE_TRIAL_NORM_2_PATTERN = (
 )
 
 VERBOSE_TRIAL_NORM_3 = (
-    "Trial train_xxxxx_00002 reported acc=7 " "with parameters={'do': 'twice'}.\n"
+    "Trial train_xxxxx_00002 reported acc=7 with parameters={'do': 'twice'}.\n"
 )
 
 VERBOSE_TRIAL_NORM_4 = (

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -1,5 +1,6 @@
 import collections
 import os
+import regex as re
 import unittest
 from unittest.mock import MagicMock, Mock, patch
 
@@ -242,14 +243,20 @@ VERBOSE_TRIAL_NORM_1 = (
     "with parameters={'do': 'complete'}. This trial completed.\n"
 )
 
-VERBOSE_TRIAL_NORM_2 = """
-Trial train_xxxxx_00001 reported _metric=6 with parameters={'do': 'once'}.
-Trial train_xxxxx_00001 completed. Last result: _metric=6
-"""
+# NOTE: We use Regex for `VERBOSE_TRIAL_NORM_2` to make the test deterministic. 
+# `"Trial train_xxxxx_00001 reported..."` and `"Trial train_xxxxx_00001 completed..."`
+# are printed in separate calls. Sometimes, a status update is printed between the 
+# calls. For more information, see #29693.
+VERBOSE_TRIAL_NORM_2_PATTERN = (
+    r"Trial train_xxxxx_00001 reported _metric=6 with parameters=\{'do': 'once'\}\."
+    r"(?s).*"
+    r"Trial train_xxxxx_00001 completed\. Last result: _metric=6"
+)
 
-VERBOSE_TRIAL_NORM_3 = """
-Trial train_xxxxx_00002 reported acc=7 with parameters={'do': 'twice'}.
-"""
+VERBOSE_TRIAL_NORM_3 = (
+    "Trial train_xxxxx_00002 reported acc=7 "
+    "with parameters={'do': 'twice'}.\n"
+)
 
 VERBOSE_TRIAL_NORM_4 = (
     "Trial train_xxxxx_00002 reported acc=8 "
@@ -639,7 +646,7 @@ class ProgressReporterTest(unittest.TestCase):
                 self.assertNotIn(VERBOSE_EXP_OUT_1, output)
                 self.assertNotIn(VERBOSE_EXP_OUT_2, output)
                 self.assertNotIn(VERBOSE_TRIAL_NORM_1, output)
-                self.assertNotIn(VERBOSE_TRIAL_NORM_2, output)
+                self.assertIsNone(re.search(VERBOSE_TRIAL_NORM_2_PATTERN, output))
                 self.assertNotIn(VERBOSE_TRIAL_NORM_3, output)
                 self.assertNotIn(VERBOSE_TRIAL_NORM_4, output)
                 self.assertNotIn(VERBOSE_TRIAL_DETAIL, output)
@@ -655,7 +662,7 @@ class ProgressReporterTest(unittest.TestCase):
                 self.assertIn(VERBOSE_EXP_OUT_1, output)
                 self.assertIn(VERBOSE_EXP_OUT_2, output)
                 self.assertNotIn(VERBOSE_TRIAL_NORM_1, output)
-                self.assertNotIn(VERBOSE_TRIAL_NORM_2, output)
+                self.assertIsNone(re.search(VERBOSE_TRIAL_NORM_2_PATTERN, output))
                 self.assertNotIn(VERBOSE_TRIAL_NORM_3, output)
                 self.assertNotIn(VERBOSE_TRIAL_NORM_4, output)
                 self.assertNotIn(VERBOSE_TRIAL_DETAIL, output)
@@ -671,7 +678,7 @@ class ProgressReporterTest(unittest.TestCase):
                 self.assertIn(VERBOSE_EXP_OUT_1, output)
                 self.assertIn(VERBOSE_EXP_OUT_2, output)
                 self.assertIn(VERBOSE_TRIAL_NORM_1, output)
-                self.assertIn(VERBOSE_TRIAL_NORM_2, output)
+                self.assertIsNotNone(re.search(VERBOSE_TRIAL_NORM_2_PATTERN, output))
                 self.assertIn(VERBOSE_TRIAL_NORM_3, output)
                 self.assertIn(VERBOSE_TRIAL_NORM_4, output)
                 self.assertNotIn(VERBOSE_TRIAL_DETAIL, output)
@@ -687,7 +694,7 @@ class ProgressReporterTest(unittest.TestCase):
                 self.assertIn(VERBOSE_EXP_OUT_1, output)
                 self.assertIn(VERBOSE_EXP_OUT_2, output)
                 self.assertNotIn(VERBOSE_TRIAL_NORM_1, output)
-                self.assertNotIn(VERBOSE_TRIAL_NORM_2, output)
+                self.assertIsNone(re.search(VERBOSE_TRIAL_NORM_2_PATTERN, output))
                 self.assertNotIn(VERBOSE_TRIAL_NORM_3, output)
                 self.assertNotIn(VERBOSE_TRIAL_NORM_4, output)
                 self.assertIn(VERBOSE_TRIAL_DETAIL, output)


### PR DESCRIPTION
Signed-off-by: Balaji <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`ProgressReportingTest::testVerboseReporting` is flakey. For more information, see #29693.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #29693 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
