### PR TITLE
[ci][cherry-pick] Obey constraints in installing build info dependencies (#29727)

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -2,7 +2,7 @@ common: &common
   env:
     BUILDKITE: "true"
     CI: "true"
-    PYTHON: "3.6"
+    PYTHON: "3.7"
     RAY_USE_RANDOM_PORTS: "1"
     RAY_DEFAULT_BUILD: "1"
     LC_ALL: en_US.UTF-8

--- a/ci/build/upload_build_info.sh
+++ b/ci/build/upload_build_info.sh
@@ -35,6 +35,7 @@ if [[ -z "${BUILDKITE-}" ]]; then
     aws s3 cp --recursive /tmp/bazel_event_logs "${DST}"
 else
     # Codepath for Buildkite
-    pip install -q docker aws_requests_auth boto3
+    # Keep cryptography/openssl in sync with `requirements_test.txt`
+    pip install -q -c "${RAY_DIR}/python/requirements.txt" docker aws_requests_auth boto3 cryptography==38.0.1 PyOpenSSL==22.1.0
     python .buildkite/copy_files.py --destination logs --path /tmp/bazel_event_logs
 fi

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -225,10 +225,6 @@ install_upgrade_pip() {
 
   if "${python}" -m pip --version || "${python}" -m ensurepip; then  # Configure pip if present
     "${python}" -m pip install --quiet pip==21.3.1
-    # cryptography 37.0.0 breaks ensurepip.
-    # Example build failure:
-    # https://buildkite.com/ray-project/ray-builders-branch/builds/7207#a16e8f76-a993-4d8d-a5f0-09c4f76245dc
-    "${python}" -m pip install cryptography==36.0.2
 
     # If we're in a CI environment, do some configuration
     if [ "${CI-}" = true ]; then

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -110,3 +110,7 @@ pytest-forked
 
 # For dataset tests
 polars
+
+# for 2.1.0 release ci
+cryptography==38.0.1
+PyOpenSSL==22.1.0


### PR DESCRIPTION
Minimal installs have to re-install boto3, and this sometimes installs an incompatible openssl version on top of the existing one. By pinning the version in `upload_build_info.sh` we should be able to resolve recent compatibility issues on the master branch.

Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
