### PR TITLE
[RLlib] Unify policy mapping function usage

### DIFF
--- a/rllib/algorithms/alpha_star/league_builder.py
+++ b/rllib/algorithms/alpha_star/league_builder.py
@@ -170,8 +170,8 @@ class AlphaStarLeagueBuilder(LeagueBuilder):
 
         # Build initial policy mapping function: main_0 vs main_exploiter_0.
         self.config.policy_mapping_fn = (
-            lambda aid, ep, worker, **kw: "main_0"
-            if ep.episode_id % 2 == aid
+            lambda aid, episode, worker, **kw: "main_0"
+            if episode.episode_id % 2 == aid
             else "main_exploiter_0"
         )
         self.config.policies = policies

--- a/rllib/algorithms/alpha_star/league_builder.py
+++ b/rllib/algorithms/alpha_star/league_builder.py
@@ -170,8 +170,8 @@ class AlphaStarLeagueBuilder(LeagueBuilder):
 
         # Build initial policy mapping function: main_0 vs main_exploiter_0.
         self.config.policy_mapping_fn = (
-            lambda aid, episode, worker, **kw: "main_0"
-            if episode.episode_id % 2 == aid
+            lambda agent_id, episode, worker, **kw: "main_0"
+            if episode.episode_id % 2 == agent_id
             else "main_exploiter_0"
         )
         self.config.policies = policies

--- a/rllib/algorithms/maddpg/tests/test_maddpg.py
+++ b/rllib/algorithms/maddpg/tests/test_maddpg.py
@@ -38,7 +38,9 @@ class TestMADDPG(unittest.TestCase):
                         config={"agent_id": 1},
                     ),
                 },
-                policy_mapping_fn=lambda aid, **kwargs: "pol2" if aid else "pol1",
+                policy_mapping_fn=lambda agent_id, **kwargs: "pol2"
+                if agent_id
+                else "pol1",
             )
         )
 

--- a/rllib/algorithms/tests/test_algorithm.py
+++ b/rllib/algorithms/tests/test_algorithm.py
@@ -42,7 +42,7 @@ class TestAlgorithm(unittest.TestCase):
         ).multi_agent(
             # Start with a single policy.
             policies={"p0"},
-            policy_mapping_fn=lambda aid, eps, worker, **kwargs: "p0",
+            policy_mapping_fn=lambda agent_id, episode, worker, **kwargs: "p0",
             # And only two policies that can be stored in memory at a
             # time.
             policy_map_capacity=2,

--- a/rllib/algorithms/tests/test_algorithm_config.py
+++ b/rllib/algorithms/tests/test_algorithm_config.py
@@ -35,7 +35,7 @@ class TestAlgorithmConfig(unittest.TestCase):
             .training(lr=0.12345, train_batch_size=3000)
             .multi_agent(
                 policies={"pol1": (None, None, None, {"lr": 0.001})},
-                policy_mapping_fn=lambda aid, episode, worker, **kw: "pol1",
+                policy_mapping_fn=lambda agent_id, episode, worker, **kw: "pol1",
             )
         )
         config.freeze()

--- a/rllib/algorithms/tests/test_worker_failures.py
+++ b/rllib/algorithms/tests/test_worker_failures.py
@@ -695,7 +695,7 @@ class TestWorkerFailures(unittest.TestCase):
                     "main_agent": PolicySpec(),
                 },
                 policies_to_train=["main_agent"],
-                policy_mapping_fn=lambda _: "main_agent",
+                policy_mapping_fn=lambda *args, **kwargs: "main_agent",
             )
             .evaluation(
                 evaluation_num_workers=2,

--- a/rllib/env/tests/test_external_multi_agent_env.py
+++ b/rllib/env/tests/test_external_multi_agent_env.py
@@ -66,7 +66,7 @@ class TestExternalMultiAgentEnv(unittest.TestCase):
             )
             .multi_agent(
                 policies={"p0", "p1"},
-                policy_mapping_fn=lambda aid, **kwargs: "p{}".format(aid % 2),
+                policy_mapping_fn=lambda agent_id, **kwargs: "p{}".format(agent_id % 2),
             ),
         )
         batch = ev.sample()

