### PR TITLE
[RLlib] disabled torch release test on APPO

### DIFF
--- a/release/rllib_tests/learning_tests/yaml_files/appo/appo-pongnoframeskip-v4.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/appo/appo-pongnoframeskip-v4.yaml
@@ -7,6 +7,8 @@ appo-pongnoframeskip-v4:
         timesteps_total: 5000000
     stop:
         time_total_s: 1800
+    # TODO (Kourosh): Torch does not learn as good as tf. Why?
+    frameworks: ["tf", "tf2"]
     config:
         vtrace: True
         use_kl_loss: False

--- a/release/rllib_tests/learning_tests/yaml_files/appo/appo-pongnoframeskip-v4.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/appo/appo-pongnoframeskip-v4.yaml
@@ -7,8 +7,8 @@ appo-pongnoframeskip-v4:
         timesteps_total: 5000000
     stop:
         time_total_s: 1800
-    # TODO (Kourosh): Torch does not learn as good as tf. Why?
-    frameworks: ["tf", "tf2"]
+    # TODO (Kourosh): Torch and tf2 do not learn as good as tf. Why?
+    frameworks: ["tf"]
     config:
         vtrace: True
         use_kl_loss: False


### PR DESCRIPTION
Signed-off-by: Kourosh Hakhamaneshi <kourosh@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<img width="439" alt="Screen Shot 2022-11-14 at 11 27 15 PM" src="https://user-images.githubusercontent.com/31483498/201856440-7f3a83b1-1796-4bef-8c1b-baf45f1fbc43.png">

This test just never passed. For some reason torch version has always been broken. We should disable this for now until this gets fixed. otherwise the release test notifs will be noisy.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
