### PR TITLE
[RLlib] Fix EnvRunnerV2 prev action and prev action at t=0 and more

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -223,7 +223,7 @@ class AlgorithmConfig:
         self.sample_collector = SimpleListCollector
         self.create_env_on_local_worker = False
         self.sample_async = False
-        self.enable_connectors = True
+        self.enable_connectors = False
         self.rollout_fragment_length = 200
         self.batch_mode = "truncate_episodes"
         self.remote_worker_envs = False

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -223,7 +223,7 @@ class AlgorithmConfig:
         self.sample_collector = SimpleListCollector
         self.create_env_on_local_worker = False
         self.sample_async = False
-        self.enable_connectors = False
+        self.enable_connectors = True
         self.rollout_fragment_length = 200
         self.batch_mode = "truncate_episodes"
         self.remote_worker_envs = False

--- a/rllib/evaluation/collectors/agent_collector.py
+++ b/rllib/evaluation/collectors/agent_collector.py
@@ -206,16 +206,16 @@ class AgentCollector:
             # the first incoming value.
             if SampleBatch.PREV_REWARDS in self.view_requirements:
                 single_row[SampleBatch.REWARDS] = get_dummy_batch_for_space(
-                    space=self.view_requirements[SampleBatch.REWARDS].space,
-                    batch_size=1,
-                    fill_value=.0
-                )[0]
+                        space=self.view_requirements[SampleBatch.REWARDS].space,
+                        batch_size=0,
+                        fill_value=.0
+                    )
             if SampleBatch.PREV_ACTIONS in self.view_requirements:
                 single_row[SampleBatch.ACTIONS] = get_dummy_batch_for_space(
                     space=self.view_requirements[SampleBatch.ACTIONS].space,
-                    batch_size=1,
+                    batch_size=0,
                     fill_value=.0
-                )[0]
+                )
             self._build_buffers(single_row)
 
         # Append data to existing buffers.

--- a/rllib/evaluation/collectors/agent_collector.py
+++ b/rllib/evaluation/collectors/agent_collector.py
@@ -206,15 +206,15 @@ class AgentCollector:
             # the first incoming value.
             if SampleBatch.PREV_REWARDS in self.view_requirements:
                 single_row[SampleBatch.REWARDS] = get_dummy_batch_for_space(
-                        space=self.view_requirements[SampleBatch.REWARDS].space,
-                        batch_size=0,
-                        fill_value=.0
-                    )
+                    space=self.view_requirements[SampleBatch.REWARDS].space,
+                    batch_size=0,
+                    fill_value=0.0,
+                )
             if SampleBatch.PREV_ACTIONS in self.view_requirements:
                 single_row[SampleBatch.ACTIONS] = get_dummy_batch_for_space(
                     space=self.view_requirements[SampleBatch.ACTIONS].space,
                     batch_size=0,
-                    fill_value=.0
+                    fill_value=0.0,
                 )
             self._build_buffers(single_row)
 

--- a/rllib/evaluation/collectors/agent_collector.py
+++ b/rllib/evaluation/collectors/agent_collector.py
@@ -189,17 +189,38 @@ class AgentCollector:
         # view requirement does not match init_obs
         self._check_view_requirement(SampleBatch.OBS, init_obs)
 
+        if SampleBatch.PREV_REWARDS in self.view_requirements:
+            prev_reward = get_dummy_batch_for_space(
+                    space=self.view_requirements[SampleBatch.REWARDS].space,
+                    batch_size=1,
+                    fill_value=.0
+                )[0]
+        if SampleBatch.PREV_REWARDS in self.view_requirements:
+            prev_action = get_dummy_batch_for_space(
+                space=self.view_requirements[SampleBatch.ACTIONS].space,
+                batch_size=1,
+                fill_value=.0
+            )[0]
+
         if SampleBatch.OBS not in self.buffers:
-            self._build_buffers(
-                single_row={
-                    SampleBatch.OBS: init_obs,
-                    SampleBatch.AGENT_INDEX: agent_index,
-                    SampleBatch.ENV_ID: env_id,
-                    SampleBatch.T: t,
-                    SampleBatch.EPS_ID: self.episode_id,
-                    SampleBatch.UNROLL_ID: self.unroll_id,
-                }
-            )
+            single_row = {
+                SampleBatch.OBS: init_obs,
+                SampleBatch.AGENT_INDEX: agent_index,
+                SampleBatch.ENV_ID: env_id,
+                SampleBatch.T: t,
+                SampleBatch.EPS_ID: self.episode_id,
+                SampleBatch.UNROLL_ID: self.unroll_id,
+            }
+            # Note (Artur): As long as we have these in our default view requirements,
+            # we should  build buffers with neutral elements instead of building them
+            # on the first AgentCollector.build_for_inference call if present.
+            # This prevents us from accidentally building buffers with duplicates of
+            # the first incoming value.
+            if SampleBatch.PREV_REWARDS in self.view_requirements:
+                single_row[SampleBatch.REWARDS] = prev_reward
+            if SampleBatch.PREV_ACTIONS in self.view_requirements:
+                single_row[SampleBatch.ACTIONS] = prev_action
+            self._build_buffers(single_row)
 
         # Append data to existing buffers.
         flattened = tree.flatten(init_obs)
@@ -210,6 +231,23 @@ class AgentCollector:
         self.buffers[SampleBatch.T][0].append(t)
         self.buffers[SampleBatch.EPS_ID][0].append(self.episode_id)
         self.buffers[SampleBatch.UNROLL_ID][0].append(self.unroll_id)