--- a/rllib/env/tests/test_multi_agent_env.py
+++ b/rllib/env/tests/test_multi_agent_env.py
@@ -190,7 +190,9 @@ class TestMultiAgentEnv(unittest.TestCase):
             )
             .multi_agent(
                 policies={"p0", "p1"},
-                policy_mapping_fn=(lambda aid, **kwargs: "p{}".format(aid % 2)),
+                policy_mapping_fn=(
+                    lambda agent_id, **kwargs: "p{}".format(agent_id % 2)
+                ),
             ),
         )
         batch = ev.sample()
@@ -208,7 +210,9 @@ class TestMultiAgentEnv(unittest.TestCase):
             )
             .multi_agent(
                 policies={"p0", "p1"},
-                policy_mapping_fn=(lambda aid, **kwarg: "p{}".format(aid % 2)),
+                policy_mapping_fn=(
+                    lambda agent_id, **kwarg: "p{}".format(agent_id % 2)
+                ),
             ),
         )
         batch = ev.sample()
@@ -226,7 +230,9 @@ class TestMultiAgentEnv(unittest.TestCase):
             )
             .multi_agent(
                 policies={"p0", "p1"},
-                policy_mapping_fn=(lambda aid, **kwargs: "p{}".format(aid % 2)),
+                policy_mapping_fn=(
+                    lambda agent_id, **kwargs: "p{}".format(agent_id % 2)
+                ),
             ),
         )
         # This used to raise an Error due to the EarlyDoneMultiAgent
@@ -462,7 +468,7 @@ class TestMultiAgentEnv(unittest.TestCase):
                     "policy_1": gen_policy(),
                     "policy_2": gen_policy(),
                 },
-                policy_mapping_fn=lambda aid, **kwargs: "policy_1",
+                policy_mapping_fn=lambda agent_id, **kwargs: "policy_1",
             )
             .framework("tf")
         )

--- a/rllib/evaluation/tests/test_episode.py
+++ b/rllib/evaluation/tests/test_episode.py
@@ -127,7 +127,7 @@ class TestEpisodeLastValues(unittest.TestCase):
             .callbacks(LastInfoCallback)
             .multi_agent(
                 policies={str(agent_id) for agent_id in range(NUM_AGENTS)},
-                policy_mapping_fn=lambda aid, eps, **kwargs: str(aid),
+                policy_mapping_fn=lambda agent_id, episode, **kwargs: str(agent_id),
             ),
         )
         ev.sample()

--- a/rllib/evaluation/tests/test_episode_v2.py
+++ b/rllib/evaluation/tests/test_episode_v2.py
@@ -83,7 +83,7 @@ class TestEpisodeV2(unittest.TestCase):
             config=AlgorithmConfig()
             .multi_agent(
                 policies={str(agent_id) for agent_id in range(NUM_AGENTS)},
-                policy_mapping_fn=lambda aid, eps, **kwargs: str(aid),
+                policy_mapping_fn=lambda agent_id, episode, **kwargs: str(agent_id),
             )
             .rollouts(num_rollout_workers=0),
         )

--- a/rllib/evaluation/tests/test_trajectory_view_api.py
+++ b/rllib/evaluation/tests/test_trajectory_view_api.py
@@ -354,7 +354,7 @@ class TestTrajectoryViewAPI(unittest.TestCase):
         config.framework("torch")
         config.multi_agent(
             policies={f"p{i}" for i in range(num_agents)},
-            policy_mapping_fn=lambda aid, **kwargs: "p{}".format(aid),
+            policy_mapping_fn=lambda agent_id, **kwargs: "p{}".format(agent_id),
             count_steps_by="agent_steps",
         )
 

--- a/rllib/examples/centralized_critic.py
+++ b/rllib/examples/centralized_critic.py
@@ -279,7 +279,9 @@ if __name__ == "__main__":
                     },
                 ),
             },
