### PR TITLE
[Datasets] Make `read_images` return structured data and add `include_paths`

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -421,13 +421,34 @@ def read_images(
         >>> ds  # doctest: +SKIP
         Dataset(num_blocks=200, num_rows=41979, schema={image: ArrowVariableShapedTensorType(dtype=uint8, ndim=3)})
 
-        If you also need the image file paths, set ``include_paths=True``.
+        If you need image file paths, set ``include_paths=True``.
 
         >>> ds = ray.data.read_images(path, include_paths=True)  # doctest: +SKIP
         >>> ds  # doctest: +SKIP
         Dataset(num_blocks=200, num_rows=41979, schema={image: ArrowVariableShapedTensorType(dtype=uint8, ndim=3), path: string})
         >>> ds.take(1)[0]["path"]  # doctest: +SKIP
         'air-example-data-2/movie-image-small-filesize-1GB/0.jpg'
+
+        If your images are arranged like:
+
+        .. code::
+
+            root/dog/xxx.png
+            root/dog/xxy.png
+
+            root/cat/123.png
+            root/cat/nsdf3.png
+
+        Then you can include the labels by specifying a
+        :class:`~ray.data.datasource.partitioning.Partitioning`.
+
+        >>> import ray
+        >>> from ray.data.datasource.partitioning import Partitioning
+        >>> root = "example://tiny-imagenet-200/train"
+        >>> partitioning = Partitioning("dir", field_names=["class"], base_dir=root)
+        >>> ds = ray.data.read_images(root, size=(224, 224), partitioning=partitioning)  # doctest: +SKIP
+        >>> ds  # doctest: +SKIP
+        Dataset(num_blocks=176, num_rows=94946, schema={image: TensorDtype(shape=(224, 224, 3), dtype=uint8), class: object})
 
     Args:
         paths: A single file/directory path or a list of file/directory paths.

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -410,6 +410,7 @@ def read_images(
     partitioning: Partitioning = None,
     size: Optional[Tuple[int, int]] = None,
     mode: Optional[str] = None,
+    include_paths: bool = False,
 ):
     """Read images from the specified paths.
 
@@ -418,28 +419,15 @@ def read_images(
         >>> path = "s3://air-example-data-2/movie-image-small-filesize-1GB"
         >>> ds = ray.data.read_images(path)  # doctest: +SKIP
         >>> ds  # doctest: +SKIP
-        Dataset(num_blocks=200, num_rows=41979, schema={__value__: ArrowTensorType(shape=(386, 256, 3), dtype=uint8)})
+        Dataset(num_blocks=200, num_rows=41979, schema={image: ArrowVariableShapedTensorType(dtype=uint8, ndim=3)})
 
-        If your images are arranged like:
+        If you also need the image file paths, set ``include_paths=True``.
 
-        .. code::
-
-            root/dog/xxx.png
-            root/dog/xxy.png
-
-            root/cat/123.png
-            root/cat/nsdf3.png
-
-        Then you can include the labels by specifying a
-        :class:`~ray.data.datasource.partitioning.Partitioning`.
-
-        >>> import ray
-        >>> from ray.data.datasource.partitioning import Partitioning
-        >>> root = "example://tiny-imagenet-200/train"
-        >>> partitioning = Partitioning("dir", field_names=["class"], base_dir=root)
-        >>> ds = ray.data.read_images(root, size=(224, 224), partitioning=partitioning)  # doctest: +SKIP
+        >>> ds = ray.data.read_images(path, include_paths=True)  # doctest: +SKIP
         >>> ds  # doctest: +SKIP
-        Dataset(num_blocks=176, num_rows=94946, schema={image: TensorDtype(shape=(224, 224, 3), dtype=uint8), class: object})
+        Dataset(num_blocks=200, num_rows=41979, schema={image: ArrowVariableShapedTensorType(dtype=uint8, ndim=3), path: string})
+        >>> ds.take(1)[0]["path"]  # doctest: +SKIP
+        'air-example-data-2/movie-image-small-filesize-1GB/0.jpg'
 
     Args:
         paths: A single file/directory path or a list of file/directory paths.
@@ -461,6 +449,8 @@ def read_images(
             describing the desired type and depth of pixels. If unspecified, image
             modes are inferred by
             `Pillow <https://pillow.readthedocs.io/en/stable/index.html>`_.
+        include_paths: If ``True``, include the path to each image. File paths are
+            stored in the ``'path'`` column.
 
     Returns:
         A :class:`~ray.data.Dataset` containing tensors that represent the images at
@@ -480,6 +470,7 @@ def read_images(
         partitioning=partitioning,
         size=size,
         mode=mode,
+        include_paths=include_paths,
     )
 
 

--- a/python/ray/data/tests/test_dataset_image.py
+++ b/python/ray/data/tests/test_dataset_image.py
@@ -1,12 +1,13 @@
+import os
 import time
 
+import numpy as np
 import pyarrow as pa
 import pytest
 
 from fsspec.implementations.local import LocalFileSystem
 
 import ray
-from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.data.datasource import Partitioning
 from ray.data.datasource.image_datasource import (
     _ImageDatasourceReader,
@@ -20,15 +21,12 @@ from ray.tests.conftest import *  # noqa
 
 class TestReadImages:
     def test_basic(self, ray_start_regular_shared):
-        """Test basic `read_images` functionality.
-        The folder "simple" contains three 32x32 RGB images.
-        """
         # "simple" contains three 32x32 RGB images.
         ds = ray.data.read_images("example://image-datasets/simple")
-        assert ds.schema().names == [TENSOR_COLUMN_NAME]
+        assert ds.schema().names == ["image"]
         column_type = ds.schema().types[0]
         assert isinstance(column_type, ArrowTensorType)
-        assert all(array.shape == (32, 32, 3) for array in ds.take())
+        assert all(record["image"].shape == (32, 32, 3) for record in ds.take())
 
     def test_multiple_paths(self, ray_start_regular_shared):
         ds = ray.data.read_images(
@@ -49,11 +47,11 @@ class TestReadImages:
         ds = ray.data.read_images(
             "example://image-datasets/different-sizes", size=(32, 32)
         )
-        assert all(array.shape == (32, 32, 3) for array in ds.take())
+        assert all(record["image"].shape == (32, 32, 3) for record in ds.take())
 
     def test_different_sizes(self, ray_start_regular_shared):
         ds = ray.data.read_images("example://image-datasets/different-sizes")
-        assert sorted(array.shape for array in ds.take()) == [
+        assert sorted(record["image"].shape for record in ds.take()) == [
             (16, 16, 3),
             (32, 32, 3),
             (64, 64, 3),
@@ -75,7 +73,7 @@ class TestReadImages:
     ):
         # "different-modes" contains 32x32 images with modes "CMYK", "L", and "RGB"
         ds = ray.data.read_images("example://image-datasets/different-modes", mode=mode)
-        assert all([array.shape == expected_shape for array in ds.take()])
+        assert all([record["image"].shape == expected_shape for record in ds.take()])
 
     def test_partitioning(
         self, ray_start_regular_shared, enable_automatic_tensor_extension_cast
@@ -98,6 +96,23 @@ class TestReadImages:
         else:
             assert all(tensor.numpy_shape == (32, 32, 3) for tensor in df["image"])
 
+    def test_include_paths(self, ray_start_regular_shared):
+        root = "example://image-datasets/simple"
+
+        ds = ray.data.read_images(root, include_paths=True)
+
+        def get_relative_path(path: str) -> str:
+            parts = os.path.normpath(path).split(os.sep)
+            # `parts[-3:]` corresponds to 'image-datasets', 'simple', and the filename.
+            return os.sep.join(parts[-3:])
+
+        relative_paths = [get_relative_path(record["path"]) for record in ds.take()]
+        assert sorted(relative_paths) == [
+            "image-datasets/simple/image1.jpg",
+            "image-datasets/simple/image2.jpg",
+            "image-datasets/simple/image3.jpg",
+        ]
+
     def test_e2e_prediction(self, ray_start_regular_shared):
         from ray.train.torch import TorchCheckpoint, TorchPredictor
         from ray.train.batch_predictor import BatchPredictor
@@ -106,9 +121,12 @@ class TestReadImages:
         from torchvision.models import resnet18
 
         dataset = ray.data.read_images("example://image-datasets/simple")
-
         transform = transforms.ToTensor()
-        dataset = dataset.map(transform)
+
+        def preprocess(batch):
+            return np.stack([transform(image) for image in batch])
+
+        dataset = dataset.map_batches(preprocess, batch_format="numpy")
 
         model = resnet18(pretrained=True)
         checkpoint = TorchCheckpoint.from_model(model=model)


### PR DESCRIPTION
Signed-off-by: Balaji <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

1. Most users have to convert the simple dataset returned by `read_images` to a structured data:

**Before**
```
ds = ray.data.read_images("/home/ray/prj-caper-ai-oct2022/circle_k_anyscale/2020-12-19/", include_paths=True)
# -> Dataset(num_blocks=..., num_rows=..., schema=<class 'tuple'>)

def convert_to_tabular(batch: list[tuple[str, np.ndarray]]) -> dict[str, np.ndarray]:
    paths = np.array([path for path, _ in batch])
    images = np.array([image for _, image in batch])
    return {"image": images, "path": paths}

ds = ds.map_batches(convert_to_tabular, batch_format="numpy")
# -> Dataset(num_blocks=..., num_rows=..., schema={image: ArrowVariableShapedTensorType(dtype=uint8, ndim=3), path: string})
```

**After**
```
ds = ray.data.read_images("/home/ray/prj-caper-ai-oct2022/circle_k_anyscale/2020-12-19/", include_paths=True)
# -> Dataset(num_blocks=..., num_rows=..., schema={image: ArrowVariableShapedTensorType(dtype=uint8, ndim=3), path: string})
```

2. Users often encode information in file paths (e.g., image label). Without `include_paths`, many users can't perform training.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
