### PR TITLE
[Datasets] Enable dynamic block splitting by default

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -27,7 +27,7 @@ DEFAULT_TARGET_MIN_BLOCK_SIZE = 1 * 1024 * 1024
 DEFAULT_STREAMING_READ_BUFFER_SIZE = 32 * 1024 * 1024
 
 # Whether block splitting is on by default
-DEFAULT_BLOCK_SPLITTING_ENABLED = False
+DEFAULT_BLOCK_SPLITTING_ENABLED = True
 
 # Whether pandas block format is enabled.
 # TODO (kfstorm): Remove this once stable.

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4380,7 +4380,7 @@
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
-    timeout: 1800
+    timeout: 3600
     script: python read_benchmark.py
 
     type: sdk_command


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Enable dynamic block splitting by default, and also add nightly test coverage to read 20G and 100G images data on single node.

Verified existing CI and nightly tests are passed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
