### PR TITLE
[RLlib] `deprecation_warning(.., error=True)` should raise `ValueError`, not `DeprecationWarning`.

### DIFF
--- a/rllib/utils/deprecation.py
+++ b/rllib/utils/deprecation.py
@@ -50,7 +50,6 @@ def deprecation_warning(
         )
 
 
-
 def Deprecated(old=None, *, new=None, help=None, error):
     """Decorator for documenting a deprecated class, method, or function.
 

--- a/rllib/utils/deprecation.py
+++ b/rllib/utils/deprecation.py
@@ -39,14 +39,16 @@ def deprecation_warning(
         old, (" Use `{}` instead.".format(new) if new else f" {help}" if help else "")
     )
 
-    if error is True:
-        raise DeprecationWarning(msg)
-    elif error and issubclass(error, Exception):
-        raise error(msg)
+    if error:
+        if issubclass(error, Exception):
+            raise error(msg)
+        else:
+            raise ValueError(msg)
     else:
         logger.warning(
             "DeprecationWarning: " + msg + " This will raise an error in the future!"
         )
+
 
 
 def Deprecated(old=None, *, new=None, help=None, error):


### PR DESCRIPTION
It should be an Exception that we raise e.g. ValueError. Otherwise the thrown error does not look like an error. 

Signed-off-by: Kourosh Hakhamaneshi <kourosh@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
