### PR TITLE
[Core] set worker non recyclable if gpu is envolved by default

### DIFF
--- a/doc/source/ray-core/tasks/using-ray-with-gpus.rst
+++ b/doc/source/ray-core/tasks/using-ray-with-gpus.rst
@@ -95,17 +95,19 @@ Workers not Releasing GPU Resources
 **Note:** Currently, when a worker executes a task that uses a GPU (e.g.,
 through TensorFlow), the task may allocate memory on the GPU and may not release
 it when the task finishes executing. This can lead to problems the next time a
-task tries to use the same GPU. You can address this by setting ``max_calls=1``
-in the remote decorator so that the worker automatically exits after executing
-the task (thereby releasing the GPU resources).
+task tries to use the same GPU. To address the problem, Ray disables the worker
+process reuse between tasks by default, where the GPU resources is released after
+the task process exists. Since this adds overhead to GPU tasks scheduling,
+you can re-enable worker reuses by setting ``max_calls=0``
+in the ``ray.remote`` decorator.
 
 .. code-block:: python
 
   import tensorflow as tf
 
-  @ray.remote(num_gpus=1, max_calls=1)
+  # By default, ray will not reuse workers for GPU tasks which prevents
+  # GPU resource leakage.
+  @ray.remote(num_gpus=1)
   def leak_gpus():
-      # This task will allocate memory on the GPU and then never release it, so
-      # we include the max_calls argument to kill the worker and release the
-      # resources.
+      # This task will allocate memory on the GPU and then never release it.
       sess = tf.Session()

--- a/doc/source/ray-core/tasks/using-ray-with-gpus.rst
+++ b/doc/source/ray-core/tasks/using-ray-with-gpus.rst
@@ -97,8 +97,8 @@ through TensorFlow), the task may allocate memory on the GPU and may not release
 it when the task finishes executing. This can lead to problems the next time a
 task tries to use the same GPU. To address the problem, Ray disables the worker
 process reuse between tasks by default, where the GPU resources is released after
-the task process exists. Since this adds overhead to GPU tasks scheduling,
-you can re-enable worker reuses by setting ``max_calls=0``
+the task process exists. Since this adds overhead to GPU task scheduling,
+you can re-enable worker reuse by setting ``max_calls=0``
 in the ``ray.remote`` decorator.
 
 .. code-block:: python

--- a/doc/source/ray-core/tasks/using-ray-with-gpus.rst
+++ b/doc/source/ray-core/tasks/using-ray-with-gpus.rst
@@ -105,7 +105,7 @@ in the ``ray.remote`` decorator.
 
   import tensorflow as tf
 
-  # By default, ray will not reuse workers for GPU tasks which prevents
+  # By default, ray will not reuse workers for GPU tasks to prevent
   # GPU resource leakage.
   @ray.remote(num_gpus=1)
   def leak_gpus():

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2935,7 +2935,7 @@ def remote(
             libraries or to reclaim resources that cannot easily be
             released, e.g., GPU memory that was acquired by TensorFlow).
             By default this is infinite for CPU tasks and 1 for GPU tasks
