### PR TITLE
Revert "[AIR][Predictor] Enable numpy based predictor"

### DIFF
--- a/doc/source/ray-air/examples/convert_existing_tf_code_to_ray_air.ipynb
+++ b/doc/source/ray-air/examples/convert_existing_tf_code_to_ray_air.ipynb
@@ -658,7 +658,7 @@
     "\n",
     "sample_images = x_test[:3]\n",
     "sample_labels = y_test[:3]\n",
-    "preds = predictor.predict(sample_images)[\"predictions\"].argmax(1)\n",
+    "preds = predictor.predict(sample_images).argmax(1)\n",
     "for image, pred, label in zip(sample_images, preds, sample_labels):\n",
     "    plt.figure(figsize=(2, 2))\n",
     "    plt.title(f\"Prediction = {pred}, Label = {label}\")\n",

--- a/doc/source/ray-air/examples/torch_incremental_learning.ipynb
+++ b/doc/source/ray-air/examples/torch_incremental_learning.ipynb
@@ -517,26 +517,24 @@
    },
    "outputs": [],
    "source": [
-    "from typing import Dict\n",
-    "import numpy as np\n",
-    "\n",
-    "import torch\n",
-    "from torchvision import transforms\n",
-    "\n",
     "from ray.data.preprocessors import BatchMapper\n",
     "\n",
-    "def preprocess_images(image_batch_dict: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:\n",
-    "    \"\"\"Preprocess images by scaling each channel in the image.\"\"\"\n",
-    "    torchvision_transforms = transforms.Compose(\n",
-    "      [transforms.Normalize((0.1307,), (0.3081,))]\n",
-    "    )\n",
-    "    # Outer dimension is batch size such as (4096, 28, 28)\n",
-    "    image_batch_dict[\"image\"] = torchvision_transforms(\n",
-    "        torch.Tensor(image_batch_dict[\"image\"])\n",
-    "    ).numpy()\n",
-    "    return image_batch_dict\n",
+    "from torchvision import transforms\n",
     "\n",
-    "mnist_normalize_preprocessor = BatchMapper(fn=preprocess_images, batch_format=\"numpy\")"
+    "def preprocess_images(df: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"Preprocess images by scaling each channel in the image.\"\"\"\n",
+    "\n",
+    "    torchvision_transforms = transforms.Compose(\n",
+    "      [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]\n",
+    "    )\n",
+    "\n",
+    "    df = df.copy()\n",
+    "    df.loc[:, \"image\"] = [\n",
+    "        torchvision_transforms(image).numpy() for image in df[\"image\"]\n",
+    "    ]\n",
+    "    return df\n",
+    "\n",
+    "mnist_normalize_preprocessor = BatchMapper(fn=preprocess_images)"
    ]
   },
   {
@@ -1406,7 +1404,7 @@
     "          # Have to specify trainer_resources as 0 so that the example works on Colab. \n",
     "          scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=use_gpu, trainer_resources={\"CPU\": 0}),\n",
     "          datasets={\"train\": train_dataset},\n",
-    "          preprocessor=mnist_normalize_preprocessor,\n",
+    "          preprocessor=BatchMapper(fn=preprocess_images),\n",
     "          resume_from_checkpoint=latest_checkpoint,\n",
     "      )\n",
     "  result = trainer.fit()\n",
@@ -1717,7 +1715,7 @@
     "            # Have to specify trainer_resources as 0 so that the example works on Colab. \n",
     "            scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=use_gpu, trainer_resources={\"CPU\": 0}),\n",
     "            datasets={\"train\": combined_training_dataset},\n",
-    "            preprocessor=mnist_normalize_preprocessor,\n",
+    "            preprocessor=BatchMapper(fn=preprocess_images),\n",
     "        )\n",
     "result = trainer.fit()\n",
     "full_training_checkpoint = result.checkpoint"
@@ -1843,7 +1841,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   },
   "vscode": {
    "interpreter": {

--- a/doc/source/ray-air/predictors.rst
+++ b/doc/source/ray-air/predictors.rst
@@ -20,7 +20,7 @@ Ray AIR Predictors are a class that loads models from `Checkpoint` to perform in
 
 Predictors are used by `BatchPredictor` and `PredictorDeployment` to do large-scale scoring or online inference.
 
-Let's walk through a basic usage of the Predictor. In the below example, we create `Checkpoint` object from a model definition.
+Let's walk through a basic usage of the Predictor. In the below example, we create `Checkpoint` object from a model definition. 
 Checkpoints can be generated from a variety of different ways -- see the :ref:`Checkpoints <air-checkpoints-doc>` user guide for more details.
 
 The checkpoint then is used to create a framework specific Predictor (in our example, a `TensorflowPredictor`), which then can be used for inference:
@@ -46,7 +46,7 @@ Batch Prediction
 
 Ray AIR provides a ``BatchPredictor`` utility for large-scale batch inference.
 
-The BatchPredictor takes in a checkpoint and a predictor class and executes
+The BatchPredictor takes in a checkpoint and a predictor class and executes 
 large-scale batch prediction on a given dataset in a parallel/distributed fashion when calling ``predict()``.
 
 .. note::
@@ -117,10 +117,10 @@ Coming soon!
 Lazy/Pipelined Prediction (experimental)
 ----------------------------------------
 
-If you have a large dataset but not a lot of available memory, you can use the
+If you have a large dataset but not a lot of available memory, you can use the 
 :meth:`predict_pipelined <ray.train.batch_predictor.BatchPredictor.predict_pipelined>` method.
 
-Unlike :py:meth:`predict` which will load the entire data into memory, ``predict_pipelined`` will create a
+Unlike :py:meth:`predict` which will load the entire data into memory, ``predict_pipelined`` will create a 
 :class:`DatasetPipeline` object, which will *lazily* load the data and perform inference on a smaller batch of data at a time.
 
 The lazy loading of the data will allow you to operate on datasets much greater than your available memory.
@@ -145,4 +145,6 @@ To implement a new Predictor for your particular framework, you should subclass 
 
 1. ``_predict_pandas``: Given a pandas.DataFrame input, return a pandas.DataFrame containing predictions.
 2. ``from_checkpoint``: Logic for creating a Predictor from an :ref:`AIR Checkpoint <air-checkpoint-ref>`.
-3. Optionally ``_predict_numpy`` for better performance when working with tensor data to avoid extra copies from Pandas conversions.
+3. Optionally ``_predict_arrow`` for better performance when working with tensor data to avoid extra copies from Pandas conversions.
+
+

--- a/doc/source/train/doc_code/xgboost_train_predict.py
+++ b/doc/source/train/doc_code/xgboost_train_predict.py
@@ -22,13 +22,11 @@ predictions = predictor.predict(np.expand_dims(np.arange(32, 64), 1))
 # __train_predict_end__
 
 # __batch_predict_start__
-import pandas as pd
 from ray.train.batch_predictor import BatchPredictor
 
 batch_predictor = BatchPredictor.from_checkpoint(result.checkpoint, XGBoostPredictor)
-predict_dataset = ray.data.from_pandas(pd.DataFrame({"x": np.arange(32)}))
 predictions = batch_predictor.predict(
-    data=predict_dataset,
+    data=ray.data.from_items([{"x": x} for x in range(32)]),
     batch_size=8,
     min_scoring_workers=2,
 )

--- a/python/ray/air/data_batch_type.py
+++ b/python/ray/air/data_batch_type.py
@@ -3,5 +3,8 @@ from typing import Dict, Union, TYPE_CHECKING
 if TYPE_CHECKING:
     import numpy
     import pandas
+    import pyarrow
 
-DataBatchType = Union["numpy.ndarray", "pandas.DataFrame", Dict[str, "numpy.ndarray"]]
+DataBatchType = Union[
+    "numpy.ndarray", "pandas.DataFrame", "pyarrow.Table", Dict[str, "numpy.ndarray"]
+]

--- a/python/ray/air/tests/test_data_batch_conversion.py
+++ b/python/ray/air/tests/test_data_batch_conversion.py
@@ -14,7 +14,7 @@ from ray.air.util.data_batch_conversion import (
     _cast_ndarray_columns_to_tensor_extension,
     _cast_tensor_columns_to_ndarrays,
 )
-from ray.air.util.data_batch_conversion import BatchFormat
+from ray.air.util.data_batch_conversion import DataType
 from ray.air.util.tensor_extensions.pandas import TensorArray
 from ray.air.util.tensor_extensions.arrow import ArrowTensorArray
 
@@ -25,7 +25,7 @@ def test_pandas_pandas():
     actual_output = convert_batch_type_to_pandas(input_data)
     pd.testing.assert_frame_equal(expected_output, actual_output)
 
-    actual_output = convert_pandas_to_batch_type(actual_output, type=BatchFormat.PANDAS)
+    actual_output = convert_pandas_to_batch_type(actual_output, type=DataType.PANDAS)
     pd.testing.assert_frame_equal(actual_output, input_data)
 
 
@@ -147,7 +147,7 @@ def test_pandas_multi_dim_pandas(cast_tensor_columns, use_tensor_extension_for_i
     pd.testing.assert_frame_equal(expected_output, actual_output)
 
     actual_output = convert_pandas_to_batch_type(
-        actual_output, type=BatchFormat.PANDAS, cast_tensor_columns=cast_tensor_columns
+        actual_output, type=DataType.PANDAS, cast_tensor_columns=cast_tensor_columns
     )
     pd.testing.assert_frame_equal(actual_output, input_data)
 
@@ -173,7 +173,7 @@ def test_numpy_pandas(cast_tensor_columns):
     pd.testing.assert_frame_equal(expected_output, actual_output)
 
     output_array = convert_pandas_to_batch_type(
-        actual_output, type=BatchFormat.NUMPY, cast_tensor_columns=cast_tensor_columns
+        actual_output, type=DataType.NUMPY, cast_tensor_columns=cast_tensor_columns
     )
     np.testing.assert_equal(output_array, input_data)
 
@@ -186,7 +186,7 @@ def test_numpy_multi_dim_pandas(cast_tensor_columns):
     pd.testing.assert_frame_equal(expected_output, actual_output)
 
     output_array = convert_pandas_to_batch_type(
-        actual_output, type=BatchFormat.NUMPY, cast_tensor_columns=cast_tensor_columns
+        actual_output, type=DataType.NUMPY, cast_tensor_columns=cast_tensor_columns
     )
     np.testing.assert_array_equal(np.array(list(output_array)), input_data)
 
@@ -198,7 +198,7 @@ def test_numpy_object_pandas():
     pd.testing.assert_frame_equal(expected_output, actual_output)
 
     np.testing.assert_array_equal(
-        convert_pandas_to_batch_type(actual_output, type=BatchFormat.NUMPY), input_data
+        convert_pandas_to_batch_type(actual_output, type=DataType.NUMPY), input_data
     )
 
 
@@ -227,7 +227,7 @@ def test_dict_pandas(cast_tensor_columns):
     pd.testing.assert_frame_equal(expected_output, actual_output)
 
     output_array = convert_pandas_to_batch_type(
-        actual_output, type=BatchFormat.NUMPY, cast_tensor_columns=cast_tensor_columns
+        actual_output, type=DataType.NUMPY, cast_tensor_columns=cast_tensor_columns
     )
     np.testing.assert_array_equal(output_array, input_data["x"])
 
@@ -241,7 +241,7 @@ def test_dict_multi_dim_to_pandas(cast_tensor_columns):
     pd.testing.assert_frame_equal(expected_output, actual_output)
 
     output_array = convert_pandas_to_batch_type(
-        actual_output, type=BatchFormat.NUMPY, cast_tensor_columns=cast_tensor_columns
+        actual_output, type=DataType.NUMPY, cast_tensor_columns=cast_tensor_columns
     )
     np.testing.assert_array_equal(np.array(list(output_array)), input_data["x"])
 
@@ -254,7 +254,7 @@ def test_dict_pandas_multi_column(cast_tensor_columns):
     pd.testing.assert_frame_equal(expected_output, actual_output)
 
     output_dict = convert_pandas_to_batch_type(
-        actual_output, type=BatchFormat.NUMPY, cast_tensor_columns=cast_tensor_columns
+        actual_output, type=DataType.NUMPY, cast_tensor_columns=cast_tensor_columns
     )
     for k, v in output_dict.items():
         np.testing.assert_array_equal(v, array_dict[k])
@@ -267,7 +267,7 @@ def test_arrow_pandas():
     actual_output = convert_batch_type_to_pandas(input_data)
     pd.testing.assert_frame_equal(expected_output, actual_output)
 
-    assert convert_pandas_to_batch_type(actual_output, type=BatchFormat.ARROW).equals(
+    assert convert_pandas_to_batch_type(actual_output, type=DataType.ARROW).equals(
         input_data
     )
 
@@ -286,7 +286,7 @@ def test_arrow_tensor_pandas(cast_tensor_columns):
     pd.testing.assert_frame_equal(expected_output, actual_output)
 
     arrow_output = convert_pandas_to_batch_type(
-        actual_output, type=BatchFormat.ARROW, cast_tensor_columns=cast_tensor_columns
+        actual_output, type=DataType.ARROW, cast_tensor_columns=cast_tensor_columns
     )
     assert arrow_output.equals(input_data)
 

--- a/python/ray/data/_internal/fast_repartition.py
+++ b/python/ray/data/_internal/fast_repartition.py
@@ -23,7 +23,7 @@ def fast_repartition(blocks, num_blocks):
     )
     # Compute the (n-1) indices needed for an equal split of the data.
     count = wrapped_ds.count()
-    dataset_format = wrapped_ds.dataset_format()
+    dataset_format = wrapped_ds._dataset_format()
     indices = []
     cur_idx = 0
     for _ in range(num_blocks - 1):

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -61,7 +61,7 @@ KeyFn = Union[None, str, Callable[[T], Any]]
 def _validate_key_fn(ds: "Dataset", key: KeyFn) -> None:
     """Check the key function is valid on the given dataset."""
     try:
-        fmt = ds.dataset_format()
+        fmt = ds._dataset_format()
     except ValueError:
         # Dataset is empty/cleared, validation not possible.
         return

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -18,7 +18,6 @@ from typing import (
 import warnings
 
 import ray
-from ray.air.util.data_batch_conversion import BlockFormat
 from ray.data._internal import progress_bar
 from ray.data._internal.block_batching import BatchType, batch_blocks
 from ray.data._internal.block_list import BlockList
@@ -562,35 +561,6 @@ class DatasetPipeline(Generic[T]):
         if not self._executed[0]:
             self._schema = self._peek().schema(fetch_if_missing)
         return self._schema
-
-    def dataset_format(self) -> BlockFormat:
-        """The format of the dataset pipeline's underlying data blocks. Possible
-        values are: "arrow", "pandas" and "simple".
-
-        This may block; if the schema is unknown, this will synchronously fetch
-        the schema for the first block.
-        """
-        # We need schema to properly validate, so synchronously
-        # fetch it if necessary.
-        schema = self.schema(fetch_if_missing=True)
-        if schema is None:
-            raise ValueError(
-                "Dataset is empty or cleared, can't determine the format of "
-                "the dataset."
-            )
-
-        try:
-            import pyarrow as pa
-
-            if isinstance(schema, pa.Schema):
-                return BlockFormat.ARROW
-        except ModuleNotFoundError:
-            pass
-        from ray.data._internal.pandas_block import PandasBlockSchema
-
-        if isinstance(schema, PandasBlockSchema):
-            return BlockFormat.PANDAS
-        return BlockFormat.SIMPLE
 
     def count(self) -> int:
         """Count the number of records in the dataset pipeline.

--- a/python/ray/data/preprocessors/batch_mapper.py
+++ b/python/ray/data/preprocessors/batch_mapper.py
@@ -4,7 +4,6 @@ import warnings
 
 import numpy as np
 
-from ray.air.util.data_batch_conversion import BatchFormat, BlockFormat
 from ray.data.preprocessor import Preprocessor
 from ray.util.annotations import PublicAPI
 
@@ -81,7 +80,7 @@ class BatchMapper(Preprocessor):
                 Union[np.ndarray, Dict[str, np.ndarray]],
             ],
         ],
-        batch_format: Optional[BatchFormat] = None,
+        batch_format: Optional[str] = None,
         batch_size: Optional[Union[int, Literal["default"]]] = "default",
         # TODO: Make batch_format required from user
         # TODO: Introduce a "zero_copy" format
@@ -93,10 +92,10 @@ class BatchMapper(Preprocessor):
                 "releases. Defaulting to 'pandas' batch format.",
                 DeprecationWarning,
             )
-            batch_format = BatchFormat.PANDAS
+            batch_format = "pandas"
         if batch_format and batch_format not in [
-            BatchFormat.PANDAS,
-            BatchFormat.NUMPY,
+            "pandas",
+            "numpy",
         ]:
             raise ValueError("BatchMapper only supports pandas and numpy batch format.")
 
@@ -112,7 +111,7 @@ class BatchMapper(Preprocessor):
     def _transform_pandas(self, df: "pandas.DataFrame") -> "pandas.DataFrame":
         return self.fn(df)
 
-    def _determine_transform_to_use(self, data_format: BlockFormat):
+    def _determine_transform_to_use(self, data_format: str):
         if self.batch_format:
             return self.batch_format
         else:

--- a/python/ray/data/random_access_dataset.py
+++ b/python/ray/data/random_access_dataset.py
@@ -37,7 +37,7 @@ class RandomAccessDataset(Generic[T]):
         The constructor is a private API. Use ``dataset.to_random_access_dataset()``
         to construct a RandomAccessDataset.
         """
-        self._format = dataset.dataset_format()
+        self._format = dataset._dataset_format()
         if self._format not in ["arrow", "pandas"]:
             raise ValueError("RandomAccessDataset only supports Arrow-format datasets.")
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2224,10 +2224,10 @@ def test_select_columns(ray_start_regular_shared):
     # Test pandas and arrow
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [2, 3, 4], "col3": [3, 4, 5]})
     ds1 = ray.data.from_pandas(df)
-    assert ds1.dataset_format() == "pandas"
+    assert ds1._dataset_format() == "pandas"
 
     ds2 = ds1.map_batches(lambda pa: pa, batch_size=1, batch_format="pyarrow")
-    assert ds2.dataset_format() == "arrow"
+    assert ds2._dataset_format() == "arrow"
 
     for each_ds in [ds1, ds2]:
         assert each_ds.select_columns(cols=[]).take(1) == [{}]
@@ -2252,7 +2252,7 @@ def test_select_columns(ray_start_regular_shared):
 
     # Test simple
     ds3 = ray.data.range(10)
-    assert ds3.dataset_format() == "simple"
+    assert ds3._dataset_format() == "simple"
     with pytest.raises(ValueError):
         ds3.select_columns(cols=[])
 
@@ -2271,7 +2271,7 @@ def test_map_batches_basic(ray_start_regular_shared, tmp_path):
     # Test pandas
     ds = ray.data.read_parquet(str(tmp_path))
     ds2 = ds.map_batches(lambda df: df + 1, batch_size=1, batch_format="pandas")
-    assert ds2.dataset_format() == "pandas"
+    assert ds2._dataset_format() == "pandas"
     ds_list = ds2.take()
     values = [s["one"] for s in ds_list]
     assert values == [2, 3, 4]
@@ -2281,7 +2281,7 @@ def test_map_batches_basic(ray_start_regular_shared, tmp_path):
     # Test Pyarrow
     ds = ray.data.read_parquet(str(tmp_path))
     ds2 = ds.map_batches(lambda pa: pa, batch_size=1, batch_format="pyarrow")
-    assert ds2.dataset_format() == "arrow"
+    assert ds2._dataset_format() == "arrow"
     ds_list = ds2.take()
     values = [s["one"] for s in ds_list]
     assert values == [1, 2, 3]
@@ -2292,7 +2292,7 @@ def test_map_batches_basic(ray_start_regular_shared, tmp_path):
     size = 300
     ds = ray.data.range(size)
     ds2 = ds.map_batches(lambda df: df + 1, batch_size=17, batch_format="pandas")
-    assert ds2.dataset_format() == "pandas"
+    assert ds2._dataset_format() == "pandas"
     ds_list = ds2.take_all()
     for i in range(size):
         # The pandas column is "value", and it originally has rows from 0~299.
@@ -2305,7 +2305,7 @@ def test_map_batches_basic(ray_start_regular_shared, tmp_path):
     # pandas => list block
     ds = ray.data.read_parquet(str(tmp_path))
     ds2 = ds.map_batches(lambda df: [1], batch_size=1)
-    assert ds2.dataset_format() == "simple"
+    assert ds2._dataset_format() == "simple"
     ds_list = ds2.take()
     assert ds_list == [1, 1, 1]
     assert ds.count() == 3
@@ -2313,7 +2313,7 @@ def test_map_batches_basic(ray_start_regular_shared, tmp_path):
     # pyarrow => list block
     ds = ray.data.read_parquet(str(tmp_path))
     ds2 = ds.map_batches(lambda df: [1], batch_size=1, batch_format="pyarrow")
-    assert ds2.dataset_format() == "simple"
+    assert ds2._dataset_format() == "simple"
     ds_list = ds2.take()
     assert ds_list == [1, 1, 1]
     assert ds.count() == 3
@@ -2380,7 +2380,7 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
         batch_format="pandas",
         fn_args=(ray.put(1),),
     )
-    assert ds2.dataset_format() == "pandas"
+    assert ds2._dataset_format() == "pandas"
     ds_list = ds2.take()
     values = [s["one"] for s in ds_list]
     assert values == [2, 3, 4]
@@ -2399,7 +2399,7 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
         batch_format="pandas",
         fn_kwargs={"b": ray.put(2)},
     )
