### PR TITLE
[testing] Add MLPerf training bulk ingest test for heterogeneous clusters

### DIFF
--- a/release/air_tests/air_benchmarks/mlperf-train/compute_cpu_16.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/compute_cpu_16.yaml
@@ -7,4 +7,9 @@ head_node_type:
     name: head_node
     instance_type: m5.4xlarge
 
-worker_node_types: []
+worker_node_types:
+    - name: worker_node
+      instance_type: m5.xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false

--- a/release/air_tests/air_benchmarks/mlperf-train/compute_cpu_16_worker_nodes_2.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/compute_cpu_16_worker_nodes_2.yaml
@@ -1,7 +1,7 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
-max_workers: 0
+max_workers: 2
 
 head_node_type:
     name: head_node

--- a/release/air_tests/air_benchmarks/mlperf-train/compute_cpu_16_worker_nodes_2.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/compute_cpu_16_worker_nodes_2.yaml
@@ -1,0 +1,15 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: m5.xlarge
+      min_workers: 2
+      max_workers: 2
+      use_spot: false

--- a/release/air_tests/air_benchmarks/mlperf-train/format_bootstrap_config.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/format_bootstrap_config.py
@@ -1,0 +1,27 @@
+import json
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config-path", type=str, required=True)
+    parser.add_argument("--num-cpu-nodes", type=int, required=True)
+    args = parser.parse_args()
+    assert args.num_cpu_nodes >= 0
+
+    with open(args.config_path, "r") as f:
+        yaml = json.load(f)
+
+    node_types = yaml["available_node_types"]
+    assert (
+        "worker-node-type-0" in node_types
+    ), "Must specify exactly one worker node type using the cluster UI"
+
+    node_types["worker-node-type-0"]["min_workers"] = args.num_cpu_nodes
+    node_types["worker-node-type-0"]["max_workers"] = args.num_cpu_nodes
+    # Cluster-level max workers includes 1 node for the head node.
+    yaml["max_workers"] = args.num_cpu_nodes + 1
+
+    with open(args.config_path, "w") as f:
+        json.dump(yaml, f)

--- a/release/air_tests/air_benchmarks/mlperf-train/format_bootstrap_config.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/format_bootstrap_config.py
@@ -14,12 +14,14 @@ if __name__ == "__main__":
         yaml = json.load(f)
 
     node_types = yaml["available_node_types"]
-    assert (
-        "worker-node-type-0" in node_types
-    ), "Must specify exactly one worker node type using the cluster UI"
+    worker_label = None
+    for label in node_types:
+        if "worker" in label:
+            assert worker_label is None, "More than one worker node type specified in config"
+            worker_label = label
 
-    node_types["worker-node-type-0"]["min_workers"] = args.num_cpu_nodes
-    node_types["worker-node-type-0"]["max_workers"] = args.num_cpu_nodes
+    node_types[worker_label]["min_workers"] = args.num_cpu_nodes
+    node_types[worker_label]["max_workers"] = args.num_cpu_nodes
     # Cluster-level max workers includes 1 node for the head node.
     yaml["max_workers"] = args.num_cpu_nodes + 1
 

--- a/release/air_tests/air_benchmarks/mlperf-train/format_bootstrap_config.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/format_bootstrap_config.py
@@ -17,7 +17,9 @@ if __name__ == "__main__":
     worker_label = None
     for label in node_types:
         if "worker" in label:
-            assert worker_label is None, "More than one worker node type specified in config"
+            assert (
+                worker_label is None
+            ), "More than one worker node type specified in config"
             worker_label = label
 
     node_types[worker_label]["min_workers"] = args.num_cpu_nodes

--- a/release/air_tests/air_benchmarks/mlperf-train/format_bootstrap_config.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/format_bootstrap_config.py
@@ -22,8 +22,7 @@ if __name__ == "__main__":
 
     node_types[worker_label]["min_workers"] = args.num_cpu_nodes
     node_types[worker_label]["max_workers"] = args.num_cpu_nodes
-    # Cluster-level max workers includes 1 node for the head node.
-    yaml["max_workers"] = args.num_cpu_nodes + 1
+    yaml["max_workers"] = args.num_cpu_nodes
 
     with open(args.config_path, "w") as f:
         json.dump(yaml, f)

--- a/release/air_tests/air_benchmarks/mlperf-train/heterogeneity_benchmark.sh
+++ b/release/air_tests/air_benchmarks/mlperf-train/heterogeneity_benchmark.sh
@@ -5,7 +5,9 @@
 set -x -e pipeline
 
 NUM_FILES="128"
-NUM_CPU_NODES="0 2"
+# NOTE: Start with larger cluster and downscale so that
+# cluster setup will sync all code files to all worker nodes.
+NUM_CPU_NODES="2 0"
 
 NUM_EPOCHS=1
 BATCH_SIZE=64

