### PR TITLE
[Core] [Arrow 7+ Support - 1/N] Handle task cancellation during argument deserialization and task error storage.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -674,7 +674,287 @@ cdef execute_dynamic_generator_and_store_task_outputs(
                     "by the first execution.\n"
                     "See https://github.com/ray-project/ray/issues/28688.")
 
-cdef execute_task(
+cdef void execute_task(
+        const CAddress &caller_address,
+        CTaskType task_type,
+        const c_string name,
+        const CRayFunction &ray_function,
+        const unordered_map[c_string, double] &c_resources,
+        const c_vector[shared_ptr[CRayObject]] &c_args,
+        const c_vector[CObjectReference] &c_arg_refs,
+        const c_string debugger_breakpoint,
+        const c_string serialized_retry_exception_allowlist,
+        c_vector[c_pair[CObjectID, shared_ptr[CRayObject]]] *returns,
+        c_vector[c_pair[CObjectID, shared_ptr[CRayObject]]] *dynamic_returns,
+        c_bool *is_retryable_error,
+        c_bool *is_application_error,
+        # This parameter is only used for actor creation task to define
+        # the concurrency groups of this actor.
+        const c_vector[CConcurrencyGroup] &c_defined_concurrency_groups,
+        const c_string c_name_of_concurrency_group_to_execute,
+        c_bool is_reattempt,
+        execution_info,
+        title,
+        task_name) except *:
+    worker = ray._private.worker.global_worker
+    manager = worker.function_actor_manager
+    actor = None
+    cdef:
+        CoreWorker core_worker = worker.core_worker
+        JobID job_id = core_worker.get_current_job_id()
+        TaskID task_id = core_worker.get_current_task_id()
+        CFiberEvent task_done_event
+        c_vector[shared_ptr[CRayObject]] dynamic_return_ptrs
+
+    # Helper method used to exit current asyncio actor.
+    # This is called when a KeyboardInterrupt is received by the main thread.
+    # Upon receiving a KeyboardInterrupt signal, Ray will exit the current
+    # worker. If the worker is processing normal tasks, Ray treat it as task
+    # cancellation from ray.cancel(object_ref). If the worker is an asyncio
+    # actor, Ray will exit the actor.
+    def exit_current_actor_if_asyncio():
+        if core_worker.current_actor_is_asyncio():
+            error = SystemExit(0)
+            error.is_ray_terminate = True
+            error.ray_terminate_msg = "exit_actor() is called."
+            raise error
+
+    function_descriptor = CFunctionDescriptorToPython(
+        ray_function.GetFunctionDescriptor())
+    function_name = execution_info.function_name
+    extra_data = (b'{"name": ' + function_name.encode("ascii") +
+                  b' "task_id": ' + task_id.hex().encode("ascii") + b'}')
+
+    name_of_concurrency_group_to_execute = \
+        c_name_of_concurrency_group_to_execute.decode("ascii")
+
+    if <int>task_type == <int>TASK_TYPE_NORMAL_TASK:
+        next_title = "ray::IDLE"
+        function_executor = execution_info.function
+        # Record the task name via :task_name: magic token in the log file.
+        # This is used for the prefix in driver logs `(task_name pid=123) ...`
+        task_name_magic_token = "{}{}\n".format(
+            ray_constants.LOG_PREFIX_TASK_NAME, task_name.replace("()", ""))
+        # Print on both .out and .err
+        print(task_name_magic_token, end="")
+        print(task_name_magic_token, file=sys.stderr, end="")
+    else:
+        actor = worker.actors[core_worker.get_actor_id()]
+        class_name = actor.__class__.__name__
+        next_title = f"ray::{class_name}"
+
+        def function_executor(*arguments, **kwarguments):
+            function = execution_info.function
+
+            if core_worker.current_actor_is_asyncio():
+                if len(inspect.getmembers(
+                        actor.__class__,
+                        predicate=inspect.iscoroutinefunction)) == 0:
+                    raise RayActorError(
+                        f"Failed to create the actor {core_worker.get_actor_id()}. "
+                        "The failure reason is that you set the async flag, "
+                        "but the actor has no any coroutine function.")
+                # Increase recursion limit if necessary. In asyncio mode,
+                # we have many parallel callstacks (represented in fibers)
+                # that's suspended for execution. Python interpreter will
+                # mistakenly count each callstack towards recusion limit.
+                # We don't need to worry about stackoverflow here because
+                # the max number of callstacks is limited in direct actor
+                # transport with max_concurrency flag.
+                increase_recursion_limit()
+
+                if inspect.iscoroutinefunction(function.method):
+                    async_function = function
+                else:
+                    # Just execute the method if it's ray internal method.
+                    if function.name.startswith("__ray"):
+                        return function(actor, *arguments, **kwarguments)
+                    async_function = sync_to_async(function)
+
+                return core_worker.run_async_func_in_event_loop(
+                    async_function, function_descriptor,
+                    name_of_concurrency_group_to_execute, actor,
+                    *arguments, **kwarguments)
+
+            return function(actor, *arguments, **kwarguments)
+
+    with core_worker.profile_event(b"task::" + name, extra_data=extra_data):
+        try:
+            if (not (<int>task_type == <int>TASK_TYPE_ACTOR_TASK
+                     and function_name == "__ray_terminate__") and
+                    ray._config.memory_monitor_interval_ms() == 0):
+                worker.memory_monitor.raise_if_low_memory()
+
+            with core_worker.profile_event(b"task:deserialize_arguments"):
+                if c_args.empty():
+                    args, kwargs = [], {}
+                else:
+                    metadata_pairs = RayObjectsToDataMetadataPairs(c_args)
+                    object_refs = VectorToObjectRefs(
+                            c_arg_refs,
+                            skip_adding_local_ref=False)
+
+                    if core_worker.current_actor_is_asyncio():
+                        # We deserialize objects in event loop thread to
+                        # prevent segfaults. See #7799
+                        async def deserialize_args():
+                            return (ray._private.worker.global_worker
+                                    .deserialize_objects(
+                                        metadata_pairs, object_refs))
+                        args = core_worker.run_async_func_in_event_loop(
+                            deserialize_args, function_descriptor,
+                            name_of_concurrency_group_to_execute)
+                    else:
+                        args = (ray._private.worker.global_worker
+                                .deserialize_objects(
+                                    metadata_pairs, object_refs))
+
+                    for arg in args:
+                        raise_if_dependency_failed(arg)
+                    args, kwargs = ray._private.signature.recover_args(args)
+
+            if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
+                actor = worker.actors[core_worker.get_actor_id()]
+                class_name = actor.__class__.__name__
+                actor_title = f"{class_name}({args!r}, {kwargs!r})"
+                core_worker.set_actor_title(actor_title.encode("utf-8"))
+            # Execute the task.
+            with core_worker.profile_event(b"task:execute"):
+                task_exception = True
+                try:
+                    is_exiting = core_worker.is_exiting()
+                    if is_exiting:
+                        title = f"{title}::Exiting"
+                        next_title = f"{next_title}::Exiting"
+                    with ray._private.worker._changeproctitle(title, next_title):
+                        if debugger_breakpoint != b"":
+                            ray.util.pdb.set_trace(
+                                breakpoint_uuid=debugger_breakpoint)
+                        outputs = function_executor(*args, **kwargs)
+                        next_breakpoint = (
+                            ray._private.worker.global_worker.debugger_breakpoint)
+                        if next_breakpoint != b"":
+                            # If this happens, the user typed "remote" and
+                            # there were no more remote calls left in this
+                            # task. In that case we just exit the debugger.
+                            ray.experimental.internal_kv._internal_kv_put(
+                                "RAY_PDB_{}".format(next_breakpoint),
+                                "{\"exit_debugger\": true}",
+                                namespace=ray_constants.KV_NAMESPACE_PDB
+                            )
+                            ray.experimental.internal_kv._internal_kv_del(
+                                "RAY_PDB_CONTINUE_{}".format(next_breakpoint),
+                                namespace=ray_constants.KV_NAMESPACE_PDB
+                            )
+                            (ray._private.worker.global_worker
+                             .debugger_breakpoint) = b""
+                    task_exception = False
+                except AsyncioActorExit as e:
+                    exit_current_actor_if_asyncio()
+                except Exception as e:
+                    is_application_error[0] = True
+                    is_retryable_error[0] = determine_if_retryable(
+                        e,
+                        serialized_retry_exception_allowlist,
+                        function_descriptor,
+                    )
+                    if (
+                        is_retryable_error[0]
+                        and core_worker.get_current_task_retry_exceptions()
+                    ):
+                        logger.info("Task failed with retryable exception:"
+                                    " {}.".format(
+                                        core_worker.get_current_task_id()),
+                                    exc_info=True)
+                    else:
+                        logger.debug("Task failed with unretryable exception:"
+                                     " {}.".format(
+                                        core_worker.get_current_task_id()),
+                                     exc_info=True)
+                    raise e
+                if returns[0].size() == 1 and not inspect.isgenerator(outputs):
+                    # If there is only one return specified, we should return
+                    # all return values as a single object.
+                    outputs = (outputs,)
+            if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
+                # Record actor repr via :actor_name: magic token in the log.
+                #
+                # (Phase 2): after `__init__` finishes, we override the
+                # log prefix with the full repr of the actor. The log monitor
+                # will pick up the updated token.
+                actor_class = manager.load_actor_class(job_id, function_descriptor)
+                if (hasattr(actor_class, "__ray_actor_class__") and
+                        (actor_class.__ray_actor_class__.__repr__
+                         != object.__repr__)):
+                    actor_magic_token = "{}{}\n".format(
+                        ray_constants.LOG_PREFIX_ACTOR_NAME, repr(actor))
+                    # Flush on both stdout and stderr.
+                    print(actor_magic_token, end="")
+                    print(actor_magic_token, file=sys.stderr, end="")
+
+            if (returns[0].size() > 0 and
+                    not inspect.isgenerator(outputs) and
+                    len(outputs) != int(returns[0].size())):
+                raise ValueError(
+                    "Task returned {} objects, but num_returns={}.".format(
+                        len(outputs), returns[0].size()))
+
+            # Store the outputs in the object store.
+            with core_worker.profile_event(b"task:store_outputs"):
+                num_returns = returns[0].size()
+                if dynamic_returns != NULL:
+                    if not inspect.isgenerator(outputs):
+                        raise ValueError(
+                                "Functions with "
+                                "@ray.remote(num_returns=\"dynamic\" must return a "
+                                "generator")
+                    task_exception = True
+
+                    execute_dynamic_generator_and_store_task_outputs(
+                            outputs,
+                            returns[0][0].first,
+                            task_type,
+                            serialized_retry_exception_allowlist,
+                            dynamic_returns,
+                            is_retryable_error,
+                            is_application_error,
+                            is_reattempt,
+                            function_name,
+                            function_descriptor,
+                            title)
+
+                    task_exception = False
+                    dynamic_refs = []
+                    for idx in range(dynamic_returns.size()):
+                        dynamic_refs.append(ObjectRef(
+                            dynamic_returns[0][idx].first.Binary(),
+                            caller_address.SerializeAsString(),
+                        ))
+                    # Swap out the generator for an ObjectRef generator.
+                    outputs = (ObjectRefGenerator(dynamic_refs), )
+
+                # TODO(swang): For generator tasks, iterating over outputs will
+                # actually run the task. We should run the usual handlers for
+                # task cancellation, retrying on application exception, etc. for
+                # all generator tasks, both static and dynamic.
+                core_worker.store_task_outputs(
+                    worker, outputs,
+                    returns)
+                objects_stored = True
+        except Exception as e:
+            num_errors_stored = store_task_errors(
+                    worker, e, task_exception, actor, function_name,
+                    task_type, title, returns)
+            objects_stored = True
+            if returns[0].size() > 0 and num_errors_stored == 0:
+                logger.exception(
+                        "Unhandled error: Task threw exception, but all "
+                        f"{returns[0].size()} return values already created. "
+                        "This should only occur when using generator tasks.\n"
+                        "See https://github.com/ray-project/ray/issues/28689.")
+
+
+cdef execute_task_with_cancellation_handler(
         const CAddress &caller_address,
         CTaskType task_type,
         const c_string name,
@@ -699,12 +979,6 @@ cdef execute_task(
 
     worker = ray._private.worker.global_worker
     manager = worker.function_actor_manager
-    actor = None
-    function_name = None
-    task_name = None
-    title = None
-    task_exception = False
-    objects_stored = False
     cdef:
         dict execution_infos = manager.execution_infos
         CoreWorker core_worker = worker.core_worker
@@ -713,302 +987,97 @@ cdef execute_task(
         CFiberEvent task_done_event
         c_vector[shared_ptr[CRayObject]] dynamic_return_ptrs
 
+    task_name = name.decode("utf-8")
+    title = f"ray::{task_name}()"
+
+    # Automatically restrict the GPUs available to this task.
+    ray._private.utils.set_cuda_visible_devices(ray.get_gpu_ids())
+
+    # Initialize the actor if this is an actor creation task. We do this here
+    # before setting the current task ID so that we can get the execution info,
+    # in case executing the main task throws an exception.
+    function_descriptor = CFunctionDescriptorToPython(
+        ray_function.GetFunctionDescriptor())
+    if <int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK:
+        actor_class = manager.load_actor_class(job_id, function_descriptor)
+        actor_id = core_worker.get_actor_id()
+        actor = actor_class.__new__(actor_class)
+        worker.actors[actor_id] = actor
+        # Record the actor class via :actor_name: magic token in the log.
+        #
+        # (Phase 1): this covers code run before __init__ finishes.
+        # We need to handle this separately because `__repr__` may not be
+        # runnable until after `__init__` (e.g., if it accesses fields
+        # defined in the constructor).
+        actor_magic_token = "{}{}\n".format(
+            ray_constants.LOG_PREFIX_ACTOR_NAME, actor_class.__name__)
+        # Flush to both .out and .err
+        print(actor_magic_token, end="")
+        print(actor_magic_token, file=sys.stderr, end="")
+
+        # Initial eventloops for asyncio for this actor.
+        if core_worker.current_actor_is_asyncio():
+            core_worker.initialize_eventloops_for_actor_concurrency_group(
+                c_defined_concurrency_groups)
+
+    execution_info = execution_infos.get(function_descriptor)
+    if not execution_info:
+        execution_info = manager.get_execution_info(
+            job_id, function_descriptor)
+        execution_infos[function_descriptor] = execution_info
+
+    global current_task_id
+
     try:
-        # Automatically restrict the GPUs available to this task.
-        ray._private.utils.set_cuda_visible_devices(ray.get_gpu_ids())
+        task_id = (ray._private.worker.
+                   global_worker.core_worker.get_current_task_id())
+        # Set the current task ID, which is checked by a separate thread during
+        # task cancellation. We must do this inside the try block so that, if
+        # the task is interrupted because of cancellation, we will catch the
+        # interrupt error here.
+        with current_task_id_lock:
+            current_task_id = task_id
 
-        # Helper method used to exit current asyncio actor.
-        # This is called when a KeyboardInterrupt is received by the main thread.
-        # Upon receiving a KeyboardInterrupt signal, Ray will exit the current
-        # worker. If the worker is processing normal tasks, Ray treat it as task
-        # cancellation from ray.cancel(object_ref). If the worker is an asyncio
-        # actor, Ray will exit the actor.
-        def exit_current_actor_if_asyncio():
-            if core_worker.current_actor_is_asyncio():
-                error = SystemExit(0)
-                error.is_ray_terminate = True
-                error.ray_terminate_msg = "exit_actor() is called."
-                raise error
+        execute_task(caller_address,
+                     task_type,
+                     name,
+                     ray_function,
+                     c_resources,
+                     c_args,
+                     c_arg_refs,
+                     debugger_breakpoint,
+                     serialized_retry_exception_allowlist,
+                     returns,
+                     dynamic_returns,
+                     is_retryable_error,
+                     is_application_error,
+                     c_defined_concurrency_groups,
+                     c_name_of_concurrency_group_to_execute,
+                     is_reattempt, execution_info, title, task_name)
 
-        function_descriptor = CFunctionDescriptorToPython(
-            ray_function.GetFunctionDescriptor())
+        # Check for cancellation.
+        PyErr_CheckSignals()
 
-        if <int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK:
-            actor_class = manager.load_actor_class(job_id, function_descriptor)
-            actor_id = core_worker.get_actor_id()
-            actor = actor_class.__new__(actor_class)
-            worker.actors[actor_id] = actor
-            # Record the actor class via :actor_name: magic token in the log.
-            #
-            # (Phase 1): this covers code run before __init__ finishes.
-            # We need to handle this separately because `__repr__` may not be
-            # runnable until after `__init__` (e.g., if it accesses fields
-            # defined in the constructor).
-            actor_magic_token = "{}{}\n".format(
-                ray_constants.LOG_PREFIX_ACTOR_NAME, actor_class.__name__)
-            # Flush to both .out and .err
-            print(actor_magic_token, end="")
-            print(actor_magic_token, file=sys.stderr, end="")
-
-            # Initial eventloops for asyncio for this actor.
-            if core_worker.current_actor_is_asyncio():
-                core_worker.initialize_eventloops_for_actor_concurrency_group(
-                    c_defined_concurrency_groups)
-
-        execution_info = execution_infos.get(function_descriptor)
-        if not execution_info:
-            execution_info = manager.get_execution_info(
-                job_id, function_descriptor)
-            execution_infos[function_descriptor] = execution_info
-
-        function_name = execution_info.function_name
-        extra_data = (b'{"name": ' + function_name.encode("ascii") +
-                      b' "task_id": ' + task_id.hex().encode("ascii") + b'}')
-
-        task_name = name.decode("utf-8")
-        name_of_concurrency_group_to_execute = \
-            c_name_of_concurrency_group_to_execute.decode("ascii")
-        title = f"ray::{task_name}()"
-
-        if <int>task_type == <int>TASK_TYPE_NORMAL_TASK:
-            next_title = "ray::IDLE"
-            function_executor = execution_info.function
-            # Record the task name via :task_name: magic token in the log file.
-            # This is used for the prefix in driver logs `(task_name pid=123) ...`
-            task_name_magic_token = "{}{}\n".format(
-                ray_constants.LOG_PREFIX_TASK_NAME, task_name.replace("()", ""))
-            # Print on both .out and .err
-            print(task_name_magic_token, end="")
-            print(task_name_magic_token, file=sys.stderr, end="")
-        else:
-            actor = worker.actors[core_worker.get_actor_id()]
-            class_name = actor.__class__.__name__
-            next_title = f"ray::{class_name}"
-
-            def function_executor(*arguments, **kwarguments):
-                function = execution_info.function
-
-                if core_worker.current_actor_is_asyncio():
-                    if len(inspect.getmembers(
-                            actor.__class__,
-                            predicate=inspect.iscoroutinefunction)) == 0:
-                        raise RayActorError(
-                            f"Failed to create the actor {core_worker.get_actor_id()}. "
-                            "The failure reason is that you set the async flag, "
-                            "but the actor has no any coroutine function.")
-                    # Increase recursion limit if necessary. In asyncio mode,
-                    # we have many parallel callstacks (represented in fibers)
-                    # that's suspended for execution. Python interpreter will
-                    # mistakenly count each callstack towards recusion limit.
-                    # We don't need to worry about stackoverflow here because
-                    # the max number of callstacks is limited in direct actor
-                    # transport with max_concurrency flag.
-                    increase_recursion_limit()
-
-                    if inspect.iscoroutinefunction(function.method):
-                        async_function = function
-                    else:
-                        # Just execute the method if it's ray internal method.
-                        if function.name.startswith("__ray"):
-                            return function(actor, *arguments, **kwarguments)
-                        async_function = sync_to_async(function)
-
-                    return core_worker.run_async_func_in_event_loop(
-                        async_function, function_descriptor,
-                        name_of_concurrency_group_to_execute, actor,
-                        *arguments, **kwarguments)
-
-                return function(actor, *arguments, **kwarguments)
-
-        with core_worker.profile_event(b"task::" + name, extra_data=extra_data):
-            try:
-                if (not (<int>task_type == <int>TASK_TYPE_ACTOR_TASK
-                         and function_name == "__ray_terminate__") and
-                        ray._config.memory_monitor_interval_ms() == 0):
-                    worker.memory_monitor.raise_if_low_memory()
-
-                with core_worker.profile_event(b"task:deserialize_arguments"):
-                    if c_args.empty():
-                        args, kwargs = [], {}
-                    else:
-                        metadata_pairs = RayObjectsToDataMetadataPairs(c_args)
-                        object_refs = VectorToObjectRefs(
-                                c_arg_refs,
-                                skip_adding_local_ref=False)
-
-                        if core_worker.current_actor_is_asyncio():
-                            # We deserialize objects in event loop thread to
-                            # prevent segfaults. See #7799
-                            async def deserialize_args():
-                                return (ray._private.worker.global_worker
-                                        .deserialize_objects(
-                                            metadata_pairs, object_refs))
-                            args = core_worker.run_async_func_in_event_loop(
-                                deserialize_args, function_descriptor,
-                                name_of_concurrency_group_to_execute)
-                        else:
-                            args = (ray._private.worker.global_worker
-                                    .deserialize_objects(
-                                        metadata_pairs, object_refs))
-
-                        for arg in args:
-                            raise_if_dependency_failed(arg)
-                        args, kwargs = ray._private.signature.recover_args(args)
-
-                if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
-                    actor = worker.actors[core_worker.get_actor_id()]
-                    class_name = actor.__class__.__name__
-                    actor_title = f"{class_name}({args!r}, {kwargs!r})"
-                    core_worker.set_actor_title(actor_title.encode("utf-8"))
-                # Execute the task.
-                with core_worker.profile_event(b"task:execute"):
-                    task_exception = True
-                    try:
-                        is_exiting = core_worker.is_exiting()
-                        if is_exiting:
-                            title = f"{title}::Exiting"
-                            next_title = f"{next_title}::Exiting"
-                        with ray._private.worker._changeproctitle(title, next_title):
-                            if debugger_breakpoint != b"":
-                                ray.util.pdb.set_trace(
-                                    breakpoint_uuid=debugger_breakpoint)
-                            outputs = function_executor(*args, **kwargs)
-                            next_breakpoint = (
-                                ray._private.worker.global_worker.debugger_breakpoint)
-                            if next_breakpoint != b"":
-                                # If this happens, the user typed "remote" and
-                                # there were no more remote calls left in this
-                                # task. In that case we just exit the debugger.
-                                ray.experimental.internal_kv._internal_kv_put(
-                                    "RAY_PDB_{}".format(next_breakpoint),
-                                    "{\"exit_debugger\": true}",
-                                    namespace=ray_constants.KV_NAMESPACE_PDB
-                                )
-                                ray.experimental.internal_kv._internal_kv_del(
-                                    "RAY_PDB_CONTINUE_{}".format(next_breakpoint),
-                                    namespace=ray_constants.KV_NAMESPACE_PDB
-                                )
-                                (ray._private.worker.global_worker
-                                 .debugger_breakpoint) = b""
-                        task_exception = False
-                    except AsyncioActorExit as e:
-                        exit_current_actor_if_asyncio()
-                    except Exception as e:
-                        is_application_error[0] = True
-                        is_retryable_error[0] = determine_if_retryable(
-                            e,
-                            serialized_retry_exception_allowlist,
-                            function_descriptor,
-                        )
-                        if (
-                            is_retryable_error[0]
-                            and core_worker.get_current_task_retry_exceptions()
-                        ):
-                            logger.info("Task failed with retryable exception:"
-                                        " {}.".format(
-                                            core_worker.get_current_task_id()),
-                                        exc_info=True)
-                        else:
-                            logger.debug("Task failed with unretryable exception:"
-                                         " {}.".format(
-                                            core_worker.get_current_task_id()),
-                                         exc_info=True)
-                        raise e
-                    if returns[0].size() == 1 and not inspect.isgenerator(outputs):
-                        # If there is only one return specified, we should return
-                        # all return values as a single object.
-                        outputs = (outputs,)
-                if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
-                    # Record actor repr via :actor_name: magic token in the log.
-                    #
-                    # (Phase 2): after `__init__` finishes, we override the
-                    # log prefix with the full repr of the actor. The log monitor
-                    # will pick up the updated token.
-                    if (hasattr(actor_class, "__ray_actor_class__") and
-                            (actor_class.__ray_actor_class__.__repr__
-                             != object.__repr__)):
-                        actor_magic_token = "{}{}\n".format(
-                            ray_constants.LOG_PREFIX_ACTOR_NAME, repr(actor))
-                        # Flush on both stdout and stderr.
-                        print(actor_magic_token, end="")
-                        print(actor_magic_token, file=sys.stderr, end="")
-
-                # Check for a cancellation that was called when the function
-                # was exiting and was raised after the except block.
-                task_exception = True
-                PyErr_CheckSignals()
-                task_exception = False
-
-                if (returns[0].size() > 0 and
-                        not inspect.isgenerator(outputs) and
-                        len(outputs) != int(returns[0].size())):
-                    raise ValueError(
-                        "Task returned {} objects, but num_returns={}.".format(
-                            len(outputs), returns[0].size()))
-
-                # Store the outputs in the object store.
-                with core_worker.profile_event(b"task:store_outputs"):
-                    num_returns = returns[0].size()
-                    if dynamic_returns != NULL:
-                        if not inspect.isgenerator(outputs):
-                            raise ValueError(
-                                    "Functions with "
-                                    "@ray.remote(num_returns=\"dynamic\" must return a "
-                                    "generator")
-                        task_exception = True
-
-                        execute_dynamic_generator_and_store_task_outputs(
-                                outputs,
-                                returns[0][0].first,
-                                task_type,
-                                serialized_retry_exception_allowlist,
-                                dynamic_returns,
-                                is_retryable_error,
-                                is_application_error,
-                                is_reattempt,
-                                function_name,
-                                function_descriptor,
-                                title)
-
-                        task_exception = False
-                        dynamic_refs = []
-                        for idx in range(dynamic_returns.size()):
-                            dynamic_refs.append(ObjectRef(
-                                dynamic_returns[0][idx].first.Binary(),
-                                caller_address.SerializeAsString(),
-                            ))
-                        # Swap out the generator for an ObjectRef generator.
-                        outputs = (ObjectRefGenerator(dynamic_refs), )
-
-                    # TODO(swang): For generator tasks, iterating over outputs will
-                    # actually run the task. We should run the usual handlers for
-                    # task cancellation, retrying on application exception, etc. for
-                    # all generator tasks, both static and dynamic.
-                    core_worker.store_task_outputs(
-                        worker, outputs,
-                        returns)
-                    objects_stored = True
-            except Exception as e:
-                num_errors_stored = store_task_errors(
-                        worker, e, task_exception, actor, function_name,
-                        task_type, title, returns)
-                objects_stored = True
-                if returns[0].size() > 0 and num_errors_stored == 0:
-                    logger.exception(
-                            "Unhandled error: Task threw exception, but all "
-                            f"{returns[0].size()} return values already created. "
-                            "This should only occur when using generator tasks.\n"
-                            "See https://github.com/ray-project/ray/issues/28689.")
     except KeyboardInterrupt as e:
         # Catch and handle SIGINT.
-        if not objects_stored:
-            # Only store a task cancellation error if we haven't already stored
-            # error/output objects.
-            e = TaskCancelledError(
-                core_worker.get_current_task_id()).with_traceback(e.__traceback__)
-            num_errors_stored = store_task_errors(
-                    worker, e, task_exception, actor, function_name,
-                    task_type, title, returns)
+        e = TaskCancelledError(
+            core_worker.get_current_task_id()).with_traceback(e.__traceback__)
+
+        actor = None
+        actor_id = core_worker.get_actor_id()
+        if not actor_id.is_nil():
+            actor = core_worker.actors[actor_id]
+
+        store_task_errors(
+                worker, e,
+                # Task cancellation can happen anytime so we don't really need
+                # to differentiate between mid-task or not.
+                False,  # task_exception
+                actor, execution_info.function_name,
+                task_type, title, returns)
+    finally:
+        with current_task_id_lock:
+            current_task_id = None
 
     if execution_info.max_calls != 0:
         # Reset the state of the worker for the next task to execute.
@@ -1048,29 +1117,26 @@ cdef CRayStatus task_execution_handler(
         const c_string name_of_concurrency_group_to_execute,
         c_bool is_reattempt) nogil:
 
-    global current_task_id
     with gil, disable_client_hook():
         try:
-            task_id = (ray._private.worker.
-                       global_worker.core_worker.get_current_task_id())
-            with current_task_id_lock:
-                current_task_id = task_id
-
             try:
-                # The call to execute_task should never raise an exception. If
-                # it does, that indicates that there was an internal error.
-                execute_task(caller_address, task_type, task_name,
-                             ray_function, c_resources,
-                             c_args, c_arg_refs,
-                             debugger_breakpoint,
-                             serialized_retry_exception_allowlist,
-                             returns,
-                             dynamic_returns,
-                             is_retryable_error,
-                             is_application_error,
-                             defined_concurrency_groups,
-                             name_of_concurrency_group_to_execute,
-                             is_reattempt)
+                # Exceptions, including task cancellation, should be handled
+                # internal to this call. If it does raise an exception, that
+                # indicates that there was an internal error.
+                execute_task_with_cancellation_handler(
+                        caller_address,
+                        task_type, task_name,
+                        ray_function, c_resources,
+                        c_args, c_arg_refs,
+                        debugger_breakpoint,
+                        serialized_retry_exception_allowlist,
+                        returns,
+                        dynamic_returns,
+                        is_retryable_error,
+                        is_application_error,
+                        defined_concurrency_groups,
+                        name_of_concurrency_group_to_execute,
+                        is_reattempt)
             except Exception as e:
                 sys_exit = SystemExit()
                 if isinstance(e, RayActorError) and \
@@ -1099,9 +1165,6 @@ cdef CRayStatus task_execution_handler(
                         job_id=None)
                     sys_exit.unexpected_error_traceback = traceback_str
                 raise sys_exit
-            finally:
-                with current_task_id_lock:
-                    current_task_id = None
         except SystemExit as e:
             # Tell the core worker to exit as soon as the result objects
             # are processed.


### PR DESCRIPTION
Task execution currently doesn't handle `KeyboardInterrupt` (which is raised via the SIGINT signal upon task cancellation) during argument deserialization or task error storage, since we are only catching `KeyboardInterrupt` during actual execution of the task function. This can result in task cancellation causing the underlying worker to crash, since the task cancellation error may never be stored, causing [a `RAY_CHECK` in the task transport](https://github.com/ray-project/ray/blob/580bacd5d1820815708a4abe9130798039dc0862/src/ray/core_worker/transport/direct_actor_transport.cc#L198) to fail. Arguments that take a particularly long time to deserialize can cause this to be hit pretty consistently.

This PR adds a top-level try-except on `KeyboardInterrupt` that covers (nearly) the entire `execute_task` function body, ensuring that the SIGINT is properly handled.

This PR is the first PR in a set of stacked PRs making up this mono-PR for adding support for Arrow 7+ support in Ray: https://github.com/ray-project/ray/pull/29161

## Summary of Changes

The PR diff is larger than the actual change due to the try-except change in indent. These are the only changes:
- we wrap the entire `execute_task` function body in a try-except for `KeyboardInterrupt` instead of only guarding the task execution block
- we change [“cancellation while function exiting”](https://github.com/ray-project/ray/pull/29984/files#diff-31e8159767361e4bc259b6d9883d9c0d5e5db780fcea4a52ead4ee3ee4a59a78R936-R940) handling to raise a `KeyboardInterrupt` via `PyErr_CheckSignals()` and join the shared `KeyboardInterrupt` handling rather than duplicate the handling with the `check_signals check` (not sure why this wasn’t done originally)
- we added [tracking](https://github.com/ray-project/ray/pull/29984/files#diff-31e8159767361e4bc259b6d9883d9c0d5e5db780fcea4a52ead4ee3ee4a59a78R990-R995) for whether we’ve already stored task outputs or task errors when the cancellation signal is received, in which case we consider the task to be done and ignore the cancellation signal
- `TaskCancelledError` is [manually constructed](https://github.com/ray-project/ray/pull/29984/files#diff-31e8159767361e4bc259b6d9883d9c0d5e5db780fcea4a52ead4ee3ee4a59a78R1007-R1008) with the appropriate traceback rather than chained on the `KeyboardInterrupt`.

## Related Issues Numbers

Closes https://github.com/ray-project/ray/issues/30054

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
