### PR TITLE
[Datasets] Fix `from_torch` docstring

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1411,14 +1411,18 @@ def from_torch(
     dataset: "torch.utils.data.Dataset",
 ) -> Dataset:
     """Create a dataset from a Torch dataset.
+
     This function is inefficient. Use it to read small datasets or prototype.
+
     .. warning::
         If your dataset is large, this function may execute slowly or raise an
         out-of-memory error. To avoid issues, read the underyling data with a function
         like :meth:`~ray.data.read_images`.
+
     .. note::
         This function isn't paralellized. It loads the entire dataset into the head
         node's memory before moving the data to the distributed object store.
+
     Examples:
         >>> import ray
         >>> from torchvision import datasets
@@ -1428,8 +1432,10 @@ def from_torch(
         Dataset(num_blocks=200, num_rows=60000, schema=<class 'tuple'>)
         >>> dataset.take(1)  # doctest: +SKIP
         [(<PIL.Image.Image image mode=L size=28x28 at 0x...>, 5)]
+
     Args:
         dataset: A Torch dataset.
+
     Returns:
         A :class:`Dataset` that contains the samples stored in the Torch dataset.
     """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

CI is failing because of missing newlines in the `from_torch` docstring. This PR adds the missing newlines.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/30105

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
