### PR TITLE
[Jobs] [CI] Add multinode and GPU release test for Jobs

### DIFF
--- a/release/jobs_tests/app_config.yaml
+++ b/release/jobs_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/jobs_tests/compute_tpl_gpu_node.yaml
+++ b/release/jobs_tests/compute_tpl_gpu_node.yaml
@@ -1,0 +1,23 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+
+head_node_type:
+    name: head_node
+    instance_type: g4dn.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: m5.4xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+aws:
+  TagSpecifications:
+    - ResourceType: "instance"
+      Tags:
+        - Key: anyscale-user
+          Value: '{{env["ANYSCALE_USER"]}}'
+        - Key: anyscale-expiration
+          Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/jobs_tests/compute_tpl_gpu_node.yaml
+++ b/release/jobs_tests/compute_tpl_gpu_node.yaml
@@ -9,8 +9,8 @@ head_node_type:
 worker_node_types:
     - name: worker_node
       instance_type: m5.4xlarge
-      min_workers: 0
-      max_workers: 0
+      min_workers: 1
+      max_workers: 1
       use_spot: false
 
 aws:

--- a/release/jobs_tests/compute_tpl_gpu_worker.yaml
+++ b/release/jobs_tests/compute_tpl_gpu_worker.yaml
@@ -1,0 +1,23 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+
+head_node_type:
+    name: head_node
+    instance_type: m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: g4dn.4xlarge
+      min_workers: 1
+      max_workers: 1
+      use_spot: false
+
+aws:
+  TagSpecifications:
+    - ResourceType: "instance"
+      Tags:
+        - Key: anyscale-user
+          Value: '{{env["ANYSCALE_USER"]}}'
+        - Key: anyscale-expiration
+          Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/jobs_tests/workloads/check_gpu_ids.py
+++ b/release/jobs_tests/workloads/check_gpu_ids.py
@@ -1,0 +1,7 @@
+import ray
+import torch
+
+ray.init()
+
+assert torch.cuda.is_available()
+

--- a/release/jobs_tests/workloads/check_gpu_ids.py
+++ b/release/jobs_tests/workloads/check_gpu_ids.py
@@ -1,7 +1,0 @@
-import ray
-import torch
-
-ray.init()
-
-assert torch.cuda.is_available()
-

--- a/release/jobs_tests/workloads/jobs_check_cuda_available.py
+++ b/release/jobs_tests/workloads/jobs_check_cuda_available.py
@@ -1,0 +1,29 @@
+"""Job Submission CUDA available test
+
+Checks that GPU resources are available in the job submission
+driver script.
+
+This file is a driver script to be submitted to a Ray cluster via
+the Ray Jobs API. This is done by specifying `type: job` in 
+`release_tests.yaml` (as opposed to, say, `type: sdk_command`).
+
+Release test for https://github.com/ray-project/ray/issues/24455
+
+Test owner: architkulkarni
+"""
+
+import ray
+import torch
+
+ray.init()
+
+# Assert that GPU resources are available in the driver script
+assert torch.cuda.is_available()
+
+# For good measure, let's also check that we can use the GPU
+# in a remote function.
+@ray.remote(num_gpus=1)
+def f():
+    return ray.get_gpu_ids()
+
+assert ray.get(f.remote()) == [0]

--- a/release/jobs_tests/workloads/jobs_check_cuda_available.py
+++ b/release/jobs_tests/workloads/jobs_check_cuda_available.py
@@ -22,7 +22,7 @@ assert torch.cuda.is_available()
 
 # For good measure, let's also check that we can use the GPU
 # in a remote function.
-@ray.remote(num_gpus=1)
+@ray.remote(num_gpus=0.1)
 def f():
     return ray.get_gpu_ids()
 

--- a/release/jobs_tests/workloads/jobs_check_cuda_available.py
+++ b/release/jobs_tests/workloads/jobs_check_cuda_available.py
@@ -4,7 +4,7 @@ Checks that GPU resources are available in the job submission
 driver script.
 
 This file is a driver script to be submitted to a Ray cluster via
-the Ray Jobs API. This is done by specifying `type: job` in 
+the Ray Jobs API. This is done by specifying `type: job` in
 `release_tests.yaml` (as opposed to, say, `type: sdk_command`).
 
 Release test for https://github.com/ray-project/ray/issues/24455

--- a/release/jobs_tests/workloads/jobs_check_cuda_available.py
+++ b/release/jobs_tests/workloads/jobs_check_cuda_available.py
@@ -26,4 +26,5 @@ assert torch.cuda.is_available()
 def f():
     return ray.get_gpu_ids()
 
+
 assert ray.get(f.remote()) == [0]

