### PR TITLE
Mark test_worker_failures.py exclusive.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -805,7 +805,7 @@ py_test(
 
 py_test(
     name = "test_worker_failures",
-    tags = ["team:rllib", "algorithms_dir", "algorithms_dir_generic"],
+    tags = ["team:rllib", "algorithms_dir", "algorithms_dir_generic", "exclusive"],
     size = "large",
     srcs = ["algorithms/tests/test_worker_failures.py"]
 )


### PR DESCRIPTION
Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

worker_failure_test.py sometimes is flaky. when I looked for errors, I notice error messages like:
```
E           ConnectionError: Found multiple active Ray instances: {'172.16.16.3:36563', '172.16.16.3:61256'}. Please specify the one to connect to by setting the `--address` flag or `RAY_ADDRESS` environment variable.
```
since we are using some low-level utils in these tests, mark them exclusive so we don't have multiple clusters running at the same time.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
