### PR TITLE
Make pandas import lazy in data_batch_conversion

### DIFF
--- a/python/ray/air/util/data_batch_conversion.py
+++ b/python/ray/air/util/data_batch_conversion.py
@@ -22,7 +22,7 @@ except ImportError:
 _pandas = None
 
 
-def lazy_import_pandas():
+def _lazy_import_pandas():
     global _pandas
     if _pandas is None:
         import pandas
@@ -63,7 +63,7 @@ def convert_batch_type_to_pandas(
         A pandas Dataframe representation of the input data.
 
     """
-    pd = lazy_import_pandas()
+    pd = _lazy_import_pandas()
 
     if isinstance(data, np.ndarray):
         data = pd.DataFrame({TENSOR_COLUMN_NAME: _ndarray_to_column(data)})
@@ -149,7 +149,7 @@ def _convert_batch_type_to_numpy(
     Returns:
         A numpy representation of the input data.
     """
-    pd = lazy_import_pandas()
+    pd = _lazy_import_pandas()
 
     if isinstance(data, np.ndarray):
         return data
@@ -209,7 +209,7 @@ def _ndarray_to_column(arr: np.ndarray) -> Union["pd.Series", List[np.ndarray]]:
     If conversion to a pandas Series fails (e.g. if the ndarray is multi-dimensional),
     fall back to a list of NumPy ndarrays.
     """
-    pd = lazy_import_pandas()
+    pd = _lazy_import_pandas()
     try:
         # Try to convert to Series, falling back to a list conversion if this fails
         # (e.g. if the ndarray is multi-dimensional).
@@ -236,7 +236,7 @@ def _cast_ndarray_columns_to_tensor_extension(df: "pd.DataFrame") -> "pd.DataFra
     """
     Cast all NumPy ndarray columns in df to our tensor extension type, TensorArray.
     """
-    pd = lazy_import_pandas()
+    pd = _lazy_import_pandas()
     from ray.air.util.tensor_extensions.pandas import (
         TensorArray,
         column_needs_tensor_extension,
@@ -270,7 +270,7 @@ def _cast_ndarray_columns_to_tensor_extension(df: "pd.DataFrame") -> "pd.DataFra
 
 def _cast_tensor_columns_to_ndarrays(df: "pd.DataFrame") -> "pd.DataFrame":
     """Cast all tensor extension columns in df to NumPy ndarrays."""
-    pd = lazy_import_pandas()
+    pd = _lazy_import_pandas()
     from ray.air.util.tensor_extensions.pandas import TensorDtype
 
     with pd.option_context("chained_assignment", None):

--- a/python/ray/air/util/data_batch_conversion.py
+++ b/python/ray/air/util/data_batch_conversion.py
@@ -3,7 +3,6 @@ from typing import Dict, Union, List
 import warnings
 
 import numpy as np
-import pandas as pd
 
 from ray.air.data_batch_type import DataBatchType
 from ray.air.constants import TENSOR_COLUMN_NAME
@@ -14,6 +13,13 @@ try:
     import pyarrow
 except ImportError:
     pyarrow = None
+
+# Lazy import to avoid ray init failures without pandas installed and allow
+# dataset to import modules in this file.
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
 
 
 @DeveloperAPI
@@ -37,7 +43,7 @@ class BlockFormat(str, Enum):
 def convert_batch_type_to_pandas(
     data: DataBatchType,
     cast_tensor_columns: bool = False,
-) -> pd.DataFrame:
+) -> "pd.DataFrame":
     """Convert the provided data to a Pandas DataFrame.
 
     Args:
@@ -48,6 +54,13 @@ def convert_batch_type_to_pandas(
         A pandas Dataframe representation of the input data.
 
     """
+    if not pd:
+        raise ImportError(
+            "Attempted to convert data to Pandas but Pandas "
+            "is not installed. Please do `pip install pandas` to "
+            "install Pandas."
+        )
+
     if isinstance(data, np.ndarray):
         data = pd.DataFrame({TENSOR_COLUMN_NAME: _ndarray_to_column(data)})
     elif isinstance(data, dict):
@@ -75,7 +88,7 @@ def convert_batch_type_to_pandas(
 
 @DeveloperAPI
 def convert_pandas_to_batch_type(
-    data: pd.DataFrame,
+    data: "pd.DataFrame",
     type: BatchFormat,
     cast_tensor_columns: bool = False,
 ) -> DataBatchType:
@@ -183,7 +196,7 @@ def _convert_batch_type_to_numpy(
         )
 
 
-def _ndarray_to_column(arr: np.ndarray) -> Union[pd.Series, List[np.ndarray]]:
+def _ndarray_to_column(arr: np.ndarray) -> Union["pd.Series", List[np.ndarray]]:
     """Convert a NumPy ndarray into an appropriate column format for insertion into a
     pandas DataFrame.
 
@@ -212,10 +225,16 @@ def _unwrap_ndarray_object_type_if_needed(arr: np.ndarray) -> np.ndarray:
     return arr
 
 
-def _cast_ndarray_columns_to_tensor_extension(df: pd.DataFrame) -> pd.DataFrame:
+def _cast_ndarray_columns_to_tensor_extension(df: "pd.DataFrame") -> "pd.DataFrame":
     """
     Cast all NumPy ndarray columns in df to our tensor extension type, TensorArray.
     """
+    if not pd:
+        raise ImportError(
+            "Attempted to handle Pandas data but Pandas "
+            "is not installed. Please do `pip install pandas` to "
+            "install Pandas."
+        )
     from ray.air.util.tensor_extensions.pandas import (
         TensorArray,
         column_needs_tensor_extension,
@@ -247,8 +266,14 @@ def _cast_ndarray_columns_to_tensor_extension(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def _cast_tensor_columns_to_ndarrays(df: pd.DataFrame) -> pd.DataFrame:
+def _cast_tensor_columns_to_ndarrays(df: "pd.DataFrame") -> "pd.DataFrame":
     """Cast all tensor extension columns in df to NumPy ndarrays."""
+    if not pd:
+        raise ImportError(
+            "Attempted to handle Pandas data but Pandas "
+            "is not installed. Please do `pip install pandas` to "
+            "install Pandas."
+        )
     from ray.air.util.tensor_extensions.pandas import TensorDtype
 
     with pd.option_context("chained_assignment", None):


### PR DESCRIPTION
## Why are these changes needed?

In my previous PR I defined a `BlockFormat` enum in data_batch_conversion and imported from dataset. But since dataset deps lives on critical path of ray.init(), it leads to test_dashboard failures without pandas installed. This PR makes it lazy and throw exception on all critical functions that requires pandas beyond typehint.

Verified by manually uninstalling pandas, run `pytest test_dashboard.py` to ensure it failed, apply this PR and ensure it works as expected.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