+        # Note (Artur): As long as we have these in our default view requirements,
+        # we should  build buffers with neutral elements instead of building them
+        # on the first AgentCollector.build_for_inference call if present.
+        # This prevents us from accidentally building buffers with duplicates of
+        # the first incoming value.
+        if SampleBatch.PREV_REWARDS in self.view_requirements:
+            single_row[SampleBatch.REWARDS] = get_dummy_batch_for_space(
+                space=self.view_requirements[SampleBatch.REWARDS].space,
+                batch_size=1,
+                fill_value=.0
+            )[0]
+        if SampleBatch.PREV_ACTIONS in self.view_requirements:
+            single_row[SampleBatch.ACTIONS] = get_dummy_batch_for_space(
+                space=self.view_requirements[SampleBatch.ACTIONS].space,
+                batch_size=1,
+                fill_value=.0
+            )[0]
 
     def add_action_reward_next_obs(self, input_values: Dict[str, TensorType]) -> None:
         """Adds the given dictionary (row) of values to the Agent's trajectory.
@@ -293,6 +331,8 @@ class AgentCollector:
             A SampleBatch with a batch size of 1.
         """
 
+        print(self.buffers)
+
         batch_data = {}
         np_data = {}
         for view_col, view_req in self.view_requirements.items():
@@ -323,7 +363,10 @@ class AgentCollector:
 
             # Keep an np-array cache so we don't have to regenerate the
             # np-array for different view_cols using to the same data_col.
-            self._cache_in_np(np_data, data_col)
+            try:
+                self._cache_in_np(np_data, data_col)
+            except:
+                a = 10
 
             data = []
             for d in np_data[data_col]:

--- a/rllib/evaluation/collectors/agent_collector.py
+++ b/rllib/evaluation/collectors/agent_collector.py
@@ -199,6 +199,7 @@ class AgentCollector:
                 SampleBatch.UNROLL_ID: self.unroll_id,
             }
 
+            # TODO (Artur): Remove when PREV_ACTIONS and PREV_REWARDS get deprecated.
             # Note (Artur): As long as we have these in our default view requirements,
             # we should  build buffers with neutral elements instead of building them
             # on the first AgentCollector.build_for_inference call if present.

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -860,12 +860,13 @@ class EnvRunnerV2:
             # Tell the sampler we have got a faulty episode.
             outputs.append(RolloutMetrics(episode_faulty=True))
         else:
-            is_error = False
-            # Output the collected episode.
-            self._build_done_episode(env_id, is_done, hit_horizon, outputs)
             episode_or_exception: EpisodeV2 = self._active_episodes[env_id]
             # Add rollout metrics.
             outputs.extend(self._get_rollout_metrics(episode_or_exception))
+            is_error = False
+            # Output the collected episode after (1) rollout metrics so that we
+            # always fetch metrics with RolloutWorker before we fetch samples
+            self._build_done_episode(env_id, is_done, hit_horizon, outputs)
 
         # Clean up and deleted the post-processed episode now that we have collected
         # its data.

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -540,8 +540,13 @@ class EnvRunnerV2:
                     f"ERROR: When a sub-environment (env-id {env_id}) returns an error "
                     "as observation, the dones[__all__] flag must also be set to True!"
                 )
+                # Tell the sampler we have got a faulty episode.
+                outputs.append(RolloutMetrics(episode_faulty=True))
                 # all_agents_obs is an Exception here.
                 # Drop this episode and skip to next.
+                # Output the collected episode after adding rollout metrics so that we
+                # always fetch metrics with RolloutWorker before we fetch samples.
+                # This is because we need to behave like env_runner() for now.
                 self._handle_done_episode(
                     env_id=env_id,
                     env_obs_or_exception=env_obs,
@@ -864,8 +869,9 @@ class EnvRunnerV2:
             # Add rollout metrics.
             outputs.extend(self._get_rollout_metrics(episode_or_exception))
             is_error = False
-            # Output the collected episode after (1) rollout metrics so that we
-            # always fetch metrics with RolloutWorker before we fetch samples
+            # Output the collected episode after adding rollout metrics so that we
+            # always fetch metrics with RolloutWorker before we fetch samples.
+            # This is because we need to behave like env_runner() for now.
             self._build_done_episode(env_id, is_done, hit_horizon, outputs)
 
         # Clean up and deleted the post-processed episode now that we have collected

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -540,13 +540,8 @@ class EnvRunnerV2:
                     f"ERROR: When a sub-environment (env-id {env_id}) returns an error "
                     "as observation, the dones[__all__] flag must also be set to True!"
                 )
-                # Tell the sampler we have got a faulty episode.
-                outputs.append(RolloutMetrics(episode_faulty=True))
                 # all_agents_obs is an Exception here.
                 # Drop this episode and skip to next.
-                # Output the collected episode after adding rollout metrics so that we
-                # always fetch metrics with RolloutWorker before we fetch samples.
-                # This is because we need to behave like env_runner() for now.
                 self._handle_done_episode(
                     env_id=env_id,
                     env_obs_or_exception=env_obs,


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Our default view requirements give us prev reward and prev action at t=0 that are copies of action and reward at t=0.
Also this fixes the fact that we return metrics after rollouts and don't receive them when collecting episodes and checking metrics thereafter.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
