### PR TITLE
Revert "[Train] Increase timeout for `test_mosaic_trainer`"

### DIFF
--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -380,7 +380,7 @@ py_test(
 
 py_test(
     name = "test_mosaic_trainer",
-    size = "large",
+    size = "medium",
     srcs = ["tests/test_mosaic_trainer.py"],
     tags = ["team:ml", "exclusive", "ray_air", "mosaic"],
     deps = [":train_lib", ":conftest"]


### PR DESCRIPTION
Reverts ray-project/ray#29793

Test is still timing out even after increasing the size