-    assert ds2.dataset_format() == "pandas"
+    assert ds2._dataset_format() == "pandas"
     ds_list = ds2.take()
     values = [s["one"] for s in ds_list]
     assert values == [2, 4, 6]
@@ -2420,7 +2420,7 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
         fn_args=(ray.put(1),),
         fn_kwargs={"b": ray.put(2)},
     )
-    assert ds2.dataset_format() == "pandas"
+    assert ds2._dataset_format() == "pandas"
     ds_list = ds2.take()
     values = [s["one"] for s in ds_list]
     assert values == [3, 5, 7]
@@ -2445,7 +2445,7 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
         compute="actors",
         fn_constructor_args=(ray.put(1),),
     )
-    assert ds2.dataset_format() == "pandas"
+    assert ds2._dataset_format() == "pandas"
     ds_list = ds2.take()
     values = [s["one"] for s in ds_list]
     assert values == [2, 3, 4]
@@ -2469,7 +2469,7 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
         compute="actors",
         fn_constructor_kwargs={"b": ray.put(2)},
     )
-    assert ds2.dataset_format() == "pandas"
+    assert ds2._dataset_format() == "pandas"
     ds_list = ds2.take()
     values = [s["one"] for s in ds_list]
     assert values == [2, 4, 6]
@@ -2496,7 +2496,7 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
         fn_constructor_args=(ray.put(1),),
         fn_constructor_kwargs={"b": ray.put(2)},
     )
