### PR TITLE
[core] Enable channelz and reflection for gRPC.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -47,6 +47,8 @@ cc_library(
         ":stats_metric",
         "@boost//:asio",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_github_grpc_grpc//:grpcpp_admin",
+        "@com_github_grpc_grpc//:grpc++_reflection",
         "@com_google_protobuf//:protobuf",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -47,8 +47,8 @@ cc_library(
         ":stats_metric",
         "@boost//:asio",
         "@com_github_grpc_grpc//:grpc++",
-        "@com_github_grpc_grpc//:grpcpp_admin",
         "@com_github_grpc_grpc//:grpc++_reflection",
+        "@com_github_grpc_grpc//:grpcpp_admin",
         "@com_google_protobuf//:protobuf",
     ],
 )

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -14,9 +14,10 @@
 
 #include "ray/rpc/grpc_server.h"
 
-#include <grpcpp/impl/service_type.h>
-#include <boost/asio/detail/socket_holder.hpp>
 #include <grpcpp/ext/channelz_service_plugin.h>
+#include <grpcpp/impl/service_type.h>
+
+#include <boost/asio/detail/socket_holder.hpp>
 
 #include "ray/common/ray_config.h"
 #include "ray/rpc/common.h"

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -15,8 +15,8 @@
 #include "ray/rpc/grpc_server.h"
 
 #include <grpcpp/impl/service_type.h>
-
 #include <boost/asio/detail/socket_holder.hpp>
+#include <grpcpp/ext/channelz_service_plugin.h>
 
 #include "ray/common/ray_config.h"
 #include "ray/rpc/common.h"
@@ -42,6 +42,8 @@ GrpcServer::GrpcServer(std::string name,
   // Enable built in health check implemented by gRPC:
   //   https://github.com/grpc/grpc/blob/master/doc/health-checking.md
   grpc::EnableDefaultHealthCheckService(true);
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+  grpc::channelz::experimental::InitChannelzService();
 }
 
 void GrpcServer::Run() {
@@ -70,7 +72,6 @@ void GrpcServer::Run() {
   // client to back-off keepalive pings. (https://github.com/ray-project/ray/issues/25367)
   builder.AddChannelArgument(GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS,
                              60000);
-
   if (RayConfig::instance().USE_TLS()) {
     // Create credentials from locations specified in config
     std::string rootcert = ReadCert(RayConfig::instance().TLS_CA_CERT());

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -15,6 +15,7 @@
 #include "ray/rpc/grpc_server.h"
 
 #include <grpcpp/ext/channelz_service_plugin.h>
+#include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/impl/service_type.h>
 
 #include <boost/asio/detail/socket_holder.hpp>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR enable channelz and reflection for gRPC.

Channelz is useful to debug grpc related issues (https://github.com/grpc/proposal/blob/master/A14-channelz.md)

gRPC reflection enable [grpcurl](https://github.com/fullstorydev/grpcurl) and [grpcui](https://github.com/fullstorydev/grpcui) to interact with gRPC servers.
With reflection turned on, we can query the gRPC server easily without protobuf predefined.



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
