### PR TITLE
Revert "[Datasets] Enable dynamic block splitting by default"

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -27,7 +27,7 @@ DEFAULT_TARGET_MIN_BLOCK_SIZE = 1 * 1024 * 1024
 DEFAULT_STREAMING_READ_BUFFER_SIZE = 32 * 1024 * 1024
 
 # Whether block splitting is on by default
-DEFAULT_BLOCK_SPLITTING_ENABLED = True
+DEFAULT_BLOCK_SPLITTING_ENABLED = False
 
 # Whether pandas block format is enabled.
 # TODO (kfstorm): Remove this once stable.

--- a/release/nightly_tests/dataset/read_benchmark.py
+++ b/release/nightly_tests/dataset/read_benchmark.py
@@ -10,22 +10,13 @@ import ray
 from ray.data.dataset import Dataset
 
 from benchmark import Benchmark
-import pandas as pd
 
 
 def read_images(
-    root: str,
-    size: Optional[Tuple[int, int]] = None,
-    mode: Optional[str] = None,
-    write_to_object_store: bool = True,
+    root: str, size: Optional[Tuple[int, int]] = None, mode: Optional[str] = None
 ) -> Dataset:
 
-    ds = ray.data.read_images(paths=root, size=size, mode=mode)
-    if not write_to_object_store:
-        # Apply UDF to generate dummy 1-row output from images.
-        # This is to avoid writing images data to object store.
-        ds = ds.map_batches(lambda _: pd.DataFrame({"one": [1]}), batch_size=None)
-    return ds
+    return ray.data.read_images(paths=root, size=size, mode=mode)
 
 
 def generate_images(
@@ -97,27 +88,11 @@ def run_images_benchmark(benchmark: Benchmark):
     for root in test_input:
         shutil.rmtree(root)
 
-    # Run benchmark on 1G, 20G and 100G imagenet data.
+    # TODO(chengsu): run benchmark on 20G and 100G imagenet data.
     benchmark.run(
         "images-imagenet-1g",
         read_images,
         root="s3://air-example-data-2/1G-image-data-synthetic-raw",
-    )
-
-    benchmark.run(
-        "images-imagenet-20g",
-        read_images,
-        root="s3://air-example-data-2/20G-image-data-synthetic-raw",
-        # Not write to object store as the images size are too large.
-        write_to_object_store=False,
-    )
-
-    benchmark.run(
-        "images-imagenet-100g",
-        read_images,
-        root="s3://air-example-data-2/100G-image-data-synthetic-raw",
-        # Not write to object store as the images size are too large.
-        write_to_object_store=False,
     )
 
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4398,7 +4398,7 @@
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
-    timeout: 3600
+    timeout: 1800
     script: python read_benchmark.py
 
     type: sdk_command


### PR DESCRIPTION
Reverts ray-project/ray#30284

<img width="443" alt="image" src="https://user-images.githubusercontent.com/74173148/202572672-f6fad60b-ed0c-48d6-ba1b-f46966438e24.png">
