### PR TITLE
[metrics] Hide finished task series by default; fix active actors query

### DIFF
--- a/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -14,8 +14,8 @@ class Target:
 
     A panel will have one or more targets. By default, all targets are rendered as
     stacked area charts, with the exception of legend="MAX", which is rendered as
-    a blue dotted line. The legend="FINISHED|FAILED" series will also be rendered hidden
-    by default.
+    a blue dotted line. Any legend="FINISHED|FAILED|DEAD" series will also be rendered
+    hidden by default.
 
     Attributes:
         expr: The prometheus query to evaluate.
@@ -357,7 +357,7 @@ PANEL_TEMPLATE = {
         },
         {
             "$$hashKey": "object:78",
-            "alias": "/FINISHED|FAILED/",
+            "alias": "/FINISHED|FAILED|DEAD/",
             "hiddenSeries": true,
         },
     ],

--- a/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -355,10 +355,10 @@ PANEL_TEMPLATE = {
             "stack": False,
         },
         {
-          "$$hashKey": "object:78",
-          "alias": "FINISHED",
-          "hiddenSeries": true,
-        }
+            "$$hashKey": "object:78",
+            "alias": "FINISHED",
+            "hiddenSeries": true,
+        },
     ],
     "spaceLength": 10,
     "stack": True,

--- a/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -14,7 +14,7 @@ class Target:
 
     A panel will have one or more targets. By default, all targets are rendered as
     stacked area charts, with the exception of legend="MAX", which is rendered as
-    a blue dotted line. The legend="FINISHED" series will also be rendered hidden
+    a blue dotted line. The legend="FINISHED|FAILED" series will also be rendered hidden
     by default.
 
     Attributes:
@@ -357,7 +357,7 @@ PANEL_TEMPLATE = {
         },
         {
             "$$hashKey": "object:78",
-            "alias": "FINISHED",
+            "alias": "/FINISHED|FAILED/",
             "hiddenSeries": true,
         },
     ],

