### PR TITLE
[metrics] Fix missing grafana.ini

### DIFF
--- a/dashboard/modules/metrics/metrics_head.py
+++ b/dashboard/modules/metrics/metrics_head.py
@@ -231,6 +231,8 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
         # Copy default grafana configurations
         if os.path.exists(grafana_config_output_path):
             shutil.rmtree(grafana_config_output_path)
+        os.makedirs(os.path.dirname(grafana_config_output_path), exist_ok=True)
+        shutil.copytree(GRAFANA_CONFIG_INPUT_PATH, grafana_config_output_path)
         # Overwrite grafana's prometheus datasource based on env var
         prometheus_host = os.environ.get(
             PROMETHEUS_HOST_ENV_VAR, DEFAULT_PROMETHEUS_HOST


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

The previous PR inadvertently removed the grafana.ini copy, which was needed to load the json dashboard config.

before:
```
./metrics/grafana
./metrics/grafana/dashboards
./metrics/grafana/dashboards/default_grafana_dashboard.json
./metrics/grafana/provisioning
./metrics/grafana/provisioning/datasources
./metrics/grafana/provisioning/datasources/default.yml
```
after:
```
./metrics/grafana
./metrics/grafana/dashboards
./metrics/grafana/dashboards/grafana_dashboard_base.json
./metrics/grafana/dashboards/default_grafana_dashboard.json
./metrics/grafana/grafana.ini
./metrics/grafana/provisioning
./metrics/grafana/provisioning/datasources
./metrics/grafana/provisioning/datasources/default.yml
./metrics/grafana/provisioning/dashboards
./metrics/grafana/provisioning/dashboards/default.yml

```