### PR TITLE
[RLlib] Fix T being off by one in EnvRunnerV2

### DIFF
--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -611,7 +611,7 @@ class EnvRunnerV2:
                     obs_space = policy.observation_space
                     obs_space = getattr(obs_space, "original_space", obs_space)
                     values_dict = {
-                        SampleBatch.T: episode.length - 1,
+                        SampleBatch.T: episode.length,
                         SampleBatch.ENV_ID: env_id,
                         SampleBatch.AGENT_INDEX: episode.agent_index(agent_id),
                         SampleBatch.REWARDS: 0.0,
@@ -837,7 +837,7 @@ class EnvRunnerV2:
                         agent_id,
                         {
                             SampleBatch.NEXT_OBS: obs,
-                            SampleBatch.T: new_episode.length - 1,
+                            SampleBatch.T: new_episode.length,
                         },
                     )
                     for agent_id, obs in agents_obs

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -568,7 +568,9 @@ class EnvRunnerV2:
                     continue
 
                 values_dict = {
-                    SampleBatch.T: episode.length - 1,
+                    SampleBatch.T: episode.length,  # Episodes start at -1 before we
+                    # add the initial obs. After that, we infer from initial obs at
+                    # t=0 since that will be our new episode.length.
                     SampleBatch.ENV_ID: env_id,
                     SampleBatch.AGENT_INDEX: episode.agent_index(agent_id),
                     # Last action (SampleBatch.ACTIONS) column will be populated by

--- a/rllib/evaluation/tests/test_env_runner_v2.py
+++ b/rllib/evaluation/tests/test_env_runner_v2.py
@@ -19,7 +19,7 @@ register_env("basic_multiagent", lambda _: BasicMultiAgent(2))
 class TestEnvRunnerV2(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        ray.init(local_mode=True)
+        ray.init()
 
         # When dealing with two policies in these tests, simply alternate between the 2
         # policies to make sure we have data for inference for both policies for each

--- a/rllib/evaluation/tests/test_env_runner_v2.py
+++ b/rllib/evaluation/tests/test_env_runner_v2.py
@@ -10,6 +10,7 @@ from ray.rllib.examples.env.multi_agent import BasicMultiAgent
 from ray.rllib.examples.policy.random_policy import RandomPolicy
 from ray.rllib.policy.policy import PolicySpec
 from ray.tune import register_env
+from ray.rllib.policy.sample_batch import convert_ma_batch_to_sample_batch
 
 
 register_env("basic_multiagent", lambda _: BasicMultiAgent(2))
@@ -60,7 +61,9 @@ class TestEnvRunnerV2(unittest.TestCase):
 
         rollout_worker = algo.workers.local_worker()
         sample_batch = rollout_worker.sample()
+        sample_batch = convert_ma_batch_to_sample_batch(sample_batch)
 
+        self.assertEqual(sample_batch["t"][0], 0)
         self.assertEqual(sample_batch.env_steps(), 200)
         self.assertEqual(sample_batch.agent_steps(), 200)
 
@@ -85,6 +88,7 @@ class TestEnvRunnerV2(unittest.TestCase):
 
         rollout_worker = algo.workers.local_worker()
         sample_batch = rollout_worker.sample()
+        sample_batch = convert_ma_batch_to_sample_batch(sample_batch)
 
         # 2 agents. So the multi-agent SampleBatch should have
         # 200 env steps, and 400 agent steps.

--- a/rllib/evaluation/tests/test_env_runner_v2.py
+++ b/rllib/evaluation/tests/test_env_runner_v2.py
@@ -19,7 +19,7 @@ register_env("basic_multiagent", lambda _: BasicMultiAgent(2))
 class TestEnvRunnerV2(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        ray.init()
+        ray.init(local_mode=True)
 
         # When dealing with two policies in these tests, simply alternate between the 2
         # policies to make sure we have data for inference for both policies for each
@@ -88,7 +88,6 @@ class TestEnvRunnerV2(unittest.TestCase):
 
         rollout_worker = algo.workers.local_worker()
         sample_batch = rollout_worker.sample()
-        sample_batch = convert_ma_batch_to_sample_batch(sample_batch)
 
         # 2 agents. So the multi-agent SampleBatch should have
         # 200 env steps, and 400 agent steps.


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

<img width="528" alt="Screenshot 2022-11-15 at 13 47 37" src="https://user-images.githubusercontent.com/9356806/202032145-d2fdcc79-6c16-4553-ae84-c35a8c570839.png">

## Why are these changes needed?

EnvRunnverV2 uses the wrong episode length / "t" when it builds values_dict to pass into connectors.
As per the behavior of the functional env_runner, we require t=0 when inferring from init obs.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
