### PR TITLE
[Tune] Make `Tuner.restore` work with relative experiment paths

### DIFF
--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -224,7 +224,9 @@ class TunerInternal:
 
         if not synced:
             # If we didn't sync, use the restore_path local dir
-            self._experiment_checkpoint_dir = os.path.expanduser(path_or_uri)
+            self._experiment_checkpoint_dir = os.path.abspath(
+                os.path.expanduser(path_or_uri)
+            )
         else:
             # If we synced, `experiment_checkpoint_dir` will contain a temporary
             # directory. Create an experiment checkpoint dir instead and move


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Relative paths can be set in `RunConfig(local_dir="relative_path")`, and the `Experiment` object that is created with this `local_dir` handles it properly by first expanding `~`, then converting to an absolute path if needed.

The path passed into `Tuner.restore(path)` does not convert to an absolute path in the same way, which results in an error due to a mismatch between the Experiment `local_dir` (which is now an absolute path), and the relative experiment path that is supplied.

See added unit test for a simple example.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/30342

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
