### PR TITLE
upgrade gtest to 1.12.1

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -181,8 +181,8 @@ def ray_deps_setup():
 
     auto_http_archive(
         name = "com_google_googletest",
-        url = "https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz",
-        sha256 = "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5",
+        url = "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz",
+        sha256 = "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2",
     )
 
     auto_http_archive(


### PR DESCRIPTION
How to reproduce:

```shell
bazel test //:actor_manager_test
```

## Why are these changes needed?

While working on https://github.com/ray-project/ray/pull/28209 I hit issue https://github.com/google/googletest/issues/3514, which causes a couple gtest-dependent tests to be unable to build

## Related issue number

Upgrades gtest to avoid https://github.com/google/googletest/issues/3514

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
