### PR TITLE
DOC: mention conda-forge ray packages and x86_64 support

### DIFF
--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -259,11 +259,11 @@ Ray can also be installed as a conda package on linux and windows
 .. code-block:: bash
 
   # also works with mamba
-  conda create -c conda-forge python=3.9 -n ray_dev  
-  conda activate ray_dev
+  conda create -c conda-forge python=3.9 -n ray
+  conda activate ray
 
   # Install Ray with support for the dashboard + cluster launcher
-  conda install -c condaforge "ray-default"
+  conda install -c conda-forge "ray-default"
 
   # Install Ray with minimal dependencies
   # conda install -c conda-forge ray

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -41,7 +41,7 @@ Ray can also be installed as a conda package on linux and windows
   conda activate ray_dev
 
   # Install Ray with support for the dashboard + cluster launcher
-  conda install -c condaforge "ray[default]"
+  conda install -c condaforge "ray-default"
 
   # Install Ray with minimal dependencies
   # conda install -c conda-forge ray
@@ -50,10 +50,10 @@ To install Ray libraries:
 
 .. code-block:: bash
 
-  conda install -c conda-forge "ray[air]" # installs Ray + dependencies for Ray AI Runtime
-  conda install -c conda-forge "ray[tune]"  # installs Ray + dependencies for Ray Tune
-  conda install -c conda-forge "ray[rllib]"  # installs Ray + dependencies for Ray RLlib
-  conda install -c conda-forge "ray[serve]"  # installs Ray + dependencies for Ray Serve
+  conda install -c conda-forge "ray-air"    # installs Ray + dependencies for Ray AI Runtime
+  conda install -c conda-forge "ray-tune"   # installs Ray + dependencies for Ray Tune
+  conda install -c conda-forge "ray-rllib"  # installs Ray + dependencies for Ray RLlib
+  conda install -c conda-forge "ray-serve"  # installs Ray + dependencies for Ray Serve
 
   
 

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -3,7 +3,7 @@
 Installing Ray
 ==============
 
-Ray currently officially supports x86_64 hardware.
+Ray currently officially supports x86_64 and Apple silicon (M1) hardware.
 Ray on Windows is currently in beta.
 
 Official Releases
@@ -30,32 +30,6 @@ To install Ray libraries:
   pip install -U "ray[tune]"  # installs Ray + dependencies for Ray Tune
   pip install -U "ray[rllib]"  # installs Ray + dependencies for Ray RLlib
   pip install -U "ray[serve]"  # installs Ray + dependencies for Ray Serve
-
-From conda-forge
-~~~~~~~~~~~~~~~~
-Ray can also be installed as a conda package on linux and windows
-
-.. code-block:: bash
-
-  conda create -c conda-forge python=3.9 -n ray_dev
-  conda activate ray_dev
-
-  # Install Ray with support for the dashboard + cluster launcher
-  conda install -c condaforge "ray-default"
-
-  # Install Ray with minimal dependencies
-  # conda install -c conda-forge ray
-
-To install Ray libraries:
-
-.. code-block:: bash
-
-  conda install -c conda-forge "ray-air"    # installs Ray + dependencies for Ray AI Runtime
-  conda install -c conda-forge "ray-tune"   # installs Ray + dependencies for Ray Tune
-  conda install -c conda-forge "ray-rllib"  # installs Ray + dependencies for Ray RLlib
-  conda install -c conda-forge "ray-serve"  # installs Ray + dependencies for Ray Serve
-
-  
 
 .. _install-nightlies:
 
@@ -278,29 +252,39 @@ on the AUR page of ``python-ray`` `here`_.
 
 .. _ray_anaconda:
 
-Installing Ray with Anaconda
-----------------------------
-
-If you use `Anaconda`_ (`installation instructions`_) and want to use Ray in a defined environment, e.g, ``ray``, use these commands:
+Installing From conda-forge
+---------------------------
+Ray can also be installed as a conda package on linux and windows
 
 .. code-block:: bash
 
