### PR TITLE
[Datasets] Return ndarray dicts for single-column tabular datasets.

### DIFF
--- a/doc/source/ray-air/examples/torch_image_batch_pretrained.py
+++ b/doc/source/ray-air/examples/torch_image_batch_pretrained.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import numpy as np
 
 import torch
@@ -10,7 +12,7 @@ from ray.train.batch_predictor import BatchPredictor
 from ray.data.preprocessors import BatchMapper
 
 
-def preprocess(image_batch: np.ndarray) -> np.ndarray:
+def preprocess(image_batch: Dict[str, np.ndarray]) -> np.ndarray:
     """
     User Pytorch code to transform user image with outer dimension of batch size.
     """
@@ -22,7 +24,7 @@ def preprocess(image_batch: np.ndarray) -> np.ndarray:
         ]
     )
     # Outer dimension is batch size such as (10, 256, 256, 3) -> (10, 3, 256, 256)
-    transposed_torch_tensor = torch.Tensor(image_batch.transpose(0, 3, 1, 2))
+    transposed_torch_tensor = torch.Tensor(image_batch["image"].transpose(0, 3, 1, 2))
     return preprocess(transposed_torch_tensor).numpy()
 
 

--- a/python/ray/air/tests/test_dataset_config.py
+++ b/python/ray/air/tests/test_dataset_config.py
@@ -162,12 +162,12 @@ def test_use_stream_api_config(ray_start_4_cpus):
 def test_fit_transform_config(ray_start_4_cpus):
     ds = ray.data.range_table(10)
 
-    def drop_odd_pandas(rows):
-        key = list(rows)[0]
-        return rows[(rows[key] % 2 == 0)]
+    def drop_odd_pandas(batch):
+        return batch[batch["value"] % 2 == 0]
 
-    def drop_odd_numpy(rows):
-        return [x for x in rows if x % 2 == 0]
+    def drop_odd_numpy(batch):
+        arr = batch["value"]
+        return arr[arr % 2 == 0]
 
     prep_pandas = BatchMapper(drop_odd_pandas, batch_format="pandas")
     prep_numpy = BatchMapper(drop_odd_numpy, batch_format="numpy")

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -197,18 +197,27 @@ class PandasBlockAccessor(TableBlockAccessor):
     ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
         if columns is None:
             columns = self._table.columns.tolist()
-        if not isinstance(columns, list):
+            should_be_single_ndarray = self.is_tensor_wrapper()
+        elif isinstance(columns, list):
+            should_be_single_ndarray = (
+                columns == self._table.columns.tolist() and self.is_tensor_wrapper()
+            )
+        else:
             columns = [columns]
+            should_be_single_ndarray = True
+
         for column in columns:
             if column not in self._table.columns:
                 raise ValueError(
                     f"Cannot find column {column}, available columns: "
                     f"{self._table.columns.tolist()}"
                 )
+
         arrays = []
         for column in columns:
             arrays.append(self._table[column].to_numpy())
-        if len(arrays) == 1:
+
+        if should_be_single_ndarray:
             arrays = arrays[0]
         else:
             arrays = dict(zip(columns, arrays))

--- a/python/ray/data/_internal/simple_block.py
+++ b/python/ray/data/_internal/simple_block.py
@@ -96,8 +96,12 @@ class SimpleBlockAccessor(BlockAccessor):
 
         return pandas.DataFrame({"value": self._items})
 
-    def to_numpy(self, columns: Optional[Union[str, List[str]]] = None) -> np.ndarray:
+    def to_numpy(
+        self, columns: Optional[Union[KeyFn, List[KeyFn]]] = None
+    ) -> np.ndarray:
         if columns is not None:
+            if not isinstance(columns, list):
+                columns = [columns]
             return BlockAccessor.for_block(self.select(columns)).to_numpy()
         return np.array(self._items)
 

--- a/python/ray/data/_internal/simple_block.py
+++ b/python/ray/data/_internal/simple_block.py
@@ -97,8 +97,8 @@ class SimpleBlockAccessor(BlockAccessor):
         return pandas.DataFrame({"value": self._items})
 
     def to_numpy(self, columns: Optional[Union[str, List[str]]] = None) -> np.ndarray:
-        if columns:
-            raise ValueError("`columns` arg is not supported for list block.")
+        if columns is not None:
+            return BlockAccessor.for_block(self.select(columns)).to_numpy()
         return np.array(self._items)
 
     def to_arrow(self) -> "pyarrow.Table":

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -329,8 +329,7 @@ class GroupedDataset(Generic[T]):
 
             boundaries = []
             # Get the keys of the batch in numpy array format
