### PR TITLE
[Datasets] Add benchmark for TFRecords read

### DIFF
--- a/release/nightly_tests/dataset/read_images_benchmark.py
+++ b/release/nightly_tests/dataset/read_images_benchmark.py
@@ -100,7 +100,7 @@ def run_images_benchmark(benchmark: Benchmark):
 if __name__ == "__main__":
     ray.init()
 
-    benchmark = Benchmark("read")
+    benchmark = Benchmark("read-images")
 
     run_images_benchmark(benchmark)
 

--- a/release/nightly_tests/dataset/read_tfrecords_benchmark.py
+++ b/release/nightly_tests/dataset/read_tfrecords_benchmark.py
@@ -1,0 +1,108 @@
+import random
+import shutil
+import tempfile
+from typing import List, Tuple
+
+import ray
+from ray.data.dataset import Dataset
+
+from benchmark import Benchmark
+from read_images_benchmark import generate_images
+import pyarrow as pa
+import numpy as np
+
+
+def read_tfrecords(path: str) -> Dataset:
+    return ray.data.read_tfrecords(paths=path)
+
+
+def generate_tfrecords_from_images(
+    num_images: int, sizes: List[Tuple[int, int]], modes: List[str], formats: List[str]
+) -> str:
+    images_dir = generate_images(num_images, sizes, modes, formats)
+    try:
+        ds = ray.data.read_images(images_dir)
+
+        # Convert images from NumPy to bytes
+        def images_to_bytes(batch):
+            images_as_bytes = [image.tobytes() for image in batch]
+            return pa.table({"image": images_as_bytes})
+
+        ds = ds.map_batches(images_to_bytes, batch_format="numpy")
+        tfrecords_dir = tempfile.mkdtemp()
+        ds.write_tfrecords(tfrecords_dir)
+    finally:
+        shutil.rmtree(images_dir)
+    return tfrecords_dir
+
+
+def generate_random_tfrecords(
+    num_rows: int,
+    num_int: int = 0,
+    num_float: int = 0,
+    num_bytes: int = 0,
+    bytes_size: int = 0,
+) -> str:
+    def generate_features(batch):
+        features = {"int_features": [], "float_features": [], "bytes_features": []}
+        lower_bound = -(2**32)
+        upper_bound = 2**32
+        for _ in batch:
+            if num_int > 0:
+                int_features = [
+                    random.randint(lower_bound, upper_bound) for _ in range(num_int)
+                ]
+                features["int_features"].append(int_features)
+            if num_float > 0:
+                float_features = [
+                    random.uniform(lower_bound, upper_bound) for _ in range(num_float)
+                ]
+                features["float_features"].append(float_features)
+            if num_bytes > 0:
+                bytes_features = [np.random.bytes(bytes_size) for _ in range(num_bytes)]
+                features["bytes_features"].append(bytes_features)
+        features = {k: v for (k, v) in features.items() if len(v) > 0}
+        return pa.table(features)
+
+    ds = ray.data.range(num_rows).map_batches(generate_features)
+    tfrecords_dir = tempfile.mkdtemp()
+    ds.write_tfrecords(tfrecords_dir)
+    return tfrecords_dir
+
+
+def run_tfrecords_benchmark(benchmark: Benchmark):
+    # Set global random seed.
+    random.seed(42)
+
+    test_input = [
+        generate_tfrecords_from_images(100, [(256, 256)], ["RGB"], ["jpg"]),
+        generate_tfrecords_from_images(100, [(2048, 2048)], ["RGB"], ["jpg"]),
+        generate_tfrecords_from_images(
+            1000, [(64, 64), (256, 256)], ["RGB"], ["jpg", "jpeg", "png"]
+        ),
+        generate_random_tfrecords(1024 * 1024 * 10, num_int=100),
+        generate_random_tfrecords(1024 * 1024 * 10, num_float=100),
+        generate_random_tfrecords(1024 * 1024, num_bytes=10, bytes_size=100),
+    ]
+
+    try:
+        benchmark.run("tfrecords-images-100-256", read_tfrecords, path=test_input[0])
+        benchmark.run("tfrecords-images-100-2048", read_tfrecords, path=test_input[1])
+        benchmark.run("tfrecords-images-1000-mix", read_tfrecords, path=test_input[2])
+        benchmark.run("tfrecords-random-int-1g", read_tfrecords, path=test_input[3])
+        benchmark.run("tfrecords-random-float-1g", read_tfrecords, path=test_input[4])
+        benchmark.run("tfrecords-random-bytes-1g", read_tfrecords, path=test_input[5])
+
+    finally:
+        for root in test_input:
+            shutil.rmtree(root)
+
+
+if __name__ == "__main__":
+    ray.init()
+
+    benchmark = Benchmark("read-tfrecords")
+
+    run_tfrecords_benchmark(benchmark)
+
+    benchmark.write_result()

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4445,11 +4445,11 @@
     type: sdk_command
     file_manager: sdk
 
