### PR TITLE
[release][no_ci] Do not test cluster scale up in ml user test.

### DIFF
--- a/release/ml_user_tests/ray-lightning/compute_tpl.yaml
+++ b/release/ml_user_tests/ray-lightning/compute_tpl.yaml
@@ -1,7 +1,7 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
-max_workers: 3
+max_workers: 2
 
 head_node_type:
     name: head_node
@@ -10,7 +10,7 @@ head_node_type:
 worker_node_types:
     - name: worker_node
       instance_type: g3.8xlarge
-      min_workers: 0
+      min_workers: 2
       max_workers: 2
       use_spot: false
 

--- a/release/ml_user_tests/train/compute_tpl.yaml
+++ b/release/ml_user_tests/train/compute_tpl.yaml
@@ -10,6 +10,6 @@ head_node_type:
 worker_node_types:
     -   name: worker_node
         instance_type: g3.8xlarge
-        min_workers: 0
+        min_workers: 2
         max_workers: 2
         use_spot: false

--- a/release/ml_user_tests/tune_rllib/compute_tpl.yaml
+++ b/release/ml_user_tests/tune_rllib/compute_tpl.yaml
@@ -10,12 +10,12 @@ head_node_type:
 worker_node_types:
     - name: worker_node_cpu
       instance_type: m5.xlarge
-      min_workers: 0
+      min_workers: 10
       max_workers: 10
       use_spot: false
     - name: worker_node_gpu
       instance_type: g3.4xlarge
-      min_workers: 0
+      min_workers: 10
       max_workers: 10
       use_spot: false
 

--- a/release/ml_user_tests/xgboost/tpl_gpu_small_scaling.yaml
+++ b/release/ml_user_tests/xgboost/tpl_gpu_small_scaling.yaml
@@ -10,7 +10,7 @@ head_node_type:
 worker_node_types:
     - name: worker_node
       instance_type: p3.2xlarge
-      min_workers: 0
+      min_workers: 4
       max_workers: 4
       use_spot: false
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1108,6 +1108,8 @@
   run:
     timeout: 1200
     script: python horovod/horovod_user_test.py
+    wait_for_nodes:
+      num_nodes: 2
     type: client
 
   alert: default
@@ -1132,6 +1134,8 @@
   run:
     timeout: 1200
     script: python horovod/horovod_user_test.py
+    wait_for_nodes:
+      num_nodes: 2
     type: client
 
   alert: default
@@ -1156,6 +1160,8 @@
   run:
     timeout: 36000
     script: python train/train_tensorflow_mnist_test.py
+    wait_for_nodes:
+      num_nodes: 3
     type: client
 
   alert: default
@@ -1180,6 +1186,8 @@
   run:
     timeout: 36000
     script: python train/train_torch_linear_test.py
+    wait_for_nodes:
+      num_nodes: 3
     type: client
 
   alert: default
@@ -1203,6 +1211,8 @@
   run:
     timeout: 1200
     script: python xgboost/train_gpu_connect.py
+    wait_for_nodes:
+      num_nodes: 5
     type: client
 
   alert: default
@@ -1226,6 +1236,8 @@
   run:
     timeout: 1200
     script: python xgboost/train_gpu_connect.py
+    wait_for_nodes:
+      num_nodes: 5
     type: client
 
   alert: default
@@ -1250,6 +1262,8 @@
   run:
     timeout: 1200
     script: python ray-lightning/ray_lightning_user_test.py
+    wait_for_nodes:
+      num_nodes: 3
     type: client
 
   alert: default
@@ -1274,6 +1288,8 @@
   run:
     timeout: 1200
     script: python ray-lightning/ray_lightning_user_test.py
+    wait_for_nodes:
+      num_nodes: 3
     type: client
 
   alert: default
@@ -1298,6 +1314,8 @@
   run:
     timeout: 2000
     script: python tune_rllib/run_connect_tests.py
+    wait_for_nodes:
+      num_nodes: 11
     type: client
 
   alert: default

--- a/release/tune_tests/scalability_tests/app_config_data.yaml
+++ b/release/tune_tests/scalability_tests/app_config_data.yaml
@@ -7,12 +7,13 @@ python:
   pip_packages:
     - pytest
     - awscli
-    - xgboost_ray
+    - xgboost_ray  # this will install protobuf version beyond the upper bound of what Tune allows
     - pyarrow>=6.0.1,<7.0.0
   conda_packages: []
 
 post_build_cmds:
   - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 install ray[tune] # Needed for Ray Client to work. Installing Tune dependency so we can get protobuf version back.
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   - sudo mkdir -p /data || true
   - sudo chown ray:1000 /data || true


### PR DESCRIPTION
Do not test cluster scale up in ml user test.

Also fix tune_scalability_xgboost_sweep.

Signed-off-by: xwjiang2010 <xwjiang2010@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The team agrees to not test for cluster scale up in ml user tests.
This helps isolate infrastructure failures.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #30230

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
