### PR TITLE
[Dashboard] Change the duration column order

### DIFF
--- a/dashboard/client/src/pages/job/JobDetail.tsx
+++ b/dashboard/client/src/pages/job/JobDetail.tsx
@@ -71,6 +71,17 @@ const JobDetailPage = (props: RouteComponentProps<{ id: string }>) => {
                   },
             },
             {
+              label: "Duration",
+              content: job.start_time ? (
+                <DurationText
+                  startTime={job.start_time}
+                  endTime={job.end_time}
+                />
+              ) : (
+                <React.Fragment>-</React.Fragment>
+              ),
+            },
+            {
               label: "Started at",
               content: {
                 value: job.start_time
@@ -85,17 +96,6 @@ const JobDetailPage = (props: RouteComponentProps<{ id: string }>) => {
                   ? dayjs(Number(job.end_time)).format("YYYY/MM/DD HH:mm:ss")
                   : "-",
               },
-            },
-            {
-              label: "Duration",
-              content: job.start_time ? (
-                <DurationText
-                  startTime={job.start_time}
-                  endTime={job.end_time}
-                />
-              ) : (
-                <React.Fragment>-</React.Fragment>
-              ),
             },
           ]}
         />

--- a/dashboard/client/src/pages/job/JobRow.tsx
+++ b/dashboard/client/src/pages/job/JobRow.tsx
@@ -50,6 +50,13 @@ export const JobRow = ({
       </TableCell>
       <TableCell align="center">{submission_id ?? "-"}</TableCell>
       <TableCell align="center">{status}</TableCell>
+      <TableCell align="center">
+        {start_time && start_time > 0 ? (
+          <DurationText startTime={start_time} endTime={end_time} />
+        ) : (
+          "-"
+        )}
+      </TableCell>
       <TableCell align="center">{progressBar}</TableCell>
       <TableCell align="center">
         {/* TODO(aguo): Also show logs for the job id instead
@@ -76,13 +83,6 @@ export const JobRow = ({
         {end_time && end_time > 0
           ? dayjs(Number(end_time)).format("YYYY/MM/DD HH:mm:ss")
           : "-"}
-      </TableCell>
-      <TableCell align="center">
-        {start_time && start_time > 0 ? (
-          <DurationText startTime={start_time} endTime={end_time} />
-        ) : (
-          "-"
-        )}
       </TableCell>
       <TableCell align="center">{driver_info?.pid ?? "-"}</TableCell>
     </TableRow>

--- a/dashboard/client/src/pages/job/index.tsx
+++ b/dashboard/client/src/pages/job/index.tsx
@@ -36,6 +36,7 @@ const columns = [
   { label: "Job ID" },
   { label: "Submission ID" },
   { label: "Status" },
+  { label: "Duration" },
   {
     label: "Tasks",
     helpInfo: (
@@ -57,7 +58,6 @@ const columns = [
   },
   { label: "StartTime" },
   { label: "EndTime" },
-  { label: "Duration" },
   { label: "Driver Pid" },
 ];
 


### PR DESCRIPTION
Signed-off-by: SangBin Cho <rkooo567@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For normal debugging / monitoring workflow, users usually care
1. job name / owner
2. job status
3. job duration
4. details (breakdown)

So it's better duration column locates before other details.  
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
