### PR TITLE
[RLlib] Add evaluation worker healthiness stats only if eval worker is not None

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2654,20 +2654,21 @@ class Algorithm(Trainable):
         else:
             eval_results = eval_func_to_use()
 
-        # After evaluation, do a round of health check to see if any of
-        # the failed workers are back.
-        self.restore_workers(self.evaluation_workers)
+        if self.evaluation_workers is not None:
+            # After evaluation, do a round of health check to see if any of
+            # the failed workers are back.
+            self.restore_workers(self.evaluation_workers)
 
-        # Add number of healthy evaluation workers after this iteration.
-        eval_results["evaluation"][
-            "num_healthy_workers"
-        ] = self.evaluation_workers.num_healthy_remote_workers()
-        eval_results["evaluation"][
-            "num_in_flight_async_reqs"
-        ] = self.evaluation_workers.num_in_flight_async_reqs()
-        eval_results["evaluation"][
-            "num_remote_worker_restarts"
-        ] = self.evaluation_workers.num_remote_worker_restarts()
+            # Add number of healthy evaluation workers after this iteration.
+            eval_results["evaluation"][
+                "num_healthy_workers"
+            ] = self.evaluation_workers.num_healthy_remote_workers()
+            eval_results["evaluation"][
+                "num_in_flight_async_reqs"
+            ] = self.evaluation_workers.num_in_flight_async_reqs()
+            eval_results["evaluation"][
+                "num_remote_worker_restarts"
+            ] = self.evaluation_workers.num_remote_worker_restarts()
 
         return eval_results
 

--- a/rllib/offline/estimators/tests/test_ope.py
+++ b/rllib/offline/estimators/tests/test_ope.py
@@ -253,7 +253,7 @@ class TestOPE(unittest.TestCase):
         num_actions = config.action_space.n
         algo = config.build()
 
-        evaluated_results = algo.evaluate()
+        evaluated_results = algo._run_one_evaluation()
         ope_results = evaluated_results["evaluation"]["off_policy_estimator"]
         policy = algo.get_policy()
 


### PR DESCRIPTION
Signed-off-by: Kourosh Hakhamaneshi <kourosh@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It fixes a bug where we attempt to access self.evaluation_workers for returning stats when it's None. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
