### PR TITLE
[Dashboard] Use a func name instead of endpoints for metrics label

### DIFF
--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -121,6 +121,7 @@ class HttpServerDashboardHead:
     @aiohttp.web.middleware
     async def metrics_middleware(self, request, handler):
         start_time = time.monotonic()
+
         try:
             response = await handler(request)
             status_tag = f"{floor(response.status / 100)}xx"
@@ -132,14 +133,14 @@ class HttpServerDashboardHead:
             resp_time = time.monotonic() - start_time
             try:
                 self.metrics.metrics_request_duration.labels(
-                    endpoint=request.path,
+                    endpoint=handler.__name__,
                     http_status=status_tag,
                     SessionName=self._session_name,
                     Component="dashboard",
                 ).observe(resp_time)
                 self.metrics.metrics_request_count.labels(
                     method=request.method,
-                    endpoint=request.path,
+                    endpoint=handler.__name__,
                     http_status=status_tag,
                     SessionName=self._session_name,
                     Component="dashboard",
@@ -151,6 +152,7 @@ class HttpServerDashboardHead:
         # Bind http routes of each module.
         for c in modules:
             dashboard_optional_utils.ClassMethodRouteTable.bind(c)
+
         # Http server should be initialized after all modules loaded.
         # working_dir uploads for job submission can be up to 100MiB.
         app = aiohttp.web.Application(


### PR DESCRIPTION
Signed-off-by: SangBin Cho <rkooo567@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current endpoint label (request.path) creates an infinite different labels when you have parameterized paths. For example "/api/jobs/{job_id}". This causes the high CPU usage when there are many jobs submitted. (It's also generally very dangerous). I observe the CPU usage is as much 70~100% all the time when this happens.

This reduces the cardinality of metrics by using `handler.__name__`. Since the function names are the same for all the parameterized paths, it will keep the small number of "endpoint" labels O(# of funcs), which I believe less than 20. 



use handler.__name__ which doesn't create so many

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
