### PR TITLE
Add grouping by depth worker killing policy and unit tests

### DIFF
--- a/src/ray/raylet/worker_killing_policy.h
+++ b/src/ray/raylet/worker_killing_policy.h
@@ -63,6 +63,15 @@ class RetriableLIFOWorkerKillingPolicy : public WorkerKillingPolicy {
       const MemoryMonitor &memory_monitor) const;
 };
 
+/// Kills the worker with the greatest depth such that all depths have at least one worker.
+class GroupByDepthWorkingKillingPolicy : public WorkerKillingPolicy {
+ public:
+  GroupByDepthWorkingKillingPolicy();
+  const std::shared_ptr<WorkerInterface> SelectWorkerToKill(
+      const std::vector<std::shared_ptr<WorkerInterface>> &workers,
+      const MemoryMonitor &memory_monitor) const;
+};
+
 }  // namespace raylet
 
 }  // namespace ray


### PR DESCRIPTION
Signed-off-by: Aviv Haber <aviv@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Implements the following kill policy:

1. Pick the highest depth that has more than one worker
a. Kill the worker in that depth with the latest start time
2. If no depth has more than one worker, kill the worker at the highest depth

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

I added new unit tests to test the killing policy correctness