### PR TITLE
Skip flaky test_autoscaler on Mac.

### DIFF
--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -646,7 +646,7 @@ class LoadMetricsTest(unittest.TestCase):
 
 
 # Flaky in MacOS CI, but pretty consistent on Mac laptops.
-# Uncomment the skip if you need to develop this test on a Mac laptop.
+# Comment out the skip if you need to develop this test on a Mac laptop.
 @unittest.skipIf(
     sys.platform == "darwin", reason="Flaky. Also, autoscaling is not supported on Mac."
 )

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -645,6 +645,9 @@ class LoadMetricsTest(unittest.TestCase):
         ) in debug
 
 
+@unittest.skipIf(
+    sys.platform == "darwin", reason="Flaky. Also, autoscaling is not supported on Mac."
+)
 class AutoscalingTest(unittest.TestCase):
     def setUp(self):
         _NODE_PROVIDERS["mock"] = lambda config: self.create_provider

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -645,6 +645,8 @@ class LoadMetricsTest(unittest.TestCase):
         ) in debug
 
 
+# Flaky in MacOS CI, but pretty consistent on Mac laptops.
+# Uncomment the skip if you need to develop this test on a Mac laptop.
 @unittest.skipIf(
     sys.platform == "darwin", reason="Flaky. Also, autoscaling is not supported on Mac."
 )


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Autoscaling is not supported on Mac.
Remove distraction for Ray CI maintainers by skipping the flaky test.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/29564.
Closes https://github.com/ray-project/ray/issues/28896.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
