### PR TITLE
[Datasets] [Arrow 7+ Support - 3/N] Add support for Arrow 8, 9, 10, and nightly.

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -269,6 +269,46 @@
     # Dask tests and examples.
     - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-client python/ray/util/dask/...
 
+- label: "Dataset tests (Arrow nightly)"
+  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
+  instance_size: medium
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+    - DATA_PROCESSING_TESTING=1 ARROW_VERSION=nightly ./ci/env/install-dependencies.sh
+    - ./ci/env/env_info.sh
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/data/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=ray_data python/ray/air/...
+
+- label: "Dataset tests (Arrow 10)"
+  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
+  instance_size: medium
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+    - DATA_PROCESSING_TESTING=1 ARROW_VERSION=10.* ./ci/env/install-dependencies.sh
+    - ./ci/env/env_info.sh
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/data/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=ray_data python/ray/air/...
+
+- label: "Dataset tests (Arrow 9)"
+  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
+  instance_size: medium
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+    - DATA_PROCESSING_TESTING=1 ARROW_VERSION=9.* ./ci/env/install-dependencies.sh
+    - ./ci/env/env_info.sh
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/data/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=ray_data python/ray/air/...
+
+- label: "Dataset tests (Arrow 8)"
+  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
+  instance_size: medium
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+    - DATA_PROCESSING_TESTING=1 ARROW_VERSION=8.* ./ci/env/install-dependencies.sh
+    - ./ci/env/env_info.sh
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/data/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=ray_data python/ray/air/...
+
 - label: "Dataset tests (Arrow 7)"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
   instance_size: medium

--- a/python/ray/_private/storage.py
+++ b/python/ray/_private/storage.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
 from ray._private.client_mode_hook import client_mode_hook
+from ray._private.utils import _add_creatable_buckets_param_if_s3_uri
 
 if TYPE_CHECKING:
     import pyarrow.fs
