### PR TITLE
[RLlib] Fix RolloutWorker filter syncing

### DIFF
--- a/rllib/connectors/connector.py
+++ b/rllib/connectors/connector.py
@@ -445,7 +445,11 @@ class ConnectorPipeline(abc.ABC):
             elif isinstance(key, int):
                 return [self.connectors[key]]
             elif isinstance(key, type):
-                key = key.__name__
+                results = []
+                for c in self.connectors:
+                    if issubclass(c.__class__, key):
+                        results.append(c)
+                return results
             else:
                 raise NotImplementedError(
                     "Indexing by {} is currently not supported.".format(type(key))
@@ -455,9 +459,6 @@ class ConnectorPipeline(abc.ABC):
         for c in self.connectors:
             if c.__class__.__name__ == key:
                 results.append(c)
-
-        if len(results) == 0:
-            return []
 
         return results
 

--- a/rllib/connectors/util.py
+++ b/rllib/connectors/util.py
@@ -145,7 +145,7 @@ def maybe_get_filters_for_syncing(rollout_worker, policy_id):
     # There can only be one filter at a time
     if filter_connectors:
         assert len(filter_connectors) == 1, (
-            "ConnectorPipeline has two connectors of type "
+            "ConnectorPipeline has multiple connectors of type "
             "SyncedFilterAgentConnector but can only have one."
         )
         rollout_worker.filters[policy_id] = filter_connectors[0].filter

--- a/rllib/connectors/util.py
+++ b/rllib/connectors/util.py
@@ -144,7 +144,7 @@ def maybe_get_filters_for_syncing(rollout_worker, policy_id):
     ]
     # There can only be one filter at a time
     if filter_connectors:
-        assert len(SyncedFilterAgentConnector) == 1, (
+        assert len(filter_connectors) == 1, (
             "ConnectorPipeline has two connectors of type "
             "SyncedFilterAgentConnector but can only have one."
         )


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

When creating filter connectors, these are not properly added to the RolloutWorker's filters.
That is because we scanned for them by class name, rather than with issubclass.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
