### PR TITLE
[RLlib] [Connectors] Fix rollout worker metrics connectors

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -222,7 +222,7 @@ class AlgorithmConfig:
         self.sample_collector = SimpleListCollector
         self.create_env_on_local_worker = False
         self.sample_async = False
-        self.enable_connectors = False
+        self.enable_connectors = True
         self.rollout_fragment_length = 200
         self.batch_mode = "truncate_episodes"
         self.remote_worker_envs = False

--- a/rllib/env/tests/test_multi_agent_env.py
+++ b/rllib/env/tests/test_multi_agent_env.py
@@ -142,8 +142,11 @@ class TestMultiAgentEnv(unittest.TestCase):
             env_creator=lambda _: BasicMultiAgent(5),
             default_policy_class=MockPolicy,
             config=AlgorithmConfig()
-            .rollouts(rollout_fragment_length=50, num_rollout_workers=0,
-                enable_connectors=True)
+            .rollouts(
+                rollout_fragment_length=50,
+                num_rollout_workers=0,
+                enable_connectors=True,
+            )
             .multi_agent(
                 policies={"p0", "p1"},
                 policy_mapping_fn=policy_mapping_fn,
@@ -153,7 +156,7 @@ class TestMultiAgentEnv(unittest.TestCase):
         self.assertEqual(batch.count, 50)
         self.assertEqual(batch.policy_batches["p0"].count, 150)
         self.assertEqual(batch.policy_batches["p1"].count, 100)
-        self.assertEqual(batch.policy_batches["p0"]["t"].tolist(), [i for i in range(-1, 24)] * 6)
+        self.assertEqual(batch.policy_batches["p0"]["t"].tolist(), list(range(25)) * 6)
 
     def test_multi_agent_sample_sync_remote(self):
         ev = RolloutWorker(

--- a/rllib/env/tests/test_multi_agent_env.py
+++ b/rllib/env/tests/test_multi_agent_env.py
@@ -142,7 +142,8 @@ class TestMultiAgentEnv(unittest.TestCase):
             env_creator=lambda _: BasicMultiAgent(5),
             default_policy_class=MockPolicy,
             config=AlgorithmConfig()
-            .rollouts(rollout_fragment_length=50, num_rollout_workers=0)
+            .rollouts(rollout_fragment_length=50, num_rollout_workers=0,
+                enable_connectors=True)
             .multi_agent(
                 policies={"p0", "p1"},
                 policy_mapping_fn=policy_mapping_fn,
@@ -152,7 +153,7 @@ class TestMultiAgentEnv(unittest.TestCase):
         self.assertEqual(batch.count, 50)
         self.assertEqual(batch.policy_batches["p0"].count, 150)
         self.assertEqual(batch.policy_batches["p1"].count, 100)
-        self.assertEqual(batch.policy_batches["p0"]["t"].tolist(), list(range(25)) * 6)
+        self.assertEqual(batch.policy_batches["p0"]["t"].tolist(), [i for i in range(-1, 24)] * 6)
 
     def test_multi_agent_sample_sync_remote(self):
         ev = RolloutWorker(

--- a/rllib/env/tests/test_multi_agent_env.py
+++ b/rllib/env/tests/test_multi_agent_env.py
@@ -329,6 +329,9 @@ class TestMultiAgentEnv(unittest.TestCase):
             def get_initial_state(self):
                 return [{}]  # empty dict
 
+            def is_recurrent(self):
+                return True
+
         ev = RolloutWorker(
             env_creator=lambda _: gym.make("CartPole-v1"),
             default_policy_class=StatefulPolicy,
@@ -342,6 +345,7 @@ class TestMultiAgentEnv(unittest.TestCase):
             ),
         )
         batch = ev.sample()
+        batch = batch["default_policy"]
         self.assertEqual(batch.count, 5)
         self.assertEqual(batch["state_in_0"][0], {})
         self.assertEqual(batch["state_out_0"][0], h)

--- a/rllib/evaluation/collectors/agent_collector.py
+++ b/rllib/evaluation/collectors/agent_collector.py
@@ -178,6 +178,10 @@ class AgentCollector:
             t: The time step (episode length - 1). The initial obs has
                 ts=-1(!), then an action/reward/next-obs at t=0, etc..
         """
+        if t == -2:
+            import ipdb
+
+            ipdb.set_trace()
         # Store episode ID + unroll ID, which will be constant throughout this
         # AgentCollector's lifecycle.
         self.episode_id = episode_id

--- a/rllib/evaluation/collectors/agent_collector.py
+++ b/rllib/evaluation/collectors/agent_collector.py
@@ -178,10 +178,6 @@ class AgentCollector:
             t: The time step (episode length - 1). The initial obs has
                 ts=-1(!), then an action/reward/next-obs at t=0, etc..
         """
-        if t == -2:
-            import ipdb
-
-            ipdb.set_trace()
         # Store episode ID + unroll ID, which will be constant throughout this
         # AgentCollector's lifecycle.
         self.episode_id = episode_id

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -527,6 +527,8 @@ class EnvRunnerV2:
                 continue
 
             episode: EpisodeV2 = self._active_episodes[env_id]
+            # Finished advancing episode by 1 step, mark it so.
+            episode.step()
             # If this episode is brand-new, call the episode start callback(s).
             # Note: EpisodeV2s are initialized with length=-1 (before the reset).
             if not episode.has_init_obs():
@@ -660,8 +662,8 @@ class EnvRunnerV2:
                         item = AgentConnectorDataType(d.env_id, d.agent_id, d.data)
                         to_eval[policy_id].append(item)
 
-            # Finished advancing episode by 1 step, mark it so.
-            episode.step()
+            # # Finished advancing episode by 1 step, mark it so.
+            # episode.step()
 
             # Exception: The very first env.poll() call causes the env to get reset
             # (no step taken yet, just a single starting observation logged).
@@ -819,6 +821,7 @@ class EnvRunnerV2:
         # If reset is async, we will get its result in some future poll.
         elif resetted_obs != ASYNC_RESET_RETURN:
             new_episode: EpisodeV2 = self._active_episodes[env_id]
+            new_episode.step()
             self._call_on_episode_start(new_episode, env_id)
 
             per_policy_resetted_obs: Dict[PolicyID, List] = defaultdict(list)
@@ -852,7 +855,7 @@ class EnvRunnerV2:
                     to_eval[policy_id].append(d)
 
             # Step after adding initial obs. This will give us 0 env and agent step.
-            new_episode.step()
+            # new_episode.step()
 
     def create_episode(self, env_id: EnvID) -> EpisodeV2:
         """Creates a new EpisodeV2 instance and returns it.

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -543,8 +543,6 @@ class EnvRunnerV2:
                     and not dones[env_id]["__all__"]
                 )
                 all_agents_done = True
-                # Add rollout metrics.
-                outputs.extend(self._get_rollout_metrics(episode))
             else:
                 hit_horizon = False
                 all_agents_done = False
@@ -778,6 +776,8 @@ class EnvRunnerV2:
             # Output the collected episode.
             self._build_done_episode(env_id, is_done, hit_horizon, outputs)
             episode_or_exception: EpisodeV2 = self._active_episodes[env_id]
+            # Add rollout metrics.
+            outputs.extend(self._get_rollout_metrics(episode_or_exception))
 
         # Clean up and deleted the post-processed episode now that we have collected
         # its data.

--- a/rllib/evaluation/episode_v2.py
+++ b/rllib/evaluation/episode_v2.py
@@ -184,6 +184,7 @@ class EpisodeV2:
                 "_disable_action_flattening", False
             ),
             is_policy_recurrent=policy.is_recurrent(),
+            intial_states=policy.get_initial_state(),
         )
         self._agent_collectors[agent_id].add_init_obs(
             episode_id=self.episode_id,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

    Rollout worker metrics in the connectors did not include the last timestep

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
