### PR TITLE
[core] Tune python tests when new health check is enabled.

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -265,6 +265,8 @@ py_test_module_list(
     "test_state_api.py",
     "test_reconstruction.py",
     "test_reconstruction_2.py",
+    "test_reconstruction_stress.py",
+    "test_reconstruction_stress_spill.py",
     "test_failure_2.py",
     "test_failure_3.py",
     "test_chaos.py",

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -316,8 +316,18 @@ def test_object_lost_error(ray_start_cluster, debug_enabled):
             "_system_config": {
                 "num_heartbeats_timeout": 10,
                 "raylet_heartbeat_period_milliseconds": 100,
+                "pull_based_healthcheck": False,
             },
-        }
+        },
+        {
+            "num_cpus": 0,
+            "_system_config": {
+                "health_check_initial_delay_ms": 0,
+                "health_check_period_ms": 100,
+                "health_check_failure_threshold": 10,
+                "pull_based_healthcheck": True,
+            },
+        },
     ],
     indirect=True,
 )

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -104,7 +104,17 @@ def test_gcs_server_restart_during_actor_creation(
         generate_system_config_map(
             gcs_failover_worker_reconnect_timeout=2,
             gcs_rpc_server_reconnect_timeout_s=60,
-        )
+            num_heartbeats_timeout=3,
+            pull_based_healthcheck=False,
+        ),
+        generate_system_config_map(
+            gcs_failover_worker_reconnect_timeout=2,
+            gcs_rpc_server_reconnect_timeout_s=60,
+            health_check_initial_delay_ms=0,
+            health_check_period_ms=1000,
+            health_check_failure_threshold=3,
+            pull_based_healthcheck=True,
+        ),
     ],
     indirect=True,
 )

--- a/python/ray/tests/test_gcs_utils.py
+++ b/python/ray/tests/test_gcs_utils.py
@@ -11,6 +11,7 @@ import ray._private.gcs_utils as gcs_utils
 from ray._private.test_utils import (
     enable_external_redis,
     find_free_port,
+    generate_system_config_map,
     async_wait_for_condition_async_predicate,
 )
 import ray._private.ray_constants as ray_constants
@@ -152,8 +153,37 @@ def test_external_storage_namespace_isolation(shutdown_only):
 
 
 @pytest.mark.asyncio
-async def test_check_liveness(monkeypatch, ray_start_cluster):
-    monkeypatch.setenv("RAY_num_heartbeats_timeout", "2")
+@pytest.mark.parametrize(
+    "pull_based,ray_start_cluster",
+    [
+        (
+            False,
+            generate_system_config_map(
+                RAY_num_heartbeats_timeout=2, pull_based_healthcheck=False
+            ),
+        ),
+        (
+            True,
+            generate_system_config_map(
+                health_check_initial_delay_ms=0,
+                health_check_period_ms=1000,
+                health_check_failure_threshold=2,
+                pull_based_healthcheck=True,
+            ),
+        ),
+    ],
+    indirect=["ray_start_cluster"],
+)
+async def test_check_liveness(pull_based, monkeypatch, ray_start_cluster):
+    if pull_based:
+        monkeypatch.setenv("RAY_pull_based_healthcheck", "true")
+        monkeypatch.setenv("RAY_health_check_initial_delay_ms", "0")
+        monkeypatch.setenv("RAY_health_check_period_ms", "1000")
+        monkeypatch.setenv("RAY_health_check_failure_threshold", "2")
+    else:
+        monkeypatch.setenv("RAY_pull_based_healthcheck", "false")
+        monkeypatch.setenv("RAY_num_heartbeats_timeout", "2")
+
     cluster = ray_start_cluster
     h = cluster.add_node(node_manager_port=find_free_port())
     n1 = cluster.add_node(node_manager_port=find_free_port())

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -622,13 +622,24 @@ def test_pull_bundle_deadlock(ray_start_cluster):
     assert ray.get(object_c) == "c"
 
 
-def test_object_directory_failure(ray_start_cluster):
+@pytest.mark.parametrize("pull_based", [True, False])
+def test_object_directory_failure(pull_based, ray_start_cluster):
     cluster = ray_start_cluster