@@ -368,6 +369,9 @@ def _init_filesystem(create_valid_file: bool = False, check_valid_file: bool = T
         fs_creator = _load_class(parsed_uri.netloc)
         _filesystem, _storage_prefix = fs_creator(parsed_uri.path)
     else:
+        # Arrow's S3FileSystem doesn't allow creating buckets by default, so we add a
+        # query arg enabling bucket creation if an S3 URI is provided.
+        _storage_uri = _add_creatable_buckets_param_if_s3_uri(_storage_uri)
         _filesystem, _storage_prefix = pyarrow.fs.FileSystem.from_uri(_storage_uri)
 
     if os.name == "nt":

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import threading
 import time
+from urllib.parse import urlencode, unquote, urlparse, parse_qsl, ParseResult
 import uuid
 import warnings
 from inspect import signature
@@ -1597,6 +1598,87 @@ def split_address(address: str) -> Tuple[str, str]:
 
     module_string, inner_address = address.split("://", maxsplit=1)
     return (module_string, inner_address)
+
+
+def _add_url_query_params(
+    url: str, params: Dict[str, str], override: bool = False
+) -> str:
+    """Add params to the provided url as query parameters.
+
+    Args:
+        url: The URL to add query parameters to.
+        params: The query parameters to add.
+        override: Whether the provided params should override existing query parameters
+            in url: if True, the existing query parameters will be overwritten; if
+            False, the existing query parameters will take precedent. Default is False.
+
+    Returns:
+        URL with params added as query parameters.
+    """
+    # Unquoting URL first so we don't loose existing args.
+    url = unquote(url)
+    # Parse URL.
+    parsed_url = urlparse(url)
+    # Converting URL query string arguments to dict.
+    base_params = dict(parse_qsl(parsed_url.query))
+    if not override:
+        # If not overriding, treat params as base parameters and override with existing
+        # query string parameters.
+        base_params, params = params, base_params
+    # Merging URL query string arguments dict with new params.
+    base_params.update(params)
+    # bool and dict values should be converted to json-friendly values.
+    base_params.update(
+        {
+            k: json.dumps(v)
+            for k, v in base_params.items()
+            if isinstance(v, (bool, dict))
+        }
+    )
+
+    # Converting URL arguments to proper query string.
+    encoded_params = urlencode(base_params, doseq=True)
+    # Creating new parsed result object based on provided with new
+    # URL arguments. Same thing happens inside of urlparse.
+    new_url = ParseResult(
+        parsed_url.scheme,
+        parsed_url.netloc,
+        parsed_url.path,
+        parsed_url.params,
+        encoded_params,
+        parsed_url.fragment,
+    ).geturl()
+
+    return new_url
+
+
+def _add_creatable_buckets_param_if_s3_uri(uri: str) -> str:
+    """If the provided URI is an S3 URL, add allow_bucket_creation=true as a query
+    parameter. For pyarrow >= 9.0.0, this is required in order to allow
+    ``S3FileSystem.create_dir()`` to create S3 buckets.
+
+    If the provided URI is not an S3 URL or if pyarrow < 9.0.0 is installed, we return
+    the URI unchanged.
+
+    Args:
+        uri: The URI that we'll add the query parameter to, if it's an S3 URL.
+
+    Returns:
+        A URI with the added allow_bucket_creation=true query parameter, if the provided
+        URI is an S3 URL; uri will be returned unchanged otherwise.
+    """
+    from pkg_resources._vendor.packaging.version import parse as parse_version
+
+    pyarrow_version = _get_pyarrow_version()
+    if pyarrow_version is not None:
+        pyarrow_version = parse_version(pyarrow_version)
+    if pyarrow_version is not None and pyarrow_version < parse_version("9.0.0"):
+        # This bucket creation query parameter is not required for pyarrow < 9.0.0.
+        return uri
+    parsed_uri = urlparse(uri)
+    if parsed_uri.scheme == "s3":
+        uri = _add_url_query_params(uri, {"allow_bucket_creation": True})
+    return uri
 
 
 def _get_pyarrow_version() -> Optional[str]:

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -13,12 +13,37 @@ from ray.util.annotations import PublicAPI
 PYARROW_VERSION = _get_pyarrow_version()
 if PYARROW_VERSION is not None:
     PYARROW_VERSION = parse_version(PYARROW_VERSION)
-# Minimum version of Arrow that supports subclassable ExtensionScalars.
-# TODO(Clark): Remove conditional definition once we only support Arrow 9.0.0+.
-MIN_PYARROW_VERSION_SCALAR_SUBCLASS = parse_version("9.0.0")
 # Minimum version of Arrow that supports ExtensionScalars.
 # TODO(Clark): Remove conditional definition once we only support Arrow 8.0.0+.
 MIN_PYARROW_VERSION_SCALAR = parse_version("8.0.0")
+# Minimum version of Arrow that supports subclassable ExtensionScalars.
+# TODO(Clark): Remove conditional definition once we only support Arrow 9.0.0+.
+MIN_PYARROW_VERSION_SCALAR_SUBCLASS = parse_version("9.0.0")
+
+
+def _arrow_supports_extension_scalars():
+    """
+    Whether Arrow ExtensionScalars are supported in the current pyarrow version.
+
+    This returns True if the pyarrow version is 8.0.0+, or if the pyarrow version is
+    unknown.
+    """
+    # TODO(Clark): Remove utility once we only support Arrow 8.0.0+.
+    return PYARROW_VERSION is None or PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR
+
+
+def _arrow_extension_scalars_are_subclassable():
+    """
+    Whether Arrow ExtensionScalars support subclassing in the current pyarrow version.
+
+    This returns True if the pyarrow version is 9.0.0+, or if the pyarrow version is
+    unknown.
+    """
+    # TODO(Clark): Remove utility once we only support Arrow 9.0.0+.
+    return (
+        PYARROW_VERSION is None
+        or PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBCLASS
+    )
 
 
 @PublicAPI(stability="beta")
@@ -75,11 +100,7 @@ class ArrowTensorType(pa.PyExtensionType):
         """
         return ArrowTensorArray
 
-    if (
-        PYARROW_VERSION is None
-        or PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBCLASS
-    ):
-        # NOTE(Clark): ExtensionScalar is only subclassable in Arrow 9.0.0+.
+    if _arrow_extension_scalars_are_subclassable():
         # TODO(Clark): Remove this version guard once we only support Arrow 9.0.0+.
         def __arrow_ext_scalar_class__(self):
             """
@@ -87,14 +108,18 @@ class ArrowTensorType(pa.PyExtensionType):
             """
             return ArrowTensorScalar
 
-    def _extension_scalar_to_ndarray(self, scalar) -> np.ndarray:
-        """
-        Convert an ExtensionScalar to a tensor element.
-        """
-        # TODO(Clark): Construct ndarray view directly on tensor element buffer to
-        # ensure reliable zero-copy semantics.
-        flat_ndarray = scalar.value.values.to_numpy(zero_copy_only=False)
-        return flat_ndarray.reshape(self.shape)
+    if _arrow_supports_extension_scalars():
+        # TODO(Clark): Remove this version guard once we only support Arrow 8.0.0+.
+        def _extension_scalar_to_ndarray(
+            self, scalar: pa.ExtensionScalar
+        ) -> np.ndarray:
+            """
+            Convert an ExtensionScalar to a tensor element.
+            """
+            # TODO(Clark): Construct ndarray view directly on tensor element buffer to
+            # ensure reliable zero-copy semantics.
+            flat_ndarray = scalar.value.values.to_numpy(zero_copy_only=False)
+            return flat_ndarray.reshape(self.shape)
 
     def __str__(self) -> str:
         return (
@@ -105,8 +130,7 @@ class ArrowTensorType(pa.PyExtensionType):
         return str(self)
 
 
-if PYARROW_VERSION is None or PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBCLASS:
-    # NOTE(Clark): ExtensionScalar is only subclassable in Arrow 9.0.0+.
+if _arrow_extension_scalars_are_subclassable():
     # TODO(Clark): Remove this version guard once we only support Arrow 9.0.0+.
     @PublicAPI(stability="beta")
     class ArrowTensorScalar(pa.ExtensionScalar):
@@ -117,37 +141,18 @@ if PYARROW_VERSION is None or PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBC
             return self.as_py()
 
 
-@PublicAPI(stability="beta")
-class ArrowTensorArray(pa.ExtensionArray):
+# TODO(Clark): Remove this mixin once we only support Arrow 9.0.0+.
+class _ArrowTensorScalarIndexingMixin:
     """
-    An array of fixed-shape, homogeneous-typed tensors.
-
-    This is the Arrow side of TensorArray.
-
-    See Arrow docs for customizing extension arrays:
-    https://arrow.apache.org/docs/python/extending_types.html#custom-extension-array-class
+    A mixin providing support for scalar indexing in tensor extension arrays for
+    Arrow < 9.0.0, before full ExtensionScalar support was added. This mixin overrides
+    __getitem__, __iter__, and to_pylist.
     """
 
-    OFFSET_DTYPE = np.int32
-
-    if PYARROW_VERSION is not None and PYARROW_VERSION < MIN_PYARROW_VERSION_SCALAR:
-        # NOTE(Clark): These __getitem__, __iter__, and to_pylist overrides are only
-        # needed for Arrow < 8.0.0, before proper ExtensionScalar support was added.
-        # TODO(Clark): Remove these methods once we only support Arrow 8.0.0+.
-        def __getitem__(self, key):
-            # This __getitem__ hook allows us to support proper indexing when accessing
-            # a single tensor (a "scalar" item of the array). Without this hook for
-            # integer keys, the indexing will fail on pyarrow < 8.0.0 due to a lack of
-            # proper ExtensionScalar support.
-
-            # NOTE(Clark): We'd like to override the pa.Array.getitem() helper
-            # instead, which would obviate the need for overriding __iter__()
-            # below, but unfortunately overriding Cython cdef methods with normal
-            # Python methods isn't allowed.
-            if isinstance(key, slice):
-                return super().__getitem__(key)
-            return self._to_numpy(key)
-
+    # This mixin will be a no-op (no methods added) for Arrow 9.0.0+.
+    if not _arrow_extension_scalars_are_subclassable():
+        # NOTE: These __iter__ and to_pylist definitions are shared for both
+        # Arrow < 8.0.0 and Arrow 8.*.
         def __iter__(self):
             # Override pa.Array.__iter__() in order to return an iterator of
             # properly shaped tensors instead of an iterator of flattened tensors.
@@ -161,40 +166,59 @@ class ArrowTensorArray(pa.ExtensionArray):
             # support (see comment in __getitem__).
             return list(self)
 
-    elif (
-        PYARROW_VERSION is not None
-        and PYARROW_VERSION < MIN_PYARROW_VERSION_SCALAR_SUBCLASS
-    ):
-        # NOTE(Clark): These __getitem__, __iter__, and to_pylist overrides are only
-        # needed for Arrow 8.*, before ExtensionScalar subclassing support was added.
-        # TODO(Clark): Remove these methods once we only support Arrow 9.0.0+.
-        def __getitem__(self, key):
-            # This __getitem__ hook allows us to support proper indexing when accessing
-            # a single tensor (a "scalar" item of the array). Without this hook for
-            # integer keys, the indexing will fail on pyarrow < 8.0.0 due to a lack of
-            # proper ExtensionScalar support.
+        if _arrow_supports_extension_scalars():
+            # NOTE(Clark): This __getitem__ override is only needed for Arrow 8.*,
+            # before ExtensionScalar subclassing support was added.
+            # TODO(Clark): Remove these methods once we only support Arrow 9.0.0+.
+            def __getitem__(self, key):
+                # This __getitem__ hook allows us to support proper indexing when
+                # accessing a single tensor (a "scalar" item of the array). Without this
+                # hook for integer keys, the indexing will fail on pyarrow < 9.0.0 due
+                # to a lack of ExtensionScalar subclassing support.
 
-            # NOTE(Clark): We'd like to override the pa.Array.getitem() helper instead,
-            # which would obviate the need for overriding __iter__() below, but
-            # unfortunately overriding Cython cdef methods with normal Python methods
-            # isn't allowed.
-            item = super().__getitem__(key)
-            if not isinstance(key, slice):
-                item = item.type._extension_scalar_to_ndarray(item)
-            return item
+                # NOTE(Clark): We'd like to override the pa.Array.getitem() helper
+                # instead, which would obviate the need for overriding __iter__(), but
+                # unfortunately overriding Cython cdef methods with normal Python
+                # methods isn't allowed.
+                item = super().__getitem__(key)
+                if not isinstance(key, slice):
+                    item = item.type._extension_scalar_to_ndarray(item)
+                return item
 
-        def __iter__(self):
-            # Override pa.Array.__iter__() in order to return an iterator of properly
-            # shaped tensors instead of an iterator of flattened tensors.
-            # See comment in above __getitem__ method.
-            for i in range(len(self)):
-                # Use overridden __getitem__ method.
-                yield self.__getitem__(i)
+        else:
+            # NOTE(Clark): This __getitem__ override is only needed for Arrow < 8.0.0,
+            # before any ExtensionScalar support was added.
+            # TODO(Clark): Remove these methods once we only support Arrow 8.0.0+.
+            def __getitem__(self, key):
+                # This __getitem__ hook allows us to support proper indexing when
+                # accessing a single tensor (a "scalar" item of the array). Without this
+                # hook for integer keys, the indexing will fail on pyarrow < 8.0.0 due
+                # to a lack of ExtensionScalar support.
 
-        def to_pylist(self):
-            # Override pa.Array.to_pylist() due to a lack of ExtensionScalar support
-            # (see comment in __getitem__).
-            return list(self)
+                # NOTE(Clark): We'd like to override the pa.Array.getitem() helper
+                # instead, which would obviate the need for overriding __iter__(), but
+                # unfortunately overriding Cython cdef methods with normal Python
+                # methods isn't allowed.
+                if isinstance(key, slice):
+                    return super().__getitem__(key)
+                return self._to_numpy(key)
+
+
+# NOTE: We need to inherit from the mixin before pa.ExtensionArray to ensure that the
+# mixin's overriding methods appear first in the MRO.
+# TODO(Clark): Remove this mixin once we only support Arrow 9.0.0+.
+@PublicAPI(stability="beta")
+class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
+    """
+    An array of fixed-shape, homogeneous-typed tensors.
+
+    This is the Arrow side of TensorArray.
+
+    See Arrow docs for customizing extension arrays:
+    https://arrow.apache.org/docs/python/extending_types.html#custom-extension-array-class
+    """
+
+    OFFSET_DTYPE = np.int32
 
     @classmethod
     def from_numpy(
@@ -518,16 +542,13 @@ class ArrowVariableShapedTensorType(pa.PyExtensionType):
         """
         return ArrowVariableShapedTensorArray
 
-    if (
-        PYARROW_VERSION is None
-        or PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBCLASS
-    ):
-
+    if _arrow_extension_scalars_are_subclassable():
+        # TODO(Clark): Remove this version guard once we only support Arrow 9.0.0+.
         def __arrow_ext_scalar_class__(self):
             """
             ExtensionScalar subclass with custom logic for this array of tensors type.
             """
-            return ArrowVariableShapedTensorScalar
+            return ArrowTensorScalar
 
     def __str__(self) -> str:
         dtype = self.storage_type["data"].type.value_type
@@ -536,30 +557,30 @@ class ArrowVariableShapedTensorType(pa.PyExtensionType):
     def __repr__(self) -> str:
         return str(self)
 
-    def _extension_scalar_to_ndarray(self, scalar) -> np.ndarray:
-        """
-        Convert an ExtensionScalar to a tensor element.
-        """
-        # TODO(Clark): Construct ndarray view directly on tensor element buffer to
-        # ensure reliable zero-copy semantics.
-        flat_ndarray = scalar.value.get("data").values.to_numpy(zero_copy_only=False)
-        shape = tuple(scalar.value.get("shape").as_py())
-        return flat_ndarray.reshape(shape)
+    if _arrow_supports_extension_scalars():
+        # TODO(Clark): Remove this version guard once we only support Arrow 8.0.0+.
+        def _extension_scalar_to_ndarray(
+            self, scalar: pa.ExtensionScalar
+        ) -> np.ndarray:
+            """
+            Convert an ExtensionScalar to a tensor element.
+            """
+            # TODO(Clark): Construct ndarray view directly on tensor element buffer to
+            # ensure reliable zero-copy semantics.
+            flat_ndarray = scalar.value.get("data").values.to_numpy(
+                zero_copy_only=False
+            )
+            shape = tuple(scalar.value.get("shape").as_py())
+            return flat_ndarray.reshape(shape)
 
 
-if PYARROW_VERSION is None or PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBCLASS:
-
-    @PublicAPI(stability="alpha")
-    class ArrowVariableShapedTensorScalar(pa.ExtensionScalar):
-        def as_py(self) -> np.ndarray:
-            return self.type._extension_scalar_to_ndarray(self)
-
-        def __array__(self) -> np.ndarray:
-            return self.as_py()
-
-
+# NOTE: We need to inherit from the mixin before pa.ExtensionArray to ensure that the
+# mixin's overriding methods appear first in the MRO.
+# TODO(Clark): Remove this mixin once we only support Arrow 9.0.0+.
 @PublicAPI(stability="alpha")
-class ArrowVariableShapedTensorArray(pa.ExtensionArray):
+class ArrowVariableShapedTensorArray(
+    _ArrowTensorScalarIndexingMixin, pa.ExtensionArray
+):
     """
     An array of heterogeneous-shaped, homogeneous-typed tensors.
 
@@ -574,72 +595,6 @@ class ArrowVariableShapedTensorArray(pa.ExtensionArray):
     """
 
     OFFSET_DTYPE = np.int32
-
-    if PYARROW_VERSION is not None and PYARROW_VERSION < MIN_PYARROW_VERSION_SCALAR:
-        # NOTE(Clark): These __getitem__, __iter__, and to_pylist overrides are only
-        # needed for Arrow < 8.0.0, before proper ExtensionScalar support was added.
-        # TODO(Clark): Remove these methods once we only support Arrow 8.0.0+.
-        def __getitem__(self, key):
-            # This __getitem__ hook allows us to support proper indexing when accessing
-            # a single tensor (a "scalar" item of the array). Without this hook for
-            # integer keys, the indexing will fail on pyarrow < 8.0.0 due to a lack of
-            # proper ExtensionScalar support.
-
-            # NOTE(Clark): We'd like to override the pa.Array.getitem() helper instead,
-            # which would obviate the need for overriding __iter__() below, but
-            # unfortunately overriding Cython cdef methods with normal Python methods
-            # isn't allowed.
-            if isinstance(key, slice):
-                return super().__getitem__(key)
-            return self._to_numpy(key)
-
-        def __iter__(self):
-            # Override pa.Array.__iter__() in order to return an iterator of properly
-            # shaped tensors instead of an iterator of flattened tensors.
-            # See comment in above __getitem__ method.
-            for i in range(len(self)):
-                # Use overridden __getitem__ method.
-                yield self.__getitem__(i)
-
-        def to_pylist(self):
-            # Override pa.Array.to_pylist() due to a lack of ExtensionScalar support
-            # (see comment in __getitem__).
-            return list(self)
-
-    elif (
-        PYARROW_VERSION is not None
-        and PYARROW_VERSION < MIN_PYARROW_VERSION_SCALAR_SUBCLASS
-    ):
-        # NOTE(Clark): These __getitem__, __iter__, and to_pylist overrides are only
-        # needed for Arrow 8.*, before ExtensionScalar subclassing support was added.
-        # TODO(Clark): Remove these methods once we only support Arrow 9.0.0+.
-        def __getitem__(self, key):
-            # This __getitem__ hook allows us to support proper indexing when accessing
-            # a single tensor (a "scalar" item of the array). Without this hook for
-            # integer keys, the indexing will fail on pyarrow < 8.0.0 due to a lack of
-            # proper ExtensionScalar support.
-
-            # NOTE(Clark): We'd like to override the pa.Array.getitem() helper instead,
-            # which would obviate the need for overriding __iter__() below, but
-            # unfortunately overriding Cython cdef methods with normal Python methods
-            # isn't allowed.
-            item = super().__getitem__(key)
-            if not isinstance(key, slice):
-                item = item.type._extension_scalar_to_ndarray(item)
-            return item
-
-        def __iter__(self):
-            # Override pa.Array.__iter__() in order to return an iterator of properly
-            # shaped tensors instead of an iterator of flattened tensors.
-            # See comment in above __getitem__ method.
-            for i in range(len(self)):
-                # Use overridden __getitem__ method.
-                yield self.__getitem__(i)
-
-        def to_pylist(self):
-            # Override pa.Array.to_pylist() due to a lack of ExtensionScalar support
-            # (see comment in __getitem__).
-            return list(self)
 
     @classmethod
     def from_numpy(

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -1,11 +1,24 @@
 import itertools
 from typing import Iterable, Optional, Tuple, List, Sequence, Union
 
+from pkg_resources._vendor.packaging.version import parse as parse_version
 import numpy as np
 import pyarrow as pa
 
 from ray.air.util.tensor_extensions.utils import _is_ndarray_variable_shaped_tensor
+from ray._private.utils import _get_pyarrow_version
 from ray.util.annotations import PublicAPI
+
+
+PYARROW_VERSION = _get_pyarrow_version()
+if PYARROW_VERSION is not None:
+    PYARROW_VERSION = parse_version(PYARROW_VERSION)
+# Minimum version of Arrow that supports subclassable ExtensionScalars.
+# TODO(Clark): Remove conditional definition once we only support Arrow 9.0.0+.
+MIN_PYARROW_VERSION_SCALAR_SUBCLASS = parse_version("9.0.0")
+# Minimum version of Arrow that supports ExtensionScalars.
+# TODO(Clark): Remove conditional definition once we only support Arrow 8.0.0+.
+MIN_PYARROW_VERSION_SCALAR = parse_version("8.0.0")
 
 
 @PublicAPI(stability="beta")
@@ -62,6 +75,27 @@ class ArrowTensorType(pa.PyExtensionType):
         """
         return ArrowTensorArray
 
+    if (
+        PYARROW_VERSION is None
+        or PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBCLASS
+    ):
+        # NOTE(Clark): ExtensionScalar is only subclassable in Arrow 9.0.0+.
+        # TODO(Clark): Remove this version guard once we only support Arrow 9.0.0+.
+        def __arrow_ext_scalar_class__(self):
+            """
+            ExtensionScalar subclass with custom logic for this array of tensors type.
+            """
+            return ArrowTensorScalar
+
+    def _extension_scalar_to_ndarray(self, scalar) -> np.ndarray:
+        """
+        Convert an ExtensionScalar to a tensor element.
+        """
+        # TODO(Clark): Construct ndarray view directly on tensor element buffer to
+        # ensure reliable zero-copy semantics.
+        flat_ndarray = scalar.value.values.to_numpy(zero_copy_only=False)
+        return flat_ndarray.reshape(self.shape)
+
     def __str__(self) -> str:
         return (
             f"ArrowTensorType(shape={self.shape}, dtype={self.storage_type.value_type})"
@@ -69,6 +103,18 @@ class ArrowTensorType(pa.PyExtensionType):
 
     def __repr__(self) -> str:
         return str(self)
+
+
+if PYARROW_VERSION is None or PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBCLASS:
+    # NOTE(Clark): ExtensionScalar is only subclassable in Arrow 9.0.0+.
+    # TODO(Clark): Remove this version guard once we only support Arrow 9.0.0+.
+    @PublicAPI(stability="beta")
+    class ArrowTensorScalar(pa.ExtensionScalar):
+        def as_py(self) -> np.ndarray:
+            return self.type._extension_scalar_to_ndarray(self)
+
+        def __array__(self) -> np.ndarray:
+            return self.as_py()
 
 
 @PublicAPI(stability="beta")
@@ -84,36 +130,71 @@ class ArrowTensorArray(pa.ExtensionArray):
 
     OFFSET_DTYPE = np.int32
 
-    def __getitem__(self, key):
-        # This __getitem__ hook allows us to support proper
-        # indexing when accessing a single tensor (a "scalar" item of the
-        # array). Without this hook for integer keys, the indexing will fail on
-        # all currently released pyarrow versions due to a lack of proper
-        # ExtensionScalar support. Support was added in
-        # https://github.com/apache/arrow/pull/10904, but hasn't been released
-        # at the time of this comment, and even with this support, the returned
-        # ndarray is a flat representation of the n-dimensional tensor.
+    if PYARROW_VERSION is not None and PYARROW_VERSION < MIN_PYARROW_VERSION_SCALAR:
+        # NOTE(Clark): These __getitem__, __iter__, and to_pylist overrides are only
+        # needed for Arrow < 8.0.0, before proper ExtensionScalar support was added.
+        # TODO(Clark): Remove these methods once we only support Arrow 8.0.0+.
+        def __getitem__(self, key):
+            # This __getitem__ hook allows us to support proper indexing when accessing
+            # a single tensor (a "scalar" item of the array). Without this hook for
+            # integer keys, the indexing will fail on pyarrow < 8.0.0 due to a lack of
+            # proper ExtensionScalar support.
 
-        # NOTE(Clark): We'd like to override the pa.Array.getitem() helper
-        # instead, which would obviate the need for overriding __iter__()
-        # below, but unfortunately overriding Cython cdef methods with normal
-        # Python methods isn't allowed.
-        if isinstance(key, slice):
-            return super().__getitem__(key)
-        return self._to_numpy(key)
+            # NOTE(Clark): We'd like to override the pa.Array.getitem() helper
+            # instead, which would obviate the need for overriding __iter__()
+            # below, but unfortunately overriding Cython cdef methods with normal
+            # Python methods isn't allowed.
+            if isinstance(key, slice):
+                return super().__getitem__(key)
+            return self._to_numpy(key)
 
-    def __iter__(self):
-        # Override pa.Array.__iter__() in order to return an iterator of
-        # properly shaped tensors instead of an iterator of flattened tensors.
-        # See comment in above __getitem__ method.
-        for i in range(len(self)):
-            # Use overridden __getitem__ method.
-            yield self.__getitem__(i)
+        def __iter__(self):
+            # Override pa.Array.__iter__() in order to return an iterator of
+            # properly shaped tensors instead of an iterator of flattened tensors.
+            # See comment in above __getitem__ method.
+            for i in range(len(self)):
+                # Use overridden __getitem__ method.
+                yield self.__getitem__(i)
 
-    def to_pylist(self):
-        # Override pa.Array.to_pylist() due to a lack of ExtensionScalar
-        # support (see comment in __getitem__).
-        return list(self)
+        def to_pylist(self):
+            # Override pa.Array.to_pylist() due to a lack of ExtensionScalar
+            # support (see comment in __getitem__).
+            return list(self)
+
+    elif (
+        PYARROW_VERSION is not None
+        and PYARROW_VERSION < MIN_PYARROW_VERSION_SCALAR_SUBCLASS
+    ):
+        # NOTE(Clark): These __getitem__, __iter__, and to_pylist overrides are only
+        # needed for Arrow 8.*, before ExtensionScalar subclassing support was added.
+        # TODO(Clark): Remove these methods once we only support Arrow 9.0.0+.
+        def __getitem__(self, key):
+            # This __getitem__ hook allows us to support proper indexing when accessing
+            # a single tensor (a "scalar" item of the array). Without this hook for
+            # integer keys, the indexing will fail on pyarrow < 8.0.0 due to a lack of
+            # proper ExtensionScalar support.
+
+            # NOTE(Clark): We'd like to override the pa.Array.getitem() helper instead,
+            # which would obviate the need for overriding __iter__() below, but
+            # unfortunately overriding Cython cdef methods with normal Python methods
+            # isn't allowed.
+            item = super().__getitem__(key)
+            if not isinstance(key, slice):
+                item = item.type._extension_scalar_to_ndarray(item)
+            return item
+
+        def __iter__(self):
+            # Override pa.Array.__iter__() in order to return an iterator of properly
+            # shaped tensors instead of an iterator of flattened tensors.
+            # See comment in above __getitem__ method.
+            for i in range(len(self)):
+                # Use overridden __getitem__ method.
+                yield self.__getitem__(i)
+
+        def to_pylist(self):
+            # Override pa.Array.to_pylist() due to a lack of ExtensionScalar support
+            # (see comment in __getitem__).
+            return list(self)
 
     @classmethod
     def from_numpy(
@@ -437,12 +518,44 @@ class ArrowVariableShapedTensorType(pa.PyExtensionType):
         """
         return ArrowVariableShapedTensorArray
 
+    if (
+        PYARROW_VERSION is None
+        or PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBCLASS
+    ):
+
+        def __arrow_ext_scalar_class__(self):
+            """
+            ExtensionScalar subclass with custom logic for this array of tensors type.
+            """
+            return ArrowVariableShapedTensorScalar
+
     def __str__(self) -> str:
         dtype = self.storage_type["data"].type.value_type
         return f"ArrowVariableShapedTensorType(dtype={dtype}, ndim={self.ndim})"
 
     def __repr__(self) -> str:
         return str(self)
+
+    def _extension_scalar_to_ndarray(self, scalar) -> np.ndarray:
+        """
+        Convert an ExtensionScalar to a tensor element.
+        """
+        # TODO(Clark): Construct ndarray view directly on tensor element buffer to
+        # ensure reliable zero-copy semantics.
+        flat_ndarray = scalar.value.get("data").values.to_numpy(zero_copy_only=False)
+        shape = tuple(scalar.value.get("shape").as_py())
+        return flat_ndarray.reshape(shape)
+
+
+if PYARROW_VERSION is None or PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBCLASS:
+
+    @PublicAPI(stability="alpha")
+    class ArrowVariableShapedTensorScalar(pa.ExtensionScalar):
+        def as_py(self) -> np.ndarray:
+            return self.type._extension_scalar_to_ndarray(self)
+
+        def __array__(self) -> np.ndarray:
+            return self.as_py()
 
 
 @PublicAPI(stability="alpha")
@@ -462,35 +575,71 @@ class ArrowVariableShapedTensorArray(pa.ExtensionArray):
 
     OFFSET_DTYPE = np.int32
 
-    def __getitem__(self, key):
-        # This __getitem__ hook allows us to support proper indexing when accessing a
-        # single tensor (a "scalar" item of the array). Without this hook for integer
-        # keys, the indexing will fail on all currently released pyarrow versions due
-        # to a lack of proper ExtensionScalar support. Support was added in
-        # https://github.com/apache/arrow/pull/10904, but hasn't been released at the
-        # time of this comment, and even with this support, the returned ndarray is a
-        # flat representation of the n-dimensional tensor.
+    if PYARROW_VERSION is not None and PYARROW_VERSION < MIN_PYARROW_VERSION_SCALAR:
+        # NOTE(Clark): These __getitem__, __iter__, and to_pylist overrides are only
+        # needed for Arrow < 8.0.0, before proper ExtensionScalar support was added.
+        # TODO(Clark): Remove these methods once we only support Arrow 8.0.0+.
+        def __getitem__(self, key):
+            # This __getitem__ hook allows us to support proper indexing when accessing
+            # a single tensor (a "scalar" item of the array). Without this hook for
+            # integer keys, the indexing will fail on pyarrow < 8.0.0 due to a lack of
+            # proper ExtensionScalar support.
 
-        # NOTE(Clark): We'd like to override the pa.Array.getitem() helper instead,
-        # which would obviate the need for overriding __iter__() below, but
-        # unfortunately overriding Cython cdef methods with normal Python methods isn't
-        # allowed.
-        if isinstance(key, slice):
-            return super().__getitem__(key)
-        return self._to_numpy(key)
+            # NOTE(Clark): We'd like to override the pa.Array.getitem() helper instead,
+            # which would obviate the need for overriding __iter__() below, but
+            # unfortunately overriding Cython cdef methods with normal Python methods
+            # isn't allowed.
+            if isinstance(key, slice):
+                return super().__getitem__(key)
+            return self._to_numpy(key)
 
-    def __iter__(self):
-        # Override pa.Array.__iter__() in order to return an iterator of properly
-        # shaped tensors instead of an iterator of flattened tensors.
-        # See comment in above __getitem__ method.
-        for i in range(len(self)):
-            # Use overridden __getitem__ method.
-            yield self.__getitem__(i)
+        def __iter__(self):
+            # Override pa.Array.__iter__() in order to return an iterator of properly
+            # shaped tensors instead of an iterator of flattened tensors.
+            # See comment in above __getitem__ method.
+            for i in range(len(self)):
+                # Use overridden __getitem__ method.
+                yield self.__getitem__(i)
 
-    def to_pylist(self):
-        # Override pa.Array.to_pylist() due to a lack of ExtensionScalar support (see
-        # comment in __getitem__).
-        return list(self)
+        def to_pylist(self):
+            # Override pa.Array.to_pylist() due to a lack of ExtensionScalar support
+            # (see comment in __getitem__).
+            return list(self)
+
+    elif (
+        PYARROW_VERSION is not None
+        and PYARROW_VERSION < MIN_PYARROW_VERSION_SCALAR_SUBCLASS
+    ):
+        # NOTE(Clark): These __getitem__, __iter__, and to_pylist overrides are only
+        # needed for Arrow 8.*, before ExtensionScalar subclassing support was added.
+        # TODO(Clark): Remove these methods once we only support Arrow 9.0.0+.
+        def __getitem__(self, key):
+            # This __getitem__ hook allows us to support proper indexing when accessing
+            # a single tensor (a "scalar" item of the array). Without this hook for
+            # integer keys, the indexing will fail on pyarrow < 8.0.0 due to a lack of
+            # proper ExtensionScalar support.
+
+            # NOTE(Clark): We'd like to override the pa.Array.getitem() helper instead,
+            # which would obviate the need for overriding __iter__() below, but
+            # unfortunately overriding Cython cdef methods with normal Python methods
+            # isn't allowed.
+            item = super().__getitem__(key)
+            if not isinstance(key, slice):
+                item = item.type._extension_scalar_to_ndarray(item)
+            return item
+
+        def __iter__(self):
+            # Override pa.Array.__iter__() in order to return an iterator of properly
+            # shaped tensors instead of an iterator of flattened tensors.
+            # See comment in above __getitem__ method.
+            for i in range(len(self)):
+                # Use overridden __getitem__ method.
+                yield self.__getitem__(i)
+
+        def to_pylist(self):
+            # Override pa.Array.to_pylist() due to a lack of ExtensionScalar support
+            # (see comment in __getitem__).
+            return list(self)
 
     @classmethod
     def from_numpy(

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -21,8 +21,6 @@ logger = logging.getLogger(__name__)
 # constraints given in python/setup.py.
 # Inclusive minimum pyarrow version.
 MIN_PYARROW_VERSION = "6.0.1"
-# Exclusive maximum pyarrow version.
-MAX_PYARROW_VERSION = "11.0.0"
 RAY_DISABLE_PYARROW_VERSION_CHECK = "RAY_DISABLE_PYARROW_VERSION_CHECK"
 _VERSION_VALIDATED = False
 _LOCAL_SCHEME = "local"
@@ -58,13 +56,11 @@ def _check_pyarrow_version():
         if version is not None:
             from pkg_resources._vendor.packaging.version import parse as parse_version
 
-            if (parse_version(version) < parse_version(MIN_PYARROW_VERSION)) or (
-                parse_version(version) >= parse_version(MAX_PYARROW_VERSION)
-            ):
+            if parse_version(version) < parse_version(MIN_PYARROW_VERSION):
                 raise ImportError(
-                    f"Datasets requires pyarrow >= {MIN_PYARROW_VERSION}, < "
-                    f"{MAX_PYARROW_VERSION}, but {version} is installed. Reinstall "
-                    f'with `pip install -U "pyarrow<{MAX_PYARROW_VERSION}"`. '
+                    f"Datasets requires pyarrow >= {MIN_PYARROW_VERSION}, but "
+                    f"{version} is installed. Reinstall with "
+                    f'`pip install -U "pyarrow"`. '
                     "If you want to disable this pyarrow version check, set the "
                     f"environment variable {RAY_DISABLE_PYARROW_VERSION_CHECK}=1."
                 )
@@ -72,8 +68,8 @@ def _check_pyarrow_version():
             logger.warning(
                 "You are using the 'pyarrow' module, but the exact version is unknown "
                 "(possibly carried as an internal component by another module). Please "
-                f"make sure you are using pyarrow >= {MIN_PYARROW_VERSION}, < "
-                f"{MAX_PYARROW_VERSION} to ensure compatibility with Ray Datasets. "
+                f"make sure you are using pyarrow >= {MIN_PYARROW_VERSION} to ensure "
+                "compatibility with Ray Datasets. "
                 "If you want to disable this pyarrow version check, set the "
                 f"environment variable {RAY_DISABLE_PYARROW_VERSION_CHECK}=1."
             )

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 # Inclusive minimum pyarrow version.
 MIN_PYARROW_VERSION = "6.0.1"
 # Exclusive maximum pyarrow version.
-MAX_PYARROW_VERSION = "8.0.0"
+MAX_PYARROW_VERSION = "11.0.0"
 RAY_DISABLE_PYARROW_VERSION_CHECK = "RAY_DISABLE_PYARROW_VERSION_CHECK"
 _VERSION_VALIDATED = False
 _LOCAL_SCHEME = "local"

--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -332,7 +332,15 @@ class DefaultParquetMetadataProvider(ParquetMetadataProvider):
 
 def _handle_read_os_error(error: OSError, paths: Union[str, List[str]]) -> str:
     # NOTE: this is not comprehensive yet, and should be extended as more errors arise.
-    aws_error_pattern = r"^(.*)AWS Error \[code \d+\]: No response body\.(.*)$"
+    # NOTE: The latter patterns are raised in Arrow 10+, while the former is raised in
+    # Arrow < 10.
+    aws_error_pattern = (
+        r"^(?:(.*)AWS Error \[code \d+\]: No response body\.(.*))|"
+        r"(?:(.*)AWS Error UNKNOWN \(HTTP status 400\) during HeadObject operation: "
+        r"No response body\.(.*))|"
+        r"(?:(.*)AWS Error ACCESS_DENIED during HeadObject operation: No response "
+        r"body\.(.*))$"
+    )
     if re.match(aws_error_pattern, str(error)):
         # Specially handle AWS error when reading files, to give a clearer error
         # message to avoid confusing users. The real issue is most likely that the AWS

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -353,21 +353,8 @@ def ds_numpy_list_of_ndarray_tensor_format(ray_start_regular_shared):
     yield ray.data.from_numpy([np.arange(4).reshape((1, 2, 2))] * 4)
 
 
-@pytest.fixture(params=["5.0.0", "11.0.0"])
-def unsupported_pyarrow_version(request):
-    orig_version = pa.__version__
-    pa.__version__ = request.param
-    # Unset pyarrow version cache.
-    import ray._private.utils as utils
-
-    utils._PYARROW_VERSION = None
-    yield request.param
-    pa.__version__ = orig_version
-
-
-# TODO(Clark): Add upper-bound of 11.0.0 once released.
 @pytest.fixture(params=["5.0.0"])
-def unsupported_pyarrow_version_that_exists(request):
+def unsupported_pyarrow_version(request):
     orig_version = pa.__version__
     pa.__version__ = request.param
     # Unset pyarrow version cache.

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -13,6 +13,7 @@ from ray.data.tests.mock_server import *  # noqa
 from ray.data.datasource.file_based_datasource import BlockWritePathProvider
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.arrow import ArrowTensorArray
+from ray._private.utils import _get_pyarrow_version
 
 # Trigger pytest hook to automatically zip test cluster logs to archive dir on failure
 from ray.tests.conftest import pytest_runtest_makereport  # noqa
@@ -96,10 +97,19 @@ def s3_fs_with_anonymous_crendential(
 
 
 def _s3_fs(aws_credentials, s3_server, s3_path):
+    from pkg_resources._vendor.packaging.version import parse as parse_version
     import urllib.parse
 
+    kwargs = aws_credentials.copy()
+
+    if parse_version(_get_pyarrow_version()) >= parse_version("9.0.0"):
+        kwargs["allow_bucket_creation"] = True
+        kwargs["allow_bucket_deletion"] = True
+
     fs = pa.fs.S3FileSystem(
-        region="us-west-2", endpoint_override=s3_server, **aws_credentials
+        region="us-west-2",
+        endpoint_override=s3_server,
+        **kwargs,
     )
     if s3_path.startswith("s3://"):
         if "@" in s3_path:
@@ -343,7 +353,7 @@ def ds_numpy_list_of_ndarray_tensor_format(ray_start_regular_shared):
     yield ray.data.from_numpy([np.arange(4).reshape((1, 2, 2))] * 4)
 
 
-@pytest.fixture(params=["5.0.0", "8.0.0"])
+@pytest.fixture(params=["5.0.0", "11.0.0"])
 def unsupported_pyarrow_version(request):
     orig_version = pa.__version__
     pa.__version__ = request.param
@@ -355,7 +365,8 @@ def unsupported_pyarrow_version(request):
     pa.__version__ = orig_version
 
 
-@pytest.fixture(params=["5.0.0", "8.0.0"])
+# TODO(Clark): Add upper-bound of 11.0.0 once released.
+@pytest.fixture(params=["5.0.0"])
 def unsupported_pyarrow_version_that_exists(request):
     orig_version = pa.__version__
     pa.__version__ = request.param

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -4767,14 +4767,10 @@ def test_random_shuffle_check_random(shutdown_only):
             prev = x
 
 
-def test_unsupported_pyarrow_versions_check(
-    shutdown_only, unsupported_pyarrow_version_that_exists
-):
+def test_unsupported_pyarrow_versions_check(shutdown_only, unsupported_pyarrow_version):
     # Test that unsupported pyarrow versions cause an error to be raised upon the
     # initial pyarrow use.
-    ray.init(
-        runtime_env={"pip": [f"pyarrow=={unsupported_pyarrow_version_that_exists}"]}
-    )
+    ray.init(runtime_env={"pip": [f"pyarrow=={unsupported_pyarrow_version}"]})
 
     # Test Arrow-native creation APIs.
     # Test range_table.
@@ -4796,14 +4792,14 @@ def test_unsupported_pyarrow_versions_check(
 
 def test_unsupported_pyarrow_versions_check_disabled(
     shutdown_only,
-    unsupported_pyarrow_version_that_exists,
+    unsupported_pyarrow_version,
     disable_pyarrow_version_check,
 ):
     # Test that unsupported pyarrow versions DO NOT cause an error to be raised upon the
     # initial pyarrow use when the version check is disabled.
     ray.init(
         runtime_env={
-            "pip": [f"pyarrow=={unsupported_pyarrow_version_that_exists}"],
+            "pip": [f"pyarrow=={unsupported_pyarrow_version}"],
             "env_vars": {"RAY_DISABLE_PYARROW_VERSION_CHECK": "1"},
         },
     )

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -312,25 +312,20 @@ def test_write_datasource_ray_remote_args(ray_start_cluster):
 def test_read_s3_file_error(ray_start_regular_shared, s3_path):
     dummy_path = s3_path + "_dummy"
     error_message = "Please check that file exists and has properly configured access."
-    with pytest.raises(OSError) as e:
+    with pytest.raises(OSError, match=error_message):
         ray.data.read_parquet(dummy_path)
-    assert error_message in str(e.value)
-    with pytest.raises(OSError) as e:
+    with pytest.raises(OSError, match=error_message):
         ray.data.read_binary_files(dummy_path)
-    assert error_message in str(e.value)
-    with pytest.raises(OSError) as e:
+    with pytest.raises(OSError, match=error_message):
         ray.data.read_csv(dummy_path)
-    assert error_message in str(e.value)
-    with pytest.raises(OSError) as e:
+    with pytest.raises(OSError, match=error_message):
         ray.data.read_json(dummy_path)
-    assert error_message in str(e.value)
-    with pytest.raises(OSError) as e:
+    with pytest.raises(OSError, match=error_message):
         error = OSError(
             f"Error creating dataset. Could not read schema from {dummy_path}: AWS "
             "Error [code 15]: No response body.. Is this a 'parquet' file?"
         )
         _handle_read_os_error(error, dummy_path)
-    assert error_message in str(e.value)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -3,12 +3,17 @@ import subprocess
 import urllib
 from pathlib import Path
 
+from pkg_resources._vendor.packaging.version import parse as parse_version
 import pyarrow.fs
 import pytest
 
 import ray
 import ray._private.storage as storage
 from ray._private.test_utils import simulate_storage
+from ray._private.utils import (
+    _add_creatable_buckets_param_if_s3_uri,
+    _get_pyarrow_version,
+)
 from ray.tests.conftest import *  # noqa
 
 
@@ -164,6 +169,39 @@ def test_connecting_to_cluster(shutdown_only, storage_type):
             assert _storage_uri == storage_uri
         finally:
             subprocess.check_call(["ray", "stop"])
+
+
+def test_add_creatable_buckets_param_if_s3_uri():
+    if parse_version(_get_pyarrow_version()) >= parse_version("9.0.0"):
+        # Test that the allow_bucket_creation=true query arg is added to an S3 URI.
+        uri = "s3://bucket/foo"
+        assert (
+            _add_creatable_buckets_param_if_s3_uri(uri)
+            == "s3://bucket/foo?allow_bucket_creation=true"
+        )
+
+        # Test that query args are merged (i.e. existing query args aren't dropped).
+        uri = "s3://bucket/foo?bar=baz"
+        assert (
+            _add_creatable_buckets_param_if_s3_uri(uri)
+            == "s3://bucket/foo?allow_bucket_creation=true&bar=baz"
+        )
+
+        # Test that existing allow_bucket_creation=false query arg isn't overridden.
+        uri = "s3://bucket/foo?allow_bucket_creation=false"
+        assert (
+            _add_creatable_buckets_param_if_s3_uri(uri)
+            == "s3://bucket/foo?allow_bucket_creation=false"
+        )
+    else:
+        # Test that the allow_bucket_creation=true query arg is not added to an S3 URI,
+        # since we're using Arrow < 9.
+        uri = "s3://bucket/foo"
+        assert _add_creatable_buckets_param_if_s3_uri(uri) == uri
+
+    # Test that non-S3 URI is unchanged.
+    uri = "gcs://bucket/foo"
+    assert _add_creatable_buckets_param_if_s3_uri(uri) == "gcs://bucket/foo"
 
 
 if __name__ == "__main__":

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -57,7 +57,7 @@ aiorwlock
 opentelemetry-exporter-otlp==1.1.0
 starlette
 typer
-pyarrow >= 6.0.1, < 8.0.0; python_version >= '3.7' and platform_system != "Windows"
+pyarrow >= 6.0.1; python_version >= '3.7' and platform_system != "Windows"
 pyarrow >= 6.0.1, < 7.0.0; python_version < '3.7' or platform_system == "Windows"
 aiohttp_cors
 opentelemetry-api==1.1.0


### PR DESCRIPTION
This PR adds support for Arrow 8, 9, 10, and nightly in Ray, and is the third PR in a set of stacked PRs making up this mono-PR for Arrow 7+ support (https://github.com/ray-project/ray/pull/29161), and is stacked on top of a PR fixing task cancellation in Ray Core (https://github.com/ray-project/ray/pull/29984) and a PR adding support for Arrow 7 (https://github.com/ray-project/ray/pull/29993). The last two commits are the relevant commits for review.

## Summary of Changes

This PR:

- For Arrow 9+, add `allow_bucket_creation=true` to S3 URIs for the Ray Core Storage API and for the Datasets S3 write API (https://github.com/ray-project/ray/issues/29815).
- For Arrow 9+, create an `ExtensionScalar` subclass for tensor extension types that returns an ndarray view from `.as_py()` (https://github.com/ray-project/ray/issues/29816).
For Arrow 8.*, we manually convert the `ExtensionScalar` to an ndarray for tensor extension types, since the `ExtensionScalar` type exists but isn't subclassable in Arrow 8 (https://github.com/ray-project/ray/issues/29816).
- For Arrow 10+, we match on other potential error messages when encountering permission issues when interacting with S3 (https://github.com/ray-project/ray/issues/29994).
- adds CI jobs for Arrow 8, 9, 10, and nightly
- removes the pyarrow version upper bound

## Related issue number

Closes https://github.com/ray-project/ray/issues/29816, closes https://github.com/ray-project/ray/issues/29815, closes https://github.com/ray-project/ray/issues/29994, closes https://github.com/ray-project/ray/issues/29995, closes https://github.com/ray-project/ray/issues/29996, closes https://github.com/ray-project/ray/issues/29997, closes https://github.com/ray-project/ray/issues/29998

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
