### PR TITLE
[Test] Fix autoscaler event flakiness

### DIFF
--- a/dashboard/modules/event/tests/test_event.py
+++ b/dashboard/modules/event/tests/test_event.py
@@ -331,8 +331,13 @@ def test_autoscaler_cluster_events(shutdown_only):
         def g():
             print("cpu ok")
 
+        wait_for_condition(lambda: ray.cluster_resources()["CPU"] == 2)
         ray.get(f.remote())
+        wait_for_condition(lambda: ray.cluster_resources()["CPU"] == 4)
+        wait_for_condition(lambda: ray.cluster_resources()["GPU"] == 1)
         ray.get(g.remote())
+        wait_for_condition(lambda: ray.cluster_resources()["CPU"] == 8)
+        wait_for_condition(lambda: ray.cluster_resources()["GPU"] == 1)
 
         # Trigger an infeasible task
         g.options(num_cpus=0, num_gpus=5).remote()

--- a/dashboard/modules/event/tests/test_event.py
+++ b/dashboard/modules/event/tests/test_event.py
@@ -10,6 +10,8 @@ import random
 import tempfile
 import socket
 
+from pprint import pprint
+
 import pytest
 import numpy as np
 
@@ -300,7 +302,7 @@ def test_autoscaler_cluster_events(shutdown_only):
                 },
                 "node_config": {},
                 "min_workers": 0,
-                "max_workers": 2,
+                "max_workers": 1,
             },
             "gpu_node": {
                 "resources": {
@@ -309,7 +311,7 @@ def test_autoscaler_cluster_events(shutdown_only):
                 },
                 "node_config": {},
                 "min_workers": 0,
-                "max_workers": 2,
+                "max_workers": 1,
             },
         },
         idle_timeout_minutes=1,
@@ -333,57 +335,42 @@ def test_autoscaler_cluster_events(shutdown_only):
         ray.get(g.remote())
 
         # Trigger an infeasible task
-        g.options(num_gpus=5).remote()
+        g.options(num_cpus=0, num_gpus=5).remote()
 
         def verify():
             cluster_events = list_cluster_events()
             messages = {(e["message"], e["source_type"]) for e in cluster_events}
 
-            assert ("Resized to 2 CPUs.", "AUTOSCALER") in messages
+            assert ("Resized to 2 CPUs.", "AUTOSCALER") in messages, cluster_events
             assert (
                 "Adding 1 node(s) of type gpu_node.",
                 "AUTOSCALER",
-            ) in messages
+            ) in messages, cluster_events
             assert (
                 "Resized to 4 CPUs, 1 GPUs.",
                 "AUTOSCALER",
-            ) in messages
-            assert (
-                "Adding 1 node(s) of type gpu_node.",
-                "AUTOSCALER",
-            ) in messages
-            assert (
-                "Resized to 6 CPUs, 2 GPUs.",
-                "AUTOSCALER",
-            ) in messages
+            ) in messages, cluster_events
             assert (
                 "Adding 1 node(s) of type cpu_node.",
                 "AUTOSCALER",
-            ) in messages
+            ) in messages, cluster_events
             assert (
-                "Resized to 10 CPUs, 2 GPUs.",
+                "Resized to 8 CPUs, 1 GPUs.",
+                "AUTOSCALER",
+            ) in messages, cluster_events
+            assert (
+                (
+                    "Error: No available node types can fulfill resource "
+                    "request {'GPU': 5.0}. Add suitable node "
+                    "types to this cluster to resolve this issue."
+                ),
                 "AUTOSCALER",
             ) in messages
-            assert (
-                "Adding 1 node(s) of type cpu_node.",
-                "AUTOSCALER",
-            ) in messages
-            assert (
-                "Resized to 14 CPUs, 2 GPUs.",
-                "AUTOSCALER",
-            ) in messages
-            # assert (
-            #     (
-            #         "Error: No available node types can fulfill resource "
-            #         "request {'CPU': 3.0, 'GPU': 5.0}. Add suitable node "
-            #         "types to this cluster to resolve this issue."
-            #     ),
-            #     "AUTOSCALER",
-            # ) in messages
 
             return True
 
         wait_for_condition(verify, timeout=30)
+        pprint(list_cluster_events())
     finally:
         ray.shutdown()
         cluster.shutdown()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix the flaky autoscaler event tests. It was flaky because it relies on the autoscaler scaling speed. I added a bunch of resource verification in the middle of the test so that we are waiting long enough until autoscaler is scaled up

<img width="484" alt="Screen Shot 2022-11-02 at 1 12 29 AM" src="https://user-images.githubusercontent.com/18510752/199435016-07815981-fcc3-412f-859a-48e9650d4658.png">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
