### PR TITLE
[Train] Immediately fail on any worker failure

### DIFF
--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -172,7 +172,6 @@ class _TorchBackend(Backend):
             raise RuntimeError("Distributed torch is not available.")
 
     def on_shutdown(self, worker_group: WorkerGroup, backend_config: TorchConfig):
-
         worker_group.execute(
             _shutdown_torch, destroy_process_group=len(worker_group) > 1
         )

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -172,6 +172,7 @@ class _TorchBackend(Backend):
             raise RuntimeError("Distributed torch is not available.")
 
     def on_shutdown(self, worker_group: WorkerGroup, backend_config: TorchConfig):
+
         worker_group.execute(
             _shutdown_torch, destroy_process_group=len(worker_group) > 1
         )

--- a/python/ray/train/trainer.py
+++ b/python/ray/train/trainer.py
@@ -235,7 +235,9 @@ class TrainingIterator:
             # If this is a StartTraceback, then this is a user error.
             # We raise it directly
             try:
-                self._backend_executor.shutdown()
+                # Exception raised in at least one training worker. Immediately raise
+                # this error to the user and do not attempt to terminate gracefully.
+                self._backend_executor.shutdown(graceful_termination=False)
                 self._finished_training = True
             except Exception:
                 pass


### PR DESCRIPTION
Signed-off-by: Amog Kamsetty <amogkamsetty@yahoo.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Follow up to https://github.com/ray-project/ray/pull/28314

https://github.com/ray-project/ray/pull/28314 did not cover all the cases. In particular, if one worker fails, but the other workers are _hanging_, then our shutdown logic will also hang since it's waiting for the actors to finish running their methods. Instead, we want to force shutdown all workers regardless of if they have finished their method or not. This PR also adds an e2e integration test.

See https://discuss.ray.io/t/torchtrainer-hangs-when-only-1-worker-raises-error/7447/16

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
