### PR TITLE
[Tune] Don't overwrite W&B runs by default

### DIFF
--- a/python/ray/air/callbacks/wandb.py
+++ b/python/ray/air/callbacks/wandb.py
@@ -407,7 +407,7 @@ class WandbLoggerCallback(LoggerCallback):
         wandb_init_kwargs = dict(
             id=trial_id,
             name=trial_name,
-            resume=False,
+            resume="never",
             reinit=True,
             allow_val_change=True,
             group=wandb_group,


### PR DESCRIPTION
Signed-off-by: Balaji <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If there are trials with duplicate IDs, then W&B runs are unexpectedly overwritten.

> The other thing I would suggest should be changed is how wandb.init() is called. We may not be able to rule out collisions with certainty, so they need to be handled here. Right now, the default behavior of wandb is that if you call wandb.init() twice with the same id argument and without setting the resume kwarg, then the run on wandb will be overwritten (!) - leading to potential data loss. Even worse, if two runs concurrently log to the same run ID, you can end up with a mix of data from both in the same run on wandb. And finally, to make things absolutely bad, if the sequence of events is just right, you can end up with the config logged from one run, but data from another! 

For more information, read this Discuss post: https://discuss.ray.io/t/clashing-trial-ids-run-id-in-wandbloggercallback/8046/3.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
