### PR TITLE
[Tune] Fix tests related to `TUNE_ORIG_WORKING_DIR` env variable

### DIFF
--- a/python/ray/tune/execution/ray_trial_executor.py
+++ b/python/ray/tune/execution/ray_trial_executor.py
@@ -146,8 +146,10 @@ class _TrialCleanup:
 
 def _noop_logger_creator(config, logdir, should_chdir: bool = True):
     # Upon remote process setup, record the actor's original working dir before
-    # changing the working dir to the Tune logdir
-    os.environ["TUNE_ORIG_WORKING_DIR"] = os.getcwd()
+    # changing to the Tune logdir
+    # The environment variable may be set already if actor reuse is enabled
+    if not os.getenv("TUNE_ORIG_WORKING_DIR", None):
+        os.environ["TUNE_ORIG_WORKING_DIR"] = os.getcwd()
 
     os.makedirs(logdir, exist_ok=True)
     if should_chdir:

--- a/python/ray/tune/execution/ray_trial_executor.py
+++ b/python/ray/tune/execution/ray_trial_executor.py
@@ -255,6 +255,9 @@ class RayTrialExecutor:
         self._trainable_kwargs = {}
 
         self._chdir_to_trial_dir = chdir_to_trial_dir
+        if ray._private.worker._mode() == ray._private.worker.LOCAL_MODE:
+            # Record the original working dir before changing to the trial logdir
+            os.environ["TUNE_ORIG_WORKING_DIR"] = os.getcwd()
 
     def setup(
         self, max_pending_trials: int, trainable_kwargs: Optional[Dict] = None

--- a/python/ray/tune/execution/ray_trial_executor.py
+++ b/python/ray/tune/execution/ray_trial_executor.py
@@ -42,7 +42,8 @@ DEFAULT_GET_TIMEOUT = 60.0  # seconds
 
 DEFAULT_ENV_VARS = {
     # https://github.com/ray-project/ray/issues/28197
-    "PL_DISABLE_FORK": "1"
+    "PL_DISABLE_FORK": "1",
+    "TUNE_ORIG_WORKING_DIR": "",
 }
 
 
@@ -148,7 +149,7 @@ def _noop_logger_creator(config, logdir, should_chdir: bool = True):
     # Upon remote process setup, record the actor's original working dir before
     # changing to the Tune logdir
     # The environment variable may be set already if actor reuse is enabled
-    if not os.getenv("TUNE_ORIG_WORKING_DIR", None):
+    if not os.getenv("TUNE_ORIG_WORKING_DIR", ""):
         os.environ["TUNE_ORIG_WORKING_DIR"] = os.getcwd()
 
     os.makedirs(logdir, exist_ok=True)

--- a/python/ray/tune/execution/ray_trial_executor.py
+++ b/python/ray/tune/execution/ray_trial_executor.py
@@ -42,8 +42,7 @@ DEFAULT_GET_TIMEOUT = 60.0  # seconds
 
 DEFAULT_ENV_VARS = {
     # https://github.com/ray-project/ray/issues/28197
-    "PL_DISABLE_FORK": "1",
-    "TUNE_ORIG_WORKING_DIR": "",
+    "PL_DISABLE_FORK": "1"
 }
 
 
@@ -148,9 +147,7 @@ class _TrialCleanup:
 def _noop_logger_creator(config, logdir, should_chdir: bool = True):
     # Upon remote process setup, record the actor's original working dir before
     # changing to the Tune logdir
-    # The environment variable may be set already if actor reuse is enabled
-    if not os.getenv("TUNE_ORIG_WORKING_DIR", ""):
-        os.environ["TUNE_ORIG_WORKING_DIR"] = os.getcwd()
+    os.environ.setdefault("TUNE_ORIG_WORKING_DIR", os.getcwd())
 
     os.makedirs(logdir, exist_ok=True)
     if should_chdir:

--- a/python/ray/tune/execution/ray_trial_executor.py
+++ b/python/ray/tune/execution/ray_trial_executor.py
@@ -252,9 +252,6 @@ class RayTrialExecutor:
         self._trainable_kwargs = {}
 
         self._chdir_to_trial_dir = chdir_to_trial_dir
-        if ray._private.worker._mode() == ray._private.worker.LOCAL_MODE:
-            # Record the original working dir before changing to the trial logdir
-            os.environ["TUNE_ORIG_WORKING_DIR"] = os.getcwd()
 
     def setup(
         self, max_pending_trials: int, trainable_kwargs: Optional[Dict] = None

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -533,34 +533,6 @@ class WorkingDirectoryTest(unittest.TestCase):
         tune.run(f)
         ray.shutdown()
 
-    def testWorkingDirLocalMode(self):
-        """Check that the `TUNE_ORIG_WORKING_DIR` also works in local mode."""
-
-        working_dir = os.getcwd()
-
-        def f(config):
-            assert os.environ.get("TUNE_ORIG_WORKING_DIR") == working_dir
-
-        ray.init(num_cpus=1, num_gpus=0, local_mode=True)
-        tune.run(f)
-        ray.shutdown()
-
-        # Env variable is set from the previous local mode run
-        assert os.getenv("TUNE_ORIG_WORKING_DIR", None)
-
-        # Try running from a new working directory without local mode,
-        # when the env variable is already set
-        tmpdir = os.path.realpath(tempfile.mkdtemp())
-        os.chdir(tmpdir)
-
-        def g(config):
-            assert os.environ.get("TUNE_ORIG_WORKING_DIR") == tmpdir
-
-        ray.init(num_cpus=1)
-        tune.run(g)
-        ray.shutdown()
-        os.chdir(working_dir)
-
 
 class TrainableCrashWithFailFast(unittest.TestCase):
     def test(self):

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -523,6 +523,7 @@ class WorkingDirectoryTest(unittest.TestCase):
     def testWorkingDir(self):
         """Trainables should know the original working dir through env variable."""
 
+        os.environ.pop("TUNE_ORIG_WORKING_DIR", None)
         working_dir = os.getcwd()
 
         def f(config):

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -521,14 +521,16 @@ class SearcherTest(unittest.TestCase):
 
 class WorkingDirectoryTest(unittest.TestCase):
     def testWorkingDir(self):
-        """Trainables should know the original working dir on driver through env
-        variable."""
+        """Trainables should know the original working dir through env variable."""
+
         working_dir = os.getcwd()
 
         def f(config):
             assert os.environ.get("TUNE_ORIG_WORKING_DIR") == working_dir
 
+        ray.init(num_cpus=1)
         tune.run(f)
+        ray.shutdown()
 
 
 class TrainableCrashWithFailFast(unittest.TestCase):

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -532,6 +532,34 @@ class WorkingDirectoryTest(unittest.TestCase):
         tune.run(f)
         ray.shutdown()
 
+    def testWorkingDirLocalMode(self):
+        """Check that the `TUNE_ORIG_WORKING_DIR` also works in local mode."""
+
+        working_dir = os.getcwd()
+
+        def f(config):
+            assert os.environ.get("TUNE_ORIG_WORKING_DIR") == working_dir
+
+        ray.init(num_cpus=1, num_gpus=0, local_mode=True)
+        tune.run(f)
+        ray.shutdown()
+
+        # Env variable is set from the previous local mode run
+        assert os.getenv("TUNE_ORIG_WORKING_DIR", None)
+
+        # Try running from a new working directory without local mode,
+        # when the env variable is already set
+        tmpdir = os.path.realpath(tempfile.mkdtemp())
+        os.chdir(tmpdir)
+
+        def g(config):
+            assert os.environ.get("TUNE_ORIG_WORKING_DIR") == tmpdir
+
+        ray.init(num_cpus=1)
+        tune.run(g)
+        ray.shutdown()
+        os.chdir(working_dir)
+
 
 class TrainableCrashWithFailFast(unittest.TestCase):
     def test(self):

--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -341,7 +341,7 @@ def test_tuner_no_chdir_to_trial_dir(runtime_env, tmpdir):
 
     def train_func(config):
         orig_working_dir = Path(os.environ["TUNE_ORIG_WORKING_DIR"])
-        assert orig_working_dir == os.getcwd(), (
+        assert str(orig_working_dir) == os.getcwd(), (
             "Working directory should not have changed from "
             f"{orig_working_dir} to {os.getcwd()}"
         )

--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -362,7 +362,8 @@ def test_tuner_no_chdir_to_trial_dir(runtime_env):
         ),
         param_space={"id": tune.grid_search(list(range(4)))},
     )
-    tuner.fit()
+    results = tuner.fit()
+    assert not results.errors
     ray.shutdown()
 
 
@@ -409,7 +410,8 @@ def test_tuner_relative_pathing_with_env_vars(runtime_env):
         ),
         param_space={"id": tune.grid_search(list(range(4)))},
     )