--- a/release/jobs_tests/workloads/jobs_check_cuda_available.py
+++ b/release/jobs_tests/workloads/jobs_check_cuda_available.py
@@ -20,6 +20,7 @@ ray.init()
 # Assert that GPU resources are available in the driver script
 assert torch.cuda.is_available()
 
+
 # For good measure, let's also check that we can use the GPU
 # in a remote function.
 @ray.remote(num_gpus=0.1)

--- a/release/jobs_tests/workloads/jobs_remote_multi_node.py
+++ b/release/jobs_tests/workloads/jobs_remote_multi_node.py
@@ -7,14 +7,7 @@ This file is a driver script to be submitted to a Ray cluster via
 the Ray Jobs API.  This is done by specifying `type: job` in
 `release_tests.yaml` (as opposed to, say, `type: sdk_command`).
 
-It runs several actors to verify that multiple nodes started up.
-The number of actors is more than the number of CPUs on a single
-node, so we expect that the actors will be spread across multiple
-nodes.
-
 Test owner: architkulkarni
-
-Acceptance criteria: Should run through and print "PASSED"
 """
 
 import ray
@@ -26,29 +19,3 @@ NUM_NODES = 5
 # Assert that we have 5 nodes
 num_nodes = len(ray.nodes())
 assert num_nodes == NUM_NODES, "Expected 5 nodes, got {}".format(num_nodes)
-
-num_available_cpus = sum(
-    ray.available_resources().get("CPU", 0) for node in ray.nodes()
-)
-
-assert (
-    num_available_cpus >= 4 * num_nodes - 1
-), "Expected at least 4 CPUs per node, got {}".format(num_available_cpus)
-
-
-@ray.remote
-class Actor:
-    def __init__(self):
-        pass
-
-    def get_node_id(self):
-        return ray.get_runtime_context().node_id
-
-
-actors = [Actor.remote() for _ in range(num_available_cpus)]
-node_ids = set(ray.get([actor.get_node_id.remote() for actor in actors]))
-
-# Assert that actors are spread across all nodes
-assert len(node_ids) == num_nodes, "Expected {} nodes, got {}".format(
-    num_nodes, len(node_ids)
-)

--- a/release/jobs_tests/workloads/jobs_remote_multi_node.py
+++ b/release/jobs_tests/workloads/jobs_remote_multi_node.py
@@ -29,10 +29,11 @@ def get_node_id():
 # Allow one fewer node in case a node fails to come up.
 num_expected_nodes = NUM_NODES - 1
 
+node_ids = set(ray.get([get_node_id.remote() for _ in range(100)]))
 
-def check_num_nodes():
-    node_ids = set(ray.get([get_node_id.remote() for _ in range(100)]))
+def check_num_nodes_and_spawn_tasks():
+    node_ids.update(ray.get([get_node_id.remote() for _ in range(10)]))
     return len(node_ids) >= num_expected_nodes
 
 
-wait_for_condition(check_num_nodes)
+wait_for_condition(check_num_nodes_and_spawn_tasks)

--- a/release/jobs_tests/workloads/jobs_remote_multi_node.py
+++ b/release/jobs_tests/workloads/jobs_remote_multi_node.py
@@ -1,0 +1,54 @@
+"""Job submission remote multinode test
+
+This tests that Ray Job submission works when submitting jobs
+to a remote cluster with multiple nodes.
+
+This file is a driver script to be submitted to a Ray cluster via
+the Ray Jobs API.  This is done by specifying `type: job` in
+`release_tests.yaml` (as opposed to, say, `type: sdk_command`).
+
+It runs several actors to verify that multiple nodes started up.
+The number of actors is more than the number of CPUs on a single
+node, so we expect that the actors will be spread across multiple
+nodes.
+
+Test owner: architkulkarni
+
+Acceptance criteria: Should run through and print "PASSED"
+"""
+
+import ray
+
+ray.init()
+
+NUM_NODES = 5
+
+# Assert that we have 5 nodes
+num_nodes = len(ray.nodes())
+assert num_nodes == NUM_NODES, "Expected 5 nodes, got {}".format(num_nodes)
+
+num_available_cpus = sum(
+    ray.available_resources().get("CPU", 0) for node in ray.nodes()
+)
+
+assert (
+    num_available_cpus >= 4 * num_nodes - 1
+), "Expected at least 4 CPUs per node, got {}".format(num_available_cpus)
+
+
+@ray.remote
+class Actor:
+    def __init__(self):
+        pass
+
+    def get_node_id(self):
+        return ray.get_runtime_context().node_id
+
+
+actors = [Actor.remote() for _ in range(num_available_cpus)]
+node_ids = set(ray.get([actor.get_node_id.remote() for actor in actors]))
+
+# Assert that actors are spread across all nodes
+assert len(node_ids) == num_nodes, "Expected {} nodes, got {}".format(
+    num_nodes, len(node_ids)
+)

--- a/release/jobs_tests/workloads/jobs_remote_multi_node.py
+++ b/release/jobs_tests/workloads/jobs_remote_multi_node.py
@@ -16,6 +16,8 @@ ray.init()
 
 NUM_NODES = 5
 
-# Assert that we have 5 nodes
 num_nodes = len(ray.nodes())
-assert num_nodes == NUM_NODES, "Expected 5 nodes, got {}".format(num_nodes)
+# Allow one fewer node in case a node fails to come up.
+assert (
+    num_nodes >= NUM_NODES - 1
+), f"Expected at least {NUM_NODES - 1} nodes, got {num_nodes}"

--- a/release/jobs_tests/workloads/jobs_remote_multi_node.py
+++ b/release/jobs_tests/workloads/jobs_remote_multi_node.py
@@ -31,6 +31,7 @@ num_expected_nodes = NUM_NODES - 1
 
 node_ids = set(ray.get([get_node_id.remote() for _ in range(100)]))
 
+
 def check_num_nodes_and_spawn_tasks():
     node_ids.update(ray.get([get_node_id.remote() for _ in range(10)]))
     return len(node_ids) >= num_expected_nodes

--- a/release/jobs_tests/workloads/jobs_specify_num_gpus.py
+++ b/release/jobs_tests/workloads/jobs_specify_num_gpus.py
@@ -86,7 +86,9 @@ if __name__ == "__main__":
     result = {
         "time_taken": taken,
     }
-    test_output_json = os.environ.get("TEST_OUTPUT_JSON", "/tmp/jobs_specify_num_gpus.json")
+    test_output_json = os.environ.get(
+        "TEST_OUTPUT_JSON", "/tmp/jobs_specify_num_gpus.json"
+    )
     with open(test_output_json, "wt") as f:
         json.dump(result, f)
 

--- a/release/jobs_tests/workloads/jobs_specify_num_gpus.py
+++ b/release/jobs_tests/workloads/jobs_specify_num_gpus.py
@@ -70,13 +70,14 @@ if __name__ == "__main__":
         )
         timeout_s = 10 * 60
         status = wait_until_finish(client=client, job_id=job_id, timeout_s=timeout_s)
-
-        print("Status message: ", client.get_job_info(job_id=job_id).message)
+        job_info = client.get_job_info(job_id)
+        print("Status message: ", job_info.message)
 
         if num_gpus == 0:
             # We didn't specify any GPUs, so the driver should run on the head node.
             # The head node should not have a GPU, so the job should fail.
             assert status == JobStatus.FAILED
+            assert "CUDA is not available in the driver script" in job_info.message
         else:
             # We specified a GPU, so the driver should run on the worker node
             # with a GPU, so the job should succeed.

--- a/release/jobs_tests/workloads/jobs_specify_num_gpus.py
+++ b/release/jobs_tests/workloads/jobs_specify_num_gpus.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     # This test script runs on the head node, which should not have a GPU.
     assert not torch.cuda.is_available()
 
-    for num_gpus in [0, 1]:
+    for num_gpus in [0, 0.1]:
         job_id = client.submit_job(
             entrypoint="python jobs_check_cuda_available.py",
             runtime_env={"working_dir": args.working_dir},

--- a/release/jobs_tests/workloads/jobs_specify_num_gpus.py
+++ b/release/jobs_tests/workloads/jobs_specify_num_gpus.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
         job_id = client.submit_job(
             entrypoint="python jobs_check_cuda_available.py",
             runtime_env={"working_dir": args.working_dir},
-            num_gpus=num_gpus,
+            entrypoint_num_gpus=num_gpus,
         )
         timeout_s = 10 * 60
         status = wait_until_finish(client=client, job_id=job_id, timeout_s=timeout_s)

--- a/release/jobs_tests/workloads/jobs_specify_num_gpus.py
+++ b/release/jobs_tests/workloads/jobs_specify_num_gpus.py
@@ -1,0 +1,93 @@
+"""Job submission test
+
+This test checks that when using the Ray Jobs API with num_gpus
+specified, the driver is run on a node that has a GPU.
+
+Test owner: architkulkarni
+
+Acceptance criteria: Should run through and print "PASSED"
+"""
+
+import argparse
+import json
+import os
+import time
+import torch
+from typing import Optional
+from ray.dashboard.modules.job.common import JobStatus
+
+from ray.job_submission import JobSubmissionClient
+
+
+def wait_until_finish(
+    client: JobSubmissionClient,
+    job_id: str,
+    timeout_s: int = 10 * 60,
+    retry_interval_s: int = 1,
+) -> Optional[JobStatus]:
+    start_time_s = time.time()
+    while time.time() - start_time_s <= timeout_s:
+        status = client.get_job_status(job_id)
+        print(f"status: {status}")
+        if status in {JobStatus.SUCCEEDED, JobStatus.STOPPED, JobStatus.FAILED}:
+            return status
+        time.sleep(retry_interval_s)
+    return None
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--smoke-test", action="store_true", help="Finish quickly for testing."
+    )
+    parser.add_argument(
+        "--working-dir",
+        required=True,
+        help="working_dir to use for the job within this test.",
+    )
+    args = parser.parse_args()
+
+    start = time.time()
+
+    address = os.environ.get("RAY_ADDRESS")
+    job_name = os.environ.get("RAY_JOB_NAME", "jobs_specify_num_gpus")
+
+    if address is not None and address.startswith("anyscale://"):
+        pass
+    else:
+        address = "http://127.0.0.1:8265"
+
+    client = JobSubmissionClient(address)
+
+    # This test script runs on the head node, which should not have a GPU.
+    assert not torch.cuda.is_available()
+
+    for num_gpus in [0, 1]:
+        job_id = client.submit_job(
+            entrypoint="python jobs_check_cuda_available.py",
+            runtime_env={"working_dir": args.working_dir},
+            num_gpus=num_gpus,
+        )
+        timeout_s = 10 * 60
+        status = wait_until_finish(client=client, job_id=job_id, timeout_s=timeout_s)
+
+        print("Status message: ", client.get_job_info(job_id=job_id).message)
+
+        if num_gpus == 0:
+            # We didn't specify any GPUs, so the driver should run on the head node.
+            # The head node should not have a GPU, so the job should fail.
+            assert status == JobStatus.FAILED
+        else:
+            # We specified a GPU, so the driver should run on the worker node
+            # with a GPU, so the job should succeed.
+            assert status == JobStatus.SUCCEEDED
+
+    taken = time.time() - start
+    result = {
+        "time_taken": taken,
+    }
+    test_output_json = os.environ.get("TEST_OUTPUT_JSON", "/tmp/jobs_specify_num_gpus.json")
+    with open(test_output_json, "wt") as f:
+        json.dump(result, f)
+
+    print("PASSED")

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2291,7 +2291,8 @@
   run:
     timeout: 600
     script: python workloads/jobs_check_cuda_available.py
-
+    wait_for_nodes:
+      num_nodes: 2
     type: job
     file_manager: job
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2257,6 +2257,63 @@
 
   alert: default
 
+- name: jobs_remote_multi_node
+  group: Jobs tests
+  team: serve
+  frequency: nightly
+  working_dir: jobs_tests
+  legacy:
+    test_name: jobs_remote_multi_node
+    test_suite: jobs_tests
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: compute_tpl_4_xlarge.yaml
+  run:
+    timeout: 600
+    script: python workloads/jobs_remote_multi_node.py
+    wait_for_nodes:
+      num_nodes: 4
+
+    type: job
+    file_manager: job
+
+- name: jobs_check_cuda_available
+  group: Jobs tests
+  team: serve
+  frequency: nightly
+  working_dir: jobs_tests
+  legacy:
+    test_name: jobs_check_cuda_available
+    test_suite: jobs_tests
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: compute_tpl_gpu_node.yaml
+  run:
+    timeout: 600
+    script: python workloads/jobs_check_cuda_available.py
+
+    type: job
+    file_manager: job
+
+- name: jobs_specify_num_gpus
+  group: Jobs tests
+  team: serve
+  frequency: nightly
+  working_dir: jobs_tests
+  legacy:
+    test_name: jobs_specify_num_gpus
+    test_suite: jobs_tests
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: compute_tpl_gpu_worker.yaml
+  run:
+    timeout: 600
+    script: python workloads/jobs_specify_num_gpus.py
+    wait_for_nodes:
+      num_nodes: 2
+
+    type: sdk_command
+    file_manager: job
 
 ########################
 # Runtime env tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2308,7 +2308,7 @@
     cluster_compute: compute_tpl_gpu_worker.yaml
   run:
     timeout: 600
-    script: python workloads/jobs_specify_num_gpus.py
+    script: python workloads/jobs_specify_num_gpus.py --working-dir "workloads"
     wait_for_nodes:
       num_nodes: 2
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
Followup to #28654 
- Adds a minimal test which connects to the Ray cluster remotely from the CI machine.  (To do this we use the `type: job` option which is already provided by the release test infrastructure, but is only used by one test right now.) Previously all Jobs tests ran a JobSubmissionClient from the head node.
- Adds release tests for https://github.com/ray-project/ray/issues/24455.
  - Checks that by default, GPUs are available in the driver script (by default the driver is scheduled on the head node, and the head node has a GPU in this test).
  - Checks that if a positive `num_gpus` is passed to the Jobs API, the driver script is scheduled on a node which has a GPU (as opposed to the head node, which is the default and which does not have a GPU in this test).
  - For both of the above, checks that GPUs are available to tasks scheduled from the driver script.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
