### PR TITLE
[Tune] Remove `include_trial_id` from `_trainable_name`

### DIFF
--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -825,12 +825,9 @@ class Trial:
         return self.saving_to is not None
 
     def __repr__(self):
-        return self._trainable_name(include_trial_id=True)
+        return self._trainable_name + "_" + self.trial_id
 
-    def __str__(self):
-        return self._trainable_name(include_trial_id=True)
-
-    def _trainable_name(self, include_trial_id=False):
+    def _trainable_name(self):
         """Combines ``env`` with ``trainable_name`` and ``trial_id``.
 
         Can be overridden with a custom string creator.
@@ -845,8 +842,7 @@ class Trial:
             identifier = "{}_{}".format(self.trainable_name, env)
         else:
             identifier = self.trainable_name
-        if include_trial_id:
-            identifier += "_" + self.trial_id
+
         return identifier.replace("/", "_")
 
     def _generate_dirname(self):

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -382,7 +382,7 @@ class Trial:
 
         self.checkpoint_manager = _CheckpointManager(
             checkpoint_config=self.checkpoint_config,
-            delete_fn=_CheckpointDeleter(self._trainable_name(), self.runner),
+            delete_fn=_CheckpointDeleter(self._trainable_name, self.runner),
         )
 
         # Restoration fields
@@ -625,7 +625,7 @@ class Trial:
                 debug_metrics_only=True
             )
         self.checkpoint_manager.set_delete_fn(
-            _CheckpointDeleter(self._trainable_name(), runner)
+            _CheckpointDeleter(self._trainable_name, runner)
         )
         # No need to invalidate state cache: runner is not stored in json
         # self.invalidate_json_state()
@@ -827,6 +827,7 @@ class Trial:
     def __repr__(self):
         return self._trainable_name + "_" + self.trial_id
 
+    @property
     def _trainable_name(self):
         """Combines ``env`` with ``trainable_name`` and ``trial_id``.
 


### PR DESCRIPTION
Signed-off-by: Balaji <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`include_trial_id` makes the method unnecessarily complex. Flags are generally an anti-pattern.

Also, if `__str__` isn't implemented, it defaults to `__repr__`. Since `__str__` was equal to `__repr__`, I removed it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
