### PR TITLE
Revert "[core][metric] Add fallback memory and seal memory breakdown(#29485)"

### DIFF
--- a/python/ray/tests/test_object_store_metrics.py
+++ b/python/ray/tests/test_object_store_metrics.py
@@ -22,27 +22,15 @@ _SYSTEM_CONFIG = {
 }
 
 
-def _objects_by_tag(info: RayContext, tag: str) -> Dict:
+def objects_by_loc(info: RayContext) -> Dict:
     res = raw_metrics(info)
     objects_info = defaultdict(int)
     if "ray_object_store_memory" in res:
         for sample in res["ray_object_store_memory"]:
-            # NOTE: SPILLED sample doesn't report sealing states. So need to
-            # filter those empty label value out.
-            print(sample)
-            if tag in sample.labels and sample.labels[tag] != "":
-                objects_info[sample.labels[tag]] += sample.value
+            objects_info[sample.labels["Location"]] += sample.value
 
-    print(f"Objects by {tag}: {objects_info}")
+    print(f"Objects by location: {objects_info}")
     return objects_info
-
-
-def objects_by_seal_state(info: RayContext) -> Dict:
-    return _objects_by_tag(info, "ObjectState")
-
-
-def objects_by_loc(info: RayContext) -> Dict:
-    return _objects_by_tag(info, "Location")
 
 
 def approx_eq_dict_in(actual: Dict, expected: Dict, e: int) -> bool:
