### PR TITLE
[Core] Defer SIGINT interrupt during task argument deserialization.

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1800,7 +1800,9 @@ class DeferSigint(contextlib.AbstractContextManager):
         if threading.current_thread() == threading.main_thread():
             return cls()
         else:
-            return contextlib.nullcontext()
+            # TODO(Clark): Use contextlib.nullcontext() once Python 3.6 support is
+            # dropped.
+            return contextlib.suppress()
 
     def _set_task_cancelled(self, signum, frame):
         """SIGINT handler that defers the signal."""

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -14,6 +14,7 @@ import msgpack
 import os
 import pickle
 import setproctitle
+import signal
 import sys
 import threading
 import time
@@ -138,7 +139,7 @@ from ray._private.client_mode_hook import disable_client_hook
 import ray._private.gcs_utils as gcs_utils
 import ray._private.memory_monitor as memory_monitor
 import ray._private.profiling as profiling
-from ray._private.utils import decode
+from ray._private.utils import decode, DeferSigint
 
 cimport cpython
 
@@ -675,6 +676,7 @@ cdef execute_dynamic_generator_and_store_task_outputs(
                     "by the first execution.\n"
                     "See https://github.com/ray-project/ray/issues/28688.")
 
+
 cdef void execute_task(
         const CAddress &caller_address,
         CTaskType task_type,
@@ -795,20 +797,28 @@ cdef void execute_task(
                             c_arg_refs,
                             skip_adding_local_ref=False)
 
-                    if core_worker.current_actor_is_asyncio():
-                        # We deserialize objects in event loop thread to
-                        # prevent segfaults. See #7799
-                        async def deserialize_args():
-                            return (ray._private.worker.global_worker
+                    # Defer task cancellation (SIGINT) until after the task argument
+                    # deserialization context has been left.
+                    # NOTE (Clark): We defer SIGINT until after task argument
+                    # deserialization completes to keep from interrupting non-reentrant
+                    # imports that may be re-entered during error serialization or
+                    # storage.
+                    # See https://github.com/ray-project/ray/issues/30453.
+                    with DeferSigint():
+                        if core_worker.current_actor_is_asyncio():
+                            # We deserialize objects in event loop thread to
+                            # prevent segfaults. See #7799
+                            async def deserialize_args():
+                                return (ray._private.worker.global_worker
+                                        .deserialize_objects(
+                                            metadata_pairs, object_refs))
+                            args = core_worker.run_async_func_in_event_loop(
+                                deserialize_args, function_descriptor,
+                                name_of_concurrency_group_to_execute)
+                        else:
+                            args = (ray._private.worker.global_worker
                                     .deserialize_objects(
                                         metadata_pairs, object_refs))
-                        args = core_worker.run_async_func_in_event_loop(
-                            deserialize_args, function_descriptor,
-                            name_of_concurrency_group_to_execute)
-                    else:
-                        args = (ray._private.worker.global_worker
-                                .deserialize_objects(
-                                    metadata_pairs, object_refs))
 
                     for arg in args:
                         raise_if_dependency_failed(arg)

--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -1,4 +1,6 @@
+import os
 import random
+import signal
 import sys
 import time
 
@@ -12,6 +14,7 @@ from ray.exceptions import (
     WorkerCrashedError,
     ObjectLostError,
 )
+from ray._private.utils import DeferSigint
 from ray._private.test_utils import SignalActor
 
 
@@ -88,6 +91,122 @@ def test_cancel_during_arg_deser(ray_start_regular, use_force):
     assert len(ray.wait([obj], timeout=0.1)[0]) == 0
     # Cancel task.
     ray.cancel(obj, force=use_force)
+    with pytest.raises(valid_exceptions(use_force)):
+        ray.get(obj)
+
+
+def test_defer_sigint():
+    # Tests a helper context manager for deferring SIGINT signals until after the
+    # context is left. This is used by Ray's task cancellation to defer cancellation
+    # interrupts during problematic areas, e.g. task argument deserialization.
+    signal_was_deferred = False
+    orig_sigint_handler = signal.getsignal(signal.SIGINT)
+    try:
+        with DeferSigint():
+            # Send singal to current process.
+            os.kill(os.getpid(), signal.SIGINT)
+            # Wait for signal to be delivered.
+            time.sleep(1)
+            # Signal should have been delivered by here, so we consider it deferred if
+            # this is reached.
+            signal_was_deferred = True
+    except KeyboardInterrupt:
+        # Check that SIGINT was deferred until the end of the context.
+        assert signal_was_deferred
+        # Check that original SIGINT handler was restored.
+        assert signal.getsignal(signal.SIGINT) is orig_sigint_handler
+
+
+def test_cancel_during_arg_deser_non_reentrant_import(ray_start_regular):
+    # This test ensures that task argument deserialization properly defers task
+    # cancellation interrupts until after deserialization completes, in order to ensure
+    # that non-reentrant imports that happen during both task argument deserialization
+    # and during error storage are not interrupted.
+
+    # We test this by doing the following:
+    #  - register a custom serializer for (a) a task argument that triggers
+    #  non-reentrant imports on deserialization, and (b) RayTaskError that triggers
+    #  non-reentrant imports on serialization; in our case, we chose pandas and Torch
+    #  since they are both non-reentrant and expensive, with a cumulative import time of
+    #  0.8-1.2 seconds, giving us a wide cancellation target,
+    #  - wait until those serializers are registered on all workers,
+    #  - launch the task and wait until we are confident that the cancellation signal
+    #  will be received by the workers during task argument deserialization (currently a
+    #  200 ms wait).
+    #  - check that a graceful task cancellation error is raised, not a
+    # WorkerCrashedError.
+    def non_reentrant_import():
+        # NOTE: Both pandas and Torch have non-reentrant imports and should cumulatively
+        # take 0.8-1.2 seconds to import, giving us a wide cancellation target.
+        import pandas  # noqa
+        import torch  # noqa
+
+    def non_reentrant_import_and_delegate(obj):
+        # Custom serializer for task argument and task error resulting in non-reentrant
+        # imports being imported on both serialization and deserialization. We use the
+        # same custom serializer for both, doing non-reentrant imports on both
+        # serialization and deserialization, for the sake of simplicity/reuse.
+
+        # Import on serialization.
+        non_reentrant_import()
+
+        reduced = obj.__reduce__()
+        func = reduced[0]
+        args = reduced[1]
+        others = reduced[2:]
+
+        def non_reentrant_import_on_reconstruction(*args, **kwargs):
+            # Import on deserialization.
+            non_reentrant_import()
+
+            return func(*args, **kwargs)
+
+        out = (non_reentrant_import_on_reconstruction, args) + others
+        return out
+
+    # Dummy task argument for which we register a serializer that will trigger
+    # non-reentrant imports on deserialization.
+    class DummyArg:
+        pass
+
+    def register_non_reentrant_import_and_delegate_reducer(worker_info):
+        from ray.exceptions import RayTaskError
+
+        context = ray._private.worker.global_worker.get_serialization_context()
+        # Register non-reentrant import serializer for task argument.
+        context._register_cloudpickle_reducer(
+            DummyArg, non_reentrant_import_and_delegate
+        )
+        # Register non-reentrant import serializer for RayTaskError.
+        context._register_cloudpickle_reducer(
+            RayTaskError, non_reentrant_import_and_delegate
+        )
+
+    ray._private.worker.global_worker.run_function_on_all_workers(
+        register_non_reentrant_import_and_delegate_reducer,
+    )
+
+    # Wait for function to run on all workers.
+    time.sleep(3)
+
+    @ray.remote
+    def run_and_fail(a: DummyArg):
+        # Should never be reached.
+        assert False
+
+    arg = DummyArg()
+    obj = run_and_fail.remote(arg)
+    # Check that task isn't done.
+    # NOTE: This timeout was finely tuned to ensure that task cancellation happens while
+    # we are deserializing task arguments (10/10 runs when this comment was added).
+    timeout_to_reach_arg_deserialization = 0.2
+    assert len(ray.wait([obj], timeout=timeout_to_reach_arg_deserialization)[0]) == 0
+
+    # Cancel task.
+    use_force = False
+    ray.cancel(obj, force=use_force)
+
+    # Should raise RayTaskError or TaskCancelledError, NOT WorkerCrashedError.
     with pytest.raises(valid_exceptions(use_force)):
         ray.get(obj)
 
@@ -336,8 +455,6 @@ def test_recursive_cancel(shutdown_only, use_force):
 
 
 if __name__ == "__main__":
-    import os
-
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:

--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -185,9 +185,9 @@ def test_cancel_during_arg_deser_non_reentrant_import(ray_start_regular):
     # We test this by doing the following:
     #  - register a custom serializer for (a) a task argument that triggers
     #  non-reentrant imports on deserialization, and (b) RayTaskError that triggers
-    #  non-reentrant imports on serialization; in our case, we chose pandas and Torch
-    #  since they are both non-reentrant and expensive, with a cumulative import time of
-    #  0.8-1.2 seconds, giving us a wide cancellation target,
+    #  non-reentrant imports on serialization; in our case, we chose pandas it is both
+    #  non-reentrant and expensive, with an import time ~0.5 seconds, giving us a wide
+    #  cancellation target,
     #  - wait until those serializers are registered on all workers,
     #  - launch the task and wait until we are confident that the cancellation signal
     #  will be received by the workers during task argument deserialization (currently a
@@ -195,10 +195,9 @@ def test_cancel_during_arg_deser_non_reentrant_import(ray_start_regular):
     #  - check that a graceful task cancellation error is raised, not a
     # WorkerCrashedError.
     def non_reentrant_import():
-        # NOTE: Both pandas and Torch have non-reentrant imports and should cumulatively
-        # take 0.8-1.2 seconds to import, giving us a wide cancellation target.
+        # NOTE: Pandas has a non-reentrant import and should take ~0.5 seconds to
+        # import, giving us a wide cancellation target.
         import pandas  # noqa
-        import torch  # noqa
 
     def non_reentrant_import_and_delegate(obj):
         # Custom serializer for task argument and task error resulting in non-reentrant

--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -118,6 +118,15 @@ def test_defer_sigint():
         assert signal.getsignal(signal.SIGINT) is orig_sigint_handler
 
 
+def test_defer_sigint_monkey_patch():
+    # Tests that setting a SIGINT signal handler within a DeferSigint context is not
+    # allowed.
+    orig_sigint_handler = signal.getsignal(signal.SIGINT)
+    with pytest.raises(ValueError):
+        with DeferSigint():
+            signal.signal(signal.SIGINT, orig_sigint_handler)
+
+
 def test_defer_sigint_noop_in_non_main_thread():
     # Tests that we don't try to defer SIGINT when not in the main thread.
 


### PR DESCRIPTION
Importing certain libraries (e.g. Arrow, Pandas, Torch) is not reentrant, and task cancellation is occasionally interrupting the Arrow import triggered via [this deserialization add-on](https://github.com/ray-project/ray/blob/b7072ea244bae72344e9dca9ebeddf9426090673/python/ray/util/serialization_addons.py#L66) during task argument deserialization, which we are then trying to import again when serializing the error. See here for an example failure: https://buildkite.com/ray-project/oss-ci-build-branch/builds/1115#018485e1-df32-480f-9c36-cc898341f0a2

This PR prevents this import reentrancy from happening for the task cancellation case by deferring interrupts until after task argument deserialization finishes, so we can be sure that the serialization-related imports have finished before processing the interrupt.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #30453 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
