### PR TITLE
[core] re-enable oom for dataset_shuffle_random_shuffle_1tb

### DIFF
--- a/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
@@ -1,8 +1,5 @@
 base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_CPU"] | default("anyscale/ray-ml:2.0.1-py37-cpu") }}
-# RAY_DISABLE_MEMORY_MONITOR=1 disables the legacy memory monitor in python that
-# crashes the test if a task is submitted when the memory usage is high. Since the
-# test is expected to run at high memory it should remain off.
-env_vars: {"RAY_task_oom_retries": "50", "RAY_DISABLE_MEMORY_MONITOR": "1", "RAY_memory_monitor_interval_ms": "100", "RAY_min_memory_free_bytes": "1000000000"}
+env_vars: {"RAY_task_oom_retries": "50", "RAY_min_memory_free_bytes": "1000000000"}
 debian_packages:
   - curl
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4485,8 +4485,7 @@
   frequency: nightly
   team: data
   cluster:
-    # re-enable once https://github.com/ray-project/ray/issues/29294 is fixed
-    cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml
+    cluster_env: shuffle/shuffle_app_config_oom.yaml
     cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
 
   run:


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
