### PR TITLE
[RLlib] To improve performance, do not wait for sync weight calls by default.

### DIFF
--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -419,6 +419,7 @@ class WorkerSet:
             # Sync to specified remote workers in this WorkerSet.
             self.foreach_worker(
                 func=set_weight,
+                local_worker=False,  # Do not sync back to local worker.
                 remote_worker_ids=to_worker_indices,
                 # We can only sync to healthy remote workers.
                 # Restored workers need to have local work state synced over first,

--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -385,6 +385,7 @@ class WorkerSet:
         from_worker: Optional[RolloutWorker] = None,
         to_worker_indices: Optional[List[int]] = None,
         global_vars: Optional[Dict[str, TensorType]] = None,
+        timeout_seconds: Optional[int] = 0,
     ) -> None:
         """Syncs model weights from the local worker to all remote workers.
 
@@ -397,6 +398,10 @@ class WorkerSet:
                 weights to. If None (default), sync to all remote workers.
             global_vars: An optional global vars dict to set this
                 worker to. If None, do not update the global_vars.
+            timeout_seconds: Timeout in seconds to wait for the sync weights
+                calls to complete. Default is 0 (sync-and-forget, do not wait
+                for any sync calls to finish). This significantly improves
+                algorithm performance.
         """
         if self.local_worker() is None and from_worker is None:
             raise TypeError(
@@ -408,12 +413,8 @@ class WorkerSet:
         weights = None
         if self.num_remote_workers() or from_worker is not None:
             weights = (from_worker or self.local_worker()).get_weights(policies)
-            # Put weights only once into object store and use same object
-            # ref to synch to all workers.
-            weights_ref = ray.put(weights)
-
             def set_weight(w):
-                w.set_weights(ray.get(weights_ref), global_vars)
+                w.set_weights(weights, global_vars)
 
             # Sync to specified remote workers in this WorkerSet.
             self.foreach_worker(
@@ -423,6 +424,7 @@ class WorkerSet:
                 # Restored workers need to have local work state synced over first,
                 # before they will have all the policies to receive these weights.
                 healthy_only=True,
+                timeout_seconds=timeout_seconds,
             )
 
         # If `from_worker` is provided, also sync to this WorkerSet's
@@ -655,7 +657,7 @@ class WorkerSet:
         # TODO(jungong) : switch to True once Algorithm is migrated.
         healthy_only=False,
         remote_worker_ids: List[int] = None,
-        timeout_seconds=None,
+        timeout_seconds: Optional[int] = None,
         return_obj_refs: bool = False,
     ) -> List[T]:
         """Calls the given function with each worker instance as the argument.
@@ -706,7 +708,7 @@ class WorkerSet:
         # TODO(jungong) : switch to True once Algorithm is migrated.
         healthy_only=False,
         remote_worker_ids: List[int] = None,
-        timeout_seconds=None,
+        timeout_seconds: Optional[int] = None,
     ) -> List[T]:
         """Similar to foreach_worker(), but calls the function with id of the worker too.
 
@@ -777,7 +779,7 @@ class WorkerSet:
     def fetch_ready_async_reqs(
         self,
         *,
-        timeout_seconds=0,
+        timeout_seconds: Optional[int] = 0,
         return_obj_refs: bool = False,
     ) -> List[Tuple[int, T]]:
         """Get esults from outstanding asynchronous requests that are ready.

--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -16,7 +16,6 @@ from typing import (
     Union,
 )
 
-import ray
 from ray.actor import ActorHandle
 from ray.exceptions import RayActorError
 from ray.rllib.evaluation.rollout_worker import RolloutWorker
@@ -392,7 +391,7 @@ class WorkerSet:
         Args:
             policies: Optional list of PolicyIDs to sync weights for.
                 If None (default), sync weights to/from all policies.
-            from_worker: Optional RolloutWorker instance to sync from.
+            from_worker: Optional local RolloutWorker instance to sync from.
                 If None (default), sync from this WorkerSet's local worker.
             to_worker_indices: Optional list of worker indices to sync the
                 weights to. If None (default), sync to all remote workers.
@@ -413,6 +412,7 @@ class WorkerSet:
         weights = None
         if self.num_remote_workers() or from_worker is not None:
             weights = (from_worker or self.local_worker()).get_weights(policies)
+
             def set_weight(w):
                 w.set_weights(weights, global_vars)
 


### PR DESCRIPTION
Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

This improves throughput by almost 2x for many of our algorithms.
As an example, 
A3C:

<img width="782" alt="Screen Shot 2022-11-19 at 3 32 12 AM" src="https://user-images.githubusercontent.com/6347585/202848687-a6e1576d-614a-433f-beeb-4b1d7aa6c456.png">

This was also the default behavior before elastic training PR.

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