--- a/release/air_tests/air_benchmarks/mlperf-train/heterogeneity_benchmark.sh
+++ b/release/air_tests/air_benchmarks/mlperf-train/heterogeneity_benchmark.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Test Ray Data bulk ingestion performance as the number of CPU nodes changes.
+
+# Exit if any of the test commands fail.
+set -x -e pipeline
+
+NUM_FILES="128"
+NUM_CPU_NODES="0 2"
+
+NUM_EPOCHS=1
+BATCH_SIZE=64
+SHUFFLE_BUFFER_SIZE=0
+DATA_DIR="/home/ray/data"
+
+
+run_with_num_images_per_file() {
+    NUM_IMAGES_PER_FILE=$1
+
+    for num_cpu_nodes in $NUM_CPU_NODES; do
+        python format_bootstrap_config.py --config-path ~/ray_bootstrap_config.yaml --num-cpu-nodes "$num_cpu_nodes"
+        ray up ~/ray_bootstrap_config.yaml -y --restart-only
+        
+        # Wait for all nodes to start and generate data files.
+        python make_fake_dataset.py \
+            --num-nodes $((num_cpu_nodes + 1)) \
+            --num-shards $NUM_FILES \
+            --num-images-per-shard "$NUM_IMAGES_PER_FILE" \
+            --output-directory $DATA_DIR
+
+        python resnet50_ray_air.py \
+            --num-images-per-input-file "$NUM_IMAGES_PER_FILE" \
+            --num-epochs $NUM_EPOCHS \
+            --batch-size $BATCH_SIZE \
+            --shuffle-buffer-size $SHUFFLE_BUFFER_SIZE \
+            --num-images-per-epoch $(( NUM_IMAGES_PER_FILE * NUM_FILES )) \
+            --num-cpu-nodes "$num_cpu_nodes" \
+            --train-sleep-time-ms 0 \
+            --data-root $DATA_DIR \
+            --use-ray-data
+        sleep 5
+    done
+}
+
+# Run with a file size that should fit in object store on the head node.
+run_with_num_images_per_file 64
+# Run with a file size that should require spilling on the head node.
+run_with_num_images_per_file 512

--- a/release/air_tests/air_benchmarks/mlperf-train/heterogeneity_benchmark.sh
+++ b/release/air_tests/air_benchmarks/mlperf-train/heterogeneity_benchmark.sh
@@ -2,12 +2,11 @@
 # Test Ray Data bulk ingestion performance as the number of CPU nodes changes.
 
 # Exit if any of the test commands fail.
-set -x -e pipeline
+set -x -e
 
 NUM_FILES="128"
-# NOTE: Start with larger cluster and downscale so that
-# cluster setup will sync all code files to all worker nodes.
-NUM_CPU_NODES="2 0"
+NUM_IMAGES_PER_FILE="64 512"
+NUM_CPU_NODES=${1:-2}
 
 NUM_EPOCHS=1
 BATCH_SIZE=64
@@ -15,35 +14,23 @@ SHUFFLE_BUFFER_SIZE=0
 DATA_DIR="/home/ray/data"
 
 
-run_with_num_images_per_file() {
-    NUM_IMAGES_PER_FILE=$1
+for num_images_per_file in $NUM_IMAGES_PER_FILE; do
+    # Wait for all nodes to start and generate data files.
+    python make_fake_dataset.py \
+        --num-nodes $((NUM_CPU_NODES + 1)) \
+        --num-shards $NUM_FILES \
+        --num-images-per-shard "$num_images_per_file" \
+        --output-directory $DATA_DIR
 
-    for num_cpu_nodes in $NUM_CPU_NODES; do
-        python format_bootstrap_config.py --config-path ~/ray_bootstrap_config.yaml --num-cpu-nodes "$num_cpu_nodes"
-        ray up ~/ray_bootstrap_config.yaml -y --restart-only
-        
-        # Wait for all nodes to start and generate data files.
-        python make_fake_dataset.py \
-            --num-nodes $((num_cpu_nodes + 1)) \
-            --num-shards $NUM_FILES \
-            --num-images-per-shard "$NUM_IMAGES_PER_FILE" \
-            --output-directory $DATA_DIR
-
-        python resnet50_ray_air.py \
-            --num-images-per-input-file "$NUM_IMAGES_PER_FILE" \
-            --num-epochs $NUM_EPOCHS \
-            --batch-size $BATCH_SIZE \
-            --shuffle-buffer-size $SHUFFLE_BUFFER_SIZE \
-            --num-images-per-epoch $(( NUM_IMAGES_PER_FILE * NUM_FILES )) \
-            --num-cpu-nodes "$num_cpu_nodes" \
-            --train-sleep-time-ms 0 \
-            --data-root $DATA_DIR \
-            --use-ray-data
-        sleep 5
-    done
-}
-
-# Run with a file size that should fit in object store on the head node.
-run_with_num_images_per_file 64
-# Run with a file size that should require spilling on the head node.
-run_with_num_images_per_file 512
+    python resnet50_ray_air.py \
+        --num-images-per-input-file "$num_images_per_file" \
+        --num-epochs $NUM_EPOCHS \
+        --batch-size $BATCH_SIZE \
+        --shuffle-buffer-size $SHUFFLE_BUFFER_SIZE \
+        --num-images-per-epoch $(( num_images_per_file * NUM_FILES )) \
+        --num-cpu-nodes "$NUM_CPU_NODES" \
+        --train-sleep-time-ms 0 \
+        --data-root $DATA_DIR \
+        --use-ray-data
+    sleep 5
+done

