### PR TITLE
[Datasets] Improve `map_batches` error

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -558,7 +558,7 @@ class Dataset(Generic[T]):
                                     f"to be of type `numpy.ndarray`, but the value "
                                     f"corresponding to key {key!r} is of type "
                                     f"{type(value)}. To fix this issue, convert "
-                                    f"the {type(value)} to a `numpy.ndarray`." 
+                                    f"the {type(value)} to a `numpy.ndarray`."
                                 )
 
             def process_next_batch(batch: Block) -> Iterator[Block]:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -551,15 +551,14 @@ class Dataset(Generic[T]):
                 if isinstance(batch, dict):
                     for key, value in batch.items():
                         if not isinstance(value, np.ndarray):
-                            with np.printoptions(edgeitems=1):
-                                raise ValueError(
-                                    "The `fn` you passed to `map_batches` returned a "
-                                    f"`dict`. `map_batches` expects all `dict` values "
-                                    f"to be of type `numpy.ndarray`, but the value "
-                                    f"corresponding to key {key!r} is of type "
-                                    f"{type(value)}. To fix this issue, convert "
-                                    f"the {type(value)} to a `numpy.ndarray`."
-                                )
+                            raise ValueError(
+                                "The `fn` you passed to `map_batches` returned a "
+                                f"`dict`. `map_batches` expects all `dict` values "
+                                f"to be of type `numpy.ndarray`, but the value "
+                                f"corresponding to key {key!r} is of type "
+                                f"{type(value)}. To fix this issue, convert "
+                                f"the {type(value)} to a `numpy.ndarray`."
+                            )
 
             def process_next_batch(batch: Block) -> Iterator[Block]:
                 # Convert to batch format.


### PR DESCRIPTION
Signed-off-by: Balaji <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

1. Error message is way too long if your dataset contains tensors.
2. The list of supported batch types (`typing.Union[ForwardRef('pandas.DataFrame'), ForwardRef('pyarrow.Table'), numpy.ndarray, typing.Dict[str, numpy.ndarray], list]`) looks goofy.
```
>>> import numpy as np
>>> import ray
>>> ds = ray.data.read_images("python/ray/data/examples/data/image-datasets/simple")
>>> def fn(batch: list[np.ndarray]) -> dict[str, object]:
...         return {"image": batch, "label": [None] * len(batch)}
>>> ds.map_batches(fn, batch_format="numpy")
ValueError: The map batches UDF returned the value {'image': array([[[[ 88,  70,  68],
         [103,  88,  85],
         [112,  96,  97],
         ...,
         [134, 169, 189],
         [139, 165, 178],
         [140, 163, 171]],

        [[ 80,  62,  58],
         [105,  87,  85],
         [111,  95,  95],
         ...,
         [141, 174, 193],
         [146, 170, 182],
         [147, 167, 174]],

        [[ 70,  51,  45],
         [102,  85,  78],
         [107,  89,  85],
         ...,
         [139, 168, 186],
         [143, 163, 174],
         [143, 160, 167]],

        ...,

        [[137, 142, 122],
         [134, 139, 119],
         [129, 133, 116],
         ...,
         [173, 153,  90],
         [170, 150,  89],
         [168, 148,  89]],

        [[133, 140, 122],
         [130, 137, 119],
         [128, 135, 117],
         ...,
         [170, 153,  84],
         [168, 150,  84],
         [167, 149,  85]],

        [[128, 137, 118],
         [127, 136, 117],
         [127, 134, 116],
         ...,
         [168, 151,  81],
         [167, 149,  83],
         [166, 148,  82]]],


       [[[ 16,  16,  16],
         [ 14,  14,  14],
         [ 18,  18,  18],
         ...,
         [ 93,  49,  48],
         [100,  52,  52],
         [ 95,  47,  47]],

        [[ 78,  78,  80],
         [ 70,  72,  71],
         [ 57,  57,  59],
         ...,
         [ 77,  35,  36],
         [114,  70,  71],
         [169, 125, 126]],

        [[106, 107, 111],
         [100, 104, 105],
         [ 83,  84,  88],
         ...,
         [116,  82,  83],
         [168, 132, 134],
         [209, 173, 175]],

        ...,

        [[193, 203, 212],
         [194, 204, 213],
         [195, 205, 214],
         ...,
         [195, 205, 214],
         [193, 206, 214],
         [193, 206, 214]],

        [[189, 202, 211],
         [191, 204, 213],
         [193, 206, 215],
         ...,
         [194, 204, 213],
         [192, 205, 211],
         [191, 204, 210]],

        [[188, 201, 210],
         [190, 203, 212],
         [192, 205, 214],
         ...,
         [193, 203, 212],
         [190, 203, 209],
         [190, 203, 209]]],


       [[[ 37,  23,  20],
         [ 49,  35,  32],
         [ 51,  37,  34],
         ...,
         [ 53,  43,  33],
         [ 46,  36,  24],
         [ 44,  34,  22]],

        [[ 57,  43,  40],
         [ 75,  61,  58],
         [ 85,  71,  68],
         ...,
         [ 74,  64,  54],
         [ 68,  58,  46],
         [ 65,  55,  43]],

        [[ 81,  67,  64],
         [101,  87,  84],
         [112,  98,  95],
         ...,
         [ 92,  82,  72],
         [ 86,  76,  66],
         [ 81,  71,  61]],

        ...,

        [[108,  97,  95],
         [135, 124, 122],
         [151, 140, 138],
         ...,
         [153, 144, 135],
         [141, 132, 123],
         [115, 106,  97]],

        [[100,  89,  87],
         [123, 112, 110],
         [133, 122, 120],
         ...,
         [142, 133, 124],
         [140, 131, 122],
         [109, 100,  91]],

        [[ 90,  79,  77],
         [109,  98,  96],
         [114, 103, 101],
         ...,
         [130, 121, 112],
         [125, 116, 107],
         [ 99,  90,  81]]]], dtype=uint8), 'label': [None, None, None]} of type <class 'dict'>, which is not allowed. The return type must be one of: typing.Union[ForwardRef('pandas.DataFrame'), ForwardRef('pyarrow.Table'), numpy.ndarray, typing.Dict[str, numpy.ndarray], list]
Read->Map_Batches:   0%|                          
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
