### PR TITLE
Fix ParameterNoise postprocessing bug

### DIFF
--- a/rllib/utils/exploration/parameter_noise.py
+++ b/rllib/utils/exploration/parameter_noise.py
@@ -233,7 +233,7 @@ class ParameterNoise(Exploration):
         # TODO(sven): Find out whether this can be scrapped by simply using
         #  the `sample_batch` to get the noisy/noise-free action dist.
         _, _, fetches = policy.compute_actions_from_input_dict(
-            input_dict=sample_batch, explore=self.weights_are_currently_noisy
+            input_dict=sample_batch.copy(), explore=self.weights_are_currently_noisy
         )
 
         # Categorical case (e.g. DQN).
@@ -251,7 +251,7 @@ class ParameterNoise(Exploration):
             noise_free_action_dist = action_dist
 
         _, _, fetches = policy.compute_actions_from_input_dict(
-            input_dict=sample_batch, explore=not self.weights_are_currently_noisy
+            input_dict=sample_batch.copy(), explore=not self.weights_are_currently_noisy
         )
 
         # Categorical case (e.g. DQN).


### PR DESCRIPTION
This should not overwrite the actions in the sample batch.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The ParameterNoise postprocessing method right now (inadvertently) overwrites all the actions in the sample batch with the non-noisy actions. I.e. if the original policy would have taken action 0, but because of the parameter noise we took action 1 and got reward 10 etc, the postprocessing will change the sample batch from `action 1, reward 10, etc` to `action 0, reward 10, etc`, even though it wasn't action 0 that led to that reward etc. This is because it passes a reference to the sample batch into `policy.compute_actions_from_input_dict()` as the input dict, which overwrites the actions in whatever is passed to it (which is usually the intent).

The PR instead passes a copy of the sample batch to `policy.compute_actions_from_input_dict()`, which fixes the issue.

## Related issue number

Closes  #30147

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
