### PR TITLE
[Lint] Frontend lint script.

### DIFF
--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -194,14 +194,11 @@ mypy_on_each() {
     popd
 }
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)"
-WORKSPACE_DIR="${ROOT_DIR}/../.."
-
 format_frontend() {
   (
     echo "$(date)" "format frontend...."
     local folder 
-    folder="${WORKSPACE_DIR}/python/ray/dashboard/client"
+    folder="$(pwd)/dashboard/client"
     local filenames
     # shellcheck disable=SC2207
     filenames=($(find "${folder}"/src -name "*.ts" -or -name "*.tsx"))


### PR DESCRIPTION
Signed-off-by: SangBin Cho <rkooo567@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add ./ci/lint/format --frontend. It also finds if there was any change in .ts and .tsx files and automatically run frontend lint. Note that it lints against all files right now. and we can optimize this in the future.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
