### PR TITLE
[AIR - Datasets] Fix concatenation of homogeneously-shaped tensors that have been cast to variable-shaped tensors.

### DIFF
--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -437,6 +437,26 @@ def test_arrow_tensor_array_concat(a1, a2):
             np.testing.assert_array_equal(arr, expected)
 
 
+def test_variable_shaped_tensor_array_chunked_concat():
+    # Test that chunking a tensor column and concatenating its chunks preserves typing
+    # and underlying data.
+    shape1 = (2, 2, 2)
+    shape2 = (3, 4, 4)
+    a1 = np.arange(np.prod(shape1)).reshape(shape1)
+    a2 = np.arange(np.prod(shape2)).reshape(shape2)
+    ta1 = ArrowTensorArray.from_numpy(a1)
+    ta2 = ArrowTensorArray.from_numpy(a2)
+    chunked_ta = ArrowTensorArray._chunk_tensor_arrays([ta1, ta2])
+    ta = ArrowTensorArray._concat_same_type(chunked_ta.chunks)
+    assert len(ta) == shape1[0] + shape2[0]
+    assert isinstance(ta.type, ArrowVariableShapedTensorType)
+    assert pa.types.is_struct(ta.type.storage_type)
+    for arr, expected in zip(
+        ta.to_numpy(), np.array([e for a in [a1, a2] for e in a], dtype=object)
+    ):
+        np.testing.assert_array_equal(arr, expected)
+
+
 def test_variable_shaped_tensor_array_uniform_dim():
     shape1 = (3, 2, 2)
     shape2 = (3, 4, 4)


### PR DESCRIPTION
The following currently fails:

```python
    shape1 = (2, 2, 2)
    shape2 = (3, 4, 4)
    a1 = np.arange(np.prod(shape1)).reshape(shape1)
    a2 = np.arange(np.prod(shape2)).reshape(shape2)
    ta1 = ArrowTensorArray.from_numpy(a1)
    ta2 = ArrowTensorArray.from_numpy(a2)
    chunked_ta = ArrowTensorArray._chunk_tensor_arrays([ta1, ta2])
    ta = ArrowTensorArray._concat_same_type(chunked_ta.chunks)
```

This is due to `ta1.to_variable_shaped_tensor_array().to_numpy()` returning an object-dtyped tensor rather than a well-typed tensor, and our naive iteration through this ndarray prevents any of the ndarray elements being well-typed.

This PR fixes this by iterating through the tensor extension array, which already converts the individual elements to ndarray views. By unwrapping the object-dtype cast, we can ensure that individual tensor elements are well-typed.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/30078

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
