### PR TITLE
[CI] [Windows] Adding logs to help debug Windows wheels flaky failure

### DIFF
--- a/python/build-wheel-windows.sh
+++ b/python/build-wheel-windows.sh
@@ -39,6 +39,10 @@ Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 
 Update-SessionEnvironment
 
+# Print out the list of env vars we're going to export.
+# Sometimes the bash source fails, this will help with debugging.
+gci env:
+
 # Round brackets in variable names cause problems with bash
 Get-ChildItem env:* | %{
   if (!($_.Name.Contains('('))) {


### PR DESCRIPTION
<img width="987" alt="Screen Shot 2022-10-31 at 5 38 03 PM" src="https://user-images.githubusercontent.com/950914/199134260-12afa6a3-dd2f-4a88-97c3-fb6bf8324d5f.png">

Windows Wheels build is flaky and it looks like it has something to do with [our usage of `refreshenv`](https://github.com/ray-project/ray/blob/master/python/build-wheel-windows.sh#L35). From my reading, `refreshenv` basically exports the powershell environment into bash. It has some special case handling for environment variables which have lparens in their name (I guess this is a thing in Windows?). But from looking at recent flaky failures, I think it is missing some special case.

I thought it might fail for cases where the commit message has a single quote in it, but I ran the script locally (on powershell on mac) and it succeeded. Before spending more time on an investigation, I think it'll be easier to just get the exact case that's failing.

Related issue: https://github.com/ray-project/ray/issues/29717

Example failures that I hope to get more information from:
```
++ export 'ChocolateyToolsLocation=C:\tools'
--
  | ++ ChocolateyToolsLocation='C:\tools'
  | /c/Users/ContainerAdministrator/AppData/Local/Temp/refreshenv.sh: line 66: syntax error near unexpected token `('
```
```
++ export 'ChocolateyToolsLocation=C:\tools'
--
  | ++ ChocolateyToolsLocation='C:\tools'
  | /c/Users/ContainerAdministrator/AppData/Local/Temp/refreshenv.sh: line 67: unexpected EOF while looking for matching `''
```
```
export 'BUILDKITE_MESSAGE=[Jobs] Deflake jobs sdk test (#29707)
--
  |  
  | Wait for all nodes to come up before running the unit test to deflake the unit test. It submits a bunch of jobs and checks that at least one was run on a worker node. However if the jobs are submitted too soon, its' possible that only the head node has come up, so 'theyll all be scheduled on the head node. The fix is to only submit the jobs after all the nodes are up.
  |  
  | Also adds some logs to improve debuggability.
  |  
  | Related issue number
  | Closes #29006'
  | ++ BUILDKITE_MESSAGE='[Jobs] Deflake jobs sdk test (#29707)
  |  
  | Wait for all nodes to come up before running the unit test to deflake the unit test. It submits a bunch of jobs and checks that at least one was run on a worker node. However if the jobs are submitted too soon, its'
  | /c/Users/ContainerAdministrator/AppData/Local/Temp/refreshenv.sh: line 66: export: `up,': not a valid identifier
  | /c/Users/ContainerAdministrator/AppData/Local/Temp/refreshenv.sh: line 66: export: `theyll all be scheduled on the head node. The fix is to only submit the jobs after all the nodes are up.
  |  
  | Also adds some logs to improve debuggability.
  |  
  | Related issue number
  | Closes #29006': not a valid identifier
```

