### PR TITLE
Fix issue with logging stacklevel in python < 3.8

### DIFF
--- a/python/ray/widgets/util.py
+++ b/python/ray/widgets/util.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import sys
 import textwrap
 from functools import wraps
 from typing import Any, Callable, Iterable, Optional, TypeVar, Union
@@ -126,9 +127,12 @@ def _has_missing(
         if not message:
             message = f"Run `pip install {' '.join(missing)}` for rich notebook output."
 
-        # stacklevel=3: First level is this function, then ensure_notebook_deps, then
-        # the actual function affected.
-        logger.warning(f"Missing packages: {missing}. {message}", stacklevel=3)
+        if sys.version_info < (3, 8):
+            logger.warning(f"Missing packages: {missing}. {message}")
+        else:
+            # stacklevel=3: First level is this function, then ensure_notebook_deps,
+            # then the actual function affected.
+            logger.warning(f"Missing packages: {missing}. {message}", stacklevel=3)
 
     return missing
 


### PR DESCRIPTION
## Why are these changes needed?

In python<3.8, loggers do not support the `stacklevel` kwarg. This PR introduces a fix for a place where this kwarg was being used, ensuring support for `python<3.8`.


## Related issue number

Closes #30405.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
