### PR TITLE
[RLlib] minor bug fix. Resetted exceptions are saved under env_id key.

### DIFF
--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -798,7 +798,7 @@ class EnvRunnerV2:
                 resetted_obs: Dict[
                     EnvID, Dict[AgentID, EnvObsType]
                 ] = self._base_env.try_reset(env_id)
-                if resetted_obs is None or not isinstance(resetted_obs, Exception):
+                if resetted_obs is None or not isinstance(resetted_obs[env_id], Exception):
                     break
                 else:
                     # Report a faulty episode.

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -798,7 +798,9 @@ class EnvRunnerV2:
                 resetted_obs: Dict[
                     EnvID, Dict[AgentID, EnvObsType]
                 ] = self._base_env.try_reset(env_id)
-                if resetted_obs is None or not isinstance(resetted_obs[env_id], Exception):
+                if resetted_obs is None or not isinstance(
+                    resetted_obs[env_id], Exception
+                ):
                     break
                 else:
                     # Report a faulty episode.


### PR DESCRIPTION
Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

This is the exact same logic _env_runner() uses.

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