-    tuner.fit()
+    results = tuner.fit()
+    assert not results.errors
     ray.shutdown()
 
 

--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -28,6 +28,21 @@ from ray.tune.tune_config import TuneConfig
 from ray.tune.tuner import Tuner
 
 
+@pytest.fixture
+def shutdown_only():
+    yield None
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+
+
+@pytest.fixture
+def chdir_tmpdir(tmpdir):
+    old_cwd = os.getcwd()
+    os.chdir(tmpdir)
+    yield tmpdir
+    os.chdir(old_cwd)
+
+
 class DummyTrainer(BaseTrainer):
     _scaling_config_allowed_keys = BaseTrainer._scaling_config_allowed_keys + [
         "num_workers",
@@ -90,6 +105,12 @@ def gen_dataset_func_eager():
 
 class TunerTest(unittest.TestCase):
     """The e2e test for hparam tuning using Tuner API."""
+
+    def setUp(self):
+        ray.init()
+
+    def tearDown(self):
+        ray.shutdown()
 
     def test_tuner_with_xgboost_trainer(self):
         """Test a successful run."""
@@ -274,7 +295,7 @@ class TunerTest(unittest.TestCase):
         ),
     ],
 )
-def test_tuner_api_kwargs(params_expected):
+def test_tuner_api_kwargs(shutdown_only, params_expected):
     tuner_params, assertion = params_expected
 
     tuner = Tuner(lambda config: 1, **tuner_params)
