### PR TITLE
[RLlib] Policy mapping function usage in env runner v2

### DIFF
--- a/rllib/evaluation/episode_v2.py
+++ b/rllib/evaluation/episode_v2.py
@@ -116,7 +116,7 @@ class EpisodeV2:
         # duration of this episode to the returned PolicyID.
         if agent_id not in self._agent_to_policy or refresh:
             policy_id = self._agent_to_policy[agent_id] = self.policy_mapping_fn(
-                agent_id, self, worker=self.worker
+                agent_id, episode=self, worker=self.worker
             )
         # Use already determined PolicyID.
         else:


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Incase of a lambda policy mapping fn `lambda x, **kwargs: <policy_id>`, we have to be explicit about the episode argument to make it part of **kwargs.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
