### PR TITLE
[RLlib] Update weights restore example now that we have per-policy structure

### DIFF
--- a/rllib/examples/restore_1_of_n_agents_from_checkpoint.py
+++ b/rllib/examples/restore_1_of_n_agents_from_checkpoint.py
@@ -114,9 +114,7 @@ if __name__ == "__main__":
 
     class RestoreWeightsCallback(DefaultCallbacks):
         def on_algorithm_init(self, *, algorithm: "Algorithm", **kwargs) -> None:
-            algorithm.set_weights(
-                {"policy_0": restored_policy_0.get_weights()}
-            )
+            algorithm.set_weights({"policy_0": restored_policy_0.get_weights()})
 
     # Make sure, the non-1st policies are not updated anymore.
     config.policies_to_train = [pid for pid in policy_ids if pid != "policy_0"]

--- a/rllib/examples/restore_1_of_n_agents_from_checkpoint.py
+++ b/rllib/examples/restore_1_of_n_agents_from_checkpoint.py
@@ -1,11 +1,6 @@
 """Simple example of how to restore only one of n agents from a trained
 multi-agent Algorithm using Ray tune.
 
-The trick/workaround is to use an intermediate algorithm that loads the
-trained checkpoint into all policies and then reverts those policies
-that we don't want to restore, then saves a new checkpoint, from which
-tune can pick up training.
-
 Control the number of agents and policies via --num-agents and --num-policies.
 """
 
@@ -17,8 +12,11 @@ import random
 import ray
 from ray import air
 from ray import tune
+from ray.rllib.algorithms.algorithm import Algorithm
+from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.examples.env.multi_agent import MultiAgentCartPole
+from ray.rllib.policy.policy import Policy
 from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.test_utils import check_learning_achieved
 
@@ -100,25 +98,10 @@ if __name__ == "__main__":
     best_checkpoint = results.get_best_result().checkpoint
     print(f".. best checkpoint was: {best_checkpoint}")
 
-    # Create a new dummy Algorithm to "fix" our checkpoint.
-    new_algo = config.build()
-    # Get untrained weights for all policies.
-    untrained_weights = new_algo.get_weights()
-    # Restore all policies from checkpoint.
-    new_algo.restore(best_checkpoint)
-    # Set back all weights (except for 1st agent) to original
-    # untrained weights.
-    new_algo.set_weights(
-        {pid: w for pid, w in untrained_weights.items() if pid != "policy_0"}
+    policy_0_checkpoint = os.path.join(
+        best_checkpoint.to_directory(), "policies/policy_0"
     )
-    # Create the checkpoint from which tune can pick up the
-    # experiment.
-    new_checkpoint = new_algo.save()
-    new_algo.stop()
-    print(
-        ".. checkpoint to restore from (all policies reset, "
-        f"except policy_0): {new_checkpoint}"
-    )
+    restored_policy_0 = Policy.from_checkpoint(policy_0_checkpoint)
 
     print("Starting new tune.Tuner().fit()")
 
@@ -129,17 +112,24 @@ if __name__ == "__main__":
         "training_iteration": args.stop_iters,
     }
 
+    class RestoreWeightsCallback(DefaultCallbacks):
+        def on_algorithm_init(self, *, algorithm: "Algorithm", **kwargs) -> None:
+            algorithm.set_weights(
+                {"policy_0": restored_policy_0.get_weights()}
+            )
+
     # Make sure, the non-1st policies are not updated anymore.
     config.policies_to_train = [pid for pid in policy_ids if pid != "policy_0"]
+    config.callbacks = RestoreWeightsCallback
 
     results = tune.run(
         "PPO",
         stop=stop,
         config=config.to_dict(),
-        restore=new_checkpoint,
         verbose=1,
     )
 
     if args.as_test:
         check_learning_achieved(results, args.stop_reward)
+
     ray.shutdown()


### PR DESCRIPTION
Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

The original example used a hack that feels really awkward.
We can do this much more cleanly now with Callbacks.

## Related issue number


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