-            (thereby GPU tasks release resources after finish).
+            (to force GPU tasks to release resources after finishing).
         max_restarts: Only for *actors*. This specifies the maximum
             number of times that the actor should be restarted when it dies
             unexpectedly. The minimum valid value is 0 (default),

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2934,7 +2934,8 @@ def remote(
             (this can be used to address memory leaks in third-party
             libraries or to reclaim resources that cannot easily be
             released, e.g., GPU memory that was acquired by TensorFlow).
-            By default this is infinite.
+            By default this is infinite for CPU tasks and 1 for GPU tasks
+            (thereby GPU tasks release resources after finish).
         max_restarts: Only for *actors*. This specifies the maximum
             number of times that the actor should be restarted when it dies
             unexpectedly. The minimum valid value is 0 (default),

--- a/python/ray/dag/tests/test_function_dag.py
+++ b/python/ray/dag/tests/test_function_dag.py
@@ -177,7 +177,7 @@ def test_dag_options(shared_ray_instance):
     def foo():
         pass
 
-    assert foo.bind().get_options() == {'max_calls': 1, "num_gpus": 100}
+    assert foo.bind().get_options() == {"max_calls": 1, "num_gpus": 100}
     assert foo.options(num_gpus=300).bind().get_options() == {"num_gpus": 300}
     assert foo.options(num_cpus=500).bind().get_options() == {
         "num_gpus": 100,

--- a/python/ray/dag/tests/test_function_dag.py
+++ b/python/ray/dag/tests/test_function_dag.py
@@ -177,7 +177,7 @@ def test_dag_options(shared_ray_instance):
     def foo():
         pass
 
-    assert foo.bind().get_options() == {"num_gpus": 100}
+    assert foo.bind().get_options() == {'max_calls': 1, "num_gpus": 100}
     assert foo.options(num_gpus=300).bind().get_options() == {"num_gpus": 300}
     assert foo.options(num_cpus=500).bind().get_options() == {
         "num_gpus": 100,

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -104,6 +104,14 @@ class RemoteFunction:
         if "runtime_env" in self._default_options:
             self._default_options["runtime_env"] = self._runtime_env
 
+        # When gpu is used, set the task non-recyclable by default.
+        # Ready https://github.com/ray-project/ray/issues/29624 for more context.
+        if (
+            self._default_options.get("num_gpus", 0) > 0
+            and self._default_options.get("max_calls", None) is None
+        ):
+            self._default_options["max_calls"] = 1
+
         self._language = language
         self._function = _inject_tracing_into_function(function)
         self._function_name = function.__module__ + "." + function.__name__

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -96,10 +96,8 @@ class RemoteFunction:
 
         # When gpu is used, set the task non-recyclable by default.
         # https://github.com/ray-project/ray/issues/29624 for more context.
-        if (
-            self._default_options.get("num_gpus", 0) > 0
-            and self._default_options.get("max_calls", None) is None
-        ):
+        num_gpus = self._default_options.get("num_gpus") or 0
+        if num_gpus > 0 and self._default_options.get("max_calls", None) is None:
             self._default_options["max_calls"] = 1
 
         # TODO(suquark): This is a workaround for class attributes of options.

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -165,7 +165,8 @@ class RemoteFunction:
                 (this can be used to address memory leaks in third-party
                 libraries or to reclaim resources that cannot easily be
                 released, e.g., GPU memory that was acquired by TensorFlow).
-                By default this is infinite.
+                By default this is infinite for CPU tasks and 1 for GPU tasks
+                (thereby GPU tasks release resources after finish).
             max_retries: This specifies the maximum number of times that the remote
                 function should be rerun when the worker process executing it
                 crashes unexpectedly. The minimum valid value is 0,

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -95,7 +95,7 @@ class RemoteFunction:
         self._default_options = task_options
 
         # When gpu is used, set the task non-recyclable by default.
-        # Ready https://github.com/ray-project/ray/issues/29624 for more context.
+        # https://github.com/ray-project/ray/issues/29624 for more context.
         if (
             self._default_options.get("num_gpus", 0) > 0
             and self._default_options.get("max_calls", None) is None

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -166,7 +166,7 @@ class RemoteFunction:
                 libraries or to reclaim resources that cannot easily be
                 released, e.g., GPU memory that was acquired by TensorFlow).
                 By default this is infinite for CPU tasks and 1 for GPU tasks
-                (thereby GPU tasks release resources after finish).
+                (to force GPU tasks to release resources after finishing).
             max_retries: This specifies the maximum number of times that the remote
                 function should be rerun when the worker process executing it
                 crashes unexpectedly. The minimum valid value is 0,

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -94,6 +94,14 @@ class RemoteFunction:
             )
         self._default_options = task_options
 
+        # When gpu is used, set the task non-recyclable by default.
+        # Ready https://github.com/ray-project/ray/issues/29624 for more context.
+        if (
+            self._default_options.get("num_gpus", 0) > 0
+            and self._default_options.get("max_calls", None) is None
+        ):
+            self._default_options["max_calls"] = 1
+
         # TODO(suquark): This is a workaround for class attributes of options.
         # They are being used in some other places, mostly tests. Need cleanup later.
         # E.g., actors uses "__ray_metadata__" to collect options, we can so something
@@ -103,14 +111,6 @@ class RemoteFunction:
         self._runtime_env = parse_runtime_env(self._runtime_env)
         if "runtime_env" in self._default_options:
             self._default_options["runtime_env"] = self._runtime_env
-
-        # When gpu is used, set the task non-recyclable by default.
-        # Ready https://github.com/ray-project/ray/issues/29624 for more context.
-        if (
-            self._default_options.get("num_gpus", 0) > 0
-            and self._default_options.get("max_calls", None) is None
-        ):
-            self._default_options["max_calls"] = 1
 
         self._language = language
         self._function = _inject_tracing_into_function(function)

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -33,7 +33,6 @@ py_test_module_list(
     "test_actor_pool.py",
     "test_async.py",
     "test_asyncio.py",
-    "test_actor_resources.py",
     "test_actor_lifetime.py",
     "test_advanced.py",
     "test_advanced_2.py",
@@ -257,6 +256,7 @@ py_test_module_list(
   files = [
     "test_actor.py",
     "test_actor_failures.py",
+    "test_actor_resources.py",
     "test_failure.py",
     "test_actor_advanced.py",
     "test_multi_node.py",

--- a/python/ray/tests/test_advanced_6.py
+++ b/python/ray/tests/test_advanced_6.py
@@ -133,6 +133,17 @@ def test_max_call_tasks(ray_start_regular):
     wait_for_pid_to_exit(pid1)
 
 
+def test_max_call_set_for_gpu_tasks(shutdown_only):
+    ray.init(num_cpus=1, num_gpus=1)
+
+    @ray.remote(num_gpus=0.1)
+    def f():
+        return os.getpid()
+
+    pid = ray.get(f.remote())
+    wait_for_pid_to_exit(pid)
+
+
 # This case tests that the worker leaked issue when task finished with errors.
 # See https://github.com/ray-project/ray/issues/19639.
 #

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -360,6 +360,7 @@ def test_options():
 
     assert foo._default_options == {
         "_metadata": {"namespace": {"a": 1, "b": 2}},
+        "max_calls": 1,
         "num_gpus": 2,
     }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

> Current Ray behavior is to reuse Python interpreters across multiple Ray tasks to reduce latency. However, this comes with a lot of baggage for GPU tasks. Specifically, libraries like CUDA (and by extension, PyTorch and TensorFlow) tend not to be very mindful about clearing up GPU memory when references to objects holding GPU memory are removed by the Python garbage collector. For example: https://github.com/ray-project/ray/issues/29606
> 
> The workaround is to always set max_calls=1 on your Ray task to ensure the Python interpreter is shut down when the task completes. This frees the GPU memory and allows subsequent tasks to allocate additional memory.

We should by-default disable worker reuse for GPU tasks.
See #29624 for more context. 

## Related issue number

Closes #29624

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