@@ -290,7 +311,7 @@ def test_tuner_api_kwargs(params_expected):
     assert assertion(caught_kwargs)
 
 
-def test_tuner_fn_trainable_checkpoint_at_end_true():
+def test_tuner_fn_trainable_checkpoint_at_end_true(shutdown_only):
     tuner = Tuner(
         lambda config, checkpoint_dir: 1,
         run_config=ray.air.RunConfig(
@@ -301,7 +322,7 @@ def test_tuner_fn_trainable_checkpoint_at_end_true():
         tuner.fit()
 
 
-def test_tuner_fn_trainable_checkpoint_at_end_false():
+def test_tuner_fn_trainable_checkpoint_at_end_false(shutdown_only):
     tuner = Tuner(
         lambda config, checkpoint_dir: 1,
         run_config=ray.air.RunConfig(
@@ -311,7 +332,7 @@ def test_tuner_fn_trainable_checkpoint_at_end_false():
     tuner.fit()
 
 
-def test_tuner_fn_trainable_checkpoint_at_end_none():
+def test_tuner_fn_trainable_checkpoint_at_end_none(shutdown_only):
     tuner = Tuner(
         lambda config, checkpoint_dir: 1,
         run_config=ray.air.RunConfig(
@@ -322,21 +343,16 @@ def test_tuner_fn_trainable_checkpoint_at_end_none():
 
 
 @pytest.mark.parametrize("runtime_env", [{}, {"working_dir": "."}])
-def test_tuner_no_chdir_to_trial_dir(runtime_env, tmpdir):
+def test_tuner_no_chdir_to_trial_dir(shutdown_only, chdir_tmpdir, runtime_env):
     """Tests that setting `chdir_to_trial_dir=False` in `TuneConfig` allows for
     reading relatives paths to the original working directory.
     Also tests that `session.get_trial_dir()` env variable can be used as the directory
     to write data to within the Trainable.
     """
-    old_cwd = os.getcwd()
-    os.chdir(tmpdir)
-
     # Write a data file that we want to read in our training loop
     with open("./read.txt", "w") as f:
         f.write("data")
 
-    if ray.is_initialized():
-        ray.shutdown()
     ray.init(num_cpus=1, runtime_env=runtime_env)
 
     def train_func(config):
@@ -365,17 +381,12 @@ def test_tuner_no_chdir_to_trial_dir(runtime_env, tmpdir):
         artifact_data = open(result.log_dir / "write.txt", "r").read()
         assert artifact_data == f"{result.config['id']}"
 
-    os.chdir(old_cwd)
-    ray.shutdown()
-
 
 @pytest.mark.parametrize("runtime_env", [{}, {"working_dir": "."}])
-def test_tuner_relative_pathing_with_env_vars(runtime_env, tmpdir):
+def test_tuner_relative_pathing_with_env_vars(shutdown_only, chdir_tmpdir, runtime_env):
     """Tests that `TUNE_ORIG_WORKING_DIR` environment variable can be used to access
     relative paths to the original working directory.
     """
-    old_cwd = os.getcwd()
-    os.chdir(tmpdir)
     # Write a data file that we want to read in our training loop
     with open("./read.txt", "w") as f:
         f.write("data")
@@ -383,8 +394,6 @@ def test_tuner_relative_pathing_with_env_vars(runtime_env, tmpdir):
     # Even if we set our runtime_env `{"working_dir": "."}` to the current directory,
     # Tune should still chdir to the trial directory, since we didn't disable the
     # `chdir_to_trial_dir` flag.
-    if ray.is_initialized():
-        ray.shutdown()
     ray.init(num_cpus=1, runtime_env=runtime_env)
 
     def train_func(config):
@@ -415,9 +424,6 @@ def test_tuner_relative_pathing_with_env_vars(runtime_env, tmpdir):
     for result in results:
         artifact_data = open(result.log_dir / "write.txt", "r").read()
         assert artifact_data == f"{result.config['id']}"
-
-    ray.shutdown()
-    os.chdir(old_cwd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/ray/pull/29258 introduced two tests that are failing silently in CI right now.

https://github.com/ray-project/ray/issues/30129 describes the errors that are being seen, and the main issue is that the `TUNE_ORIG_WORKING_DIR` environment variable gets updated incorrectly when `reuse_actors=True`.

Failure mode:
1. Run an experiment from some `orig_working_dir` with `should_chdir_to_trial_dir=True`.
2. Upon trial 0's actor initialization, the environment variable for this actor gets set to `orig_working_dir`. Then, the actor changes its working dir to trial 0's logdir: `~/ray_results/exp_name/trial_0`.
3. Trial 0 finishes, and trial 1 reuses trial 0's actor. Trial 1 then overwrites the existing `TUNE_ORIG_WORKING_DIR` to the current working directory, which has already changed to trial 0's logdir.
    - **Instead, the environment variable should only be set once.**

This PR also fixes the tests to fail on any trial failures and also changes to using a tempdir as the working directory (so that the `runtime_env` test doesn't need to copy many files).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/30129

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
