### PR TITLE
[Dashboard] Handle diskless machine breaking the stats report.

### DIFF
--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -431,12 +431,16 @@ class ReporterAgent(
     @staticmethod
     def _get_disk_io_stats():
         stats = psutil.disk_io_counters()
-        return (
-            stats.read_bytes,
-            stats.write_bytes,
-            stats.read_count,
-            stats.write_count,
-        )
+        # stats can be None or {} if the machine is diskless.
+        if not stats:
+            return (0, 0, 0, 0)
+        else:
+            return (
+                stats.read_bytes,
+                stats.write_bytes,
+                stats.read_count,
+                stats.write_count,
+            )
 
     def _get_workers(self):
         raylet_proc = self._get_raylet_proc()

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -432,6 +432,7 @@ class ReporterAgent(
     def _get_disk_io_stats():
         stats = psutil.disk_io_counters()
         # stats can be None or {} if the machine is diskless.
+        # https://psutil.readthedocs.io/en/latest/#psutil.disk_io_counters
         if not stats:
             return (0, 0, 0, 0)
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When the ndoe is diskless, `psutil.disk_io_counters()` can return None or {}

The stats when it is diskless is RFC. I thought it makes sense to just return 0,0,0,0 because it is not used. But we can return None instead (however, this is more complicated because the upstream callers should handle this case from reporter agent -> reporter_head)

## Related issue number

Closes https://github.com/ray-project/ray/issues/30229

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
