### PR TITLE
[Datasets] [Arrow 7+ Support - 4/N] [RFC] Add zero-copy batch API for `ds.map_batches()`.

### DIFF
--- a/doc/source/data/transforming-datasets.rst
+++ b/doc/source/data/transforming-datasets.rst
@@ -205,6 +205,14 @@ Here is an overview of the available batch formats:
    instead of iterating over each row of a batch and summing up values of that column,
    use ``df_batch["col_foo"].sum()``.
 
+.. tip::
+
+  If the UDF for :meth:`ds.map_batches() <ray.data.Dataset.map_batches>` does **not**
+  mutate its input, we can prevent an unnecessary data batch copy by specifying
+  ``zero_copy_batch=True``, which will provide the UDF with zero-copy, read-only
+  batches. See the :meth:`ds.map_batches() <ray.data.Dataset.map_batches>` docstring for
+  more information.
+
 .. _transform_datasets_batch_output_types:
 
 Batch UDF Output Types

--- a/doc/source/data/transforming-datasets.rst
+++ b/doc/source/data/transforming-datasets.rst
@@ -197,6 +197,43 @@ Here is an overview of the available batch formats:
     :start-after: __writing_numpy_udfs_begin__
     :end-before: __writing_numpy_udfs_end__
 
+Converting between the underlying Datasets data representations (Arrow, Pandas, and
+Python lists) and the requested batch format (``"default"``, ``"pandas"``,
+``"pyarrow"``, ``"numpy"``) may incur data copies; which conversions cause data copying
+is given in the below table:
+
+
+.. list-table:: Data Format Conversion Costs
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Dataset Format x Batch Format
+     - ``"default"``
+     - ``"pandas"``
+     - ``"numpy"``
+     - ``"pyarrow"``
+   * - ``"pandas"``
+     - Zero-copy
+     - Zero-copy
+     - Copy*
+     - Copy*
+   * - ``"arrow"``
+     - Copy*
+     - Copy*
+     - Zero-copy*
+     - Zero-copy
+   * - ``"simple"``
+     - Zero-copy
+     - Copy
+     - Copy
+     - Copy
+
+.. note::
+  \* No copies occur when converting between Arrow, Pandas, and NumPy formats for columns
+  represented in our tensor extension type (unless data is boolean). Copies **always**
+  occur when converting boolean data from/to Arrow to/from Pandas/NumPy, since Arrow
+  bitpacks boolean data while Pandas/NumPy does not.
+
 .. tip::
 
    Prefer using vectorized operations on the ``pandas.DataFrame``,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -327,6 +327,7 @@ class Dataset(Generic[T]):
         batch_size: Optional[Union[int, Literal["default"]]] = "default",
         compute: Optional[Union[str, ComputeStrategy]] = None,
         batch_format: Literal["default", "pandas", "pyarrow", "numpy"] = "default",
+        allow_mutate_batch: bool = True,
         fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
         fn_constructor_args: Optional[Iterable[Any]] = None,
@@ -363,6 +364,10 @@ class Dataset(Generic[T]):
             If you have a small number of big blocks, it may limit parallelism. You may
             consider increase the number of blocks via ``.repartition()`` before
             applying the ``.map_batches()``.
+
+        .. note::
+            If ``fn`` mutates its input, you will need to ensure that the batch provided
+            to ``fn`` is writable. See the ``allow_mutate_batch`` parameter.
 
         .. note::
             The size of the batches provided to ``fn`` may be smaller than the provided
@@ -461,6 +466,14 @@ class Dataset(Generic[T]):
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
                 ``"numpy"`` to select ``numpy.ndarray`` for tensor datasets and
                 ``Dict[str, numpy.ndarray]`` for tabular datasets. Default is "default".
+            allow_mutate_batch: Whether the ``fn`` UDF needs to be able to mutate the
+                input batch. If this is ``True``, the batch will be writable, which may
+                require an extra copy. If this is ``False``, the batch may be a
+                zero-copy, read-only view on data in Ray's object store, which can
+                decrease memory utilization and improve performance. If ``fn`` mutates
+                its input, this will need to be ``True`` in order to avoid "assignment
+                destination is read-only" or "buffer source array is read-only" errors.
+                Default is ``True``.
             fn_args: Positional arguments to pass to ``fn`` after the first argument.
                 These arguments are top-level arguments to the underlying Ray task.
             fn_kwargs: Keyword arguments to pass to ``fn``. These arguments are
@@ -545,7 +558,9 @@ class Dataset(Generic[T]):
             DatasetContext._set_current(context)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
             # Ensure that zero-copy batch views are copied so mutating UDFs don't error.
