### PR TITLE
[Train] Deprecate old `prepare_model` DDP args

### DIFF
--- a/python/ray/train/tests/test_torch_trainer.py
+++ b/python/ray/train/tests/test_torch_trainer.py
@@ -364,6 +364,16 @@ def test_torch_amp_with_custom_get_state(ray_start_4_cpus):
     assert results.checkpoint
 
 
+def test_torch_prepare_model_deprecated():
+    model = torch.nn.Linear(1, 1)
+
+    with pytest.raises(DeprecationWarning):
+        train.torch.prepare_model(model, wrap_ddp=True)
+
+    with pytest.raises(DeprecationWarning):
+        train.torch.prepare_model(model, ddp_kwargs={"x": "y"})
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -397,7 +397,7 @@ class _TorchAccelerator(Accelerator):
                     worker_init_fn: Optional[Callable[[int], None]]
                 ):
                     def wrapper(worker_id: int):
-                        worker_seed = torch.initial_seed() % 2 ** 32
+                        worker_seed = torch.initial_seed() % 2**32
                         np.random.seed(worker_seed)
                         random.seed(worker_seed)
                         if worker_init_fn:

--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -2,7 +2,6 @@ import logging
 import os
 import random
 import types
-import warnings
 import collections
 from distutils.version import LooseVersion
 
@@ -55,7 +54,7 @@ def prepare_model(
     parallel_strategy: Optional[str] = "ddp",
     parallel_strategy_kwargs: Optional[Dict[str, Any]] = None,
     # Deprecated args.
-    wrap_ddp: bool = True,
+    wrap_ddp: bool = False,
     ddp_kwargs: Optional[Dict[str, Any]] = None,
 ) -> torch.nn.Module:
     """Prepares the model for distributed execution.
@@ -76,39 +75,18 @@ def prepare_model(
             initialization if ``parallel_strategy`` is set to "ddp"
             or "fsdp", respectively.
     """
-    if not wrap_ddp and parallel_strategy != "ddp":
-        raise ValueError(
-            "`parallel_strategy` and `wrap_ddp` cannot both be set. "
-            "`wrap_ddp` argument is deprecated as of Ray 2.1. To "
-            "disable DDP wrapping, set `parallel_strategy=None`."
-        )
 
-    if parallel_strategy_kwargs and ddp_kwargs:
-        raise ValueError(
-            "`parallel_strategy_kwargs` and `ddp_kwargs` cannot both be "
-            "set. The `ddp_kwargs` argument is deprecated as of Ray 2.1. "
-            "To provide DDP kwargs, use the "
-            "`parallel_strategy_kwargs` argument."
-        )
-
-    if not wrap_ddp:
-        warnings.warn(
+    if wrap_ddp:
+        raise DeprecationWarning(
             "The `wrap_ddp` argument is deprecated as of Ray 2.1. Use the "
-            "`parallel_strategy` argument instead.",
-            DeprecationWarning,
-            stacklevel=2,
+            "`parallel_strategy` argument instead."
         )
-        # If wrap_ddp is False, then set parallel_strategy to None.
-        parallel_strategy = None
 
     if ddp_kwargs:
-        warnings.warn(
+        raise DeprecationWarning(
             "The `ddp_kwargs` argument is deprecated as of Ray 2.1. Use the "
-            "`parallel_strategy_kwargs` arg instead.",
-            DeprecationWarning,
-            stacklevel=2,
+            "`parallel_strategy_kwargs` arg instead."
         )
-        parallel_strategy_kwargs = ddp_kwargs
 
     if parallel_strategy == "fsdp" and FullyShardedDataParallel is None:
         raise ImportError(
@@ -419,7 +397,7 @@ class _TorchAccelerator(Accelerator):
                     worker_init_fn: Optional[Callable[[int], None]]
                 ):
                     def wrapper(worker_id: int):
-                        worker_seed = torch.initial_seed() % 2**32
+                        worker_seed = torch.initial_seed() % 2 ** 32
                         np.random.seed(worker_seed)
                         random.seed(worker_seed)
                         if worker_init_fn:


### PR DESCRIPTION
Signed-off-by: amogkam <amogkamsetty@yahoo.com>

Upgrade previously deprecated arguments from logging a warning to now raising an error

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
