### PR TITLE
[release][no_ci] Mark tf mnist gpu benchmark test as unstable.

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -498,6 +498,8 @@
   team: ml
   env: staging
 
+  stable: false
+
   cluster:
     cluster_env: app_config.yaml
     cluster_compute: compute_gpu_4x4.yaml


### PR DESCRIPTION
Signed-off-by: xwjiang2010 <xwjiang2010@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Mark weekly tf mnist gpu benchmark test as unstable.

For the following reason:
1. The nightly counterpart is already marked unstable.
2. The test has a pretty high chance of timing out (since the day it was written) when acquiring vanilla tf time (20% of the time). It seems to be a native issue from distributed tf. Hence we don't have a reliable way of acquiring vanilla tf time leading to the test flakiness.
3. Since updating cuda version, both air timing and vanilla tf timing have increased greatly from 400+ to 800+ for 200 epochs. Currently I don't have a good understanding of why that's the case. But this just makes the whole test even more likely to time out.

Overall, the test is not providing much signal as to how AIR is doing compared to vanilla tf. 

See more details in #29922.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#29922

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
