### PR TITLE
[RLlib] Disabled r2d2 release tests on multi-gpu

### DIFF
--- a/release/rllib_tests/multi_gpu_with_attention_learning_tests/multi_gpu_with_attention_learning_tests.yaml
+++ b/release/rllib_tests/multi_gpu_with_attention_learning_tests/multi_gpu_with_attention_learning_tests.yaml
@@ -154,36 +154,37 @@ ppo-stateless-cartpole:
         # Double batch size (2 GPUs).
         train_batch_size: 8000
 
-r2d2-stateless-cartpole:
-    env: ray.rllib.examples.env.stateless_cartpole.StatelessCartPole
-    run: R2D2
-    # Minimum reward and total ts (in given time_total_s) to pass this test.
-    pass_criteria:
-        episode_reward_mean: 150.0
-        timesteps_total: 130000
-    stop:
-        time_total_s: 1200
-    config:
-        num_gpus: 2
-        num_workers: 0
-        # R2D2 settings.
-        burn_in: 20
-        zero_init_states: true
-        lr: 0.0005
-        # Give some more time to explore.
-        exploration_config:
-          epsilon_timesteps: 50000
-        model:
-            # Test w/ GTrXL net.
-            use_attention: true
-            max_seq_len: 20
-            attention_num_transformer_units: 1
-            attention_dim: 32
-            attention_memory_inference: 10
-            attention_memory_training: 10
-            attention_num_heads: 1
-            attention_head_dim: 32
-            attention_position_wise_mlp_dim: 32
-            # Use a very simple base-model.
-            fcnet_hiddens: [64]
-            fcnet_activation: linear
+# TODO (Kourosh): Activate these tests back when the new modeling stack is merged
+# r2d2-stateless-cartpole:
+#     env: ray.rllib.examples.env.stateless_cartpole.StatelessCartPole
+#     run: R2D2
+#     # Minimum reward and total ts (in given time_total_s) to pass this test.
+#     pass_criteria:
+#         episode_reward_mean: 150.0
+#         timesteps_total: 130000
+#     stop:
+#         time_total_s: 1200
+#     config:
+#         num_gpus: 2
+#         num_workers: 0
+#         # R2D2 settings.
+#         burn_in: 20
+#         zero_init_states: true
+#         lr: 0.0005
+#         # Give some more time to explore.
+#         exploration_config:
+#           epsilon_timesteps: 50000
+#         model:
+#             # Test w/ GTrXL net.
+#             use_attention: true
+#             max_seq_len: 20
+#             attention_num_transformer_units: 1
+#             attention_dim: 32
+#             attention_memory_inference: 10
+#             attention_memory_training: 10
+#             attention_num_heads: 1
+#             attention_head_dim: 32
+#             attention_position_wise_mlp_dim: 32
+#             # Use a very simple base-model.
+#             fcnet_hiddens: [64]
+#             fcnet_activation: linear

--- a/release/rllib_tests/multi_gpu_with_lstm_learning_tests/multi_gpu_with_lstm_learning_tests.yaml
+++ b/release/rllib_tests/multi_gpu_with_lstm_learning_tests/multi_gpu_with_lstm_learning_tests.yaml
@@ -134,30 +134,31 @@ ppo-stateless-cartpole:
         # Double batch size (2 GPUs).
         train_batch_size: 8000
 
-r2d2-stateless-cartpole:
-    env: ray.rllib.examples.env.stateless_cartpole.StatelessCartPole
-    run: R2D2
-    # Minimum reward and total ts (in given time_total_s) to pass this test.
-    pass_criteria:
-        episode_reward_mean: 150.0
-        timesteps_total: 65000
-    stop:
-        time_total_s: 800
-    config:
-        num_gpus: 2
-        num_workers: 0
-        # R2D2 settings.
-        burn_in: 20
-        zero_init_states: true
-        lr: 0.0005
-        # Give some more time to explore.
-        exploration_config:
-          epsilon_timesteps: 50000
-        model:
-            # Test w/ LSTMs.
-            use_lstm: true
-            lstm_cell_size: 64
-            # Use a very simple base-model.
-            fcnet_hiddens: [64]
-            fcnet_activation: linear
-            max_seq_len: 20
+# TODO (Kourosh): Activate these tests back when the new modeling stack is merged
+# r2d2-stateless-cartpole:
+#     env: ray.rllib.examples.env.stateless_cartpole.StatelessCartPole
+#     run: R2D2
+#     # Minimum reward and total ts (in given time_total_s) to pass this test.
+#     pass_criteria:
+#         episode_reward_mean: 150.0
+#         timesteps_total: 65000
+#     stop:
+#         time_total_s: 800
+#     config:
+#         num_gpus: 2
+#         num_workers: 0
+#         # R2D2 settings.
+#         burn_in: 20
+#         zero_init_states: true
+#         lr: 0.0005
+#         # Give some more time to explore.
+#         exploration_config:
+#           epsilon_timesteps: 50000
+#         model:
+#             # Test w/ LSTMs.
+#             use_lstm: true
+#             lstm_cell_size: 64
+#             # Use a very simple base-model.
+#             fcnet_hiddens: [64]
+#             fcnet_activation: linear
+#             max_seq_len: 20


### PR DESCRIPTION
Signed-off-by: Kourosh Hakhamaneshi <kourosh@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This test have been failing for quite some time as it is not learning. The initial investigation suggests that the problem is with the R2D2 algorithm itself and not the fact that it is running on multi-gpus. So it should not become a blocker on this release test. We will recover this test back when the R2D2 problems are resolved. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
