### PR TITLE
[RLlib] Fix RolloutWorker.compute_gradients for env runner v2

### DIFF
--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -1108,7 +1108,8 @@ class RolloutWorker(ParallelIteratorWorker):
         # op must not return multi-agent dict b/c of A2C's `.batch()` in the execution
         # plan; this would "batch" over the "default_policy" keys instead of the data).
         if single_agent is True:
-            # SampleBatch -> Calculate gradients for the default policy.
+            if self.config.get("enable_connectors"):
+                samples = samples.policy_batches[DEFAULT_POLICY_ID]
             grad_out, info_out = self.policy_map[DEFAULT_POLICY_ID].compute_gradients(
                 samples
             )

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -1104,11 +1104,9 @@ class RolloutWorker(ParallelIteratorWorker):
         if log_once("compute_gradients"):
             logger.info("Compute gradients on:\n\n{}\n".format(summarize(samples)))
 
-        # Backward compatibility for A2C: Single-agent only (ComputeGradients execution
-        # op must not return multi-agent dict b/c of A2C's `.batch()` in the execution
-        # plan; this would "batch" over the "default_policy" keys instead of the data).
         if single_agent is True:
             if self.config.get("enable_connectors"):
+                # We always sample MA batches from EnvRunnerV2
                 samples = samples.policy_batches[DEFAULT_POLICY_ID]
             grad_out, info_out = self.policy_map[DEFAULT_POLICY_ID].compute_gradients(
                 samples

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -53,6 +53,7 @@ from ray.rllib.offline import (
 )
 from ray.rllib.policy.policy import Policy, PolicySpec
 from ray.rllib.policy.policy_map import PolicyMap
+from ray.rllib.policy.sample_batch import convert_ma_batch_to_sample_batch
 from ray.rllib.utils.filter import NoFilter
 from ray.rllib.utils.from_config import from_config
 from ray.rllib.policy.sample_batch import (
@@ -1105,9 +1106,7 @@ class RolloutWorker(ParallelIteratorWorker):
             logger.info("Compute gradients on:\n\n{}\n".format(summarize(samples)))
 
         if single_agent is True:
-            if self.config.get("enable_connectors"):
-                # We always sample MA batches from EnvRunnerV2
-                samples = samples.policy_batches[DEFAULT_POLICY_ID]
+            samples = convert_ma_batch_to_sample_batch(samples)
             grad_out, info_out = self.policy_map[DEFAULT_POLICY_ID].compute_gradients(
                 samples
             )

--- a/rllib/offline/estimators/direct_method.py
+++ b/rllib/offline/estimators/direct_method.py
@@ -3,6 +3,7 @@ from typing import Dict, Any, Optional, List
 from ray.rllib.offline.estimators.off_policy_estimator import OffPolicyEstimator
 from ray.rllib.offline.estimators.fqe_torch_model import FQETorchModel
 from ray.rllib.policy import Policy
+from ray.rllib.policy.sample_batch import convert_ma_batch_to_sample_batch
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import DeveloperAPI, override
 from ray.rllib.utils.typing import SampleBatchType
@@ -112,6 +113,6 @@ class DirectMethod(OffPolicyEstimator):
         Returns:
             A dict with key "loss" and value as the mean training loss.
         """
-        batch = self.convert_ma_batch_to_sample_batch(batch)
+        batch = convert_ma_batch_to_sample_batch(batch)
         losses = self.model.train(batch)
         return {"loss": np.mean(losses)}

--- a/rllib/offline/estimators/doubly_robust.py
+++ b/rllib/offline/estimators/doubly_robust.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from typing import Dict, Any, Optional, List
 from ray.rllib.policy import Policy
-from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.policy.sample_batch import SampleBatch, convert_ma_batch_to_sample_batch
 from ray.rllib.utils.annotations import DeveloperAPI, override
 from ray.rllib.utils.typing import SampleBatchType
 from ray.rllib.utils.numpy import convert_to_numpy
@@ -142,6 +142,6 @@ class DoublyRobust(OffPolicyEstimator):
         Returns:
             A dict with key "loss" and value as the mean training loss.
         """
-        batch = self.convert_ma_batch_to_sample_batch(batch)
+        batch = convert_ma_batch_to_sample_batch(batch)
         losses = self.model.train(batch)
         return {"loss": np.mean(losses)}

--- a/rllib/offline/estimators/off_policy_estimator.py
+++ b/rllib/offline/estimators/off_policy_estimator.py
@@ -6,6 +6,7 @@ from typing import Dict, Any, List
 import logging
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.policy import Policy
+from ray.rllib.policy.sample_batch import convert_ma_batch_to_sample_batch
 from ray.rllib.utils.policy import compute_log_likelihoods_from_input_dict
 from ray.rllib.utils.annotations import (
     DeveloperAPI,
@@ -150,7 +151,7 @@ class OffPolicyEstimator(OfflineEvaluator):
             - v_gain: v_target / max(v_behavior, 1e-8)
             - v_delta: The difference between v_target and v_behavior.
         """
-        batch = self.convert_ma_batch_to_sample_batch(batch)
+        batch = convert_ma_batch_to_sample_batch(batch)
         self.check_action_prob_in_batch(batch)
         estimates_per_epsiode = []
         if split_batch_by_episode:

--- a/rllib/offline/estimators/tests/utils.py
+++ b/rllib/offline/estimators/tests/utils.py
@@ -60,7 +60,6 @@ def get_cliff_walking_wall_policy_and_data(
     n_eps = 0
     while n_eps < num_episodes:
         batch = synchronous_parallel_sample(worker_set=workers)
-
         for episode in batch.split_by_episode():
             ret = 0
             for r in episode[SampleBatch.REWARDS][::-1]:

--- a/rllib/offline/estimators/tests/utils.py
+++ b/rllib/offline/estimators/tests/utils.py
@@ -60,6 +60,7 @@ def get_cliff_walking_wall_policy_and_data(
     n_eps = 0
     while n_eps < num_episodes:
         batch = synchronous_parallel_sample(worker_set=workers)
+
         for episode in batch.split_by_episode():
             ret = 0
             for r in episode[SampleBatch.REWARDS][::-1]:

--- a/rllib/offline/feature_importance.py
+++ b/rllib/offline/feature_importance.py
@@ -1,5 +1,6 @@
 from typing import Callable, Dict, Any
 from ray.rllib.policy import Policy
+from ray.rllib.policy.sample_batch import convert_ma_batch_to_sample_batch
 from ray.rllib.utils.annotations import override, DeveloperAPI
 from ray.rllib.utils.typing import SampleBatchType
 from ray.rllib.offline.offline_evaluator import OfflineEvaluator
@@ -80,7 +81,7 @@ class FeatureImportance(OfflineEvaluator):
         Returns:
             A dict mapping each feature index string to its importance.
         """
-        batch = self.convert_ma_batch_to_sample_batch(batch)
+        batch = convert_ma_batch_to_sample_batch(batch)
         obs_batch = batch["obs"]
         n_features = obs_batch.shape[-1]
         importance = np.zeros((self.repeat, n_features))

--- a/rllib/offline/offline_evaluator.py
+++ b/rllib/offline/offline_evaluator.py
@@ -55,29 +55,3 @@ class OfflineEvaluator:
         """
         return {}
 
-    @DeveloperAPI
-    def convert_ma_batch_to_sample_batch(self, batch: SampleBatchType) -> SampleBatch:
-        """Converts a MultiAgentBatch to a SampleBatch if neccessary.
-
-        Args:
-            batch: The SampleBatchType to convert.
-
-        Returns:
-            batch: the converted SampleBatch
-
-        Raises:
-            ValueError if the MultiAgentBatch has more than one policy_id
-            or if the policy_id is not `DEFAULT_POLICY_ID`
-        """
-        # TODO: Make this a util to sample_batch.py
-        if isinstance(batch, MultiAgentBatch):
-            policy_keys = batch.policy_batches.keys()
-            if len(policy_keys) == 1 and DEFAULT_POLICY_ID in policy_keys:
-                batch = batch.policy_batches[DEFAULT_POLICY_ID]
-            else:
-                raise ValueError(
-                    "Off-Policy Estimation is not implemented for "
-                    "multi-agent batches. You can set "
-                    "`off_policy_estimation_methods: {}` to resolve this."
-                )
-        return batch

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -1564,3 +1564,30 @@ def concat_samples_into_ma_batch(samples: List[SampleBatchType]) -> "MultiAgentB
 
 def _concat_key(*values, time_major=None):
     return concat_aligned(list(values), time_major)
+
+
+@DeveloperAPI
+def convert_ma_batch_to_sample_batch(batch: SampleBatchType) -> SampleBatch:
+    """Converts a MultiAgentBatch to a SampleBatch if neccessary.
+
+    Args:
+        batch: The SampleBatchType to convert.
+
+    Returns:
+        batch: the converted SampleBatch
+
+    Raises:
+        ValueError if the MultiAgentBatch has more than one policy_id
+        or if the policy_id is not `DEFAULT_POLICY_ID`
+    """
+    if isinstance(batch, MultiAgentBatch):
+        policy_keys = batch.policy_batches.keys()
+        if len(policy_keys) == 1 and DEFAULT_POLICY_ID in policy_keys:
+            batch = batch.policy_batches[DEFAULT_POLICY_ID]
+        else:
+            raise ValueError(
+                "Off-Policy Estimation is not implemented for "
+                "multi-agent batches. You can set "
+                "`off_policy_estimation_methods: {}` to resolve this."
+            )
+    return batch


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Use SampleBatch in compute_gradients in Rolloutworker instead of MA batch when using env runner v2 since it always returns MA batch. This PR is needed to turn connectors on by default.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
