### PR TITLE
[core][scalability] Don't duplicate pull resources.

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1019,24 +1019,6 @@ void NodeManager::NodeAdded(const GcsNodeInfo &node_info) {
   // Store address of the new node manager for rpc requests.
   remote_node_manager_addresses_[node_id] =
       std::make_pair(node_info.node_manager_address(), node_info.node_manager_port());
-
-  // Fetch resource info for the remote node and update cluster resource map.
-  RAY_CHECK_OK(gcs_client_->NodeResources().AsyncGetResources(
-      node_id,
-      [this, node_id](
-          Status status,
-          const boost::optional<gcs::NodeResourceInfoAccessor::ResourceMap> &data) {
-        if (data) {
-          ResourceRequest resources;
-          for (auto &resource_entry : *data) {
-            resources.Set(scheduling::ResourceID(resource_entry.first),
-                          FixedPoint(resource_entry.second->resource_capacity()));
-          }
-          if (ResourceCreateUpdated(node_id, resources)) {
-            cluster_task_manager_->ScheduleAndDispatchTasks();
-          }
-        }
-      }));
 }
 
 void NodeManager::NodeRemoved(const NodeID &node_id) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1019,6 +1019,7 @@ void NodeManager::NodeAdded(const GcsNodeInfo &node_info) {
   // Store address of the new node manager for rpc requests.
   remote_node_manager_addresses_[node_id] =
       std::make_pair(node_info.node_manager_address(), node_info.node_manager_port());
+  cluster_resource_scheduler_->GetClusterResourceManager().AddNode(scheduling::NodeID(node_id.Binary()));
 }
 
 void NodeManager::NodeRemoved(const NodeID &node_id) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1019,7 +1019,8 @@ void NodeManager::NodeAdded(const GcsNodeInfo &node_info) {
   // Store address of the new node manager for rpc requests.
   remote_node_manager_addresses_[node_id] =
       std::make_pair(node_info.node_manager_address(), node_info.node_manager_port());
-  cluster_resource_scheduler_->GetClusterResourceManager().AddNode(scheduling::NodeID(node_id.Binary()));
+  cluster_resource_scheduler_->GetClusterResourceManager().AddNode(
+      scheduling::NodeID(node_id.Binary()));
 }
 
 void NodeManager::NodeRemoved(const NodeID &node_id) {

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -79,6 +79,16 @@ bool ClusterResourceManager::UpdateNode(scheduling::NodeID node_id,
   return true;
 }
 
+bool ClusterResourceManager::AddNode(scheduling::NodeID node_id) {
+  auto it = nodes_.find(node_id);
+  if (it != nodes_.end()) {
+    return false;
+  }
+
+  nodes_.emplace(node_id, NodeResources());
+  return true;
+}
+
 bool ClusterResourceManager::RemoveNode(scheduling::NodeID node_id) {
   auto it = nodes_.find(node_id);
   if (it == nodes_.end()) {

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -69,6 +69,11 @@ class ClusterResourceManager {
   /// \param node_id ID of the node to be removed.
   bool RemoveNode(scheduling::NodeID node_id);
 
+  /// Add node to the cluster.
+  ///
+  /// \param node_id ID of the node to be removed.
+  bool AddNode(scheduling::NodeID node_id);
+
   /// Get number of nodes in the cluster.
   int64_t NumNodes() const;
 


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The node resources now is pushed in resource broadcasting ([code](https://github.com/ray-project/ray/blob/master/src/ray/gcs/gcs_server/ray_syncer.h#L62-L85)). So pull it on demand is not necessary since eventually it'll be pushed from GCS to the raylet. Besides, the push from GCS to the Raylet aggregate the messages so the request is smaller.

The worst thing is that pull it on demand will increase the overhead of GCS a lot. If we have 2k nodes, then it'll be 4m requests (N^2) and it slow down GCS.

This PR disable the on demand pull.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
