### PR TITLE
[Metrics] Fix dead actors count is incorrect because the actor metadata is GC'ed as soon as the job is done

### DIFF
--- a/python/ray/tests/test_actor_state_metrics.py
+++ b/python/ray/tests/test_actor_state_metrics.py
@@ -15,7 +15,7 @@ from ray._private.worker import RayContext
 
 _SYSTEM_CONFIG = {
     "metrics_report_interval_ms": 200,
-    "gcs_actor_table_min_duration_ms": 10000
+    "gcs_actor_table_min_duration_ms": 2000,
 }
 
 
@@ -166,7 +166,6 @@ ray.get([actor.ready.remote() for actor in actors])
     """
     # Wait until the state API returns the # of actors are 0
     # becasue entries are GC'ed by GCS.
-    print("abc")
     wait_for_condition(lambda: len(list_actors()) == 0, timeout=60)
     # DEAD count shouldn't be changed.
     wait_for_condition(

--- a/python/ray/tests/test_actor_state_metrics.py
+++ b/python/ray/tests/test_actor_state_metrics.py
@@ -5,6 +5,7 @@ import time
 from typing import Dict
 
 import ray
+from ray.experimental.state.api import list_actors
 from ray._private.test_utils import (
     raw_metrics,
     wait_for_condition,
@@ -14,6 +15,7 @@ from ray._private.worker import RayContext
 
 _SYSTEM_CONFIG = {
     "metrics_report_interval_ms": 200,
+    "gcs_actor_table_min_duration_ms": 10000
 }
 
 
@@ -141,25 +143,32 @@ class Actor:
     def ready(self):
         pass
 
-actors = [Actor.remote() for _ in range(40)]
+actors = [Actor.remote() for _ in range(10)]
 ray.get([actor.ready.remote() for actor in actors])
 """
     info = ray.init(num_cpus=3, _system_config=_SYSTEM_CONFIG)
 
     output = run_string_as_driver(driver)
     print(output)
-    # @ray.remote(num_cpus=0)
-    # class Actor:
-    #     def ready(self):
-    #         pass
-
-    # actors = [Actor.remote() for _ in range(40)]
-    # ray.get([actor.ready.remote() for actor in actors])
-    # del actors
 
     expected = {
-        "DEAD": 40,
+        "DEAD": 10,
     }
+    wait_for_condition(
+        lambda: actors_by_state(info) == expected,
+        timeout=20,
+        retry_interval_ms=500,
+    )
+
+    """
+    Make sure even after the actor entries are deleted from GCS by GC
+    (100ms after actors are cleaned) the metrics are correct.
+    """
+    # Wait until the state API returns the # of actors are 0
+    # becasue entries are GC'ed by GCS.
+    print("abc")
+    wait_for_condition(lambda: len(list_actors()) == 0, timeout=60)
+    # DEAD count shouldn't be changed.
     wait_for_condition(
         lambda: actors_by_state(info) == expected,
         timeout=20,

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -1338,23 +1338,23 @@ void GcsActorManager::OnJobFinished(const JobID &job_id) {
       }
 
       run_delayed_(
-          [this, non_detached_actors = std::move(non_detached_actors)]() {
+          [this, job_id, non_detached_actors = std::move(non_detached_actors)]() {
+            for (auto iter = destroyed_actors_.begin();
+                 iter != destroyed_actors_.end();) {
+              if (iter->first.JobId() == job_id && !iter->second->IsDetached()) {
+                destroyed_actors_.erase(iter++);
+              } else {
+                iter++;
+              }
+            }
+
             RAY_CHECK_OK(gcs_table_storage_->ActorTable().BatchDelete(
                 non_detached_actors, [this, non_detached_actors](const Status &status) {
                   RAY_CHECK_OK(gcs_table_storage_->ActorTaskSpecTable().BatchDelete(
                       non_detached_actors, nullptr));
                 }));
           },
-
           actor_gc_delay_);
-
-      for (auto iter = destroyed_actors_.begin(); iter != destroyed_actors_.end();) {
-        if (iter->first.JobId() == job_id && !iter->second->IsDetached()) {
-          destroyed_actors_.erase(iter++);
-        } else {
-          iter++;
-        }
-      };
     }
   };
 

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -1338,23 +1338,23 @@ void GcsActorManager::OnJobFinished(const JobID &job_id) {
       }
 
       run_delayed_(
-          [this, job_id, non_detached_actors = std::move(non_detached_actors)]() {
-            for (auto iter = destroyed_actors_.begin();
-                 iter != destroyed_actors_.end();) {
-              if (iter->first.JobId() == job_id && !iter->second->IsDetached()) {
-                destroyed_actors_.erase(iter++);
-              } else {
-                iter++;
-              }
-            }
-
+          [this, non_detached_actors = std::move(non_detached_actors)]() {
             RAY_CHECK_OK(gcs_table_storage_->ActorTable().BatchDelete(
                 non_detached_actors, [this, non_detached_actors](const Status &status) {
                   RAY_CHECK_OK(gcs_table_storage_->ActorTaskSpecTable().BatchDelete(
                       non_detached_actors, nullptr));
                 }));
           },
+
           actor_gc_delay_);
+
+      for (auto iter = destroyed_actors_.begin(); iter != destroyed_actors_.end();) {
+        if (iter->first.JobId() == job_id && !iter->second->IsDetached()) {
+          destroyed_actors_.erase(iter++);
+        } else {
+          iter++;
+        }
+      }
     }
   };
 

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -418,11 +418,13 @@ void GcsServer::InitGcsActorManager(const GcsInitData &gcs_init_data) {
       },
       [this](std::function<void(void)> fn, boost::posix_time::milliseconds delay) {
         boost::asio::deadline_timer timer(main_service_);
+        RAY_LOG(INFO) << "SANG-TODO deadline timer";
         timer.expires_from_now(delay);
         timer.async_wait([fn](const boost::system::error_code &error) {
           if (error != boost::asio::error::operation_aborted) {
             fn();
           } else {
+            RAY_LOG(INFO) << "SANG-TODO error " << error;
             RAY_LOG(WARNING)
                 << "The GCS actor metadata garbage collector timer failed to fire. This "
                    "could old actor metadata not being properly cleaned up. For more "

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -417,14 +417,12 @@ void GcsServer::InitGcsActorManager(const GcsInitData &gcs_init_data) {
         gcs_placement_group_manager_->CleanPlacementGroupIfNeededWhenActorDead(actor_id);
       },
       [this](std::function<void(void)> fn, boost::posix_time::milliseconds delay) {
-        boost::asio::deadline_timer timer(main_service_);
-        RAY_LOG(INFO) << "SANG-TODO deadline timer";
-        timer.expires_from_now(delay);
-        timer.async_wait([fn](const boost::system::error_code &error) {
+        auto timer = std::make_shared<boost::asio::deadline_timer>(main_service_);
+        timer->expires_from_now(delay);
+        timer->async_wait([fn, timer](const boost::system::error_code &error) {
           if (error != boost::asio::error::operation_aborted) {
             fn();
           } else {
-            RAY_LOG(INFO) << "SANG-TODO error " << error;
             RAY_LOG(WARNING)
                 << "The GCS actor metadata garbage collector timer failed to fire. This "
                    "could old actor metadata not being properly cleaned up. For more "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It's incorrect because as soon as the job is terminated we garbage collect GcsActor. This is supposed to happen after 5 minutes based on the existing logic. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
