### PR TITLE
Fix Java flaky test.

### DIFF
--- a/java/test/src/main/java/io/ray/test/SetupJavaWorkerTest.java
+++ b/java/test/src/main/java/io/ray/test/SetupJavaWorkerTest.java
@@ -45,7 +45,7 @@ public class SetupJavaWorkerTest extends BaseTest {
   public void testCreateActorFail() {
     ActorHandle<ActorTest.Counter> actor = Ray.actor(ActorTest.Counter::new, 1).remote();
     // throw RayTimeoutException exception if actor is not started correctly by raylet
-    Integer value = actor.task(ActorTest.Counter::getValue).remote().get(3 * 1000);
+    Integer value = actor.task(ActorTest.Counter::getValue).remote().get(30 * 1000);
     Assert.assertEquals(Integer.valueOf(1), value);
   }
 }

--- a/java/test/src/main/java/io/ray/test/WorkerJvmOptionsTest.java
+++ b/java/test/src/main/java/io/ray/test/WorkerJvmOptionsTest.java
@@ -25,6 +25,6 @@ public class WorkerJvmOptionsTest extends BaseTest {
                 ImmutableList.of("-Dtest.suffix=suffix", "-Dtest.suffix1=suffix1 suffix1"))
             .remote();
     ObjectRef<String> obj = actor.task(Echo::getOptions).remote();
-    Assert.assertEquals(obj.get(3 * 1000), "suffix");
+    Assert.assertEquals(obj.get(30 * 1000), "suffix");
   }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The cases fail with timeout because of a short time to get objects from actors. We fix it by increase them. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#29672
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
