### PR TITLE
[Datasets] Fix ndarray representation of single-element ragged tensor slices.

### DIFF
--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -178,7 +178,14 @@ def test_arrow_variable_shaped_tensor_array_slice():
         slice(0, 3),
     ]
     for slice_ in slices:
-        for o, e in zip(ata[slice_], arr[slice_]):
+        ata_slice = ata[slice_]
+        ata_slice_np = ata_slice.to_numpy()
+        arr_slice = arr[slice_]
+        # Check for equivalent dtypes and shapes.
+        assert ata_slice_np.dtype == arr_slice.dtype
+        assert ata_slice_np.shape == arr_slice.shape
+        # Iteration over tensor array slices triggers NumPy conversion.
+        for o, e in zip(ata_slice, arr_slice):
             np.testing.assert_array_equal(o, e)
 
 

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -5,7 +5,10 @@ from pkg_resources._vendor.packaging.version import parse as parse_version
 import numpy as np
 import pyarrow as pa
 
-from ray.air.util.tensor_extensions.utils import _is_ndarray_variable_shaped_tensor
+from ray.air.util.tensor_extensions.utils import (
+    _is_ndarray_variable_shaped_tensor,
+    _create_strict_ragged_ndarray,
+)
 from ray._private.utils import _get_pyarrow_version
 from ray.util.annotations import PublicAPI
 
@@ -721,9 +724,7 @@ class ArrowVariableShapedTensorArray(
             arrs = [self._to_numpy(i, zero_copy_only) for i in range(len(self))]
             # Return ragged NumPy ndarray in the ndarray of ndarray pointers
             # representation.
-            arr = np.empty(len(self), dtype=object)
-            arr[:] = arrs
-            return arr
+            return _create_strict_ragged_ndarray(arrs)
         data = self.storage.field("data")
         shapes = self.storage.field("shape")
         value_type = data.type.value_type

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -664,10 +664,11 @@ class ArrowVariableShapedTensorArray(
             np_data_buffer = np.concatenate(raveled)
         dtype = np_data_buffer.dtype
         if dtype.type is np.object_:
+            types_and_shapes = [(f"dtype={a.dtype}", f"shape={a.shape}") for a in arr]
             raise ValueError(
                 "ArrowVariableShapedTensorArray only supports heterogeneous-shaped "
-                "tensor collections, not arbitrarily nested ragged tensors. Got: "
-                f"{arr}"
+                "tensor collections, not arbitrarily nested ragged tensors. Got "
+                f"arrays: {types_and_shapes}"
             )
         pa_dtype = pa.from_numpy_dtype(dtype)
         if dtype.type is np.bool_:
@@ -720,7 +721,9 @@ class ArrowVariableShapedTensorArray(
             arrs = [self._to_numpy(i, zero_copy_only) for i in range(len(self))]
             # Return ragged NumPy ndarray in the ndarray of ndarray pointers
             # representation.
-            return np.array(arrs, dtype=object)
+            arr = np.empty(len(self), dtype=object)
+            arr[:] = arrs
+            return arr
         data = self.storage.field("data")
         shapes = self.storage.field("shape")
         value_type = data.type.value_type

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 
 
@@ -20,3 +22,23 @@ def _is_ndarray_variable_shaped_tensor(arr: np.ndarray) -> bool:
         if a.shape != shape:
             return True
     return True
+
+
+def _create_strict_ragged_ndarray(values: Any) -> np.ndarray:
+    """Create a ragged ndarray; the representation will be ragged (1D array of
+    subndarray pointers) even if it's possible to represent it as a non-ragged ndarray.
+    """
+    # Use the create-empty-and-fill method. This avoids the following pitfalls of the
+    # np.array constructor - np.array(values, dtype=object):
+    #  1. It will fail to construct an ndarray if the first element dimension is
+    #  uniform, e.g. for imagery whose first element dimension is the channel.
+    #  2. It will construct the wrong representation for a single-row column (i.e. unit
+    #  outer dimension). Namely, it will consolidate it into a single multi-dimensional
+    #  ndarray rather than a 1D array of subndarray pointers, resulting in the single
+    #  row not being well-typed (having object dtype).
+
+    # Create an empty object-dtyped 1D array.
+    arr = np.empty(len(values), dtype=object)
+    # Try to fill the 1D array of pointers with the (ragged) tensors.
+    arr[:] = list(values)
+    return arr


### PR DESCRIPTION
Single-element ragged tensor slices (e.g. `a[5:6]`) currently have the wrong NumPy representation; namely, although they are object-dtyped, they have a multi-dimensional shape, and its single tensor element isn't well-typed (in other words, it doesn't use the pointer-to-subdarrays representation). This is due to `np.array([subndarray], dtype=object)` trying to create a more consolidated representation than `np.array([subndarray1, subndarray2], dtype=object)`. This causes single-element batches of ragged tensor slices failing to eventually be put back into the tensor extension representation.

This PR fixes this by doing a very explicit ragged tensor construction via the create-and-fill method: we allocate an empty, object-dtyped 1D array and fill it with the tensor elements. This prevents NumPy from trying to optimize the ragged tensor representation.

## Example

Have `subndarray = np.array([[1, 2], [3, 4]], dtype=np.int64)` and `arr` be an `(N, 2, 2)` ndarray.

### N > 1 (Single-Element) Case

With `arr = np.array([subndarray, subndarray], dtype=object])`, you get
```python
ndarray(
    [
        ndarray([[1, 2], [3, 4]], dtype=np.int64),
        ndarray([[1, 2], [3, 4]], dtype=np.int64),
    ],
    dtype=object
)
```
I.e., you get a 1D array of pointers to the subndarrays, so the subndarrays are well-typed, e.g. `arr[0].dtype == np.int64`.

### N == 1 (Multi-Element) Case

But the single-element case, `arr = np.array([subndarray], dtype=object)`, tries to consolidate the inner subndarray into the outer ndarray representation:
```python
ndarray([[[1, 2], [3, 4]]], dtype=object)
```
The biggest impact of this is `arr[0].dtype == object`, which breaks a big tensor extension array assumption: that individual tensor elements are well-typed.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #30513, closes https://github.com/ray-project/ray/issues/30406, closes https://github.com/ray-project/ray/issues/30059

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
