### PR TITLE
[ci] fix mac build

### DIFF
--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -121,6 +121,7 @@ elif [[ "$platform" == "macosx" ]]; then
     "$PIP_CMD" install -q aiohttp aiosignal frozenlist grpcio 'pytest==7.0.1' requests proxy.py
 
     # Run a simple test script to make sure that the wheel works.
+    # We set the python path to prefer the directory of the wheel content: https://github.com/ray-project/ray/pull/30090
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do
       PY_IGNORE_IMPORTMISMATCH=1 PATH="$(dirname "$PYTHON_EXE"):$PATH" retry "$PYTHON_EXE" "$SCRIPT"
     done

--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -122,7 +122,7 @@ elif [[ "$platform" == "macosx" ]]; then
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do
-      PATH="$(dirname "$PYTHON_EXE"):$PATH" retry "$PYTHON_EXE" "$SCRIPT"
+      PY_IGNORE_IMPORTMISMATCH=1 PATH="$(dirname "$PYTHON_EXE"):$PATH" retry "$PYTHON_EXE" "$SCRIPT"
     done
   done
 elif [ "${platform}" = windows ]; then


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

Temp fix for mac build failing due to import mismatch error 


> ImportError while loading conftest '/Users/ec2-user/.buildkite-agent/builds/bk-mac1-experimental-queue-i-0a1bb499b4443203c-1/ray-project/oss-ci-build-pr/python/ray/tests/conftest.py'.
> --
>   | _pytest.pathlib.ImportPathMismatchError: ('ray.tests.conftest', '/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/ray/tests/conftest.py', PosixPath('/Users/ec2-user/.buildkite-agent/builds/bk-mac1-experimental-queue-i-0a1bb499b4443203c-1/ray-project/oss-ci-build-pr/python/ray/tests/conftest.py'))



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
