### PR TITLE
[RLlib] Numeric dummy agent ID in base env to be able to convert to float

### DIFF
--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -364,7 +364,7 @@ class BaseEnv:
 
 
 # Fixed agent identifier when there is only the single agent in the env
-_DUMMY_AGENT_ID = "agent0"
+_DUMMY_AGENT_ID = -1
 
 
 @PublicAPI


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

The dummy agent ID can show up in input_dict tensors to models.
Therefore, it should be convertible to a float.
This otherwise breaks the modelv3 test from test_model.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
