### PR TITLE
[Datasets] [Arrow 7+ Support - 2/N] Add support for Arrow 7 by fixing Arrow serialization bug.

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -269,14 +269,25 @@
     # Dask tests and examples.
     - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-client python/ray/util/dask/...
 
-- label: "Dataset tests"
+- label: "Dataset tests (Arrow 7)"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
   instance_size: medium
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - DATA_PROCESSING_TESTING=1 ./ci/env/install-dependencies.sh
+    - DATA_PROCESSING_TESTING=1 ARROW_VERSION=7.* ./ci/env/install-dependencies.sh
     - ./ci/env/env_info.sh
     - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/data/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=ray_data python/ray/air/...
+
+- label: "Dataset tests (Arrow 6)"
+  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
+  instance_size: medium
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+    - DATA_PROCESSING_TESTING=1 ARROW_VERSION=6.* ./ci/env/install-dependencies.sh
+    - ./ci/env/env_info.sh
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/data/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=ray_data python/ray/air/...
 
 - label: "Workflow tests"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_WORKFLOW_AFFECTED"]

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -399,6 +399,13 @@ install_pip_packages() {
   fi
   if [ "${DATA_PROCESSING_TESTING-}" = 1 ]; then
     pip install -U -c "${WORKSPACE_DIR}"/python/requirements.txt -r "${WORKSPACE_DIR}"/python/requirements/data_processing/requirements_dataset.txt
+    if [ -n "${ARROW_VERSION-}" ]; then
+      if [ "${ARROW_VERSION-}" = nightly ]; then
+        pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ --prefer-binary --pre pyarrow
+      else
+        pip install -U pyarrow=="${ARROW_VERSION}"
+      fi
+    fi
   fi
 
   # Remove this entire section once Serve dependencies are fixed.

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -61,6 +61,7 @@ win32_AssignProcessToJobObject = None
 
 
 ENV_DISABLE_DOCKER_CPU_WARNING = "RAY_DISABLE_DOCKER_CPU_WARNING" in os.environ
+_PYARROW_VERSION = None
 
 
 def get_user_temp_dir():
@@ -1596,3 +1597,20 @@ def split_address(address: str) -> Tuple[str, str]:
 
     module_string, inner_address = address.split("://", maxsplit=1)
     return (module_string, inner_address)
+
+
+def _get_pyarrow_version() -> Optional[str]:
+    """Get the version of the installed pyarrow package, returned as a tuple of ints.
+    Returns None if the package is not found.
+    """
+    global _PYARROW_VERSION
+    if _PYARROW_VERSION is None:
+        try:
+            import pyarrow
+        except ModuleNotFoundError:
+            # pyarrow not installed, short-circuit.
+            pass
+        else:
+            if hasattr(pyarrow, "__version__"):
+                _PYARROW_VERSION = pyarrow.__version__
+    return _PYARROW_VERSION

--- a/python/ray/air/BUILD
+++ b/python/ray/air/BUILD
@@ -62,7 +62,7 @@ py_test(
     name = "test_data_batch_conversion",
     size = "small",
     srcs = ["tests/test_data_batch_conversion.py"],
-    tags = ["team:ml", "exclusive"],
+    tags = ["team:ml", "exclusive", "ray_data"],
     deps = [":ml_lib"]
 )
 
@@ -110,7 +110,7 @@ py_test(
     name = "test_tensor_extension",
     size = "small",
     srcs = ["tests/test_tensor_extension.py"],
-    tags = ["team:ml", "exclusive"],
+    tags = ["team:ml", "exclusive", "ray_data"],
     deps = [":ml_lib"]
 )
 

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -470,12 +470,7 @@ class ArrowVariableShapedTensorArray(pa.ExtensionArray):
         # unfortunately overriding Cython cdef methods with normal Python methods isn't
         # allowed.
         if isinstance(key, slice):
-            sliced = super().__getitem__(key).to_numpy()
-            if sliced.dtype.type is not np.object_:
-                # Force ths slice to match NumPy semantics for unit (single-element)
-                # slices.
-                sliced = sliced[0:1]
-            return sliced
+            return super().__getitem__(key)
         return self._to_numpy(key)
 
     def __iter__(self):

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -1,8 +1,3 @@
-import ray
-from ray.data._internal.arrow_serialization import (
-    _register_arrow_json_parseoptions_serializer,
-    _register_arrow_json_readoptions_serializer,
-)
 from ray.data._internal.compute import ActorPoolStrategy
 from ray.data._internal.progress_bar import set_progress_bars
 from ray.data.dataset import Dataset
@@ -38,15 +33,6 @@ from ray.data.read_api import (  # noqa: F401
     read_text,
     read_tfrecords,
 )
-
-# Register custom Arrow JSON ReadOptions and ParseOptions serializer after worker has
-# initialized.
-if ray.is_initialized():
-    _register_arrow_json_readoptions_serializer()
-    _register_arrow_json_parseoptions_serializer()
-else:
-    pass
-#    ray._internal.worker._post_init_hooks.append(_register_arrow_json_readoptions_serializer)
 
 __all__ = [
     "ActorPoolStrategy",

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
 
     from ray.data._internal.sort import SortKeyT
 
+
 T = TypeVar("T")
 
 
@@ -70,6 +71,19 @@ class ArrowRow(TableRow):
     """
 
     def __getitem__(self, key: str) -> Any:
+        from ray.data.extensions.tensor_extension import (
+            ArrowTensorType,
+            ArrowVariableShapedTensorType,
+        )
+
+        schema = self._row.schema
+        if isinstance(
+            schema.field(schema.get_field_index(key)).type,
+            (ArrowTensorType, ArrowVariableShapedTensorType),
+        ):
+            # Build a tensor row.
+            return ArrowBlockAccessor._build_tensor_row(self._row, col_name=key)
+
         col = self._row[key]
         if len(col) == 0:
             return None
@@ -79,7 +93,7 @@ class ArrowRow(TableRow):
             return item.as_py()
         except AttributeError:
             # Assume that this row is an element of an extension array, and
-            # that it is bypassing pyarrow's scalar model.
+            # that it is bypassing pyarrow's scalar model for Arrow < 8.0.0.
             return item
 
     def __iter__(self) -> Iterator:
@@ -166,10 +180,13 @@ class ArrowBlockAccessor(TableBlockAccessor):
         return pa.Table.from_pydict(new_batch)
 
     @staticmethod
-    def _build_tensor_row(row: ArrowRow) -> np.ndarray:
-        return row[VALUE_COL_NAME][0]
+    def _build_tensor_row(row: ArrowRow, col_name: str = VALUE_COL_NAME) -> np.ndarray:
+        element = row[col_name][0]
+        # For Arrow < 8.0.0, accessing an element in a chunked tensor array produces an
+        # ndarray, which we return directly.
+        return element
 
-    def slice(self, start: int, end: int, copy: bool) -> "pyarrow.Table":
+    def slice(self, start: int, end: int, copy: bool = False) -> "pyarrow.Table":
         view = self._table.slice(start, end - start)
         if copy:
             view = _copy_table(view)
@@ -212,10 +229,10 @@ class ArrowBlockAccessor(TableBlockAccessor):
         arrays = []
         for column in columns:
             array = self._table[column]
-            if array.num_chunks == 0:
-                array = pyarrow.array([], type=array.type)
-            elif _is_column_extension_type(array):
+            if _is_column_extension_type(array):
                 array = _concatenate_extension_column(array)
+            elif array.num_chunks == 0:
+                array = pyarrow.array([], type=array.type)
             else:
                 array = array.combine_chunks()
             arrays.append(array.to_numpy(zero_copy_only=False))
@@ -399,11 +416,9 @@ class ArrowBlockAccessor(TableBlockAccessor):
             bounds = np.searchsorted(table[col], boundaries)
         last_idx = 0
         for idx in bounds:
-            # Slices need to be copied to avoid including the base table
-            # during serialization.
-            partitions.append(_copy_table(table.slice(last_idx, idx - last_idx)))
+            partitions.append(table.slice(last_idx, idx - last_idx))
             last_idx = idx
-        partitions.append(_copy_table(table.slice(last_idx)))
+        partitions.append(table.slice(last_idx))
         return partitions
 
     def combine(self, key: KeyFn, aggs: Tuple[AggregateFn]) -> Block[ArrowRow]:
@@ -449,7 +464,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
                         except StopIteration:
                             next_row = None
                             break
-                    yield next_key, self.slice(start, end, copy=False)
+                    yield next_key, self.slice(start, end)
                     start = end
                 except StopIteration:
                     break

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -78,7 +78,7 @@ class ArrowRow(TableRow):
 
         schema = self._row.schema
         if isinstance(
-            schema.field(schema.get_field_index(key)).type,
+            schema.field(key).type,
             (ArrowTensorType, ArrowVariableShapedTensorType),
         ):
             # Build a tensor row.

--- a/python/ray/data/_internal/arrow_ops/transform_polars.py
+++ b/python/ray/data/_internal/arrow_ops/transform_polars.py
@@ -7,7 +7,7 @@ except ImportError:
 
 
 if TYPE_CHECKING:
-    from ray.data.impl.sort import SortKeyT
+    from ray.data._internal.sort import SortKeyT
 
 pl = None
 

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -6,7 +6,7 @@ except ImportError:
     pyarrow = None
 
 if TYPE_CHECKING:
-    from ray.data.impl.sort import SortKeyT
+    from ray.data._internal.sort import SortKeyT
 
 
 def sort(table: "pyarrow.Table", key: "SortKeyT", descending: bool) -> "pyarrow.Table":

--- a/python/ray/data/_internal/arrow_serialization.py
+++ b/python/ray/data/_internal/arrow_serialization.py
@@ -1,13 +1,33 @@
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pyarrow
 
 RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION = (
     "RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION"
 )
+RAY_DISABLE_CUSTOM_ARROW_DATA_SERIALIZATION = (
+    "RAY_DISABLE_CUSTOM_ARROW_DATA_SERIALIZATION"
+)
 
 
-def _register_arrow_json_readoptions_serializer():
-    import ray
+def _register_custom_datasets_serializers(serialization_context):
+    try:
+        import pyarrow as pa  # noqa: F401
+    except ModuleNotFoundError:
+        # No pyarrow installed so not using Arrow, so no need for custom serializers.
+        return
 
+    # Register all custom serializers required by Datasets.
+    _register_arrow_data_serializer(serialization_context)
+    _register_arrow_json_readoptions_serializer(serialization_context)
+    _register_arrow_json_parseoptions_serializer(serialization_context)
+
+
+# Register custom Arrow JSON ReadOptions serializer to workaround it not being picklable
+# in Arrow < 8.0.0.
+def _register_arrow_json_readoptions_serializer(serialization_context):
     if (
         os.environ.get(
             RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION,
@@ -15,27 +35,18 @@ def _register_arrow_json_readoptions_serializer():
         )
         == "1"
     ):
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.info("Disabling custom Arrow JSON ReadOptions serialization.")
         return
 
-    try:
-        import pyarrow.json as pajson
-    except ModuleNotFoundError:
-        return
+    import pyarrow.json as pajson
 
-    ray.util.register_serializer(
+    serialization_context._register_cloudpickle_serializer(
         pajson.ReadOptions,
-        serializer=lambda opts: (opts.use_threads, opts.block_size),
-        deserializer=lambda args: pajson.ReadOptions(*args),
+        custom_serializer=lambda opts: (opts.use_threads, opts.block_size),
+        custom_deserializer=lambda args: pajson.ReadOptions(*args),
     )
 
 
-def _register_arrow_json_parseoptions_serializer():
-    import ray
-
+def _register_arrow_json_parseoptions_serializer(serialization_context):
     if (
         os.environ.get(
             RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION,
@@ -43,23 +54,65 @@ def _register_arrow_json_parseoptions_serializer():
         )
         == "1"
     ):
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.info("Disabling custom Arrow JSON ParseOptions serialization.")
         return
 
-    try:
-        import pyarrow.json as pajson
-    except ModuleNotFoundError:
-        return
+    import pyarrow.json as pajson
 
-    ray.util.register_serializer(
+    serialization_context._register_cloudpickle_serializer(
         pajson.ParseOptions,
-        serializer=lambda opts: (
+        custom_serializer=lambda opts: (
             opts.explicit_schema,
             opts.newlines_in_values,
             opts.unexpected_field_behavior,
         ),
-        deserializer=lambda args: pajson.ParseOptions(*args),
+        custom_deserializer=lambda args: pajson.ParseOptions(*args),
     )
+
+
+# Register custom Arrow data serializer to work around zero-copy slice pickling bug.
+# See https://issues.apache.org/jira/browse/ARROW-10739.
+def _register_arrow_data_serializer(serialization_context):
+    """Custom reducer for Arrow data that works around a zero-copy slicing pickling
+    bug by using the Arrow IPC format for the underlying serialization.
+
+    Background:
+        Arrow has both array-level slicing and buffer-level slicing; both are zero-copy,
+        but the former has a serialization bug where the entire buffer is serialized
+        instead of just the slice, while the latter's serialization works as expected
+        and only serializes the slice of the buffer. I.e., array-level slicing doesn't
+        propagate the slice down to the buffer when serializing the array.
+
+        All that these copy methods do is, at serialization time, take the array-level
+        slicing and translate them to buffer-level slicing, so only the buffer slice is
+        sent over the wire instead of the entire buffer.
+
+    See https://issues.apache.org/jira/browse/ARROW-10739.
+    """
+    import pyarrow as pa
+
+    if os.environ.get(RAY_DISABLE_CUSTOM_ARROW_DATA_SERIALIZATION, "0") == "1":
+        return
+
+    # Register custom reducer for Arrow Tables.
+    serialization_context._register_cloudpickle_reducer(pa.Table, _arrow_table_reduce)
+
+
+def _arrow_table_reduce(table: "pyarrow.Table"):
+    """Custom reducer for Arrow Table that works around a zero-copy slicing pickling
+    bug by using the Arrow IPC format for the underlying serialization.
+    """
+    from pyarrow.ipc import RecordBatchStreamWriter
+    from pyarrow.lib import BufferOutputStream
+
+    output_stream = BufferOutputStream()
+    with RecordBatchStreamWriter(output_stream, schema=table.schema) as wr:
+        wr.write_table(table)
+    return _restore_table, (output_stream.getvalue(),)
+
+
+def _restore_table(buf: bytes) -> "pyarrow.Table":
+    """Restore a serialized Arrow Table."""
+    from pyarrow.ipc import RecordBatchStreamReader
+
+    with RecordBatchStreamReader(buf) as reader:
+        return reader.read_all()

--- a/python/ray/data/_internal/arrow_serialization.py
+++ b/python/ray/data/_internal/arrow_serialization.py
@@ -82,9 +82,9 @@ def _register_arrow_data_serializer(serialization_context):
         and only serializes the slice of the buffer. I.e., array-level slicing doesn't
         propagate the slice down to the buffer when serializing the array.
 
-        All that these copy methods do is, at serialization time, take the array-level
-        slicing and translate them to buffer-level slicing, so only the buffer slice is
-        sent over the wire instead of the entire buffer.
+        We work around this by registering a custom cloudpickle reducers for Arrow
+        Tables that delegates serialization to the Arrow IPC format; thankfully, Arrow's
+        IPC serialization has fixed this buffer truncation bug.
 
     See https://issues.apache.org/jira/browse/ARROW-10739.
     """

--- a/python/ray/data/_internal/delegating_block_builder.py
+++ b/python/ray/data/_internal/delegating_block_builder.py
@@ -59,6 +59,7 @@ class DelegatingBlockBuilder(BlockBuilder[T]):
         if self._builder is None:
             if self._empty_block is not None:
                 self._builder = BlockAccessor.for_block(self._empty_block).builder()
+                self._builder.add_block(self._empty_block)
             else:
                 self._builder = ArrowBlockBuilder()
         return self._builder.build()

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -143,7 +143,7 @@ class PandasBlockAccessor(TableBlockAccessor):
             tensor = tensor.to_numpy()
         return tensor
 
-    def slice(self, start: int, end: int, copy: bool) -> "pandas.DataFrame":
+    def slice(self, start: int, end: int, copy: bool = False) -> "pandas.DataFrame":
         view = self._table[start:end]
         view.reset_index(drop=True, inplace=True)
         if copy:

--- a/python/ray/data/_internal/shuffle_and_partition.py
+++ b/python/ray/data/_internal/shuffle_and_partition.py
@@ -56,7 +56,7 @@ class _ShufflePartitionOp(ShuffleOp):
         slice_sz = max(1, math.ceil(block.num_rows() / output_num_blocks))
         slices = []
         for i in range(output_num_blocks):
-            slices.append(block.slice(i * slice_sz, (i + 1) * slice_sz, copy=True))
+            slices.append(block.slice(i * slice_sz, (i + 1) * slice_sz))
 
         # Randomize the distribution order of the blocks (this prevents empty
         # outputs when input blocks are very small).

--- a/python/ray/data/_internal/simple_block.py
+++ b/python/ray/data/_internal/simple_block.py
@@ -67,7 +67,7 @@ class SimpleBlockAccessor(BlockAccessor):
     def iter_rows(self) -> Iterator[T]:
         return iter(self._items)
 
-    def slice(self, start: int, end: int, copy: bool) -> List[T]:
+    def slice(self, start: int, end: int, copy: bool = False) -> List[T]:
         view = self._items[start:end]
         if copy:
             view = view.copy()
@@ -333,7 +333,7 @@ class SimpleBlockAccessor(BlockAccessor):
                             has_next_row = False
                             next_row = None
                             break
-                    yield next_key, self.slice(start, end, copy=False)
+                    yield next_key, self.slice(start, end)
                     start = end
                 except StopIteration:
                     break

--- a/python/ray/data/_internal/split.py
+++ b/python/ray/data/_internal/split.py
@@ -118,7 +118,7 @@ def _split_single_block(
     for index in split_indices:
         logger.debug(f"slicing block {prev_index}:{index}")
         stats = BlockExecStats.builder()
-        split_block = block_accessor.slice(prev_index, index, copy=True)
+        split_block = block_accessor.slice(prev_index, index)
         accessor = BlockAccessor.for_block(split_block)
         _meta = BlockMetadata(
             num_rows=accessor.num_rows(),

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -9,6 +9,7 @@ import numpy as np
 
 import ray
 from ray.data.context import DatasetContext
+from ray._private.utils import _get_pyarrow_version
 
 if TYPE_CHECKING:
     from ray.data.datasource import Reader
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 # Inclusive minimum pyarrow version.
 MIN_PYARROW_VERSION = "6.0.1"
 # Exclusive maximum pyarrow version.
-MAX_PYARROW_VERSION = "7.0.0"
+MAX_PYARROW_VERSION = "8.0.0"
 RAY_DISABLE_PYARROW_VERSION_CHECK = "RAY_DISABLE_PYARROW_VERSION_CHECK"
 _VERSION_VALIDATED = False
 _LOCAL_SCHEME = "local"
@@ -53,31 +54,12 @@ def _check_pyarrow_version():
             _VERSION_VALIDATED = True
             return
 
-        try:
-            import pyarrow
-        except ModuleNotFoundError:
-            # pyarrow not installed, short-circuit.
-            return
+        version = _get_pyarrow_version()
+        if version is not None:
+            from pkg_resources._vendor.packaging.version import parse as parse_version
 
-        import pkg_resources
-
-        if not hasattr(pyarrow, "__version__"):
-            logger.warning(
-                "You are using the 'pyarrow' module, but the exact version is unknown "
-                "(possibly carried as an internal component by another module). Please "
-                f"make sure you are using pyarrow >= {MIN_PYARROW_VERSION}, < "
-                f"{MAX_PYARROW_VERSION} to ensure compatibility with Ray Datasets. "
-                "If you want to disable this pyarrow version check, set the "
-                f"environment variable {RAY_DISABLE_PYARROW_VERSION_CHECK}=1."
-            )
-        else:
-            version = pyarrow.__version__
-            if (
-                pkg_resources.packaging.version.parse(version)
-                < pkg_resources.packaging.version.parse(MIN_PYARROW_VERSION)
-            ) or (
-                pkg_resources.packaging.version.parse(version)
-                >= pkg_resources.packaging.version.parse(MAX_PYARROW_VERSION)
+            if (parse_version(version) < parse_version(MIN_PYARROW_VERSION)) or (
+                parse_version(version) >= parse_version(MAX_PYARROW_VERSION)
             ):
                 raise ImportError(
                     f"Datasets requires pyarrow >= {MIN_PYARROW_VERSION}, < "
@@ -86,6 +68,15 @@ def _check_pyarrow_version():
                     "If you want to disable this pyarrow version check, set the "
                     f"environment variable {RAY_DISABLE_PYARROW_VERSION_CHECK}=1."
                 )
+        else:
+            logger.warning(
+                "You are using the 'pyarrow' module, but the exact version is unknown "
+                "(possibly carried as an internal component by another module). Please "
+                f"make sure you are using pyarrow >= {MIN_PYARROW_VERSION}, < "
+                f"{MAX_PYARROW_VERSION} to ensure compatibility with Ray Datasets. "
+                "If you want to disable this pyarrow version check, set the "
+                f"environment variable {RAY_DISABLE_PYARROW_VERSION_CHECK}=1."
+            )
         _VERSION_VALIDATED = True
 
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -95,7 +95,7 @@ from ray.data.datasource import (
 )
 from ray.data.datasource.file_based_datasource import (
     _unwrap_arrow_serialization_workaround,
-    _wrap_and_register_arrow_serialization_workaround,
+    _wrap_arrow_serialization_workaround,
 )
 from ray.data.random_access_dataset import RandomAccessDataset
 from ray.data.row import TableRow
@@ -2498,7 +2498,7 @@ class Dataset(Generic[T]):
                     blocks,
                     metadata,
                     ray_remote_args,
-                    _wrap_and_register_arrow_serialization_workaround(write_args),
+                    _wrap_arrow_serialization_workaround(write_args),
                 )
             )
 

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -16,10 +16,6 @@ from typing import (
 )
 
 from ray.data._internal.arrow_block import ArrowRow
-from ray.data._internal.arrow_serialization import (
-    _register_arrow_json_parseoptions_serializer,
-    _register_arrow_json_readoptions_serializer,
-)
 from ray.data._internal.block_list import BlockMetadata
 from ray.data._internal.output_buffer import BlockOutputBuffer
 from ray.data._internal.remote_fn import cached_remote_fn
@@ -410,15 +406,6 @@ class _FileBasedDatasourceReader(Reader):
         convert_block_to_tabular_block = self._delegate._convert_block_to_tabular_block
         column_name = reader_args.get("column_name", None)
         filesystem = _wrap_s3_serialization_workaround(self._filesystem)
-        read_options = reader_args.get("read_options")
-        parse_options = reader_args.get("parse_options")
-        if read_options is not None or parse_options is not None:
-            import pyarrow.json as pajson
-
-            if isinstance(read_options, pajson.ReadOptions):
-                _register_arrow_json_readoptions_serializer()
-            if isinstance(parse_options, pajson.ParseOptions):
-                _register_arrow_json_parseoptions_serializer()
 
         if open_stream_args is None:
             open_stream_args = {}
@@ -783,23 +770,9 @@ class _S3FileSystemWrapper:
         return _S3FileSystemWrapper._reconstruct, self._fs.__reduce__()
 
 
-def _wrap_and_register_arrow_serialization_workaround(kwargs: dict) -> dict:
+def _wrap_arrow_serialization_workaround(kwargs: dict) -> dict:
     if "filesystem" in kwargs:
         kwargs["filesystem"] = _wrap_s3_serialization_workaround(kwargs["filesystem"])
-
-    # TODO(Clark): Remove this serialization workaround once Datasets only supports
-    # pyarrow >= 8.0.0.
-    read_options = kwargs.get("read_options")
-    parse_options = kwargs.get("parse_options")
-    if read_options is not None or parse_options is not None:
-        import pyarrow.json as pajson
-
-        # Register a custom serializer instead of wrapping the options, since a
-        # custom reducer will suffice.
-        if isinstance(read_options, pajson.ReadOptions):
-            _register_arrow_json_readoptions_serializer()
-        if isinstance(parse_options, pajson.ParseOptions):
-            _register_arrow_json_parseoptions_serializer()
 
     return kwargs
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -444,15 +444,19 @@ def _sample_piece(
     # Use first batch in-memory size as ratio estimation.
     try:
         batch = next(batches)
-        in_memory_size = batch.nbytes / batch.num_rows
-        metadata = piece.metadata
-        total_size = 0
-        for idx in range(metadata.num_row_groups):
-            total_size += metadata.row_group(idx).total_byte_size
-        file_size = total_size / metadata.num_rows
-        ratio = in_memory_size / file_size
     except StopIteration:
         ratio = PARQUET_ENCODING_RATIO_ESTIMATE_LOWER_BOUND
+    else:
+        if batch.num_rows > 0:
+            in_memory_size = batch.nbytes / batch.num_rows
+            metadata = piece.metadata
+            total_size = 0
+            for idx in range(metadata.num_row_groups):
+                total_size += metadata.row_group(idx).total_byte_size
+            file_size = total_size / metadata.num_rows
+            ratio = in_memory_size / file_size
+        else:
+            ratio = PARQUET_ENCODING_RATIO_ESTIMATE_LOWER_BOUND
     logger.debug(
         f"Estimated Parquet encoding ratio is {ratio} for piece {piece} "
         f"with batch size {batch_size}."

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -434,7 +434,9 @@ def _sample_piece(
 
     # Only sample the first row group.
     piece = piece.subset(row_group_ids=[0])
-    batch_size = min(piece.metadata.num_rows, PARQUET_ENCODING_RATIO_ESTIMATE_NUM_ROWS)
+    batch_size = max(
+        min(piece.metadata.num_rows, PARQUET_ENCODING_RATIO_ESTIMATE_NUM_ROWS), 1
+    )
     batches = piece.to_batches(
         columns=columns,
         schema=schema,

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -335,7 +335,7 @@ class GroupedDataset(Generic[T]):
             builder = DelegatingBlockBuilder()
             start = 0
             for end in boundaries:
-                group = block_accessor.slice(start, end, False)
+                group = block_accessor.slice(start, end)
                 applied = fn(group)
                 builder.add_block(applied)
                 start = end

--- a/python/ray/data/random_access_dataset.py
+++ b/python/ray/data/random_access_dataset.py
@@ -225,7 +225,7 @@ class _RandomAccessWorker:
             col = block[self.key_field]
             indices = np.searchsorted(col, keys)
             acc = BlockAccessor.for_block(block)
-            result = [acc._get_row(i, copy=True) for i in indices]
+            result = [acc._get_row(i) for i in indices]
             # assert result == [self._get(i, k) for i, k in zip(block_indices, keys)]
         else:
             result = [self._get(i, k) for i, k in zip(block_indices, keys)]
@@ -254,7 +254,7 @@ class _RandomAccessWorker:
         if i is None:
             return None
         acc = BlockAccessor.for_block(block)
-        return acc._get_row(i, copy=True)
+        return acc._get_row(i)
 
 
 def _binary_search_find(column, x):

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -43,7 +43,7 @@ from ray.data.datasource import (
 )
 from ray.data.datasource.file_based_datasource import (
     _unwrap_arrow_serialization_workaround,
-    _wrap_and_register_arrow_serialization_workaround,
+    _wrap_arrow_serialization_workaround,
 )
 from ray.data.datasource.partitioning import Partitioning
 from ray.types import ObjectRef
@@ -279,7 +279,7 @@ def read_datasource(
                 ctx,
                 cur_pg,
                 parallelism,
-                _wrap_and_register_arrow_serialization_workaround(read_args),
+                _wrap_arrow_serialization_workaround(read_args),
             )
         )
 

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -16,6 +16,7 @@ from ray.air.util.tensor_extensions.arrow import ArrowTensorArray
 
 # Trigger pytest hook to automatically zip test cluster logs to archive dir on failure
 from ray.tests.conftest import pytest_runtest_makereport  # noqa
+from ray.tests.conftest import *  # noqa
 
 
 @pytest.fixture(scope="function")
@@ -278,31 +279,31 @@ def enable_auto_log_stats(request):
 
 # ===== Pandas dataset formats =====
 @pytest.fixture(scope="function")
-def ds_pandas_single_column_format():
+def ds_pandas_single_column_format(ray_start_regular_shared):
     in_df = pd.DataFrame({"column_1": [1, 2, 3, 4]})
     yield ray.data.from_pandas(in_df)
 
 
 @pytest.fixture(scope="function")
-def ds_pandas_multi_column_format():
+def ds_pandas_multi_column_format(ray_start_regular_shared):
     in_df = pd.DataFrame({"column_1": [1, 2, 3, 4], "column_2": [1, -1, 1, -1]})
     yield ray.data.from_pandas(in_df)
 
 
 @pytest.fixture(scope="function")
-def ds_pandas_list_multi_column_format():
+def ds_pandas_list_multi_column_format(ray_start_regular_shared):
     in_df = pd.DataFrame({"column_1": [1], "column_2": [1]})
     yield ray.data.from_pandas([in_df] * 4)
 
 
 # ===== Arrow dataset formats =====
 @pytest.fixture(scope="function")
-def ds_arrow_single_column_format():
+def ds_arrow_single_column_format(ray_start_regular_shared):
     yield ray.data.from_arrow(pa.table({"column_1": [1, 2, 3, 4]}))
 
 
 @pytest.fixture(scope="function")
-def ds_arrow_single_column_tensor_format():
+def ds_arrow_single_column_tensor_format(ray_start_regular_shared):
     yield ray.data.from_arrow(
         pa.table(
             {
@@ -315,7 +316,7 @@ def ds_arrow_single_column_tensor_format():
 
 
 @pytest.fixture(scope="function")
-def ds_arrow_multi_column_format():
+def ds_arrow_multi_column_format(ray_start_regular_shared):
     yield ray.data.from_arrow(
         pa.table(
             {
@@ -327,25 +328,41 @@ def ds_arrow_multi_column_format():
 
 
 @pytest.fixture(scope="function")
-def ds_list_arrow_multi_column_format():
+def ds_list_arrow_multi_column_format(ray_start_regular_shared):
     yield ray.data.from_arrow([pa.table({"column_1": [1], "column_2": [1]})] * 4)
 
 
 # ===== Numpy dataset formats =====
 @pytest.fixture(scope="function")
-def ds_numpy_single_column_tensor_format():
+def ds_numpy_single_column_tensor_format(ray_start_regular_shared):
     yield ray.data.from_numpy(np.arange(16).reshape((4, 2, 2)))
 
 
 @pytest.fixture(scope="function")
-def ds_numpy_list_of_ndarray_tensor_format():
+def ds_numpy_list_of_ndarray_tensor_format(ray_start_regular_shared):
     yield ray.data.from_numpy([np.arange(4).reshape((1, 2, 2))] * 4)
 
 
-@pytest.fixture(params=["5.0.0", "7.0.0"])
+@pytest.fixture(params=["5.0.0", "8.0.0"])
 def unsupported_pyarrow_version(request):
     orig_version = pa.__version__
     pa.__version__ = request.param
+    # Unset pyarrow version cache.
+    import ray._private.utils as utils
+
+    utils._PYARROW_VERSION = None
+    yield request.param
+    pa.__version__ = orig_version
+
+
+@pytest.fixture(params=["5.0.0", "8.0.0"])
+def unsupported_pyarrow_version_that_exists(request):
+    orig_version = pa.__version__
+    pa.__version__ = request.param
+    # Unset pyarrow version cache.
+    import ray._private.utils as utils
+
+    utils._PYARROW_VERSION = None
     yield request.param
     pa.__version__ = orig_version
 

--- a/python/ray/data/tests/test_arrow_serialization.py
+++ b/python/ray/data/tests/test_arrow_serialization.py
@@ -1,0 +1,251 @@
+import os
+
+from pkg_resources._vendor.packaging.version import parse as parse_version
+import pytest
+import pyarrow as pa
+import pyarrow.parquet as pq
+import numpy as np
+
+import ray
+import ray.cloudpickle as pickle
+from ray._private.utils import _get_pyarrow_version
+from ray.tests.conftest import *  # noqa
+from ray.data.extensions.tensor_extension import (
+    ArrowTensorArray,
+    ArrowVariableShapedTensorArray,
+)
+
+
+pytest_custom_serialization_arrays = [
+    # Null array
+    (pa.array([]), 1.0),
+    # Int array
+    (pa.array(list(range(1000))), 0.1),
+    # Array with nulls
+    (pa.array((list(range(9)) + [None]) * 100), 0.1),
+    # Float array
+    (pa.array([float(i) for i in range(1000)]), 0.1),
+    # Boolean array
+    # Due to bit-packing, most of the pickle bytes are metadata.
+    (pa.array([True, False] * 500), 0.8),
+    # String array
+    (pa.array(["foo", "bar", "bz", None, "quux"] * 200), 0.1),
+    # Binary array
+    (pa.array([b"foo", b"bar", b"bz", None, b"quux"] * 200), 0.1),
+    # List array with nulls
+    (pa.array(([None] + [list(range(9)) + [None]] * 9) * 100), 0.1),
+    # Large list array with nulls
+    (
+        pa.array(
+            ([None] + [list(range(9)) + [None]] * 9) * 100,
+            type=pa.large_list(pa.int64()),
+        ),
+        0.1,
+    ),
+    # Fixed size list array
+    (
+        pa.FixedSizeListArray.from_arrays(
+            pa.array((list(range(9)) + [None]) * 1000), 10
+        ),
+        0.1,
+    ),
+    # Map array
+    (
+        pa.array(
+            [
+                [(key, item) for key, item in zip("abcdefghij", range(10))]
+                for _ in range(1000)
+            ],
+            type=pa.map_(pa.string(), pa.int64()),
+        ),
+        0.1,
+    ),
+    # Struct array
+    (pa.array({"a": i} for i in range(1000)), 0.1),
+    # Union array (sparse)
+    (
+        pa.UnionArray.from_sparse(
+            pa.array([0, 1] * 500, type=pa.int8()),
+            [pa.array(list(range(1000))), pa.array([True, False] * 500)],
+        ),
+        0.1,
+    ),
+    # Union array (dense)
+    (
+        pa.UnionArray.from_dense(
+            pa.array([0, 1] * 500, type=pa.int8()),
+            pa.array(
+                [i if i % 2 == 0 else (i % 3) % 2 for i in range(1000)], type=pa.int32()
+            ),
+            [pa.array(list(range(1000))), pa.array([True, False])],
+        ),
+        0.1,
+    ),
+    # Dictionary array
+    (
+        pa.DictionaryArray.from_arrays(
+            pa.array((list(range(9)) + [None]) * 100),
+            pa.array(["a", "b", "c", "d", "e", "f", "g", "h", "i"]),
+        ),
+        0.1,
+    ),
+    # Tensor extension array
+    (
+        ArrowTensorArray.from_numpy(np.arange(1000 * 4 * 4).reshape((1000, 4, 4))),
+        0.1,
+    ),
+    # Boolean tensor extension array
+    (
+        ArrowTensorArray.from_numpy(
+            np.array(
+                [True, False, False, True, False, False, True, True] * 2 * 1000
+            ).reshape((1000, 4, 4))
+        ),
+        0.25,
+    ),
+    # Variable-shaped tensor extension array
+    (
+        ArrowVariableShapedTensorArray.from_numpy(
+            np.array(
+                [
+                    np.arange(4).reshape((2, 2)),
+                    np.arange(4, 13).reshape((3, 3)),
+                ]
+                * 500,
+                dtype=object,
+            ),
+        ),
+        0.1,
+    ),
+    # Boolean variable-shaped tensor extension array
+    (
+        ArrowVariableShapedTensorArray.from_numpy(
+            np.array(
+                [
+                    np.array([[True, False], [False, True]]),
+                    np.array(
+                        [
+                            [False, True, False],
+                            [True, True, False],
+                            [False, False, False],
+                        ],
+                    ),
+                ]
+                * 500,
+                dtype=object,
+            )
+        ),
+        0.25,
+    ),
+    # Complex nested array
+    (
+        pa.UnionArray.from_sparse(
+            pa.array([0, 1] * 500, type=pa.int8()),
+            [
+                pa.array(
+                    [
+                        {
+                            "a": i % 2 == 0,
+                            "b": i,
+                            "c": "bar",
+                        }
+                        for i in range(1000)
+                    ]
+                ),
+                pa.array(
+                    [
+                        [(key, item) for key, item in zip("abcdefghij", range(10))]
+                        for _ in range(1000)
+                    ],
+                    type=pa.map_(pa.string(), pa.int64()),
+                ),
+            ],
+        ),
+        0.1,
+    ),
+]
+
+pytest_custom_serialization_data = []
+for arr, cap in pytest_custom_serialization_arrays:
+    if len(arr) == 0:
+        pytest_custom_serialization_data.append((pa.table({"a": []}), cap))
+    else:
+        pytest_custom_serialization_data.append(
+            (
+                pa.Table.from_arrays(
+                    [arr, arr, pa.array(range(1000), type=pa.int32())],
+                    schema=pa.schema(
+                        [
+                            pa.field("arr1", arr.type),
+                            pa.field("arr2", arr.type),
+                            pa.field("arr3", pa.int32()),
+                        ],
+                        metadata={b"foo": b"bar"},
+                    ),
+                ),
+                cap,
+            )
+        )
+
+
+@pytest.mark.parametrize("data,cap_mult", pytest_custom_serialization_data)
+def test_custom_arrow_data_serializer(ray_start_regular_shared, data, cap_mult):
+    ray._private.worker.global_worker.get_serialization_context()
+    data.validate()
+    pyarrow_version = parse_version(_get_pyarrow_version())
+    if pyarrow_version >= parse_version("7.0.0"):
+        # get_total_buffer_size API was added in Arrow 7.0.0.
+        buf_size = data.get_total_buffer_size()
+    # Create a zero-copy slice view of data.
+    view = data.slice(10, 10)
+    s_arr = pickle.dumps(data)
+    s_view = pickle.dumps(view)
+    post_slice = pickle.loads(s_view)
+    post_slice.validate()
+    # Check for round-trip equality.
+    assert view.equals(post_slice), post_slice
+    # Check that the slice view was truncated upon serialization.
+    assert len(s_view) <= cap_mult * len(s_arr)
+    # Check that offset was reset on slice.
+    for column in post_slice.columns:
+        if column.num_chunks > 0:
+            assert column.chunk(0).offset == 0
+    if pyarrow_version >= parse_version("7.0.0"):
+        # Check that slice buffer only contains slice data.
+        slice_buf_size = post_slice.get_total_buffer_size()
+        if buf_size > 0:
+            assert buf_size / slice_buf_size - len(data) / len(post_slice) < 100
+
+
+def test_custom_arrow_data_serializer_parquet_roundtrip(
+    ray_start_regular_shared, tmp_path
+):
+    ray._private.worker.global_worker.get_serialization_context()
+    t = pa.table({"a": list(range(10000000))})
+    pq.write_table(t, f"{tmp_path}/test.parquet")
+    t2 = pq.read_table(f"{tmp_path}/test.parquet")
+    s_t = pickle.dumps(t)
+    s_t2 = pickle.dumps(t2)
+    # Check that the post-Parquet slice view chunks don't cause a serialization blow-up.
+    assert len(s_t2) < 1.1 * len(s_t)
+    # Check for round-trip equality.
+    assert t2.equals(pickle.loads(s_t2))
+
+
+def test_custom_arrow_data_serializer_disable(shutdown_only):
+    ray.shutdown()
+    context = ray.worker.global_worker.get_serialization_context()
+    context._unregister_cloudpickle_reducer(pa.Table)
+    # Disable custom Arrow array serialization.
+    os.environ["RAY_DISABLE_CUSTOM_ARROW_ARRAY_SERIALIZATION"] = "1"
+    ray.init()
+    # Create a zero-copy slice view of table.
+    t = pa.table({"a": list(range(10000000))})
+    view = t.slice(10, 10)
+    s_t = pickle.dumps(t)
+    s_view = pickle.dumps(view)
+    # Check that the slice view contains the full buffer of the underlying array.
+    d_view = pickle.loads(s_view)
+    assert d_view["a"].chunk(0).buffers()[1].size == t["a"].chunk(0).buffers()[1].size
+    # Check that the serialized slice view is large
+    assert len(s_view) > 0.8 * len(s_t)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -4767,10 +4767,14 @@ def test_random_shuffle_check_random(shutdown_only):
             prev = x
 
 
-def test_unsupported_pyarrow_versions_check(shutdown_only, unsupported_pyarrow_version):
+def test_unsupported_pyarrow_versions_check(
+    shutdown_only, unsupported_pyarrow_version_that_exists
+):
     # Test that unsupported pyarrow versions cause an error to be raised upon the
     # initial pyarrow use.
-    ray.init(runtime_env={"pip": [f"pyarrow=={unsupported_pyarrow_version}"]})
+    ray.init(
+        runtime_env={"pip": [f"pyarrow=={unsupported_pyarrow_version_that_exists}"]}
+    )
 
     # Test Arrow-native creation APIs.
     # Test range_table.
@@ -4792,14 +4796,14 @@ def test_unsupported_pyarrow_versions_check(shutdown_only, unsupported_pyarrow_v
 
 def test_unsupported_pyarrow_versions_check_disabled(
     shutdown_only,
-    unsupported_pyarrow_version,
+    unsupported_pyarrow_version_that_exists,
     disable_pyarrow_version_check,
 ):
     # Test that unsupported pyarrow versions DO NOT cause an error to be raised upon the
     # initial pyarrow use when the version check is disabled.
     ray.init(
         runtime_env={
-            "pip": [f"pyarrow=={unsupported_pyarrow_version}"],
+            "pip": [f"pyarrow=={unsupported_pyarrow_version_that_exists}"],
             "env_vars": {"RAY_DISABLE_PYARROW_VERSION_CHECK": "1"},
         },
     )

--- a/python/ray/data/tests/test_dataset_parquet.py
+++ b/python/ray/data/tests/test_dataset_parquet.py
@@ -898,6 +898,14 @@ def test_parquet_roundtrip(ray_start_regular_shared, fs, data_path):
         fs.delete_dir(_unwrap_protocol(path))
 
 
+def test_parquet_read_empty_file(ray_start_regular_shared, tmp_path):
+    path = os.path.join(tmp_path, "data.parquet")
+    table = pa.table({})
+    pq.write_table(table, path)
+    ds = ray.data.read_parquet(path)
+    pd.testing.assert_frame_equal(ds.to_pandas(), table.to_pandas())
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/util/serialization.py
+++ b/python/ray/util/serialization.py
@@ -39,6 +39,9 @@ class StandaloneSerializationContext:
     # use the SerializationContext because it requires Ray workers. Please
     # make sure to keep the API consistent.
 
+    def _register_cloudpickle_reducer(self, cls, reducer):
+        pickle.CloudPickler.dispatch[cls] = reducer
+
     def _unregister_cloudpickle_reducer(self, cls):
         pickle.CloudPickler.dispatch.pop(cls, None)
 

--- a/python/ray/util/serialization_addons.py
+++ b/python/ray/util/serialization_addons.py
@@ -3,6 +3,8 @@ This module is intended for implementing internal serializers for some
 site packages.
 """
 
+import sys
+
 from ray.util.annotations import DeveloperAPI
 
 
@@ -55,3 +57,10 @@ def register_starlette_serializer(serialization_context):
 def apply(serialization_context):
     register_pydantic_serializer(serialization_context)
     register_starlette_serializer(serialization_context)
+
+    if sys.platform != "win32":
+        from ray.data._internal.arrow_serialization import (
+            _register_custom_datasets_serializers,
+        )
+
+        _register_custom_datasets_serializers(serialization_context)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -57,7 +57,8 @@ aiorwlock
 opentelemetry-exporter-otlp==1.1.0
 starlette
 typer
-pyarrow<7.0.0,>=6.0.1
+pyarrow >= 6.0.1, < 8.0.0; python_version >= '3.7' and platform_system != "Windows"
+pyarrow >= 6.0.1, < 7.0.0; python_version < '3.7' or platform_system == "Windows"
 aiohttp_cors
 opentelemetry-api==1.1.0
 pyyaml

--- a/python/requirements/data_processing/requirements.txt
+++ b/python/requirements/data_processing/requirements.txt
@@ -11,6 +11,9 @@ s3fs
 modin>=0.8.3;  python_version < '3.7'
 modin>=0.11.0; python_version >= '3.7'
 pytest-repeat
-raydp-nightly==2022.6.30.dev1
+# Uncomment when RayDP:
+# - Makes MLDataset an optional dependency.
+# - Removes pyarrow < 7.0.0 upperbound.
+# raydp-nightly==2022.6.30.dev1
 responses==0.13.4
 pymars>=0.8.3

--- a/python/setup.py
+++ b/python/setup.py
@@ -217,13 +217,19 @@ if setup_spec.type == SetupType.RAY:
     else:
         # Pandas dropped python 3.6 support in 1.2.
         pandas_dep = "pandas >= 1.0.5"
-        # Numpy dropped python 3.6 support in 1.20.
+        # NumPy dropped python 3.6 support in 1.20.
         numpy_dep = "numpy >= 1.19"
+    if sys.version_info >= (3, 7) and sys.platform != "win32":
+        pyarrow_dep = "pyarrow >= 6.0.1, < 8.0.0"
+    else:
+        # pyarrow dropped python 3.6 support in 7.0.0.
+        # Serialization workaround for pyarrow 7.0.0+ doesn't work for Windows.
+        pyarrow_dep = "pyarrow >= 6.0.1, < 7.0.0"
     setup_spec.extras = {
         "data": [
             numpy_dep,
             pandas_dep,
-            "pyarrow >= 6.0.1, < 7.0.0",
+            pyarrow_dep,
             "fsspec",
         ],
         "default": [


### PR DESCRIPTION
This PR adds support for Arrow 7 in Ray, and is the second PR in a set of stacked PRs making up this mono-PR for Arrow 7+ support: https://github.com/ray-project/ray/pull/29161, and is stacked on top of a PR fixing task cancellation in Ray Core: https://github.com/ray-project/ray/pull/29984.

## Summary of Changes

This PR:
- fixes a serialization bug in Arrow with a custom serializer for Arrow data (https://github.com/ray-project/ray/issues/29814)
- removes a bunch of defensive copying of Arrow data, which was a workaround for the aforementioned Arrow serialization bug
- adds a CI job for Arrow 7
- bumps the pyarrow upper bound to 8.0.0

## Related issue number

Closes https://github.com/ray-project/ray/issues/29992, closes https://github.com/ray-project/ray/issues/29814

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
