### PR TITLE
[Dashboard] Fix a bug from object store percentage bar

### DIFF
--- a/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.tsx
@@ -102,13 +102,13 @@ const NodeRow = ({ node, expanded, onExpandButtonClick }: NodeRowProps) => {
         <NodeGRAM node={node} />
       </TableCell>
       <TableCell>
-        {raylet && raylet.objectStoreUsedMemory && (
+        {raylet && objectStoreTotalMemory && (
           <PercentageBar
             num={raylet.objectStoreUsedMemory}
             total={objectStoreTotalMemory}
           >
             {memoryConverter(raylet.objectStoreUsedMemory)}/
-            {memoryConverter(objectStoreTotalMemory)}
+            {memoryConverter(objectStoreTotalMemory)}({(raylet.objectStoreUsedMemory / objectStoreTotalMemory).toFixed(2)}%)
           </PercentageBar>
         )}
       </TableCell>

--- a/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.tsx
@@ -108,7 +108,9 @@ const NodeRow = ({ node, expanded, onExpandButtonClick }: NodeRowProps) => {
             total={objectStoreTotalMemory}
           >
             {memoryConverter(raylet.objectStoreUsedMemory)}/
-            {memoryConverter(objectStoreTotalMemory)}({(raylet.objectStoreUsedMemory / objectStoreTotalMemory).toFixed(2)}%)
+            {memoryConverter(objectStoreTotalMemory)}(
+            {(raylet.objectStoreUsedMemory / objectStoreTotalMemory).toFixed(2)}
+            %)
           </PercentageBar>
         )}
       </TableCell>


### PR DESCRIPTION
Signed-off-by: SangBin Cho <rkooo567@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixing 2 issues.

1. When the used memory == 0%, it doesn't display anything (we should rather display the [0/total] bar).
2. It currently doesn't display the %. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
