### PR TITLE
[Agent] Fix the agent logs streamed to drivers.

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -476,6 +476,7 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+
     try:
         logging_params = dict(
             logging_level=args.logging_level,

--- a/dashboard/optional_utils.py
+++ b/dashboard/optional_utils.py
@@ -271,7 +271,7 @@ def init_ray_and_catch_exceptions() -> Callable:
                         ray.init(
                             address=address,
                             log_to_driver=False,
-                            _logging_handler=logging.getLogger(),
+                            configure_logging=False,
                             namespace=RAY_INTERNAL_DASHBOARD_NAMESPACE,
                         )
                     except Exception as e:

--- a/dashboard/optional_utils.py
+++ b/dashboard/optional_utils.py
@@ -271,6 +271,7 @@ def init_ray_and_catch_exceptions() -> Callable:
                         ray.init(
                             address=address,
                             log_to_driver=False,
+                            _logging_handler=logging.getLogger(),
                             namespace=RAY_INTERNAL_DASHBOARD_NAMESPACE,
                         )
                     except Exception as e:

--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -25,8 +25,8 @@ def setup_logger(
         _default_handler = logging.StreamHandler()
         logger.addHandler(_default_handler)
     _default_handler.setFormatter(logging.Formatter(logging_format))
-    # # Setting this will avoid the message
-    # # being propagated to the parent logger.
+    # Setting this will avoid the message
+    # being propagated to the parent logger.
     logger.propagate = False
 
 

--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -3,7 +3,7 @@ import os
 import sys
 import threading
 from logging.handlers import RotatingFileHandler
-from typing import Callable
+from typing import Callable, Optional
 
 import ray
 from ray._private.utils import binary_to_hex
@@ -11,20 +11,23 @@ from ray._private.utils import binary_to_hex
 _default_handler = None
 
 
-def setup_logger(logging_level, logging_format):
+def setup_logger(
+    logging_level, logging_format, logging_handler: Optional[logging.Handler] = None
+):
     """Setup default logging for ray."""
-    logger = logging.getLogger("ray")
-    if type(logging_level) is str:
-        logging_level = logging.getLevelName(logging_level.upper())
-    logger.setLevel(logging_level)
-    global _default_handler
-    if _default_handler is None:
-        _default_handler = logging.StreamHandler()
-        logger.addHandler(_default_handler)
-    _default_handler.setFormatter(logging.Formatter(logging_format))
-    # Setting this will avoid the message
-    # being propagated to the parent logger.
-    logger.propagate = False
+    if not logging_handler:
+        logger = logging.getLogger("ray")
+        if type(logging_level) is str:
+            logging_level = logging.getLevelName(logging_level.upper())
+        logger.setLevel(logging_level)
+        global _default_handler
+        if _default_handler is None:
+            _default_handler = logging.StreamHandler()
+            logger.addHandler(_default_handler)
+        _default_handler.setFormatter(logging.Formatter(logging_format))
+        # # Setting this will avoid the message
+        # # being propagated to the parent logger.
+        logger.propagate = False
 
 
 def setup_component_logger(
@@ -226,74 +229,6 @@ def configure_log_file(out_file, err_file):
     sys.stderr = ray._private.utils.open_log(
         stderr_fileno, unbuffered=True, closefd=False
     )
-
-
-def setup_and_get_worker_interceptor_logger(
-    args, max_bytes=0, backup_count=0, is_for_stdout: bool = True
-):
-    """Setup a logger to be used to intercept worker log messages.
-
-    NOTE: This method is only meant to be used within default_worker.py.
-
-    Ray worker logs should be treated in a special way because
-    there's a need to intercept stdout and stderr to support various
-    ray features. For example, ray will prepend 0 or 1 in the beggining
-    of each log message to decide if logs should be streamed to driveres.
-
-    This logger will also setup the RotatingFileHandler for
-    ray workers processes.
-
-    If max_bytes and backup_count is not set, files will grow indefinitely.
-
-    Args:
-        args: args received from default_worker.py.
-        max_bytes: maxBytes argument of RotatingFileHandler.
-        backup_count: backupCount argument of RotatingFileHandler.
-        is_for_stdout: True if logger will be used to intercept stdout.
-                             False otherwise.
-    """
-    file_extension = "out" if is_for_stdout else "err"
-    logger = logging.getLogger(f"ray_default_worker_{file_extension}")
-    if len(logger.handlers) == 1:
-        return logger
-    logger.setLevel(logging.INFO)
-    # TODO(sang): This is how the job id is propagated to workers now.
-    # But eventually, it will be clearer to just pass the job id.
-    job_id = os.environ.get("RAY_JOB_ID")
-    if args.worker_type == "WORKER":
-        assert job_id is not None, (
-            "RAY_JOB_ID should be set as an env "
-            "variable within default_worker.py. If you see this error, "
-            "please report it to Ray's Github issue."
-        )
-        worker_name = "worker"
-    else:
-        job_id = ray.JobID.nil()
-        worker_name = "io_worker"
-
-    # Make sure these values are set already.
-    assert ray._private.worker._global_node is not None
-    assert ray._private.worker.global_worker is not None
-    filename = (
-        f"{ray._private.worker._global_node.get_session_dir_path()}/logs/"
-        f"{worker_name}-"
-        f"{binary_to_hex(ray._private.worker.global_worker.worker_id)}-"
-        f"{job_id}-{os.getpid()}.{file_extension}"
-    )
-    handler = StandardFdRedirectionRotatingFileHandler(
-        filename,
-        maxBytes=max_bytes,
-        backupCount=backup_count,
-        is_for_stdout=is_for_stdout,
-    )
-    logger.addHandler(handler)
-    handler.setFormatter(logging.Formatter("%(message)s"))
-    # Avoid messages are propagated to parent loggers.
-    logger.propagate = False
-    # Remove the terminator. It is important because we don't want this
-    # logger to add a newline at the end of string.
-    handler.terminator = ""
-    return logger
 
 
 class WorkerStandardStreamDispatcher:

--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -3,7 +3,7 @@ import os
 import sys
 import threading
 from logging.handlers import RotatingFileHandler
-from typing import Callable, Optional
+from typing import Callable
 
 import ray
 from ray._private.utils import binary_to_hex
@@ -12,22 +12,22 @@ _default_handler = None
 
 
 def setup_logger(
-    logging_level, logging_format, logging_handler: Optional[logging.Handler] = None
+    logging_level: int,
+    logging_format: str,
 ):
     """Setup default logging for ray."""
-    if not logging_handler:
-        logger = logging.getLogger("ray")
-        if type(logging_level) is str:
-            logging_level = logging.getLevelName(logging_level.upper())
-        logger.setLevel(logging_level)
-        global _default_handler
-        if _default_handler is None:
-            _default_handler = logging.StreamHandler()
-            logger.addHandler(_default_handler)
-        _default_handler.setFormatter(logging.Formatter(logging_format))
-        # # Setting this will avoid the message
-        # # being propagated to the parent logger.
-        logger.propagate = False
+    logger = logging.getLogger("ray")
+    if type(logging_level) is str:
+        logging_level = logging.getLevelName(logging_level.upper())
+    logger.setLevel(logging_level)
+    global _default_handler
+    if _default_handler is None:
+        _default_handler = logging.StreamHandler()
+        logger.addHandler(_default_handler)
+    _default_handler.setFormatter(logging.Formatter(logging_format))
+    # # Setting this will avoid the message
+    # # being propagated to the parent logger.
+    logger.propagate = False
 
 
 def setup_component_logger(

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1192,7 +1192,11 @@ def init(
             arguments is passed in.
     """
     if configure_logging:
-        setup_logger(logging_level, logging_format or ray_constants.LOGGER_FORMAT)
+        setup_logger(
+            logging_level,
+            logging_format or ray_constants.LOGGER_FORMAT,
+            kwargs.pop("_logging_handler", None),
+        )
 
     # Parse the hidden options:
     _enable_object_reconstruction: bool = kwargs.pop(

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1192,11 +1192,7 @@ def init(
             arguments is passed in.
     """
     if configure_logging:
-        setup_logger(
-            logging_level,
-            logging_format or ray_constants.LOGGER_FORMAT,
-            kwargs.pop("_logging_handler", None),
-        )
+        setup_logger(logging_level, logging_format or ray_constants.LOGGER_FORMAT)
 
     # Parse the hidden options:
     _enable_object_reconstruction: bool = kwargs.pop(


### PR DESCRIPTION
Signed-off-by: SangBin Cho <rkooo567@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Right now, when ray is initialized, it starts its own logger (getLogger("ray")) with a handler (streamHandler) that's not controllable by users. When the ray.init is called within an agent, all the children loggers start sending logs to this "ray" logger, which prints all logs to stderr. Since the agent is a child of raylet, all stderr are redirected to the parent stderr, which is raylet.err. All the logs in raylet.err are printed to the driver by the log monitor.

This PR fixes the issue by not configuring the default ray logger when ray.init is called. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/29944

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
