### PR TITLE
[RLLib] Fit MBMPO to connectors

### DIFF
--- a/rllib/algorithms/mbmpo/mbmpo.py
+++ b/rllib/algorithms/mbmpo/mbmpo.py
@@ -23,7 +23,12 @@ from ray.rllib.execution.common import (
 )
 from ray.rllib.execution.metric_ops import CollectMetrics
 from ray.rllib.policy.policy import Policy
-from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, SampleBatch, concat_samples
+from ray.rllib.policy.sample_batch import (
+    DEFAULT_POLICY_ID,
+    SampleBatch,
+    concat_samples,
+    convert_ma_batch_to_sample_batch,
+)
 from ray.rllib.utils.annotations import Deprecated, override
 from ray.rllib.utils.deprecation import DEPRECATED_VALUE
 from ray.rllib.utils.metrics.learner_info import LEARNER_INFO
@@ -544,6 +549,7 @@ class MBMPO(Algorithm):
             for samples in itr:
                 print("Collecting Samples, Inner Adaptation {}".format(len(split)))
                 # Processing Samples (Standardize Advantages)
+                samples = [convert_ma_batch_to_sample_batch(batch) for batch in samples]
                 samples, split_lst = post_process_samples(samples, config)
 
                 buf.extend(samples)

--- a/rllib/algorithms/mbmpo/model_ensemble.py
+++ b/rllib/algorithms/mbmpo/model_ensemble.py
@@ -1,13 +1,16 @@
 import gym
-from gym.spaces import Discrete, Box
 import numpy as np
-from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
-from ray.rllib.utils.framework import try_import_torch
+
+from gym.spaces import Discrete, Box
+
 from ray.rllib.evaluation.rollout_worker import get_global_worker
-from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.execution.common import STEPS_SAMPLED_COUNTER
-from ray.rllib.utils.typing import SampleBatchType
+from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
+from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.policy.sample_batch import convert_ma_batch_to_sample_batch
+from ray.rllib.utils.framework import try_import_torch
 from ray.rllib.utils.torch_utils import convert_to_torch_tensor
+from ray.rllib.utils.typing import SampleBatchType
 
 torch, nn = try_import_torch()
 
@@ -197,9 +200,11 @@ class DynamicsEnsembleCustomModel(TorchModelV2, nn.Module):
         for pid, pol in local_worker.policy_map.items():
             pol.view_requirements[SampleBatch.NEXT_OBS].used_for_training = True
         new_samples = local_worker.sample()
+        new_samples = convert_ma_batch_to_sample_batch(new_samples)
         # Initial Exploration of 8000 timesteps
         if not self.global_itr:
             extra = local_worker.sample()
+            extra = convert_ma_batch_to_sample_batch(extra)
             new_samples.concat(extra)
 
         # Process Samples

--- a/rllib/algorithms/mbmpo/tests/test_mbmpo.py
+++ b/rllib/algorithms/mbmpo/tests/test_mbmpo.py
@@ -12,7 +12,7 @@ from ray.rllib.utils.test_utils import (
 class TestMBMPO(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        ray.init()
+        ray.init(local_mode=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/rllib/algorithms/mbmpo/tests/test_mbmpo.py
+++ b/rllib/algorithms/mbmpo/tests/test_mbmpo.py
@@ -12,7 +12,7 @@ from ray.rllib.utils.test_utils import (
 class TestMBMPO(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        ray.init(local_mode=True)
+        ray.init()
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

MBMPO expects sample batches instead of MA batches, which we sample with connectors.

**Prequisite: #30024** 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
