### PR TITLE
[Datasets] Marking ray-data-bulk-ingest-file-size-benchmark as unstable for now.

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -580,7 +580,7 @@
   group: AIR tests
   working_dir: air_tests/air_benchmarks/mlperf-train
 
-  stable: true
+  stable: false
   env: staging
 
   frequency: nightly


### PR DESCRIPTION
We haven't solidified this test yet, marking unstable and creating a P1 to solidify it. Closes https://github.com/ray-project/ray/issues/30447.