-    assert ds2.dataset_format() == "pandas"
+    assert ds2._dataset_format() == "pandas"
     ds_list = ds2.take()
     values = [s["one"] for s in ds_list]
     assert values == [3, 5, 7]
@@ -2526,7 +2526,7 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
             fn_constructor_kwargs=fn_constructor_kwargs,
         )
     )
-    assert ds2.dataset_format() == "pandas"
+    assert ds2._dataset_format() == "pandas"
     ds_list = ds2.take()
     values = [s["one"] for s in ds_list]
     assert values == [7, 11, 15]
@@ -2556,7 +2556,7 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
             fn_constructor_kwargs=fn_constructor_kwargs,
         )
     )
-    assert ds2.dataset_format() == "pandas"
+    assert ds2._dataset_format() == "pandas"
     ds_list = ds2.take()
     values = [s["one"] for s in ds_list]
     assert values == [7, 11, 15]

--- a/python/ray/data/tests/test_dataset_pandas.py
+++ b/python/ray/data/tests/test_dataset_pandas.py
@@ -25,7 +25,7 @@ def test_from_pandas(ray_start_regular_shared, enable_pandas_block):
         df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
         df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
         ds = ray.data.from_pandas([df1, df2])
-        assert ds.dataset_format() == "pandas" if enable_pandas_block else "arrow"
+        assert ds._dataset_format() == "pandas" if enable_pandas_block else "arrow"
         values = [(r["one"], r["two"]) for r in ds.take(6)]
         rows = [(r.one, r.two) for _, r in pd.concat([df1, df2]).iterrows()]
         assert values == rows
@@ -34,7 +34,7 @@ def test_from_pandas(ray_start_regular_shared, enable_pandas_block):
 
         # test from single pandas dataframe
         ds = ray.data.from_pandas(df1)
-        assert ds.dataset_format() == "pandas" if enable_pandas_block else "arrow"
+        assert ds._dataset_format() == "pandas" if enable_pandas_block else "arrow"
         values = [(r["one"], r["two"]) for r in ds.take(3)]
         rows = [(r.one, r.two) for _, r in df1.iterrows()]
         assert values == rows
@@ -53,7 +53,7 @@ def test_from_pandas_refs(ray_start_regular_shared, enable_pandas_block):
         df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
         df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
         ds = ray.data.from_pandas_refs([ray.put(df1), ray.put(df2)])
-        assert ds.dataset_format() == "pandas" if enable_pandas_block else "arrow"
+        assert ds._dataset_format() == "pandas" if enable_pandas_block else "arrow"
         values = [(r["one"], r["two"]) for r in ds.take(6)]
         rows = [(r.one, r.two) for _, r in pd.concat([df1, df2]).iterrows()]
         assert values == rows
@@ -62,7 +62,7 @@ def test_from_pandas_refs(ray_start_regular_shared, enable_pandas_block):
 
         # test from single pandas dataframe ref
         ds = ray.data.from_pandas_refs(ray.put(df1))
-        assert ds.dataset_format() == "pandas" if enable_pandas_block else "arrow"
+        assert ds._dataset_format() == "pandas" if enable_pandas_block else "arrow"
         values = [(r["one"], r["two"]) for r in ds.take(3)]
         rows = [(r.one, r.two) for _, r in df1.iterrows()]
         assert values == rows

--- a/python/ray/data/tests/test_preprocessors.py
+++ b/python/ray/data/tests/test_preprocessors.py
@@ -1709,9 +1709,9 @@ def test_numpy_pandas_support_pandas_dataset(create_dummy_preprocessors):
     with pytest.raises(NotImplementedError):
         with_nothing.transform(ds)
 
-    assert with_pandas.transform(ds).dataset_format() == "pandas"
+    assert with_pandas.transform(ds)._dataset_format() == "pandas"
 
-    assert with_pandas_and_numpy.transform(ds).dataset_format() == "pandas"
+    assert with_pandas_and_numpy.transform(ds)._dataset_format() == "pandas"
 
 
 def test_numpy_pandas_support_arrow_dataset(create_dummy_preprocessors):
@@ -1728,12 +1728,12 @@ def test_numpy_pandas_support_arrow_dataset(create_dummy_preprocessors):
     with pytest.raises(NotImplementedError):
         with_nothing.transform(ds)
 
-    assert with_pandas.transform(ds).dataset_format() == "pandas"
+    assert with_pandas.transform(ds)._dataset_format() == "pandas"
 
-    assert with_numpy.transform(ds).dataset_format() == "arrow"
+    assert with_numpy.transform(ds)._dataset_format() == "arrow"
 
     # Auto select data_format = "arrow" -> batch_format = "numpy" for performance
-    assert with_pandas_and_numpy.transform(ds).dataset_format() == "arrow"
+    assert with_pandas_and_numpy.transform(ds)._dataset_format() == "arrow"
 
 
 def test_numpy_pandas_support_transform_batch_wrong_format(create_dummy_preprocessors):

--- a/python/ray/data/tests/test_random_access.py
+++ b/python/ray/data/tests/test_random_access.py
@@ -11,10 +11,10 @@ def test_basic(ray_start_regular_shared, pandas):
     ds = ray.data.range_table(100, parallelism=10)
     ds = ds.add_column("embedding", lambda b: b["value"] ** 2)
     if pandas:
-        assert ds.dataset_format() == "pandas"
+        assert ds._dataset_format() == "pandas"
     else:
         ds = ds.map_batches(lambda df: pyarrow.Table.from_pandas(df))
-        assert ds.dataset_format() == "arrow"
+        assert ds._dataset_format() == "arrow"
 
     rad = ds.to_random_access_dataset("value", num_workers=1)
 