-            keys_block = block_accessor.select([self._key])
-            keys = BlockAccessor.for_block(keys_block).to_numpy()
+            keys = block_accessor.to_numpy(self._key)
             start = 0
             while start < keys.size:
                 end = start + np.searchsorted(keys[start:], keys[start], side="right")

--- a/python/ray/data/tests/preprocessors/test_batch_mapper.py
+++ b/python/ray/data/tests/preprocessors/test_batch_mapper.py
@@ -54,9 +54,7 @@ def test_batch_mapper_basic(ray_start_regular_shared):
             ),
             pd.DataFrame(
                 {
-                    # Single column pandas automatically converts `TENSOR_COLUMN_NAME`
-                    # In UDFs
-                    TENSOR_COLUMN_NAME: [2, 3, 4, 5],
+                    "column_1": [2, 3, 4, 5],
                 }
             ),
         ),
@@ -170,9 +168,7 @@ def test_batch_mapper_batch_size(ray_start_regular_shared, ds):
             ),
             pd.DataFrame(
                 {
-                    # Single column pandas automatically converts `TENSOR_COLUMN_NAME`
-                    # In UDFs
-                    TENSOR_COLUMN_NAME: [2, 3, 4, 5],
+                    "column_1": [2, 3, 4, 5],
                 }
             ),
         ),
@@ -274,8 +270,6 @@ def test_batch_mapper_arrow_data_format(
             lazy_fixture("ds_numpy_single_column_tensor_format"),
             pd.DataFrame(
                 {
-                    # Single column pandas automatically converts `TENSOR_COLUMN_NAME`
-                    # In UDFs
                     TENSOR_COLUMN_NAME: [
                         [[1, 2], [3, 4]],
                         [[5, 6], [7, 8]],
@@ -287,14 +281,7 @@ def test_batch_mapper_arrow_data_format(
         ),
         (
             lazy_fixture("ds_numpy_list_of_ndarray_tensor_format"),
-            pd.DataFrame(
-                {
-                    # Single column pandas automatically converts `TENSOR_COLUMN_NAME`
-                    # In UDFs
-                    TENSOR_COLUMN_NAME: [[[1, 2], [3, 4]]]
-                    * 4
-                }
-            ),
+            pd.DataFrame({TENSOR_COLUMN_NAME: [[[1, 2], [3, 4]]] * 4}),
         ),
     ],
 )

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -552,12 +552,13 @@ def test_tensors_basic(ray_start_regular_shared):
     np.testing.assert_equal(res, [np.array([2]), np.array([3])])
 
     # Arrow columns in NumPy format.
-    def mapper(col_arrs):
+    def multi_mapper(col_arrs):
         assert isinstance(col_arrs, dict)
         assert list(col_arrs.keys()) == ["a", "b", "c"]
         assert all(isinstance(col_arr, np.ndarray) for col_arr in col_arrs.values())
         return {"a": col_arrs["a"] + 1, "b": col_arrs["b"] + 1, "c": col_arrs["c"] + 1}
 
+    # Multiple columns.
     t = pa.table(
         {
             "a": [1, 2, 3],
@@ -567,7 +568,7 @@ def test_tensors_basic(ray_start_regular_shared):
     )
     res = (
         ray.data.from_arrow(t)
-        .map_batches(mapper, batch_size=2, batch_format="numpy")
+        .map_batches(multi_mapper, batch_size=2, batch_format="numpy")
         .take()
     )
     np.testing.assert_equal(
@@ -579,8 +580,30 @@ def test_tensors_basic(ray_start_regular_shared):
         ],
     )
 
+    def single_mapper(col_arrs):
+        assert isinstance(col_arrs, dict)
+        assert list(col_arrs.keys()) == ["c"]
+        assert all(isinstance(col_arr, np.ndarray) for col_arr in col_arrs.values())
+        return {"c": col_arrs["c"] + 1}
+
+    # Single column (should still yield ndarray dict batches).
+    t = t.select(["c"])
+    res = (
+        ray.data.from_arrow(t)
+        .map_batches(single_mapper, batch_size=2, batch_format="numpy")
+        .take()
+    )
+    np.testing.assert_equal(
+        [r.as_pydict() for r in res],
+        [
+            {"c": np.array([2, 3])},
+            {"c": np.array([4, 5])},
+            {"c": np.array([6, 7])},
+        ],
+    )
+
     # Pandas columns in NumPy format.
-    def mapper(col_arrs):
+    def multi_mapper(col_arrs):
         assert isinstance(col_arrs, dict)
         assert list(col_arrs.keys()) == ["a", "b", "c"]
         assert all(isinstance(col_arr, np.ndarray) for col_arr in col_arrs.values())
@@ -592,6 +615,7 @@ def test_tensors_basic(ray_start_regular_shared):
             }
         )
 
