### PR TITLE
[Agent] Fix a bug when parent is None

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -180,12 +180,17 @@ class DashboardAgent:
                     parent = curr_proc.parent()
                     # If the parent is dead, it is None.
                     parent_gone = parent is None
-                    # Sometimes, the parent is changed to the `init` process.
-                    # In this case, the parent.pid is 1.
-                    init_assigned_for_parent = parent.pid == 1
-                    # Sometimes, the parent is dead, and the pid is reused
-                    # by other processes. In this case, this condition is triggered.
-                    parent_changed = self.ppid != parent.pid
+                    init_assigned_for_parent = False
+                    parent_changed = False
+
+                    if parent:
+                        # Sometimes, the parent is changed to the `init` process.
+                        # In this case, the parent.pid is 1.
+                        init_assigned_for_parent = parent.pid == 1
+                        # Sometimes, the parent is dead, and the pid is reused
+                        # by other processes. In this case, this condition is triggered.
+                        parent_changed = self.ppid != parent.pid
+
                     if parent_gone or init_assigned_for_parent or parent_changed:
                         parent_death_cnt += 1
                         logger.warning(


### PR DESCRIPTION
Signed-off-by: SangBin Cho <rkooo567@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When `parent` is None, it raises an exception. This fixes the issue. 

## Related issue number

https://github.com/ray-project/ray/issues/29412

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