-  conda config --env --add channels conda-forge
-  conda create -n ray  # works with mamba too
-  conda activate ray
-  pip install ray  # or `conda install ray-core`
+  # also works with mamba
+  conda create -c conda-forge python=3.9 -n ray_dev  
+  conda activate ray_dev
+
+  # Install Ray with support for the dashboard + cluster launcher
+  conda install -c condaforge "ray-default"
+
+  # Install Ray with minimal dependencies
+  # conda install -c conda-forge ray
+
+To install Ray libraries, you can use ``pip`` as above or ``conda``/``mamba``
+
+.. code-block:: bash
+
+  conda install -c conda-forge "ray-air"    # installs Ray + dependencies for Ray AI Runtime
+  conda install -c conda-forge "ray-tune"   # installs Ray + dependencies for Ray Tune
+  conda install -c conda-forge "ray-rllib"  # installs Ray + dependencies for Ray RLlib
+  conda install -c conda-forge "ray-serve"  # installs Ray + dependencies for Ray Serve
 
 For a complete list of available ``ray`` libraries on Conda-forge, have a look
-at: https://github.com/conda-forge/ray-packages-feedstock
+at https://anaconda.org/conda-forge/ray-default
 
 .. note::
 
   Ray conda packages are maintained by the community, not the Ray team. While
   using a conda environment, it is recommended to install Ray from PyPi using
   `pip install ray` in the newly created environment.
-
-.. _`Anaconda`: https://www.anaconda.com/
-.. _`installation instructions`: https://docs.anaconda.com/anaconda/install/index.html
 
 Building Ray from Source
 ------------------------

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -3,13 +3,16 @@
 Installing Ray
 ==============
 
-Ray currently supports Linux, MacOS and Windows.
+Ray currently officially supports x86_64 hardware.
 Ray on Windows is currently in beta.
 
 Official Releases
 -----------------
 
-You can install the latest official version of Ray as follows.
+From Wheels
+~~~~~~~~~~~
+You can install the latest official version of Ray from PyPI on linux, windows
+and macos as follows:
 
 .. code-block:: bash
 
@@ -27,6 +30,32 @@ To install Ray libraries:
   pip install -U "ray[tune]"  # installs Ray + dependencies for Ray Tune
   pip install -U "ray[rllib]"  # installs Ray + dependencies for Ray RLlib
   pip install -U "ray[serve]"  # installs Ray + dependencies for Ray Serve
+
+From conda-forge
+~~~~~~~~~~~~~~~~
+Ray can also be installed as a conda package on linux and windows
+
+.. code-block:: bash
+
+  conda create -c conda-forge python=3.9 -n ray_dev
+  conda activate ray_dev
+
+  # Install Ray with support for the dashboard + cluster launcher
+  conda install -c condaforge "ray[default]"
+
+  # Install Ray with minimal dependencies
+  # conda install -c conda-forge ray
+
+To install Ray libraries:
+
+.. code-block:: bash
+
+  conda install -c conda-forge "ray[air]" # installs Ray + dependencies for Ray AI Runtime
+  conda install -c conda-forge "ray[tune]"  # installs Ray + dependencies for Ray Tune
+  conda install -c conda-forge "ray[rllib]"  # installs Ray + dependencies for Ray RLlib
+  conda install -c conda-forge "ray[serve]"  # installs Ray + dependencies for Ray Serve
+
+  
 
 .. _install-nightlies:
 


### PR DESCRIPTION
## Why are these changes needed?

Recently ray has grown support on conda for 2.0.1 and 2.1.0 is close to release. Mention it in the documentation. Also mention that the official releases only support x86_64 architecture.

## Related issue number
Related to #12128, #4309, #7476, #13780 since they all want non-x86_64 binary builds which are currently not available.

Related to conda-forge/ray-packages-feedstock#78 (for 2.1.0 on conda-forge) and conda-forge/ray-packages-feedstock#80 (for macos on conda-forge).

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