--- a/python/ray/serve/air_integrations.py
+++ b/python/ray/serve/air_integrations.py
@@ -57,30 +57,20 @@ def _load_predictor_cls(
     return predictor_cls
 
 
-def _unpack_dataframe_to_serializable(output_df: "pd.DataFrame") -> "pd.DataFrame":
-    """Unpack predictor's pandas return value to JSON serializable format.
+def _unpack_tensorarray_from_pandas(output_df: "pd.DataFrame") -> "pd.DataFrame":
+    """Unpack predictor's return value with TensorArray into numpy.
 
     In dl_predictor.py we return a pd.DataFrame that could have multiple
     columns but value of each column is a TensorArray. Flatten the
     TensorArray to list to ensure output is json serializable as http
     response.
-
-    In numpy predictor path, we might return collection of np.ndarrays that also
-    requires flattening to list to ensure output is json serializable as http
-    response.
     """
     from ray.data.extensions import TensorDtype
 
     for col in output_df.columns:
-        # TensorArray requires special handling to numpy array.
         if isinstance(output_df.dtypes[col], TensorDtype):
-            output_df.loc[:, col] = list(output_df[col].to_numpy())
-        # # DL predictor outputs raw ndarray outputs as opaque numpy object.
-        # # ex: output_df = pd.DataFrame({"predictions": [np.array(1)]})
-        elif output_df.dtypes[col] == np.dtype(object) and all(
-            isinstance(v, np.ndarray) for v in output_df[col]
-        ):
-            output_df.loc[:, col] = [v.tolist() for v in output_df[col]]
+            output_df[col] = output_df[col].to_numpy()
+
     return output_df
 
 
@@ -131,7 +121,7 @@ class _BatchingManager:
                 f"but Serve got length {len(output_df)}."
             )
 
-        output_df = _unpack_dataframe_to_serializable(output_df)
+        output_df = _unpack_tensorarray_from_pandas(output_df)
 
         return [df.reset_index(drop=True) for df in np.split(output_df, batch_size)]
 
@@ -295,7 +285,7 @@ class PredictorWrapper(SimpleSchemaIngress):
                 if isinstance(out, ray.ObjectRef):
                     out = await out
                 elif pd is not None and isinstance(out, pd.DataFrame):
-                    out = _unpack_dataframe_to_serializable(out)
+                    out = _unpack_tensorarray_from_pandas(out)
                 return out
 
         else:

--- a/python/ray/serve/tests/test_air_integrations.py
+++ b/python/ray/serve/tests/test_air_integrations.py
@@ -75,54 +75,27 @@ class TestBatchingFunctionFunctions:
         for i, j in zip(unpacked_list, list_of_dfs):
             assert i.equals(j)
 
-    @pytest.mark.parametrize(
-        "batched_df,expected",
-        [
-            (
-                pd.DataFrame(
-                    {
-                        "a": TensorArray(np.arange(12).reshape((3, 2, 2))),
-                        "b": TensorArray(np.arange(12, 24).reshape((3, 2, 2))),
-                    }
-                ),
-                pd.DataFrame(
-                    {
-                        "a": [[[0, 1], [2, 3]], [[4, 5], [6, 7]], [[8, 9], [10, 11]]],
-                        "b": [
-                            [[12, 13], [14, 15]],
-                            [[16, 17], [18, 19]],
-                            [[20, 21], [22, 23]],
-                        ],
-                    }
-                ),
-            ),
-            (
-                pd.DataFrame(
-                    {
-                        "a": [np.ones((2, 2)), np.ones((3, 3))],
-                        "b": [np.zeros((2, 2)), np.zeros((3, 3))],
-                    }
-                ),
-                pd.DataFrame(
-                    {
-                        "a": [[[1, 1], [1, 1]], [[1, 1, 1], [1, 1, 1], [1, 1, 1]]],
-                        "b": [[[0, 0], [0, 0]], [[0, 0, 0], [0, 0, 0], [0, 0, 0]]],
-                    }
-                ),
-            ),
-        ],
-    )
-    def test_unpack_dataframe(self, batched_df, expected):
-        """Test _unpack_dataframe_to_serializable with TensorArray and
-        list of ndarrays.
-        """
+    def test_dataframe_with_tensorarray(self):
+        batched_df = pd.DataFrame(
+            {
+                "a": TensorArray([1, 2, 3, 4]),
+                "b": TensorArray([5, 6, 7, 8]),
+            }
+        )
+        split_df = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4],
+                "b": [5, 6, 7, 8],
+            }
+        )
+
         unpacked_list = _BatchingManager.split_dataframe(batched_df, 1)
         assert len(unpacked_list) == 1
         # On windows, conversion dtype is not preserved.
         check_dtype = not os.name == "nt"
         pd.testing.assert_frame_equal(
             unpacked_list[0].reset_index(drop=True),
-            expected.reset_index(drop=True),
+            split_df.reset_index(drop=True),
             check_dtype=check_dtype,
         )
 

--- a/python/ray/train/batch_predictor.py
+++ b/python/ray/train/batch_predictor.py
@@ -2,12 +2,10 @@ import inspect
 import logging
 from typing import Any, Dict, Optional, List, Type, Union, Callable
 import pandas as pd
-import numpy as np
 
 import ray
 from ray.air import Checkpoint
-from ray.air.data_batch_type import DataBatchType
-from ray.air.util.data_batch_conversion import BatchFormat, BlockFormat
+from ray.air.util.data_batch_conversion import convert_batch_type_to_pandas
 from ray.data import Preprocessor
 from ray.data.context import DatasetContext
 from ray.data.preprocessors import BatchMapper
@@ -188,16 +186,6 @@ class BatchPredictor:
             )
             predictor_kwargs["use_gpu"] = True
 
-        # In case of [arrow block] -> [X] -> [Pandas UDF] -> [Y] -> [TorchPredictor]
-        # We have two places where we can chose data format with less conversion cost.
-        # This is the [X], between data block and first preprocessor.
-        preprocessor_batch_format: BatchFormat = (
-            self._determine_preprocessor_batch_format(data)
-        )
-        # This is the [Y] in case of separated GPU stage prediction
-        predict_stage_batch_format: BatchFormat = (
-            self._predictor_cls._batch_format_to_use()
-        )
         ctx = DatasetContext.get_current()
         cast_tensor_columns = ctx.enable_tensor_extension_casting
 
@@ -213,66 +201,19 @@ class BatchPredictor:
                 if override_prep:
                     self._predictor.set_preprocessor(override_prep)
 
-            def _select_columns_from_input_batch(
-                self,
-                batch_data: DataBatchType,
-                select_columns: Optional[List[str]] = None,
-            ):
-                """Return a subset of input batch based on provided columns."""
-                # No select columns specified, use all columns.
-                if not select_columns:
-                    return batch_data
-                elif isinstance(batch_data, np.ndarray):
-                    raise ValueError(
-                        f"Column name(s) {select_columns} should not be provided "
-                        "for prediction input data type of ``numpy.ndarray``"
-                    )
-                elif isinstance(batch_data, dict):
-                    return {k: v for k, v in batch_data.items() if k in select_columns}
-                elif isinstance(batch_data, pd.DataFrame):
-                    # Select a subset of the pandas columns.
-                    return batch_data[select_columns]
-
-            def _keep_columns_from_input_batch(
-                self,
-                input_batch: DataBatchType,
-                prediction_output_batch: DataBatchType,
-                keep_columns: Optional[List[str]] = None,
-            ):
-                """Return a union of input batch and prediction output batch
-                based on provided columns.
-                """
-                if not keep_columns:
-                    return prediction_output_batch
-                elif isinstance(input_batch, np.ndarray):
-                    raise ValueError(
-                        f"Column name(s) {keep_columns} should not be provided "
-                        "for prediction input data type of ``numpy.ndarray``"
-                    )
-                elif isinstance(input_batch, dict):
-                    for column in keep_columns:
-                        prediction_output_batch[column] = input_batch[column]
-                    return prediction_output_batch
-                elif isinstance(input_batch, pd.DataFrame):
-                    prediction_output_batch[keep_columns] = input_batch[keep_columns]
-                    return prediction_output_batch
-
-            def __call__(self, input_batch: DataBatchType) -> DataBatchType:
-                # TODO (jiaodong): Investigate if there's room to optimize prediction
-                # result joins to minimize GPU <> CPU transfer
-                prediction_batch: DataBatchType = self._select_columns_from_input_batch(
-                    input_batch, select_columns=feature_columns
-                )
-                prediction_output_batch: DataBatchType = self._predictor.predict(
+            def __call__(self, batch):
+                if feature_columns:
+                    prediction_batch = batch[feature_columns]
+                else:
+                    prediction_batch = batch
+                prediction_output = self._predictor.predict(
                     prediction_batch, **predict_kwargs
                 )
-                prediction_output_batch: DataBatchType = (
-                    self._keep_columns_from_input_batch(
-                        input_batch, prediction_output_batch, keep_columns=keep_columns
-                    )
+                if keep_columns:
+                    prediction_output[keep_columns] = batch[keep_columns]
+                return convert_batch_type_to_pandas(
+                    prediction_output, cast_tensor_columns
                 )
-
-                return prediction_output_batch
 
         compute = ray.data.ActorPoolStrategy(
             min_size=min_scoring_workers, max_size=max_scoring_workers
@@ -288,19 +229,13 @@ class BatchPredictor:
                 # Set the in-predictor preprocessing to a no-op when using a separate
                 # GPU stage. Otherwise, the preprocessing will be applied twice.
                 override_prep = BatchMapper(lambda x: x)
-                # preprocessor.transform will break for DatasetPipeline due to
-                # missing _dataset_format()
                 batch_fn = preprocessor._transform_batch
-                data = data.map_batches(
-                    batch_fn, batch_format=predict_stage_batch_format
-                )
+                data = data.map_batches(batch_fn, batch_format="pandas")
 
         prediction_results = data.map_batches(
             ScoringWrapper,
             compute=compute,
-            batch_format=preprocessor_batch_format
-            if self.get_preprocessor() is not None
-            else predict_stage_batch_format,
+            batch_format="pandas",
             batch_size=batch_size,
             **ray_remote_args,
         )
@@ -413,38 +348,3 @@ class BatchPredictor:
             ray_remote_args=ray_remote_args,
             **predict_kwargs,
         )
-
-    def _determine_preprocessor_batch_format(
-        self, ds: Union[ray.data.Dataset, ray.data.DatasetPipeline]
-    ) -> BatchFormat:
-        """Determine batch format we use for the first preprocessor.
-
-        In case of [arrow block] -> [X] -> [Pandas/Numpy UDF] -> [Predictor]
-        We choose the best X based on dataset block format and preprocessor's
-        transform type to avoid unnecessary data conversion.
-
-        Args:
-            ds (Union[ray.data.Dataset, ray.data.DatasetPipeline]): Input
-                dataset or dataset pipeline.
-
-        Returns:
-            BatchFormat: Batch format to use for the preprocessor.
-        """
-        preprocessor = self.get_preprocessor()
-        dataset_block_format = ds.dataset_format()
-        if dataset_block_format == BlockFormat.SIMPLE:
-            # Naive case that we cast to pandas for compatibility.
-            # TODO: Revisit
-            return BatchFormat.PANDAS
-
-        if preprocessor is None:
-            # No preprocessor, just use the predictor format.
-            return self._predictor_cls._batch_format_to_use()
-        elif hasattr(preprocessor, "preprocessors"):
-            # For Chain preprocessor, we picked the first one as entry point.
-            # TODO (jiaodong): We should revisit if our Chain preprocessor is
-            # still optimal with context of lazy execution.
-            preprocessor = preprocessor.preprocessors[0]
-
-        # Use same batch format as first preprocessor to minimize data copies.
-        return preprocessor._determine_transform_to_use(dataset_block_format)

--- a/python/ray/train/predictor.py
+++ b/python/ray/train/predictor.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Dict, Type, Optional, Union, Callable
+from typing import Dict, Type, Optional, Callable
 
 import numpy as np
 import pandas as pd
@@ -7,9 +7,9 @@ import pandas as pd
 from ray.air.checkpoint import Checkpoint
 from ray.air.data_batch_type import DataBatchType
 from ray.air.util.data_batch_conversion import (
-    BatchFormat,
+    DataType,
     convert_batch_type_to_pandas,
-    _convert_batch_type_to_numpy,
+    convert_pandas_to_batch_type,
 )
 from ray.data import Preprocessor
 from ray.util.annotations import DeveloperAPI, PublicAPI
@@ -21,11 +21,11 @@ try:
 except ImportError:
     pa_table = None
 
-# Reverse mapping from data batch type to batch format.
-TYPE_TO_ENUM: Dict[Type[DataBatchType], BatchFormat] = {
-    np.ndarray: BatchFormat.NUMPY,
-    dict: BatchFormat.NUMPY,
-    pd.DataFrame: BatchFormat.PANDAS,
+TYPE_TO_ENUM: Dict[Type[DataBatchType], DataType] = {
+    np.ndarray: DataType.NUMPY,
+    dict: DataType.NUMPY,
+    pd.DataFrame: DataType.PANDAS,
+    pa_table: DataType.ARROW,
 }
 
 
@@ -70,7 +70,7 @@ class Predictor(abc.ABC):
        pandas.DataFrame containing predictions.
     2. ``from_checkpoint``: Logic for creating a Predictor from an
        :ref:`AIR Checkpoint <air-checkpoint-ref>`.
-    3. Optionally ``_predict_numpy`` for better performance when working with
+    3. Optionally ``_predict_arrow`` for better performance when working with
        tensor data to avoid extra copies from Pandas conversions.
     """
 
@@ -124,38 +124,6 @@ class Predictor(abc.ABC):
         """Set the preprocessor to use prior to executing predictions."""
         self._preprocessor = preprocessor
 
-    @classmethod
-    @DeveloperAPI
-    def preferred_batch_format(cls) -> BatchFormat:
-        """Batch format hint for upstream producers to try yielding best block format.
-
-        The preferred batch format to use if both `_predict_pandas` and
-        `_predict_numpy` are implemented. Defaults to Pandas.
-
-        Can be overriden by predictor classes depending on the framework type,
-        e.g. TorchPredictor prefers Numpy and XGBoostPredictor prefers Pandas as
-        native batch format.
-
-        """
-        return BatchFormat.PANDAS
-
-    @classmethod
-    def _batch_format_to_use(cls) -> BatchFormat:
-        """Determine the batch format to use for the predictor."""
-        has_pandas_implemented = cls._predict_pandas != Predictor._predict_pandas
-        has_numpy_implemented = cls._predict_numpy != Predictor._predict_numpy
-        if has_pandas_implemented and has_numpy_implemented:
-            return cls.preferred_batch_format()
-        elif has_pandas_implemented:
-            return BatchFormat.PANDAS
-        elif has_numpy_implemented:
-            return BatchFormat.NUMPY
-        else:
-            raise NotImplementedError(
-                f"Predictor {cls.__name__} must implement at least one of "
-                "`_predict_pandas` and `_predict_numpy`."
-            )
-
     def _set_cast_tensor_columns(self):
         """Enable automatic tensor column casting.
 
@@ -171,57 +139,34 @@ class Predictor(abc.ABC):
         Args:
             data: A batch of input data of type ``DataBatchType``.
             kwargs: Arguments specific to predictor implementations. These are passed
-            directly to ``_predict_numpy`` or ``_predict_pandas``.
+            directly to ``_predict_pandas``.
 
         Returns:
             DataBatchType:
                 Prediction result. The return type will be the same as the input type.
         """
+        data_df = convert_batch_type_to_pandas(data, self._cast_tensor_columns)
+
         if not hasattr(self, "_preprocessor"):
             raise NotImplementedError(
                 "Subclasses of Predictor must call Predictor.__init__(preprocessor)."
             )
-        if self._preprocessor:
-            data = self._preprocessor.transform_batch(data)
-        try:
-            batch_format = TYPE_TO_ENUM[type(data)]
-        except KeyError:
-            raise RuntimeError(
-                f"Invalid input data type of {type(data)}, supported "
-                f"types: {list(TYPE_TO_ENUM.keys())}"
-            )
 
-        has_predict_numpy = self.__class__._predict_numpy != Predictor._predict_numpy
-        has_predict_pandas = self.__class__._predict_pandas != Predictor._predict_pandas
-        if not has_predict_numpy and not has_predict_pandas:
-            raise NotImplementedError(
-                "None of `_predict_pandas` or `_predict_numpy` are "
-                f"implemented for input data batch format `{batch_format}`."
-            )
-        # We can finish prediction as long as one predict method is implemented.
-        if batch_format == BatchFormat.PANDAS:
-            if has_predict_pandas:
-                return self._predict_pandas(data, **kwargs)
-            elif has_predict_numpy:
-                predict_data = _convert_batch_type_to_numpy(data)
-                predictions = self._predict_numpy(predict_data, **kwargs)
-                return convert_batch_type_to_pandas(predictions)
-        elif batch_format == BatchFormat.NUMPY:
-            if has_predict_numpy:
-                return self._predict_numpy(data, **kwargs)
-            elif has_predict_pandas:
-                # Fallback to convert to pandas batch and call _predict_pandas
-                # ex: xgboost predict with np.ndarray batch data
-                predict_data = convert_batch_type_to_pandas(data)
-                predictions = self._predict_pandas(predict_data, **kwargs)
-                # Base predictor's return value are used by both BatchPredictor
-                # and Ray Serve, thus keep return value as raw DataFrame or Numpy
-                # without any TensorArray casting and leave it to caller to decide.
-                return _convert_batch_type_to_numpy(predictions)
+        if self._preprocessor:
+            data_df = self._preprocessor.transform_batch(data_df)
+
+        predictions_df = self._predict_pandas(data_df, **kwargs)
+        return convert_pandas_to_batch_type(
+            predictions_df,
+            type=TYPE_TO_ENUM[type(data)],
+            cast_tensor_columns=self._cast_tensor_columns,
+        )
 
     @DeveloperAPI
     def _predict_pandas(self, data: "pd.DataFrame", **kwargs) -> "pd.DataFrame":
         """Perform inference on a Pandas DataFrame.
+
+        All predictors are expected to implement this method.
 
         Args:
             data: A pandas DataFrame to perform predictions on.
@@ -234,22 +179,21 @@ class Predictor(abc.ABC):
         raise NotImplementedError
 
     @DeveloperAPI
-    def _predict_numpy(
-        self, data: Union[np.ndarray, Dict[str, np.ndarray]], **kwargs
-    ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
-        """Perform inference on a Numpy data.
+    def _predict_arrow(self, data: "pyarrow.Table", **kwargs) -> "pyarrow.Table":
+        """Perform inference on an Arrow Table.
 
-        All Predictors working with tensor data (like deep learning predictors)
-        should implement this method.
+        Predictors can implement this method instead of ``_predict_pandas``
+        for better performance when the input batch type is a Numpy array, dict of
+        numpy arrays, or an Arrow Table as conversion from these types are zero copy.
 
         Args:
-            data: A Numpy ndarray or dictionary of ndarrays to perform predictions on.
+            data: An Arrow Table to perform predictions on.
             kwargs: Arguments specific to the predictor implementation.
 
         Returns:
-            A Numpy ndarray or dictionary of ndarray containing the prediction result.
-
+            An Arrow Table containing the prediction result.
         """
+
         raise NotImplementedError
 
     def __reduce__(self):

--- a/python/ray/train/tests/dummy_preprocessor.py
+++ b/python/ray/train/tests/dummy_preprocessor.py
@@ -12,9 +12,6 @@ class DummyPreprocessor(Preprocessor):
         self._batch_transformed = True
         return self.transform(batch)
 
-    def _transform_pandas(self, df):
-        return df
-
     @property
     def has_preprocessed(self):
         return hasattr(self, "_batch_transformed")

--- a/python/ray/train/tests/test_batch_predictor.py
+++ b/python/ray/train/tests/test_batch_predictor.py
@@ -3,14 +3,11 @@ import time
 from typing import Optional
 
 import pandas as pd
-import pyarrow as pa
-
 import pytest
 from ray.air.constants import MAX_REPR_LENGTH, PREPROCESSOR_KEY
 
 import ray
 from ray.air.checkpoint import Checkpoint
-from ray.air.util.data_batch_conversion import BatchFormat
 from ray.data import Preprocessor
 from ray.tests.conftest import *  # noqa
 from ray.train.batch_predictor import BatchPredictor
@@ -25,14 +22,6 @@ class DummyPreprocessor(Preprocessor):
 
     def _transform_pandas(self, df):
         return df * self.multiplier
-
-
-class DummyWithNumpyPreprocessor(DummyPreprocessor):
-    def _transform_numpy(self, np_data):
-        if isinstance(np_data, dict):
-            return {k: v * self.multiplier for k, v in np_data.items()}
-        else:
-            return np_data * self.multiplier
 
 
 def test_repr(shutdown_only):
@@ -76,18 +65,6 @@ class DummyPredictor(Predictor):
             raise ValueError("DummyPredictor does not support GPU prediction.")
         else:
             return data * self.factor
-
-
-class DummyWithNumpyPredictor(DummyPredictor):
-    def _predict_numpy(self, data, **kwargs):
-        if isinstance(data, dict):
-            return {k: v * self.factor for k, v in data.items()}
-        else:
-            return data * self.factor
-
-    @classmethod
-    def preferred_batch_format(cls) -> BatchFormat:
-        return BatchFormat.NUMPY
 
 
 class DummyPredictorFS(DummyPredictor):
@@ -149,7 +126,7 @@ def test_automatic_enable_gpu_from_num_gpus_per_worker(shutdown_only):
         _ = batch_predictor.predict(test_dataset, num_gpus_per_worker=1)
 
 
-def test_batch_prediction_simple():
+def test_batch_prediction():
     batch_predictor = BatchPredictor.from_checkpoint(
         Checkpoint.from_dict({"factor": 2.0, PREPROCESSOR_KEY: DummyPreprocessor()}),
         DummyPredictor,
@@ -177,98 +154,6 @@ def test_batch_prediction_simple():
     ]
 
 
-def test_batch_prediction_various_combination():
-    """Dataset level predictor test against various
-    - Dataset format
-    - Preprocessor implementation (pandas vs numpy)
-    - Predictor implementation (pandas vs numpy)
-    """
-    # Got to inline this rather than using @pytest.mark.parametrize to void
-    # unknown object owner error when running test with python cli.
-    test_cases = [
-        (
-            DummyPreprocessor(),
-            DummyPredictor,
-            ray.data.from_pandas(pd.DataFrame({"x": [1, 2, 3]})),
-            # Pandas dataset format should be preserved in output.
-            "pandas",
-        ),
-        (
-            DummyWithNumpyPreprocessor(),
-            DummyPredictor,
-            ray.data.from_pandas(pd.DataFrame({"x": [1, 2, 3]})),
-            # Pandas dataset format should be preserved in output.
-            "pandas",
-        ),
-        (
-            DummyPreprocessor(),
-            DummyWithNumpyPredictor,
-            ray.data.from_pandas(pd.DataFrame({"x": [1, 2, 3]})),
-            # Pandas dataset format should be preserved in output.
-            "pandas",
-        ),
-        (
-            DummyWithNumpyPreprocessor(),
-            DummyWithNumpyPredictor,
-            ray.data.from_pandas(pd.DataFrame({"x": [1, 2, 3]})),
-            # Preprocessing and prediction is done in numpy, but preprocessor
-            # batch format is still pandas, thus output is casted back.
-            "pandas",
-        ),
-        (
-            DummyPreprocessor(),
-            DummyWithNumpyPredictor,
-            ray.data.from_arrow(pa.Table.from_pydict({"x": [1, 2, 3]})),
-            # Output dataset format should be pandas given only pandas
-            # preprocessor is available.
-            "pandas",
-        ),
-        (
-            DummyWithNumpyPreprocessor(),
-            DummyWithNumpyPredictor,
-            ray.data.from_arrow(pa.Table.from_pydict({"x": [1, 2, 3]})),
-            # Output dataset format should be arrow given numpy path is taken
-            # for both preprocessor and predictor.
-            "arrow",
-        ),
-        (
-            DummyPreprocessor(),
-            DummyPredictor,
-            ray.data.from_arrow(pa.Table.from_pydict({"x": [1, 2, 3]})),
-            # Output dataset format should be pandas given only pandas
-            # preprocessor is available.
-            "pandas",
-        ),
-        (
-            DummyWithNumpyPreprocessor(),
-            DummyPredictor,
-            ray.data.from_arrow(pa.Table.from_pydict({"x": [1, 2, 3]})),
-            # Preprocessing and prediction is done in pandas, but preprocessor
-            # batch format is still numpy, thus output is casted back.
-            "arrow",
-        ),
-    ]
-
-    for test_case in test_cases:
-        preprocessor, predictor_cls, input_dataset, dataset_format = test_case
-        # Test with pandas preprocessor
-        batch_predictor = BatchPredictor.from_checkpoint(
-            Checkpoint.from_dict({"factor": 2.0, PREPROCESSOR_KEY: preprocessor}),
-            predictor_cls,
-        )
-
-        ds = batch_predictor.predict(input_dataset)
-        # Check no fusion needed since we're not doing a dataset read.
-        assert "Stage 1 map_batches" in ds.stats(), ds.stats()
-        assert ds.to_pandas().to_numpy().squeeze().tolist() == [
-            4.0,
-            8.0,
-            12.0,
-        ]
-
-        assert ds.dataset_format() == dataset_format
-
-
 def test_batch_prediction_fs():
     batch_predictor = BatchPredictor.from_checkpoint(
         Checkpoint.from_dict({"factor": 2.0, PREPROCESSOR_KEY: DummyPreprocessor()}),
@@ -293,7 +178,6 @@ def test_batch_prediction_fs():
 
 
 def test_batch_prediction_feature_cols():
-    # Pandas path
     batch_predictor = BatchPredictor.from_checkpoint(
         Checkpoint.from_dict({"factor": 2.0, PREPROCESSOR_KEY: DummyPreprocessor()}),
         DummyPredictor,
@@ -305,25 +189,8 @@ def test_batch_prediction_feature_cols():
         test_dataset, feature_columns=["a"]
     ).to_pandas().to_numpy().squeeze().tolist() == [4.0, 8.0, 12.0]
 
-    # Numpy path
-    batch_predictor = BatchPredictor.from_checkpoint(
-        Checkpoint.from_dict(
-            {"factor": 2.0, PREPROCESSOR_KEY: DummyWithNumpyPreprocessor()}
-        ),
-        DummyWithNumpyPredictor,
-    )
-
-    test_dataset = ray.data.from_arrow(
-        pa.Table.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
-    )
-
-    assert batch_predictor.predict(
-        test_dataset, feature_columns=["a"]
-    ).to_pandas().to_numpy().squeeze().tolist() == [4.0, 8.0, 12.0]
-
 
 def test_batch_prediction_keep_cols():
-    # Pandas path
     batch_predictor = BatchPredictor.from_checkpoint(
         Checkpoint.from_dict({"factor": 2.0, PREPROCESSOR_KEY: DummyPreprocessor()}),
         DummyPredictor,
@@ -331,27 +198,6 @@ def test_batch_prediction_keep_cols():
 
     test_dataset = ray.data.from_pandas(
         pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
-    )
-
-    output_df = batch_predictor.predict(
-        test_dataset, feature_columns=["a"], keep_columns=["b"]
-    ).to_pandas()
-
-    assert set(output_df.columns) == {"a", "b"}
-
-    assert output_df["a"].tolist() == [4.0, 8.0, 12.0]
-    assert output_df["b"].tolist() == [4, 5, 6]
-
-    # Numpy path
-    batch_predictor = BatchPredictor.from_checkpoint(
-        Checkpoint.from_dict(
-            {"factor": 2.0, PREPROCESSOR_KEY: DummyWithNumpyPreprocessor()}
-        ),
-        DummyWithNumpyPredictor,
-    )
-
-    test_dataset = ray.data.from_arrow(
-        pa.Table.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
     )
 
     output_df = batch_predictor.predict(
@@ -453,4 +299,4 @@ def test_separate_gpu_stage_pipelined(shutdown_only):
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-v", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/train/tests/test_batchpredictor_runtime.py
+++ b/python/ray/train/tests/test_batchpredictor_runtime.py
@@ -34,9 +34,6 @@ class DummyPredictor(Predictor):
     def predict(self, data, **kwargs):
         return data
 
-    def _predict_pandas(self, data):
-        return data
-
 
 def create_test_data():
     large = 1024 * 1024 * 1024  # 1GB

--- a/python/ray/train/tests/test_huggingface_checkpoint.py
+++ b/python/ray/train/tests/test_huggingface_checkpoint.py
@@ -6,7 +6,7 @@ import ray
 from ray.train.huggingface import HuggingFaceCheckpoint, HuggingFacePredictor
 
 
-from ray.train.tests.dummy_preprocessor import DummyPreprocessor
+from dummy_preprocessor import DummyPreprocessor
 from test_huggingface_predictor import (
     model_checkpoint,
     tokenizer_checkpoint,

--- a/python/ray/train/tests/test_huggingface_predictor.py
+++ b/python/ray/train/tests/test_huggingface_predictor.py
@@ -17,7 +17,7 @@ from transformers.pipelines import pipeline
 import ray
 from ray.train.huggingface import HuggingFaceCheckpoint, HuggingFacePredictor
 
-from ray.train.tests.dummy_preprocessor import DummyPreprocessor
+from dummy_preprocessor import DummyPreprocessor
 
 test_strings = ["Complete me", "And me", "Please complete"]
 prompts = pd.DataFrame(test_strings, columns=["sentences"])
@@ -38,7 +38,7 @@ def test_repr(tmpdir):
     assert pattern.match(representation)
 
 
-@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, dict])
+@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, pa.Table, dict])
 def test_predict(tmpdir, ray_start_runtime_env, batch_type):
     dtype_prompts = convert_pandas_to_batch_type(prompts, type=TYPE_TO_ENUM[batch_type])
 
@@ -100,7 +100,7 @@ def create_checkpoint():
         return HuggingFaceCheckpoint.from_dict(checkpoint.to_dict())
 
 
-@pytest.mark.parametrize("batch_type", [pd.DataFrame])
+@pytest.mark.parametrize("batch_type", [pd.DataFrame, pa.Table])
 def test_predict_batch(ray_start_4_cpus, batch_type):
     checkpoint = create_checkpoint()
     predictor = BatchPredictor.from_checkpoint(

--- a/python/ray/train/tests/test_lightgbm_predictor.py
+++ b/python/ray/train/tests/test_lightgbm_predictor.py
@@ -16,7 +16,7 @@ from ray.train.lightgbm import LightGBMCheckpoint, LightGBMPredictor
 from ray.train.predictor import TYPE_TO_ENUM
 from typing import Tuple
 
-from ray.train.tests.dummy_preprocessor import DummyPreprocessor
+from dummy_preprocessor import DummyPreprocessor
 
 
 dummy_data = np.array([[1, 2], [3, 4], [5, 6]])
@@ -57,7 +57,7 @@ def test_lightgbm_checkpoint():
     assert checkpoint_predictor.get_preprocessor() == predictor.get_preprocessor()
 
 
-@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, dict])
+@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, pa.Table, dict])
 def test_predict(batch_type):
     preprocessor = DummyPreprocessor()
     predictor = LightGBMPredictor(model=model, preprocessor=preprocessor)
