### PR TITLE
[Jobs] Fix edge case where entrypoint finishes before `getpid` call

### DIFF
--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -410,6 +410,15 @@ class JobSupervisor:
                 "Got unexpected exception while trying to execute driver "
                 f"command. {traceback.format_exc()}"
             )
+            try:
+                await self._job_info_client.put_status(
+                    self._job_id, JobStatus.FAILED, message=traceback.format_exc()
+                )
+            except Exception:
+                logger.error(
+                    "Failed to update job status to FAILED. "
+                    f"Exception: {traceback.format_exc()}"
+                )
         finally:
             # clean up actor after tasks are finished
             ray.actor.exit_actor()

--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -228,7 +228,11 @@ class JobSupervisor:
             # Create new pgid with new subprocess to execute driver command
 
             if sys.platform != "win32":
-                child_pgid = os.getpgid(child_pid)
+                try:
+                    child_pgid = os.getpgid(child_pid)
+                except ProcessLookupError:
+                    # Process died before we could get its pgid.
+                    return child_process
 
                 # Open a new subprocess to kill the child process when the parent
                 # process dies kill -s 0 parent_pid will succeed if the parent is


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When running a load test for Jobs, we use the minimal entrypoint script `echo hello`.  This occasionally (happened after ~1000 jobs) triggers a race condition where the process exits before we get its `pgid` internally, causing the following error buried in the worker logs:

```python-traceback
2022-11-07 12:31:10,305	ERROR job_manager.py:405 -- Got unexpected exception while trying to execute driver command. Traceback (most recent call last):
  File "/Users/archit/ray/python/ray/dashboard/modules/job/job_manager.py", line 366, in run
    child_process = self._exec_entrypoint(log_path)
  File "/Users/archit/ray/python/ray/util/tracing/tracing_helper.py", line 466, in _resume_span
    return method(self, *_args, **_kwargs)
  File "/Users/archit/ray/python/ray/dashboard/modules/job/job_manager.py", line 231, in _exec_entrypoint
    child_pgid = os.getpgid(child_pid)
ProcessLookupError: [Errno 3] No such process
```

This PR
- Propagates the error correctly to the `JobStatus`, which would have sped up debugging.
- Catches the exception to fix the error. We only get the `pgid` to start a new process that kills the process group, so if the child process is already dead we don't need to start the new process.  

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
