### PR TITLE
[doc][minor] 2.1.0 doc patch: Update legacy Ray operator migration link 

### DIFF
--- a/doc/source/cluster/kubernetes/index.md
+++ b/doc/source/cluster/kubernetes/index.md
@@ -90,7 +90,7 @@ the project.
 and discussion of new and upcoming features.
 
 ```{note}
-The KubeRay operator replaces the older Ray operator hosted in the [Ray repository](https://github.com/ray-project/ray/tree/master/python/ray/ray_operator).
+The KubeRay operator replaces the older Ray operator hosted in the [Ray repository](https://github.com/ray-project/ray/tree/releases/2.1.0/python/ray/ray_operator).
 The legacy Ray operator will be compatible with Ray versions up to Ray 2.1.0.
 However, **the legacy Ray operator will be removed in Ray 2.2.0.**
 Check the linked README for migration notes.


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

All master branch files related to the legacy Ray Operator have been removed. This created a broken link in the latest (2.1.0) release docs. (Master docs do not have this issue.)

This patch fixes the 2.1.0 docs.

(I'm not sure about our procedure for patching documentation in a release branch.)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