@@ -70,7 +70,7 @@ def test_predict(batch_type):
     assert predictor.get_preprocessor().has_preprocessed
 
 
-@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame])
+@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, pa.Table])
 def test_predict_batch(ray_start_4_cpus, batch_type):
     checkpoint, _ = create_checkpoint_preprocessor()
     predictor = BatchPredictor.from_checkpoint(checkpoint, LightGBMPredictor)

--- a/python/ray/train/tests/test_predictor.py
+++ b/python/ray/train/tests/test_predictor.py
@@ -1,13 +1,13 @@
-from typing import Optional, Dict, Union
+from typing import Optional
 from unittest import mock
-import pytest
 
 import pandas as pd
-import numpy as np
+import pytest
+from ray.air.util.data_batch_conversion import DataType
 
 import ray
 from ray.air.checkpoint import Checkpoint
-from ray.air.constants import PREPROCESSOR_KEY, TENSOR_COLUMN_NAME
+from ray.air.constants import PREPROCESSOR_KEY
 from ray.data import Preprocessor
 from ray.train.predictor import Predictor, PredictorNotSerializableException
 
@@ -15,28 +15,9 @@ from ray.train.predictor import Predictor, PredictorNotSerializableException
 class DummyPreprocessor(Preprocessor):
     def __init__(self, multiplier=2):
         self.multiplier = multiplier
