### PR TITLE
[RLlib] Enable .py files with AlgorithmConfig objects in them to be run by our `run_regression_test.py` script.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -77,7 +77,7 @@ load("//bazel:python.bzl", "py_test_module_list")
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/a2c/cartpole-a2c.yaml"],
-#    args = ["--yaml-dir=tuned_examples/a2c"]
+#    args = ["--dir=tuned_examples/a2c"]
 # )
 
 py_test(
@@ -87,7 +87,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/a2c/cartpole-a2c-microbatch.yaml"],
-    args = ["--yaml-dir=tuned_examples/a2c"]
+    args = ["--dir=tuned_examples/a2c"]
 )
 
 py_test(
@@ -97,7 +97,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/a2c/cartpole-a2c-fake-gpus.yaml"],
-    args = ["--yaml-dir=tuned_examples/a2c"]
+    args = ["--dir=tuned_examples/a2c"]
 )
 
 # A3C
@@ -109,7 +109,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/a3c/cartpole-a3c.yaml"],
-#    args = ["--yaml-dir=tuned_examples/a3c"]
+#    args = ["--dir=tuned_examples/a3c"]
 # )
 
 # AlphaStar
@@ -120,7 +120,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/alpha_star/multi-agent-cartpole-alpha-star.yaml"],
-    args = ["--yaml-dir=tuned_examples/alpha_star", "--num-cpus=10"]
+    args = ["--dir=tuned_examples/alpha_star", "--num-cpus=10"]
 )
 
 # AlphaZero
@@ -131,7 +131,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/alpha_zero/cartpole-sparse-rewards-alpha-zero.yaml"],
-    args = ["--yaml-dir=tuned_examples/alpha_zero", "--num-cpus=8"]
+    args = ["--dir=tuned_examples/alpha_zero", "--num-cpus=8"]
 )
 
 # APEX-DQN
@@ -144,7 +144,7 @@ py_test(
 #    data = [
 #        "tuned_examples/apex_dqn/cartpole-apex.yaml",
 #    ],
-#    args = ["--yaml-dir=tuned_examples/apex_dqn", "--num-cpus=6"]
+#    args = ["--dir=tuned_examples/apex_dqn", "--num-cpus=6"]
 # )
 
 # Once APEX supports multi-GPU.
@@ -155,7 +155,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/apex_dqn/cartpole-apex-fake-gpus.yaml"],
-#    args = ["--yaml-dir=tuned_examples/apex_dqn"]
+#    args = ["--dir=tuned_examples/apex_dqn"]
 # )
 
 # APPO
@@ -166,7 +166,7 @@ py_test(
     size = "medium", # bazel may complain about it being too long sometimes - medium is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/cartpole-appo.yaml"],
-    args = ["--yaml-dir=tuned_examples/appo"]
+    args = ["--dir=tuned_examples/appo"]
 )
 
 # py_test(
@@ -176,7 +176,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/appo/cartpole-appo-vtrace.yaml"],
-#    args = ["--yaml-dir=tuned_examples/appo"]
+#    args = ["--dir=tuned_examples/appo"]
 # )
 
 py_test(
@@ -188,7 +188,7 @@ py_test(
     data = [
         "tuned_examples/appo/cartpole-appo-vtrace-separate-losses.yaml"
     ],
-    args = ["--yaml-dir=tuned_examples/appo"]
+    args = ["--dir=tuned_examples/appo"]
 )
 
 py_test(
@@ -198,7 +198,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/multi-agent-cartpole-appo.yaml"],
-    args = ["--yaml-dir=tuned_examples/appo"]
+    args = ["--dir=tuned_examples/appo"]
 )
 
 # py_test(
@@ -208,7 +208,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/appo/frozenlake-appo-vtrace.yaml"],
-#    args = ["--yaml-dir=tuned_examples/appo"]
+#    args = ["--dir=tuned_examples/appo"]
 # )
 
 py_test(
@@ -218,7 +218,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/cartpole-appo-vtrace-fake-gpus.yaml"],
-    args = ["--yaml-dir=tuned_examples/appo"]
+    args = ["--dir=tuned_examples/appo"]
 )
 
 # ARS
@@ -229,7 +229,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ars/cartpole-ars.yaml"],
-    args = ["--yaml-dir=tuned_examples/ars"]
+    args = ["--dir=tuned_examples/ars"]
 )
 
 # CQL
@@ -244,7 +244,7 @@ py_test(
         "tuned_examples/cql/pendulum-cql.yaml",
         "tests/data/pendulum/enormous.zip",
     ],
-    args = ["--yaml-dir=tuned_examples/cql"]
+    args = ["--dir=tuned_examples/cql"]
 )
 
 
