### PR TITLE
[Jobs] [CI] Deflake `test_sdk.py` by setting test env vars for head node, not just workers

### DIFF
--- a/dashboard/modules/job/tests/test_sdk.py
+++ b/dashboard/modules/job/tests/test_sdk.py
@@ -109,9 +109,12 @@ def test_parse_cluster_info(
 
 
 def test_parse_cluster_info_default_address():
-    assert parse_cluster_info(
-        address=None,
-    ) == ClusterInfo(address=DEFAULT_DASHBOARD_ADDRESS)
+    assert (
+        parse_cluster_info(
+            address=None,
+        )
+        == ClusterInfo(address=DEFAULT_DASHBOARD_ADDRESS)
+    )
 
 
 @pytest.mark.parametrize("expiration_s", [0, 10])
@@ -172,13 +175,22 @@ def get_register_agents_number(webui_url):
 
 
 @pytest.mark.parametrize(
-    "ray_start_cluster_head", [{"include_dashboard": True}], indirect=True
+    "ray_start_cluster_head",
+    [
+        {
+            "include_dashboard": True,
+            "env_vars": {
+                "CANDIDATE_AGENT_NUMBER": "2",
+                RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR: "1",
+            },
+        }
+    ],
+    indirect=True,
 )
 def test_job_head_choose_job_agent_E2E(
-    mock_candidate_number, ray_start_cluster_head, monkeypatch
+    ray_start_cluster_head_with_env_vars
 ):
-    monkeypatch.setenv(RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR, "1")
-    cluster = ray_start_cluster_head
+    cluster = ray_start_cluster_head_with_env_vars
     assert wait_until_server_available(cluster.webui_url) is True
     webui_url = cluster.webui_url
     webui_url = format_web_url(webui_url)
@@ -287,21 +299,26 @@ def test_job_head_choose_job_agent_E2E(
 
 
 @pytest.mark.parametrize(
-    "ray_start_cluster_head", [{"include_dashboard": True}], indirect=True
+    "ray_start_cluster_head",
+    [
+        {
+            "include_dashboard": True,
+            "env_vars": {RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR: "1"},
+        },
+        {
+            "include_dashboard": True,
+            "env_vars": {RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR: "0"},
+        },
+    ],
+    indirect=True,
 )
 @pytest.mark.parametrize("allow_driver_on_worker_nodes", [True, False])
 def test_jobs_run_on_head_by_default_E2E(
-    ray_start_cluster_head, monkeypatch, allow_driver_on_worker_nodes
+    ray_start_cluster_head_with_env_vars, allow_driver_on_worker_nodes
 ):
-    """This test makes sure that the job will be run on the head node by default,
-    unless the environment variable `RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES` is set
-    to `1`.
-    """
-    if allow_driver_on_worker_nodes:
-        monkeypatch.setenv(RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR, "1")
 
     # Cluster setup
-    cluster = ray_start_cluster_head
+    cluster = ray_start_cluster_head_with_env_vars
     cluster.add_node(dashboard_agent_listen_port=52366)
     cluster.add_node(dashboard_agent_listen_port=52367)
     assert wait_until_server_available(cluster.webui_url) is True

--- a/dashboard/modules/job/tests/test_sdk.py
+++ b/dashboard/modules/job/tests/test_sdk.py
@@ -187,9 +187,7 @@ def get_register_agents_number(webui_url):
     ],
     indirect=True,
 )
-def test_job_head_choose_job_agent_E2E(
-    ray_start_cluster_head_with_env_vars
-):
+def test_job_head_choose_job_agent_E2E(ray_start_cluster_head_with_env_vars):
     cluster = ray_start_cluster_head_with_env_vars
     assert wait_until_server_available(cluster.webui_url) is True
     webui_url = cluster.webui_url

--- a/dashboard/modules/job/tests/test_sdk.py
+++ b/dashboard/modules/job/tests/test_sdk.py
@@ -307,11 +307,10 @@ def test_job_head_choose_job_agent_E2E(ray_start_cluster_head_with_env_vars):
     ],
     indirect=True,
 )
-@pytest.mark.parametrize("allow_driver_on_worker_nodes", [True, False])
-def test_jobs_run_on_head_by_default_E2E(
-    ray_start_cluster_head_with_env_vars, allow_driver_on_worker_nodes
-):
-
+def test_jobs_run_on_head_by_default_E2E(ray_start_cluster_head_with_env_vars):
+    allow_driver_on_worker_nodes = (
+        os.environ.get(RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR) == "1"
+    )
     # Cluster setup
     cluster = ray_start_cluster_head_with_env_vars
     cluster.add_node(dashboard_agent_listen_port=52366)

--- a/dashboard/modules/job/tests/test_sdk.py
+++ b/dashboard/modules/job/tests/test_sdk.py
@@ -172,7 +172,7 @@ def get_register_agents_number(webui_url):
 
 
 @pytest.mark.parametrize(
-    "ray_start_cluster_head",
+    "ray_start_cluster_head_with_env_vars",
     [
         {
             "include_dashboard": True,
@@ -294,7 +294,7 @@ def test_job_head_choose_job_agent_E2E(ray_start_cluster_head_with_env_vars):
 
 
 @pytest.mark.parametrize(
-    "ray_start_cluster_head",
+    "ray_start_cluster_head_with_env_vars",
     [
         {
             "include_dashboard": True,

--- a/dashboard/modules/job/tests/test_sdk.py
+++ b/dashboard/modules/job/tests/test_sdk.py
@@ -109,12 +109,9 @@ def test_parse_cluster_info(
 
 
 def test_parse_cluster_info_default_address():
-    assert (
-        parse_cluster_info(
-            address=None,
-        )
-        == ClusterInfo(address=DEFAULT_DASHBOARD_ADDRESS)
-    )
+    assert parse_cluster_info(
+        address=None,
+    ) == ClusterInfo(address=DEFAULT_DASHBOARD_ADDRESS)
 
 
 @pytest.mark.parametrize("expiration_s", [0, 10])

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -362,6 +362,16 @@ def ray_start_cluster_head_with_external_redis(request, external_redis):
 
 
 @pytest.fixture
+def ray_start_cluster_head_with_env_vars(request, maybe_external_redis, monkeypatch):
+    param = getattr(request, "param", {})
+    env_vars = param.pop("env_vars", {})
+    for k, v in env_vars.items():
+        monkeypatch.setenv(k, v)
+    with _ray_start_cluster(do_init=True, num_nodes=1, **param) as res:
+        yield res
+
+
+@pytest.fixture
 def ray_start_cluster_2_nodes(request, maybe_external_redis):
     param = getattr(request, "param", {})
     with _ray_start_cluster(do_init=True, num_nodes=2, **param) as res:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The environment variables for a test were supposed to be set for all workers in a cluster.  However, the head node of the cluster was started by a pytest fixture before the call to `monkeypatch.setenv` that sets the environment variables.  
Thus, the environment variables were only being set in the worker nodes, since they were started after `monkeypatch.setenv`. 

This PR adds a fixture to set environment variables before starting the cluster head and uses that fixture in the tests.

It's likely that this will fix the flakiness, but this should be fixed regardless.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
May address #29006 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
