### PR TITLE
[Datasets] Clean up logic of read metadata with dynamic block splitting

### DIFF
--- a/python/ray/data/_internal/lazy_block_list.py
+++ b/python/ray/data/_internal/lazy_block_list.py
@@ -34,9 +34,7 @@ class LazyBlockList(BlockList):
         self,
         tasks: List[ReadTask],
         block_partition_refs: Optional[List[ObjectRef[MaybeBlockPartition]]] = None,
-        block_partition_meta_refs: Optional[
-            List[ObjectRef[BlockPartitionMetadata]]
-        ] = None,
+        block_partition_meta_refs: Optional[List[ObjectRef[BlockMetadata]]] = None,
         cached_metadata: Optional[List[BlockPartitionMetadata]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
         stats_uuid: str = None,
@@ -101,12 +99,13 @@ class LazyBlockList(BlockList):
         """Get the metadata for all blocks."""
         if all(meta is not None for meta in self._cached_metadata):
             # Always return fetched metadata if we already have it.
-            metadata = self._cached_metadata
+            metadata = self._flatten_metadata(self._cached_metadata)
         elif not fetch_if_missing:
             metadata = [
-                m if m is not None else t.get_metadata()
+                m if m is not None else [t.get_metadata()]
                 for m, t in zip(self._cached_metadata, self._tasks)
             ]
+            metadata = self._flatten_metadata(metadata)
         else:
             _, metadata = self._get_blocks_with_metadata()
         return metadata
@@ -318,15 +317,14 @@ class LazyBlockList(BlockList):
                 ref_to_blocks[ref] = refs_list
                 ref_to_metadata[ref] = meta
 
-            output_block_refs, metadata = [], []
-            for ref in block_refs:
+            output_block_refs = []
+            for idx, ref in enumerate(block_refs):
                 output_block_refs += ref_to_blocks[ref]
-                metadata += ref_to_metadata[ref]
-            self._cached_metadata = metadata
-            return output_block_refs, metadata
+                self._cached_metadata[idx] = ref_to_metadata[ref]
+            return output_block_refs, self._flatten_metadata(self._cached_metadata)
         if all(meta is not None for meta in self._cached_metadata):
             # Short-circuit on cached metadata.
-            return block_refs, self._cached_metadata
+            return block_refs, self._flatten_metadata(self._cached_metadata)
         if not meta_refs:
             # Short-circuit on empty set of block partitions.
             assert not block_refs, block_refs
@@ -339,9 +337,8 @@ class LazyBlockList(BlockList):
         ref_to_data = {
             meta_ref: data for meta_ref, data in zip(unique_meta_refs, metadata)
         }
-        metadata = [ref_to_data[meta_ref] for meta_ref in meta_refs]
-        self._cached_metadata = metadata
-        return block_refs, metadata
+        self._cached_metadata = [[ref_to_data[meta_ref]] for meta_ref in meta_refs]
+        return block_refs, self._flatten_metadata(self._cached_metadata)
 
     def compute_to_blocklist(self) -> BlockList:
         """Launch all tasks and return a concrete BlockList."""
@@ -388,10 +385,10 @@ class LazyBlockList(BlockList):
                 generator = ray.get(block_partition_ref)
                 blocks_ref = list(generator)
                 metadata = ray.get(blocks_ref[-1])
-                self._cached_metadata[0] = metadata[0]
+                self._cached_metadata[0] = metadata
             else:
                 metadata = ray.get(metadata_ref)
-                self._cached_metadata[0] = metadata
+                self._cached_metadata[0] = [metadata]
         return metadata
 
     def iter_blocks(self) -> Iterator[ObjectRef[Block]]:
@@ -517,7 +514,7 @@ class LazyBlockList(BlockList):
     ) -> Iterator[
         Tuple[
             ObjectRef[MaybeBlockPartition],
-            Union[None, ObjectRef[BlockPartitionMetadata]],
+            Union[None, ObjectRef[BlockMetadata]],
         ]
     ]:
         """Iterate over the block futures and their corresponding metadata futures.
@@ -544,9 +541,7 @@ class LazyBlockList(BlockList):
     def _get_or_compute(
         self,
         i: int,
-    ) -> Tuple[
-        ObjectRef[MaybeBlockPartition], Union[None, ObjectRef[BlockPartitionMetadata]]
-    ]:
+    ) -> Tuple[ObjectRef[MaybeBlockPartition], Union[None, ObjectRef[BlockMetadata]]]:
         assert i < len(self._tasks), i
         # Check if we need to compute more block_partition_refs.
         if not self._block_partition_refs[i]:
@@ -570,9 +565,7 @@ class LazyBlockList(BlockList):
 
     def _submit_task(
         self, task_idx: int
-    ) -> Tuple[
-        ObjectRef[MaybeBlockPartition], Union[None, ObjectRef[BlockPartitionMetadata]]
-    ]:
+    ) -> Tuple[ObjectRef[MaybeBlockPartition], Union[None, ObjectRef[BlockMetadata]]]:
         """Submit the task with index task_idx.
 
         NOTE: When dynamic block splitting is enabled, returns