-        self.inputs = []
-        self.outputs = []
 
-    def fit_status(self) -> Preprocessor.FitStatus:
-        """Override fit status to test full transform_batch path."""
-        return Preprocessor.FitStatus.FITTED
-
-    def _transform_pandas(self, df: pd.DataFrame) -> pd.DataFrame:
-        self.inputs.append(df)
-        rst = df * self.multiplier
-        self.outputs.append(rst)
-        return rst
-
-
-class DummyWithNumpyPreprocessor(DummyPreprocessor):
-    def _transform_numpy(
-        self, np_data: Union[np.ndarray, Dict[str, np.ndarray]]
-    ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
-        self.inputs.append(np_data)
-        rst = np_data * self.multiplier
-        self.outputs.append(rst)
-        return rst
+    def transform_batch(self, df):
+        return df * self.multiplier
 
 
 class DummyPredictor(Predictor):
@@ -53,13 +34,6 @@ class DummyPredictor(Predictor):
         return cls(checkpoint_data["factor"], preprocessor)
 
     def _predict_pandas(self, data: pd.DataFrame, **kwargs) -> pd.DataFrame:
-        return data * self.factor
-
-
-class DummyWithNumpyPredictor(DummyPredictor):
-    def _predict_numpy(
-        self, data: Union[np.ndarray, Dict[str, np.ndarray]], **kwargs
-    ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
         return data * self.factor
 
 
@@ -80,122 +54,32 @@ def test_from_checkpoint():
     assert DummyPredictor.from_checkpoint(checkpoint).factor == 2.0
 
 
-def test_predict_pandas_with_pandas_data():
-    """Data batch level predictor test where both input data and prediction
-    batch format are pandas dataframes.
-    """
+@mock.patch("ray.train.predictor.convert_pandas_to_batch_type")
+@mock.patch("ray.train.predictor.convert_batch_type_to_pandas")
+def test_predict(convert_to_pandas_mock, convert_from_pandas_mock):
+
     input = pd.DataFrame({"x": [1, 2, 3]})
+    expected_output = input * 4.0
+
+    convert_to_pandas_mock.return_value = input
+    convert_from_pandas_mock.return_value = expected_output
+
     checkpoint = Checkpoint.from_dict(
         {"factor": 2.0, PREPROCESSOR_KEY: DummyPreprocessor()}
     )
     predictor = DummyPredictor.from_checkpoint(checkpoint)
 
     actual_output = predictor.predict(input)
-    pd.testing.assert_frame_equal(actual_output, pd.DataFrame({"x": [4.0, 8.0, 12.0]}))
-    pd.testing.assert_frame_equal(
-        predictor.get_preprocessor().inputs[0],
-        pd.DataFrame({"x": [1, 2, 3]}),
-    )
-    pd.testing.assert_frame_equal(
-        predictor.get_preprocessor().outputs[0],
-        pd.DataFrame({"x": [2, 4, 6]}),
-    )
+    pd.testing.assert_frame_equal(actual_output, expected_output)
 
-    # Test predict with both Numpy and Pandas preprocessor available
-    checkpoint = Checkpoint.from_dict(
-        {"factor": 2.0, PREPROCESSOR_KEY: DummyWithNumpyPreprocessor()}
-    )
-    predictor = DummyPredictor.from_checkpoint(checkpoint)
-    actual_output = predictor.predict(input)
-    pd.testing.assert_frame_equal(actual_output, pd.DataFrame({"x": [4.0, 8.0, 12.0]}))
-    # Nothing should change compare to previous path since preprocessor will
-    # go through Pandas path
+    # Ensure the proper conversion functions are called.
+    convert_to_pandas_mock.assert_called_once_with(input, False)
+    convert_from_pandas_mock.assert_called_once()
+
     pd.testing.assert_frame_equal(
-        predictor.get_preprocessor().inputs[0],
-        pd.DataFrame({"x": [1, 2, 3]}),
+        convert_from_pandas_mock.call_args[0][0], expected_output
     )
-    pd.testing.assert_frame_equal(
-        predictor.get_preprocessor().outputs[0],
-        pd.DataFrame({"x": [2, 4, 6]}),
-    )
-
-
-def test_predict_numpy_with_numpy_data():
-    """Data batch level predictor test where both input data and prediction
-    batch format are numpy formats.
-    """
-    input = np.array([1, 2, 3])
-    # Test predict with only Pandas preprocessor
-    checkpoint = Checkpoint.from_dict(
-        {"factor": 2.0, PREPROCESSOR_KEY: DummyPreprocessor()}
-    )
-    predictor = DummyWithNumpyPredictor.from_checkpoint(checkpoint)
-    actual_output = predictor.predict(input)
-    # Multiply by 2 from preprocessor, another multiply by 2.0 from predictor
-    pd.testing.assert_frame_equal(
-        actual_output, pd.DataFrame({TENSOR_COLUMN_NAME: [4.0, 8.0, 12.0]})
-    )
-    pd.testing.assert_frame_equal(
-        predictor.get_preprocessor().inputs[0],
-        pd.DataFrame({TENSOR_COLUMN_NAME: [1, 2, 3]}),
-    )
-    pd.testing.assert_frame_equal(
-        predictor.get_preprocessor().outputs[0],
-        pd.DataFrame({TENSOR_COLUMN_NAME: [2, 4, 6]}),
-    )
-
-    # Test predict with both Numpy and Pandas preprocessor available
-    checkpoint = Checkpoint.from_dict(
-        {"factor": 2.0, PREPROCESSOR_KEY: DummyWithNumpyPreprocessor()}
-    )
-    predictor = DummyWithNumpyPredictor.from_checkpoint(checkpoint)
-
-    actual_output = predictor.predict(input)
-    np.testing.assert_equal(actual_output, np.array([4.0, 8.0, 12.0]))
-    np.testing.assert_equal(predictor.get_preprocessor().inputs[0], np.array([1, 2, 3]))
-    np.testing.assert_equal(
-        predictor.get_preprocessor().outputs[0], np.array([2, 4, 6])
-    )
-
-
-def test_predict_pandas_with_numpy_data():
-    """Data batch level predictor test where both input data is numpy format but
-    predictor only has _predict_pandas implementation.
-    """
-    input = np.array([1, 2, 3])
-    # Test predict with only Pandas preprocessor
-    checkpoint = Checkpoint.from_dict(
-        {"factor": 2.0, PREPROCESSOR_KEY: DummyPreprocessor()}
-    )
-    predictor = DummyPredictor.from_checkpoint(checkpoint)
-    actual_output = predictor.predict(input)
-
-    # Multiply by 2 from preprocessor, another multiply by 2.0 from predictor
-    pd.testing.assert_frame_equal(
-        actual_output, pd.DataFrame({TENSOR_COLUMN_NAME: [4.0, 8.0, 12.0]})
-    )
-    pd.testing.assert_frame_equal(
-        predictor.get_preprocessor().inputs[0],
-        pd.DataFrame({TENSOR_COLUMN_NAME: [1, 2, 3]}),
-    )
-    pd.testing.assert_frame_equal(
-        predictor.get_preprocessor().outputs[0],
-        pd.DataFrame({TENSOR_COLUMN_NAME: [2, 4, 6]}),
-    )
-
-    # Test predict with both Numpy and Pandas preprocessor available
-    checkpoint = Checkpoint.from_dict(
-        {"factor": 2.0, PREPROCESSOR_KEY: DummyWithNumpyPreprocessor()}
-    )
-    predictor = DummyPredictor.from_checkpoint(checkpoint)
-
-    actual_output = predictor.predict(input)
-    np.testing.assert_equal(actual_output, np.array([4.0, 8.0, 12.0]))
-    # Preprocessor should still go through the Numpy path
-    np.testing.assert_equal(predictor.get_preprocessor().inputs[0], np.array([1, 2, 3]))
-    np.testing.assert_equal(
-        predictor.get_preprocessor().outputs[0], np.array([2, 4, 6])
-    )
+    assert convert_from_pandas_mock.call_args[1]["type"] == DataType.PANDAS
 
 
 def test_from_udf():

--- a/python/ray/train/tests/test_rl_predictor.py
+++ b/python/ray/train/tests/test_rl_predictor.py
@@ -30,7 +30,7 @@ from ray.train.rl import RLTrainer
 # from ray.train.rl.rl_predictor import RLPredictor
 from ray.tune.trainable.util import TrainableUtil
 
-# from ray.train.tests.dummy_preprocessor import DummyPreprocessor
+# from dummy_preprocessor import DummyPreprocessor
 
 
 class _DummyAlgo(Algorithm):

--- a/python/ray/train/tests/test_sklearn_predictor.py
+++ b/python/ray/train/tests/test_sklearn_predictor.py
@@ -19,7 +19,7 @@ from ray.train.batch_predictor import BatchPredictor
 from ray.train.sklearn import SklearnCheckpoint, SklearnPredictor
 from typing import Tuple
 
-from ray.train.tests.dummy_preprocessor import DummyPreprocessor
+from dummy_preprocessor import DummyPreprocessor
 
 
 dummy_data = np.array([[1, 2], [3, 4], [5, 6]])
@@ -65,7 +65,7 @@ def test_sklearn_checkpoint():
     assert checkpoint_predictor.get_preprocessor() == predictor.get_preprocessor()
 
 
-@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, dict])
+@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, pa.Table, dict])
 def test_predict(batch_type):
     preprocessor = DummyPreprocessor()
     predictor = SklearnPredictor(estimator=model, preprocessor=preprocessor)