-            policy_mapping_fn=lambda aid, **kwargs: "pol1" if aid == 0 else "pol2",
+            policy_mapping_fn=lambda agent_id, **kwargs: "pol1"
+            if agent_id == 0
+            else "pol2",
         )
         # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
         .resources(num_gpus=int(os.environ.get("RLLIB_NUM_GPUS", "0")))

--- a/rllib/examples/centralized_critic_2.py
+++ b/rllib/examples/centralized_critic_2.py
@@ -127,7 +127,9 @@ if __name__ == "__main__":
                 "pol1": (None, observer_space, action_space, {}),
                 "pol2": (None, observer_space, action_space, {}),
             },
-            policy_mapping_fn=lambda aid, **kwargs: "pol1" if aid == 0 else "pol2",
+            policy_mapping_fn=lambda agent_id, **kwargs: "pol1"
+            if agent_id == 0
+            else "pol2",
             observation_fn=central_critic_observer,
         )
         # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.

--- a/rllib/examples/multi_agent_custom_policy.py
+++ b/rllib/examples/multi_agent_custom_policy.py
@@ -71,7 +71,9 @@ if __name__ == "__main__":
             },
             # Map to either random behavior or PR learning behavior based on
             # the agent's ID.
-            policy_mapping_fn=lambda aid, **kwargs: ["pg_policy", "random"][aid % 2],
+            policy_mapping_fn=lambda agent_id, **kwargs: ["pg_policy", "random"][
+                agent_id % 2
+            ],
             # We wouldn't have to specify this here as the RandomPolicy does
             # not learn anyways (it has an empty `learn_on_batch` method), but
             # it's good practice to define this list here either way.

--- a/rllib/examples/two_step_game.py
+++ b/rllib/examples/two_step_game.py
@@ -136,7 +136,9 @@ if __name__ == "__main__":
                         config={"agent_id": 1},
                     ),
                 },
-                policy_mapping_fn=lambda aid, **kwargs: "pol2" if aid else "pol1",
+                policy_mapping_fn=lambda agent_id, **kwargs: "pol2"
+                if agent_id
+                else "pol1",
             )
         )
     elif args.run == "QMIX":

--- a/rllib/tests/test_io.py
+++ b/rllib/tests/test_io.py
@@ -224,7 +224,7 @@ class AgentIOTest(unittest.TestCase):
             .multi_agent(
                 policies={"policy_1", "policy_2"},
                 policy_mapping_fn=(
-                    lambda aid, **kwargs: random.choice(["policy_1", "policy_2"])
+                    lambda agent_id, **kwargs: random.choice(["policy_1", "policy_2"])
                 ),
             )
         )

--- a/rllib/tests/test_nested_observation_spaces.py
+++ b/rllib/tests/test_nested_observation_spaces.py
@@ -504,10 +504,10 @@ class TestNestedObservationSpaces(unittest.TestCase):
                     ),
                 },
                 policy_mapping_fn=(
-                    lambda aid, **kwargs: {
+                    lambda agent_id, **kwargs: {
                         "tuple_agent": "tuple_policy",
                         "dict_agent": "dict_policy",
-                    }[aid]
+                    }[agent_id]
                 ),
             )
         )

--- a/rllib/utils/tests/test_check_multi_agent.py
+++ b/rllib/utils/tests/test_check_multi_agent.py
@@ -22,7 +22,7 @@ class TestCheckMultiAgent(unittest.TestCase):
             lambda: (
                 PGConfig().multi_agent(
                     policies={1, "good_id"},
-                    policy_mapping_fn=lambda aid, episode, worker, **kw: "good_id",
+                    policy_mapping_fn=lambda agent_id, episode, worker, **kw: "good_id",
                 )
             ),
         )


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Env Runner V2 relies on policy mapping function including agent_id and episode.
If these are either not the first two arguments, or policy mapping function is something like `lambda aid, ep: "1"`, things quickly get messy. This PR is needed to migrate to connectors.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
