### PR TITLE
[CI] hotfix mac wheels build issues.

### DIFF
--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -108,13 +108,14 @@ elif [[ "$platform" == "macosx" ]]; then
     PY_WHEEL_VERSION="${PY_WHEEL_VERSIONS[i]}"
 
     PYTHON_EXE="$MACPYTHON_PY_PREFIX/$PY_MM/bin/python$PY_MM"
+    PYTHON_SITE_PACKAGE_PATH="$MACPYTHON_PY_PREFIX/$PY_MM/lib/python$PY_MM/site-packages/"
     PIP_CMD="$(dirname "$PYTHON_EXE")/pip$PY_MM"
 
     # Find the appropriate wheel by grepping for the Python version.
     PYTHON_WHEEL="$(printf "%s\n" "$ROOT_DIR"/../../.whl/*"$PY_WHEEL_VERSION"* | head -n 1)"
 
     # Install the wheel.
-    "$PIP_CMD" uninstall -y ray
+    PYTHONPATH="${PYTHONPATH}:${PYTHON_SITE_PACKAGE_PATH}" "$PIP_CMD" uninstall -y ray
     "$PIP_CMD" install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.

--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -102,6 +102,8 @@ elif [[ "$platform" == "macosx" ]]; then
           "3.9"
           "3.10")
 
+  _PYTHONPATH="${PYTHONPATH}"
+
   for ((i=0; i<${#PY_MMS[@]}; ++i)); do
     PY_MM="${PY_MMS[i]}"
 
@@ -109,13 +111,14 @@ elif [[ "$platform" == "macosx" ]]; then
 
     PYTHON_EXE="$MACPYTHON_PY_PREFIX/$PY_MM/bin/python$PY_MM"
     PYTHON_SITE_PACKAGE_PATH="$MACPYTHON_PY_PREFIX/$PY_MM/lib/python$PY_MM/site-packages/"
+
     PIP_CMD="$(dirname "$PYTHON_EXE")/pip$PY_MM"
 
     # Find the appropriate wheel by grepping for the Python version.
     PYTHON_WHEEL="$(printf "%s\n" "$ROOT_DIR"/../../.whl/*"$PY_WHEEL_VERSION"* | head -n 1)"
 
     # Install the wheel.
-    PYTHONPATH="${PYTHONPATH}:${PYTHON_SITE_PACKAGE_PATH}" "$PIP_CMD" uninstall -y ray
+    PYTHONPATH="${_PYTHONPATH}:${PYTHON_SITE_PACKAGE_PATH}" "$PIP_CMD" uninstall -y ray
     "$PIP_CMD" install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.

--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -102,8 +102,6 @@ elif [[ "$platform" == "macosx" ]]; then
           "3.9"
           "3.10")
 
-  _PYTHONPATH="${PYTHONPATH}"
-
   for ((i=0; i<${#PY_MMS[@]}; ++i)); do
     PY_MM="${PY_MMS[i]}"
 
@@ -112,17 +110,15 @@ elif [[ "$platform" == "macosx" ]]; then
     PYTHON_EXE="$MACPYTHON_PY_PREFIX/$PY_MM/bin/python$PY_MM"
     PYTHON_SITE_PACKAGE_PATH="$MACPYTHON_PY_PREFIX/$PY_MM/lib/python$PY_MM/site-packages/"
 
-    PIP_CMD="$(dirname "$PYTHON_EXE")/pip$PY_MM"
-
     # Find the appropriate wheel by grepping for the Python version.
     PYTHON_WHEEL="$(printf "%s\n" "$ROOT_DIR"/../../.whl/*"$PY_WHEEL_VERSION"* | head -n 1)"
 
     # Install the wheel.
-    PYTHONPATH="${_PYTHONPATH}:${PYTHON_SITE_PACKAGE_PATH}" "$PIP_CMD" uninstall -y ray
-    "$PIP_CMD" install -q "$PYTHON_WHEEL"
+    "$PYTHON_EXE" -m pip uninstall -y ray
+    "$PYTHON_EXE" -m pip install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp aiosignal frozenlist grpcio 'pytest==7.0.1' requests proxy.py
+    "$PYTHON_EXE" -m pip install -q aiohttp aiosignal frozenlist grpcio 'pytest==7.0.1' requests proxy.py
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do

--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -108,17 +108,16 @@ elif [[ "$platform" == "macosx" ]]; then
     PY_WHEEL_VERSION="${PY_WHEEL_VERSIONS[i]}"
 
     PYTHON_EXE="$MACPYTHON_PY_PREFIX/$PY_MM/bin/python$PY_MM"
-    PYTHON_SITE_PACKAGE_PATH="$MACPYTHON_PY_PREFIX/$PY_MM/lib/python$PY_MM/site-packages/"
 
     # Find the appropriate wheel by grepping for the Python version.
     PYTHON_WHEEL="$(printf "%s\n" "$ROOT_DIR"/../../.whl/*"$PY_WHEEL_VERSION"* | head -n 1)"
 
     # Install the wheel.
-    "$PYTHON_EXE" -m pip uninstall -y ray
-    "$PYTHON_EXE" -m pip install -q "$PYTHON_WHEEL"
+    PATH="$(dirname "$PYTHON_EXE"):$PATH" "$PYTHON_EXE" -m pip uninstall -y ray
+    PATH="$(dirname "$PYTHON_EXE"):$PATH" "$PYTHON_EXE" -m pip install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.
-    "$PYTHON_EXE" -m pip install -q aiohttp aiosignal frozenlist grpcio 'pytest==7.0.1' requests proxy.py
+    PATH="$(dirname "$PYTHON_EXE"):$PATH" "$PYTHON_EXE" -m pip install -q aiohttp aiosignal frozenlist grpcio 'pytest==7.0.1' requests proxy.py
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do


### PR DESCRIPTION

Try to fix follow issue:
_pytest.pathlib.ImportPathMismatchError: ('ray.tests.conftest', '/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/ray/tests/conftest.py', PosixPath('/Users/ec2-user/.buildkite-agent/builds/bk-mac1-branch-queue-i-0cce6cf77c1456efa-1/ray-project/oss-ci-build-branch/python/ray/tests/conftest.py'))



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
