### PR TITLE
Make sure the dst dir doesn't exist when calling shutil.copytree

### DIFF
--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -170,7 +170,7 @@
     - ./java/test.sh
 
 - label: ":cpp: Ray CPP Worker"
-  conditions: [ "RAY_CI_PYTHON_AFFECTED" ]
+  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   instance_size: small
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
@@ -600,7 +600,7 @@
     - pip install -U typing-extensions
     - HOROVOD_WITH_GLOO=1 HOROVOD_WITHOUT_MPI=1 HOROVOD_WITHOUT_MXNET=1 HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 pip install horovod
     - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=compat_py36
+    - bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=compat_py36 
       python/ray/tests/horovod/...
       python/ray/tests/lightgbm/...
       python/ray/tests/ml_py36_compat/...

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -170,7 +170,7 @@
     - ./java/test.sh
 
 - label: ":cpp: Ray CPP Worker"
-  conditions: [ "RAY_CI_CPP_AFFECTED" ]
+  conditions: [ "RAY_CI_PYTHON_AFFECTED" ]
   instance_size: small
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
@@ -600,7 +600,7 @@
     - pip install -U typing-extensions
     - HOROVOD_WITH_GLOO=1 HOROVOD_WITHOUT_MPI=1 HOROVOD_WITHOUT_MXNET=1 HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 pip install horovod
     - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=compat_py36 
+    - bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=compat_py36
       python/ray/tests/horovod/...
       python/ray/tests/lightgbm/...
       python/ray/tests/ml_py36_compat/...

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -250,7 +250,7 @@ test_cpp() {
   bazel test --test_output=all //cpp:test_python_call_cpp
 
   # run the cpp example
-  rm -rf ray-template && mkdir ray-template
+  rm -rf ray-template
   ray cpp --generate-bazel-project-template-to ray-template
   pushd ray-template && bash run.sh
 }

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -175,7 +175,7 @@ You can install and use Ray C++ API as follows.
   pip install -U ray[cpp]
 
   # Create a Ray C++ project template to start with.
-  mkdir ray-template && ray cpp --generate-bazel-project-template-to ray-template
+  ray cpp --generate-bazel-project-template-to ray-template
 
 .. note::
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -10,8 +10,8 @@ import traceback
 import urllib
 import urllib.parse
 import warnings
+import shutil
 from datetime import datetime
-from shutil import copytree
 from typing import Optional, Set
 
 import click
@@ -2507,22 +2507,21 @@ def cpp(show_library_path, generate_bazel_project_template_to):
         cli_logger.print("Ray C++ include path {} ", cf.bold(f"{include_dir}"))
         cli_logger.print("Ray C++ library path {} ", cf.bold(f"{lib_dir}"))
     if generate_bazel_project_template_to:
-        if not os.path.isdir(generate_bazel_project_template_to):
-            cli_logger.abort(
-                "The provided directory "
-                f"{generate_bazel_project_template_to} doesn't exist."
-            )
-        copytree(cpp_templete_dir, generate_bazel_project_template_to)
+        # copytree expects that the dst dir doesn't exist
+        # so we manually delete it if it exists.
+        if os.path.exists(generate_bazel_project_template_to):
+            shutil.rmtree(generate_bazel_project_template_to)
+        shutil.copytree(cpp_templete_dir, generate_bazel_project_template_to)
         out_include_dir = os.path.join(
             generate_bazel_project_template_to, "thirdparty/include"
         )
-        if not os.path.exists(out_include_dir):
-            os.makedirs(out_include_dir)
-        copytree(include_dir, out_include_dir)
+        if os.path.exists(out_include_dir):
+            shutil.rmtree(out_include_dir)
+        shutil.copytree(include_dir, out_include_dir)
         out_lib_dir = os.path.join(generate_bazel_project_template_to, "thirdparty/lib")
-        if not os.path.exists(out_lib_dir):
-            os.makedirs(out_lib_dir)
-        copytree(lib_dir, out_lib_dir)
+        if os.path.exists(out_lib_dir):
+            shutil.rmtree(out_lib_dir)
+        shutil.copytree(lib_dir, out_lib_dir)
 
         cli_logger.print(
             "Project template generated to {}",

--- a/release/util/sanity_check_cpp.sh
+++ b/release/util/sanity_check_cpp.sh
@@ -2,6 +2,6 @@
 
 # This script generate a ray C++ template and run example
 set -e
-rm -rf ray-template && mkdir ray-template
+rm -rf ray-template
 ray cpp --generate-bazel-project-template-to ray-template
 pushd ray-template && bash run.sh


### PR DESCRIPTION
Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In https://github.com/ray-project/ray/pull/29603, we replaced `distutils.dir_util.copy_tree` with `shutil.copytree` since the former is deprecated. There is a big difference between these two methods that we ignored and caused test failures: `distutils.dir_util.copy_tree` works regardless whether dst dir exists or not but `shutil.copytree` expects that the dst dir doesn't exist.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