@@ -620,6 +613,16 @@ class LazyBlockList(BlockList):
             if b is not None:
                 i += 1
         return i
+
+    def _flatten_metadata(
+        self, metadata: List[BlockPartitionMetadata]
+    ) -> List[BlockMetadata]:
+        """Flatten the metadata of computed blocks into a list.
+
+        This is required because dynamic block splitting can produce more than one
+        output block.
+        """
+        return [meta for meta_list in metadata for meta in meta_list]
 
 
 def _execute_read_task_nosplit(

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -245,7 +245,8 @@ class DatasetStats:
             # TODO(chengsu): this is a super hack, clean it up.
             stats_map, self.time_total_s = ray.get(ac.get.remote(self.stats_uuid))
             if DatasetContext.get_current().block_splitting_enabled:
-                # Only populate stats when all read stats are ready from stats actor.
+                # Only populate stats when stats from all read tasks are ready at
+                # stats actor.
                 if len(stats_map.items()) == len(self.stages["read"]):
                     self.stages["read"] = []
                     for _, blocks_metadata in sorted(stats_map.items()):

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -245,9 +245,11 @@ class DatasetStats:
             # TODO(chengsu): this is a super hack, clean it up.
             stats_map, self.time_total_s = ray.get(ac.get.remote(self.stats_uuid))
             if DatasetContext.get_current().block_splitting_enabled:
-                self.stages["read"] = []
-                for _, blocks_metadata in sorted(stats_map.items()):
-                    self.stages["read"] += blocks_metadata
+                # Only populate stats when all read stats are ready from stats actor.
+                if len(stats_map.items()) == len(self.stages["read"]):
+                    self.stages["read"] = []
+                    for _, blocks_metadata in sorted(stats_map.items()):
+                        self.stages["read"] += blocks_metadata
             else:
                 for i, metadata in stats_map.items():
                     self.stages["read"][i] = metadata[0]

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -137,7 +137,7 @@ BlockPartition = List[Tuple[ObjectRef[Block], "BlockMetadata"]]
 
 # The metadata that describes the output of a BlockPartition. This has the
 # same type as the metadata that describes each block in the partition.
-BlockPartitionMetadata = "BlockMetadata"
+BlockPartitionMetadata = List["BlockMetadata"]
 
 # TODO(ekl/chengsu): replace this with just `ObjectRefGenerator` once block splitting
 # is on by default. When block splitting is off, the type is a plain block.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -68,7 +68,6 @@ from ray.data.block import (
     BlockAccessor,
     BlockMetadata,
     BlockPartition,
-    BlockPartitionMetadata,
     KeyFn,
     RowUDF,
     T,
@@ -1442,7 +1441,7 @@ class Dataset(Generic[T]):
         else:
             tasks: List[ReadTask] = []
             block_partition_refs: List[ObjectRef[BlockPartition]] = []
-            block_partition_meta_refs: List[ObjectRef[BlockPartitionMetadata]] = []
+            block_partition_meta_refs: List[ObjectRef[BlockMetadata]] = []
             for bl in bls:
                 tasks.extend(bl._tasks)
                 block_partition_refs.extend(bl._block_partition_refs)

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -11,7 +11,6 @@ from ray.data.block import (
     Block,
     BlockAccessor,
     BlockMetadata,
-    BlockPartitionMetadata,
     T,
 )
 from ray.data.context import DatasetContext
@@ -165,13 +164,11 @@ class ReadTask(Callable[[], Iterable[Block]]):
     contents of the block itself.
     """
 
-    def __init__(
-        self, read_fn: Callable[[], Iterable[Block]], metadata: BlockPartitionMetadata
-    ):
+    def __init__(self, read_fn: Callable[[], Iterable[Block]], metadata: BlockMetadata):
         self._metadata = metadata
         self._read_fn = read_fn
 
-    def get_metadata(self) -> BlockPartitionMetadata:
+    def get_metadata(self) -> BlockMetadata:
         return self._metadata
 
     def __call__(self) -> Iterable[Block]:

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -287,6 +287,15 @@ def enable_auto_log_stats(request):
     ctx.enable_auto_log_stats = original
 
 
+@pytest.fixture(params=[True])
+def enable_dynamic_block_splitting(request):
+    ctx = ray.data.context.DatasetContext.get_current()
+    original = ctx.block_splitting_enabled
+    ctx.block_splitting_enabled = request.param
+    yield request.param
+    ctx.block_splitting_enabled = original
+
+
 # ===== Pandas dataset formats =====
 @pytest.fixture(scope="function")
 def ds_pandas_single_column_format(ray_start_regular_shared):

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -296,6 +296,15 @@ def enable_dynamic_block_splitting(request):
     ctx.block_splitting_enabled = original
 
 
+@pytest.fixture(params=[1024])
+def target_max_block_size(request):
+    ctx = ray.data.context.DatasetContext.get_current()
+    original = ctx.target_max_block_size
+    ctx.target_max_block_size = request.param
+    yield request.param
+    ctx.target_max_block_size = original
+
+
 # ===== Pandas dataset formats =====
 @pytest.fixture(scope="function")
 def ds_pandas_single_column_format(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 import ray
+from ray.data._internal.lazy_block_list import LazyBlockList
 from ray.data.block import BlockMetadata
 from ray.data.datasource import Datasource
 from ray.data.datasource.datasource import ReadTask, Reader
@@ -10,60 +11,260 @@ from ray.data.datasource.datasource import ReadTask, Reader
 from ray.tests.conftest import *  # noqa
 
 
-def test_read_large_data(ray_start_cluster):
-    # Test 20G input with single task
-    num_batch = 20
+# Data source generates random bytes data
+class RandomBytesDatasource(Datasource):
+    def create_reader(self, **read_args):
+        return RandomBytesReader(read_args["num_batches"], read_args["batch_size"])
+
+
+class RandomBytesReader(Reader):
+    def __init__(self, num_batches: int, batch_size: int):
+        self.num_batches = num_batches
+        self.batch_size = batch_size
+
+    def estimate_inmemory_data_size(self):
+        return None
+
+    def get_read_tasks(self, parallelism: int):
+        def _batches_generator():
+            for _ in range(self.num_batches):
+                yield pd.DataFrame({"one": [np.random.bytes(self.batch_size)]})
+
+        return parallelism * [
+            ReadTask(
+                lambda: _batches_generator(),
+                BlockMetadata(
+                    num_rows=self.num_batches,
+                    size_bytes=self.num_batches * self.batch_size,
+                    schema=None,
+                    input_files=None,
+                    exec_stats=None,
+                ),
+            )
+        ]
+
+
+def test_dataset(ray_start_regular_shared, enable_dynamic_block_splitting):
+    # Test 10 blocks from 10 tasks, each block is 1024 bytes.
+    num_batches = 10
+    batch_size = 1024
+    num_tasks = 10
+
     ctx = ray.data.context.DatasetContext.get_current()
-    block_splitting_enabled = ctx.block_splitting_enabled
-    ctx.block_splitting_enabled = True
+    target_max_block_size = ctx.target_max_block_size
+    ctx.target_max_block_size = batch_size
 
     try:
-        cluster = ray_start_cluster
-        cluster.add_node(num_cpus=1)
-
-        ray.init(cluster.address)
-
-        # Data source generates multiple 1G random bytes data
-        class LargeBytesDatasource(Datasource):
-            def create_reader(self, **read_args):
-                return LargeBytesReader()
-
-        class LargeBytesReader(Reader):
-            def estimate_inmemory_data_size(self):
-                return None
-
-            def get_read_tasks(self, parallelism: int):
-                def _1g_batches_generator():
-                    for _ in range(num_batch):
-                        yield pd.DataFrame(
-                            {"one": [np.random.bytes(1024 * 1024 * 1024)]}
-                        )
-
-                return parallelism * [
-                    ReadTask(
-                        lambda: _1g_batches_generator(),
-                        BlockMetadata(
-                            num_rows=None,
-                            size_bytes=None,
-                            schema=None,
-                            input_files=None,
-                            exec_stats=None,
-                        ),
-                    )
-                ]
-
-        def foo(batch):
-            return pd.DataFrame({"one": [1]})
-
         ds = ray.data.read_datasource(
-            LargeBytesDatasource(),
-            parallelism=1,
+            RandomBytesDatasource(),
+            parallelism=num_tasks,
+            num_batches=num_batches,
+            batch_size=batch_size,
+        )
+        assert ds.schema() is not None
+        assert ds.count() == num_batches * num_tasks
+        assert ds.num_blocks() == num_tasks
+        assert ds.size_bytes() >= 0.7 * batch_size * num_batches * num_tasks
+
+        map_ds = ds.map_batches(lambda x: x)
+        assert map_ds.num_blocks() == num_tasks
+        map_ds = ds.map_batches(lambda x: x, batch_size=num_batches * num_tasks)
+        assert map_ds.num_blocks() == 1
+        map_ds = ds.map(lambda x: x)
+        assert map_ds.num_blocks() == num_batches * num_tasks
+
+        ds_list = ds.split(5)
+        assert len(ds_list) == 5
+        for new_ds in ds_list:
+            assert new_ds.num_blocks() == num_batches * num_tasks / 5
+
+        train, test = ds.train_test_split(test_size=0.25)
+        assert train.num_blocks() == num_batches * num_tasks * 0.75
+        assert test.num_blocks() == num_batches * num_tasks * 0.25
+
+        new_ds = ds.union(ds, ds)
+        assert new_ds.num_blocks() == num_tasks * 3
+        new_ds.fully_executed()
+        assert new_ds.num_blocks() == num_batches * num_tasks * 3
+
+        new_ds = ds.random_shuffle()
+        assert new_ds.num_blocks() == num_tasks
+        new_ds = ds.randomize_block_order()
+        assert new_ds.num_blocks() == num_tasks
+        assert ds.groupby("one").count().count() == num_batches * num_tasks
+
+        new_ds = ds.zip(ds)
+        assert new_ds.num_blocks() == num_batches * num_tasks
+
+        assert len(ds.take(5)) == 5
+        assert len(ds.take_all()) == num_batches * num_tasks
+        for batch in ds.iter_batches(batch_size=10):
+            assert len(batch) == 10
+    finally:
+        ctx.target_max_block_size = target_max_block_size
+
+
+def test_dataset_pipeline(ray_start_regular_shared, enable_dynamic_block_splitting):
+    # Test 10 blocks from 10 tasks, each block is 1024 bytes.
+    num_batches = 10
+    batch_size = 1024
+    num_tasks = 10
+
+    ctx = ray.data.context.DatasetContext.get_current()
+    target_max_block_size = ctx.target_max_block_size
+    ctx.target_max_block_size = batch_size
+
+    try:
+        ds = ray.data.read_datasource(
+            RandomBytesDatasource(),
+            parallelism=num_tasks,
+            num_batches=num_batches,
+            batch_size=batch_size,
+        )
+        dsp = ds.window(blocks_per_window=2)
+        assert dsp._length == num_tasks / 2
+
+        dsp = dsp.map_batches(lambda x: x)
+        result_batches = list(ds.iter_batches(batch_size=5))
+        for batch in result_batches:
+            assert len(batch) == 5
+        assert len(result_batches) == num_batches * num_tasks / 5
+
+        dsp = ds.window(blocks_per_window=2)
+        assert dsp._length == num_tasks / 2
+
+        dsp = ds.repeat().map_batches(lambda x: x)
+        assert len(dsp.take(5)) == 5
+    finally:
+        ctx.target_max_block_size = target_max_block_size
+
+
+def test_lazy_block_list(shutdown_only, enable_dynamic_block_splitting):
+    # Test 10 blocks from 10 tasks, each block is 1024 bytes.
+    num_batches = 10
+    batch_size = 1024
+    num_tasks = 10
+
+    ctx = ray.data.context.DatasetContext.get_current()
+    target_max_block_size = ctx.target_max_block_size
+    ctx.target_max_block_size = batch_size
+
+    try:
+        ds = ray.data.read_datasource(
+            RandomBytesDatasource(),
+            parallelism=num_tasks,
+            num_batches=num_batches,
+            batch_size=batch_size,
         )
 
-        ds = ds.map_batches(foo, batch_size=None)
-        assert ds.count() == num_batch
+        # Check internal states of LazyBlockList before execution
+        block_list = ds._plan._in_blocks
+        block_refs = block_list._block_partition_refs
+        cached_metadata = block_list._cached_metadata
+        metadata = block_list.get_metadata()
+
+        assert isinstance(block_list, LazyBlockList)
+        assert len(block_refs) == num_tasks
+        assert block_refs[0] is not None and all(
+            map(lambda ref: ref is None, block_refs[1:])
+        )
+        assert all(map(lambda ref: ref is None, block_list._block_partition_meta_refs))
+        assert len(cached_metadata) == num_tasks
+        for i, block_metadata in enumerate(cached_metadata):
+            if i == 0:
+                assert len(block_metadata) == num_batches
+                for m in block_metadata:
+                    assert m.num_rows == 1
+            else:
+                assert block_metadata is None
+        assert len(metadata) == num_tasks - 1 + num_batches
+        for i, block_metadata in enumerate(metadata):
+            if i < num_batches:
+                assert block_metadata.num_rows == 1
+                assert block_metadata.schema is not None
+            else:
+                assert block_metadata.num_rows == num_batches
+                assert block_metadata.schema is None
+
+        # Check APIs of LazyBlockList
+        new_block_list = block_list.copy()
+        new_block_list.clear()
+        assert len(block_list._block_partition_refs) == num_tasks
+
+        block_lists = block_list.split(2)
+        assert len(block_lists) == num_tasks / 2
+        assert len(block_lists[0]._block_partition_refs) == 2
+        assert len(block_lists[0]._cached_metadata) == 2
+
+        block_lists = block_list.split_by_bytes(batch_size * num_batches * 2)
+        assert len(block_lists) == num_tasks / 2
+        assert len(block_lists[0]._block_partition_refs) == 2
+        assert len(block_lists[0]._cached_metadata) == 2
+
+        new_block_list = block_list.truncate_by_rows(num_batches * 3)
+        assert len(new_block_list._block_partition_refs) == 3
+        assert len(new_block_list._cached_metadata) == 3
+
+        left_block_list, right_block_list = block_list.divide(3)
+        assert len(left_block_list._block_partition_refs) == 3
+        assert len(left_block_list._cached_metadata) == 3
+        assert len(right_block_list._block_partition_refs) == num_tasks - 3
+        assert len(right_block_list._cached_metadata) == num_tasks - 3
+
+        new_block_list = block_list.randomize_block_order()
+        assert len(new_block_list._block_partition_refs) == num_tasks
+        assert len(new_block_list._cached_metadata) == num_tasks
+
+        output_blocks = block_list.get_blocks_with_metadata()
+        assert len(output_blocks) == num_tasks * num_batches
+        for _, metadata in output_blocks:
+            assert metadata.num_rows == 1
+        for _, metadata in block_list.iter_blocks_with_metadata():
+            assert metadata.num_rows == 1
+
+        # Check internal states of LazyBlockList after execution
+        ds.fully_executed()
+        metadata = block_list.get_metadata()
+
+        assert block_list._num_computed() == num_tasks
+        assert len(block_refs) == num_tasks
+        assert all(map(lambda ref: ref is not None, block_refs))
+        assert all(map(lambda ref: ref is None, block_list._block_partition_meta_refs))
+        assert len(cached_metadata) == num_tasks
+        for block_metadata in cached_metadata:
+            assert len(block_metadata) == num_batches
+            for m in block_metadata:
+                assert m.num_rows == 1
+        assert len(metadata) == num_tasks * num_batches
+        for block_metadata in metadata:
+            assert block_metadata.num_rows == 1
+            assert block_metadata.schema is not None
     finally:
-        ctx.block_splitting_enabled = block_splitting_enabled
+        ctx.target_max_block_size = target_max_block_size
+
+
+def test_read_large_data(ray_start_cluster, enable_dynamic_block_splitting):
+    # Test 20G input with single task
+    num_batches = 20
+    batch_size = 1024 * 1024 * 1024
+
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=1)
+
+    ray.init(cluster.address)
+
+    def foo(batch):
+        return pd.DataFrame({"one": [1]})
+
+    ds = ray.data.read_datasource(
+        RandomBytesDatasource(),
+        parallelism=1,
+        num_batches=num_batches,
+        batch_size=batch_size,
+    )
+
+    ds = ds.map_batches(foo, batch_size=None)
+    assert ds.count() == num_batches
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -44,208 +44,193 @@ class RandomBytesReader(Reader):
         ]
 
 
-def test_dataset(ray_start_regular_shared, enable_dynamic_block_splitting):
+def test_dataset(
+    ray_start_regular_shared, enable_dynamic_block_splitting, target_max_block_size
+):
     # Test 10 blocks from 10 tasks, each block is 1024 bytes.
     num_blocks = 10
     block_size = 1024
     num_tasks = 10
 
-    ctx = ray.data.context.DatasetContext.get_current()
-    target_max_block_size = ctx.target_max_block_size
-    ctx.target_max_block_size = block_size
+    ds = ray.data.read_datasource(
+        RandomBytesDatasource(),
+        parallelism=num_tasks,
+        num_blocks=num_blocks,
+        block_size=block_size,
+    )
+    assert ds.schema() is not None
+    assert ds.count() == num_blocks * num_tasks
+    assert ds.num_blocks() == num_tasks
+    assert ds.size_bytes() >= 0.7 * block_size * num_blocks * num_tasks
 
-    try:
-        ds = ray.data.read_datasource(
-            RandomBytesDatasource(),
-            parallelism=num_tasks,
-            num_blocks=num_blocks,
-            block_size=block_size,
-        )
-        assert ds.schema() is not None
-        assert ds.count() == num_blocks * num_tasks
-        assert ds.num_blocks() == num_tasks
-        assert ds.size_bytes() >= 0.7 * block_size * num_blocks * num_tasks
+    map_ds = ds.map_batches(lambda x: x)
+    assert map_ds.num_blocks() == num_tasks
+    map_ds = ds.map_batches(lambda x: x, batch_size=num_blocks * num_tasks)
+    assert map_ds.num_blocks() == 1
+    map_ds = ds.map(lambda x: x)
+    assert map_ds.num_blocks() == num_blocks * num_tasks
 
-        map_ds = ds.map_batches(lambda x: x)
-        assert map_ds.num_blocks() == num_tasks
-        map_ds = ds.map_batches(lambda x: x, batch_size=num_blocks * num_tasks)
-        assert map_ds.num_blocks() == 1
-        map_ds = ds.map(lambda x: x)
-        assert map_ds.num_blocks() == num_blocks * num_tasks
+    ds_list = ds.split(5)
+    assert len(ds_list) == 5
+    for new_ds in ds_list:
+        assert new_ds.num_blocks() == num_blocks * num_tasks / 5
 
-        ds_list = ds.split(5)
-        assert len(ds_list) == 5
-        for new_ds in ds_list:
-            assert new_ds.num_blocks() == num_blocks * num_tasks / 5
+    train, test = ds.train_test_split(test_size=0.25)
+    assert train.num_blocks() == num_blocks * num_tasks * 0.75
+    assert test.num_blocks() == num_blocks * num_tasks * 0.25
 
-        train, test = ds.train_test_split(test_size=0.25)
-        assert train.num_blocks() == num_blocks * num_tasks * 0.75
-        assert test.num_blocks() == num_blocks * num_tasks * 0.25
+    new_ds = ds.union(ds, ds)
+    assert new_ds.num_blocks() == num_tasks * 3
+    new_ds.fully_executed()
+    assert new_ds.num_blocks() == num_blocks * num_tasks * 3
 
-        new_ds = ds.union(ds, ds)
-        assert new_ds.num_blocks() == num_tasks * 3
-        new_ds.fully_executed()
-        assert new_ds.num_blocks() == num_blocks * num_tasks * 3
+    new_ds = ds.random_shuffle()
+    assert new_ds.num_blocks() == num_tasks
+    new_ds = ds.randomize_block_order()
+    assert new_ds.num_blocks() == num_tasks
+    assert ds.groupby("one").count().count() == num_blocks * num_tasks
 
-        new_ds = ds.random_shuffle()
-        assert new_ds.num_blocks() == num_tasks
-        new_ds = ds.randomize_block_order()
-        assert new_ds.num_blocks() == num_tasks
-        assert ds.groupby("one").count().count() == num_blocks * num_tasks
+    new_ds = ds.zip(ds)
+    assert new_ds.num_blocks() == num_blocks * num_tasks
 
-        new_ds = ds.zip(ds)
-        assert new_ds.num_blocks() == num_blocks * num_tasks
-
-        assert len(ds.take(5)) == 5
-        assert len(ds.take_all()) == num_blocks * num_tasks
-        for batch in ds.iter_batches(batch_size=10):
-            assert len(batch) == 10
-    finally:
-        ctx.target_max_block_size = target_max_block_size
+    assert len(ds.take(5)) == 5
+    assert len(ds.take_all()) == num_blocks * num_tasks
+    for batch in ds.iter_batches(batch_size=10):
+        assert len(batch) == 10
 
 
-def test_dataset_pipeline(ray_start_regular_shared, enable_dynamic_block_splitting):
+def test_dataset_pipeline(
+    ray_start_regular_shared, enable_dynamic_block_splitting, target_max_block_size
+):
     # Test 10 blocks from 10 tasks, each block is 1024 bytes.
     num_blocks = 10
     block_size = 1024
     num_tasks = 10
 
-    ctx = ray.data.context.DatasetContext.get_current()
-    target_max_block_size = ctx.target_max_block_size
-    ctx.target_max_block_size = block_size
+    ds = ray.data.read_datasource(
+        RandomBytesDatasource(),
+        parallelism=num_tasks,
+        num_blocks=num_blocks,
+        block_size=block_size,
+    )
+    dsp = ds.window(blocks_per_window=2)
+    assert dsp._length == num_tasks / 2
 
-    try:
-        ds = ray.data.read_datasource(
-            RandomBytesDatasource(),
-            parallelism=num_tasks,
-            num_blocks=num_blocks,
-            block_size=block_size,
-        )
-        dsp = ds.window(blocks_per_window=2)
-        assert dsp._length == num_tasks / 2
+    dsp = dsp.map_batches(lambda x: x)
+    result_batches = list(ds.iter_batches(batch_size=5))
+    for batch in result_batches:
+        assert len(batch) == 5
+    assert len(result_batches) == num_blocks * num_tasks / 5
 
-        dsp = dsp.map_batches(lambda x: x)
-        result_batches = list(ds.iter_batches(batch_size=5))
-        for batch in result_batches:
-            assert len(batch) == 5
-        assert len(result_batches) == num_blocks * num_tasks / 5
+    dsp = ds.window(blocks_per_window=2)
+    assert dsp._length == num_tasks / 2
 
-        dsp = ds.window(blocks_per_window=2)
-        assert dsp._length == num_tasks / 2
-
-        dsp = ds.repeat().map_batches(lambda x: x)
-        assert len(dsp.take(5)) == 5
-    finally:
-        ctx.target_max_block_size = target_max_block_size
+    dsp = ds.repeat().map_batches(lambda x: x)
+    assert len(dsp.take(5)) == 5
 
 
-def test_lazy_block_list(shutdown_only, enable_dynamic_block_splitting):
+def test_lazy_block_list(
+    shutdown_only, enable_dynamic_block_splitting, target_max_block_size
+):
     # Test 10 blocks from 10 tasks, each block is 1024 bytes.
     num_blocks = 10
     block_size = 1024
     num_tasks = 10
 
-    ctx = ray.data.context.DatasetContext.get_current()
-    target_max_block_size = ctx.target_max_block_size
-    ctx.target_max_block_size = block_size
+    ds = ray.data.read_datasource(
+        RandomBytesDatasource(),
+        parallelism=num_tasks,
+        num_blocks=num_blocks,
+        block_size=block_size,
+    )
 
-    try:
-        ds = ray.data.read_datasource(
-            RandomBytesDatasource(),
-            parallelism=num_tasks,
-            num_blocks=num_blocks,
-            block_size=block_size,
-        )
+    # Check internal states of LazyBlockList before execution
+    block_list = ds._plan._in_blocks
+    block_refs = block_list._block_partition_refs
+    cached_metadata = block_list._cached_metadata
+    metadata = block_list.get_metadata()
 
-        # Check internal states of LazyBlockList before execution
-        block_list = ds._plan._in_blocks
-        block_refs = block_list._block_partition_refs
-        cached_metadata = block_list._cached_metadata
-        metadata = block_list.get_metadata()
-
-        assert isinstance(block_list, LazyBlockList)
-        assert len(block_refs) == num_tasks
-        assert block_refs[0] is not None and all(
-            map(lambda ref: ref is None, block_refs[1:])
-        )
-        assert all(map(lambda ref: ref is None, block_list._block_partition_meta_refs))
-        assert len(cached_metadata) == num_tasks
-        for i, block_metadata in enumerate(cached_metadata):
-            if i == 0:
-                assert len(block_metadata) == num_blocks
-                for m in block_metadata:
-                    assert m.num_rows == 1
-            else:
-                assert block_metadata is None
-        assert len(metadata) == num_tasks - 1 + num_blocks
-        for i, block_metadata in enumerate(metadata):
-            if i < num_blocks:
-                assert block_metadata.num_rows == 1
-                assert block_metadata.schema is not None
-            else:
-                assert block_metadata.num_rows == num_blocks
-                assert block_metadata.schema is None
-
-        # Check APIs of LazyBlockList
-        new_block_list = block_list.copy()
-        new_block_list.clear()
-        assert len(block_list._block_partition_refs) == num_tasks
-
-        block_lists = block_list.split(2)
-        assert len(block_lists) == num_tasks / 2
-        assert len(block_lists[0]._block_partition_refs) == 2
-        assert len(block_lists[0]._cached_metadata) == 2
-
-        block_lists = block_list.split_by_bytes(block_size * num_blocks * 2)
-        assert len(block_lists) == num_tasks / 2
-        assert len(block_lists[0]._block_partition_refs) == 2
-        assert len(block_lists[0]._cached_metadata) == 2
-
-        new_block_list = block_list.truncate_by_rows(num_blocks * 3)
-        assert len(new_block_list._block_partition_refs) == 3
-        assert len(new_block_list._cached_metadata) == 3
-
-        left_block_list, right_block_list = block_list.divide(3)
-        assert len(left_block_list._block_partition_refs) == 3
-        assert len(left_block_list._cached_metadata) == 3
-        assert len(right_block_list._block_partition_refs) == num_tasks - 3
-        assert len(right_block_list._cached_metadata) == num_tasks - 3
-
-        new_block_list = block_list.randomize_block_order()
-        assert len(new_block_list._block_partition_refs) == num_tasks
-        assert len(new_block_list._cached_metadata) == num_tasks
-
-        output_blocks = block_list.get_blocks_with_metadata()
-        assert len(output_blocks) == num_tasks * num_blocks
-        for _, metadata in output_blocks:
-            assert metadata.num_rows == 1
-        for _, metadata in block_list.iter_blocks_with_metadata():
-            assert metadata.num_rows == 1
-
-        # Check internal states of LazyBlockList after execution
-        ds.fully_executed()
-        metadata = block_list.get_metadata()
-
-        assert block_list._num_computed() == num_tasks
-        assert len(block_refs) == num_tasks
-        assert all(map(lambda ref: ref is not None, block_refs))
-        assert all(map(lambda ref: ref is None, block_list._block_partition_meta_refs))
-        assert len(cached_metadata) == num_tasks
-        for block_metadata in cached_metadata:
+    assert isinstance(block_list, LazyBlockList)
+    assert len(block_refs) == num_tasks
+    assert block_refs[0] is not None and all(
+        map(lambda ref: ref is None, block_refs[1:])
+    )
+    assert all(map(lambda ref: ref is None, block_list._block_partition_meta_refs))
+    assert len(cached_metadata) == num_tasks
+    for i, block_metadata in enumerate(cached_metadata):
+        if i == 0:
             assert len(block_metadata) == num_blocks
             for m in block_metadata:
                 assert m.num_rows == 1
-        assert len(metadata) == num_tasks * num_blocks
-        for block_metadata in metadata:
+        else:
+            assert block_metadata is None
+    assert len(metadata) == num_tasks - 1 + num_blocks
+    for i, block_metadata in enumerate(metadata):
+        if i < num_blocks:
             assert block_metadata.num_rows == 1
             assert block_metadata.schema is not None
-    finally:
-        ctx.target_max_block_size = target_max_block_size
+        else:
+            assert block_metadata.num_rows == num_blocks
+            assert block_metadata.schema is None
+
+    # Check APIs of LazyBlockList
+    new_block_list = block_list.copy()
+    new_block_list.clear()
+    assert len(block_list._block_partition_refs) == num_tasks
+
+    block_lists = block_list.split(2)
+    assert len(block_lists) == num_tasks / 2
+    assert len(block_lists[0]._block_partition_refs) == 2
+    assert len(block_lists[0]._cached_metadata) == 2
+
+    block_lists = block_list.split_by_bytes(block_size * num_blocks * 2)
+    assert len(block_lists) == num_tasks / 2
+    assert len(block_lists[0]._block_partition_refs) == 2
+    assert len(block_lists[0]._cached_metadata) == 2
+
+    new_block_list = block_list.truncate_by_rows(num_blocks * 3)
+    assert len(new_block_list._block_partition_refs) == 3
+    assert len(new_block_list._cached_metadata) == 3
+
+    left_block_list, right_block_list = block_list.divide(3)
+    assert len(left_block_list._block_partition_refs) == 3
+    assert len(left_block_list._cached_metadata) == 3
+    assert len(right_block_list._block_partition_refs) == num_tasks - 3
+    assert len(right_block_list._cached_metadata) == num_tasks - 3
+
+    new_block_list = block_list.randomize_block_order()
+    assert len(new_block_list._block_partition_refs) == num_tasks
+    assert len(new_block_list._cached_metadata) == num_tasks
+
+    output_blocks = block_list.get_blocks_with_metadata()
+    assert len(output_blocks) == num_tasks * num_blocks
+    for _, metadata in output_blocks:
+        assert metadata.num_rows == 1
+    for _, metadata in block_list.iter_blocks_with_metadata():
+        assert metadata.num_rows == 1
+
+    # Check internal states of LazyBlockList after execution
+    ds.fully_executed()
+    metadata = block_list.get_metadata()
+
+    assert block_list._num_computed() == num_tasks
+    assert len(block_refs) == num_tasks
+    assert all(map(lambda ref: ref is not None, block_refs))
+    assert all(map(lambda ref: ref is None, block_list._block_partition_meta_refs))
+    assert len(cached_metadata) == num_tasks
+    for block_metadata in cached_metadata:
+        assert len(block_metadata) == num_blocks
+        for m in block_metadata:
+            assert m.num_rows == 1
+    assert len(metadata) == num_tasks * num_blocks
+    for block_metadata in metadata:
+        assert block_metadata.num_rows == 1
+        assert block_metadata.schema is not None
 
 
 def test_read_large_data(ray_start_cluster, enable_dynamic_block_splitting):
     # Test 20G input with single task
-    num_blocks = 1
+    num_blocks = 20
     block_size = 1024 * 1024 * 1024
 
     cluster = ray_start_cluster


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is to clean up the logic of read metadata when dynamic block splitting is enabled. Make sure we still maintain the same bahavior for cached metadata, and simplify some code.

Also added more unit tests for dynamic block splitting.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