--- a/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -59,7 +59,7 @@ GRAFANA_PANELS = [
     Panel(
         id=26,
         title="Scheduler Task State",
-        description="Current number of tasks currently in a particular state.\n\nState: the task state, as described by rpc::TaskState proto in common.proto.",
+        description="Current number of tasks in a particular state.\n\nState: the task state, as described by rpc::TaskState proto in common.proto.",
         unit="tasks",
         targets=[
             Target(
@@ -83,7 +83,7 @@ GRAFANA_PANELS = [
     Panel(
         id=33,
         title="Scheduler Actor State",
-        description="Current number of actors currently in a particular state.\n\nState: the actor state, as described by rpc::ActorTableData proto in gcs.proto.",
+        description="Current number of actors in a particular state.\n\nState: the actor state, as described by rpc::ActorTableData proto in gcs.proto.",
         unit="actors",
         targets=[
             Target(
@@ -99,7 +99,7 @@ GRAFANA_PANELS = [
         unit="actors",
         targets=[
             Target(
-                expr="sum(ray_actors{State!=\"DEAD\") by (Name)",
+                expr='sum(ray_actors{State!="DEAD") by (Name)',
                 legend="{{Name}}",
             )
         ],
@@ -107,7 +107,7 @@ GRAFANA_PANELS = [
     Panel(
         id=27,
         title="Scheduler CPUs (logical slots)",
-        description="Logical CPU usage of Ray. The dotted line indicates the total number of CPUs. The logical CPU is allocated by `num_cpus` arguments from tasks and actors. \n\nNOTE: Ray's logical CPU is different from physical CPU usage. Ray's logical CPU is allocated by `num_cpus` arguments.",
+        description="Logical CPU usage of Ray. The dotted line indicates the total number of CPUs. The logical CPU is allocated by `num_cpus` arguments from tasks and actors.\n\nNOTE: Ray's logical CPU is different from physical CPU usage. Ray's logical CPU is allocated by `num_cpus` arguments.",
         unit="cores",
         targets=[
             Target(

--- a/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -353,6 +353,11 @@ PANEL_TEMPLATE = {
             "color": "#1F60C4",
             "fill": 0,
             "stack": False,
+        },
+        {
+          "$$hashKey": "object:78",
+          "alias": "FINISHED",
+          "hiddenSeries": true,
         }
     ],
     "spaceLength": 10,

--- a/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -358,7 +358,7 @@ PANEL_TEMPLATE = {
         {
             "$$hashKey": "object:78",
             "alias": "/FINISHED|FAILED|DEAD/",
-            "hiddenSeries": true,
+            "hiddenSeries": True,
         },
     ],
     "spaceLength": 10,

--- a/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -99,7 +99,7 @@ GRAFANA_PANELS = [
         unit="actors",
         targets=[
             Target(
-                expr="sum(ray_actors) by (Name)",
+                expr="sum(ray_actors{State!=\"DEAD\") by (Name)",
                 legend="{{Name}}",
             )
         ],

--- a/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -14,7 +14,8 @@ class Target:
 
     A panel will have one or more targets. By default, all targets are rendered as
     stacked area charts, with the exception of legend="MAX", which is rendered as
-    a blue dotted line.
+    a blue dotted line. The legend="FINISHED" series will also be rendered hidden
+    by default.
 
     Attributes:
         expr: The prometheus query to evaluate.

--- a/src/ray/stats/metric_defs.cc
+++ b/src/ray/stats/metric_defs.cc
@@ -31,6 +31,11 @@ namespace stats {
 /// NOTE: When adding a new metric, add the metric name to the _METRICS list in
 /// python/ray/tests/test_metrics_agent.py to ensure that its existence is tested.
 
+
+/// ===============================================================================
+/// =============== PUBLIC METRICS; keep in sync with metrics.rst =================
+/// ===============================================================================
+
 /// Tracks tasks by state, including pending, running, and finished tasks.
 /// This metric may be recorded from multiple components processing the task in Ray,
 /// including the submitting core worker, executor core worker, and pull manager.
@@ -60,6 +65,42 @@ DEFINE_stats(actors,
              ("State", "Name", "Source"),
              (),
              ray::stats::GAUGE);
+
+/// Logical resource usage reported by raylets.
+DEFINE_stats(resources,
+             // TODO(sang): Support placement_group_reserved_available | used
+             "Logical Ray resources broken per state {AVAILABLE, USED}",
+             ("Name", "State"),
+             (),
+             ray::stats::GAUGE);
+
+/// Object store memory usage.
+DEFINE_stats(
+    object_store_memory,
+    "Object store memory by various sub-kinds on this node",
+    /// Location:
+    ///    - MMAP_SHM: currently in shared memory(e.g. /dev/shm).
+    ///    - MMAP_DISK: memory that's fallback allocated on mmapped disk,
+    ///      e.g. /tmp.
+    ///    - WORKER_HEAP: ray objects smaller than ('max_direct_call_object_size',
+    ///      default 100KiB) stored in process memory, i.e. inlined return
+    ///      values, placeholders for objects stored in plasma store.
+    ///    - SPILLED: current number of bytes from objects spilled
+    ///      to external storage. Note this might be smaller than
+    ///      the physical storage incurred on the external storage because
+    ///      Ray might fuse spilled objects into a single file, so a deleted
+    ///      spill object might still exist in the spilled file. Check
+    ///      spilled object fusing for more details.
+    /// ObjectState:
+    ///    - SEALED: sealed objects bytes (could be MMAP_SHM or MMAP_DISK)
+    ///    - UNSEALED: unsealed objects bytes (could be MMAP_SHM or MMAP_DISK)
+    (ray::stats::LocationKey.name(), ray::stats::ObjectStateKey.name()),
+    (),
+    ray::stats::GAUGE);
+
+/// ===============================================================================
+/// ===================== INTERNAL SYSTEM METRICS =================================
+/// ===============================================================================
 
 /// Event stats
 DEFINE_stats(operation_count, "operation count", ("Method"), (), ray::stats::GAUGE);
@@ -184,14 +225,6 @@ DEFINE_stats(scheduler_failed_worker_startup_total,
              (),
              ray::stats::GAUGE);
 
-/// Raylet Resource Manager
-DEFINE_stats(resources,
-             // TODO(sang): Support placement_group_reserved_available | used
-             "Logical Ray resources broken per state {AVAILABLE, USED}",
-             ("Name", "State"),
-             (),
-             ray::stats::GAUGE);
-
 /// Local Object Manager
 DEFINE_stats(
     spill_manager_objects,
@@ -226,30 +259,6 @@ DEFINE_stats(gcs_storage_operation_count,
              ("Operation"),
              (),
              ray::stats::COUNT);
-
-/// Object store
-DEFINE_stats(
-    object_store_memory,
-    "Object store memory by various sub-kinds on this node",
-    /// Location:
-    ///    - MMAP_SHM: currently in shared memory(e.g. /dev/shm).
-    ///    - MMAP_DISK: memory that's fallback allocated on mmapped disk,
-    ///      e.g. /tmp.
-    ///    - WORKER_HEAP: ray objects smaller than ('max_direct_call_object_size',
-    ///      default 100KiB) stored in process memory, i.e. inlined return
-    ///      values, placeholders for objects stored in plasma store.
-    ///    - SPILLED: current number of bytes from objects spilled
-    ///      to external storage. Note this might be smaller than
-    ///      the physical storage incurred on the external storage because
-    ///      Ray might fuse spilled objects into a single file, so a deleted
-    ///      spill object might still exist in the spilled file. Check
-    ///      spilled object fusing for more details.
-    /// ObjectState:
-    ///    - SEALED: sealed objects bytes (could be MMAP_SHM or MMAP_DISK)
-    ///    - UNSEALED: unsealed objects bytes (could be MMAP_SHM or MMAP_DISK)
-    (ray::stats::LocationKey.name(), ray::stats::ObjectStateKey.name()),
-    (),
-    ray::stats::GAUGE);
 
 /// Placement Group
 // The end to end placement group creation latency.

--- a/src/ray/stats/metric_defs.cc
+++ b/src/ray/stats/metric_defs.cc
@@ -31,7 +31,6 @@ namespace stats {
 /// NOTE: When adding a new metric, add the metric name to the _METRICS list in
 /// python/ray/tests/test_metrics_agent.py to ensure that its existence is tested.
 
-
 /// ===============================================================================
 /// =============== PUBLIC METRICS; keep in sync with metrics.rst =================
 /// ===============================================================================

--- a/src/ray/stats/metric_defs.cc
+++ b/src/ray/stats/metric_defs.cc
@@ -32,7 +32,7 @@ namespace stats {
 /// python/ray/tests/test_metrics_agent.py to ensure that its existence is tested.
 
 /// ===============================================================================
-/// =============== PUBLIC METRICS; keep in sync with metrics.rst =================
+/// =========== PUBLIC METRICS; keep in sync with ray-metrics.rst =================
 /// ===============================================================================
 
 /// Tracks tasks by state, including pending, running, and finished tasks.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Use the hiddenSeries feature to hide this by default. It can be shown by clicking on the series, and re-hidden with Ctrl-Click.

Also fix the active actors chart to hide dead actors.