--- a/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
@@ -304,6 +304,7 @@ def build_dataset(data_root, num_images_per_epoch, num_images_per_input_file):
 FIELDS = [
     "data_loader",
     "train_sleep_time_ms",
+    "num_cpu_nodes",
     "num_epochs",
     "num_images_per_epoch",
     "num_images_per_input_file",
@@ -383,12 +384,13 @@ def append_to_test_output_json(path, metrics):
     num_images_per_file = metrics["num_images_per_input_file"]
     num_files = metrics["num_files"]
     data_loader = metrics["data_loader"]
+    num_cpu_nodes = metrics["num_cpu_nodes"]
 
     # Append select performance metrics to perf_metrics.
     perf_metrics = output_json.get("perf_metrics", [])
     perf_metrics.append(
         {
-            "perf_metric_name": f"{data_loader}_{num_images_per_file}-images-per-file_{num_files}-num-files_throughput-img-per-second",  # noqa: E501
+            "perf_metric_name": f"{data_loader}_{num_images_per_file}-images-per-file_{num_files}-num-files-{num_cpu_nodes}-num-cpu-nodes_throughput-img-per-second",  # noqa: E501
             "perf_metric_value": metrics["tput_images_per_s"],
             "perf_metric_type": "THROUGHPUT",
         }
@@ -447,6 +449,7 @@ if __name__ == "__main__":
     parser.add_argument("--output-file", default="out.csv", type=str)
     parser.add_argument("--use-gpu", action="store_true")
     parser.add_argument("--online-processing", action="store_true")
+    parser.add_argument("--num-cpu-nodes", default=0, type=int)
     args = parser.parse_args()
 
     if args.use_tf_data or args.use_ray_data:

--- a/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
@@ -452,6 +452,12 @@ if __name__ == "__main__":
     parser.add_argument("--num-cpu-nodes", default=0, type=int)
     args = parser.parse_args()
 
+    ray.init(
+        runtime_env={
+            "working_dir": os.path.dirname(__file__),
+        }
+    )
+
     if args.use_tf_data or args.use_ray_data:
         assert (
             args.data_root is not None

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -649,7 +649,7 @@
   team: core
   cluster:
     cluster_env: app_config_oom.yaml
-    cluster_compute: compute_cpu_16.yaml
+    cluster_compute: compute_cpu_16_worker_nodes_2.yaml
 
   run:
     timeout: 1800

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -600,6 +600,7 @@
 
   alert: default
 
+# Test tiny, medium, and huge input files.
 - name: ray-data-bulk-ingest-file-size-benchmark
   group: AIR tests
   working_dir: air_tests/air_benchmarks/mlperf-train
@@ -619,6 +620,7 @@
     type: sdk_command
     file_manager: sdk
 
+# Test dataset larger than object store memory.
 - name: ray-data-bulk-ingest-out-of-core-benchmark
   group: AIR tests
   working_dir: air_tests/air_benchmarks/mlperf-train
@@ -638,6 +640,7 @@
     type: sdk_command
     file_manager: sdk
 
+# Test additional CPU nodes for preprocessing.
 - name: ray-data-bulk-ingest-heterogeneity-benchmark
   group: AIR tests
   working_dir: air_tests/air_benchmarks/mlperf-train
@@ -652,8 +655,11 @@
     cluster_compute: compute_cpu_16_worker_nodes_2.yaml
 
   run:
+    wait_for_nodes:
+      num_nodes: 3
+
     timeout: 1800
-    script: bash heterogeneity_benchmark.sh
+    script: bash heterogeneity_benchmark.sh 2
     type: sdk_command
     file_manager: sdk
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -638,6 +638,25 @@
     type: sdk_command
     file_manager: sdk
 
+- name: ray-data-bulk-ingest-heterogeneity-benchmark
+  group: AIR tests
+  working_dir: air_tests/air_benchmarks/mlperf-train
+
+  stable: true
+  env: staging
+
+  frequency: nightly
+  team: core
+  cluster:
+    cluster_env: app_config_oom.yaml
+    cluster_compute: compute_cpu_16.yaml
+
+  run:
+    timeout: 1800
+    script: bash heterogeneity_benchmark.sh
+    type: sdk_command
+    file_manager: sdk
+
 #######################
 # XGBoost release tests
 #######################

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -645,7 +645,7 @@
   group: AIR tests
   working_dir: air_tests/air_benchmarks/mlperf-train
 
-  stable: true
+  stable: false
   env: staging
 
   frequency: nightly


### PR DESCRIPTION
Signed-off-by: Stephanie Wang <swang@cs.berkeley.edu>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a release test for heterogeneous clusters with 1 trainer node and multiple smaller CPU instances. The goal is to ensure stable performance when preprocessing tasks and data are spread in the cluster. Ideally we would compare against single-node performance too, but will leave this for a follow-up.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
