### PR TITLE
[Serve] Add method info to HTTP metrics

### DIFF
--- a/doc/source/serve/production-guide/monitoring.md
+++ b/doc/source/serve/production-guide/monitoring.md
@@ -225,30 +225,56 @@ The following metrics are exposed by Ray Serve:
    :header-rows: 1
 
    * - Name
+     - Fields
      - Description
    * - ``serve_deployment_request_counter`` [**]
+     - * deployment
+       * replica
      - The number of queries that have been processed in this replica.
    * - ``serve_deployment_error_counter`` [**]
+     - * deployment
+       * replica
      - The number of exceptions that have occurred in the deployment.
    * - ``serve_deployment_replica_starts`` [**]
+     - * deployment
+       * replica
      - The number of times this replica has been restarted due to failure.
    * - ``serve_deployment_replica_healthy``
+     - * deployment
+       * replica
      - Whether this deployment replica is healthy. 1 means healthy, 0 unhealthy.
    * - ``serve_deployment_processing_latency_ms`` [**]
+     - * deployment
+       * replica
      - The latency for queries to be processed.
    * - ``serve_replica_processing_queries`` [**]
+     - * deployment
+       * replica
      - The current number of queries being processed.
    * - ``serve_num_http_requests`` [*]
+     - * route
+       * method
      - The number of HTTP requests processed.
    * - ``serve_num_http_error_requests`` [*]
+     - * route
+       * error_code
+       * method
      - The number of non-200 HTTP responses.
    * - ``serve_num_router_requests`` [*]
+     - * deployment
      - The number of requests processed by the router.
    * - ``serve_handle_request_counter`` [**]
+     - * handle
+       * deployment
      - The number of requests processed by this ServeHandle.
    * - ``serve_deployment_queued_queries`` [*]
+     - * deployment
+       * endpoint
      - The number of queries for this deployment waiting to be assigned to a replica.
    * - ``serve_num_deployment_http_error_requests`` [*]
