### PR TITLE
[RLlib] Deprecate `AlgorithmConfig.framework("tfe")`: Use `tf2` instead.

### DIFF
--- a/doc/source/rllib/rllib-training.rst
+++ b/doc/source/rllib/rllib-training.rst
@@ -345,20 +345,19 @@ The following is a list of the common algorithm hyper-parameters:
     # === Deep Learning Framework Settings ===
     # tf: TensorFlow (static-graph)
     # tf2: TensorFlow 2.x (eager or traced, if eager_tracing=True)
-    # tfe: TensorFlow eager (or traced, if eager_tracing=True)
     # torch: PyTorch
     "framework": "tf",
     # Enable tracing in eager mode. This greatly improves performance
     # (speedup ~2x), but makes it slightly harder to debug since Python
     # code won't be evaluated after the initial eager pass.
-    # Only possible if framework=[tf2|tfe].
+    # Only supported if framework=tf2.
     "eager_tracing": False,
     # Maximum number of tf.function re-traces before a runtime error is raised.
     # This is to prevent unnoticed retraces of methods inside the
     # `..._eager_traced` Policy, which could slow down execution by a
     # factor of 4, without the user noticing what the root cause for this
     # slowdown could be.
-    # Only necessary for framework=[tf2|tfe].
+    # Only supported for framework=tf2.
     # Set to None to ignore the re-trace count and never throw an error.
     "eager_max_retraces": 20,
 
@@ -1549,7 +1548,7 @@ Eager Mode
 
 Policies built with ``build_tf_policy`` (most of the reference algorithms are)
 can be run in eager mode by setting the
