### PR TITLE
Fix html reprs to work with ipywidgets v8

### DIFF
--- a/python/ray/widgets/util.py
+++ b/python/ray/widgets/util.py
@@ -1,7 +1,21 @@
-from typing import Any, Optional
+import importlib
+import logging
+import textwrap
+from functools import wraps
+from typing import Any, Callable, Iterable, Optional, TypeVar, Union
 
 from ray.util.annotations import DeveloperAPI
 from ray.widgets import Template
+
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import LooseVersion as Version
+
+
+logger = logging.getLogger(__name__)
+
+F = TypeVar("F", bound=Callable[..., Any])
 
 
 @DeveloperAPI
@@ -59,3 +73,93 @@ def make_table_html_repr(
         content = table
 
     return content
+
+
+@DeveloperAPI
+def ensure_notebook_deps(
+    *deps: Iterable[Union[str, Optional[str]]],
+    missing_message: Optional[str] = None,
+    outdated_message: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Generate a decorator which checks for soft dependencies.
+
+    This decorator is meant to wrap _ipython_display_. If the dependency is not found,
+    or a version is specified here and the version of the package is older than the
+    specified version, the wrapped function is not executed and None is returned. If
+    the dependency is missing or the version is old, a log message is displayed.
+
+    Args:
+        *deps: Iterable of (dependency name, min version (optional))
+        missing_message: Message to log if missing package is found
+        outdated_message: Message to log if outdated package is found
+
+    Returns:
+        Wrapped function. Guaranteed to be safe to import soft dependencies specified
+        above.
+    """
+
+    def wrapper(func: F) -> F:
+        @wraps(func)
+        def wrapped(*args, **kwargs):
+            if _has_missing(*deps, message=missing_message) or _has_outdated(
+                *deps, message=outdated_message
+            ):
+                return None
+            return func(*args, **kwargs)
+
+        return wrapped
+
+    return wrapper
+
+
+def _has_missing(
+    *deps: Iterable[Union[str, Optional[str]]], message: Optional[str] = None
+):
+    missing = []
+    for (lib, _) in deps:
+        try:
+            importlib.import_module(lib)
+        except ImportError:
+            missing.append(lib)
+
+    if missing:
+        if not message:
+            message = f"Run `pip install {' '.join(missing)}` for rich notebook output."
+
+        # stacklevel=3: First level is this function, then ensure_notebook_deps, then
+        # the actual function affected.
+        logger.warning(f"Missing packages: {missing}. {message}", stacklevel=3)
+
+    return missing
+
+
+def _has_outdated(
+    *deps: Iterable[Union[str, Optional[str]]], message: Optional[str] = None
+):
+    outdated = []
+    for (lib, version) in deps:
+        try:
+            module = importlib.import_module(lib)
+            if version and Version(module.__version__) < Version(version):
+                outdated.append([lib, version, module.__version__])
+        except ImportError:
+            pass
+
+    if outdated:
+        outdated_strs = []
+        install_args = []
+        for lib, version, installed in outdated:
+            outdated_strs.append(f"{lib}=={installed} found, needs {lib}>={version}")
+            install_args.append(f"{lib}>={version}")
+
+        outdated_str = textwrap.indent("\n".join(outdated_strs), "  ")
+        install_str = " ".join(install_args)
+
+        if not message:
+            message = f"Run `pip install -U {install_str}` for rich notebook output."
+
+        # stacklevel=3: First level is this function, then ensure_notebook_deps, then
+        # the actual function affected.
+        logger.warning(f"Outdated packages:\n{outdated_str}\n{message}", stacklevel=3)
+
+    return outdated


### PR DESCRIPTION
## Why are these changes needed?

With newer versions of `ipywidgets`, `Tab.set_title` is no longer the accepted way of setting tab titles. This breaks notebook display for the `DataParallelTrainer` and `Dataset`.

`ipywidgets` is a soft dependency, so I think it should be fine to require the update. Let me know if this is not the case.

## Related issue number

Closes #30038.

### Manual testing

Run these in a notebook.

For the `DataParallelTrainer`:

```python
import ray
from ray.train.torch import TorchTrainer
from ray.air.config import ScalingConfig

trainer = TorchTrainer(
    train_loop_per_worker=lambda c: None,
    train_loop_config={"batch_size": 2},
    datasets={"train": ray.data.range(10)},
    scaling_config=ScalingConfig(num_workers=2)
)
trainer
```

For `Dataset`:
```python
import pandas as pd
import numpy as np

from torchvision import transforms
from torchvision.models import resnet18

import ray
from ray.train.torch import TorchCheckpoint, TorchPredictor
from ray.train.batch_predictor import BatchPredictor
from ray.data.preprocessors import BatchMapper


def preprocess(batch: np.ndarray) -> pd.DataFrame:
    """
    User Pytorch code to transform user image. Note we still use pandas as
    intermediate format to hold images as shorthand of python dictionary.
    """
    preprocess = transforms.Compose(
        [
            transforms.ToTensor(),
            transforms.Resize(256),
            transforms.CenterCrop(224),
            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
        ]
    )
    return pd.DataFrame({"image": [preprocess(image) for image in batch]})

data_url = "s3://anonymous@air-example-data-2/1G-image-data-synthetic-raw"
print(f"Running GPU batch prediction with 1GB data from {data_url}")
dataset = ray.data.read_images(data_url, size=(256, 256)).limit(10)

model = resnet18(pretrained=True)

preprocessor = BatchMapper(preprocess, batch_format="numpy")
ckpt = TorchCheckpoint.from_model(model=model, preprocessor=preprocessor)

predictor = BatchPredictor.from_checkpoint(ckpt, TorchPredictor)
predictor.predict(dataset, batch_size=80)
```

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
