### PR TITLE
We need to track envs that are active explicitly.

### DIFF
--- a/rllib/evaluation/tests/test_env_runner_v2.py
+++ b/rllib/evaluation/tests/test_env_runner_v2.py
@@ -146,7 +146,7 @@ class TestEnvRunnerV2(unittest.TestCase):
         env_id = 0
         env_runner = local_worker.sampler._env_runner_obj
         env_runner.create_episode(env_id)
-        to_eval, _ = env_runner._process_observations(
+        _, to_eval, _ = env_runner._process_observations(
             {0: obs}, {0: rewards}, {0: dones}, {0: infos}
         )
 
@@ -336,13 +336,14 @@ class TestEnvRunnerV2(unittest.TestCase):
         env_runner.step()
         env_runner.step()
 
-        to_eval, outputs = env_runner._process_observations(
+        active_envs, to_eval, outputs = env_runner._process_observations(
             unfiltered_obs={0: AttributeError("mock error")},
             rewards={0: {}},
             dones={0: {"__all__": True}},
             infos={0: {}},
         )
 
+        self.assertEqual(active_envs, {0})
         self.assertTrue(to_eval)  # to_eval contains data for the resetted new episode.
         self.assertEqual(len(outputs), 1)
         self.assertTrue(isinstance(outputs[0], RolloutMetrics))


### PR DESCRIPTION
Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

We need to send an empty action dict to any env that is still active, but doesn't require specific agent actions.

## Related issue number


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
