### PR TITLE
[Datasets] Change `read_tfrecords` output from Pandas to Arrow format

### DIFF
--- a/doc/source/data/dataset-internals.rst
+++ b/doc/source/data/dataset-internals.rst
@@ -139,6 +139,7 @@ Different ways of creating Datasets leads to a different starting internal forma
 * Reading tabular files (Parquet, CSV, JSON) creates Arrow blocks initially.
 * Converting from Pandas, Dask, Modin, and Mars creates Pandas blocks initially.
 * Reading NumPy files or converting from NumPy ndarrays creates Arrow blocks.
+* Reading TFRecord file creates Arrow blocks.
 
 However, this internal format is not exposed to the user. Datasets converts between formats
 as needed internally depending on the specified ``batch_format`` of transformations.

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -64,9 +64,25 @@ class TFRecordDatasource(FileBasedDatasource):
 
 def _convert_example_to_dict(
     example: "tf.train.Example",
-) -> Dict[str, Union[List[List[bytes]], List[List[float]], List[List[int]]]]:
+) -> Dict[
+    str,
+    Union[
+        List[bytes],
+        List[List[bytes]],
+        List[float],
+        List[List[float]],
+        List[int],
+        List[List[int]],
+    ],
+]:
     record = {}
     for feature_name, feature in example.features.feature.items():
+        value = _get_feature_value(feature)
+        # Return value itself if the list has single value.
+        # This is to give better user experience when writing preprocessing UDF on
+        # these single-value lists.
+        if len(value) == 1:
+            value = value[0]
         record[feature_name] = [_get_feature_value(feature)]
     return record
 

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -22,7 +22,7 @@ class TFRecordDatasource(FileBasedDatasource):
         self, f: "pyarrow.NativeFile", path: str, **reader_args
     ) -> Iterator[Block]:
         from google.protobuf.message import DecodeError
-        import pandas as pd
+        import pyarrow as pa
         import tensorflow as tf
 
         for record in _read_records(f):
@@ -36,7 +36,7 @@ class TFRecordDatasource(FileBasedDatasource):
                     f"file contains a message type other than `tf.train.Example`: {e}"
                 )
 
-            yield pd.DataFrame([_convert_example_to_dict(example)])
+            yield pa.Table.from_pydict(_convert_example_to_dict(example))
 
     def _write_block(
         self,

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -64,13 +64,10 @@ class TFRecordDatasource(FileBasedDatasource):
 
 def _convert_example_to_dict(
     example: "tf.train.Example",
-) -> Dict[str, Union[bytes, List[bytes], float, List[float], int, List[int]]]:
+) -> Dict[str, Union[List[List[bytes]], List[List[float]], List[List[int]]]]:
     record = {}
     for feature_name, feature in example.features.feature.items():
