### PR TITLE
[rfc] [air] Create checkpoints from directory populator fn

### DIFF
--- a/python/ray/air/checkpoint.py
+++ b/python/ray/air/checkpoint.py
@@ -230,7 +230,7 @@ class Checkpoint:
 
         # If set, Ray AIR manages the lifecycle. In the base case, data will be
         # deleted from disk on checkpoint deconstruction.
-        self._managed = False
+        self._ephemeral = False
 
     def __repr__(self):
         parameter, argument = self.get_internal_representation()
@@ -270,6 +270,9 @@ class Checkpoint:
             cloud storage or locally available file URI).
 
         """
+        if self._ephemeral:
+            return None
+
         if self._uri:
             return self._uri
 
@@ -493,7 +496,7 @@ class Checkpoint:
         temp_directory = tempfile.mkdtemp()
         populator(temp_directory)
         checkpoint = cls.from_directory(temp_directory)
-        checkpoint._managed = True
+        checkpoint._ephemeral = True
         return checkpoint
 
     # TODO: Deprecate `from_checkpoint`. For context, see #29058.
@@ -801,7 +804,7 @@ class Checkpoint:
         )
 
     def __del__(self):
-        if self._managed:
+        if self._ephemeral:
             assert self._local_path
             shutil.rmtree(self._local_path)
 

--- a/python/ray/air/checkpoint.py
+++ b/python/ray/air/checkpoint.py
@@ -14,13 +14,13 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     Iterator,
     Optional,
     Tuple,
     Type,
     Union,
-    Callable,
 )
 
 import ray

--- a/python/ray/air/tests/test_checkpoints.py
+++ b/python/ray/air/tests/test_checkpoints.py
@@ -7,10 +7,10 @@ import unittest
 from pathlib import Path
 from typing import Any
 
-import cloudpickle
 import pytest
 
 import ray
+import ray.cloudpickle as cloudpickle
 from ray.air._internal.remote_storage import _ensure_directory, delete_at_uri
 from ray.air.checkpoint import _DICT_CHECKPOINT_ADDITIONAL_FILE_KEY, Checkpoint
 from ray.air.constants import MAX_REPR_LENGTH, PREPROCESSOR_KEY

--- a/python/ray/air/tests/test_checkpoints.py
+++ b/python/ray/air/tests/test_checkpoints.py
@@ -488,6 +488,9 @@ class CheckpointsConversionTest(unittest.TestCase):
             lambda dir: (Path(dir) / "data.txt").write_text("Data")
         )
 
+        # Ephemeral checkpoints shouldn't have their URI set
+        assert not checkpoint.uri
+
         # Assert data is correctly saved
         with checkpoint.as_directory() as dir:
             assert (Path(dir) / "data.txt").read_text() == "Data"


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This adds `Checkpoint.from_directory_populator()` to offer a way to simply create checkpoints from directories.

A common user flow is to write checkpoint content to a directory. User-created directories have the problem that it's the users burden to manage the lifecycle, i.e. the directories have to be cleaned up after creation. It also prevents us from optimizing directory storage or transfer, as this would implicitly take over control of user-created directories.

The proposed API is the counterpart to `Checkpoint.as_directory()`, but for writing instead of reading. Ray AIR guarantees to create a writable directory to put checkpoint content into. After creating the checkpoint object, the data on local disk is managed by us. In this case, this just means that the data is cleaned up once the checkpoint object is destructed.

Open to different naming.



## Related issue number

Closes #30070

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