+     - * deployment
+       * error_code
+       * method
      - The number of non-200 HTTP responses returned by each deployment.
 ```
 [*] - only available when using HTTP calls  

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -246,6 +246,7 @@ class HTTPProxy:
             ),
             tag_keys=(
                 "deployment",
+                "error_code",
                 "method",
             ),
         )
@@ -347,6 +348,7 @@ class HTTPProxy:
             self.deployment_request_error_counter.inc(
                 tags={
                     "deployment": handle.deployment_name,
+                    "error_code": status_code,
                     "method": scope["method"].upper(),
                 }
             )

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -223,13 +223,20 @@ class HTTPProxy:
         self.request_counter = metrics.Counter(
             "serve_num_http_requests",
             description="The number of HTTP requests processed.",
-            tag_keys=("route",),
+            tag_keys=(
+                "route",
+                "method",
+            ),
         )
 
         self.request_error_counter = metrics.Counter(
             "serve_num_http_error_requests",
             description="The number of non-200 HTTP responses.",
-            tag_keys=("route", "error_code"),
+            tag_keys=(
+                "route",
+                "error_code",
+                "method",
+            ),
         )
 
         self.deployment_request_error_counter = metrics.Counter(
@@ -237,7 +244,10 @@ class HTTPProxy:
             description=(
                 "The number of non-200 HTTP responses returned by each deployment."
             ),
-            tag_keys=("deployment",),
+            tag_keys=(
+                "deployment",
+                "method",
+            ),
         )
 
     def _update_routes(self, endpoints: Dict[EndpointTag, EndpointInfo]) -> None:
@@ -282,7 +292,9 @@ class HTTPProxy:
         root_path = scope["root_path"]
         route_path = scope["path"][len(root_path) :]
 
-        self.request_counter.inc(tags={"route": route_path})
+        self.request_counter.inc(
+            tags={"route": route_path, "method": scope["method"].upper()}
+        )
 
         if route_path == "/-/routes":
             return await starlette.responses.JSONResponse(self.route_info)(
@@ -297,7 +309,11 @@ class HTTPProxy:
         route_prefix, handle = self.prefix_router.match_route(route_path)
         if route_prefix is None:
             self.request_error_counter.inc(
-                tags={"route": route_path, "error_code": "404"}
+                tags={
+                    "route": route_path,
+                    "error_code": "404",
+                    "method": scope["method"].upper(),
+                }
             )
             return await self._not_found(scope, receive, send)
 
@@ -322,10 +338,17 @@ class HTTPProxy:
         )
         if status_code != "200":
             self.request_error_counter.inc(
-                tags={"route": route_path, "error_code": status_code}
+                tags={
+                    "route": route_path,
+                    "error_code": status_code,
+                    "method": scope["method"].upper(),
+                }
             )
             self.deployment_request_error_counter.inc(
-                tags={"deployment": handle.deployment_name}
+                tags={
+                    "deployment": handle.deployment_name,
+                    "method": scope["method"].upper(),
+                }
             )
 
 

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -1,4 +1,5 @@
 import os
+from typing import List, Dict
 
 import requests
 import pytest
@@ -154,6 +155,50 @@ def test_http_metrics(serve_instance):
         verify_error_count(do_assert=True)
 
 
+def test_http_metrics_fields(serve_instance):
+    """Tests the http metrics' fields' behavior."""
+
+    @serve.deployment(route_prefix="/real_route")
+    def f(*args):
+        return 1 / 0
+
+    serve.run(f.bind())
+
+    # Should generate 404 responses
+    broken_url = "http://127.0.0.1:8000/fake_route"
+    for _ in range(10):
+        requests.get(broken_url).text
+    print("Sent requests to broken URL.")
+
+    num_requests = get_metric_dictionaries("serve_num_http_requests")
+    assert len(num_requests) == 1
+    assert num_requests[0]["route"] == "/fake_route"
+    assert num_requests[0]["method"] == "GET"
+    print("serve_num_http_requests working as expected.")
+
+    num_errors = get_metric_dictionaries("serve_num_http_error_requests")
+    assert len(num_errors) == 1
+    assert num_errors[0]["route"] == "/fake_route"
+    assert num_errors[0]["error_code"] == "404"
+    assert num_errors[0]["method"] == "GET"
+    print("serve_num_http_error_requests working as expected.")
+
+    # Deployment should generate divide-by-zero errors
+    correct_url = "http://127.0.0.1:8000/real_route"
+    for _ in range(10):
+        requests.get(correct_url).text
+    print("Sent requests to correct URL.")
+
+    num_deployment_errors = get_metric_dictionaries(
+        "serve_num_deployment_http_error_requests"
+    )
+    assert len(num_deployment_errors) == 1
+    assert num_deployment_errors[0]["deployment"] == "f"
+    assert num_deployment_errors[0]["error_code"] == "500"
+    assert num_deployment_errors[0]["method"] == "GET"
+    print("serve_num_deployment_http_error_requests working as expected.")
+
+
 def test_actor_summary(serve_instance):
     @serve.deployment
     def f():
@@ -165,6 +210,48 @@ def test_actor_summary(serve_instance):
     assert class_names.issuperset(
         {"ServeController", "HTTPProxyActor", "ServeReplica:f"}
     )
+
+
+def get_metric_dictionaries(name: str, timeout: float = 20) -> List[Dict]:
+    """Gets a list of metric's dictionaries from metrics' text output.
+
+    Return:
+        Example:
+
+        >>> get_metric_dictionaries("ray_serve_num_http_requests")
+        [
+            {
+                'Component': 'core_worker',
+                'JobId': '01000000',
+                ...
+                'method': 'GET',
+                'route': '/hello'
+            },
+            {
+                'Component': 'core_worker',
+                ...
+                'method': 'GET',
+                'route': '/hello/'
+            }
+        ]
+    """
+
+    def metric_available() -> bool:
+        metrics = requests.get("http://127.0.0.1:9999").text
+        return name in metrics
+
+    wait_for_condition(metric_available, retry_interval_ms=1000, timeout=timeout)
+
+    metrics = requests.get("http://127.0.0.1:9999").text
+
+    metric_dicts = []
+    for line in metrics.split("\n"):
+        if name + "{" in line:
+            dict_body_start, dict_body_end = line.find("{") + 1, line.rfind("}")
+            metric_dict_str = f"dict({line[dict_body_start:dict_body_end]})"
+            metric_dicts.append(eval(metric_dict_str))
+
+    return metric_dicts
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -12,7 +12,7 @@ import ray.experimental.state.api as state_api
 
 
 @pytest.fixture
-def start_and_stop_serve():
+def serve_start_shutdown():
     """Fixture provides a fresh Ray cluster to prevent metrics state sharing."""
     ray.init(
         _metrics_export_port=9999,
@@ -26,7 +26,7 @@ def start_and_stop_serve():
     ray.shutdown()
 
 
-def test_serve_metrics_for_successful_connection(serve_instance):
+def test_serve_metrics_for_successful_connection(serve_start_shutdown):
     @serve.deployment(name="metrics")
     async def f(request):
         return "hello"
@@ -83,7 +83,7 @@ def test_serve_metrics_for_successful_connection(serve_instance):
         verify_metrics(do_assert=True)
 
 
-def test_http_metrics(serve_instance):
+def test_http_metrics(serve_start_shutdown):
 
     # NOTE: These metrics should be documented at
     # https://docs.ray.io/en/latest/serve/monitoring.html#metrics
@@ -170,7 +170,7 @@ def test_http_metrics(serve_instance):
         verify_error_count(do_assert=True)
 
 
-def test_http_metrics_fields(start_and_stop_serve):
+def test_http_metrics_fields(serve_start_shutdown):
     """Tests the http metrics' fields' behavior."""
 
     @serve.deployment(route_prefix="/real_route")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change updates some metrics that Serve uses to gauge HTTP requests successes and failures:

* `serve_num_http_requests`
    * Adds the `method` field
* `serve_num_http_error_requests`
    * Adds the `method` field
* `serve_num_deployment_http_error_requests`
    * Adds the `error_code` field
    * Adds the `method` field

This helps distinguish between different methods used when pinging the same endpoint.

Link to documentation changes: https://ray--29918.org.readthedocs.build/en/29918/serve/production-guide/monitoring.html#built-in-ray-serve-metrics

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change adds a unit test to `test_metrics.py`.
   - Manually verified that these metrics show up in the output using this script:

```python
# File name: repro.py
import ray
from ray import serve

import logging
import requests
from fastapi import FastAPI

ray.init(address="auto")

app = FastAPI()
logger = logging.getLogger("ray.serve")

@serve.deployment(route_prefix="/hello")
@serve.ingress(app)
class MyFastAPIDeployment:

    def __init__(self):
        logger.setLevel(logging.DEBUG)

    @app.get("/")
    def root(self):
        logger.info("What a wonderful kind of day!")
        return "Hello, world!"


serve.run(MyFastAPIDeployment.bind())
resp = requests.get("http://localhost:8000/hello")
assert resp.json() == "Hello, world!"
```

**Repro steps:**
1. `ray start --head --metrics-export-port=8080`
2. `python repro.py`
3. Go to `localhost:8080`. After a short period of time, the updated metrics should appear with the `GET` method and error code `307`.