+    # Multiple columns.
     df = pd.DataFrame(
         {
             "a": [1, 2, 3],
@@ -601,7 +625,7 @@ def test_tensors_basic(ray_start_regular_shared):
     )
     res = (
         ray.data.from_pandas(df)
-        .map_batches(mapper, batch_size=2, batch_format="numpy")
+        .map_batches(multi_mapper, batch_size=2, batch_format="numpy")
         .take()
     )
     np.testing.assert_equal(
@@ -610,6 +634,28 @@ def test_tensors_basic(ray_start_regular_shared):
             {"a": 2, "b": 5.0, "c": np.array([2, 3])},
             {"a": 3, "b": 6.0, "c": np.array([4, 5])},
             {"a": 4, "b": 7.0, "c": np.array([6, 7])},
+        ],
+    )
+
+    # Single column (should still yield ndarray dict batches).
+    def single_mapper(col_arrs):
+        assert isinstance(col_arrs, dict)
+        assert list(col_arrs.keys()) == ["c"]
+        assert all(isinstance(col_arr, np.ndarray) for col_arr in col_arrs.values())
+        return pd.DataFrame({"c": TensorArray(col_arrs["c"] + 1)})
+
+    df = df[["c"]]
+    res = (
+        ray.data.from_pandas(df)
+        .map_batches(single_mapper, batch_size=2, batch_format="numpy")
+        .take()
+    )
+    np.testing.assert_equal(
+        [r.as_pydict() for r in res],
+        [
+            {"c": np.array([2, 3])},
+            {"c": np.array([4, 5])},
+            {"c": np.array([6, 7])},
         ],
     )
 
@@ -1762,6 +1808,14 @@ def test_iter_batches_basic(ray_start_regular_shared):
         assert all(isinstance(col, np.ndarray) for col in batch.values())
         pd.testing.assert_frame_equal(pd.DataFrame(batch), df)
 
+    # Numpy format (single column).
+    ds2 = ds.select_columns(["one"])
+    for batch, df in zip(ds2.iter_batches(batch_size=None, batch_format="numpy"), dfs):
+        assert isinstance(batch, dict)
+        assert list(batch.keys()) == ["one"]
+        assert all(isinstance(col, np.ndarray) for col in batch.values())
+        pd.testing.assert_frame_equal(pd.DataFrame(batch), df[["one"]])
+
     # Test NumPy format on Arrow blocks.
     ds2 = ds.map_batches(lambda b: b, batch_size=None, batch_format="pyarrow")
     for batch, df in zip(ds2.iter_batches(batch_size=None, batch_format="numpy"), dfs):
@@ -1769,6 +1823,14 @@ def test_iter_batches_basic(ray_start_regular_shared):
         assert list(batch.keys()) == ["one", "two"]
         assert all(isinstance(col, np.ndarray) for col in batch.values())
         pd.testing.assert_frame_equal(pd.DataFrame(batch), df)
+
+    # Test NumPy format on Arrow blocks (single column).
+    ds3 = ds2.select_columns(["one"])
+    for batch, df in zip(ds3.iter_batches(batch_size=None, batch_format="numpy"), dfs):
+        assert isinstance(batch, dict)
+        assert list(batch.keys()) == ["one"]
+        assert all(isinstance(col, np.ndarray) for col in batch.values())
+        pd.testing.assert_frame_equal(pd.DataFrame(batch), df[["one"]])
 
     # Native format (deprecated).
     for batch, df in zip(ds.iter_batches(batch_size=None, batch_format="native"), dfs):
@@ -1868,14 +1930,18 @@ def test_iter_batches_basic(ray_start_regular_shared):
 
     # Prefetch with ray.wait.
     context = DatasetContext.get_current()
