### PR TITLE
Add serialization/deserialization for MultiBinary space

### DIFF
--- a/rllib/utils/serialization.py
+++ b/rllib/utils/serialization.py
@@ -81,11 +81,10 @@ def gym_space_to_dict(space: gym.spaces.Space) -> Dict:
         }
 
     def _multi_binary(sp: gym.spaces.MultiBinary) -> Dict:
-        d = {
+        return {
             "space": "multi-binary",
             "n": sp.n,
         }
-        return d
 
     def _tuple(sp: gym.spaces.Tuple) -> Dict:
         return {

--- a/rllib/utils/serialization.py
+++ b/rllib/utils/serialization.py
@@ -80,6 +80,13 @@ def gym_space_to_dict(space: gym.spaces.Space) -> Dict:
             "dtype": sp.dtype.str,
         }
 
+    def _multi_binary(sp: gym.spaces.MultiBinary) -> Dict:
+        d = {
+            "space": "multi-binary",
+            "n": sp.n,
+        }
+        return d
+
     def _tuple(sp: gym.spaces.Tuple) -> Dict:
         return {
             "space": "tuple",
@@ -121,6 +128,8 @@ def gym_space_to_dict(space: gym.spaces.Space) -> Dict:
         return _discrete(space)
     elif isinstance(space, gym.spaces.MultiDiscrete):
         return _multi_discrete(space)
+    elif isinstance(space, gym.spaces.MultiBinary):
+        return _multi_binary(space)
     elif isinstance(space, gym.spaces.Tuple):
         return _tuple(space)
     elif isinstance(space, gym.spaces.Dict):
@@ -184,6 +193,9 @@ def gym_space_from_dict(d: Dict) -> gym.spaces.Space:
         )
         return gym.spaces.MultiDiscrete(**__common(ret))
 
+    def _multi_binary(d: Dict) -> gym.spaces.MultiBinary:
+        return gym.spaces.MultiBinary(**__common(d))
+
     def _tuple(d: Dict) -> gym.spaces.Discrete:
         spaces = [gym_space_from_dict(sp) for sp in d["spaces"]]
         return gym.spaces.Tuple(spaces=spaces)
@@ -207,6 +219,7 @@ def gym_space_from_dict(d: Dict) -> gym.spaces.Space:
         "box": _box,
         "discrete": _discrete,
         "multi-discrete": _multi_discrete,
+        "multi-binary": _multi_binary,
         "tuple": _tuple,
         "dict": _dict,
         "simplex": _simplex,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`MultiDiscrete([2] * n)` is supported, but not equivalent to `MultiBinary`. They both give vectors that look like `[0,1,0]` if `n = 3`. But it seems RLLib's internal comprehension of the size of MultiDiscrete spaces are `2 * n`. This is true for every size except `[2]`Trying to minimally reproduce the bug right now, but I had this fix implemented already in my version of `ray`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

I've tested saving an environment with MultiBinary spaces and loading it. It works.