### PR TITLE
[doc] walkthrough.rst: "returns" is more accurate than "yields"

### DIFF
--- a/doc/source/ray-core/walkthrough.rst
+++ b/doc/source/ray-core/walkthrough.rst
@@ -28,7 +28,7 @@ Running a Task
 
 Ray lets you run functions as remote tasks in the cluster. To do this, you decorate your function with ``@ray.remote`` to declare that you want to run this function remotely.
 Then, you call that function with ``.remote()`` instead of calling it normally.
-This remote call yields a future, a so-called Ray *object reference*, that you can then fetch with ``ray.get``:
+This remote call returns a future, a so-called Ray *object reference*, that you can then fetch with ``ray.get``:
 
 .. literalinclude:: doc_code/getting_started.py
     :language: python


### PR DESCRIPTION
@richardliaw Here's the improved version of the previous pull request. 