### PR TITLE
[Train] Increase timeout for `test_mosaic_trainer`

### DIFF
--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -380,7 +380,7 @@ py_test(
 
 py_test(
     name = "test_mosaic_trainer",
-    size = "medium",
+    size = "large",
     srcs = ["tests/test_mosaic_trainer.py"],
     tags = ["team:ml", "exclusive", "ray_air", "mosaic"],
     deps = [":train_lib", ":conftest"]


### PR DESCRIPTION
Signed-off-by: Amog Kamsetty <amogkamsetty@yahoo.com>

`test_mosaic_trainer` is sometimes flaky due to timing out. We increase the the test size to large.

Close #29769 

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