@@ -78,7 +78,7 @@ def test_predict(batch_type):
     assert predictor.get_preprocessor().has_preprocessed
 
 
-@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame])
+@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, pa.Table])
 def test_predict_batch(ray_start_4_cpus, batch_type):
     checkpoint, _ = create_checkpoint_preprocessor()
     predictor = BatchPredictor.from_checkpoint(checkpoint, SklearnPredictor)

--- a/python/ray/train/tests/test_tensorflow_predictor.py
+++ b/python/ray/train/tests/test_tensorflow_predictor.py
@@ -18,7 +18,7 @@ from ray.train.predictor import TYPE_TO_ENUM
 from ray.train.tensorflow import TensorflowCheckpoint, TensorflowPredictor
 from typing import Tuple
 
-from ray.train.tests.dummy_preprocessor import DummyPreprocessor
+from dummy_preprocessor import DummyPreprocessor
 
 
 def build_raw_model() -> tf.keras.Model:
@@ -123,11 +123,8 @@ def test_predict_array(use_gpu):
     data_batch = np.asarray([1, 2, 3])
     predictions = predictor.predict(data_batch)
 
-    assert len(predictions) == 1
-    # [1 2 3] returns [[2],[4],[6]] with shape: (3,1) from Tensorflow model
-    np.testing.assert_array_equal(
-        predictions["predictions"], np.asarray([[2], [4], [6]])
-    )
+    assert len(predictions) == 3
+    assert predictions.flatten().tolist() == [2, 4, 6]
 
 
 @pytest.mark.parametrize("use_gpu", [False, True])
