### PR TITLE
[AIR benchmarks] Adding num_files to out-of-core and file-size mlperf benchmarks

### DIFF
--- a/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
@@ -267,7 +267,8 @@ def build_synthetic_dataset(batch_size):
     image_dims = IMAGE_DIMS[1:]
     empty = np.empty(image_dims, dtype=np.uint8)
     ds = ray.data.from_items(
-        [{"image": empty, "label": 1} for _ in range(int(batch_size))], parallelism=1,
+        [{"image": empty, "label": 1} for _ in range(int(batch_size))],
+        parallelism=1,
     )
     return ds
 


### PR DESCRIPTION
This fixes a release test perf regression that was caused by us reporting two different tests under the same metric name.

These two rows should actually have different metric labels. The first one used 128 files, the second used 1 file, so the lower throughput is expected.

<img width="690" alt="Screen Shot 2022-11-02 at 10 36 22 AM" src="https://user-images.githubusercontent.com/950914/199561513-0bcddfb7-4619-4de6-a246-188bda3d9d51.png">

Test run: https://buildkite.com/ray-project/release-tests-branch/builds/1179#018439e9-eed4-4c2c-bec5-ca6260aaa600

Release test run passed

```json
[
    {
        "perf_metric_name": "ray.data_512-images-per-file_1-num-files_throughput-img-per-second",
        "perf_metric_value": 30.27144207763898,
        "perf_metric_type": "THROUGHPUT"
    },
    {
        "perf_metric_name": "ray.data_512-images-per-file_128-num-files_throughput-img-per-second",
        "perf_metric_value": 169.4119166986363,
        "perf_metric_type": "THROUGHPUT"
    }
]
```