-``"framework": "[tf2|tfe]"`` / ``"eager_tracing": true`` config options or using
+``"framework": "tf2"`` / ``"eager_tracing": true`` config options or using
 ``rllib train --config '{"framework": "tf2"}' [--trace]``.
 This will tell RLlib to execute the model forward pass, action distribution,
 loss, and stats functions in eager mode.

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2680,7 +2680,7 @@ py_test(
     tags = ["team:rllib", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/complex_struct_space.py"],
-    args = ["--framework=tfe"],
+    args = ["--framework=tf2"],
 )
 
 py_test(

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2776,10 +2776,7 @@ class Algorithm(Trainable):
         # In case we are training (in a thread) parallel to evaluation,
         # we may have to re-enable eager mode here (gets disabled in the
         # thread).
-        if (
-            self.config.get("framework") == "tf2"
-            and not tf.executing_eagerly()
-        ):
+        if self.config.get("framework") == "tf2" and not tf.executing_eagerly():
             tf1.enable_eager_execution()
 
         results = None

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2223,7 +2223,7 @@ class Algorithm(Trainable):
         _tf1, _tf, _tfv = None, None, None
         _torch = None
         framework = config["framework"]
-        tf_valid_frameworks = {"tf", "tf2", "tfe"}
+        tf_valid_frameworks = {"tf", "tf2"}
         if framework not in tf_valid_frameworks and framework != "torch":
             return
         elif framework in tf_valid_frameworks:
@@ -2257,7 +2257,7 @@ class Algorithm(Trainable):
         def resolve_tf_settings():
             """Check and resolve tf settings."""
 
-            if _tf1 and config["framework"] in ["tf2", "tfe"]:
+            if _tf1 and config["framework"] == "tf2":
                 if config["framework"] == "tf2" and _tfv < 2:
                     raise ValueError(
                         "You configured `framework`=tf2, but your installed "
@@ -2323,7 +2323,7 @@ class Algorithm(Trainable):
             # TODO: AlphaStar uses >1 GPUs differently (1 per policy actor), so this is
             #  ok for tf2 here.
             #  Remove this hacky check, once we have fully moved to the RLTrainer API.
-            if framework in ["tfe", "tf2"] and type(self).__name__ != "AlphaStar":
+            if framework == "tf2" and type(self).__name__ != "AlphaStar":
                 raise ValueError(
                     "`num_gpus` > 1 not supported yet for "
                     "framework={}!".format(framework)
@@ -2378,7 +2378,7 @@ class Algorithm(Trainable):
 
         # User manually set simple-optimizer to False -> Error if tf-eager.
         elif simple_optim_setting is False:
-            if framework in ["tfe", "tf2"]:
+            if framework == "tf2":
                 raise ValueError(
                     "`simple_optimizer=False` not supported for "
                     "config.framework({})!".format(framework)
@@ -2777,7 +2777,7 @@ class Algorithm(Trainable):
         # we may have to re-enable eager mode here (gets disabled in the
         # thread).
         if (
-            self.config.get("framework") in ["tf2", "tfe"]
+            self.config.get("framework") == "tf2"
             and not tf.executing_eagerly()
         ):
             tf1.enable_eager_execution()

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -588,7 +588,7 @@ class AlgorithmConfig:
                 methods inside the `..._eager_traced` Policy, which could slow down
                 execution by a factor of 4, without the user noticing what the root
                 cause for this slowdown could be.
-                Only necessary for framework=[tf2|tfe].
+                Only necessary for framework=tf2.
                 Set to None to ignore the re-trace count and never throw an error.
             tf_session_args: Configures TF for single-process operation by default.
             local_tf_session_args: Override the following tf session args on the local
@@ -598,6 +598,12 @@ class AlgorithmConfig:
             This updated AlgorithmConfig object.
         """
         if framework is not None:
+            if framework == "tfe":
+                raise deprecation_warning(
+                    old="AlgorithmConfig.framework('tfe')",
+                    new="AlgorithmConfig.framework('tf2')",
+                    error=True,
+                )
             self.framework_str = framework
         if eager_tracing is not None:
             self.eager_tracing = eager_tracing

--- a/rllib/algorithms/ars/ars_tf_policy.py
+++ b/rllib/algorithms/ars/ars_tf_policy.py
@@ -46,12 +46,13 @@ class ARSTFPolicy(Policy):
                 tf1.enable_eager_execution()
             self.sess = self.inputs = None
             if config.get("seed") is not None:
-                # Tf2.x.
+                # Non-static-graph TF.
                 if config.get("framework") == "tf2":
-                    tf.random.set_seed(config["seed"])
-                # Tf-eager.
-                elif tf1 and config.get("framework") == "tfe":
-                    tf1.set_random_seed(config["seed"])
+                    # Tf1.x.
+                    if tf1:
+                        tf1.set_random_seed(config["seed"])
+                    else:
+                        tf.random.set_seed(config["seed"])
 
         # Policy network.
         self.dist_class, dist_dim = ModelCatalog.get_action_dist(

--- a/rllib/algorithms/cql/cql.py
+++ b/rllib/algorithms/cql/cql.py
@@ -151,7 +151,7 @@ class CQL(SAC):
         if config["simple_optimizer"] is not True and config["framework"] == "torch":
             config["simple_optimizer"] = True
 
-        if config["framework"] in ["tf", "tf2", "tfe"] and tfp is None:
+        if config["framework"] in ["tf", "tf2"] and tfp is None:
             logger.warning(
                 "You need `tensorflow_probability` in order to run CQL! "
                 "Install it via `pip install tensorflow_probability`. Your "

--- a/rllib/algorithms/cql/cql_tf_policy.py
+++ b/rllib/algorithms/cql/cql_tf_policy.py
@@ -299,7 +299,7 @@ class ActorCriticOptimizerMixin(SACActorCriticOptimizerMixin):
         super().__init__(config)
         if config["lagrangian"]:
             # Eager mode.
-            if config["framework"] in ["tf2", "tfe"]:
+            if config["framework"] == "tf2":
                 self._alpha_prime_optimizer = tf.keras.optimizers.Adam(
                     learning_rate=config["optimization"]["critic_learning_rate"]
                 )
@@ -354,7 +354,7 @@ def compute_gradients_fn(
     if policy.config["lagrangian"]:
         # Eager: Use GradientTape (which is a property of the `optimizer`
         # object (an OptimizerWrapper): see rllib/policy/eager_tf_policy.py).
-        if policy.config["framework"] in ["tf2", "tfe"]:
+        if policy.config["framework"] == "tf2":
             tape = optimizer.tape
             log_alpha_prime = [policy.model.log_alpha_prime]
             alpha_prime_grads_and_vars = list(
@@ -391,7 +391,7 @@ def apply_gradients_fn(policy, optimizer, grads_and_vars):
 
     if policy.config["lagrangian"]:
         # Eager mode -> Just apply and return None.
-        if policy.config["framework"] in ["tf2", "tfe"]:
+        if policy.config["framework"] == "tf2":
             policy._alpha_prime_optimizer.apply_gradients(
                 policy._alpha_prime_grads_and_vars
             )

--- a/rllib/algorithms/ddpg/ddpg_tf_policy.py
+++ b/rllib/algorithms/ddpg/ddpg_tf_policy.py
@@ -120,7 +120,7 @@ def get_ddpg_tf_policy(
             self,
         ) -> List["tf.keras.optimizers.Optimizer"]:
             """Create separate optimizers for actor & critic losses."""
-            if self.config["framework"] in ["tf2", "tfe"]:
+            if self.config["framework"] == "tf2":
                 self.global_step = get_variable(0, tf_name="global_step")
                 self._actor_optimizer = tf.keras.optimizers.Adam(
                     learning_rate=self.config["actor_lr"]
@@ -143,7 +143,7 @@ def get_ddpg_tf_policy(
         def compute_gradients_fn(
             self, optimizer: LocalOptimizer, loss: TensorType
         ) -> ModelGradients:
-            if self.config["framework"] in ["tf2", "tfe"]:
+            if self.config["framework"] == "tf2":
                 tape = optimizer.tape
                 pol_weights = self.model.policy_variables()
                 actor_grads_and_vars = list(
@@ -203,7 +203,7 @@ def get_ddpg_tf_policy(
                 self._critic_grads_and_vars
             )
             # Increment global step & apply ops.
-            if self.config["framework"] in ["tf2", "tfe"]:
+            if self.config["framework"] == "tf2":
                 self.global_step.assign_add(1)
                 return tf.no_op()
             else:

--- a/rllib/algorithms/ddpg/ddpg_tf_policy.py
+++ b/rllib/algorithms/ddpg/ddpg_tf_policy.py
@@ -326,7 +326,7 @@ def get_ddpg_tf_policy(
             # Compute RHS of bellman equation.
             q_t_selected_target = tf.stop_gradient(
                 tf.cast(train_batch[SampleBatch.REWARDS], tf.float32)
-                + gamma ** n_step * q_tp1_best_masked
+                + gamma**n_step * q_tp1_best_masked
             )
 
             # Compute the error (potentially clipped).

--- a/rllib/algorithms/ddpg/ddpg_tf_policy.py
+++ b/rllib/algorithms/ddpg/ddpg_tf_policy.py
@@ -326,7 +326,7 @@ def get_ddpg_tf_policy(
             # Compute RHS of bellman equation.
             q_t_selected_target = tf.stop_gradient(
                 tf.cast(train_batch[SampleBatch.REWARDS], tf.float32)
-                + gamma**n_step * q_tp1_best_masked
+                + gamma ** n_step * q_tp1_best_masked
             )
 
             # Compute the error (potentially clipped).

--- a/rllib/algorithms/dqn/dqn_tf_policy.py
+++ b/rllib/algorithms/dqn/dqn_tf_policy.py
@@ -339,7 +339,7 @@ def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> Tensor
 def adam_optimizer(
     policy: Policy, config: AlgorithmConfigDict
 ) -> "tf.keras.optimizers.Optimizer":
-    if policy.config["framework"] in ["tf2", "tfe"]:
+    if policy.config["framework"] == "tf2":
         return tf.keras.optimizers.Adam(
             learning_rate=policy.cur_lr, epsilon=config["adam_epsilon"]
         )

--- a/rllib/algorithms/dqn/dqn_tf_policy.py
+++ b/rllib/algorithms/dqn/dqn_tf_policy.py
@@ -60,7 +60,7 @@ class QLoss:
             z = v_min + z * (v_max - v_min) / float(num_atoms - 1)
 
             # (batch_size, 1) * (1, num_atoms) = (batch_size, num_atoms)
-            r_tau = tf.expand_dims(rewards, -1) + gamma ** n_step * tf.expand_dims(
+            r_tau = tf.expand_dims(rewards, -1) + gamma**n_step * tf.expand_dims(
                 1.0 - done_mask, -1
             ) * tf.expand_dims(z, 0)
             r_tau = tf.clip_by_value(r_tau, v_min, v_max)
@@ -100,7 +100,7 @@ class QLoss:
             q_tp1_best_masked = (1.0 - done_mask) * q_tp1_best
 
             # compute RHS of bellman equation
-            q_t_selected_target = rewards + gamma ** n_step * q_tp1_best_masked
+            q_t_selected_target = rewards + gamma**n_step * q_tp1_best_masked
 
             # compute the error (potentially clipped)
             self.td_error = q_t_selected - tf.stop_gradient(q_t_selected_target)

--- a/rllib/algorithms/dqn/dqn_tf_policy.py
+++ b/rllib/algorithms/dqn/dqn_tf_policy.py
@@ -60,7 +60,7 @@ class QLoss:
             z = v_min + z * (v_max - v_min) / float(num_atoms - 1)
 
             # (batch_size, 1) * (1, num_atoms) = (batch_size, num_atoms)
-            r_tau = tf.expand_dims(rewards, -1) + gamma**n_step * tf.expand_dims(
+            r_tau = tf.expand_dims(rewards, -1) + gamma ** n_step * tf.expand_dims(
                 1.0 - done_mask, -1
             ) * tf.expand_dims(z, 0)
             r_tau = tf.clip_by_value(r_tau, v_min, v_max)
@@ -100,7 +100,7 @@ class QLoss:
             q_tp1_best_masked = (1.0 - done_mask) * q_tp1_best
 
             # compute RHS of bellman equation
-            q_t_selected_target = rewards + gamma**n_step * q_tp1_best_masked
+            q_t_selected_target = rewards + gamma ** n_step * q_tp1_best_masked
 
             # compute the error (potentially clipped)
             self.td_error = q_t_selected - tf.stop_gradient(q_t_selected_target)

--- a/rllib/algorithms/dqn/learner_thread.py
+++ b/rllib/algorithms/dqn/learner_thread.py
@@ -36,7 +36,7 @@ class LearnerThread(threading.Thread):
 
     def run(self):
         # Switch on eager mode if configured.
-        if self.local_worker.policy_config.get("framework") in ["tf2", "tfe"]:
+        if self.local_worker.policy_config.get("framework") == "tf2":
             tf1.enable_eager_execution()
         while not self.stopped:
             self.step()

--- a/rllib/algorithms/es/es_tf_policy.py
+++ b/rllib/algorithms/es/es_tf_policy.py
@@ -109,10 +109,10 @@ class ESTFPolicy(Policy):
             self.sess = self.inputs = None
             if config.get("seed") is not None:
                 # Tf2.x.
-                if config.get("framework") == "tf2":
+                if tfv == 2:
                     tf.random.set_seed(config["seed"])
-                # Tf-eager.
-                elif tf1 and config.get("framework") == "tfe":
+                # Tf1.x.
+                else:
                     tf1.set_random_seed(config["seed"])
 
         # Policy network.

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -524,7 +524,7 @@ class Impala(Algorithm):
             # TODO(sven): Need to change APPO|IMPALATorchPolicies (and the
             #  models to return separate sets of weights in order to create
             #  the different torch optimizers).
-            if config["framework"] not in ["tf", "tf2", "tfe"]:
+            if config["framework"] not in ["tf", "tf2"]:
                 raise ValueError(
                     "`_separate_vf_optimizer` only supported to tf so far!"
                 )

--- a/rllib/algorithms/impala/impala_tf_policy.py
+++ b/rllib/algorithms/impala/impala_tf_policy.py
@@ -226,7 +226,7 @@ class VTraceOptimizer:
     ) -> Union["tf.keras.optimizers.Optimizer", List["tf.keras.optimizers.Optimizer"]]:
         config = self.config
         if config["opt_type"] == "adam":
-            if config["framework"] in ["tf2", "tfe"]:
+            if config["framework"] == "tf2":
                 optim = tf.keras.optimizers.Adam(self.cur_lr)
                 if config["_separate_vf_optimizer"]:
                     return optim, tf.keras.optimizers.Adam(config["_lr_vf"])

--- a/rllib/algorithms/marwil/marwil_tf_policy.py
+++ b/rllib/algorithms/marwil/marwil_tf_policy.py
@@ -98,7 +98,7 @@ class MARWILLoss:
 
             # Update averaged advantage norm.
             # Eager.
-            if policy.config["framework"] in ["tf2", "tfe"]:
+            if policy.config["framework"] == "tf2":
                 update_term = adv_squared - policy._moving_average_sqd_adv_norm
                 policy._moving_average_sqd_adv_norm.assign_add(rate * update_term)
 

--- a/rllib/algorithms/ppo/tests/test_ppo.py
+++ b/rllib/algorithms/ppo/tests/test_ppo.py
@@ -308,7 +308,7 @@ class TestPPO(unittest.TestCase):
             check(train_batch[Postprocessing.VALUE_TARGETS], [0.50005, -0.505, 0.5])
 
             # Calculate actual PPO loss.
-            if fw in ["tf2", "tfe"]:
+            if fw == "tf2":
                 PPOTF2Policy.loss(policy, policy.model, Categorical, train_batch)
             elif fw == "torch":
                 PPOTorchPolicy.loss(

--- a/rllib/algorithms/sac/sac.py
+++ b/rllib/algorithms/sac/sac.py
@@ -335,7 +335,7 @@ class SAC(DQN):
         if config["grad_clip"] is not None and config["grad_clip"] <= 0.0:
             raise ValueError("`grad_clip` value must be > 0.0!")
 
-        if config["framework"] in ["tf", "tf2", "tfe"] and tfp is None:
+        if config["framework"] in ["tf", "tf2"] and tfp is None:
             logger.warning(
                 "You need `tensorflow_probability` in order to run SAC! "
                 "Install it via `pip install tensorflow_probability`. Your "

--- a/rllib/algorithms/sac/sac_tf_policy.py
+++ b/rllib/algorithms/sac/sac_tf_policy.py
@@ -457,7 +457,7 @@ def compute_and_clip_gradients(
     """
     # Eager: Use GradientTape (which is a property of the `optimizer` object
     # (an OptimizerWrapper): see rllib/policy/eager_tf_policy.py).
-    if policy.config["framework"] in ["tf2", "tfe"]:
+    if policy.config["framework"] == "tf2":
         tape = optimizer.tape
         pol_weights = policy.model.policy_variables()
         actor_grads_and_vars = list(
@@ -563,7 +563,7 @@ def apply_gradients(
         critic_apply_ops = [policy._critic_optimizer[0].apply_gradients(cgrads)]
 
     # Eager mode -> Just apply and return None.
-    if policy.config["framework"] in ["tf2", "tfe"]:
+    if policy.config["framework"] == "tf2":
         policy._alpha_optimizer.apply_gradients(policy._alpha_grads_and_vars)
         return
     # Tf static graph -> Return op.
@@ -607,7 +607,7 @@ class ActorCriticOptimizerMixin:
 
     def __init__(self, config):
         # Eager mode.
-        if config["framework"] in ["tf2", "tfe"]:
+        if config["framework"] == "tf2":
             self.global_step = get_variable(0, tf_name="global_step")
             self._actor_optimizer = tf.keras.optimizers.Adam(
                 learning_rate=config["optimization"]["actor_learning_rate"]

--- a/rllib/algorithms/sac/tests/test_sac.py
+++ b/rllib/algorithms/sac/tests/test_sac.py
@@ -260,7 +260,7 @@ class TestSAC(unittest.TestCase):
             # Set all weights (of all nets) to fixed values.
             if weights_dict is None:
                 # Start with the tf vars-dict.
-                assert fw in ["tf2", "tf", "tfe"]
+                assert fw in ["tf2", "tf"]
 
                 weights_dict_list = (
                     policy.model.variables() + policy.target_model.variables()
@@ -271,9 +271,9 @@ class TestSAC(unittest.TestCase):
                     )
                     weights_dict = collector.get_weights()
 
-                if fw == "tfe":
+                if fw == "tf2":
                     log_alpha = weights_dict[10]
-                    weights_dict = self._translate_tfe_weights(weights_dict, map_)
+                    weights_dict = self._translate_tf2_weights(weights_dict, map_)
             else:
                 assert fw == "torch"  # Then transfer that to torch Model.
                 model_dict = self._translate_weights_to_torch(weights_dict, map_)
@@ -339,7 +339,7 @@ class TestSAC(unittest.TestCase):
                 tf_a_grads = [g for g, v in tf_a_grads]
                 tf_e_grads = [g for g, v in tf_e_grads]
 
-            elif fw == "tfe":
+            elif fw == "tf2":
                 with tf.GradientTape() as tape:
                     tf_loss(policy, policy.model, None, input_)
                 c, a, e, t = (
@@ -680,7 +680,7 @@ class TestSAC(unittest.TestCase):
                 framework=fw,
             )
         else:
-            assert fw == "tfe"
+            assert fw == "tf2"
             q_tp1 = fc(
                 relu(
                     fc(
@@ -733,7 +733,7 @@ class TestSAC(unittest.TestCase):
 
         return model_dict
 
-    def _translate_tfe_weights(self, weights_dict, map_):
+    def _translate_tf2_weights(self, weights_dict, map_):
         model_dict = {
             "default_policy/log_alpha": None,
             "default_policy/log_alpha_target": None,

--- a/rllib/algorithms/slateq/slateq_tf_policy.py
+++ b/rllib/algorithms/slateq/slateq_tf_policy.py
@@ -344,7 +344,7 @@ def setup_late_mixins(
 def rmsprop_optimizer(
     policy: Policy, config: AlgorithmConfigDict
 ) -> "tf.keras.optimizers.Optimizer":
-    if policy.config["framework"] in ["tf2", "tfe"]:
+    if policy.config["framework"] == "tf2":
         return tf.keras.optimizers.RMSprop(
             learning_rate=policy.cur_lr,
             epsilon=config["rmsprop_epsilon"],

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -487,9 +487,7 @@ class RolloutWorker(ParallelIteratorWorker):
 
         if (
             tf1
-            and (
-                config.framework_str == "tf2" or config.enable_tf1_exec_eagerly
-            )
+            and (config.framework_str == "tf2" or config.enable_tf1_exec_eagerly)
             # This eager check is necessary for certain all-framework tests
             # that use tf's eager_mode() context generator.
             and not tf1.executing_eagerly()

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -488,7 +488,7 @@ class RolloutWorker(ParallelIteratorWorker):
         if (
             tf1
             and (
-                config.framework_str in ["tf2", "tfe"] or config.enable_tf1_exec_eagerly
+                config.framework_str == "tf2" or config.enable_tf1_exec_eagerly
             )
             # This eager check is necessary for certain all-framework tests
             # that use tf's eager_mode() context generator.
@@ -667,7 +667,7 @@ class RolloutWorker(ParallelIteratorWorker):
         ):
 
             devices = []
-            if self.config.framework_str in ["tf2", "tf", "tfe"]:
+            if self.config.framework_str in ["tf2", "tf"]:
                 devices = get_tf_gpu_devices()
             elif self.config.framework_str == "torch":
                 devices = list(range(torch.cuda.device_count()))

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -451,10 +451,10 @@ class AsyncSampler(threading.Thread, SamplerInput):
             raise e
 
     def _run(self):
-        # We are in a thread: Switch on eager execution mode, iff framework==tf2|tfe.
+        # We are in a thread: Switch on eager execution mode, iff framework==tf2.
         if (
             tf1
-            and self.worker.config.framework_str in ["tf2", "tfe"]
+            and self.worker.config.framework_str == "tf2"
             and not tf1.executing_eagerly()
         ):
             tf1.enable_eager_execution()

--- a/rllib/examples/action_masking.py
+++ b/rllib/examples/action_masking.py
@@ -69,7 +69,7 @@ def get_cli_args():
     parser.add_argument("--num-cpus", type=int, default=0)
     parser.add_argument(
         "--framework",
-        choices=["tf", "tf2", "tfe", "torch"],
+        choices=["tf", "tf2", "torch"],
         default="tf",
         help="The DL framework specifier.",
     )
@@ -131,7 +131,7 @@ if __name__ == "__main__":
         # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
         "num_gpus": int(os.environ.get("RLLIB_NUM_GPUS", "0")),
         "framework": args.framework,
-        # Run with tracing enabled for tfe/tf2?
+        # Run with tracing enabled for tf2?
         "eager_tracing": args.eager_tracing,
     }
 

--- a/rllib/examples/attention_net.py
+++ b/rllib/examples/attention_net.py
@@ -73,7 +73,7 @@ def get_cli_args():
     parser.add_argument("--num-cpus", type=int, default=3)
     parser.add_argument(
         "--framework",
-        choices=["tf", "tf2", "tfe", "torch"],
+        choices=["tf", "tf2", "torch"],
         default="tf",
         help="The DL framework specifier.",
     )

--- a/rllib/examples/autoregressive_action_dist.py
+++ b/rllib/examples/autoregressive_action_dist.py
@@ -73,7 +73,7 @@ def get_cli_args():
     )
     parser.add_argument(
         "--framework",
-        choices=["tf", "tf2", "tfe", "torch"],
+        choices=["tf", "tf2", "torch"],
         default="tf",
         help="The DL framework specifier.",
     )

--- a/rllib/examples/batch_norm_model.py
+++ b/rllib/examples/batch_norm_model.py
@@ -22,7 +22,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/cartpole_lstm.py
+++ b/rllib/examples/cartpole_lstm.py
@@ -11,7 +11,7 @@ parser.add_argument(
 parser.add_argument("--num-cpus", type=int, default=0)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )
@@ -70,7 +70,7 @@ if __name__ == "__main__":
                 "lstm_use_prev_reward": args.use_prev_reward,
             },
             "framework": args.framework,
-            # Run with tracing enabled for tfe/tf2?
+            # Run with tracing enabled for tf2?
             "eager_tracing": args.eager_tracing,
         }
     )

--- a/rllib/examples/centralized_critic.py
+++ b/rllib/examples/centralized_critic.py
@@ -50,7 +50,7 @@ OPPONENT_ACTION = "opponent_action"
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/centralized_critic_2.py
+++ b/rllib/examples/centralized_critic_2.py
@@ -28,7 +28,7 @@ from ray.rllib.utils.test_utils import check_learning_achieved
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/checkpoint_by_custom_criteria.py
+++ b/rllib/examples/checkpoint_by_custom_criteria.py
@@ -11,7 +11,7 @@ parser.add_argument(
 parser.add_argument("--num-cpus", type=int, default=0)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )
@@ -32,8 +32,8 @@ if __name__ == "__main__":
         # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
         "num_gpus": int(os.environ.get("RLLIB_NUM_GPUS", "0")),
         "framework": args.framework,
-        # Run with tracing enabled for tfe/tf2.
-        "eager_tracing": args.framework in ["tfe", "tf2"],
+        # Run with tracing enabled for tf2.
+        "eager_tracing": args.framework == "tf2",
     }
 
     stop = {

--- a/rllib/examples/complex_struct_space.py
+++ b/rllib/examples/complex_struct_space.py
@@ -4,7 +4,7 @@ This example shows:
   - using a custom environment with Repeated / struct observations
   - using a custom model to view the batched list observations
 
-For PyTorch / TF eager mode, use the `--framework=[torch|tf2|tfe]` flag.
+For PyTorch / TF eager mode, use the `--framework=[torch|tf2]` flag.
 """
 
 import argparse
@@ -22,7 +22,7 @@ from ray.rllib.examples.models.simple_rpg_model import (
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf2",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/curriculum_learning.py
+++ b/rllib/examples/curriculum_learning.py
@@ -31,7 +31,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/custom_env.py
+++ b/rllib/examples/custom_env.py
@@ -42,7 +42,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/custom_eval.py
+++ b/rllib/examples/custom_eval.py
@@ -80,7 +80,7 @@ parser.add_argument("--evaluation-parallel-to-training", action="store_true")
 parser.add_argument("--num-cpus", type=int, default=0)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/custom_fast_model.py
+++ b/rllib/examples/custom_fast_model.py
@@ -18,7 +18,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--num-cpus", type=int, default=4)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/custom_input_api.py
+++ b/rllib/examples/custom_input_api.py
@@ -24,7 +24,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/custom_logger.py
+++ b/rllib/examples/custom_logger.py
@@ -24,7 +24,7 @@ parser.add_argument(
 parser.add_argument("--num-cpus", type=int, default=0)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )
@@ -80,8 +80,8 @@ if __name__ == "__main__":
         # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
         "num_gpus": int(os.environ.get("RLLIB_NUM_GPUS", "0")),
         "framework": args.framework,
-        # Run with tracing enabled for tfe/tf2.
-        "eager_tracing": args.framework in ["tfe", "tf2"],
+        # Run with tracing enabled for tf2.
+        "eager_tracing": args.framework == "tf2",
         # Setting up a custom logger config.
         # ----------------------------------
         # The following are different examples of custom logging setups:

--- a/rllib/examples/custom_metrics_and_callbacks.py
+++ b/rllib/examples/custom_metrics_and_callbacks.py
@@ -20,7 +20,7 @@ from ray.rllib.policy.sample_batch import SampleBatch
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/custom_model_api.py
+++ b/rllib/examples/custom_model_api.py
@@ -18,7 +18,7 @@ torch, _ = try_import_torch()
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/custom_model_loss_and_metrics.py
+++ b/rllib/examples/custom_model_loss_and_metrics.py
@@ -33,7 +33,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/custom_rnn_model.py
+++ b/rllib/examples/custom_rnn_model.py
@@ -20,7 +20,7 @@ parser.add_argument("--env", type=str, default="RepeatAfterMeEnv")
 parser.add_argument("--num-cpus", type=int, default=0)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/custom_train_fn.py
+++ b/rllib/examples/custom_train_fn.py
@@ -15,7 +15,7 @@ from ray.rllib.algorithms.ppo import PPO
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/custom_vector_env.py
+++ b/rllib/examples/custom_vector_env.py
@@ -16,7 +16,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/deterministic_training.py
+++ b/rllib/examples/deterministic_training.py
@@ -16,7 +16,7 @@ from ray.rllib.utils.test_utils import check
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--run", type=str, default="PPO")
-parser.add_argument("--framework", choices=["tf2", "tf", "tfe", "torch"], default="tf")
+parser.add_argument("--framework", choices=["tf2", "tf", "torch"], default="tf")
 parser.add_argument("--seed", type=int, default=42)
 parser.add_argument("--as-test", action="store_true")
 parser.add_argument("--stop-iters", type=int, default=2)

--- a/rllib/examples/eager_execution.py
+++ b/rllib/examples/eager_execution.py
@@ -25,8 +25,8 @@ tf1, tf, tfv = try_import_tf()
 # >> x.numpy()
 # 0.0
 
-# RLlib will automatically enable eager mode, if you specify your "framework"
-# config key to be either "tfe" or "tf2".
+# RLlib will automatically enable eager mode, if you set
+# AlgorithmConfig.framework("tf2", eager_tracing=False).
 # If you would like to remain in tf static-graph mode, but still use tf2.x's
 # new APIs (some of which are not supported by tf1.x), specify your "framework"
 # as "tf" and check for the version (tfv) to be 2:

--- a/rllib/examples/env_rendering_and_recording.py
+++ b/rllib/examples/env_rendering_and_recording.py
@@ -10,7 +10,7 @@ from ray.rllib.env.multi_agent_env import make_multi_agent
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/fractional_gpus.py
+++ b/rllib/examples/fractional_gpus.py
@@ -24,7 +24,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/hierarchical_training.py
+++ b/rllib/examples/hierarchical_training.py
@@ -36,7 +36,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--flat", action="store_true")
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/inference_and_serving/policy_inference_after_training.py
+++ b/rllib/examples/inference_and_serving/policy_inference_after_training.py
@@ -20,7 +20,7 @@ parser.add_argument(
 parser.add_argument("--num-cpus", type=int, default=0)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )
@@ -66,7 +66,7 @@ if __name__ == "__main__":
         # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
         "num_gpus": int(os.environ.get("RLLIB_NUM_GPUS", "0")),
         "framework": args.framework,
-        # Run with tracing enabled for tfe/tf2?
+        # Run with tracing enabled for tf2?
         "eager_tracing": args.eager_tracing,
     }
 

--- a/rllib/examples/inference_and_serving/policy_inference_after_training_with_attention.py
+++ b/rllib/examples/inference_and_serving/policy_inference_after_training_with_attention.py
@@ -21,7 +21,7 @@ parser.add_argument(
 parser.add_argument("--num-cpus", type=int, default=0)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )
@@ -93,7 +93,7 @@ if __name__ == "__main__":
             "attention_memory_training": 10,
         },
         "framework": args.framework,
-        # Run with tracing enabled for tfe/tf2?
+        # Run with tracing enabled for tf2?
         "eager_tracing": args.eager_tracing,
     }
 

--- a/rllib/examples/inference_and_serving/policy_inference_after_training_with_lstm.py
+++ b/rllib/examples/inference_and_serving/policy_inference_after_training_with_lstm.py
@@ -21,7 +21,7 @@ parser.add_argument(
 parser.add_argument("--num-cpus", type=int, default=0)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )
@@ -88,7 +88,7 @@ if __name__ == "__main__":
             "lstm_use_prev_reward": args.prev_reward,
         },
         "framework": args.framework,
-        # Run with tracing enabled for tfe/tf2?
+        # Run with tracing enabled for tf2?
         "eager_tracing": args.eager_tracing,
     }
 

--- a/rllib/examples/inference_and_serving/serve_and_rllib.py
+++ b/rllib/examples/inference_and_serving/serve_and_rllib.py
@@ -18,7 +18,7 @@ from ray import serve
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/iterated_prisoners_dilemma_env.py
+++ b/rllib/examples/iterated_prisoners_dilemma_env.py
@@ -15,7 +15,7 @@ from ray.rllib.examples.env.matrix_sequential_social_dilemma import (
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/mobilenet_v2_with_lstm.py
+++ b/rllib/examples/mobilenet_v2_with_lstm.py
@@ -25,7 +25,7 @@ cnn_shape_torch = (3, 224, 224)
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/multi_agent_cartpole.py
+++ b/rllib/examples/multi_agent_cartpole.py
@@ -36,7 +36,7 @@ parser.add_argument("--num-policies", type=int, default=2)
 parser.add_argument("--num-cpus", type=int, default=0)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     # Register the models to use.
     if args.framework == "torch":
         mod1 = mod2 = TorchSharedWeightsModel
-    elif args.framework in ["tfe", "tf2"]:
+    elif args.framework == "tf2":
         mod1 = mod2 = TF2SharedWeightsModel
     else:
         mod1 = SharedWeightsModel1

--- a/rllib/examples/multi_agent_custom_policy.py
+++ b/rllib/examples/multi_agent_custom_policy.py
@@ -27,7 +27,7 @@ from ray.rllib.utils.test_utils import check_learning_achieved
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/multi_agent_different_spaces_for_agents.py
+++ b/rllib/examples/multi_agent_different_spaces_for_agents.py
@@ -78,7 +78,7 @@ def get_cli_args():
     parser.add_argument("--num-cpus", type=int, default=0)
     parser.add_argument(
         "--framework",
-        choices=["tf", "tf2", "tfe", "torch"],
+        choices=["tf", "tf2", "torch"],
         default="tf",
         help="The DL framework specifier.",
     )

--- a/rllib/examples/multi_agent_two_trainers.py
+++ b/rllib/examples/multi_agent_two_trainers.py
@@ -28,7 +28,7 @@ parser = argparse.ArgumentParser()
 # Use torch for both policies.
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/nested_action_spaces.py
+++ b/rllib/examples/nested_action_spaces.py
@@ -16,7 +16,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/parallel_evaluation_and_training.py
+++ b/rllib/examples/parallel_evaluation_and_training.py
@@ -41,7 +41,7 @@ parser.add_argument(
 parser.add_argument("--num-cpus", type=int, default=0)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )
@@ -125,8 +125,8 @@ if __name__ == "__main__":
         # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
         "num_gpus": int(os.environ.get("RLLIB_NUM_GPUS", "0")),
         "framework": args.framework,
-        # Run with tracing enabled for tfe/tf2.
-        "eager_tracing": args.framework in ["tfe", "tf2"],
+        # Run with tracing enabled for tf2.
+        "eager_tracing": args.framework == "tf2",
         # Parallel evaluation+training config.
         # Switch on evaluation in parallel with training.
         "evaluation_parallel_to_training": True,

--- a/rllib/examples/parametric_actions_cartpole.py
+++ b/rllib/examples/parametric_actions_cartpole.py
@@ -34,7 +34,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/parametric_actions_cartpole_embeddings_learnt_by_model.py
+++ b/rllib/examples/parametric_actions_cartpole_embeddings_learnt_by_model.py
@@ -33,7 +33,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--run", type=str, default="PPO")
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe"],
+    choices=["tf", "tf2"],
     default="tf",
     help="The DL framework specifier (torch not supported yet "
     "due to lack of model).",

--- a/rllib/examples/preprocessing_disabled.py
+++ b/rllib/examples/preprocessing_disabled.py
@@ -29,7 +29,7 @@ def get_cli_args():
     parser.add_argument("--num-cpus", type=int, default=3)
     parser.add_argument(
         "--framework",
-        choices=["tf", "tf2", "tfe", "torch"],
+        choices=["tf", "tf2", "torch"],
         default="tf",
         help="The DL framework specifier.",
     )

--- a/rllib/examples/recommender_system_with_recsim_and_slateq.py
+++ b/rllib/examples/recommender_system_with_recsim_and_slateq.py
@@ -34,7 +34,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/remote_base_env_with_custom_api.py
+++ b/rllib/examples/remote_base_env_with_custom_api.py
@@ -22,7 +22,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/remote_envs_with_inference_done_on_main_node.py
+++ b/rllib/examples/remote_envs_with_inference_done_on_main_node.py
@@ -33,7 +33,7 @@ def get_cli_args():
     # general args
     parser.add_argument(
         "--framework",
-        choices=["tf", "tf2", "tfe", "torch"],
+        choices=["tf", "tf2", "torch"],
         default="tf",
         help="The DL framework specifier.",
     )

--- a/rllib/examples/replay_buffer_api.py
+++ b/rllib/examples/replay_buffer_api.py
@@ -23,7 +23,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--num-cpus", type=int, default=0)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/restore_1_of_n_agents_from_checkpoint.py
+++ b/rllib/examples/restore_1_of_n_agents_from_checkpoint.py
@@ -32,7 +32,7 @@ parser.add_argument("--pre-training-iters", type=int, default=5)
 parser.add_argument("--num-cpus", type=int, default=0)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/rock_paper_scissors_multiagent.py
+++ b/rllib/examples/rock_paper_scissors_multiagent.py
@@ -37,7 +37,7 @@ torch, _ = try_import_torch()
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )
@@ -159,7 +159,6 @@ def run_with_custom_entropy_loss(args, stop):
         "torch": PGTorchPolicy,
         "tf": PGTF1Policy,
         "tf2": PGTF2Policy,
-        "tfe": PGTF2Policy,
     }[args.framework]
 
     class EntropyPolicy(policy_cls):

--- a/rllib/examples/self_play_league_based_with_open_spiel.py
+++ b/rllib/examples/self_play_league_based_with_open_spiel.py
@@ -50,7 +50,7 @@ from ray.tune import register_env
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/self_play_with_open_spiel.py
+++ b/rllib/examples/self_play_with_open_spiel.py
@@ -37,7 +37,7 @@ from ray.tune import CLIReporter, register_env
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/serving/cartpole_server.py
+++ b/rllib/examples/serving/cartpole_server.py
@@ -83,7 +83,7 @@ def get_cli_args():
     parser.add_argument("--num-cpus", type=int, default=3)
     parser.add_argument(
         "--framework",
-        choices=["tf", "tf2", "tfe", "torch"],
+        choices=["tf", "tf2", "torch"],
         default="tf",
         help="The DL framework specifier.",
     )

--- a/rllib/examples/serving/unity3d_server.py
+++ b/rllib/examples/serving/unity3d_server.py
@@ -48,7 +48,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/trajectory_view_api.py
+++ b/rllib/examples/trajectory_view_api.py
@@ -21,7 +21,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/two_step_game.py
+++ b/rllib/examples/two_step_game.py
@@ -30,7 +30,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/unity3d_env_local.py
+++ b/rllib/examples/unity3d_env_local.py
@@ -93,7 +93,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )

--- a/rllib/examples/vizdoom_with_attention_net.py
+++ b/rllib/examples/vizdoom_with_attention_net.py
@@ -8,7 +8,7 @@ parser.add_argument(
 parser.add_argument("--num-cpus", type=int, default=0)
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default="tf",
     help="The DL framework specifier.",
 )
@@ -54,8 +54,8 @@ if __name__ == "__main__":
             "attention_use_n_prev_rewards": args.use_n_prev_rewards,
         },
         "framework": args.framework,
-        # Run with tracing enabled for tfe/tf2.
-        "eager_tracing": args.framework in ["tfe", "tf2"],
+        # Run with tracing enabled for tf2.
+        "eager_tracing": args.framework == "tf2",
         "num_workers": args.num_workers,
         "vf_loss_coeff": 0.01,
     }

--- a/rllib/execution/learner_thread.py
+++ b/rllib/execution/learner_thread.py
@@ -68,7 +68,7 @@ class LearnerThread(threading.Thread):
 
     def run(self) -> None:
         # Switch on eager mode if configured.
-        if self.local_worker.policy_config.get("framework") in ["tf2", "tfe"]:
+        if self.local_worker.policy_config.get("framework") == "tf2":
             tf1.enable_eager_execution()
         while not self.stopped:
             self.step()

--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -305,14 +305,10 @@ class ModelCatalog:
             else:
                 dist_cls = Categorical
         # Tuple/Dict Spaces -> MultiAction.
-        elif (
-            dist_type
-            in (
-                MultiActionDistribution,
-                TorchMultiActionDistribution,
-            )
-            or isinstance(action_space, (Tuple, Dict))
-        ):
+        elif dist_type in (
+            MultiActionDistribution,
+            TorchMultiActionDistribution,
+        ) or isinstance(action_space, (Tuple, Dict)):
             return ModelCatalog._get_multi_action_distribution(
                 (
                     MultiActionDistribution

--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -305,10 +305,14 @@ class ModelCatalog:
             else:
                 dist_cls = Categorical
         # Tuple/Dict Spaces -> MultiAction.
-        elif dist_type in (
-            MultiActionDistribution,
-            TorchMultiActionDistribution,
-        ) or isinstance(action_space, (Tuple, Dict)):
+        elif (
+            dist_type
+            in (
+                MultiActionDistribution,
+                TorchMultiActionDistribution,
+            )
+            or isinstance(action_space, (Tuple, Dict))
+        ):
             return ModelCatalog._get_multi_action_distribution(
                 (
                     MultiActionDistribution
@@ -755,8 +759,7 @@ class ModelCatalog:
             )
         else:
             raise NotImplementedError(
-                "`framework` must be 'tf2|tf|torch', but is "
-                "{}!".format(framework)
+                "`framework` must be 'tf2|tf|torch', but is " "{}!".format(framework)
             )
 
     @staticmethod

--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -224,7 +224,7 @@ class ModelCatalog:
             dist_type (Optional[Union[str, Type[ActionDistribution]]]):
                 Identifier of the action distribution (str) interpreted as a
                 hint or the actual ActionDistribution class to use.
-            framework: One of "tf2", "tf", "tfe", "torch", or "jax".
+            framework: One of "tf2", "tf", "torch", or "jax".
             kwargs: Optional kwargs to pass on to the Distribution's
                 constructor.
 
@@ -428,7 +428,7 @@ class ModelCatalog:
             num_outputs: The size of the output vector of the model.
             model_config: The "model" sub-config dict
                 within the Trainer's config dict.
-            framework: One of "tf2", "tf", "tfe", "torch", or "jax".
+            framework: One of "tf2", "tf", "torch", or "jax".
             name: Name (scope) for the model.
             model_interface: Interface required for the model
             default_model: Override the default class for the model. This
@@ -472,7 +472,7 @@ class ModelCatalog:
 
             # Only allow ModelV2 or native keras Models.
             if not issubclass(model_cls, ModelV2):
-                if framework not in ["tf", "tf2", "tfe"] or not issubclass(
+                if framework not in ["tf", "tf2"] or not issubclass(
                     model_cls, tf.keras.Model
                 ):
                     raise ValueError(
@@ -483,7 +483,7 @@ class ModelCatalog:
             logger.info("Wrapping {} as {}".format(model_cls, model_interface))
             model_cls = ModelCatalog._wrap_if_needed(model_cls, model_interface)
 
-            if framework in ["tf2", "tf", "tfe"]:
+            if framework in ["tf2", "tf"]:
                 # Try wrapping custom model with LSTM/attention, if required.
                 if model_config.get("use_lstm") or model_config.get("use_attention"):
                     from ray.rllib.models.tf.attention_net import (
@@ -644,14 +644,14 @@ class ModelCatalog:
                         raise e
             else:
                 raise NotImplementedError(
-                    "`framework` must be 'tf2|tf|tfe|torch', but is "
+                    "`framework` must be 'tf2|tf|torch', but is "
                     "{}!".format(framework)
                 )
 
             return instance
 
         # Find a default TFModelV2 and wrap with model_interface.
-        if framework in ["tf", "tfe", "tf2"]:
+        if framework in ["tf", "tf2"]:
             v2_class = None
             # Try to get a default v2 model.
             if not model_config.get("custom_model"):
@@ -755,7 +755,7 @@ class ModelCatalog:
             )
         else:
             raise NotImplementedError(
-                "`framework` must be 'tf2|tf|tfe|torch', but is "
+                "`framework` must be 'tf2|tf|torch', but is "
                 "{}!".format(framework)
             )
 
@@ -897,7 +897,7 @@ class ModelCatalog:
         Keras_FCNet = None
         Keras_VisionNet = None
 
-        if framework in ["tf2", "tf", "tfe"]:
+        if framework in ["tf2", "tf"]:
             from ray.rllib.models.tf.fcnet import (
                 FullyConnectedNetwork as FCNet,
                 Keras_FullyConnectedNetwork as Keras_FCNet,
@@ -998,7 +998,7 @@ class ModelCatalog:
                 within the Trainer's config dict.
             action_space: The action space of the model, whose config are
                     validated.
-            framework: One of "jax", "tf2", "tf", "tfe", or "torch".
+            framework: One of "jax", "tf2", "tf", or "torch".
 
         Raises:
             ValueError: If something is wrong with the given config.

--- a/rllib/models/modelv2.py
+++ b/rllib/models/modelv2.py
@@ -367,7 +367,7 @@ class ModelV2:
 @DeveloperAPI
 def flatten(obs: TensorType, framework: str) -> TensorType:
     """Flatten the given tensor."""
-    if framework in ["tf2", "tf", "tfe"]:
+    if framework in ["tf2", "tf"]:
         return tf1.keras.layers.Flatten()(obs)
     elif framework == "torch":
         assert torch is not None
@@ -398,7 +398,7 @@ def restore_original_dimensions(
         observation space.
     """
 
-    if tensorlib in ["tf", "tfe", "tf2"]:
+    if tensorlib in ["tf", "tf2"]:
         assert tf is not None
         tensorlib = tf
     elif tensorlib == "torch":

--- a/rllib/models/tests/test_distributions.py
+++ b/rllib/models/tests/test_distributions.py
@@ -491,9 +491,7 @@ class TestDistributions(unittest.TestCase):
 
     def test_gumbel_softmax(self):
         """Tests the GumbelSoftmax ActionDistribution (tf + eager only)."""
-        for fw, sess in framework_iterator(
-            frameworks=("tf2", "tf"), session=True
-        ):
+        for fw, sess in framework_iterator(frameworks=("tf2", "tf"), session=True):
             batch_size = 1000
             num_categories = 5
             input_space = Box(-1.0, 1.0, shape=(batch_size, num_categories))

--- a/rllib/models/tests/test_distributions.py
+++ b/rllib/models/tests/test_distributions.py
@@ -492,7 +492,7 @@ class TestDistributions(unittest.TestCase):
     def test_gumbel_softmax(self):
         """Tests the GumbelSoftmax ActionDistribution (tf + eager only)."""
         for fw, sess in framework_iterator(
-            frameworks=("tf2", "tf", "tfe"), session=True
+            frameworks=("tf2", "tf"), session=True
         ):
             batch_size = 1000
             num_categories = 5

--- a/rllib/models/utils.py
+++ b/rllib/models/utils.py
@@ -11,7 +11,7 @@ def get_activation_fn(name: Optional[str] = None, framework: str = "tf"):
     Args:
         name (Optional[str]): One of "relu" (default), "tanh", "elu",
             "swish", or "linear" (same as None).
-        framework: One of "jax", "tf|tfe|tf2" or "torch".
+        framework: One of "jax", "tf|tf2" or "torch".
 
     Returns:
         A framework-specific activtion function. e.g. tf.nn.tanh or
@@ -52,7 +52,7 @@ def get_activation_fn(name: Optional[str] = None, framework: str = "tf"):
         elif name == "elu":
             return jax.nn.elu
     else:
-        assert framework in ["tf", "tfe", "tf2"], "Unsupported framework `{}`!".format(
+        assert framework in ["tf", "tf2"], "Unsupported framework `{}`!".format(
             framework
         )
         if name in ["linear", None]:
@@ -146,7 +146,7 @@ def get_initializer(name, framework="tf"):
 
     Args:
         name: One of "xavier_uniform" (default), "xavier_normal".
-        framework: One of "jax", "tf|tfe|tf2" or "torch".
+        framework: One of "jax", "tf|tf2" or "torch".
 
     Returns:
         A framework-specific initializer function, e.g.
@@ -177,7 +177,7 @@ def get_initializer(name, framework="tf"):
         elif name == "xavier_normal":
             return nn.init.xavier_normal_
     else:
-        assert framework in ["tf", "tfe", "tf2"], "Unsupported framework `{}`!".format(
+        assert framework in ["tf", "tf2"], "Unsupported framework `{}`!".format(
             framework
         )
         tf1, tf, tfv = try_import_tf()

--- a/rllib/policy/eager_tf_policy.py
+++ b/rllib/policy/eager_tf_policy.py
@@ -142,7 +142,7 @@ def _traced_eager_policy(eager_policy_cls):
     """Wrapper class that enables tracing for all eager policy methods.
 
     This is enabled by the `--trace`/`eager_tracing=True` config when
-    framework=[tf2|tfe].
+    framework=tf2.
     """
 
     class TracedEagerPolicy(eager_policy_cls):
@@ -296,8 +296,8 @@ def _build_eager_tf_policy(
     much simpler, but has lower performance.
 
     You shouldn't need to call this directly. Rather, prefer to build a TF
-    graph policy and use set {"framework": "tfe"} in the Algorithm's config to have
-    it automatically be converted to an eager policy.
+    graph policy and use set `.framework("tf2", eager_tracing=False) in your
+    AlgorithmConfig to have it automatically be converted to an eager policy.
 
     This has the same signature as build_tf_policy()."""
 
@@ -322,7 +322,7 @@ def _build_eager_tf_policy(
             # have been activated yet.
             if not tf1.executing_eagerly():
                 tf1.enable_eager_execution()
-            self.framework = config.get("framework", "tfe")
+            self.framework = config.get("framework", "tf2")
             EagerTFPolicy.__init__(self, observation_space, action_space, config)
 
             # Global timestep should be a tensor.

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -995,7 +995,7 @@ class Policy(metaclass=ABCMeta):
         # steps).
         # Make sure, we keep global_timestep as a Tensor for tf-eager
         # (leads to memory leaks if not doing so).
-        if self.framework in ["tfe", "tf2"]:
+        if self.framework == "tf2":
             self.global_timestep.assign(global_vars["timestep"])
         else:
             self.global_timestep = global_vars["timestep"]

--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -173,7 +173,7 @@ def add_time_dimension(
             A, B, C are sequence elements and * denotes padding.
         seq_lens: A 1D tensor of sequence lengths, denoting the non-padded length
             in timesteps of each rollout in the batch.
-        framework: The framework string ("tf2", "tf", "tfe", "torch").
+        framework: The framework string ("tf2", "tf", "torch").
         time_major: Whether data should be returned in time-major (TxB)
             format or not (BxT).
 
@@ -184,7 +184,7 @@ def add_time_dimension(
     # Sequence lengths have to be specified for LSTM batch inputs. The
     # input batch must be padded to the max seq length given here. That is,
     # batch_size == len(seq_lens) * max(seq_lens)
-    if framework in ["tf2", "tf", "tfe"]:
+    if framework in ["tf2", "tf"]:
         assert time_major is False, "time-major not supported yet for tf!"
         padded_batch_size = tf.shape(padded_inputs)[0]
         # Dynamically reshape the padded batch to introduce a time dimension.

--- a/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
+++ b/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
@@ -42,7 +42,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--framework",
-    choices=["tf", "tf2", "tfe", "torch"],
+    choices=["tf", "tf2", "torch"],
     default=None,
     help="The DL framework specifier.",
 )

--- a/rllib/tests/run_regression_tests.py
+++ b/rllib/tests/run_regression_tests.py
@@ -29,7 +29,7 @@ from ray.rllib import _register_all
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["jax", "tf2", "tf", "tfe", "torch"],
+    choices=["jax", "tf2", "tf", "torch"],
     default="tf",
     help="The deep learning framework to use.",
 )
@@ -108,7 +108,7 @@ if __name__ == "__main__":
             continue
 
         # Always run with eager-tracing when framework=tf2 if not in local-mode.
-        if args.framework in ["tf2", "tfe"] and not args.local_mode:
+        if args.framework == "tf2" and not args.local_mode:
             exp["config"]["eager_tracing"] = True
 
         # Print out the actual config.

--- a/rllib/tests/test_checkpoint_restore.py
+++ b/rllib/tests/test_checkpoint_restore.py
@@ -71,13 +71,13 @@ CONFIGS = {
 }
 
 
-def ckpt_restore_test(alg_name, tfe=False, object_store=False, replay_buffer=False):
+def ckpt_restore_test(alg_name, tf2=False, object_store=False, replay_buffer=False):
     config = CONFIGS[alg_name].copy()
     # If required, store replay buffer data in checkpoints as well.
     if replay_buffer:
         config["store_buffer_in_checkpoints"] = True
 
-    frameworks = (["tf2"] if tfe else []) + ["torch", "tf"]
+    frameworks = (["tf2"] if tf2 else []) + ["torch", "tf"]
     for fw in framework_iterator(config, frameworks=frameworks):
         for use_object_store in [False, True] if object_store else [False]:
             print("use_object_store={}".format(use_object_store))
@@ -108,7 +108,7 @@ def ckpt_restore_test(alg_name, tfe=False, object_store=False, replay_buffer=Fal
             if optim_state:
                 s2 = alg2.get_policy().get_state().get("_optimizer_variables")
                 # Tf -> Compare states 1:1.
-                if fw in ["tf2", "tf", "tfe"]:
+                if fw in ["tf2", "tf"]:
                     check(s2, optim_state)
                 # For torch, optimizers have state_dicts with keys=params,
                 # which are different for the two models (ignore these

--- a/rllib/tests/test_eager_support.py
+++ b/rllib/tests/test_eager_support.py
@@ -10,7 +10,7 @@ tf1, tf, tfv = try_import_tf()
 
 
 def check_support(alg, config, test_eager=False, test_trace=True):
-    config["framework"] = "tfe"
+    config["framework"] = "tf2"
     config["log_level"] = "ERROR"
     # Test both continuous and discrete actions.
     for cont in [True, False]:

--- a/rllib/tests/test_nn_framework_import_errors.py
+++ b/rllib/tests/test_nn_framework_import_errors.py
@@ -14,7 +14,7 @@ def test_dont_import_tf_error():
     os.environ["RLLIB_TEST_NO_TF_IMPORT"] = "1"
 
     config = {}
-    for _ in framework_iterator(config, frameworks=("tf", "tf2", "tfe")):
+    for _ in framework_iterator(config, frameworks=("tf", "tf2")):
         with pytest.raises(
             ImportError, match="However, there was no installation found."
         ):

--- a/rllib/tests/test_supported_multi_agent.py
+++ b/rllib/tests/test_supported_multi_agent.py
@@ -33,7 +33,7 @@ def check_support_multiagent(alg, config):
     }
 
     for fw in framework_iterator(config):
-        if fw in ["tf2", "tfe"] and alg in ["A3C", "APEX", "APEX_DDPG", "IMPALA"]:
+        if fw == "tf2" and alg in ["A3C", "APEX", "APEX_DDPG", "IMPALA"]:
             continue
         if alg in ["DDPG", "APEX_DDPG", "SAC"]:
             a = get_algorithm_class(alg)(config=config, env="multi_agent_mountaincar")

--- a/rllib/tests/test_supported_spaces.py
+++ b/rllib/tests/test_supported_spaces.py
@@ -48,7 +48,7 @@ OBSERVATION_SPACES_TO_TEST = {
 }
 
 
-def check_support(alg, config, train=True, check_bounds=False, tfe=False):
+def check_support(alg, config, train=True, check_bounds=False, tf2=False):
     config["log_level"] = "ERROR"
     config["train_batch_size"] = 10
     config["rollout_fragment_length"] = 10
@@ -115,8 +115,8 @@ def check_support(alg, config, train=True, check_bounds=False, tfe=False):
         print(stat)
 
     frameworks = ("tf", "torch")
-    if tfe:
-        frameworks += ("tf2", "tfe")
+    if tf2:
+        frameworks += ("tf2",)
     for _ in framework_iterator(config, frameworks=frameworks):
         # Zip through action- and obs-spaces.
         for a_name, o_name in zip(
@@ -160,11 +160,11 @@ class TestSupportedSpacesPG(unittest.TestCase):
             "num_sgd_iter": 1,
             "sgd_minibatch_size": 10,
         }
-        check_support("PPO", config, check_bounds=True, tfe=True)
+        check_support("PPO", config, check_bounds=True, tf2=True)
 
     def test_pg(self):
         config = {"num_workers": 1, "optimizer": {}}
-        check_support("PG", config, train=False, check_bounds=True, tfe=True)
+        check_support("PG", config, train=False, check_bounds=True, tf2=True)
 
 
 class TestSupportedSpacesOffPolicy(unittest.TestCase):
@@ -197,7 +197,7 @@ class TestSupportedSpacesOffPolicy(unittest.TestCase):
                 "capacity": 1000,
             },
         }
-        check_support("DQN", config, tfe=True)
+        check_support("DQN", config, tf2=True)
 
     def test_sac(self):
         check_support(

--- a/rllib/utils/debug/deterministic.py
+++ b/rllib/utils/debug/deterministic.py
@@ -49,11 +49,11 @@ def update_global_seed_if_necessary(
                 torch.set_deterministic(True)
         # This is only for Convolution no problem.
         torch.backends.cudnn.deterministic = True
-    elif framework == "tf2" or framework == "tfe":
-        tf1, tf, _ = try_import_tf()
+    elif framework == "tf2":
+        tf1, tf, tfv = try_import_tf()
         # Tf2.x.
-        if framework == "tf2":
+        if tfv == 2:
             tf.random.set_seed(seed)
-        # Tf-eager.
-        elif framework == "tfe":
+        # Tf1.x.
+        else:
             tf1.set_random_seed(seed)

--- a/rllib/utils/exploration/epsilon_greedy.py
+++ b/rllib/utils/exploration/epsilon_greedy.py
@@ -92,7 +92,7 @@ class EpsilonGreedy(Exploration):
         explore: Optional[Union[bool, TensorType]] = True,
     ):
 
-        if self.framework in ["tf2", "tf", "tfe"]:
+        if self.framework in ["tf2", "tf"]:
             return self._get_tf_exploration_action_op(
                 action_distribution, explore, timestep
             )
@@ -152,7 +152,7 @@ class EpsilonGreedy(Exploration):
             false_fn=lambda: exploit_action,
         )
 
-        if self.framework in ["tf2", "tfe"] and not self.policy_config["eager_tracing"]:
+        if self.framework == "tf2" and not self.policy_config["eager_tracing"]:
             self.last_timestep = timestep
             return action, tf.zeros_like(action, dtype=tf.float32)
         else:

--- a/rllib/utils/exploration/gaussian_noise.py
+++ b/rllib/utils/exploration/gaussian_noise.py
@@ -159,7 +159,7 @@ class GaussianNoise(Exploration):
         logp = zero_logps_from_actions(deterministic_actions)
 
         # Increment `last_timestep` by 1 (or set to `timestep`).
-        if self.framework in ["tf2", "tfe"]:
+        if self.framework == "tf2":
             if timestep is None:
                 self.last_timestep.assign_add(1)
             else:

--- a/rllib/utils/exploration/ornstein_uhlenbeck_noise.py
+++ b/rllib/utils/exploration/ornstein_uhlenbeck_noise.py
@@ -115,7 +115,7 @@ class OrnsteinUhlenbeckNoise(GaussianNoise):
             shape=[self.action_space.low.size], stddev=self.stddev
         )
         ou_new = self.ou_theta * -self.ou_state + self.ou_sigma * gaussian_sample
-        if self.framework in ["tf2", "tfe"]:
+        if self.framework == "tf2":
             self.ou_state.assign_add(ou_new)
             ou_state_new = self.ou_state
         else:
@@ -153,7 +153,7 @@ class OrnsteinUhlenbeckNoise(GaussianNoise):
         logp = zero_logps_from_actions(deterministic_actions)
 
         # Increment `last_timestep` by 1 (or set to `timestep`).
-        if self.framework in ["tf2", "tfe"]:
+        if self.framework == "tf2":
             if timestep is None:
                 self.last_timestep.assign_add(1)
             else:

--- a/rllib/utils/exploration/parameter_noise.py
+++ b/rllib/utils/exploration/parameter_noise.py
@@ -308,7 +308,7 @@ class ParameterNoise(Exploration):
         """Samples new noise and stores it in `self.noise`."""
         if self.framework == "tf":
             tf_sess.run(self.tf_sample_new_noise_op)
-        elif self.framework in ["tfe", "tf2"]:
+        elif self.framework == "tf2":
             self._tf_sample_new_noise_op()
         else:
             for i in range(len(self.noise)):
@@ -359,7 +359,7 @@ class ParameterNoise(Exploration):
         # Add stored noise to the model's parameters.
         if self.framework == "tf":
             tf_sess.run(self.tf_add_stored_noise_op)
-        elif self.framework in ["tf2", "tfe"]:
+        elif self.framework == "tf2":
             self._tf_add_stored_noise_op()
         else:
             for var, noise in zip(self.model_variables, self.noise):
@@ -399,7 +399,7 @@ class ParameterNoise(Exploration):
         # Removes the stored noise from the model's parameters.
         if self.framework == "tf":
             tf_sess.run(self.tf_remove_noise_op)
-        elif self.framework in ["tf2", "tfe"]:
+        elif self.framework == "tf2":
             self._tf_remove_noise_op()
         else:
             for var, noise in zip(self.model_variables, self.noise):

--- a/rllib/utils/exploration/random.py
+++ b/rllib/utils/exploration/random.py
@@ -34,7 +34,7 @@ class Random(Exploration):
 
         Args:
             action_space: The gym action space used by the environment.
-            framework: One of None, "tf", "tfe", "torch".
+            framework: One of None, "tf", "torch".
         """
         super().__init__(
             action_space=action_space, model=model, framework=framework, **kwargs
@@ -51,7 +51,7 @@ class Random(Exploration):
         explore: bool = True
     ):
         # Instantiate the distribution object.
-        if self.framework in ["tf2", "tf", "tfe"]:
+        if self.framework in ["tf2", "tf"]:
             return self.get_tf_exploration_action_op(action_distribution, explore)
         else:
             return self.get_torch_exploration_action(action_distribution, explore)

--- a/rllib/utils/exploration/slate_epsilon_greedy.py
+++ b/rllib/utils/exploration/slate_epsilon_greedy.py
@@ -61,7 +61,7 @@ class SlateEpsilonGreedy(EpsilonGreedy):
             false_fn=lambda: exploit_action,
         )
 
-        if self.framework in ["tf2", "tfe"] and not self.policy_config["eager_tracing"]:
+        if self.framework == "tf2" and not self.policy_config["eager_tracing"]:
             self.last_timestep = timestep
             return action, action_logp
         else:

--- a/rllib/utils/exploration/stochastic_sampling.py
+++ b/rllib/utils/exploration/stochastic_sampling.py
@@ -114,7 +114,7 @@ class StochasticSampling(Exploration):
         )
 
         # Increment `last_timestep` by 1 (or set to `timestep`).
-        if self.framework in ["tf2", "tfe"]:
+        if self.framework == "tf2":
             self.last_timestep.assign_add(1)
             return action, logp
         else:

--- a/rllib/utils/exploration/tests/test_parameter_noise.py
+++ b/rllib/utils/exploration/tests/test_parameter_noise.py
@@ -221,7 +221,7 @@ class TestParameterNoise(unittest.TestCase):
             # DDPG model.
             else:
                 return weights["policy_model.action_0._model.0.weight"][0][0]
-        key = 0 if fw in ["tf2", "tfe"] else list(weights.keys())[0]
+        key = 0 if fw == "tf2" else list(weights.keys())[0]
         return weights[key][0][0]
 
 

--- a/rllib/utils/framework.py
+++ b/rllib/utils/framework.py
@@ -239,7 +239,7 @@ def get_variable(
         A framework-specific variable (tf.Variable, torch.tensor, or
         python primitive).
     """
-    if framework in ["tf2", "tf", "tfe"]:
+    if framework in ["tf2", "tf"]:
         import tensorflow as tf
 
         dtype = dtype or getattr(

--- a/rllib/utils/policy.py
+++ b/rllib/utils/policy.py
@@ -90,7 +90,7 @@ def create_policy_for_framework(
 
     framework = merged_config.get("framework", "tf")
     # Tf.
-    if framework in ["tf2", "tf", "tfe"]:
+    if framework in ["tf2", "tf"]:
         var_scope = policy_id + (f"_wk{worker_index}" if worker_index else "")
         # For tf static graph, build every policy in its own graph
         # and create a new session for it.

--- a/rllib/utils/schedules/schedule.py
+++ b/rllib/utils/schedules/schedule.py
@@ -37,7 +37,7 @@ class Schedule(metaclass=ABCMeta):
         Returns:
             The calculated value depending on the schedule and `t`.
         """
-        if self.framework in ["tf2", "tf", "tfe"]:
+        if self.framework in ["tf2", "tf"]:
             return self._tf_value_op(t)
         return self._value(t)
 

--- a/rllib/utils/schedules/tests/test_schedules.py
+++ b/rllib/utils/schedules/tests/test_schedules.py
@@ -22,7 +22,7 @@ class TestSchedules(unittest.TestCase):
 
         config = {"value": value}
 
-        for fw in framework_iterator(frameworks=["tf2", "tf", "tfe", "torch", None]):
+        for fw in framework_iterator(frameworks=["tf2", "tf", "torch", None]):
             constant = from_config(ConstantSchedule, config, framework=fw)
             for t in ts:
                 out = constant(t)
@@ -39,7 +39,7 @@ class TestSchedules(unittest.TestCase):
         expected = [2.1 - (min(t, 100) / 100) * (2.1 - 0.6) for t in ts]
         config = {"schedule_timesteps": 100, "initial_p": 2.1, "final_p": 0.6}
 
-        for fw in framework_iterator(frameworks=["tf2", "tf", "tfe", "torch", None]):
+        for fw in framework_iterator(frameworks=["tf2", "tf", "torch", None]):
             linear = from_config(LinearSchedule, config, framework=fw)
             for t, e in zip(ts, expected):
                 out = linear(t)
@@ -62,7 +62,7 @@ class TestSchedules(unittest.TestCase):
             power=2.0,
         )
 
-        for fw in framework_iterator(frameworks=["tf2", "tf", "tfe", "torch", None]):
+        for fw in framework_iterator(frameworks=["tf2", "tf", "torch", None]):
             polynomial = from_config(config, framework=fw)
             for t, e in zip(ts, expected):
                 out = polynomial(t)
@@ -80,7 +80,7 @@ class TestSchedules(unittest.TestCase):
         expected = [2.0 * decay_rate ** (t / 100) for t in ts]
         config = dict(initial_p=2.0, decay_rate=decay_rate, schedule_timesteps=100)
 
-        for fw in framework_iterator(frameworks=["tf2", "tf", "tfe", "torch", None]):
+        for fw in framework_iterator(frameworks=["tf2", "tf", "torch", None]):
             exponential = from_config(ExponentialSchedule, config, framework=fw)
             for t, e in zip(ts, expected):
                 out = exponential(t)
@@ -99,7 +99,7 @@ class TestSchedules(unittest.TestCase):
             endpoints=[(0, 50.0), (25, 100.0), (30, 200.0)], outside_value=14.5
         )
 
-        for fw in framework_iterator(frameworks=["tf2", "tf", "tfe", "torch", None]):
+        for fw in framework_iterator(frameworks=["tf2", "tf", "torch", None]):
             piecewise = from_config(PiecewiseSchedule, config, framework=fw)
             for t, e in zip(ts, expected):
                 out = piecewise(t)

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 
 def framework_iterator(
     config: Optional[Union["AlgorithmConfig", PartialAlgorithmConfigDict]] = None,
-    frameworks: Sequence[str] = ("tf2", "tf", "tfe", "torch"),
+    frameworks: Sequence[str] = ("tf2", "tf", "torch"),
     session: bool = False,
     with_eager_tracing: bool = False,
     time_iterations: Optional[dict] = None,
@@ -58,34 +58,30 @@ def framework_iterator(
     """An generator that allows for looping through n frameworks for testing.
 
     Provides the correct config entries ("framework") as well
-    as the correct eager/non-eager contexts for tfe/tf.
+    as the correct eager/non-eager contexts for tf/tf2.
 
     Args:
         config: An optional config dict or AlgorithmConfig object. This will be modified
             (value for "framework" changed) depending on the iteration.
         frameworks: A list/tuple of the frameworks to be tested.
-            Allowed are: "tf2", "tf", "tfe", "torch", and None.
+            Allowed are: "tf2", "tf", "torch", and None.
         session: If True and only in the tf-case: Enter a tf.Session()
             and yield that as second return value (otherwise yield (fw, None)).
             Also sets a seed (42) on the session to make the test
             deterministic.
         with_eager_tracing: Include `eager_tracing=True` in the returned
-            configs, when framework=[tfe|tf2].
+            configs, when framework=tf2.
         time_iterations: If provided, will write to the given dict (by
             framework key) the times in seconds that each (framework's)
             iteration takes.
 
     Yields:
-        If `session` is False: The current framework [tf2|tf|tfe|torch] used.
+        If `session` is False: The current framework [tf2|tf|torch] used.
         If `session` is True: A tuple consisting of the current framework
         string and the tf1.Session (if fw="tf", otherwise None).
     """
     config = config or {}
     frameworks = [frameworks] if isinstance(frameworks, str) else list(frameworks)
-
-    # Both tf2 and tfe present -> remove "tfe" or "tf2" depending on version.
-    if "tf2" in frameworks and "tfe" in frameworks:
-        frameworks.remove("tfe" if tfv == 2 else "tf2")
 
     for fw in frameworks:
         # Skip non-installed frameworks.
@@ -97,19 +93,13 @@ def framework_iterator(
                 "framework_iterator skipping {} (tf not installed)!".format(fw)
             )
             continue
-        elif fw == "tfe" and not eager_mode:
-            logger.warning(
-                "framework_iterator skipping tf-eager (could not "
-                "import `eager_mode` from tensorflow.python)!"
-            )
-            continue
         elif fw == "tf2" and tfv != 2:
             logger.warning("framework_iterator skipping tf2.x (tf version is < 2.0)!")
             continue
         elif fw == "jax" and not jax:
             logger.warning("framework_iterator skipping JAX (not installed)!")
             continue
-        assert fw in ["tf2", "tf", "tfe", "torch", "jax", None]
+        assert fw in ["tf2", "tf", "torch", "jax", None]
 
         # Do we need a test session?
         sess = None
@@ -124,8 +114,8 @@ def framework_iterator(
             config.framework(fw)
 
         eager_ctx = None
-        # Enable eager mode for tf2 and tfe.
-        if fw in ["tf2", "tfe"]:
+        # Enable eager mode for tf2.
+        if fw == "tf2":
             eager_ctx = eager_mode()
             eager_ctx.__enter__()
             assert tf1.executing_eagerly()
@@ -134,7 +124,7 @@ def framework_iterator(
             assert not tf1.executing_eagerly()
 
         # Additionally loop through eager_tracing=True + False, if necessary.
-        if fw in ["tf2", "tfe"] and with_eager_tracing:
+        if fw == "tf2" and with_eager_tracing:
             for tracing in [True, False]:
                 if isinstance(config, dict):
                     config["eager_tracing"] = tracing
@@ -179,7 +169,7 @@ def check(x, y, decimals=5, atol=None, rtol=None, false=False):
         x: The value to be compared (to the expectation: `y`). This
             may be a Tensor.
         y: The expected value to be compared to `x`. This must not
-            be a tf-Tensor, but may be a tfe/torch-Tensor.
+            be a tf-Tensor, but may be a tf/torch-Tensor.
         decimals: The number of digits after the floating point up to
             which all numeric values have to match.
         atol: Absolute tolerance of the difference between x and y

--- a/rllib/utils/tests/run_memory_leak_tests.py
+++ b/rllib/utils/tests/run_memory_leak_tests.py
@@ -30,7 +30,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
     required=False,
-    choices=["jax", "tf2", "tf", "tfe", "torch", None],
+    choices=["jax", "tf2", "tf", "torch", None],
     default=None,
     help="The deep learning framework to use.",
 )
@@ -94,7 +94,7 @@ if __name__ == "__main__":
         # Create env on local_worker for memory leak testing just the env.
         experiment["config"]["create_env_on_driver"] = True
         # Always run with eager-tracing when framework=tf2 if not in local-mode.
-        if args.framework in ["tf2", "tfe"] and not args.local_mode:
+        if args.framework == "tf2" and not args.local_mode:
             experiment["config"]["eager_tracing"] = True
         # experiment["config"]["callbacks"] = MemoryTrackingCallbacks
 

--- a/rllib/utils/tests/test_framework_agnostic_components.py
+++ b/rllib/utils/tests/test_framework_agnostic_components.py
@@ -64,23 +64,22 @@ class TestFrameWorkAgnosticComponents(unittest.TestCase):
         abs_path = script_dir.absolute()
 
         for fw, sess in framework_iterator(session=True):
-            fw_ = fw if fw != "tfe" else "tf"
             # Try to create from an abstract class w/o default constructor.
             # Expect None.
-            test = from_config({"type": AbstractDummyComponent, "framework": fw_})
+            test = from_config({"type": AbstractDummyComponent, "framework": fw})
             check(test, None)
 
             # Create a Component via python API (config dict).
             component = from_config(
                 dict(
-                    type=DummyComponent, prop_a=1.0, prop_d="non_default", framework=fw_
+                    type=DummyComponent, prop_a=1.0, prop_d="non_default", framework=fw
                 )
             )
             check(component.prop_d, "non_default")
 
             # Create a tf Component from json file.
             config_file = str(abs_path.joinpath("dummy_config.json"))
-            component = from_config(config_file, framework=fw_)
+            component = from_config(config_file, framework=fw)
             check(component.prop_c, "default")
             check(component.prop_d, 4)  # default
             value = component.add(3.3)
@@ -90,7 +89,7 @@ class TestFrameWorkAgnosticComponents(unittest.TestCase):
 
             # Create a torch Component from yaml file.
             config_file = str(abs_path.joinpath("dummy_config.yml"))
-            component = from_config(config_file, framework=fw_)
+            component = from_config(config_file, framework=fw)
             check(component.prop_a, "something else")
             check(component.prop_d, 3)
             value = component.add(1.2)
@@ -103,7 +102,7 @@ class TestFrameWorkAgnosticComponents(unittest.TestCase):
                 '{"type": "ray.rllib.utils.tests.'
                 'test_framework_agnostic_components.DummyComponent", '
                 '"prop_a": "A", "prop_b": -1.0, "prop_c": "non-default", '
-                '"framework": "' + fw_ + '"}'
+                '"framework": "' + fw + '"}'
             )
             check(component.prop_a, "A")
             check(component.prop_d, 4)  # default
@@ -117,7 +116,7 @@ class TestFrameWorkAgnosticComponents(unittest.TestCase):
                 DummyComponent,
                 '{"type": "NonAbstractChildOfDummyComponent", '
                 '"prop_a": "A", "prop_b": -1.0, "prop_c": "non-default",'
-                '"framework": "' + fw_ + '"}',
+                '"framework": "' + fw + '"}',
             )
             check(component.prop_a, "A")
             check(component.prop_d, 4)  # default
@@ -136,7 +135,7 @@ class TestFrameWorkAgnosticComponents(unittest.TestCase):
                 {
                     "type": "EpsilonGreedy",
                     "action_space": Discrete(2),
-                    "framework": fw_,
+                    "framework": fw,
                     "num_workers": 0,
                     "worker_index": 0,
                     "policy_config": {},
@@ -152,7 +151,7 @@ class TestFrameWorkAgnosticComponents(unittest.TestCase):
                 "type: ray.rllib.utils.tests."
                 "test_framework_agnostic_components.DummyComponent\n"
                 "prop_a: B\nprop_b: -1.5\nprop_c: non-default\nframework: "
-                "{}".format(fw_)
+                "{}".format(fw)
             )
             check(component.prop_a, "B")
             check(component.prop_d, 4)  # default

--- a/rllib/utils/tf_utils.py
+++ b/rllib/utils/tf_utils.py
@@ -243,10 +243,10 @@ def get_tf_eager_cls_if_necessary(
     cls = orig_cls
     framework = config.get("framework", "tf")
 
-    if framework in ["tf2", "tf", "tfe"] and not tf1:
+    if framework in ["tf2", "tf"] and not tf1:
         raise ImportError("Could not import tensorflow!")
 
-    if framework in ["tf2", "tfe"]:
+    if framework == "tf2":
         assert tf1.executing_eagerly()
 
         from ray.rllib.policy.tf_policy import TFPolicy


### PR DESCRIPTION
Signed-off-by: sven1977 <svenmika1977@gmail.com>

Deprecate `AlgorithmConfig.framework("tfe")`: Use `tf2` instead.

`tfe` and `tf2` have the same meaning. There used to be a difference in the tf main-version (1.x vs 2.x) for these two settings, but that difference has already been equalized in RLlib's code.
We are now throwing an error, hinting to use "tf2", if a user tries to set framework="tfe".

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
