### PR TITLE
[RLlib] Don't error out when using agent collector in inference directly after instantiation

### DIFF
--- a/rllib/evaluation/collectors/agent_collector.py
+++ b/rllib/evaluation/collectors/agent_collector.py
@@ -493,7 +493,12 @@ class AgentCollector:
     def _cache_in_np(self, cache_dict: Dict[str, List[np.ndarray]], key: str) -> None:
         """Caches the numpy version of the key in the buffer dict."""
         if key not in cache_dict:
-            cache_dict[key] = [_to_float_np_array(d) for d in self.buffers[key]]
+            arrays_to_cache = []
+            for d in self.buffers[key]:
+                # Don't attempt to cache empty arrays
+                if len(d):
+                    arrays_to_cache.append(_to_float_np_array(d))
+            cache_dict[key] = arrays_to_cache
 
     def _unflatten_as_buffer_struct(
         self, data: List[np.ndarray], key: str

--- a/rllib/evaluation/tests/test_agent_collector.py
+++ b/rllib/evaluation/tests/test_agent_collector.py
@@ -332,6 +332,19 @@ class TestAgentCollector(unittest.TestCase):
         # check if the padding in the beginning is correct
         check(sample_batch["prev_obses"][0], np.ones((3, 1)) * expected_obses[0])
 
+    def test_begin_with_inference(self):
+        # Test if AC is able to build for inference immediately
+        obs_space = gym.spaces.Box(-np.ones(4), np.ones(4))
+        view_reqs = {
+            SampleBatch.T: ViewRequirement(SampleBatch.T),
+            SampleBatch.OBS: ViewRequirement("obs", space=obs_space),
+            "prev_obs": ViewRequirement("obs", shift=-1),
+        }
+
+        ac = AgentCollector(view_reqs=view_reqs, is_policy_recurrent=True)
+
+        ac.build_for_inference()
+
 
 if __name__ == "__main__":
     import pytest

--- a/rllib/evaluation/tests/test_agent_collector.py
+++ b/rllib/evaluation/tests/test_agent_collector.py
@@ -334,10 +334,9 @@ class TestAgentCollector(unittest.TestCase):
 
     def test_begin_with_inference(self):
         # Test if AC is able to build for inference immediately
-        obs_space = gym.spaces.Box(-np.ones(4), np.ones(4))
         view_reqs = {
             SampleBatch.T: ViewRequirement(SampleBatch.T),
-            SampleBatch.REWARDS: ViewRequirement("reward", space=obs_space),
+            SampleBatch.REWARDS: ViewRequirement("reward"),
             "prev_reward": ViewRequirement("reward", shift=-1),
         }
 

--- a/rllib/evaluation/tests/test_agent_collector.py
+++ b/rllib/evaluation/tests/test_agent_collector.py
@@ -337,8 +337,8 @@ class TestAgentCollector(unittest.TestCase):
         obs_space = gym.spaces.Box(-np.ones(4), np.ones(4))
         view_reqs = {
             SampleBatch.T: ViewRequirement(SampleBatch.T),
-            SampleBatch.OBS: ViewRequirement("obs", space=obs_space),
-            "prev_obs": ViewRequirement("obs", shift=-1),
+            SampleBatch.REWARDS: ViewRequirement("reward", space=obs_space),
+            "prev_reward": ViewRequirement("reward", shift=-1),
         }
 
         ac = AgentCollector(view_reqs=view_reqs, is_policy_recurrent=True)


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

In order to use our policies in inference, we should be able to directly call policy.compute_actions...(), for example after restoring from a checkpoint. This PR makes it so that agent collector's build-for-inference method can be called immediately with a single prev reward, which is what we need for recurrent policies.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
