### PR TITLE
Save release test metrics under a single column

### DIFF
--- a/release/ray_release/reporter/db.py
+++ b/release/ray_release/reporter/db.py
@@ -32,8 +32,8 @@ class DBReporter(Reporter):
             "stable": result.stable,
             "return_code": result.return_code,
             "smoke_test": result.smoke_test,
+            "prometheus_metrics": result.prometheus_metrics or {},
         }
-        result_json.update(result.prometheus_metrics)
 
         logger.debug(f"Result json: {json.dumps(result_json)}")
 


### PR DESCRIPTION
Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/ray/pull/30075 saves release test metrics to DB. Instead of adding a top-level column for each metric, it's cleaner and clearer to put all the metrics under a `prometheus_metrics` column.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