@@ -260,7 +260,7 @@ py_test(
        "tuned_examples/crr/pendulum-v1-crr.yaml",
        "tests/data/pendulum/pendulum_replay_v1.1.0.zip",
    ],
-   args = ["--yaml-dir=tuned_examples/crr"]
+   args = ["--dir=tuned_examples/crr"]
 )
 
 py_test(
@@ -274,7 +274,7 @@ py_test(
         "tuned_examples/crr/cartpole-v0-crr.yaml",
         "tests/data/cartpole/large.json",
     ],
-    args = ["--yaml-dir=tuned_examples/crr", '--framework=torch']
+    args = ["--dir=tuned_examples/crr", '--framework=torch']
 )
 
 py_test(
@@ -288,7 +288,7 @@ py_test(
         "tuned_examples/crr/cartpole-v0-crr_expectation.yaml",
         "tests/data/cartpole/large.json",
     ],
-    args = ["--yaml-dir=tuned_examples/crr", '--framework=torch']
+    args = ["--dir=tuned_examples/crr", '--framework=torch']
 )
 
 # DDPG
@@ -299,7 +299,7 @@ py_test(
 #   size = "large",
 #   srcs = ["tests/run_regression_tests.py"],
 #   data = glob(["tuned_examples/ddpg/pendulum-ddpg.yaml"]),
-#   args = ["--yaml-dir=tuned_examples/ddpg"]
+#   args = ["--dir=tuned_examples/ddpg"]
 # )
 
 py_test(
@@ -309,7 +309,7 @@ py_test(
    size = "large",
    srcs = ["tests/run_regression_tests.py"],
    data = ["tuned_examples/ddpg/pendulum-ddpg-fake-gpus.yaml"],
-   args = ["--yaml-dir=tuned_examples/ddpg"]
+   args = ["--dir=tuned_examples/ddpg"]
 )
 
 # DDPPO
@@ -320,7 +320,7 @@ py_test(
     size = "small",
     srcs = ["tests/run_regression_tests.py"],
     data = glob(["tuned_examples/ddppo/cartpole-ddppo.yaml"]),
-    args = ["--yaml-dir=tuned_examples/ddppo"]
+    args = ["--dir=tuned_examples/ddppo"]
 )
 
 py_test(
@@ -330,7 +330,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = glob(["tuned_examples/ddppo/pendulum-ddppo.yaml"]),
-    args = ["--yaml-dir=tuned_examples/ddppo"]
+    args = ["--dir=tuned_examples/ddppo"]
 )
 
 # DQN
@@ -341,7 +341,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/dqn/cartpole-dqn.yaml"],
-#    args = ["--yaml-dir=tuned_examples/dqn"]
+#    args = ["--dir=tuned_examples/dqn"]
 # )
 
 py_test(
@@ -351,7 +351,7 @@ py_test(
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/dqn/cartpole-dqn-softq.yaml"],
-    args = ["--yaml-dir=tuned_examples/dqn"]
+    args = ["--dir=tuned_examples/dqn"]
 )
 
 # Does not work with tf-eager tracing due to Exploration's postprocessing
@@ -364,7 +364,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/dqn/cartpole-dqn-param-noise.yaml"],
-    args = ["--yaml-dir=tuned_examples/dqn"]
+    args = ["--dir=tuned_examples/dqn"]
 )
 
 py_test(
@@ -374,7 +374,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/dqn/cartpole-dqn-fake-gpus.yaml"],
-    args = ["--yaml-dir=tuned_examples/dqn"]
+    args = ["--dir=tuned_examples/dqn"]
 )
 
 # DT
@@ -389,7 +389,7 @@ py_test(
        "tuned_examples/dt/pendulum-v1-dt.yaml",
        "tests/data/pendulum/pendulum_expert_sac_50eps.zip",
    ],
-   args = ["--yaml-dir=tuned_examples/dt"]
+   args = ["--dir=tuned_examples/dt"]
 )
 
 py_test(
@@ -403,7 +403,7 @@ py_test(
         "tuned_examples/dt/cartpole-v0-dt.yaml",
         "tests/data/cartpole/large.json",
     ],
-    args = ["--yaml-dir=tuned_examples/dt"]
+    args = ["--dir=tuned_examples/dt"]
 )
 
 # Simple-Q
@@ -416,7 +416,7 @@ py_test(
     data = [
         "tuned_examples/simple_q/cartpole-simpleq.yaml",
     ],
-    args = ["--yaml-dir=tuned_examples/simple_q"]
+    args = ["--dir=tuned_examples/simple_q"]
 )
 
 py_test(
@@ -426,7 +426,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/simple_q/cartpole-simpleq-fake-gpus.yaml"],
-    args = ["--yaml-dir=tuned_examples/simple_q"]
+    args = ["--dir=tuned_examples/simple_q"]
 )
 
 # ES
@@ -437,7 +437,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/es/cartpole-es.yaml"],
-#    args = ["--yaml-dir=tuned_examples/es"]
+#    args = ["--dir=tuned_examples/es"]
 # )
 
 # IMPALA
@@ -448,7 +448,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/impala/cartpole-impala.yaml"],
-#    args = ["--yaml-dir=tuned_examples/impala"]
+#    args = ["--dir=tuned_examples/impala"]
 # )
 
 py_test(
@@ -458,7 +458,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/impala/multi-agent-cartpole-impala.yaml"],
-    args = ["--yaml-dir=tuned_examples/impala"]
+    args = ["--dir=tuned_examples/impala"]
 )
 
 py_test(
@@ -468,7 +468,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/impala/cartpole-impala-fake-gpus.yaml"],
-    args = ["--yaml-dir=tuned_examples/impala"]
+    args = ["--dir=tuned_examples/impala"]
 )
 
 # MADDPG
@@ -479,7 +479,7 @@ py_test(
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/maddpg/two-step-game-maddpg.yaml"],
-    args = ["--yaml-dir=tuned_examples/maddpg", "--framework=tf"]
+    args = ["--dir=tuned_examples/maddpg", "--framework=tf"]
 )
 
 # Working, but takes a long time to learn (>15min).
@@ -492,7 +492,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/mbmpo/pendulum-mbmpo.yaml"],
-#    args = ["--yaml-dir=tuned_examples/mbmpo"]
+#    args = ["--dir=tuned_examples/mbmpo"]
 #)
 
 # PG
@@ -503,7 +503,7 @@ py_test(
     size = "medium", # bazel may complain about it being too long sometimes - medium is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/pg/cartpole-pg.yaml"],
-    args = ["--yaml-dir=tuned_examples/pg"]
+    args = ["--dir=tuned_examples/pg"]
 )
 
 py_test(
@@ -513,7 +513,7 @@ py_test(
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/pg/cartpole-crashing-pg.yaml"],
-    args = ["--yaml-dir=tuned_examples/pg"]
+    args = ["--dir=tuned_examples/pg"]
 )
 
 py_test(
@@ -523,7 +523,7 @@ py_test(
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/pg/cartpole-crashing-with-remote-envs-pg.yaml"],
-    args = ["--yaml-dir=tuned_examples/pg"]
+    args = ["--dir=tuned_examples/pg"]
 )
 
 py_test(
@@ -533,7 +533,7 @@ py_test(
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/pg/multi-agent-cartpole-crashing-restart-sub-envs-pg.yaml"],
-    args = ["--yaml-dir=tuned_examples/pg"]
+    args = ["--dir=tuned_examples/pg"]
 )
 
 py_test(
@@ -543,7 +543,7 @@ py_test(
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/pg/multi-agent-cartpole-crashing-with-remote-envs-pg.yaml"],
-    args = ["--yaml-dir=tuned_examples/pg", "--num-cpus=14"]
+    args = ["--dir=tuned_examples/pg", "--num-cpus=14"]
 )
 
 py_test(
@@ -553,7 +553,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/pg/cartpole-pg-fake-gpus.yaml"],
-    args = ["--yaml-dir=tuned_examples/pg"]
+    args = ["--dir=tuned_examples/pg"]
 )
 
 # PPO
@@ -564,7 +564,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/ppo/cartpole-ppo.yaml"],
-#    args = ["--yaml-dir=tuned_examples/ppo"]
+#    args = ["--dir=tuned_examples/ppo"]
 # )
 
 py_test(
@@ -574,7 +574,7 @@ py_test(
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/pendulum-ppo.yaml"],
-    args = ["--yaml-dir=tuned_examples/ppo"]
+    args = ["--dir=tuned_examples/ppo"]
 )
 
 py_test(
@@ -584,7 +584,7 @@ py_test(
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/pendulum-transformed-actions-ppo.yaml"],
-    args = ["--yaml-dir=tuned_examples/ppo"]
+    args = ["--dir=tuned_examples/ppo"]
 )
 
 py_test(
@@ -594,7 +594,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/repeatafterme-ppo-lstm.yaml"],
-    args = ["--yaml-dir=tuned_examples/ppo"]
+    args = ["--dir=tuned_examples/ppo"]
 )
 
 py_test(
@@ -604,7 +604,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/cartpole-ppo-fake-gpus.yaml"],
-    args = ["--yaml-dir=tuned_examples/ppo"]
+    args = ["--dir=tuned_examples/ppo"]
 )
 
 # QMIX
@@ -615,7 +615,7 @@ py_test(
     size = "medium", # bazel may complain about it being too long sometimes - medium is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/qmix/two-step-game-qmix.yaml"],
-    args = ["--yaml-dir=tuned_examples/qmix", "--framework=torch"]
+    args = ["--dir=tuned_examples/qmix", "--framework=torch"]
 )
 
 py_test(
@@ -625,7 +625,7 @@ py_test(
     size = "medium", # bazel may complain about it being too long sometimes - medium is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/qmix/two-step-game-qmix-vdn-mixer.yaml"],
-    args = ["--yaml-dir=tuned_examples/qmix", "--framework=torch"]
+    args = ["--dir=tuned_examples/qmix", "--framework=torch"]
 )
 
 py_test(
@@ -635,7 +635,7 @@ py_test(
     size = "medium", # bazel may complain about it being too long sometimes - medium is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/qmix/two-step-game-qmix-no-mixer.yaml"],
-    args = ["--yaml-dir=tuned_examples/qmix", "--framework=torch"]
+    args = ["--dir=tuned_examples/qmix", "--framework=torch"]
 )
 
 # R2D2
@@ -646,7 +646,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/r2d2/stateless-cartpole-r2d2.yaml"],
-    args = ["--yaml-dir=tuned_examples/r2d2"]
+    args = ["--dir=tuned_examples/r2d2"]
 )
 
 py_test(
@@ -656,7 +656,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/r2d2/stateless-cartpole-r2d2-fake-gpus.yaml"],
-    args = ["--yaml-dir=tuned_examples/r2d2"]
+    args = ["--dir=tuned_examples/r2d2"]
 )
 
 # SAC
@@ -667,7 +667,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/sac/cartpole-sac.yaml"],
-    args = ["--yaml-dir=tuned_examples/sac"]
+    args = ["--dir=tuned_examples/sac"]
 )
 
 # py_test(
@@ -677,7 +677,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/sac/cartpole-continuous-pybullet-sac.yaml"],
-#    args = ["--yaml-dir=tuned_examples/sac"]
+#    args = ["--dir=tuned_examples/sac"]
 # )
 
 # py_test(
@@ -687,7 +687,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/sac/pendulum-sac.yaml"],
-#    args = ["--yaml-dir=tuned_examples/sac"]
+#    args = ["--dir=tuned_examples/sac"]
 # )
 
 # py_test(
@@ -697,7 +697,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/sac/pendulum-transformed-actions-sac.yaml"],
-#    args = ["--yaml-dir=tuned_examples/sac"]
+#    args = ["--dir=tuned_examples/sac"]
 # )
 
 # py_test(
@@ -707,7 +707,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/sac/pendulum-sac-fake-gpus.yaml"],
-#    args = ["--yaml-dir=tuned_examples/sac"]
+#    args = ["--dir=tuned_examples/sac"]
 # )
 
 # SlateQ
@@ -718,7 +718,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/slateq/interest-evolution-10-candidates-recsim-env-slateq.yaml"],
-#    args = ["--yaml-dir=tuned_examples/slateq"]
+#    args = ["--dir=tuned_examples/slateq"]
 # )
 
 py_test(
@@ -728,7 +728,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/slateq/interest-evolution-10-candidates-recsim-env-slateq.yaml"],
-    args = ["--yaml-dir=tuned_examples/slateq"]
+    args = ["--dir=tuned_examples/slateq"]
 )
 
 # TD3
@@ -739,7 +739,7 @@ py_test(
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/ddpg/pendulum-td3.yaml"],
-#    args = ["--yaml-dir=tuned_examples/ddpg"]
+#    args = ["--dir=tuned_examples/ddpg"]
 # )
 
 
@@ -1156,7 +1156,7 @@ py_test(
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
     data = ["tuned_examples/a3c/memory-leak-test-a3c.yaml"],
-    args = ["--yaml-dir=tuned_examples/a3c"]
+    args = ["--dir=tuned_examples/a3c"]
 )
 
 py_test(
@@ -1166,7 +1166,7 @@ py_test(
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
     data = ["tuned_examples/appo/memory-leak-test-appo.yaml"],
-    args = ["--yaml-dir=tuned_examples/appo"]
+    args = ["--dir=tuned_examples/appo"]
 )
 
 py_test(
@@ -1176,7 +1176,7 @@ py_test(
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
     data = ["tuned_examples/ddpg/memory-leak-test-ddpg.yaml"],
-    args = ["--yaml-dir=tuned_examples/ddpg"]
+    args = ["--dir=tuned_examples/ddpg"]
 )
 
 py_test(
@@ -1186,7 +1186,7 @@ py_test(
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
     data = ["tuned_examples/dqn/memory-leak-test-dqn.yaml"],
-    args = ["--yaml-dir=tuned_examples/dqn"]
+    args = ["--dir=tuned_examples/dqn"]
 )
 
 py_test(
@@ -1196,7 +1196,7 @@ py_test(
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
     data = ["tuned_examples/impala/memory-leak-test-impala.yaml"],
-    args = ["--yaml-dir=tuned_examples/impala"]
+    args = ["--dir=tuned_examples/impala"]
 )
 
 py_test(
@@ -1206,7 +1206,7 @@ py_test(
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
     data = ["tuned_examples/ppo/memory-leak-test-ppo.yaml"],
-    args = ["--yaml-dir=tuned_examples/ppo"]
+    args = ["--dir=tuned_examples/ppo"]
 )
 
 py_test(
@@ -1216,7 +1216,7 @@ py_test(
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
     data = ["tuned_examples/sac/memory-leak-test-sac.yaml"],
-    args = ["--yaml-dir=tuned_examples/sac"]
+    args = ["--dir=tuned_examples/sac"]
 )
 
 # --------------------------------------------------------------------

--- a/rllib/tests/run_regression_tests.py
+++ b/rllib/tests/run_regression_tests.py
@@ -67,7 +67,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.yaml_dir != "":
-        deprecation_warning(old="--yaml-dir", new="--dir", error=True)
+        deprecation_warning(old="--yaml-dir", new="--dir", error=False)
+        args.dir = args.yaml_dir
 
     # Bazel regression test mode: Get path to look for yaml files.
     # Get the path or single file to use.

--- a/rllib/tests/run_regression_tests.py
+++ b/rllib/tests/run_regression_tests.py
@@ -20,11 +20,15 @@ import argparse
 import os
 from pathlib import Path
 import sys
+import re
 import yaml
 
 import ray
 from ray.tune import run_experiments
 from ray.rllib import _register_all
+from ray.rllib.common import SupportedFileType
+from ray.rllib.train import load_experiments_from_file
+from ray.rllib.utils.deprecation import deprecation_warning
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -34,10 +38,10 @@ parser.add_argument(
     help="The deep learning framework to use.",
 )
 parser.add_argument(
-    "--yaml-dir",
+    "--dir",
     type=str,
     required=True,
-    help="The directory in which to find all yamls to test.",
+    help="The directory or file in which to find all tests.",
 )
 parser.add_argument("--num-cpus", type=int, default=None)
 parser.add_argument(
@@ -56,43 +60,51 @@ parser.add_argument(
     ),
 )
 
-# Obsoleted arg, use --framework=torch instead.
-parser.add_argument(
-    "--torch", action="store_true", help="Runs all tests with PyTorch enabled."
-)
+# Obsoleted arg, use --dir instead.
+parser.add_argument("--yaml-dir", type=str, default="")
 
 if __name__ == "__main__":
     args = parser.parse_args()
 
+    if args.yaml_dir != "":
+        deprecation_warning(old="--yaml-dir", new="--dir", error=True)
+
     # Bazel regression test mode: Get path to look for yaml files.
     # Get the path or single file to use.
     rllib_dir = Path(__file__).parent.parent
-    print("rllib dir={}".format(rllib_dir))
+    print(f"rllib dir={rllib_dir}")
 
-    abs_yaml_path = os.path.join(rllib_dir, args.yaml_dir)
+    abs_path = os.path.join(rllib_dir, args.dir)
     # Single file given.
-    if os.path.isfile(abs_yaml_path):
-        yaml_files = [abs_yaml_path]
-    # Given path/file does not exist.
-    elif not os.path.isdir(abs_yaml_path):
-        raise ValueError("yaml-dir ({}) not found!".format(args.yaml_dir))
+    if os.path.isfile(abs_path):
+        files = [abs_path]
     # Path given -> Get all yaml files in there via rglob.
-    else:
-        yaml_files = rllib_dir.rglob(args.yaml_dir + "/*.yaml")
-        yaml_files = sorted(
-            map(lambda path: str(path.absolute()), yaml_files), reverse=True
+    elif os.path.isdir(abs_path):
+        files = rllib_dir.rglob(args.dir + "/*.yaml")
+        files = sorted(
+            map(lambda path: str(path.absolute()), files), reverse=True
         )
+    # Given path/file does not exist.
+    else:
+        raise ValueError(f"--dir ({args.dir}) not found!")
 
     print("Will run the following regression tests:")
-    for yaml_file in yaml_files:
-        print("->", yaml_file)
+    for file in files:
+        print("->", file)
 
     # Loop through all collected files.
-    for yaml_file in yaml_files:
-        experiments = yaml.safe_load(open(yaml_file).read())
+    for file in files:
+        if file.endswith(".py"):
+            file = re.sub("^.*/ray/rllib/", "ray/rllib/", file)
+            experiments = load_experiments_from_file(
+                file, SupportedFileType.python
+            )
+        else:
+            experiments = load_experiments_from_file(file, SupportedFileType.yaml)
+
         assert (
             len(experiments) == 1
-        ), "Error, can only run a single experiment per yaml file!"
+        ), "Error, can only run a single experiment per file!"
 
         exp = list(experiments.values())[0]
         exp["config"]["framework"] = args.framework

--- a/rllib/tests/run_regression_tests.py
+++ b/rllib/tests/run_regression_tests.py
@@ -81,7 +81,9 @@ if __name__ == "__main__":
         files = [abs_path]
     # Path given -> Get all yaml files in there via rglob.
     elif os.path.isdir(abs_path):
-        files = rllib_dir.rglob(args.dir + "/*.yaml")
+        files = []
+        for type_ in ["yaml", "yml", "py"]:
+            files += list(rllib_dir.rglob(args.dir + f"/*.{type_}"))
         files = sorted(map(lambda path: str(path.absolute()), files), reverse=True)
     # Given path/file does not exist.
     else:

--- a/rllib/tests/run_regression_tests.py
+++ b/rllib/tests/run_regression_tests.py
@@ -82,9 +82,7 @@ if __name__ == "__main__":
     # Path given -> Get all yaml files in there via rglob.
     elif os.path.isdir(abs_path):
         files = rllib_dir.rglob(args.dir + "/*.yaml")
-        files = sorted(
-            map(lambda path: str(path.absolute()), files), reverse=True
-        )
+        files = sorted(map(lambda path: str(path.absolute()), files), reverse=True)
     # Given path/file does not exist.
     else:
         raise ValueError(f"--dir ({args.dir}) not found!")
@@ -95,11 +93,11 @@ if __name__ == "__main__":
 
     # Loop through all collected files.
     for file in files:
+        # For python files, need to make sure, we only deliver the module name into the
+        # `load_experiments_from_file` function (everything from "/ray/rllib" on).
         if file.endswith(".py"):
             file = re.sub("^.*/ray/rllib/", "ray/rllib/", file)
-            experiments = load_experiments_from_file(
-                file, SupportedFileType.python
-            )
+            experiments = load_experiments_from_file(file, SupportedFileType.python)
         else:
             experiments = load_experiments_from_file(file, SupportedFileType.yaml)
 

--- a/rllib/train.py
+++ b/rllib/train.py
@@ -51,7 +51,9 @@ def _patch_path(path: str):
 
 
 def load_experiments_from_file(
-    config_file: str, file_type: SupportedFileType, checkpoint_config: dict
+    config_file: str,
+    file_type: SupportedFileType,
+    checkpoint_config: Optional[dict] = None,
 ) -> dict:
     """Load experiments from a file. Supports YAML, JSON and Python files.
     If you want to use a Python file, it has to have a 'config' variable
@@ -94,7 +96,7 @@ def load_experiments_from_file(
             experiments["default"]["stop"] = stop
 
     for key, val in experiments.items():
-        experiments[key]["checkpoint_config"] = checkpoint_config
+        experiments[key]["checkpoint_config"] = checkpoint_config or {}
 
     return experiments
 

--- a/rllib/utils/tests/run_memory_leak_tests.py
+++ b/rllib/utils/tests/run_memory_leak_tests.py
@@ -19,12 +19,16 @@
 import argparse
 import os
 from pathlib import Path
+import re
 import sys
 import yaml
 
 import ray
 from ray.rllib.algorithms.registry import get_algorithm_class
+from ray.rllib.common import SupportedFileType
+from ray.rllib.train import load_experiments_from_file
 from ray.rllib.utils.debug.memory import check_memory_leaks
+from ray.rllib.utils.deprecation import deprecation_warning
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -35,10 +39,10 @@ parser.add_argument(
     help="The deep learning framework to use.",
 )
 parser.add_argument(
-    "--yaml-dir",
-    required=True,
+    "--dir",
     type=str,
-    help="The directory in which to find all yamls to test.",
+    required=True,
+    help="The directory or file in which to find all tests.",
 )
 parser.add_argument(
     "--local-mode",
@@ -52,36 +56,48 @@ parser.add_argument(
     help="List of 'env', 'policy', 'rollout_worker', 'model'.",
 )
 
+# Obsoleted arg, use --dir instead.
+parser.add_argument("--yaml-dir", type=str, default="")
+
 
 if __name__ == "__main__":
     args = parser.parse_args()
+
+    if args.yaml_dir != "":
+        deprecation_warning(old="--yaml-dir", new="--dir", error=False)
+        args.dir = args.yaml_dir
 
     # Bazel regression test mode: Get path to look for yaml files.
     # Get the path or single file to use.
     rllib_dir = Path(__file__).parent.parent.parent
     print("rllib dir={}".format(rllib_dir))
 
-    abs_yaml_path = os.path.join(rllib_dir, args.yaml_dir)
+    abs_path = os.path.join(rllib_dir, args.dir)
     # Single file given.
-    if os.path.isfile(abs_yaml_path):
-        yaml_files = [abs_yaml_path]
-    # Given path/file does not exist.
-    elif not os.path.isdir(abs_yaml_path):
-        raise ValueError("yaml-dir ({}) not found!".format(args.yaml_dir))
+    if os.path.isfile(abs_path):
+        files = [abs_path]
     # Path given -> Get all yaml files in there via rglob.
+    elif os.path.isdir(abs_path):
+        files = rllib_dir.rglob(args.dir + "/*.yaml")
+        files = sorted(map(lambda path: str(path.absolute()), files), reverse=True)
+    # Given path/file does not exist.
     else:
-        yaml_files = rllib_dir.rglob(args.yaml_dir + "/*.yaml")
-        yaml_files = sorted(
-            map(lambda path: str(path.absolute()), yaml_files), reverse=True
-        )
+        raise ValueError(f"--dir ({args.dir}) not found!")
 
     print("Will run the following memory-leak tests:")
-    for yaml_file in yaml_files:
-        print("->", yaml_file)
+    for file in files:
+        print("->", file)
 
     # Loop through all collected files.
-    for yaml_file in yaml_files:
-        experiments = yaml.safe_load(open(yaml_file).read())
+    for file in files:
+        # For python files, need to make sure, we only deliver the module name into the
+        # `load_experiments_from_file` function (everything from "/ray/rllib" on).
+        if file.endswith(".py"):
+            file = re.sub("^.*/ray/rllib/", "ray/rllib/", file)
+            experiments = load_experiments_from_file(file, SupportedFileType.python)
+        else:
+            experiments = load_experiments_from_file(file, SupportedFileType.yaml)
+
         assert (
             len(experiments) == 1
         ), "Error, can only run a single experiment per yaml file!"

--- a/rllib/utils/tests/run_memory_leak_tests.py
+++ b/rllib/utils/tests/run_memory_leak_tests.py
@@ -76,9 +76,11 @@ if __name__ == "__main__":
     # Single file given.
     if os.path.isfile(abs_path):
         files = [abs_path]
-    # Path given -> Get all yaml files in there via rglob.
+    # Path given -> Get all py/yaml files in there via rglob.
     elif os.path.isdir(abs_path):
-        files = rllib_dir.rglob(args.dir + "/*.yaml")
+        files = []
+        for type_ in ["yaml", "yml", "py"]:
+            files += list(rllib_dir.rglob(args.dir + f"/*.{type_}"))
         files = sorted(map(lambda path: str(path.absolute()), files), reverse=True)
     # Given path/file does not exist.
     else:


### PR DESCRIPTION
Signed-off-by: sven1977 <svenmika1977@gmail.com>

Enable .py files with AlgorithmConfig objects in them to be run by our `run_regression_test.py` script.
* In preparation of converting CI learning tests to .py files (and thus making it easier to configure multi-agent and callbacks  settings).

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
