### PR TITLE
[RLlib] Convert to SampleBatch in a couple of places to fit EnvRunnerV2

### DIFF
--- a/rllib/algorithms/dreamer/dreamer.py
+++ b/rllib/algorithms/dreamer/dreamer.py
@@ -8,7 +8,11 @@ from ray.rllib.algorithms.algorithm_config import AlgorithmConfig, NotProvided
 from ray.rllib.algorithms.dreamer.dreamer_torch_policy import DreamerTorchPolicy
 from ray.rllib.execution.common import STEPS_SAMPLED_COUNTER, _get_shared_metrics
 from ray.rllib.policy.policy import Policy
-from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, concat_samples
+from ray.rllib.policy.sample_batch import (
+    DEFAULT_POLICY_ID,
+    concat_samples,
+    convert_ma_batch_to_sample_batch,
+)
 from ray.rllib.evaluation.metrics import collect_metrics
 from ray.rllib.algorithms.dreamer.dreamer_model import DreamerModel
 from ray.rllib.execution.rollout_ops import (
@@ -350,8 +354,7 @@ class Dreamer(Algorithm):
             samples = self.workers.local_worker().sample()
             # Dreamer only ever has one policy and we receive MA batches when
             # connectors are on
-            if self.config.get("enable_connectors"):
-                samples = samples.policy_batches[DEFAULT_POLICY_ID]
+            samples = convert_ma_batch_to_sample_batch(samples)
             self.local_replay_buffer.add(samples)
 
     @override(Algorithm)

--- a/rllib/algorithms/dreamer/dreamer.py
+++ b/rllib/algorithms/dreamer/dreamer.py
@@ -348,6 +348,10 @@ class Dreamer(Algorithm):
             < self.config.prefill_timesteps
         ):
             samples = self.workers.local_worker().sample()
+            # Dreamer only ever has one policy and we receive MA batches when
+            # connectors are on
+            if self.config.get("enable_connectors"):
+                samples = samples.policy_batches[DEFAULT_POLICY_ID]
             self.local_replay_buffer.add(samples)
 
     @override(Algorithm)

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -1108,7 +1108,8 @@ class RolloutWorker(ParallelIteratorWorker):
         # op must not return multi-agent dict b/c of A2C's `.batch()` in the execution
         # plan; this would "batch" over the "default_policy" keys instead of the data).
         if single_agent is True:
-            # SampleBatch -> Calculate gradients for the default policy.
+            if self.config.get("enable_connectors"):
+                samples = samples.policy_batches[DEFAULT_POLICY_ID]
             grad_out, info_out = self.policy_map[DEFAULT_POLICY_ID].compute_gradients(
                 samples
             )

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -1104,11 +1104,9 @@ class RolloutWorker(ParallelIteratorWorker):
         if log_once("compute_gradients"):
             logger.info("Compute gradients on:\n\n{}\n".format(summarize(samples)))
 
-        # Backward compatibility for A2C: Single-agent only (ComputeGradients execution
-        # op must not return multi-agent dict b/c of A2C's `.batch()` in the execution
-        # plan; this would "batch" over the "default_policy" keys instead of the data).
         if single_agent is True:
             if self.config.get("enable_connectors"):
+                # We always sample MA batches from EnvRunnerV2
                 samples = samples.policy_batches[DEFAULT_POLICY_ID]
             grad_out, info_out = self.policy_map[DEFAULT_POLICY_ID].compute_gradients(
                 samples

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -53,6 +53,7 @@ from ray.rllib.offline import (
 )
 from ray.rllib.policy.policy import Policy, PolicySpec
 from ray.rllib.policy.policy_map import PolicyMap
+from ray.rllib.policy.sample_batch import convert_ma_batch_to_sample_batch
 from ray.rllib.utils.filter import NoFilter
 from ray.rllib.utils.from_config import from_config
 from ray.rllib.policy.sample_batch import (
@@ -1105,9 +1106,7 @@ class RolloutWorker(ParallelIteratorWorker):
             logger.info("Compute gradients on:\n\n{}\n".format(summarize(samples)))
 
         if single_agent is True:
-            if self.config.get("enable_connectors"):
-                # We always sample MA batches from EnvRunnerV2
-                samples = samples.policy_batches[DEFAULT_POLICY_ID]
+            samples = convert_ma_batch_to_sample_batch(samples)
             grad_out, info_out = self.policy_map[DEFAULT_POLICY_ID].compute_gradients(
                 samples
             )

--- a/rllib/offline/estimators/tests/utils.py
+++ b/rllib/offline/estimators/tests/utils.py
@@ -11,7 +11,11 @@ from ray.rllib.offline.estimators import (
     DoublyRobust,
 )
 from ray.rllib.policy import Policy
-from ray.rllib.policy.sample_batch import SampleBatch, concat_samples
+from ray.rllib.policy.sample_batch import (
+    SampleBatch,
+    concat_samples,
+    convert_ma_batch_to_sample_batch,
+)
 from ray.rllib.utils.debug import update_global_seed_if_necessary
 
 
@@ -60,6 +64,8 @@ def get_cliff_walking_wall_policy_and_data(
     n_eps = 0
     while n_eps < num_episodes:
         batch = synchronous_parallel_sample(worker_set=workers)
+        batch = convert_ma_batch_to_sample_batch(batch)
+
         for episode in batch.split_by_episode():
             ret = 0
             for r in episode[SampleBatch.REWARDS][::-1]:

--- a/rllib/offline/estimators/tests/utils.py
+++ b/rllib/offline/estimators/tests/utils.py
@@ -60,6 +60,9 @@ def get_cliff_walking_wall_policy_and_data(
     n_eps = 0
     while n_eps < num_episodes:
         batch = synchronous_parallel_sample(worker_set=workers)
+        if config.get("enable_connectors"):
+            # We assume there is only CliffWalkingWallPolicy
+            batch = batch.policy_batches["default_policy"]
         for episode in batch.split_by_episode():
             ret = 0
             for r in episode[SampleBatch.REWARDS][::-1]:

--- a/rllib/offline/estimators/tests/utils.py
+++ b/rllib/offline/estimators/tests/utils.py
@@ -60,9 +60,6 @@ def get_cliff_walking_wall_policy_and_data(
     n_eps = 0
     while n_eps < num_episodes:
         batch = synchronous_parallel_sample(worker_set=workers)
-        if config.get("enable_connectors"):
-            # We assume there is only CliffWalkingWallPolicy
-            batch = batch.policy_batches["default_policy"]
         for episode in batch.split_by_episode():
             ret = 0
             for r in episode[SampleBatch.REWARDS][::-1]:


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

DoublyRobust estimator samples with synchronous_parallel_sample but expects a sample batch.
A2C uses rolloutworker for computing gradients and also needs this.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
