### PR TITLE
[RLlib] Fix doc test for foreach_worker_with_index

### DIFF
--- a/doc/source/rllib/doc_code/getting_started.py
+++ b/doc/source/rllib/doc_code/getting_started.py
@@ -98,8 +98,4 @@ algo.workers.local_worker().policy_map["default_policy"].get_weights()
 # Get list of weights of each worker, including remote replicas
 algo.workers.foreach_worker(lambda worker: worker.get_policy().get_weights())
 
-# Same as above, but with index.
-algo.workers.foreach_worker_with_index(
-    lambda worker, _: worker.get_policy().get_weights()
-)
 # __rllib-get-state-end__

--- a/doc/source/rllib/doc_code/getting_started.py
+++ b/doc/source/rllib/doc_code/getting_started.py
@@ -100,6 +100,6 @@ algo.workers.foreach_worker(lambda worker: worker.get_policy().get_weights())
 
 # Same as above, but with index.
 algo.workers.foreach_worker_with_id(
-    lambda worker, _: worker.get_policy().get_weights()
+    lambda _id, worker: worker.get_policy().get_weights()
 )
 # __rllib-get-state-end__

--- a/doc/source/rllib/doc_code/getting_started.py
+++ b/doc/source/rllib/doc_code/getting_started.py
@@ -98,4 +98,8 @@ algo.workers.local_worker().policy_map["default_policy"].get_weights()
 # Get list of weights of each worker, including remote replicas
 algo.workers.foreach_worker(lambda worker: worker.get_policy().get_weights())
 
+# Same as above, but with index.
+algo.workers.foreach_worker_with_id(
+    lambda worker, _: worker.get_policy().get_weights()
+)
 # __rllib-get-state-end__


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

<img width="599" alt="Screenshot 2022-11-14 at 09 03 56" src="https://user-images.githubusercontent.com/9356806/201722488-1a80dbdd-43da-46e7-afaf-e300806fb493.png">

WorkerSet no long has `foreach_worker_with_index`

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