@@ -73,9 +61,9 @@ def test_all_shared_memory(shutdown_only):
     )
 
     expected = {
-        "MMAP_SHM": 80 * MiB,
-        "MMAP_DISK": 0,
+        "IN_MEMORY": 80 * MiB,
         "SPILLED": 0,
+        "UNSEALED": 0,
     }
 
     wait_for_condition(
@@ -89,9 +77,9 @@ def test_all_shared_memory(shutdown_only):
     del objs_in_use
 
     expected = {
-        "MMAP_SHM": 0,
-        "MMAP_DISK": 0,
+        "IN_MEMORY": 0,
         "SPILLED": 0,
+        "UNSEALED": 0,
     }
 
     wait_for_condition(
@@ -120,9 +108,9 @@ def test_spilling(object_spilling_config, shutdown_only):
     objs1 = [ray.put(np.zeros(50 * MiB, dtype=np.uint8)) for _ in range(2)]
 
     expected = {
-        "MMAP_SHM": 100 * MiB,
-        "MMAP_DISK": 0,
+        "IN_MEMORY": 100 * MiB,
         "SPILLED": 0,
+        "UNSEALED": 0,
     }
 
     wait_for_condition(
@@ -136,9 +124,9 @@ def test_spilling(object_spilling_config, shutdown_only):
     objs2 = [ray.put(np.zeros(50 * MiB, dtype=np.uint8)) for _ in range(2)]
 
     expected = {
-        "MMAP_SHM": 100 * MiB,
-        "MMAP_DISK": 0,
+        "IN_MEMORY": 100 * MiB,
         "SPILLED": 100 * MiB,
+        "UNSEALED": 0,
     }
     wait_for_condition(
         # 1KiB for metadata difference
@@ -150,9 +138,9 @@ def test_spilling(object_spilling_config, shutdown_only):
     # Delete spilled objects
     del objs1
     expected = {
-        "MMAP_SHM": 100 * MiB,
-        "MMAP_DISK": 0,
+        "IN_MEMORY": 100 * MiB,
         "SPILLED": 0,
+        "UNSEALED": 0,
     }
     wait_for_condition(
         # 1KiB for metadata difference
@@ -164,9 +152,9 @@ def test_spilling(object_spilling_config, shutdown_only):
     # Delete all
     del objs2
     expected = {
-        "MMAP_SHM": 0,
-        "MMAP_DISK": 0,
+        "IN_MEMORY": 0,
         "SPILLED": 0,
+        "UNSEALED": 0,
     }
     wait_for_condition(
         # 1KiB for metadata difference
@@ -178,7 +166,7 @@ def test_spilling(object_spilling_config, shutdown_only):
 
 @pytest.mark.parametrize("metric_report_interval_ms", [500, 1000, 3000])
 def test_object_metric_report_interval(shutdown_only, metric_report_interval_ms):
-    """Test object store metric on raylet controlled by `metric_report_interval_ms`"""
+    """Test objects allocated in shared memory"""
     import time
 
     info = ray.init(
@@ -190,9 +178,9 @@ def test_object_metric_report_interval(shutdown_only, metric_report_interval_ms)
     obj = ray.get(ray.put(np.zeros(20 * MiB, dtype=np.uint8)))
 
     expected = {
-        "MMAP_SHM": 20 * MiB,
-        "MMAP_DISK": 0,
+        "IN_MEMORY": 20 * MiB,
         "SPILLED": 0,
+        "UNSEALED": 0,
     }
     start = time.time()
     wait_for_condition(
@@ -207,129 +195,6 @@ def test_object_metric_report_interval(shutdown_only, metric_report_interval_ms)
     assert (end - start) * 1000 > metric_report_interval_ms, "Reporting too quickly"
 
     del obj
-
-
-def test_fallback_memory(shutdown_only):
-    """Test some fallback allocated objects"""
-
-    expected_fallback = 6
-    expected_in_memory = 5
-    obj_size_mb = 20
-
-    # So expected_in_memory objects could fit in object store
-    delta_mb = 5
-    info = ray.init(
-        object_store_memory=expected_in_memory * obj_size_mb * MiB + delta_mb * MiB,
-        _system_config=_SYSTEM_CONFIG,
-    )
-    obj_refs = [
-        ray.put(np.zeros(obj_size_mb * MiB, dtype=np.uint8))
-        for _ in range(expected_in_memory)
-    ]
-
-    # Getting and using the objects to prevent spilling
-    in_use_objs = [ray.get(obj) for obj in obj_refs]
-
-    # No fallback and spilling yet
-    expected = {
-        "MMAP_SHM": expected_in_memory * obj_size_mb * MiB,
-        "MMAP_DISK": 0,
-        "SPILLED": 0,
-    }
-
-    wait_for_condition(
-        # 2KiB for metadata difference
-        lambda: approx_eq_dict_in(objects_by_loc(info), expected, 2 * KiB),
-        timeout=20,
-        retry_interval_ms=500,
-    )
-
-    # Fallback allocated and make them not spillable
-    obj_refs_fallback = []
-    in_use_objs_fallback = []
-    for _ in range(expected_fallback):
-        obj = ray.put(np.zeros(obj_size_mb * MiB, dtype=np.uint8))
-        in_use_objs_fallback.append(ray.get(obj))
-        obj_refs_fallback.append(obj)
-
-        # NOTE(rickyx): I actually wasn't aware this reference would
-        # keep the reference count? Removing this line would cause
-        # a single object not deleted.
-        del obj
-
-    # Fallback allocated and still no spilling
-    expected = {
-        "MMAP_SHM": expected_in_memory * obj_size_mb * MiB,
-        "MMAP_DISK": expected_fallback * obj_size_mb * MiB,
-        "SPILLED": 0,
-    }
-
-    wait_for_condition(
-        # 1KiB for metadata difference
-        lambda: approx_eq_dict_in(objects_by_loc(info), expected, 2 * KiB),
-        timeout=20,
-        retry_interval_ms=500,
-    )
-
-    # Free all of them
-    del in_use_objs
-    del obj_refs
-    del in_use_objs_fallback
-    del obj_refs_fallback
-
-    expected = {
-        "MMAP_SHM": 0,
-        "MMAP_DISK": 0,
-        "SPILLED": 0,
-    }
-
-    wait_for_condition(
-        # 1KiB for metadata difference
-        lambda: approx_eq_dict_in(objects_by_loc(info), expected, 2 * KiB),
-        timeout=20,
-        retry_interval_ms=500,
-    )
-
-
-def test_seal_memory(shutdown_only):
-    """Test objects sealed states reported correctly"""
-    import numpy as np
-
-    info = ray.init(
-        object_store_memory=100 * MiB,
-        _system_config=_SYSTEM_CONFIG,
-    )
-
-    # Allocate 80MiB data
-    objs_in_use = ray.get(
-        [ray.put(np.zeros(20 * MiB, dtype=np.uint8)) for _ in range(4)]
-    )
-
-    expected = {
-        "SEALED": 80 * MiB,
-        "UNSEALED": 0,
-    }
-
-    wait_for_condition(
-        # 1KiB for metadata difference
-        lambda: approx_eq_dict_in(objects_by_seal_state(info), expected, 1 * KiB),
-        timeout=20,
-        retry_interval_ms=500,
-    )
-
-    del objs_in_use
-
-    expected = {
-        "SEALED": 0,
-        "UNSEALED": 0,
-    }
-
-    wait_for_condition(
-        # 1KiB for metadata difference
-        lambda: approx_eq_dict_in(objects_by_seal_state(info), expected, 1 * KiB),
-        timeout=20,
-        retry_interval_ms=500,
-    )
 
 
 if __name__ == "__main__":

--- a/src/ray/object_manager/plasma/common.h
+++ b/src/ray/object_manager/plasma/common.h
@@ -60,8 +60,6 @@ struct Allocation {
   int device_num;
   /// the total size of this mapped memory.
   int64_t mmap_size;
-  /// if it was fallback allocated.
-  bool fallback_allocated;
 
   // only allow moves.
   RAY_DISALLOW_COPY_AND_ASSIGN(Allocation);
@@ -75,25 +73,17 @@ struct Allocation {
              MEMFD_TYPE fd,
              ptrdiff_t offset,
              int device_num,
-             int64_t mmap_size,
-             bool fallback_allocated)
+             int64_t mmap_size)
       : address(address),
         size(size),
         fd(std::move(fd)),
         offset(offset),
         device_num(device_num),
-        mmap_size(mmap_size),
-        fallback_allocated(fallback_allocated) {}
+        mmap_size(mmap_size) {}
 
   // Test only
   Allocation()
-      : address(nullptr),
-        size(0),
-        fd(),
-        offset(0),
-        device_num(0),
-        mmap_size(0),
-        fallback_allocated(false) {}
+      : address(nullptr), size(0), fd(), offset(0), device_num(0), mmap_size(0) {}
 
   friend class PlasmaAllocator;
   friend class DummyAllocator;

--- a/src/ray/object_manager/plasma/object_lifecycle_manager.cc
+++ b/src/ray/object_manager/plasma/object_lifecycle_manager.cc
@@ -29,7 +29,7 @@ ObjectLifecycleManager::ObjectLifecycleManager(
       eviction_policy_(std::make_unique<EvictionPolicy>(*object_store_, allocator)),
       delete_object_callback_(delete_object_callback),
       earger_deletion_objects_(),
-      stats_collector_(std::make_unique<ObjectStatsCollector>()) {}
+      stats_collector_() {}
 
 std::pair<const LocalObject *, flatbuf::PlasmaError> ObjectLifecycleManager::CreateObject(
     const ray::ObjectInfo &object_info,
@@ -46,7 +46,7 @@ std::pair<const LocalObject *, flatbuf::PlasmaError> ObjectLifecycleManager::Cre
     return {nullptr, PlasmaError::OutOfMemory};
   }
   eviction_policy_->ObjectCreated(object_info.object_id);
-  stats_collector_->OnObjectCreated(*entry);
+  stats_collector_.OnObjectCreated(*entry);
   return {entry, PlasmaError::OK};
 }
 
@@ -58,7 +58,7 @@ const LocalObject *ObjectLifecycleManager::SealObject(const ObjectID &object_id)
   // TODO(scv119): should we check delete object from earger_deletion_objects_?
   auto entry = object_store_->SealObject(object_id);
   if (entry != nullptr) {
-    stats_collector_->OnObjectSealed(*entry);
+    stats_collector_.OnObjectSealed(*entry);
   }
   return entry;
 }
@@ -132,7 +132,7 @@ bool ObjectLifecycleManager::AddReference(const ObjectID &object_id) {
   }
   // Increase reference count.
   entry->ref_count++;
-  stats_collector_->OnObjectRefIncreased(*entry);
+  stats_collector_.OnObjectRefIncreased(*entry);
   RAY_LOG(DEBUG) << "Object " << object_id << " reference has incremented"
                  << ", num bytes in use is now " << GetNumBytesInUse();
   return true;
@@ -148,7 +148,7 @@ bool ObjectLifecycleManager::RemoveReference(const ObjectID &object_id) {
   }
 
   entry->ref_count--;
-  stats_collector_->OnObjectRefDecreased(*entry);
+  stats_collector_.OnObjectRefDecreased(*entry);
 
   if (entry->ref_count > 0) {
     return true;
@@ -239,7 +239,7 @@ void ObjectLifecycleManager::DeleteObjectInternal(const ObjectID &object_id) {
 
   bool aborted = entry->state == ObjectState::PLASMA_CREATED;
 
-  stats_collector_->OnObjectDeleting(*entry);
+  stats_collector_.OnObjectDeleting(*entry);
   earger_deletion_objects_.erase(object_id);
   eviction_policy_->RemoveObject(object_id);
   object_store_->DeleteObject(object_id);
@@ -251,7 +251,7 @@ void ObjectLifecycleManager::DeleteObjectInternal(const ObjectID &object_id) {
 }
 
 int64_t ObjectLifecycleManager::GetNumBytesInUse() const {
-  return stats_collector_->GetNumBytesInUse();
+  return stats_collector_.GetNumBytesInUse();
 }
 
 bool ObjectLifecycleManager::IsObjectSealed(const ObjectID &object_id) const {
@@ -260,33 +260,32 @@ bool ObjectLifecycleManager::IsObjectSealed(const ObjectID &object_id) const {
 }
 
 int64_t ObjectLifecycleManager::GetNumBytesCreatedTotal() const {
-  return stats_collector_->GetNumBytesCreatedTotal();
+  return stats_collector_.GetNumBytesCreatedTotal();
 }
 
 int64_t ObjectLifecycleManager::GetNumBytesUnsealed() const {
-  return stats_collector_->GetNumBytesUnsealed();
+  return stats_collector_.GetNumBytesUnsealed();
 }
 
 int64_t ObjectLifecycleManager::GetNumObjectsUnsealed() const {
-  return stats_collector_->GetNumObjectsUnsealed();
+  return stats_collector_.GetNumObjectsUnsealed();
 }
 
-void ObjectLifecycleManager::RecordMetrics() const { stats_collector_->RecordMetrics(); }
+void ObjectLifecycleManager::RecordMetrics() const { stats_collector_.RecordMetrics(); }
 
 void ObjectLifecycleManager::GetDebugDump(std::stringstream &buffer) const {
-  return stats_collector_->GetDebugDump(buffer);
+  return stats_collector_.GetDebugDump(buffer);
 }
 
 // For test only.
 ObjectLifecycleManager::ObjectLifecycleManager(
     std::unique_ptr<IObjectStore> store,
     std::unique_ptr<IEvictionPolicy> eviction_policy,
-    ray::DeleteObjectCallback delete_object_callback,
-    std::unique_ptr<ObjectStatsCollector> stats_collector)
+    ray::DeleteObjectCallback delete_object_callback)
     : object_store_(std::move(store)),
       eviction_policy_(std::move(eviction_policy)),
       delete_object_callback_(delete_object_callback),
       earger_deletion_objects_(),
-      stats_collector_(std::move(stats_collector)) {}
+      stats_collector_() {}
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/object_lifecycle_manager.h
+++ b/src/ray/object_manager/plasma/object_lifecycle_manager.h
@@ -147,15 +147,7 @@ class ObjectLifecycleManager : public IObjectLifecycleManager {
   // Test only
   ObjectLifecycleManager(std::unique_ptr<IObjectStore> store,
                          std::unique_ptr<IEvictionPolicy> eviction_policy,
-                         ray::DeleteObjectCallback delete_object_callback,
-                         std::unique_ptr<ObjectStatsCollector> stats_collector);
-
-  friend struct ObjectLifecycleManagerTest;
-  friend struct ObjectStatsCollectorTest;
-  FRIEND_TEST(ObjectLifecycleManagerTest, DeleteFailure);
-  FRIEND_TEST(ObjectLifecycleManagerTest, RemoveReferenceOneRefEagerlyDeletion);
-  friend struct GetRequestQueueTest;
-  FRIEND_TEST(GetRequestQueueTest, TestAddRequest);
+                         ray::DeleteObjectCallback delete_object_callback);
 
   const LocalObject *CreateObjectInternal(const ray::ObjectInfo &object_info,
                                           plasma::flatbuf::ObjectSource source,
@@ -167,6 +159,15 @@ class ObjectLifecycleManager : public IObjectLifecycleManager {
   void EvictObjects(const std::vector<ObjectID> &object_ids);
 
   void DeleteObjectInternal(const ObjectID &object_id);
+
+ private:
+  friend struct ObjectLifecycleManagerTest;
+  friend struct ObjectStatsCollectorTest;
+  FRIEND_TEST(ObjectLifecycleManagerTest, DeleteFailure);
+  FRIEND_TEST(ObjectLifecycleManagerTest, RemoveReferenceOneRefEagerlyDeletion);
+  friend struct GetRequestQueueTest;
+  FRIEND_TEST(GetRequestQueueTest, TestAddRequest);
+
   std::unique_ptr<IObjectStore> object_store_;
   std::unique_ptr<IEvictionPolicy> eviction_policy_;
   const ray::DeleteObjectCallback delete_object_callback_;
@@ -175,6 +176,7 @@ class ObjectLifecycleManager : public IObjectLifecycleManager {
   // once reference count becomes 0.
   absl::flat_hash_set<ObjectID> earger_deletion_objects_;
 
-  std::unique_ptr<ObjectStatsCollector> stats_collector_;
+  ObjectStatsCollector stats_collector_;
 };
+
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/plasma_allocator.h
+++ b/src/ray/object_manager/plasma/plasma_allocator.h
@@ -84,9 +84,7 @@ class PlasmaAllocator : public IAllocator {
   int64_t FallbackAllocated() const override;
 
  private:
-  absl::optional<Allocation> BuildAllocation(void *addr,
-                                             size_t size,
-                                             bool is_fallback_allocated);
+  absl::optional<Allocation> BuildAllocation(void *addr, size_t size);
 
  private:
   const int64_t kFootprintLimit;

--- a/src/ray/object_manager/plasma/stats_collector.h
+++ b/src/ray/object_manager/plasma/stats_collector.h
@@ -17,10 +17,7 @@
 
 #pragma once
 
-#include <utility>  // std::pair
-
 #include "ray/object_manager/plasma/common.h"
-#include "ray/util/counter_map.h"  // CounterMap
 
 namespace plasma {
 
@@ -31,19 +28,14 @@ namespace plasma {
 // ObjectLifeCycleManager into this class.
 class ObjectStatsCollector {
  public:
-  virtual ~ObjectStatsCollector() = default;
-
   // Called after a new object is created.
-  // Marked virtual for test mocking
-  virtual void OnObjectCreated(const LocalObject &object);
+  void OnObjectCreated(const LocalObject &object);
 
   // Called after an object is sealed.
-  // Marked virtual for test mocking
-  virtual void OnObjectSealed(const LocalObject &object);
+  void OnObjectSealed(const LocalObject &object);
 
   // Called BEFORE an object is deleted.
-  // Marked virtual for test mocking
-  virtual void OnObjectDeleting(const LocalObject &object);
+  void OnObjectDeleting(const LocalObject &object);
 
   // Called after an object's ref count is bumped by 1.
   void OnObjectRefIncreased(const LocalObject &object);
@@ -70,7 +62,6 @@ class ObjectStatsCollector {
 
   int64_t GetNumBytesCreatedCurrent() const;
 
-  CounterMap<std::pair</* fallback_allocated*/ bool, /*sealed*/ bool>> bytes_by_loc_seal_;
   int64_t num_objects_spillable_ = 0;
   int64_t num_bytes_spillable_ = 0;
   int64_t num_objects_unsealed_ = 0;

--- a/src/ray/object_manager/plasma/test/fallback_allocator_test.cc
+++ b/src/ray/object_manager/plasma/test/fallback_allocator_test.cc
@@ -44,11 +44,9 @@ TEST(FallbackPlasmaAllocatorTest, FallbackPassThroughTest) {
   {
     auto allocation_1 = allocator.Allocate(object_size);
     EXPECT_TRUE(allocation_1.has_value());
-    EXPECT_FALSE(allocation_1->fallback_allocated);
 
     auto allocation_2 = allocator.Allocate(object_size);
     EXPECT_TRUE(allocation_2.has_value());
-    EXPECT_FALSE(allocation_2->fallback_allocated);
 
     EXPECT_EQ(2 * object_size, allocator.Allocated());
 
@@ -71,7 +69,6 @@ TEST(FallbackPlasmaAllocatorTest, FallbackPassThroughTest) {
     auto allocation = allocator.Allocate(kMB);
     expect_allocated += kMB;
     EXPECT_TRUE(allocation.has_value());
-    EXPECT_FALSE(allocation->fallback_allocated);
     EXPECT_EQ(expect_allocated, allocator.Allocated());
     EXPECT_EQ(0, allocator.FallbackAllocated());
     allocations.push_back(std::move(allocation.value()));
@@ -93,7 +90,6 @@ TEST(FallbackPlasmaAllocatorTest, FallbackPassThroughTest) {
       expect_allocated += kMB;
       expect_fallback_allocated += kMB;
       EXPECT_TRUE(allocation.has_value());
-      EXPECT_TRUE(allocation->fallback_allocated);
       EXPECT_EQ(expect_allocated, allocator.Allocated());
       EXPECT_EQ(expect_fallback_allocated, allocator.FallbackAllocated());
       fallback_allocations.push_back(std::move(allocation.value()));

--- a/src/ray/object_manager/plasma/test/object_lifecycle_manager_test.cc
+++ b/src/ray/object_manager/plasma/test/object_lifecycle_manager_test.cc
@@ -49,28 +49,17 @@ class MockObjectStore : public IObjectStore {
   MOCK_CONST_METHOD1(GetDebugDump, void(std::stringstream &buffer));
 };
 
-class MockObjectStatsCollector : public ObjectStatsCollector {
- public:
-  MOCK_METHOD1(OnObjectCreated, void(const LocalObject &));
-  MOCK_METHOD1(OnObjectSealed, void(const LocalObject &));
-  MOCK_METHOD1(OnObjectDeleting, void(const LocalObject &));
-};
-
 struct ObjectLifecycleManagerTest : public Test {
   void SetUp() override {
     Test::SetUp();
     auto eviction_policy = std::make_unique<MockEvictionPolicy>();
     auto object_store = std::make_unique<MockObjectStore>();
-    auto stats_collector = std::make_unique<MockObjectStatsCollector>();
     eviction_policy_ = eviction_policy.get();
     object_store_ = object_store.get();
-    stats_collector_ = stats_collector.get();
-    auto delete_object_cb = [this](auto &id) { notify_deleted_ids_.push_back(id); };
-    manager_ = std::make_unique<ObjectLifecycleManager>(
-        ObjectLifecycleManager(std::move(object_store),
-                               std::move(eviction_policy),
-                               delete_object_cb,
-                               std::move(stats_collector)));
+    manager_ = std::make_unique<ObjectLifecycleManager>(ObjectLifecycleManager(
+        std::move(object_store), std::move(eviction_policy), [this](auto &id) {
+          notify_deleted_ids_.push_back(id);
+        }));
     sealed_object_.state = ObjectState::PLASMA_SEALED;
     not_sealed_object_.state = ObjectState::PLASMA_CREATED;
     one_ref_object_.state = ObjectState::PLASMA_SEALED;
@@ -81,7 +70,6 @@ struct ObjectLifecycleManagerTest : public Test {
 
   MockEvictionPolicy *eviction_policy_;
   MockObjectStore *object_store_;
-  MockObjectStatsCollector *stats_collector_;
   std::unique_ptr<ObjectLifecycleManager> manager_;
   std::vector<ObjectID> notify_deleted_ids_;
 

--- a/src/ray/object_manager/plasma/test/object_store_test.cc
+++ b/src/ray/object_manager/plasma/test/object_store_test.cc
@@ -32,13 +32,10 @@ T Random(T max = std::numeric_limits<T>::max()) {
   return absl::Uniform(bitgen, 0, max);
 }
 
-Allocation CreateAllocation(Allocation alloc,
-                            int64_t size,
-                            bool fallback_allocated = false) {
+Allocation CreateAllocation(Allocation alloc, int64_t size) {
   alloc.size = size;
   alloc.offset = Random<ptrdiff_t>();
   alloc.mmap_size = Random<int64_t>();
-  alloc.fallback_allocated = fallback_allocated;
   return alloc;
 }
 
@@ -103,7 +100,6 @@ TEST(ObjectStoreTest, PassThroughTest) {
     EXPECT_EQ(entry->state, ObjectState::PLASMA_CREATED);
     EXPECT_EQ(alloc_str, Serialize(entry->allocation));
     EXPECT_EQ(info, entry->object_info);
-    EXPECT_FALSE(entry->allocation.fallback_allocated);
 
     // verify get
     auto entry1 = store.GetObject(kId1);
@@ -149,9 +145,6 @@ TEST(ObjectStoreTest, PassThroughTest) {
     EXPECT_EQ(nullptr, store.CreateObject(info, {}, /*fallback_allocate*/ false));
 
     // fallback allocation successful
-    allocation = CreateAllocation(Allocation(), 12, /* fallback_allocated */ true);
-    alloc_str = Serialize(allocation);
-
     EXPECT_CALL(allocator, FallbackAllocate(12))
         .Times(1)
         .WillOnce(Invoke([&](size_t bytes) {
@@ -165,7 +158,6 @@ TEST(ObjectStoreTest, PassThroughTest) {
     EXPECT_EQ(entry->state, ObjectState::PLASMA_CREATED);
     EXPECT_EQ(alloc_str, Serialize(entry->allocation));
     EXPECT_EQ(info, entry->object_info);
-    EXPECT_TRUE(entry->allocation.fallback_allocated);
 
     // delete unsealed
     EXPECT_CALL(allocator, Free(_)).Times(1).WillOnce(Invoke([&](auto &&allocation) {

--- a/src/ray/object_manager/plasma/test/stats_collector_test.cc
+++ b/src/ray/object_manager/plasma/test/stats_collector_test.cc
@@ -66,7 +66,7 @@ struct ObjectStatsCollectorTest : public Test {
     allocator_ = std::make_unique<DummyAllocator>();
     manager_ =
         std::make_unique<ObjectLifecycleManager>(*allocator_, [](auto /* unused */) {});
-    collector_ = manager_->stats_collector_.get();
+    collector_ = &manager_->stats_collector_;
     object_store_ = dynamic_cast<ObjectStore *>(manager_->object_store_.get());
     used_ids_.clear();
     num_bytes_created_total_ = 0;
@@ -147,18 +147,6 @@ struct ObjectStatsCollectorTest : public Test {
     EXPECT_EQ(num_bytes_received, collector_->num_bytes_received_);
     EXPECT_EQ(num_objects_errored, collector_->num_objects_errored_);
     EXPECT_EQ(num_bytes_errored, collector_->num_bytes_errored_);
-
-    // Expect counter map containing the correct values
-    const auto &counters = collector_->bytes_by_loc_seal_;
-    EXPECT_EQ(collector_->GetNumBytesCreatedCurrent(),
-              counters.Get({/*fallback_allocated*/ true, /*sealed*/ true}) +
-                  counters.Get({/*fallback_allocated*/ true, /*sealed*/ false}) +
-                  counters.Get({/*fallback_allocated*/ false, /*sealed*/ true}) +
-                  counters.Get({/*fallback_allocated*/ false, /*sealed*/ false}));
-
-    EXPECT_EQ(num_bytes_unsealed,
-              counters.Get({/*fallback_allocated*/ true, /*sealed*/ false}) +
-                  counters.Get({/*fallback_allocated*/ false, /*sealed*/ false}));
   }
 
   ray::ObjectInfo CreateNewObjectInfo(int64_t data_size) {

--- a/src/ray/stats/metric_defs.cc
+++ b/src/ray/stats/metric_defs.cc
@@ -231,19 +231,17 @@ DEFINE_stats(gcs_storage_operation_count,
 DEFINE_stats(object_store_memory,
              "Object store memory by various sub-kinds on this node",
              /// Location:
-             ///    - MMAP_SHM: currently in shared memory(e.g. /dev/shm).
-             ///    - MMAP_DISK: memory that's fallback allocated on mmapped disk,
-             ///      e.g. /tmp.
+             ///    TODO(rickyx): spill fallback from in memory
+             ///    - IN_MEMORY: currently in shared memory(e.g. /dev/shm) and
+             ///      fallback allocated. This is memory already sealed.
              ///    - SPILLED: current number of bytes from objects spilled
              ///      to external storage. Note this might be smaller than
              ///      the physical storage incurred on the external storage because
              ///      Ray might fuse spilled objects into a single file, so a deleted
              ///      spill object might still exist in the spilled file. Check
              ///      spilled object fusing for more details.
-             /// ObjectState:
-             ///    - SEALED: sealed objects bytes (could be MMAP_SHM or MMAP_DISK)
-             ///    - UNSEALED: unsealed objects bytes (could be MMAP_SHM or MMAP_DISK)
-             (ray::stats::LocationKey.name(), ray::stats::ObjectStateKey.name()),
+             ///    - UNSEALED: unsealed bytes that come from objects just created.
+             ("Location"),
              (),
              ray::stats::GAUGE);
 

--- a/src/ray/stats/tag_defs.cc
+++ b/src/ray/stats/tag_defs.cc
@@ -45,7 +45,5 @@ const TagKeyType SessionNameKey = TagKeyType::Register("SessionName");
 const TagKeyType NameKey = TagKeyType::Register("Name");
 
 const TagKeyType LocationKey = TagKeyType::Register("Location");
-
-const TagKeyType ObjectStateKey = TagKeyType::Register("ObjectState");
 }  // namespace stats
 }  // namespace ray

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -50,11 +50,6 @@ extern const TagKeyType NameKey;
 
 // Object store memory location tag constants
 extern const TagKeyType LocationKey;
-constexpr char kObjectLocMmapShm[] = "MMAP_SHM";
-constexpr char kObjectLocMmapDisk[] = "MMAP_DISK";
+constexpr char kObjectLocInMemory[] = "IN_MEMORY";
 constexpr char kObjectLocSpilled[] = "SPILLED";
-
-// Object store memory sealed/unsealed tag
-extern const TagKeyType ObjectStateKey;
-constexpr char kObjectSealed[] = "SEALED";
-constexpr char kObjectUnsealed[] = "UNSEALED";
+constexpr char kObjectLocUnsealed[] = "UNSEALED";

--- a/src/ray/util/counter_map.h
+++ b/src/ray/util/counter_map.h
@@ -66,14 +66,14 @@ class CounterMap {
     }
   }
 
-  /// Decrement the specified key by `val`, default to 1. If the count for the key drops
-  /// to zero, the entry for the key is erased from the counter. It is not allowed for the
-  /// count to be decremented below zero.
-  void Decrement(const K &key, int64_t val = 1) {
+  /// Decrement the specified key by one. If the count for the key drops to zero,
+  /// the entry for the key is erased from the counter. It is not allowed for
+  /// the count to be decremented below zero.
+  void Decrement(const K &key) {
     auto it = counters_.find(key);
     RAY_CHECK(it != counters_.end());
-    it->second -= val;
-    total_ -= val;
+    it->second -= 1;
+    total_ -= 1;
     int64_t new_value = it->second;
     if (new_value <= 0) {
       counters_.erase(it);
@@ -94,11 +94,11 @@ class CounterMap {
     }
   }
 
-  /// Decrement `old_key` by one and increment `new_key` by `val`, default to 1.
-  void Swap(const K &old_key, const K &new_key, int64_t val = 1) {
+  /// Decrement `old_key` by one and increment `new_key` by one.
+  void Swap(const K &old_key, const K &new_key) {
     if (old_key != new_key) {
-      Decrement(old_key, val);
-      Increment(new_key, val);
+      Decrement(old_key);
+      Increment(new_key);
     }
   }
 

--- a/src/ray/util/counter_test.cc
+++ b/src/ray/util/counter_test.cc
@@ -43,27 +43,6 @@ TEST_F(CounterMapTest, TestBasic) {
   EXPECT_EQ(c.Get("k2"), 1);
   EXPECT_EQ(c.Total(), 1);
   EXPECT_EQ(c.Size(), 1);
-
-  // Test multi-value ops
-  c.Increment("k1", 10);
-  c.Increment("k2", 5);
-  EXPECT_EQ(c.Get("k1"), 10);
-  EXPECT_EQ(c.Get("k2"), 6);
-  EXPECT_EQ(c.Total(), 16);
-  EXPECT_EQ(c.Size(), 2);
-
-  c.Decrement("k1", 5);
-  c.Decrement("k2", 1);
-  EXPECT_EQ(c.Get("k1"), 5);
-  EXPECT_EQ(c.Get("k2"), 5);
-  EXPECT_EQ(c.Total(), 10);
-  EXPECT_EQ(c.Size(), 2);
-
-  c.Swap("k1", "k2", 5);
-  EXPECT_EQ(c.Get("k1"), 0);
-  EXPECT_EQ(c.Get("k2"), 10);
-  EXPECT_EQ(c.Total(), 10);
-  EXPECT_EQ(c.Size(), 1);
 }
 
 TEST_F(CounterMapTest, TestCallback) {


### PR DESCRIPTION
This reverts commit 5da96b813e0c8986634af62783b3718752edea5a (https://github.com/ray-project/ray/pull/29485).

Caused by failures in a MacOS test, see https://github.com/ray-project/ray/issues/29803

BK w/failed test https://buildkite.com/ray-project/oss-ci-build-branch/builds/762#01841dd9-b8d1-4b41-af5b-df9c3021ce7e/963-7700