### PR TITLE
[release][no_ci] Remove torch tune big gpu weekly test.

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
@@ -34,7 +34,6 @@ def prepare_mnist():
 def get_trainer(
     num_workers: int = 4,
     use_gpu: bool = False,
-    strict_pack: bool = True,
     config: Optional[Dict] = None,
 ):
     """Get the trainer to be used across train and tune to ensure consistency."""
@@ -60,7 +59,7 @@ def get_trainer(
             resources_per_worker={"CPU": 2},
             trainer_resources={"CPU": 0},
             use_gpu=use_gpu,
-            placement_strategy="STRICT_PACK" if strict_pack else "PACK",
+            placement_strategy="STRICT_PACK",
         ),
     )
     return trainer
@@ -75,7 +74,6 @@ def tune_torch(
     num_workers: int = 4,
     num_trials: int = 8,
     use_gpu: bool = False,
-    strict_pack: bool = True,
     config: Optional[Dict] = None,
 ):
     """Making sure that tuning multiple trials in parallel is not
@@ -94,9 +92,7 @@ def tune_torch(
         },
     }
 
-    trainer = get_trainer(
-        num_workers=num_workers, use_gpu=use_gpu, strict_pack=strict_pack, config=config
-    )
+    trainer = get_trainer(num_workers=num_workers, use_gpu=use_gpu, config=config)
     tuner = Tuner(
         trainable=trainer,
         param_space=param_space,
@@ -111,14 +107,12 @@ def tune_torch(
 @click.option("--num-workers", type=int, default=4)
 @click.option("--use-gpu", is_flag=True)
 @click.option("--smoke-test", is_flag=True, default=False)
-@click.option("--disable-strict-pack", is_flag=True, default=False)
 def main(
     num_runs: int = 1,
     num_trials: int = 8,
     num_workers: int = 4,
     use_gpu: bool = False,
     smoke_test: bool = False,
-    disable_strict_pack: bool = False,
 ):
     ray.init(
         runtime_env={
@@ -156,7 +150,6 @@ def main(
                 num_workers=num_workers,
                 num_trials=num_trials,
                 use_gpu=use_gpu,
-                strict_pack=not disable_strict_pack,
                 config=config,
             ),
             number=1,

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -415,31 +415,6 @@
 
   alert: default
 
-- name: air_benchmark_tune_torch_mnist_large_gpu
-  group: AIR tests
-  working_dir: air_tests/air_benchmarks
-
-  frequency: weekly
-  team: ml
-  env: staging
-
-  cluster:
-    cluster_env: app_config.yaml
-    cluster_compute: compute_gpu_8_g4_12xl.yaml
-
-  run:
-    timeout: 3600
-    script: python workloads/tune_torch_benchmark.py --num-runs 2 --num-trials 4 --num-workers 8 --use-gpu --disable-strict-pack
-
-    wait_for_nodes:
-      num_nodes: 8
-
-    type: sdk_command
-    file_manager: job
-
-  alert: default
-
-
 # Ray AIR distributed Tensorflow benchmarks
 - name: air_benchmark_tensorflow_mnist_cpu_4x1
   group: AIR tests


### PR DESCRIPTION
Signed-off-by: xwjiang2010 <xwjiang2010@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The torch tune nightly GPU test is running 4 trials with 4 distributed workers each. 
The corresponding weekly test (that the PR is removing) is running 4 trials with 8 distributed workers each.
To compare train with tune in a meaningful way, a "strict-pack" placement group strategy is needed. Hence, we need instances with 8 GPUs in order for the 8 workers to be strictly packed together.

Given this additional weekly test is not providing much value on top of the nightly test, proposing to remove it. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