-    config = {
-        "num_heartbeats_timeout": 10,
-        "raylet_heartbeat_period_milliseconds": 500,
-        "object_timeout_milliseconds": 200,
-    }
+    if pull_based:
+        config = {
+            "health_check_initial_delay_ms": 0,
+            "health_check_period_ms": 1000,
+            "health_check_failure_threshold": 10,
+            "object_timeout_milliseconds": 200,
+            "pull_based_healthcheck": True,
+        }
+    else:
+        config = {
+            "num_heartbeats_timeout": 10,
+            "raylet_heartbeat_period_milliseconds": 500,
+            "object_timeout_milliseconds": 200,
+            "pull_based_healthcheck": False,
+        }
     # Add a head node.
     cluster.add_node(_system_config=config)
     ray.init(address=cluster.address)

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -628,7 +628,7 @@ def test_object_directory_failure(pull_based, ray_start_cluster):
     if pull_based:
         config = {
             "health_check_initial_delay_ms": 0,
-            "health_check_period_ms": 1000,
+            "health_check_period_ms": 500,
             "health_check_failure_threshold": 10,
             "object_timeout_milliseconds": 200,
             "pull_based_healthcheck": True,

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -624,27 +624,43 @@ time.sleep(5)
     assert actor_repr not in out
 
 
-def test_node_name_in_raylet_death():
+@pytest.mark.parametrize("pull_based", [True, False])
+def test_node_name_in_raylet_death(pull_based):
     NODE_NAME = "RAY_TEST_RAYLET_DEATH_NODE_NAME"
     script = f"""
-import ray
 import time
 import os
 
-NUM_HEARTBEATS=10
-HEARTBEAT_PERIOD=500
 WAIT_BUFFER_SECONDS=5
 
-os.environ["RAY_num_heartbeats_timeout"]=str(NUM_HEARTBEATS)
-os.environ["RAY_raylet_heartbeat_period_milliseconds"]=str(HEARTBEAT_PERIOD)
+if {pull_based}:
+    os.environ["RAY_pull_based_healthcheck"]="true"
+    os.environ["RAY_health_check_initial_delay_ms"]="0"
+    os.environ["RAY_health_check_period_ms"]="1000"
+    os.environ["RAY_health_check_timeout_ms"]="10"
+    os.environ["RAY_health_check_failure_threshold"]="2"
+    sleep_time = float(os.environ["RAY_health_check_period_ms"]) / 1000.0 * \
+        int(os.environ["RAY_health_check_failure_threshold"])
+    sleep_time += WAIT_BUFFER_SECONDS
+else:
+    NUM_HEARTBEATS=10
+    HEARTBEAT_PERIOD=500
+    os.environ["RAY_pull_based_healthcheck"]="false"
+    os.environ["RAY_num_heartbeats_timeout"]=str(NUM_HEARTBEATS)
+    os.environ["RAY_raylet_heartbeat_period_milliseconds"]=str(HEARTBEAT_PERIOD)
+    sleep_time = NUM_HEARTBEATS * HEARTBEAT_PERIOD / 1000 + WAIT_BUFFER_SECONDS
+
+import ray
 
 ray.init(_node_name=\"{NODE_NAME}\")
 # This will kill raylet without letting it exit gracefully.
 ray._private.worker._global_node.kill_raylet()
-time.sleep(NUM_HEARTBEATS * HEARTBEAT_PERIOD / 1000 + WAIT_BUFFER_SECONDS)
+
+time.sleep(sleep_time)
 ray.shutdown()
     """
     out = run_string_as_driver(script)
+    print(out)
     assert out.count(f"node name: {NODE_NAME} has been marked dead") == 1
 
 

--- a/python/ray/tests/test_reconstruction_2.py
+++ b/python/ray/tests/test_reconstruction_2.py
@@ -221,7 +221,7 @@ def test_multiple_returns(config, ray_start_cluster, reconstruction_enabled):
 
 @pytest.mark.parametrize("reconstruction_enabled", [False, True])
 def test_nested(config, ray_start_cluster, reconstruction_enabled):
-    config["fetch_fail_timeout_milliseconds"] = (10_000,)
+    config["fetch_fail_timeout_milliseconds"] = 10_000
     # Workaround to reset the config to the default value.
     if not reconstruction_enabled:
         config["lineage_pinning_enabled"] = False

--- a/python/ray/tests/test_reconstruction_2.py
+++ b/python/ray/tests/test_reconstruction_2.py
@@ -42,7 +42,7 @@ def config(request):
 @pytest.mark.parametrize("reconstruction_enabled", [False, True])
 def test_nondeterministic_output(config, ray_start_cluster, reconstruction_enabled):
     config["max_direct_call_object_size"] = 100
-    config["task_retry_delay_ms"] = (100,)
+    config["task_retry_delay_ms"] = 100
     config["object_timeout_milliseconds"] = 200
 
     cluster = ray_start_cluster
@@ -84,7 +84,7 @@ def test_nondeterministic_output(config, ray_start_cluster, reconstruction_enabl
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_reconstruction_hangs(config, ray_start_cluster):
     config["max_direct_call_object_size"] = 100
-    config["task_retry_delay_ms"] = (100,)
+    config["task_retry_delay_ms"] = 100
     config["object_timeout_milliseconds"] = 200
     config["fetch_warn_timeout_milliseconds"] = 1000
 

--- a/python/ray/tests/test_reconstruction_2.py
+++ b/python/ray/tests/test_reconstruction_2.py
@@ -17,16 +17,34 @@ FINISHED = "FINISHED"
 WAITING_FOR_EXECUTION = "SUBMITTED_TO_WORKER"
 
 
+@pytest.fixture(params=[True, False])
+def config(request):
+    pull_based = request.param
+    if pull_based:
+        config = {
+            "health_check_initial_delay_ms": 0,
+            "health_check_period_ms": 100,
+            "health_check_failure_threshold": 10,
+            "object_timeout_milliseconds": 200,
+            "pull_based_healthcheck": True,
+        }
+    else:
+        config = {
+            "num_heartbeats_timeout": 10,
+            "raylet_heartbeat_period_milliseconds": 100,
+            "pull_based_healthcheck": False,
+            "object_timeout_milliseconds": 200,
+        }
+    yield config
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize("reconstruction_enabled", [False, True])
-def test_nondeterministic_output(ray_start_cluster, reconstruction_enabled):
-    config = {
-        "num_heartbeats_timeout": 10,
-        "raylet_heartbeat_period_milliseconds": 100,
-        "max_direct_call_object_size": 100,
-        "task_retry_delay_ms": 100,
-        "object_timeout_milliseconds": 200,
-    }
+def test_nondeterministic_output(config, ray_start_cluster, reconstruction_enabled):
+    config["max_direct_call_object_size"] = 100
+    config["task_retry_delay_ms"] = (100,)
+    config["object_timeout_milliseconds"] = 200
+
     cluster = ray_start_cluster
     # Head node with no resources.
     cluster.add_node(
@@ -64,15 +82,12 @@ def test_nondeterministic_output(ray_start_cluster, reconstruction_enabled):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_reconstruction_hangs(ray_start_cluster):
-    config = {
-        "num_heartbeats_timeout": 10,
-        "raylet_heartbeat_period_milliseconds": 100,
-        "max_direct_call_object_size": 100,
-        "task_retry_delay_ms": 100,
-        "object_timeout_milliseconds": 200,
-        "fetch_warn_timeout_milliseconds": 1000,
-    }
+def test_reconstruction_hangs(config, ray_start_cluster):
+    config["max_direct_call_object_size"] = 100
+    config["task_retry_delay_ms"] = (100,)
+    config["object_timeout_milliseconds"] = 200
+    config["fetch_warn_timeout_milliseconds"] = 1000
+
     cluster = ray_start_cluster
     # Head node with no resources.
     cluster.add_node(
@@ -107,13 +122,8 @@ def test_reconstruction_hangs(ray_start_cluster):
         ray.get(x)
 
 
-def test_lineage_evicted(ray_start_cluster):
-    config = {
-        "num_heartbeats_timeout": 10,
-        "raylet_heartbeat_period_milliseconds": 100,
-        "object_timeout_milliseconds": 200,
-        "max_lineage_bytes": 10_000,
-    }
+def test_lineage_evicted(config, ray_start_cluster):
+    config["max_lineage_bytes"] = 10_000
 
     cluster = ray_start_cluster
     # Head node with no resources.
@@ -163,12 +173,7 @@ def test_lineage_evicted(ray_start_cluster):
 
 
 @pytest.mark.parametrize("reconstruction_enabled", [False, True])
-def test_multiple_returns(ray_start_cluster, reconstruction_enabled):
-    config = {
-        "num_heartbeats_timeout": 10,
-        "raylet_heartbeat_period_milliseconds": 100,
-        "object_timeout_milliseconds": 200,
-    }
+def test_multiple_returns(config, ray_start_cluster, reconstruction_enabled):
     # Workaround to reset the config to the default value.
     if not reconstruction_enabled:
         config["lineage_pinning_enabled"] = False
@@ -215,13 +220,8 @@ def test_multiple_returns(ray_start_cluster, reconstruction_enabled):
 
 
 @pytest.mark.parametrize("reconstruction_enabled", [False, True])
-def test_nested(ray_start_cluster, reconstruction_enabled):
-    config = {
-        "num_heartbeats_timeout": 10,
-        "raylet_heartbeat_period_milliseconds": 100,
-        "object_timeout_milliseconds": 200,
-        "fetch_fail_timeout_milliseconds": 10_000,
-    }
+def test_nested(config, ray_start_cluster, reconstruction_enabled):
+    config["fetch_fail_timeout_milliseconds"] = (10_000,)
     # Workaround to reset the config to the default value.
     if not reconstruction_enabled:
         config["lineage_pinning_enabled"] = False
@@ -283,12 +283,7 @@ def test_nested(ray_start_cluster, reconstruction_enabled):
 
 
 @pytest.mark.parametrize("reconstruction_enabled", [False, True])
-def test_spilled(ray_start_cluster, reconstruction_enabled):
-    config = {
-        "num_heartbeats_timeout": 10,
-        "raylet_heartbeat_period_milliseconds": 100,
-        "object_timeout_milliseconds": 200,
-    }
+def test_spilled(config, ray_start_cluster, reconstruction_enabled):
     # Workaround to reset the config to the default value.
     if not reconstruction_enabled:
         config["lineage_pinning_enabled"] = False
@@ -336,13 +331,7 @@ def test_spilled(ray_start_cluster, reconstruction_enabled):
             ray.get(obj, timeout=60)
 
 
-def test_memory_util(ray_start_cluster):
-    config = {
-        "num_heartbeats_timeout": 10,
-        "raylet_heartbeat_period_milliseconds": 100,
-        "object_timeout_milliseconds": 200,
-    }
-
+def test_memory_util(config, ray_start_cluster):
     cluster = ray_start_cluster
     # Head node with no resources.
     cluster.add_node(
@@ -477,12 +466,7 @@ def test_override_max_retries(ray_start_cluster, override_max_retries):
 
 
 @pytest.mark.parametrize("reconstruction_enabled", [False, True])
-def test_reconstruct_freed_object(ray_start_cluster, reconstruction_enabled):
-    config = {
-        "num_heartbeats_timeout": 10,
-        "raylet_heartbeat_period_milliseconds": 100,
-        "object_timeout_milliseconds": 200,
-    }
+def test_reconstruct_freed_object(config, ray_start_cluster, reconstruction_enabled):
     # Workaround to reset the config to the default value.
     if not reconstruction_enabled:
         config["lineage_pinning_enabled"] = False

--- a/python/ray/tests/test_reconstruction_stress.py
+++ b/python/ray/tests/test_reconstruction_stress.py
@@ -1,0 +1,89 @@
+import os
+import signal
+import sys
+
+import numpy as np
+import pytest
+
+import ray
+
+SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
+
+
+@pytest.fixture(params=[True, False])
+def config(request):
+    pull_based = request.param
+    if pull_based:
+        config = {
+            "health_check_initial_delay_ms": 0,
+            "health_check_period_ms": 100,
+            "health_check_failure_threshold": 10,
+            "object_timeout_milliseconds": 200,
+            "pull_based_healthcheck": True,
+        }
+    else:
+        config = {
+            "num_heartbeats_timeout": 10,
+            "raylet_heartbeat_period_milliseconds": 100,
+            "pull_based_healthcheck": False,
+            "object_timeout_milliseconds": 200,
+        }
+    yield config
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+def test_reconstruction_stress(config, ray_start_cluster):
+    config["task_retry_delay_ms"] = 100
+    config["max_direct_call_object_size"] = 100
+    cluster = ray_start_cluster
+    # Head node with no resources.
+    cluster.add_node(
+        num_cpus=0, _system_config=config, enable_object_reconstruction=True
+    )
+    ray.init(address=cluster.address)
+    # Node to place the initial object.
+    node_to_kill = cluster.add_node(
+        num_cpus=1, resources={"node1": 1}, object_store_memory=10**8
+    )
+    cluster.add_node(num_cpus=1, resources={"node2": 1}, object_store_memory=10**8)
+    cluster.wait_for_nodes()
+
+    @ray.remote
+    def large_object():
+        return np.zeros(10**5, dtype=np.uint8)
+
+    @ray.remote
+    def dependent_task(x):
+        return
+
+    for _ in range(3):
+        obj = large_object.options(resources={"node1": 1}).remote()
+        ray.get(dependent_task.options(resources={"node2": 1}).remote(obj))
+
+        outputs = [
+            large_object.options(resources={"node1": 1}).remote() for _ in range(1000)
+        ]
+        outputs = [
+            dependent_task.options(resources={"node2": 1}).remote(obj)
+            for obj in outputs
+        ]
+
+        cluster.remove_node(node_to_kill, allow_graceful=False)
+        node_to_kill = cluster.add_node(
+            num_cpus=1, resources={"node1": 1}, object_store_memory=10**8
+        )
+
+        i = 0
+        while outputs:
+            ray.get(outputs.pop(0))
+            print(i)
+            i += 1
+
+
+if __name__ == "__main__":
+    import pytest
+
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reconstruction_stress_spill.py
+++ b/python/ray/tests/test_reconstruction_stress_spill.py
@@ -1,0 +1,90 @@
+import os
+import signal
+import sys
+
+import numpy as np
+import pytest
+
+import ray
+
+SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
+
+
+@pytest.fixture(params=[True, False])
+def config(request):
+    pull_based = request.param
+    if pull_based:
+        config = {
+            "health_check_initial_delay_ms": 0,
+            "health_check_period_ms": 100,
+            "health_check_failure_threshold": 10,
+            "object_timeout_milliseconds": 200,
+            "pull_based_healthcheck": True,
+        }
+    else:
+        config = {
+            "num_heartbeats_timeout": 10,
+            "raylet_heartbeat_period_milliseconds": 100,
+            "pull_based_healthcheck": False,
+            "object_timeout_milliseconds": 200,
+        }
+    yield config
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+def test_reconstruction_stress_spill(config, ray_start_cluster):
+    config["task_retry_delay_ms"] = 100
+    config["max_direct_call_object_size"] = 100
+    cluster = ray_start_cluster
+    # Head node with no resources.
+    cluster.add_node(
+        num_cpus=0, _system_config=config, enable_object_reconstruction=True
+    )
+    ray.init(address=cluster.address)
+    # Node to place the initial object.
+    node_to_kill = cluster.add_node(
+        num_cpus=1, resources={"node1": 1}, object_store_memory=10**8
+    )
+    cluster.add_node(num_cpus=1, resources={"node2": 1}, object_store_memory=10**8)
+    cluster.wait_for_nodes()
+
+    @ray.remote
+    def large_object():
+        return np.zeros(10**6, dtype=np.uint8)
+
+    @ray.remote
+    def dependent_task(x):
+        return
+
+    for _ in range(3):
+        obj = large_object.options(resources={"node1": 1}).remote()
+        ray.get(dependent_task.options(resources={"node2": 1}).remote(obj))
+
+        outputs = [
+            large_object.options(resources={"node1": 1}).remote() for _ in range(1000)
+        ]
+        outputs = [
+            dependent_task.options(resources={"node2": 1}).remote(obj)
+            for obj in outputs
+        ]
+
+        cluster.remove_node(node_to_kill, allow_graceful=False)
+        node_to_kill = cluster.add_node(
+            num_cpus=1, resources={"node1": 1}, object_store_memory=10**8
+        )
+
+        i = 0
+        while outputs:
+            ref = outputs.pop(0)
+            print(i, ref)
+            ray.get(ref)
+            i += 1
+
+
+if __name__ == "__main__":
+    import pytest
+
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR fixed the unit tests when the flag is turned on. Most of the failure is because the default value got changed or the setup of the timeout only works for the old ones.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
