### PR TITLE
[metrics] Missing aggregation for node state

### DIFF
--- a/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -295,15 +295,15 @@ GRAFANA_PANELS = [
         unit="nodes",
         targets=[
             Target(
-                expr="ray_cluster_active_nodes{{{global_filters}}}",
+                expr="sum(ray_cluster_active_nodes{{{global_filters}}}) by (node_type)",
                 legend="Active Nodes: {{node_type}}",
             ),
             Target(
-                expr="ray_cluster_failed_nodes{{{global_filters}}}",
+                expr="sum(ray_cluster_failed_nodes{{{global_filters}}}) by (node_type)",
                 legend="Failed Nodes: {{node_type}}",
             ),
             Target(
-                expr="ray_cluster_pending_nodes{{{global_filters}}}",
+                expr="sum(ray_cluster_pending_nodes{{{global_filters}}}) by (node_type)",
                 legend="Pending Nodes: {{node_type}}",
             ),
         ],


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The query was missing a group by, causing duplicate time series of the same legend if Ray restarts.