### PR TITLE
[autoscaler][kuberay] Fix e2e test logic.

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -547,6 +547,9 @@ def wait_for_stdout(strings_to_match: List[str], timeout_s: int):
     by a function contains the provided list of strings.
     Raises an exception if the stdout doesn't have the expected output in time.
 
+    Note: The decorated function should not block!
+    (It should return soon after being called.)
+
     Args:
         strings_to_match: Wait until stdout contains all of these string.
         timeout_s: Max time to wait, in seconds, before raising a RuntimeError.
@@ -560,7 +563,7 @@ def wait_for_stdout(strings_to_match: List[str], timeout_s: int):
                 # Redirect stdout to an in-memory stream.
                 out_stream = io.StringIO()
                 sys.stdout = out_stream
-                # Execute the func.
+                # Execute the func. (Make sure the function doesn't block!)
                 out = func(*args, **kwargs)
                 # Check out_stream once a second until the timeout.
                 # Raise a RuntimeError if we timeout.
@@ -575,14 +578,15 @@ def wait_for_stdout(strings_to_match: List[str], timeout_s: int):
                 # out_stream has the expected strings
                 success = True
                 return out
+            # Exception raised on failure.
             finally:
                 sys.stdout = sys.__stdout__
+                print(out_stream.getvalue())
+                out_stream.close()
                 if success:
                     print("Confirmed expected function stdout. Stdout follows:")
                 else:
                     print("Did not confirm expected function stdout. Stdout follows:")
-                print(out_stream.getvalue())
-                out_stream.close()
 
         return decorated_func
 

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -581,12 +581,12 @@ def wait_for_stdout(strings_to_match: List[str], timeout_s: int):
             # Exception raised on failure.
             finally:
                 sys.stdout = sys.__stdout__
-                print(out_stream.getvalue())
-                out_stream.close()
                 if success:
                     print("Confirmed expected function stdout. Stdout follows:")
                 else:
                     print("Did not confirm expected function stdout. Stdout follows:")
+                print(out_stream.getvalue())
+                out_stream.close()
 
         return decorated_func
 

--- a/python/ray/tests/kuberay/scripts/scale_up.py
+++ b/python/ray/tests/kuberay/scripts/scale_up.py
@@ -1,6 +1,5 @@
 import ray
 from ray._private import test_utils
-import time
 
 
 @test_utils.wait_for_stdout(
@@ -15,8 +14,6 @@ def main():
     flakiness.
     """
     ray.autoscaler.sdk.request_resources(num_cpus=2)
-    while ray.cluster_resources().get("CPU", 0) < 2:
-        time.sleep(0.1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

There's incorrect test logic in the KubeRay autoscaling test.
If scale up fails, the test will just hang forever rather than exiting after a timeout.

This PR fixes that.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
