### PR TITLE
[AIR] Add `training_state` to `TorchCheckpoint`

### DIFF
--- a/python/ray/train/tests/test_torch_checkpoint.py
+++ b/python/ray/train/tests/test_torch_checkpoint.py
@@ -25,6 +25,18 @@ def test_from_model():
     assert_equal_torch_models(checkpoint_model, model)
 
 
+def test_get_training_state():
+    model = torch.nn.Linear(1, 1)
+
+    checkpoint = TorchCheckpoint.from_model(model, training_state={"epoch": 0})
+    assert checkpoint.get_training_state() == {"epoch": 0}
+
+    checkpoint = TorchCheckpoint.from_state_dict(
+        model.state_dict(), training_state={"epoch": 0}
+    )
+    assert checkpoint.get_training_state() == {"epoch": 0}
+
+
 def test_from_state_dict():
     model = torch.nn.Linear(1, 1)
     expected_state_dict = model.state_dict()

--- a/python/ray/train/torch/torch_checkpoint.py
+++ b/python/ray/train/torch/torch_checkpoint.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from ray.data.preprocessor import Preprocessor
 
 ENCODED_DATA_KEY = "torch_encoded_data"
+TRAINING_STATE_KEY = "_training_state"
 
 
 @PublicAPI(stability="beta")
@@ -74,6 +75,7 @@ class TorchCheckpoint(Checkpoint):
         state_dict: Dict[str, Any],
         *,
         preprocessor: Optional["Preprocessor"] = None,
+        training_state: Optional[Dict[str, Any]] = None,
     ) -> "TorchCheckpoint":
         """Create a :class:`~ray.air.checkpoint.Checkpoint` that stores a model state
         dictionary.
@@ -103,7 +105,7 @@ class TorchCheckpoint(Checkpoint):
             >>> checkpoint.get_model(torch.nn.Linear(1, 1))
             Linear(in_features=1, out_features=1, bias=True)
         """
-        return cls.from_dict({PREPROCESSOR_KEY: preprocessor, MODEL_KEY: state_dict})
+        return cls.from_dict({PREPROCESSOR_KEY: preprocessor, MODEL_KEY: state_dict, TRAINING_STATE_KEY: training_state})
 
     @classmethod
     def from_model(
@@ -111,6 +113,7 @@ class TorchCheckpoint(Checkpoint):
         model: torch.nn.Module,
         *,
         preprocessor: Optional["Preprocessor"] = None,
+        training_state: Optional[Dict[str, Any]] = None,
     ) -> "TorchCheckpoint":
         """Create a :class:`~ray.air.checkpoint.Checkpoint` that stores a Torch model.
 
@@ -143,7 +146,7 @@ class TorchCheckpoint(Checkpoint):
             >>>
             >>> predictor = TorchPredictor.from_checkpoint(checkpoint)
         """  # noqa: E501
-        return cls.from_dict({PREPROCESSOR_KEY: preprocessor, MODEL_KEY: model})
+        return cls.from_dict({PREPROCESSOR_KEY: preprocessor, MODEL_KEY: model, TRAINING_STATE_KEY: training_state})
 
     def get_model(self, model: Optional[torch.nn.Module] = None) -> torch.nn.Module:
         """Retrieve the model stored in this checkpoint.
@@ -169,3 +172,6 @@ class TorchCheckpoint(Checkpoint):
                 )
         model = load_torch_model(saved_model=saved_model, model_definition=model)
         return model
+
+    def get_training_state(self) -> Dict[str, Any]:
+        return self.to_dict()[TRAINING_STATE_KEY]


### PR DESCRIPTION
Signed-off-by: Balaji <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Users can't resume training because there's no way to save data like the optimizer state. To address this issue, this PR adds a parameter called `training_state` to `from_model` and `from_checkpoint`. For more information, see https://github.com/ray-project/ray/issues/28910.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/28910 and closes #29857 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
