### PR TITLE
[ml-release] [no_ci] fix xgboost/lightgbm tune release tests.

### DIFF
--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -26,7 +26,7 @@ optuna==2.10.0
 pymoo==0.5.0
 pytest-remotedata==0.3.2
 lightning-bolts==0.4.0
-protobuf<=3.20.1
+protobuf==3.20.1
 pytorch-lightning==1.5.10
 shortuuid==1.0.1
 scikit-optimize==0.9.0

--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -26,6 +26,7 @@ optuna==2.10.0
 pymoo==0.5.0
 pytest-remotedata==0.3.2
 lightning-bolts==0.4.0
+protobuf<=3.20.1
 pytorch-lightning==1.5.10
 shortuuid==1.0.1
 scikit-optimize==0.9.0

--- a/release/lightgbm_tests/app_config.yaml
+++ b/release/lightgbm_tests/app_config.yaml
@@ -6,14 +6,14 @@ debian_packages:
 python:
   pip_packages:
     - pytest
-    - lightgbm_ray
+    - lightgbm_ray  # this will install protobuf version beyond the upper bound of what Tune allows
     - petastorm
     - tblib
   conda_packages: []
 
 post_build_cmds:
   - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
-  - pip3 install ray[default] # Needed for Ray Client to work.
+  - pip3 install ray[tune] # Needed for Ray Client to work. Installing Tune dependency so we can get protobuf version back.
   - pip3 install -U --force-reinstall --no-deps xgboost xgboost_ray lightgbm_ray petastorm  # Avoid caching
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   - sudo mkdir -p /data || true

--- a/release/xgboost_tests/app_config.yaml
+++ b/release/xgboost_tests/app_config.yaml
@@ -6,14 +6,14 @@ debian_packages:
 python:
   pip_packages:
     - pytest
-    - xgboost_ray
+    - xgboost_ray  # this will install protobuf version beyond the upper bound of what Tune allows
     - petastorm
     - tblib
   conda_packages: []
 
 post_build_cmds:
   - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
-  - pip3 install ray[default] # Needed for Ray Client to work.
+  - pip3 install ray[tune] # Needed for Ray Client to work. nstalling Tune dependency so we can get protobuf version back.
   - pip3 install -U --force-reinstall --no-deps xgboost xgboost_ray petastorm  # Avoid caching
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   - sudo mkdir -p /data || true


### PR DESCRIPTION
Signed-off-by: xwjiang2010 <xwjiang2010@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?


Seeing errors:
```

(_run_test pid=1194) from ray.air import session
(_run_test pid=1194)
(_run_test pid=1194) def train(config):
(_run_test pid=1194)     # ...
(_run_test pid=1194)     session.report({"metric": metric}, checkpoint=checkpoint)
(_run_test pid=1194)
(_run_test pid=1194) For more information please see https://docs.ray.io/en/master/tune/api_docs/trainable.html
(_run_test pid=1194)
(_run_test pid=1194)   DeprecationWarning,
(_run_test pid=1194) Running on node 172.18.1.163 with settings:
(_run_test pid=1194) {'no_syncer': False, 'upload_dir': 'gs://tune-cloud-tests/durable_upload/test_1666052666', 'experiment_name': 'cloud_durable_upload', 'indicator_file': '/tmp/cloud_durable_upload_indicator', 'trainable': 'function', 'num_cpus_per_trial': 8}
(_run_test pid=1194) Traceback (most recent call last):
(_run_test pid=1194)   File "/tmp/_tune_script.py", line 142, in <module>
(_run_test pid=1194)     run_tune(**run_kwargs)
...in <module>
(_run_test pid=1194)     from tensorboardX.proto import resource_handle_pb2 as tensorboardX_dot_proto_dot_resource__handle__pb2
(_run_test pid=1194)   File "/home/ray/anaconda3/lib/python3.7/site-packages/tensorboardX/proto/resource_handle_pb2.py", line 42, in <module>
(_run_test pid=1194)     serialized_options=None, file=DESCRIPTOR),
(_run_test pid=1194)   File "/home/ray/anaconda3/lib/python3.7/site-packages/google/protobuf/descriptor.py", line 560, in __new__
(_run_test pid=1194)     _message.Message._CheckCalledFromGeneratedFile()
(_run_test pid=1194) TypeError: Descriptors cannot not be created directly.
(_run_test pid=1194) If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
(_run_test pid=1194) If you cannot immediately regenerate your protos, some other possible workarounds are:
(_run_test pid=1194)  1. Downgrade the protobuf package to 3.20.x or lower.
(_run_test pid=1194)  2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```

This is only happening for xgboost/lightgbm_tune tests. The reason is they install xgboost-ray, lightgbm-ray in their corresponding app.yaml. This will unfortunately install protobuf version that is conflicting with tensorboard, which is needed for Tune to work.
The solution is in post-build commands of these cluster env we need to `pip install ray[tune]` which will reinforce the protobuf version needed by tensorboard.
This is an issue that's happening in the specific app.yamls. The ml dockers still have the right protobuf version.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #30193


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
