### PR TITLE
[core] disable legacy memory monitor if oom killer is enabled

### DIFF
--- a/python/ray/_private/memory_monitor.py
+++ b/python/ray/_private/memory_monitor.py
@@ -148,7 +148,11 @@ class MemoryMonitor:
         return used_gb, total_gb
 
     def enabled(self) -> bool:
-        return ray._config.memory_monitor_interval_ms() == 0 or "RAY_DEBUG_DISABLE_MEMORY_MONITOR" in os.environ or "RAY_DISABLE_MEMORY_MONITOR" in os.environ
+        return (
+            ray._config.memory_monitor_interval_ms() == 0
+            or "RAY_DEBUG_DISABLE_MEMORY_MONITOR" in os.environ
+            or "RAY_DISABLE_MEMORY_MONITOR" in os.environ
+        )
 
     def raise_if_low_memory(self):
         if time.time() - self.last_checked > self.check_interval:

--- a/python/ray/_private/memory_monitor.py
+++ b/python/ray/_private/memory_monitor.py
@@ -147,14 +147,16 @@ class MemoryMonitor:
             assert used_gb >= 0
         return used_gb, total_gb
 
+    def enabled(self) -> bool:
+        return True
+        # return ray._config.memory_monitor_interval_ms() == 0 or "RAY_DEBUG_DISABLE_MEMORY_MONITOR" in os.environ or "RAY_DISABLE_MEMORY_MONITOR" in os.environ
+
     def raise_if_low_memory(self):
         if time.time() - self.last_checked > self.check_interval:
-            if (
-                "RAY_DEBUG_DISABLE_MEMORY_MONITOR" in os.environ
-                or "RAY_DISABLE_MEMORY_MONITOR" in os.environ
-            ):
+            if not self.enabled():
+                print("FK")
                 return
-
+            print("FKEN")
             self.last_checked = time.time()
             used_gb, total_gb = self.get_memory_usage()
 

--- a/python/ray/_private/memory_monitor.py
+++ b/python/ray/_private/memory_monitor.py
@@ -147,17 +147,18 @@ class MemoryMonitor:
             assert used_gb >= 0
         return used_gb, total_gb
 
-    def enabled(self) -> bool:
+    def disabled(self) -> bool:
         return (
-            ray._config.memory_monitor_interval_ms() == 0
+            ray._config.memory_monitor_interval_ms() > 0
             or "RAY_DEBUG_DISABLE_MEMORY_MONITOR" in os.environ
             or "RAY_DISABLE_MEMORY_MONITOR" in os.environ
         )
 
     def raise_if_low_memory(self):
+        if self.disabled():
+            return
+
         if time.time() - self.last_checked > self.check_interval:
-            if not self.enabled():
-                return
             self.last_checked = time.time()
             used_gb, total_gb = self.get_memory_usage()
 

--- a/python/ray/_private/memory_monitor.py
+++ b/python/ray/_private/memory_monitor.py
@@ -148,15 +148,12 @@ class MemoryMonitor:
         return used_gb, total_gb
 
     def enabled(self) -> bool:
-        return True
-        # return ray._config.memory_monitor_interval_ms() == 0 or "RAY_DEBUG_DISABLE_MEMORY_MONITOR" in os.environ or "RAY_DISABLE_MEMORY_MONITOR" in os.environ
+        return ray._config.memory_monitor_interval_ms() == 0 or "RAY_DEBUG_DISABLE_MEMORY_MONITOR" in os.environ or "RAY_DISABLE_MEMORY_MONITOR" in os.environ
 
     def raise_if_low_memory(self):
         if time.time() - self.last_checked > self.check_interval:
             if not self.enabled():
-                print("FK")
                 return
-            print("FKEN")
             self.last_checked = time.time()
             used_gb, total_gb = self.get_memory_usage()
 

--- a/python/ray/_private/memory_monitor.py
+++ b/python/ray/_private/memory_monitor.py
@@ -129,6 +129,10 @@ class MemoryMonitor:
                 "`pip install psutil` to enable "
                 "debugging of memory-related crashes."
             )