-- name: read_benchmark_single_node
+- name: read_images_benchmark_single_node
   group: core-dataset-tests
   working_dir: nightly_tests/dataset
 
-  frequency: multi
+  frequency: nightly
   team: data
   cluster:
     cluster_env: app_config.yaml
@@ -4457,7 +4457,24 @@
 
   run:
     timeout: 1800
-    script: python read_benchmark.py
+    script: python read_images_benchmark.py
+
+    type: sdk_command
+    file_manager: sdk
+
+- name: read_tfrecords_benchmark_single_node
+  group: core-dataset-tests
+  working_dir: nightly_tests/dataset
+
+  frequency: nightly
+  team: data
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: single_node_benchmark_compute.yaml
+
+  run:
+    timeout: 1800
+    script: python read_tfrecords_benchmark.py
 
     type: sdk_command
     file_manager: sdk

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4473,6 +4473,7 @@
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
+    # Expect the benchmark to finish around 22 minutes.
     timeout: 1800
     script: python read_tfrecords_benchmark.py
 


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is to add data benchmark for reading TFRecords files (`read_tfrecords` API) in single node. The input TFRecords files are generated from (1).randomly generated images, (2).randomly generated int, float, bytes value.

Ran the benchmark and verified it succeed:

```
Running benchmark: read-tfrecords
Read->Map_Batches: 100%|███████████████████████████████████████████████| 32/32 [00:04<00:00,  7.84it/s]
Write Progress: 100%|██████████████████████████████████████████████████| 32/32 [00:06<00:00,  4.78it/s]
Read->Map_Batches: 100%|█████████████████████████████████████████████| 100/100 [00:03<00:00, 32.52it/s]
Write Progress: 100%|████████████████████████████████████████████████| 100/100 [00:05<00:00, 19.03it/s]
Read->Map_Batches: 100%|███████████████████████████████████████████████| 51/51 [00:02<00:00, 19.91it/s]
Write Progress: 100%|██████████████████████████████████████████████████| 51/51 [00:05<00:00,  9.85it/s]
Read->Map_Batches: 100%|███████████████████████████████████████████████| 80/80 [02:53<00:00,  2.17s/it]
Write Progress: 100%|██████████████████████████████████████████████████| 80/80 [03:46<00:00,  2.84s/it]
Read->Map_Batches: 100%|███████████████████████████████████████████████| 80/80 [01:07<00:00,  1.19it/s]
Read->Map_Batches: 100%|███████████████████████████████████████████████| 80/80 [01:07<00:00,  1.19it/s]
Write Progress: 100%|██████████████████████████████████████████████████| 80/80 [03:24<00:00,  2.56s/it]
Read->Map_Batches: 100%|███████████████████████████████████████████████| 32/32 [00:21<00:00,  1.51it/s]
Write Progress: 100%|██████████████████████████████████████████████████| 32/32 [00:16<00:00,  1.89it/s]
Running case: tfrecords-images-100-256
Read progress: 100%|███████████████████████████████████████████████████| 32/32 [00:03<00:00, 10.57it/s]
Result of case tfrecords-images-100-256: {'time': 3.16600097999617}
Running case: tfrecords-images-100-2048
Read progress: 100%|█████████████████████████████████████████████████| 100/100 [00:14<00:00,  6.80it/s]
Result of case tfrecords-images-100-2048: {'time': 15.941341369005386}
Running case: tfrecords-images-1000-mix
Read progress: 100%|███████████████████████████████████████████████████| 51/51 [00:01<00:00, 34.99it/s]
Result of case tfrecords-images-1000-mix: {'time': 1.7659148280072259}
Running case: tfrecords-random-int-1g
Read progress: 100%|███████████████████████████████████████████████████| 80/80 [03:03<00:00,  2.29s/it]
Result of case tfrecords-random-int-1g: {'time': 204.05738306099374}
Running case: tfrecords-images-float-1g
Read progress: 100%|███████████████████████████████████████████████████| 80/80 [02:47<00:00,  2.09s/it]
Result of case tfrecords-images-float-1g: {'time': 186.0372944809933}
Running case: tfrecords-images-bytes-1g
Read progress: 100%|███████████████████████████████████████████████████| 32/32 [00:17<00:00,  1.83it/s]
Result of case tfrecords-images-bytes-1g: {'time': 22.197236428997712}
Finish benchmark: read-tfrecords

real    21m47.484s
user    2m30.749s
sys     0m58.017s
(base) ray@ip-172-31-80-220:~/default$ 
```
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
