### PR TITLE
[CI] [runtime env] Skip flaky `test_no_spurious_worker_startup` on windows

### DIFF
--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -184,7 +184,7 @@ def test_container_option_serialize(runtime_env_class):
     assert job_config_serialized.count(b"ray:latest") == 1
     assert job_config_serialized.count(b"--name=test") == 1
 
-
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 @pytest.mark.parametrize("runtime_env_class", [dict, RuntimeEnv])
 def test_no_spurious_worker_startup(shutdown_only, runtime_env_class):
     """Test that no extra workers start up during a long env installation."""

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -184,6 +184,7 @@ def test_container_option_serialize(runtime_env_class):
     assert job_config_serialized.count(b"ray:latest") == 1
     assert job_config_serialized.count(b"--name=test") == 1
 
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 @pytest.mark.parametrize("runtime_env_class", [dict, RuntimeEnv])
 def test_no_spurious_worker_startup(shutdown_only, runtime_env_class):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This test recently became much flakier:
<img width="1697" alt="Screen Shot 2022-11-18 at 1 27 59 PM" src="https://user-images.githubusercontent.com/5459654/202805939-22a5cb3b-a077-4ee4-afb3-7605cbf2484a.png">
It's not clear what caused it. The seemingly most relevant PR around that time is https://github.com/ray-project/ray/pull/30219 but it's not obvious how it connects to the failing test.

This PR skips the test on Windows to fix CI, but we should identify and fix the cause of flakiness.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Mitigates #30474 but we should fix the root cause of the flakiness before closing that issue.
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
