### PR TITLE
[Dashboard] Fix resource names formatted to google style + change the actions order + tooltips

### DIFF
--- a/dashboard/client/src/common/RowStyles.tsx
+++ b/dashboard/client/src/common/RowStyles.tsx
@@ -21,6 +21,9 @@ const rowStyles = makeStyles((theme) =>
       textOverflow: "ellipsis",
       whiteSpace: "nowrap",
     },
+    helpInfo: {
+      marginLeft: theme.spacing(1),
+    },
   }),
 );
 

--- a/dashboard/client/src/components/ActorTable.tsx
+++ b/dashboard/client/src/components/ActorTable.tsx
@@ -46,16 +46,16 @@ const ActorTable = ({
   const columns = [
     { label: "" },
     { label: "ID" },
-    { 
+    {
       label: "Class",
       helpInfo: (
         <Typography>
-          The class name of the actor. 
-          For example, the below actor has a class name `Actor`.
+          The class name of the actor. For example, the below actor has a class
+          name `Actor`.
           <br />
-          <br/>
+          <br />
           @ray.remote
-          <br/>
+          <br />
           class Actor:
           <br />
           &emsp;pass
@@ -63,38 +63,39 @@ const ActorTable = ({
         </Typography>
       ),
     },
-    { 
+    {
       label: "Name",
       helpInfo: (
         <Typography>
-          The name of the actor given by an `name` argument. 
-          For example, this actor's name is `unique_name`.
+          The name of the actor given by an `name` argument. For example, this
+          actor's name is `unique_name`.
           <br />
           <br />
           Actor.options(name="unique_name").remote()
         </Typography>
       ),
-     },
-    { 
-      label: "State", 
+    },
+    {
+      label: "State",
       helpInfo: (
         <Typography>
-          The state of the actor. States are documented
-          at a `ActorState` from a `gcs.proto` file.
+          The state of the actor. States are documented at a `ActorState` from a
+          `gcs.proto` file.
         </Typography>
       ),
     },
-    { 
-      label: "Actions", 
+    {
+      label: "Actions",
       helpInfo: (
         <Typography>
           A list of actions performable on this actor.
           <br />
-          - Log: See a log message of this actor. Only available if a node is alive.
+          - Log: See a log message of this actor. Only available if a node is
+          alive.
           <br />
           - Stack Trace: Get a stacktrace of the alive actor.
-          <br />
-          - Flame Graph: Get a flamegraph of the alive actor. It profiles for 5 seconds by default.
+          <br />- Flame Graph: Get a flamegraph of the alive actor. It profiles
+          for 5 seconds by default.
         </Typography>
       ),
     },
@@ -102,7 +103,7 @@ const ActorTable = ({
     { label: "Job Id" },
     { label: "Pid" },
     { label: "IP" },
-    { 
+    {
       label: "Restarted",
       helpInfo: (
         <Typography>
@@ -110,12 +111,12 @@ const ActorTable = ({
         </Typography>
       ),
     },
-    { 
+    {
       label: "Required Resources",
       helpInfo: (
         <Typography>
           The required Ray resources to start an actor.
-          <br/>
+          <br />
           For example, this actor has GPU:1 required resources.
           <br />
           <br />
@@ -128,7 +129,7 @@ const ActorTable = ({
         </Typography>
       ),
     },
-    { 
+    {
       label: "Exit Detail",
       helpInfo: (
         <Typography>
@@ -242,16 +243,10 @@ const ActorTable = ({
           <TableRow>
             {columns.map(({ label, helpInfo }) => (
               <TableCell align="center" key={label}>
-                <Box
-                  display="flex"
-                  justifyContent="center"
-                  alignItems="center"
-                >
+                <Box display="flex" justifyContent="center" alignItems="center">
                   {label}
                   {helpInfo && (
-                    <HelpInfo className={classes.helpInfo}>
-                      {helpInfo}
-                    </HelpInfo>
+                    <HelpInfo className={classes.helpInfo}>{helpInfo}</HelpInfo>
                   )}
                 </Box>
               </TableCell>
@@ -377,9 +372,9 @@ const ActorTable = ({
                     interactive
                   >
                     <div>
-                      {Object.entries(requiredResources || {}).map(
-                        ([key, val]) => `${key}: ${val}`,
-                      ).join(", ")}
+                      {Object.entries(requiredResources || {})
+                        .map(([key, val]) => `${key}: ${val}`)
+                        .join(", ")}
                     </div>
                   </Tooltip>
                 </TableCell>

--- a/dashboard/client/src/components/ActorTable.tsx
+++ b/dashboard/client/src/components/ActorTable.tsx
@@ -51,7 +51,7 @@ const ActorTable = ({
       helpInfo: (
         <Typography>
           The class name of the actor. For example, the below actor has a class
-          name `Actor`.
+          name "Actor".
           <br />
           <br />
           @ray.remote
@@ -67,8 +67,8 @@ const ActorTable = ({
       label: "Name",
       helpInfo: (
         <Typography>
-          The name of the actor given by an `name` argument. For example, this
-          actor's name is `unique_name`.
+          The name of the actor given by the "name" argument. For example, this
+          actor's name is "unique_name".
           <br />
           <br />
           Actor.options(name="unique_name").remote()
@@ -79,8 +79,8 @@ const ActorTable = ({
       label: "State",
       helpInfo: (
         <Typography>
-          The state of the actor. States are documented at a `ActorState` from a
-          `gcs.proto` file.
+          The state of the actor. States are documented as a "ActorState" in the
+          "gcs.proto" file.
         </Typography>
       ),
     },
@@ -90,12 +90,12 @@ const ActorTable = ({
         <Typography>
           A list of actions performable on this actor.
           <br />
-          - Log: See a log message of this actor. Only available if a node is
+          - Log: view log messages of this actor. Only available if a node is
           alive.
           <br />
           - Stack Trace: Get a stacktrace of the alive actor.
-          <br />- Flame Graph: Get a flamegraph of the alive actor. It profiles
-          for 5 seconds by default.
+          <br />- Flame Graph: Get a flamegraph for the next 5 seconds of an
+          alive actor.
         </Typography>
       ),
     },

--- a/dashboard/client/src/components/ActorTable.tsx
+++ b/dashboard/client/src/components/ActorTable.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   InputAdornment,
   Table,
   TableBody,
@@ -8,6 +9,7 @@ import {
   TextField,
   TextFieldProps,
   Tooltip,
+  Typography,
 } from "@material-ui/core";
 import { orange } from "@material-ui/core/colors";
 import { SearchOutlined } from "@material-ui/icons";
@@ -23,6 +25,7 @@ import { Worker } from "../type/worker";
 import { useFilter } from "../util/hook";
 import StateCounter from "./StatesCounter";
 import { StatusChip } from "./StatusChip";
+import { HelpInfo } from "./Tooltip";
 import RayletWorkerTable, { ExpandableTableRow } from "./WorkerTable";
 
 const ActorTable = ({
@@ -39,6 +42,101 @@ const ActorTable = ({
   const actorList = Object.values(actors || {}).filter(filterFunc);
   const list = actorList.slice((pageNo - 1) * pageSize, pageNo * pageSize);
   const classes = rowStyles();
+
+  const columns = [
+    { label: "" },
+    { label: "ID" },
+    { 
+      label: "Class",
+      helpInfo: (
+        <Typography>
+          The class name of the actor. 
+          For example, the below actor has a class name `Actor`.
+          <br />
+          <br/>
+          @ray.remote
+          <br/>
+          class Actor:
+          <br />
+          &emsp;pass
+          <br />
+        </Typography>
+      ),
+    },
+    { 
+      label: "Name",
+      helpInfo: (
+        <Typography>
+          The name of the actor given by an `name` argument. 
+          For example, this actor's name is `unique_name`.
+          <br />
+          <br />
+          Actor.options(name="unique_name").remote()
+        </Typography>
+      ),
+     },
+    { 
+      label: "State", 
+      helpInfo: (
+        <Typography>
+          The state of the actor. States are documented
+          at a `ActorState` from a `gcs.proto` file.
+        </Typography>
+      ),
+    },
+    { 
+      label: "Actions", 
+      helpInfo: (
+        <Typography>
+          A list of actions performable on this actor.
+          <br />
+          - Log: See a log message of this actor. Only available if a node is alive.
+          <br />
+          - Stack Trace: Get a stacktrace of the alive actor.
+          <br />
+          - Flame Graph: Get a flamegraph of the alive actor. It profiles for 5 seconds by default.
+        </Typography>
+      ),
+    },
+    { label: "Uptime" },
+    { label: "Job Id" },
+    { label: "Pid" },
+    { label: "IP" },
+    { 
+      label: "Restarted",
+      helpInfo: (
+        <Typography>
+          The total number of the count this actor has been restarted.
+        </Typography>
+      ),
+    },
+    { 
+      label: "Required Resources",
+      helpInfo: (
+        <Typography>
+          The required Ray resources to start an actor.
+          <br/>
+          For example, this actor has GPU:1 required resources.
+          <br />
+          <br />
+          @ray.remote(num_gpus=1)
+          <br />
+          class Actor:
+          <br />
+          &emsp;pass
+          <br />
+        </Typography>
+      ),
+    },
+    { 
+      label: "Exit Detail",
+      helpInfo: (
+        <Typography>
+          The detail of an actor exit. Only available when an actor is dead.
+        </Typography>
+      ),
+    },
+  ];
 
   return (
     <React.Fragment>
@@ -142,23 +240,20 @@ const ActorTable = ({
       <Table>
         <TableHead>
           <TableRow>
-            {[
-              "",
-              "ID",
-              "Class",
-              "Name",
-              "State",
-              "Uptime",
-              "Job Id",
-              "Pid",
-              "IP",
-              "Restarted",
-              "Required Resources",
-              "Exit Detail",
-              "Log",
-            ].map((col) => (
-              <TableCell align="center" key={col}>
-                {col}
+            {columns.map(({ label, helpInfo }) => (
+              <TableCell align="center" key={label}>
+                <Box
+                  display="flex"
+                  justifyContent="center"
+                  alignItems="center"
+                >
+                  {label}
+                  {helpInfo && (
+                    <HelpInfo className={classes.helpInfo}>
+                      {helpInfo}
+                    </HelpInfo>
+                  )}
+                </Box>
               </TableCell>
             ))}
           </TableRow>
@@ -216,6 +311,39 @@ const ActorTable = ({
                   <StatusChip type="actor" status={state} />
                 </TableCell>
                 <TableCell align="center">
+                  {ipLogMap[address?.ipAddress] && (
+                    <React.Fragment>
+                      <Link
+                        target="_blank"
+                        to={`/log/${encodeURIComponent(
+                          ipLogMap[address?.ipAddress],
+                        )}?fileName=${jobId}-${pid}`}
+                      >
+                        Log
+                      </Link>
+                      <br />
+                      <a
+                        href={`/worker/traceback?pid=${pid}&ip=${address?.ipAddress}`}
+                        target="_blank"
+                        title="Sample the current Python stack trace for this worker."
+                        rel="noreferrer"
+                      >
+                        Stack&nbsp;Trace
+                      </a>
+                      <br />
+                      <a
+                        href={`/worker/cpu_profile?pid=${pid}&ip=${address?.ipAddress}&duration=5`}
+                        target="_blank"
+                        title="Profile the Python worker for 5 seconds (default) and display a flame graph."
+                        rel="noreferrer"
+                      >
+                        Flame&nbsp;Graph
+                      </a>
+                      <br />
+                    </React.Fragment>
+                  )}
+                </TableCell>
+                <TableCell align="center">
                   {startTime && startTime > 0 ? (
                     <DurationText startTime={startTime} endTime={endTime} />
                   ) : (
@@ -250,8 +378,8 @@ const ActorTable = ({
                   >
                     <div>
                       {Object.entries(requiredResources || {}).map(
-                        ([key, val]) => `${key}: ${val}\n`,
-                      )}
+                        ([key, val]) => `${key}: ${val}`,
+                      ).join(", ")}
                     </div>
                   </Tooltip>
                 </TableCell>
@@ -264,39 +392,6 @@ const ActorTable = ({
                   >
                     <div>{exitDetail}</div>
                   </Tooltip>
-                </TableCell>
-                <TableCell align="center">
-                  {ipLogMap[address?.ipAddress] && (
-                    <React.Fragment>
-                      <Link
-                        target="_blank"
-                        to={`/log/${encodeURIComponent(
-                          ipLogMap[address?.ipAddress],
-                        )}?fileName=${jobId}-${pid}`}
-                      >
-                        Log
-                      </Link>
-                      <br />
-                      <a
-                        href={`/worker/traceback?pid=${pid}&ip=${address?.ipAddress}`}
-                        target="_blank"
-                        title="Sample the current Python stack trace for this worker."
-                        rel="noreferrer"
-                      >
-                        Stack&nbsp;Trace
-                      </a>
-                      <br />
-                      <a
-                        href={`/worker/cpu_profile?pid=${pid}&ip=${address?.ipAddress}&duration=5`}
-                        target="_blank"
-                        title="Profile the Python worker for 5 seconds (default) and display a flame graph."
-                        rel="noreferrer"
-                      >
-                        Flame&nbsp;Graph
-                      </a>
-                      <br />
-                    </React.Fragment>
-                  )}
                 </TableCell>
               </ExpandableTableRow>
             ),

--- a/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.tsx
@@ -86,6 +86,9 @@ const NodeRow = ({ node, expanded, onExpandButtonClick }: NodeRowProps) => {
         </Box>
       </TableCell>
       <TableCell>
+        <Link to={`/log/${encodeURIComponent(logUrl)}`}>Log</Link>
+      </TableCell>
+      <TableCell>
         <PercentageBar num={Number(cpu)} total={100}>
           {cpu}%
         </PercentageBar>
@@ -128,9 +131,6 @@ const NodeRow = ({ node, expanded, onExpandButtonClick }: NodeRowProps) => {
       </TableCell>
       <TableCell align="center">{memoryConverter(networkSpeed[0])}/s</TableCell>
       <TableCell align="center">{memoryConverter(networkSpeed[1])}/s</TableCell>
-      <TableCell>
-        <Link to={`/log/${encodeURIComponent(logUrl)}`}>Log</Link>
-      </TableCell>
     </TableRow>
   );
 };
@@ -184,30 +184,6 @@ const WorkerRow = ({ node, worker }: WorkerRowProps) => {
       </TableCell>
       <TableCell align="center">{pid}</TableCell>
       <TableCell>
-        <PercentageBar num={Number(cpu)} total={100}>
-          {cpu}%
-        </PercentageBar>
-      </TableCell>
-      <TableCell>
-        {mem && (
-          <PercentageBar num={memoryInfo.rss} total={mem[0]}>
-            {memoryConverter(memoryInfo.rss)}/{memoryConverter(mem[0])}(
-            {(memoryInfo.rss / mem[0]).toFixed(1)}
-            %)
-          </PercentageBar>
-        )}
-      </TableCell>
-      <TableCell>
-        <WorkerGPU worker={worker} />
-      </TableCell>
-      <TableCell>
-        <WorkerGRAM worker={worker} node={node} />
-      </TableCell>
-      <TableCell>N/A</TableCell>
-      <TableCell>N/A</TableCell>
-      <TableCell align="center">N/A</TableCell>
-      <TableCell align="center">N/A</TableCell>
-      <TableCell>
         <Link to={workerLogUrl} target="_blank">
           Logs
         </Link>
@@ -231,6 +207,30 @@ const WorkerRow = ({ node, worker }: WorkerRowProps) => {
         </a>
         <br />
       </TableCell>
+      <TableCell>
+        <PercentageBar num={Number(cpu)} total={100}>
+          {cpu}%
+        </PercentageBar>
+      </TableCell>
+      <TableCell>
+        {mem && (
+          <PercentageBar num={memoryInfo.rss} total={mem[0]}>
+            {memoryConverter(memoryInfo.rss)}/{memoryConverter(mem[0])}(
+            {(memoryInfo.rss / mem[0]).toFixed(1)}
+            %)
+          </PercentageBar>
+        )}
+      </TableCell>
+      <TableCell>
+        <WorkerGPU worker={worker} />
+      </TableCell>
+      <TableCell>
+        <WorkerGRAM worker={worker} node={node} />
+      </TableCell>
+      <TableCell>N/A</TableCell>
+      <TableCell>N/A</TableCell>
+      <TableCell align="center">N/A</TableCell>
+      <TableCell align="center">N/A</TableCell>
     </TableRow>
   );
 };

--- a/dashboard/client/src/pages/node/index.tsx
+++ b/dashboard/client/src/pages/node/index.tsx
@@ -40,6 +40,7 @@ const columns = [
   "State",
   "ID",
   "IP / PID",
+  "Actions",
   "CPU Usage",
   "Memory",
   "GPU",
@@ -48,7 +49,6 @@ const columns = [
   "Disk(root)",
   "Sent",
   "Received",
-  "Actions",
 ];
 
 export const brpcLinkChanger = (href: string) => {

--- a/dashboard/modules/actor/actor_head.py
+++ b/dashboard/modules/actor/actor_head.py
@@ -77,7 +77,6 @@ def actor_table_data_to_dict(message):
     light_message["startTime"] = int(light_message["startTime"])
     light_message["endTime"] = int(light_message["endTime"])
     light_message["requiredResources"] = dict(message.required_resources)
-    logger.info(light_message)
 
     return light_message
 
@@ -245,6 +244,8 @@ class ActorHead(dashboard_utils.DashboardHeadModule):
             message="All actors fetched.",
             actors=DataSource.actors,
             # False to avoid converting Ray resource name to google style.
+            # It's not necessary here because the fields are already
+            # google formatted when protobuf was converted into dict.
             convert_google_style=False,
         )
 

--- a/dashboard/modules/actor/actor_head.py
+++ b/dashboard/modules/actor/actor_head.py
@@ -55,7 +55,6 @@ def actor_table_data_to_dict(message):
         "numRestarts",
         "timestamp",
         "className",
-        "requiredResources",
         "startTime",
         "endTime",
     }
@@ -77,6 +76,8 @@ def actor_table_data_to_dict(message):
     light_message["exitDetail"] = exit_detail
     light_message["startTime"] = int(light_message["startTime"])
     light_message["endTime"] = int(light_message["endTime"])
+    light_message["requiredResources"] = dict(message.required_resources)
+    logger.info(light_message)
 
     return light_message
 
@@ -240,7 +241,11 @@ class ActorHead(dashboard_utils.DashboardHeadModule):
     @dashboard_optional_utils.aiohttp_cache
     async def get_all_actors(self, req) -> aiohttp.web.Response:
         return rest_response(
-            success=True, message="All actors fetched.", actors=DataSource.actors
+            success=True,
+            message="All actors fetched.",
+            actors=DataSource.actors,
+            # False to avoid converting Ray resource name to google style.
+            convert_google_style=False,
         )
 
     async def run(self, server):


### PR DESCRIPTION
Signed-off-by: SangBin Cho <rkooo567@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR does 4 things.
1. For actor table's required_resources column, we join entries by ","
2. Move Actions column next to IP (node table) and state (actor table) for a bette feature discoverability
3. Fix a bug that required_resources were formatted by google style (e.g., instead of `a_bc: 1`, it was formatted as `aBc: 1`).
4. Add tooltips to actor table columns

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
