### PR TITLE
[AIR] Upgrade `Checkpoint.to_object_ref` and `Checkpoint.from_object_ref` deprecation

### DIFF
--- a/python/ray/air/checkpoint.py
+++ b/python/ray/air/checkpoint.py
@@ -8,7 +8,6 @@ import tarfile
 import tempfile
 import traceback
 import uuid
-import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Tuple, Type, Union
@@ -399,13 +398,11 @@ class Checkpoint:
         Returns:
             Checkpoint: checkpoint object.
         """
-        warnings.warn(
+        raise DeprecationWarning(
             "`from_object_ref` is deprecated and will be removed in a future Ray "
             "version. To restore a Checkpoint from a remote object ref, call "
             "`ray.get(obj_ref)` instead.",
-            DeprecationWarning,
         )
-        return cls(obj_ref=obj_ref)
 
     @Deprecated(
         message="To store the checkpoint in the Ray object store, call `ray.put(ckpt)` "
@@ -417,16 +414,11 @@ class Checkpoint:
         Returns:
             ray.ObjectRef: ObjectRef pointing to checkpoint data.
         """
-        warnings.warn(
+        raise DeprecationWarning(
             "`to_object_ref` is deprecated and will be removed in a future Ray "
             "version. To store the checkpoint in the Ray object store, call "
             "`ray.put(ckpt)` instead of `ckpt.to_object_ref()`.",
-            DeprecationWarning,
         )
-        if self._obj_ref:
-            return self._obj_ref
-        else:
-            return ray.put(self.to_dict())
 
     @classmethod
     def from_directory(cls, path: str) -> "Checkpoint":


### PR DESCRIPTION
Signed-off-by: amogkam <amogkamsetty@yahoo.com>
Upgrade deprecation of these two methods from logging a warning to raising an error for Ray 2.2

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