-            batcher = Batcher(batch_size, ensure_copy=batch_size is not None)
+            batcher = Batcher(
+                batch_size, ensure_copy=allow_mutate_batch and batch_size is not None
+            )
 
             def validate_batch(batch: Block) -> None:
                 if not isinstance(
@@ -574,7 +589,26 @@ class Dataset(Generic[T]):
                 # Convert to batch format.
                 batch = BlockAccessor.for_block(batch).to_batch_format(batch_format)
                 # Apply UDF.
-                batch = batch_fn(batch, *fn_args, **fn_kwargs)
+                try:
+                    batch = batch_fn(batch, *fn_args, **fn_kwargs)
+                except ValueError as e:
+                    read_only_msgs = [
+                        "assignment destination is read-only",
+                        "buffer source array is read-only",
+                    ]
+                    err_msg = str(e)
+                    if any(msg in err_msg for msg in read_only_msgs):
+                        raise ValueError(
+                            f"Batch mapper function {fn.__name__} tried to mutate a "
+                            "zero-copy read-only batch. To be able to mutate the "
+                            "batch, pass allow_mutate_batch=True to map_batches(); "
+                            "this will copy the batch before giving it to fn. To elide "
+                            "this copy, modify your mapper function so it doesn't try "
+                            "to mutate its input."
+                        ) from e
+                    else:
+                        raise e from None
+
                 validate_batch(batch)
                 # Add output batch to output buffer.
                 output_buffer.add_batch(batch)
@@ -660,7 +694,11 @@ class Dataset(Generic[T]):
             raise ValueError("`fn` must be callable, got {}".format(fn))
 
         return self.map_batches(
-            process_batch, batch_format="pandas", compute=compute, **ray_remote_args
+            process_batch,
+            batch_format="pandas",
+            compute=compute,
+            allow_mutate_batch=True,
+            **ray_remote_args,
         )
 
     def drop_columns(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -479,7 +479,9 @@ class Dataset(Generic[T]):
                 will be writable, which will require an extra copy to guarantee.
                 If ``fn`` mutates its input, this will need to be ``False`` in order to
                 avoid "assignment destination is read-only" or "buffer source array is
-                read-only" errors. Default is ``False``.
+                read-only" errors. Default is ``False``. See
+                :ref:`batch format docs <transform_datasets_batch_formats>` for details
+                on which format conversion always require a copy.
             fn_args: Positional arguments to pass to ``fn`` after the first argument.
                 These arguments are top-level arguments to the underlying Ray task.
             fn_kwargs: Keyword arguments to pass to ``fn``. These arguments are

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2596,6 +2596,34 @@ def test_map_batches_batch_mutation(
     assert [row["value"] for row in ds.iter_rows()] == list(range(1, num_rows + 1))
 
 
+@pytest.mark.parametrize(
+    "num_rows,num_blocks,batch_size",
+    [
+        (10, 5, 2),
+        (10, 1, 10),
+        (12, 3, 2),
+    ],
+)
+def test_map_batches_batch_zero_copy(
+    ray_start_regular_shared, num_rows, num_blocks, batch_size
+):
+    # Test that batches are zero-copy read-only views when allow_mutate_batch=False.
+    def mutate(df):
+        # Check that batch is read-only.
+        assert not df.values.flags.writeable
+        df["value"] += 1
+        return df
+
+    ds = ray.data.range_table(num_rows, parallelism=num_blocks).repartition(num_blocks)
+    # Convert to Pandas blocks.
+    ds = ds.map_batches(lambda df: df, batch_format="pandas", batch_size=None)
+
+    # Apply UDF that mutates the batches, which should fail since the batch is
+    # read-only.
+    with pytest.raises(ValueError, match="tried to mutate a zero-copy read-only batch"):
+        ds.map_batches(mutate, batch_size=batch_size, allow_mutate_batch=False)
+
+
 BLOCK_BUNDLING_TEST_CASES = [
     (block_size, batch_size)
     for batch_size in range(1, 8)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2607,7 +2607,7 @@ def test_map_batches_batch_mutation(
 def test_map_batches_batch_zero_copy(
     ray_start_regular_shared, num_rows, num_blocks, batch_size
 ):
-    # Test that batches are zero-copy read-only views when allow_mutate_batch=False.
+    # Test that batches are zero-copy read-only views when zero_copy_batch=True.
     def mutate(df):
         # Check that batch is read-only.
         assert not df.values.flags.writeable
@@ -2621,7 +2621,7 @@ def test_map_batches_batch_zero_copy(
     # Apply UDF that mutates the batches, which should fail since the batch is
     # read-only.
     with pytest.raises(ValueError, match="tried to mutate a zero-copy read-only batch"):
-        ds.map_batches(mutate, batch_size=batch_size, allow_mutate_batch=False)
+        ds.map_batches(mutate, batch_size=batch_size, zero_copy_batch=True)
 
 
 BLOCK_BUNDLING_TEST_CASES = [


### PR DESCRIPTION
By fixing the Arrow serialization bug we were able to remove a lot of the defensive copying throughout the Datasets codebase, enabling us to provide a zero-copy batch optimization path for `ds.map_batches()`. For UDFs that don't mutate a batch, this can elide a batch copy, resulting in lower worker heap memory utilization and better performance.

## API

We have two primary API choices:

1. `allow_mutate_batch: bool`: This API is geared towards the requirements of the user's UDF - if their UDF doesn't mutate the batch, they will set this to `False`, at which point they will get a zero-copy (immutable) batch; if they UDF does mutate the batch, this should be `True` (default) in order to guarantee that their UDF is provided a mutable batch copy.
2. `zero_copy_batch: bool`: This API is geared towards the zero-copy optimization - if the user is looking to optimize their `ds.map_batches()` performance, they will flip this flag to elide a batch copy.

Each has their merits - `allow_mutate_batch` keeps the zero-copy optimization an implementation detail and instead defines the API in terms of UDF requirements that's easy for the user to understand, and may be easier to migrate to a default of `False`; `zero_copy_batch` is more discoverable for devs looking for optimizations, but the immutability aspect of the zero-copy batch then leaks a bit of the Datasets implementation detail.

This PR currently implements option (2), the `zero_copy_batch` API, since the discoverability for users wanting to take advantage of this optimization is better. See the first commit for option (1).

## TODOs

- [x] Update transformation feature guide with tip about this arg.
- [ ] (Follow-up PR) Port preprocessors that don't mutate their input batches to use the `zero_copy_batch=True` arg.
- [ ] (Follow-up PR) Elide batch copy when batch format conversion already creates a copy.
- [ ] (Follow-up PR) Elide batch copy when base block is not in the object store (e.g. upon fusion between read and map_batches tasks).
- [ ] (Follow-up PR) Only create a batch copy when the underlying batch is read-only, without incurring expensive buffer checks.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/29817

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