-        value = _get_feature_value(feature)
-        if len(value) == 1:
-            value = value[0]
-        record[feature_name] = value
+        record[feature_name] = [_get_feature_value(feature)]
     return record
 
 

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -83,7 +83,7 @@ def _convert_example_to_dict(
         # these single-value lists.
         if len(value) == 1:
             value = value[0]
-        record[feature_name] = [_get_feature_value(feature)]
+        record[feature_name] = [value]
     return record
 
 

--- a/python/ray/data/tests/test_dataset_tfrecords.py
+++ b/python/ray/data/tests/test_dataset_tfrecords.py
@@ -37,18 +37,18 @@ def test_read_tfrecords(ray_start_regular_shared, tmp_path):
     df = ds.to_pandas()
     # Protobuf serializes features in a non-deterministic order.
     assert dict(df.dtypes) == {
-        "int64": object,
+        "int64": np.int64,
         "int64_list": object,
-        "float": object,
+        "float": np.float,
         "float_list": object,
         "bytes": object,
         "bytes_list": object,
     }
-    assert np.array_equal(df["int64"][0], np.array([1]))
+    assert list(df["int64"]) == [1]
     assert np.array_equal(df["int64_list"][0], np.array([1, 2, 3, 4]))
-    assert np.array_equal(df["float"][0], np.array([1.0]))
+    assert list(df["float"]) == [1.0]
     assert np.array_equal(df["float_list"][0], np.array([1.0, 2.0, 3.0, 4.0]))
-    assert np.array_equal(df["bytes"][0], np.array([b"abc"]))
+    assert list(df["bytes"]) == [b"abc"]
     assert np.array_equal(df["bytes_list"][0], np.array([b"abc", b"1234"]))
 
 
@@ -174,20 +174,20 @@ def test_readback_tfrecords(ray_start_regular_shared, tmp_path):
         [
             # Row one.
             {
-                "int_item": [1],
+                "int_item": 1,
                 "int_list": [2, 2, 3],
-                "float_item": [1.0],
+                "float_item": 1.0,
                 "float_list": [2.0, 3.0, 4.0],
-                "bytes_item": [b"abc"],
+                "bytes_item": b"abc",
                 "bytes_list": [b"abc", b"1234"],
             },
             # Row two.
             {
-                "int_item": [2],
+                "int_item": 2,
                 "int_list": [3, 3, 4],
-                "float_item": [2.0],
+                "float_item": 2.0,
                 "float_list": [2.0, 2.0, 3.0],
-                "bytes_item": [b"def"],
+                "bytes_item": b"def",
                 "bytes_list": [b"def", b"1234"],
             },
         ]

--- a/python/ray/data/tests/test_dataset_tfrecords.py
+++ b/python/ray/data/tests/test_dataset_tfrecords.py
@@ -37,19 +37,19 @@ def test_read_tfrecords(ray_start_regular_shared, tmp_path):
     df = ds.to_pandas()
     # Protobuf serializes features in a non-deterministic order.
     assert dict(df.dtypes) == {
-        "int64": np.int64,
+        "int64": object,
         "int64_list": object,
-        "float": np.float,
+        "float": object,
         "float_list": object,
         "bytes": object,
         "bytes_list": object,
     }
-    assert list(df["int64"]) == [1]
-    assert list(df["int64_list"]) == [[1, 2, 3, 4]]
-    assert list(df["float"]) == [1.0]
-    assert list(df["float_list"]) == [[1.0, 2.0, 3.0, 4.0]]
-    assert list(df["bytes"]) == [b"abc"]
-    assert list(df["bytes_list"]) == [[b"abc", b"1234"]]
+    assert np.array_equal(df["int64"][0], np.array([1]))
+    assert np.array_equal(df["int64_list"][0], np.array([1, 2, 3, 4]))
+    assert np.array_equal(df["float"][0], np.array([1.0]))
+    assert np.array_equal(df["float_list"][0], np.array([1.0, 2.0, 3.0, 4.0]))
+    assert np.array_equal(df["bytes"][0], np.array([b"abc"]))
+    assert np.array_equal(df["bytes_list"][0], np.array([b"abc", b"1234"]))
 
 
 def test_write_tfrecords(ray_start_regular_shared, tmp_path):
@@ -174,20 +174,20 @@ def test_readback_tfrecords(ray_start_regular_shared, tmp_path):
         [
             # Row one.
             {
-                "int_item": 1,
+                "int_item": [1],
                 "int_list": [2, 2, 3],
-                "float_item": 1.0,
+                "float_item": [1.0],
                 "float_list": [2.0, 3.0, 4.0],
-                "bytes_item": b"abc",
+                "bytes_item": [b"abc"],
                 "bytes_list": [b"abc", b"1234"],
             },
             # Row two.
             {
-                "int_item": 2,
+                "int_item": [2],
                 "int_list": [3, 3, 4],
-                "float_item": 2.0,
+                "float_item": [2.0],
                 "float_list": [2.0, 2.0, 3.0],
-                "bytes_item": b"def",
+                "bytes_item": [b"def"],
                 "bytes_list": [b"def", b"1234"],
             },
         ]


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is to change `read_tfrecords` output from Pandas to Arrow format. From benchmark https://github.com/ray-project/ray/pull/30389, found the `read_tfrecords` is signigicantly slower than `write_tfrecords`.

E.g., for 1G TFRecords files (integers), the `write_tfrecords` took around 4 minutes, but `read_tfrecords` took more than 20 minutes. From flame graph, identified the bottleneck is coming from (1).creating Pandas dataframe from each row, and (2).Pandas `size_bytes()` call when adding each Pandas block to output buffer.

Change output from Pandas to Arrow (this is also the same format we use for `read_images`) fix the issue. The `read_tfrecords` latency drop from 24 minutes to less than 4 minutes (similar to `write_tfrecords`).

Before this fix:

<img width="1234" alt="Screen Shot 2022-11-16 at 4 43 40 PM" src="https://user-images.githubusercontent.com/4629931/202363139-d2d77d18-7459-4f4f-bdc4-1116459e6e68.png">



<img width="1725" alt="Screen Shot 2022-11-16 at 4 44 01 PM" src="https://user-images.githubusercontent.com/4629931/202363151-4d86ea0b-adf5-457b-b41a-22fd4bd317f8.png">

After this fix:

<img width="1172" alt="Screen Shot 2022-11-16 at 6 34 24 PM" src="https://user-images.githubusercontent.com/4629931/202363224-076288ba-1d21-4ab4-833d-c422082b7186.png">

<img width="1719" alt="Screen Shot 2022-11-16 at 6 34 51 PM" src="https://user-images.githubusercontent.com/4629931/202363251-7c04eb32-8d00-4fe9-b2d9-93278e6d210d.png">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
