### PR TITLE
[kuberay][autoscaler] Set resourceVersion and resourceVersionMatching in list pods.

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -449,8 +449,10 @@ class StandardAutoscaler:
         # Record the amount of time the autoscaler took for
         # this _update() iteration.
         update_time = time.time() - self.last_update_time
-        logger.info(f"The autoscaler took {round(update_time, 3)}"
-                    " seconds to complete the update iteration.")
+        logger.info(
+            f"The autoscaler took {round(update_time, 3)}"
+            " seconds to complete the update iteration."
+        )
         self.prom_metrics.update_time.observe(update_time)
 
     def terminate_nodes_to_enforce_config_constraints(self, now: float):

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -140,7 +140,7 @@ class NonTerminatedNodes:
         self.non_terminated_nodes_time = time.time() - start_time
         logger.info(
             f"The autoscaler took {round(self.non_terminated_nodes_time, 3)}"
-            " secounds to fetch the list of non-terminated nodes."
+            " seconds to fetch the list of non-terminated nodes."
         )
 
     def remove_terminating_nodes(self, terminating_nodes: List[NodeID]) -> None:

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -138,6 +138,10 @@ class NonTerminatedNodes:
         # time because on some clients, there may be pagination and the
         # underlying api calls may be done lazily.
         self.non_terminated_nodes_time = time.time() - start_time
+        logger.info(
+            f"The autoscaler took {round(self.non_terminated_nodes_time, 3)}"
+            " secounds to fetch the list of non-terminated nodes."
+        )
 
     def remove_terminating_nodes(self, terminating_nodes: List[NodeID]) -> None:
         """Remove nodes we're in the process of terminating from internal
@@ -445,6 +449,8 @@ class StandardAutoscaler:
         # Record the amount of time the autoscaler took for
         # this _update() iteration.
         update_time = time.time() - self.last_update_time
+        logger.info(f"The autoscaler took {round(update_time, 3)}"
+                    " seconds to complete the update iteration.")
         self.prom_metrics.update_time.observe(update_time)
 
     def terminate_nodes_to_enforce_config_constraints(self, now: float):

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -241,16 +241,15 @@ class KuberayNodeProvider(BatchingNodeProvider):  # type: ignore
             f" at pods resource version >= {resource_version}."
         )
         resource_path = (
-            "pods" +
-            f"?labelSelector={label_selector}" +
-            f"&resourceVersion={resource_version}"
+            "pods"
+            + f"?labelSelector={label_selector}"
+            + f"&resourceVersion={resource_version}"
         )
 
         pod_list = self._get(resource_path)
         fetched_resource_version = pod_list["metadata"]["resourceVersion"]
         logger.info(
-            f"Fetched pod data at resource version"
-            f" {fetched_resource_version}."
+            f"Fetched pod data at resource version" f" {fetched_resource_version}."
         )
 
         # Extract node data from the pod list.

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -323,12 +323,13 @@ class KuberayNodeProvider(BatchingNodeProvider):  # type: ignore
         """
         if not RAY_HEAD_POD_NAME:
             return ""
+        # Patch the head pod.
         resource_path = f"pods/{RAY_HEAD_POD_NAME}"
         # Patch the annotation "ray.io/autoscaler-update-timestamp"
         patch_path = "/metadata/annotations/ray.io~1autoscaler-update-timestamp"
         # Mimic the timestamp format used by K8s.
-        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        payload = [replace_patch(patch_path, timestamp)]
+        value = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        payload = [replace_patch(patch_path, value)]
         pod_resp = self._patch(resource_path, payload)
         # The response carries the pod resource version at which the patch
         # was accepted.

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -248,8 +248,8 @@ class KuberayNodeProvider(BatchingNodeProvider):  # type: ignore
         resource_path = f"pods?labelSelector={label_selector}"
         if resource_version:
             resource_path += (
-                f"&resourceVersion={resource_version}" +
-                "&resourceVersionMatch=NotOlderThan"
+                f"&resourceVersion={resource_version}"
+                + "&resourceVersionMatch=NotOlderThan"
             )
 
         pod_list = self._get(resource_path)

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -178,7 +178,9 @@ def url_from_resource(namespace: str, path: str) -> str:
 
 def _worker_group_index(raycluster: Dict[str, Any], group_name: str) -> int:
     """Extract worker group index from RayCluster."""
-    group_names = [spec["groupName"] for spec in raycluster["spec"].get("workerGroupSpecs", [])]
+    group_names = [
+        spec["groupName"] for spec in raycluster["spec"].get("workerGroupSpecs", [])
+    ]
     return group_names.index(group_name)
 
 

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -247,7 +247,10 @@ class KuberayNodeProvider(BatchingNodeProvider):  # type: ignore
 
         resource_path = f"pods?labelSelector={label_selector}"
         if resource_version:
-            resource_path += f"&resourceVersion={resource_version}"
+            resource_path += (
+                f"&resourceVersion={resource_version}" +
+                "&resourceVersionMatch=NotOlderThan"
+            )
 
         pod_list = self._get(resource_path)
         fetched_resource_version = pod_list["metadata"]["resourceVersion"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

According to the K8s docs,

> Unless you have strong consistency requirements, using resourceVersionMatch=NotOlderThan and a known resourceVersion is preferable since it can achieve better performance and scalability of your cluster than leaving resourceVersion and resourceVersionMatch unset, which requires quorum read to be served.

This PR implements that recommendation in Kuberay NodeProvider.

The strategy is to obtain a sufficiently fresh resource version by patching the head pod's annotations and reading the response.

This strategy requires
- pods/patch permissions for the autoscaler
- knowledge of the head pod's name
To make this possible, Kuberay PR https://github.com/ray-project/kuberay/pull/740 ensures that the autoscaler has patch permissions and can access the name of the head pod.

When running with operator versions without the change from https://github.com/ray-project/kuberay/pull/740, this PR does not introduce any behavior changes.

The con of this strategy is that it introduces pod patch permissions for the Ray head pod.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/21656

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Existing autoscaling integration test
   - [x] I ran some benchmarks with many Ray cluster and many pods to confirm that there's an improvement in the time it takes to list pods.
