### PR TITLE
[core] fix test failure for test_object_unpin

### DIFF
--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -454,8 +454,8 @@ def test_object_unpin(ray_start_cluster):
     wait_for_condition(lambda: check_memory(11))
 
     # The second node is dead, and actor 2 is dead.
-    # Increase timeout for node failure to address CI failure in https://github.com/ray-project/ray/issues/30149
     cluster.remove_node(nodes[1], allow_graceful=False)
+    # Increase timeout for node failure to address CI failure in https://github.com/ray-project/ray/issues/30149q
     wait_for_condition(lambda: wait_until_node_dead(nodes[1]), timeout=20)
     wait_for_condition(lambda: check_memory(10))
 

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -361,11 +361,11 @@ def test_object_unpin(ray_start_cluster):
         num_cpus=0,
         object_store_memory=100 * 1024 * 1024,
         _system_config={
-            "num_heartbeats_timeout": 10,
+            "num_heartbeats_timeout": 5,
             "subscriber_timeout_ms": 100,
             "health_check_initial_delay_ms": 0,
             "health_check_period_ms": 1000,
-            "health_check_failure_threshold": 10,
+            "health_check_failure_threshold": 5,
         },
     )
     ray.init(address=cluster.address)
@@ -455,9 +455,7 @@ def test_object_unpin(ray_start_cluster):
 
     # The second node is dead, and actor 2 is dead.
     cluster.remove_node(nodes[1], allow_graceful=False)
-    # Increase timeout for node failure to address CI failure in
-    # https://github.com/ray-project/ray/issues/30149q
-    wait_for_condition(lambda: wait_until_node_dead(nodes[1]), timeout=20)
+    wait_for_condition(lambda: wait_until_node_dead(nodes[1]))
     wait_for_condition(lambda: check_memory(10))
 
     # The first actor is dead, so object should be GC'ed.

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -455,7 +455,8 @@ def test_object_unpin(ray_start_cluster):
 
     # The second node is dead, and actor 2 is dead.
     cluster.remove_node(nodes[1], allow_graceful=False)
-    # Increase timeout for node failure to address CI failure in https://github.com/ray-project/ray/issues/30149q
+    # Increase timeout for node failure to address CI failure in
+    # https://github.com/ray-project/ray/issues/30149q
     wait_for_condition(lambda: wait_until_node_dead(nodes[1]), timeout=20)
     wait_for_condition(lambda: check_memory(10))
 

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -454,8 +454,9 @@ def test_object_unpin(ray_start_cluster):
     wait_for_condition(lambda: check_memory(11))
 
     # The second node is dead, and actor 2 is dead.
+    # Increase timeout for node failure to address CI failure in https://github.com/ray-project/ray/issues/30149
     cluster.remove_node(nodes[1], allow_graceful=False)
-    wait_for_condition(lambda: wait_until_node_dead(nodes[1]))
+    wait_for_condition(lambda: wait_until_node_dead(nodes[1]), timeout=20)
     wait_for_condition(lambda: check_memory(10))
 
     # The first actor is dead, so object should be GC'ed.


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

Fix CI failure

seems it is now taking longer for the node to be killed and that triggered timeout in the test: https://github.com/ray-project/ray/issues/30149

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