-    context.actor_prefetcher_enabled = False
-    batches = list(
-        ds.iter_batches(prefetch_blocks=1, batch_size=None, batch_format="pandas")
-    )
-    assert len(batches) == len(dfs)
-    for batch, df in zip(batches, dfs):
-        assert isinstance(batch, pd.DataFrame)
-        assert batch.equals(df)
+    old_config = context.actor_prefetcher_enabled
+    try:
+        context.actor_prefetcher_enabled = False
+        batches = list(
+            ds.iter_batches(prefetch_blocks=1, batch_size=None, batch_format="pandas")
+        )
+        assert len(batches) == len(dfs)
+        for batch, df in zip(batches, dfs):
+            assert isinstance(batch, pd.DataFrame)
+            assert batch.equals(df)
+    finally:
+        context.actor_prefetcher_enabled = old_config
 
 
 def test_iter_batches_empty_block(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset_image.py
+++ b/python/ray/data/tests/test_dataset_image.py
@@ -1,5 +1,6 @@
 import os
 import time
+from typing import Dict
 
 import numpy as np
 import pyarrow as pa
@@ -123,8 +124,8 @@ class TestReadImages:
         dataset = ray.data.read_images("example://image-datasets/simple")
         transform = transforms.ToTensor()
 
-        def preprocess(batch):
-            return np.stack([transform(image) for image in batch])
+        def preprocess(batch: Dict[str, np.ndarray]):
+            return np.stack([transform(image) for image in batch["image"]])
 
         dataset = dataset.map_batches(preprocess, batch_format="numpy")
 

--- a/python/ray/data/tests/test_dataset_numpy.py
+++ b/python/ray/data/tests/test_dataset_numpy.py
@@ -87,7 +87,7 @@ def test_to_numpy_refs(ray_start_regular_shared):
 
     # Table Dataset
     ds = ray.data.range_table(10)
-    arr = np.concatenate(ray.get(ds.to_numpy_refs()))
+    arr = np.concatenate([t["value"] for t in ray.get(ds.to_numpy_refs())])
     np.testing.assert_equal(arr, np.arange(0, 10))
 
     # Test multi-column Arrow dataset.

--- a/release/air_tests/air_benchmarks/workloads/gpu_batch_prediction.py
+++ b/release/air_tests/air_benchmarks/workloads/gpu_batch_prediction.py
@@ -2,6 +2,8 @@ import click
 import time
 import json
 import os
+from typing import Dict
+
 import numpy as np
 
 import torch
@@ -14,7 +16,7 @@ from ray.train.batch_predictor import BatchPredictor
 from ray.data.preprocessors import BatchMapper
 
 
-def preprocess(image_batch: np.ndarray) -> np.ndarray:
+def preprocess(image_batch: Dict[str, np.ndarray]) -> np.ndarray:
     """
     User Pytorch code to transform user image with outer dimension of batch size.
     """
@@ -26,7 +28,7 @@ def preprocess(image_batch: np.ndarray) -> np.ndarray:
         ]
     )
     # Outer dimension is batch size such as (10, 256, 256, 3) -> (10, 3, 256, 256)
-    transposed_torch_tensor = torch.Tensor(image_batch.transpose(0, 3, 1, 2))
+    transposed_torch_tensor = torch.Tensor(image_batch["image"].transpose(0, 3, 1, 2))
     return preprocess(transposed_torch_tensor).numpy()
 
 

--- a/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
+++ b/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
@@ -2,6 +2,8 @@ import click
 import time
 import json
 import os
+from typing import Dict
+
 import numpy as np
 import pandas as pd
 
@@ -19,7 +21,7 @@ from ray.train.torch import TorchTrainer
 from ray.air.config import ScalingConfig
 
 
-def preprocess_image_with_label(batch: np.ndarray) -> pd.DataFrame:
+def preprocess_image_with_label(batch: Dict[str, np.ndarray]) -> pd.DataFrame:
     """
     User Pytorch code to transform user image.
     """
@@ -31,6 +33,7 @@ def preprocess_image_with_label(batch: np.ndarray) -> pd.DataFrame:
             transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ]
     )
+    batch = batch["image"]
     df = pd.DataFrame(
         {"image": [preprocess(image) for image in batch], "label": [1] * len(batch)}
     )


### PR DESCRIPTION
Single-column tabular datasets have a human-readable column name (e.g. "images" for data read using our `ray.data.read_images()`) API, so we should preserve that human-readable column name when using the NumPy batch format for mapper and iterator APIs. This PR does that, ensuring that single-column ndarray dict batches are yielded instead of just ndarrays.

## Before

```python
ds = ray.data.from_items([{"col_name": np.ones((2, 2))}, {"col_name": np.ones((2, 2))}])

def udf(batch: np.ndarray) -> Dict[str, np.ndarray]:
    # batch is a single ndarray, and the "col_name" column name is lost
    # unless we hardcode it back.
    return {"col_name": process(batch)}

ds = ds.map_batches(udf, batch_format="numpy")
```

## After

```python
ds = ray.data.from_items([{"col_name": np.ones((2, 2))}, {"col_name": np.ones((2, 2))}])

def udf(batch: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
    # batch is a single-item dict, preserving the "col_name" column name.
    return {k: process(v) for k, v in batch.items()}

ds = ds.map_batches(udf, batch_format="numpy")
```

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/30407

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
