### PR TITLE
[Tune] Update `generate_id` algorithm

### DIFF
--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -528,7 +528,7 @@ class Trial:
 
     @classmethod
     def generate_id(cls):
-        return str(uuid.uuid1().hex)[:8]
+        return str(uuid.uuid4().hex)[:8]
 
     @property
     def remote_checkpoint_dir(self):


### PR DESCRIPTION
Signed-off-by: Balaji <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

tl;dr: `uuid1` is based on time, so if you start trials at the same time, their IDs will conflict. See https://discuss.ray.io/t/clashing-trial-ids-run-id-in-wandbloggercallback/8046/3. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