+        self.disabled = (
+            "RAY_DEBUG_DISABLE_MEMORY_MONITOR" in os.environ
+            or "RAY_DISABLE_MEMORY_MONITOR" in os.environ
+        )
 
     def get_memory_usage(self):
         psutil_mem = psutil.virtual_memory()
@@ -147,15 +151,8 @@ class MemoryMonitor:
             assert used_gb >= 0
         return used_gb, total_gb
 
-    def disabled(self) -> bool:
-        return (
-            ray._config.memory_monitor_interval_ms() > 0
-            or "RAY_DEBUG_DISABLE_MEMORY_MONITOR" in os.environ
-            or "RAY_DISABLE_MEMORY_MONITOR" in os.environ
-        )
-
     def raise_if_low_memory(self):
-        if self.disabled():
+        if self.disabled:
             return
 
         if time.time() - self.last_checked > self.check_interval:

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -817,8 +817,9 @@ cdef execute_task(
     with core_worker.profile_event(b"task::" + name, extra_data=extra_data):
         try:
             task_exception = False
-            if not (<int>task_type == <int>TASK_TYPE_ACTOR_TASK
-                    and function_name == "__ray_terminate__"):
+            if (not (<int>task_type == <int>TASK_TYPE_ACTOR_TASK
+                     and function_name == "__ray_terminate__") and
+               ray._config.memory_monitor_interval_ms() == 0):
                 worker.memory_monitor.raise_if_low_memory()
 
             with core_worker.profile_event(b"task:deserialize_arguments"):

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -80,3 +80,5 @@ cdef extern from "ray/common/ray_config.h" nogil:
         c_string REDIS_CLIENT_KEY() const
 
         c_string REDIS_SERVER_NAME() const
+
+        uint64_t memory_monitor_interval_ms() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -136,3 +136,8 @@ cdef class Config:
     @staticmethod
     def REDIS_SERVER_NAME():
         return RayConfig.instance().REDIS_SERVER_NAME()
+
+    @staticmethod
+    def memory_monitor_interval_ms():
+        return (RayConfig.instance()
+                .memory_monitor_interval_ms())

--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -438,6 +438,7 @@ def test_put_object_task_usage_slightly_below_limit_does_not_crash():
             timeout=90,
         )
 
+
 @pytest.mark.skipif(
     sys.platform != "linux" and sys.platform != "linux2",
     reason="memory monitor only on linux currently",

--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -452,11 +452,8 @@ def test_legacy_memory_monitor_disabled_by_oom_killer():
         },
     ):
         bytes_to_alloc = get_additional_bytes_to_reach_memory_usage_pct(0.6)
-        ray.get(
-            allocate_memory.options(max_retries=0).remote(
-                allocate_bytes=bytes_to_alloc,
-            ),
-        )
+        leaker = Leaker.options(max_restarts=0, max_task_retries=0).remote()
+        ray.get(leaker.allocate.remote(bytes_to_alloc))
 
         bytes_to_alloc = get_additional_bytes_to_reach_memory_usage_pct(0.8)
         ray.get(

--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -452,16 +452,12 @@ def test_legacy_memory_monitor_disabled_by_oom_killer():
             "min_memory_free_bytes": -1,
         },
     ):
-        bytes_to_alloc = get_additional_bytes_to_reach_memory_usage_pct(0.6)
+        bytes_to_alloc = get_additional_bytes_to_reach_memory_usage_pct(0.7)
         leaker = Leaker.options(max_restarts=0, max_task_retries=0).remote()
         ray.get(leaker.allocate.remote(bytes_to_alloc))
 
         bytes_to_alloc = get_additional_bytes_to_reach_memory_usage_pct(0.8)
-        ray.get(
-            allocate_memory.options(max_retries=0).remote(
-                allocate_bytes=bytes_to_alloc,
-            ),
-        )
+        ray.get(leaker.allocate.remote(allocate_bytes=bytes_to_alloc, sleep_time_s=10))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

When the OOM killer is enabled, the legacy memory monitor should stop crashing the app when it submits a task when the memory usage is > 95%. as this will cause the workload to fail that would pass otherwise when OOM killer is enabled

## Related issue number

Closes [#29836](https://github.com/ray-project/ray/issues/29836)

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
