### PR TITLE
[CI] Fix java logging rotated test on slow CI machine.

### DIFF
--- a/java/test/src/main/java/io/ray/test/RayJavaLoggingTest.java
+++ b/java/test/src/main/java/io/ray/test/RayJavaLoggingTest.java
@@ -55,8 +55,12 @@ public class RayJavaLoggingTest extends BaseTest {
                   return false;
                 }
                 long fileSize = rotatedFile.length();
-                return fileSize > 1024 && fileSize < 1024 * 2;
+                boolean fileSizeExpected = fileSize > 1024 && fileSize < 1024 * 2;
+                if (!fileSizeExpected) {
+                  return false;
+                }
               }
+              return true;
             },
             10 * 1000);
     Assert.assertTrue(rotated);

--- a/java/test/src/main/java/io/ray/test/RayJavaLoggingTest.java
+++ b/java/test/src/main/java/io/ray/test/RayJavaLoggingTest.java
@@ -42,6 +42,9 @@ public class RayJavaLoggingTest extends BaseTest {
     final JobId jobId = Ray.getRuntimeContext().getCurrentJobId();
     String currLogDir = "/tmp/ray/session_latest/logs";
     for (int i = 1; i <= 3; ++i) {
+      // Note(qwang): Due to log4j2 is async, once the `log()` actor method returned, we
+      // still have no confident to make sure all log messages are printed to the log files,
+      // especially on slow CI machine.
       boolean rotated =
           TestUtils.waitForCondition(
               () -> {

--- a/java/test/src/main/java/io/ray/test/RayJavaLoggingTest.java
+++ b/java/test/src/main/java/io/ray/test/RayJavaLoggingTest.java
@@ -39,15 +39,15 @@ public class RayJavaLoggingTest extends BaseTest {
             .remote();
     Assert.assertTrue(loggingActor.task(HeavyLoggingActor::log).remote().get());
     final int pid = loggingActor.task(HeavyLoggingActor::getPid).remote().get();
-    final JobId jobId = Ray.getRuntimeContext().getCurrentJobId();
-    String currLogDir = "/tmp/ray/session_latest/logs";
-    for (int i = 1; i <= 3; ++i) {
-      // Note(qwang): Due to log4j2 is async, once the `log()` actor method returned, we
-      // still have no confident to make sure all log messages are printed to the log files,
-      // especially on slow CI machine.
-      boolean rotated =
-          TestUtils.waitForCondition(
-              () -> {
+    // Note(qwang): Due to log4j2 is async, once the `log()` actor method returned, we
+    // still have no confident to make sure all log messages are printed to the log files,
+    // especially on slow CI machine.
+    boolean rotated =
+        TestUtils.waitForCondition(
+            () -> {
+              final JobId jobId = Ray.getRuntimeContext().getCurrentJobId();
+              String currLogDir = "/tmp/ray/session_latest/logs";
+              for (int i = 1; i <= 3; ++i) {
                 File rotatedFile =
                     new File(
                         String.format("%s/java-worker-%s-%d.%d.log", currLogDir, jobId, pid, i));
@@ -56,9 +56,9 @@ public class RayJavaLoggingTest extends BaseTest {
                 }
                 long fileSize = rotatedFile.length();
                 return fileSize > 1024 && fileSize < 1024 * 2;
-              },
-              10 * 1000);
-      Assert.assertTrue(rotated);
-    }
+              }
+            },
+            10 * 1000);
+    Assert.assertTrue(rotated);
   }
 }

--- a/java/test/src/main/java/io/ray/test/RayJavaLoggingTest.java
+++ b/java/test/src/main/java/io/ray/test/RayJavaLoggingTest.java
@@ -42,11 +42,20 @@ public class RayJavaLoggingTest extends BaseTest {
     final JobId jobId = Ray.getRuntimeContext().getCurrentJobId();
     String currLogDir = "/tmp/ray/session_latest/logs";
     for (int i = 1; i <= 3; ++i) {
-      File rotatedFile =
-          new File(String.format("%s/java-worker-%s-%d.%d.log", currLogDir, jobId, pid, i));
-      Assert.assertTrue(rotatedFile.exists());
-      long fileSize = rotatedFile.length();
-      Assert.assertTrue(fileSize > 1024 && fileSize < 1024 * 2);
+      boolean rotated =
+          TestUtils.waitForCondition(
+              () -> {
+                File rotatedFile =
+                    new File(
+                        String.format("%s/java-worker-%s-%d.%d.log", currLogDir, jobId, pid, i));
+                if (!rotatedFile.exists()) {
+                  return false;
+                }
+                long fileSize = rotatedFile.length();
+                return fileSize > 1024 && fileSize < 1024 * 2;
+              },
+              10 * 1000);
+      Assert.assertTrue(rotated);
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Qing Wang <kingchin1218@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR fixed java logging rotated test on slow CI machine. The failure reason is that log4j2 is async, so when the log() method finished, the log messages might be not printed immediately.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