@@ -142,15 +139,12 @@ def test_predict_array_with_preprocessor(use_gpu):
     data_batch = np.array([1, 2, 3])
     predictions = predictor.predict(data_batch)
 
-    assert len(predictions) == 1
-    # [1 2 3] returns [[2],[4],[6]] with shape: (3,1) from Tensorflow model
-    np.testing.assert_array_equal(
-        predictions["predictions"], np.asarray([[2], [4], [6]])
-    )
+    assert len(predictions) == 3
     assert predictor.get_preprocessor().has_preprocessed
+    assert predictions.flatten().tolist() == [2, 4, 6]
 
 
-@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, dict])
+@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, pa.Table, dict])
 def test_predict(batch_type):
     predictor = TensorflowPredictor(model=build_model_multi_input())
 
@@ -163,8 +157,8 @@ def test_predict(batch_type):
     assert predictions.to_numpy().flatten().tolist() == [1.0, 2.0, 3.0]
 
 
-@pytest.mark.parametrize("block_type", [pd.DataFrame, pa.Table])
-def test_predict_dataset_block(ray_start_4_cpus, block_type):
+@pytest.mark.parametrize("batch_type", [pd.DataFrame, pa.Table])
+def test_predict_batch(ray_start_4_cpus, batch_type):
     checkpoint = TensorflowCheckpoint.from_model(model=build_model_multi_input())
     predictor = BatchPredictor.from_checkpoint(
         checkpoint, TensorflowPredictor, model_definition=build_model_multi_input
@@ -172,9 +166,12 @@ def test_predict_dataset_block(ray_start_4_cpus, block_type):
 
     dummy_data = pd.DataFrame([[0.0, 1.0], [0.0, 2.0], [0.0, 3.0]], columns=["A", "B"])
 
-    if block_type == pd.DataFrame:
+    # Todo: Ray data does not support numpy dicts
+    if batch_type == np.ndarray:
+        dataset = ray.data.from_numpy(dummy_data.to_numpy())
+    elif batch_type == pd.DataFrame:
         dataset = ray.data.from_pandas(dummy_data)
-    elif block_type == pa.Table:
+    elif batch_type == pa.Table:
         dataset = ray.data.from_arrow(pa.Table.from_pandas(dummy_data))
     else:
         raise RuntimeError("Invalid batch_type")

--- a/python/ray/train/tests/test_torch_predictor.py
+++ b/python/ray/train/tests/test_torch_predictor.py
@@ -17,7 +17,7 @@ from ray.train.batch_predictor import BatchPredictor
 from ray.train.predictor import TYPE_TO_ENUM
 from ray.train.torch import TorchCheckpoint, TorchPredictor
 
-from ray.train.tests.dummy_preprocessor import DummyPreprocessor
+from dummy_preprocessor import DummyPreprocessor
 
 
 class DummyModelSingleTensor(torch.nn.Module):
@@ -84,7 +84,7 @@ def test_predict_model_not_training(model, use_gpu):
     assert not predictor.model.training
 
 
-@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, dict])
+@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, pa.Table, dict])
 def test_predict(batch_type):
     predictor = TorchPredictor(model=DummyModelMultiInput())
 
@@ -97,9 +97,9 @@ def test_predict(batch_type):
     assert predictions.to_numpy().flatten().tolist() == [1.0, 2.0, 3.0]
 
 
-@pytest.mark.parametrize("block_type", [pd.DataFrame, pa.Table])
+@pytest.mark.parametrize("batch_type", [pd.DataFrame, pa.Table])
 @pytest.mark.parametrize("use_state_dict", [True, False])
-def test_predict_dataset_block(ray_start_4_cpus, block_type, use_state_dict):
+def test_predict_batch(ray_start_4_cpus, batch_type, use_state_dict):
     if use_state_dict:
         checkpoint = TorchCheckpoint.from_state_dict({})
         # Notice here that predictor needs to take in additional information
@@ -118,9 +118,12 @@ def test_predict_dataset_block(ray_start_4_cpus, block_type, use_state_dict):
         [[0.0, 1.0], [0.0, 2.0], [0.0, 3.0]], columns=["X0", "X1"]
     )
 
-    if block_type == pd.DataFrame:
+    # Todo: Ray data does not support numpy dicts
+    if batch_type == np.ndarray:
+        dataset = ray.data.from_numpy(dummy_data.to_numpy())
+    elif batch_type == pd.DataFrame:
         dataset = ray.data.from_pandas(dummy_data)
-    elif block_type == pa.Table:
+    elif batch_type == pa.Table:
         dataset = ray.data.from_arrow(pa.Table.from_pandas(dummy_data))
     else:
         raise RuntimeError("Invalid batch_type")
@@ -138,8 +141,8 @@ def test_predict_array(model, use_gpu):
     data_batch = np.asarray([1, 2, 3])
     predictions = predictor.predict(data_batch)
 
-    assert len(predictions) == 1
-    np.testing.assert_array_equal(predictions["predictions"], np.asarray([2, 4, 6]))
+    assert len(predictions) == 3
+    assert predictions.flatten().tolist() == [2, 4, 6]
 
 
 @pytest.mark.parametrize("use_gpu", [False, True])
@@ -149,8 +152,8 @@ def test_predict_array_with_preprocessor(model, preprocessor, use_gpu):
     data_batch = np.array([1, 2, 3])
     predictions = predictor.predict(data_batch)
 
-    assert len(predictions) == 1
-    np.testing.assert_array_equal(predictions["predictions"], np.asarray([2, 4, 6]))
+    assert len(predictions) == 3
+    assert predictions.flatten().tolist() == [2, 4, 6]
     assert predictor.get_preprocessor().has_preprocessed
 
 
@@ -223,7 +226,7 @@ def test_predict_array_with_different_dtypes(
     data_batch = np.array([1, 2, 3])
     predictions = predictor.predict(data_batch, dtype=input_dtype)
 
-    assert predictions["predictions"].dtype == expected_output_dtype
+    assert predictions.dtype == expected_output_dtype
 
 
 @pytest.mark.parametrize("use_gpu", [False, True])
@@ -234,8 +237,8 @@ def test_predict_array_no_training(model, use_gpu):
     data_batch = np.array([1, 2, 3])
     predictions = predictor.predict(data_batch)
 
-    assert len(predictions) == 1
-    np.testing.assert_array_equal(predictions["predictions"], np.asarray([2, 4, 6]))
+    assert len(predictions) == 3
+    assert predictions.flatten().tolist() == [2, 4, 6]
 
 
 @pytest.mark.parametrize("use_gpu", [False, True])
@@ -245,8 +248,7 @@ def test_array_real_model(use_gpu):
 
     data = np.array([[1, 2], [3, 4]])
     predictions = predictor.predict(data, dtype=torch.float)
-    assert len(predictions) == 1
-    assert len(predictions["predictions"]) == 2
+    assert len(predictions) == 2
 
 
 @pytest.mark.parametrize("use_gpu", [False, True])

--- a/python/ray/train/tests/test_xgboost_predictor.py
+++ b/python/ray/train/tests/test_xgboost_predictor.py
@@ -15,7 +15,8 @@ from ray.train.predictor import TYPE_TO_ENUM
 from ray.train.xgboost import XGBoostCheckpoint, XGBoostPredictor
 from typing import Tuple
 
-from ray.train.tests.dummy_preprocessor import DummyPreprocessor
+from dummy_preprocessor import DummyPreprocessor
+
 
 dummy_data = np.array([[1, 2], [3, 4], [5, 6]])
 dummy_target = np.array([0, 1, 0])
@@ -46,7 +47,7 @@ def test_xgboost_checkpoint():
     assert checkpoint_predictor.get_preprocessor() == predictor.get_preprocessor()
 
 
-@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, dict])
+@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, pa.Table, dict])
 def test_predict(batch_type):
     preprocessor = DummyPreprocessor()
     predictor = XGBoostPredictor(model=model, preprocessor=preprocessor)
@@ -59,7 +60,7 @@ def test_predict(batch_type):
     assert predictor.get_preprocessor().has_preprocessed
 
 
-@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame])
+@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, pa.Table])
 def test_predict_batch(ray_start_4_cpus, batch_type):
     checkpoint, _ = create_checkpoint_preprocessor()
     predictor = BatchPredictor.from_checkpoint(checkpoint, XGBoostPredictor)

--- a/python/ray/train/torch/torch_predictor.py
+++ b/python/ray/train/torch/torch_predictor.py
@@ -213,12 +213,12 @@ class TorchPredictor(DLPredictor):
 
             .. testoutput::
 
-                Standard model predictions: {'predictions': array([[1.5487633],
-                       [3.8037925]], dtype=float32)}
+                Standard model predictions: [[1.5487633]
+                 [3.8037925]]
                 ---
                 Custom model predictions:     predictions
                 0  [0.61623406]
-                1    [2.857038]
+                1  [  2.857038]
         """
         return super(TorchPredictor, self).predict(data=data, dtype=dtype)
 


### PR DESCRIPTION
Reverts ray-project/ray#28917

<img width="436" alt="image" src="https://user-images.githubusercontent.com/74173148/202303548-8038ee4f-673a-45b3-a44a-ace3ea1cf479.png">


```
Executed 1 out of 1 test: 1 fails locally.
(13:58:01) INFO: Build completed, 1 test FAILED, 4 total actions
(base) root@9947804ba968:/ray# cat   /root/.cache/bazel/_bazel_root/5fe90af4e7d1ed9fcf52f59e39e126f5/execroot/com_github_ray_project_ray/bazel-out/k8-opt/testlogs/python/ray/tests/test_basic/test_attempts/attempt_2.log
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //python/ray/tests:test_basic
-----------------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/5fe90af4e7d1ed9fcf52f59e39e126f5/execroot/com_github_ray_project_ray/bazel-out/k8-opt/bin/python/ray/tests/test_basic.runfiles/com_github_ray_project_ray/python/ray/tests/test_basic.py", line 11, in <module>
    import ray
  File "/ray/python/ray/__init__.py", line 171, in <module>
    from ray import data  # noqa: E402,F401
  File "/ray/python/ray/data/__init__.py", line 3, in <module>
    from ray.data.dataset import Dataset
  File "/ray/python/ray/data/dataset.py", line 30, in <module>
    from ray.air.util.data_batch_conversion import BlockFormat
  File "/ray/python/ray/air/util/data_batch_conversion.py", line 6, in <module>
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
```

It seems that unnecessary libs are imported with minimal install.