### PR TITLE
[Datasets] Revert to manual buffer copying custom Arrow serializer.

### DIFF
--- a/python/ray/data/_internal/arrow_serialization.py
+++ b/python/ray/data/_internal/arrow_serialization.py
@@ -1,8 +1,11 @@
+import logging
 import os
-from typing import TYPE_CHECKING
+import sys
+from typing import List, Tuple, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import pyarrow
+    from ray.data.extensions import ArrowTensorArray, ArrowVariableShapedTensorArray
 
 RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION = (
     "RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION"
@@ -10,6 +13,27 @@ RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION = (
 RAY_DISABLE_CUSTOM_ARROW_DATA_SERIALIZATION = (
     "RAY_DISABLE_CUSTOM_ARROW_DATA_SERIALIZATION"
 )
+
+logger = logging.getLogger(__name__)
+
+# Whether we have already warned the user about bloated fallback serialization.
+_serialization_fallback_set = set()
+
+# Whether we're currently running in a test, either local or CI.
+_in_test = None
+
+
+def _is_in_test():
+    global _in_test
+
+    if _in_test is None:
+        _in_test = any(
+            env_var in os.environ
+            # These environment variables are always set by pytest and Buildkite,
+            # respectively.
+            for env_var in ("PYTEST_CURRENT_TEST", "BUILDKITE")
+        )
+    return _in_test
 
 
 def _register_custom_datasets_serializers(serialization_context):
@@ -88,31 +112,449 @@ def _register_arrow_data_serializer(serialization_context):
 
     See https://issues.apache.org/jira/browse/ARROW-10739.
     """
-    import pyarrow as pa
-
     if os.environ.get(RAY_DISABLE_CUSTOM_ARROW_DATA_SERIALIZATION, "0") == "1":
         return
 
-    # Register custom reducer for Arrow Tables.
-    serialization_context._register_cloudpickle_reducer(pa.Table, _arrow_table_reduce)
+    # TODO (Clark): Port this to an Arrow Table reducer to reduce scope.
+    array_types = _get_arrow_array_types()
+    for array_type in array_types:
+        serialization_context._register_cloudpickle_reducer(
+            array_type, _arrow_array_reduce
+        )
 
 
-def _arrow_table_reduce(table: "pyarrow.Table"):
-    """Custom reducer for Arrow Table that works around a zero-copy slicing pickling
-    bug by using the Arrow IPC format for the underlying serialization.
+def _get_arrow_array_types() -> List[type]:
+    """Get all Arrow array types that we want to register a custom serializer for."""
+    try:
+        import pyarrow as pa
+    except ModuleNotFoundError:
+        # No pyarrow installed so not using Arrow, so no need for custom serializer.
+        return []
+
+    from ray.data.extensions import ArrowTensorArray, ArrowVariableShapedTensorArray
+
+    array_types = [
+        pa.lib.NullArray,
+        pa.lib.BooleanArray,
+        pa.lib.UInt8Array,
+        pa.lib.UInt16Array,
+        pa.lib.UInt32Array,
+        pa.lib.UInt64Array,
+        pa.lib.Int8Array,
+        pa.lib.Int16Array,
+        pa.lib.Int32Array,
+        pa.lib.Int64Array,
+        pa.lib.Date32Array,
+        pa.lib.Date64Array,
+        pa.lib.TimestampArray,
+        pa.lib.Time32Array,
+        pa.lib.Time64Array,
+        pa.lib.DurationArray,
+        pa.lib.HalfFloatArray,
+        pa.lib.FloatArray,
+        pa.lib.DoubleArray,
+        pa.lib.ListArray,
+        pa.lib.LargeListArray,
+        pa.lib.MapArray,
+        pa.lib.FixedSizeListArray,
+        pa.lib.UnionArray,
+        pa.lib.BinaryArray,
+        pa.lib.StringArray,
+        pa.lib.LargeBinaryArray,
+        pa.lib.LargeStringArray,
+        pa.lib.DictionaryArray,
+        pa.lib.FixedSizeBinaryArray,
+        pa.lib.Decimal128Array,
+        pa.lib.Decimal256Array,
+        pa.lib.StructArray,
+        pa.lib.ExtensionArray,
+        ArrowTensorArray,
+        ArrowVariableShapedTensorArray,
+    ]
+    try:
+        array_types.append(pa.lib.MonthDayNanoIntervalArray)
+    except AttributeError:
+        # MonthDayNanoIntervalArray doesn't exist on older pyarrow versions.
+        pass
+    return array_types
+
+
+def _arrow_array_reduce(a: "pyarrow.Array"):
+    """Custom reducer for Arrow arrays that works around a zero-copy slicing pickling
+    bug.
+    Background:
+        Arrow has both array-level slicing and buffer-level slicing; both are zero-copy,
+        but the former has a serialization bug where the entire buffer is serialized
+        instead of just the slice, while the latter's serialization works as expected
+        and only serializes the slice of the buffer. I.e., array-level slicing doesn't
+        propagate the slice down to the buffer when serializing the array.
+        All that these copy methods do is, at serialization time, take the array-level
+        slicing and translate them to buffer-level slicing, so only the buffer slice is
+        sent over the wire instead of the entire buffer.
+    See https://issues.apache.org/jira/browse/ARROW-10739.
     """
-    from pyarrow.ipc import RecordBatchStreamWriter
-    from pyarrow.lib import BufferOutputStream
+    global _serialization_fallback_set
 
-    output_stream = BufferOutputStream()
-    with RecordBatchStreamWriter(output_stream, schema=table.schema) as wr:
-        wr.write_table(table)
-    return _restore_table, (output_stream.getvalue(),)
+    import time
+
+    start = time.perf_counter()
+
+    try:
+        maybe_copy = _copy_array_if_needed(a)
+        print("maybe copied in:", time.perf_counter() - start)
+    except Exception as e:
+        if _is_in_test():
+            # If running in a test, we want to raise the error, not fall back.
+            raise e from None
+        if type(a) not in _serialization_fallback_set:
+            logger.warning(
+                "Failed to complete optimized serialization of Arrow array of type "
+                f"{type(a)}, falling back to default serialization. Note that this "
+                "may result in bloated serialized arrays. Error:",
+                exc_info=True,
+            )
+            _serialization_fallback_set.add(type(a))
+        maybe_copy = a
+    return maybe_copy.__reduce__()
 
 
-def _restore_table(buf: bytes) -> "pyarrow.Table":
-    """Restore a serialized Arrow Table."""
-    from pyarrow.ipc import RecordBatchStreamReader
+def _copy_array_if_needed(a: "pyarrow.Array") -> "pyarrow.Array":
+    """Copy the provided Arrow array, if needed.
+    This method recursively traverses the array and subarrays, translating array-level
+    slices to buffer-level slices, thereby ensuring a copy at pickle time.
+    """
+    # See the Arrow buffer layouts for each type for information on how this buffer
+    # traversal and copying works:
+    # https://arrow.apache.org/docs/format/Columnar.html#buffer-listing-for-each-layout
+    # TODO(Clark): Preserve null count on copy (if already computed) to prevent it
+    # needing to be recomputed on deserialization?
+    import pyarrow as pa
 
-    with RecordBatchStreamReader(buf) as reader:
-        return reader.read_all()
+    from ray.air.util.tensor_extensions.arrow import (
+        ArrowTensorArray,
+        ArrowVariableShapedTensorArray,
+    )
+
+    if pa.types.is_union(a.type) and a.type.mode != "sparse":
+        # Dense unions not supported.
+        # TODO(Clark): Support dense unions.
+        raise NotImplementedError(
+            "Custom slice view serialization of dense union arrays is not yet "
+            "supported."
+        )
+
+    if isinstance(a, ArrowTensorArray):
+        # Custom path for copying the buffers underlying our tensor column extension
+        # array.
+        return _copy_tensor_array_if_needed(a)
+
+    if isinstance(a, ArrowVariableShapedTensorArray):
+        # Custom path for copying the buffers underlying our variable-shaped tensor
+        # column extension array.
+        return _copy_variable_shaped_tensor_array_if_needed(a)
+
+    if pa.types.is_dictionary(a.type):
+        # Custom path for dictionary arrays.
+        dictionary = _copy_array_if_needed(a.dictionary)
+        indices = _copy_array_if_needed(a.indices)
+        return pa.DictionaryArray.from_arrays(indices, dictionary)
+
+    if pa.types.is_null(a.type):
+        # Return NullArray as is.
+        return a
+
+    buffers = a.buffers()
+    bitmap = buffers[0]
+    buf = buffers[1]
+    # Let remaining buffers be handled downstream.
+    buffers = buffers[2:]
+    children = None
+    if pa.types.is_struct(a.type) or pa.types.is_union(a.type):
+        # Struct and union arrays directly expose children arrays, which are easier
+        # to work with than the raw buffers.
+        children = [a.field(i) for i in range(a.type.num_fields)]
+        buffers = None
+    if pa.types.is_map(a.type):
+        if isinstance(a, pa.lib.ListArray):
+            # Map arrays directly expose the one child array in pyarrow>=7.0.0, which
+            # is easier to work with than the raw buffers.
+            children = [a.values]
+            buffers = None
+        else:
+            # In pyarrow<7.0.0, the child array is not exposed, so we work with the key
+            # and item arrays.
+            if bitmap is not None:
+                bitmap = _copy_bitpacked_buffer_if_needed(bitmap, a.offset, len(a))
+            offset_buf, data_offset, data_length = _copy_offsets_buffer_if_needed(
+                buf, a.type, a.offset, len(a)
+            )
+            offsets = pa.Array.from_buffers(
+                pa.int32(), len(a) + 1, [bitmap, offset_buf]
+            )
+            keys = _copy_array_if_needed(a.keys.slice(data_offset, data_length))
+            items = _copy_array_if_needed(a.items.slice(data_offset, data_length))
+            return pa.MapArray.from_arrays(offsets, keys, items)
+    return _copy_array_buffers_if_needed(
+        bitmap, buf, a.type, a.offset, len(a), buffers=buffers, children=children
+    )
+
+
+def _copy_array_buffers_if_needed(
+    bitmap: "pyarrow.Buffer",
+    buf: "pyarrow.Buffer",
+    type_: "pyarrow.DataType",
+    offset: int,
+    length: int,
+    *,
+    buffers: Optional[List["pyarrow.Buffer"]] = None,
+    children: Optional[List["pyarrow.Array"]] = None,
+) -> "pyarrow.Array":
+    """
+    Copy provided array buffers, if needed.
+    """
+    import pyarrow as pa
+
+    new_buffers = []
+    new_children = None
+
+    # Copy bitmap buffer, if needed.
+    if bitmap is not None:
+        bitmap = _copy_bitpacked_buffer_if_needed(bitmap, offset, length)
+    new_buffers.append(bitmap)
+
+    if pa.types.is_list(type_) or pa.types.is_large_list(type_):
+        # Dedicated path for ListArrays. These arrays have a nested set of bitmap and
+        # offset buffers, eventually bottoming out on a data buffer.
+        # However, pyarrow doesn't expose the children arrays in the Python API, so we
+        # have to work directly with the underlying buffers.
+        # Buffer scheme for nested ListArray:
+        # [bitmap, offsets, bitmap, offsets, ..., bitmap, data]
+        assert buffers is not None
+        assert children is None
+        buf, child_offset, child_length = _copy_offsets_buffer_if_needed(
+            buf, type_, offset, length
+        )
+        # Recursively construct child array based on remaining buffers.
+        # Assumption: Every ListArray has 2 buffers (bitmap, offsets) and 1 child.
+        child = _copy_array_buffers_if_needed(
+            bitmap=buffers[0],
+            buf=buffers[1],
+            type_=type_.value_type,
+            offset=child_offset,
+            length=child_length,
+            buffers=buffers[2:],
+        )
+        new_children = [child]
+        new_buffers.append(buf)
+    elif pa.types.is_fixed_size_list(type_):
+        # Dedicated path for fixed-size lists.
+        # Buffer scheme for FixedSizeListArray:
+        # [bitmap, values_bitmap, values_data, values_subbuffers...]
+        child = _copy_array_buffers_if_needed(
+            bitmap=buf,
+            buf=buffers[0],
+            type_=type_.value_type,
+            offset=type_.list_size * offset,
+            length=type_.list_size * length,
+            buffers=buffers[1:],
+        )
+        new_children = [child]
+    elif pa.types.is_map(type_):
+        # Dedicated path for MapArrays.
+        # Buffer scheme for MapArrays:
+        # [bitmap, offsets, child_struct_array_buffers...]
+        buf, child_offset, child_length = _copy_offsets_buffer_if_needed(
+            buf, type_, offset, length
+        )
+        # We copy the children arrays (should be single child struct array).
+        assert len(children) == 1
+        new_children = []
+        for child in children:
+            child = child.slice(child_offset, child_length)
+            new_children.append(_copy_array_if_needed(child))
+        new_buffers.append(buf)
+    elif pa.types.is_struct(type_) or pa.types.is_union(type_):
+        # Dedicated path for StructArrays and UnionArrays.
+        # StructArrays have a top-level bitmap buffer and one or more children arrays.
+        # UnionArrays have a top-level bitmap buffer and type code buffer, and one or
+        # more children arrays.
+        assert children is not None
+        assert buffers is None
+        if pa.types.is_union(type_):
+            # Only sparse unions are supported.
+            assert type_.mode == "sparse"
+            assert buf is not None
+            buf = _copy_buffer_if_needed(buf, pa.int8(), offset, length)
+            new_buffers.append(buf)
+        else:
+            assert buf is None
+        # We copy the children arrays.
+        new_children = []
+        for child in children:
+            new_children.append(_copy_array_if_needed(child))
+    elif (
+        pa.types.is_string(type_)
+        or pa.types.is_large_string(type_)
+        or pa.types.is_binary(type_)
+        or pa.types.is_large_binary(type_)
+    ):
+        # Dedicated path for StringArrays.
+        assert len(buffers) == 1
+        # StringArray buffer scheme: [bitmap, value_offsets, data]
+        offset_buf, data_offset, data_length = _copy_offsets_buffer_if_needed(
+            buf, type_, offset, length
+        )
+        data_buf = _copy_buffer_if_needed(buffers[0], None, data_offset, data_length)
+        new_buffers.append(offset_buf)
+        new_buffers.append(data_buf)
+    else:
+        # If not a nested Array, buf is a plain data buffer.
+        # Copy data buffer, if needed.
+        if buf is not None:
+            buf = _copy_buffer_if_needed(buf, type_, offset, length)
+        new_buffers.append(buf)
+    return pa.Array.from_buffers(type_, length, new_buffers, children=new_children)
+
+
+def _copy_buffer_if_needed(
+    buf: "pyarrow.Buffer",
+    type_: Optional["pyarrow.DataType"],
+    offset: int,
+    length: int,
+) -> "pyarrow.Buffer":
+    """Copy buffer, if needed."""
+    import pyarrow as pa
+
+    if type_ is not None and pa.types.is_boolean(type_):
+        # Arrow boolean array buffers are bit-packed, with 8 entries per byte,
+        # and are accessed via bit offsets.
+        buf = _copy_bitpacked_buffer_if_needed(buf, offset, length)
+    else:
+        type_bytewidth = type_.bit_width // 8 if type_ is not None else 1
+        buf = _copy_normal_buffer_if_needed(buf, type_bytewidth, offset, length)
+    return buf
+
+
+def _copy_normal_buffer_if_needed(
+    buf: "pyarrow.Buffer",
+    byte_width: int,
+    offset: int,
+    length: int,
+) -> "pyarrow.Buffer":
+    """Copy buffer, if needed."""
+    byte_offset = offset * byte_width
+    byte_length = length * byte_width
+    if offset > 0 or byte_length < buf.size:
+        # Array is a zero-copy slice, so we need to copy to a new buffer before
+        # serializing; this slice of the underlying buffer (not the array) will ensure
+        # that the buffer is properly copied at pickle-time.
+        buf = buf.slice(byte_offset, byte_length)
+        print("buffer copy made! ", offset, byte_length)
+    return buf
+
+
+def _copy_bitpacked_buffer_if_needed(
+    buf: "pyarrow.Buffer",
+    offset: int,
+    length: int,
+) -> "pyarrow.Buffer":
+    """Copy bit-packed binary buffer, if needed."""
+    bit_offset = offset % 8
+    byte_offset = offset // 8
+    byte_length = _bytes_for_bits(bit_offset + length) // 8
+    if offset > 0 or byte_length < buf.size:
+        buf = buf.slice(byte_offset, byte_length)
+        print("buffer copy made! ", offset, byte_length)
+        if bit_offset != 0:
+            # Need to manually shift the buffer to eliminate the bit offset.
+            buf = _align_bit_offset(buf, bit_offset, byte_length)
+    return buf
+
+
+def _copy_offsets_buffer_if_needed(
+    buf: "pyarrow.Buffer",
+    arr_type: "pyarrow.DataType",
+    offset: int,
+    length: int,
+) -> Tuple["pyarrow.Buffer", int, int]:
+    """Copy the provided offsets buffer, returning the copied buffer and the
+    offset + length of the underlying data.
+    """
+    import pyarrow as pa
+    import pyarrow.compute as pac
+
+    offset_type = pa.int64() if pa.types.is_large_list(arr_type) else pa.int32()
+    # Copy offset buffer, if needed.
+    buf = _copy_buffer_if_needed(buf, offset_type, offset, length + 1)
+    # Reconstruct the offset array so we can determine the offset and length
+    # of the child array.
+    offsets = pa.Array.from_buffers(offset_type, length + 1, [None, buf])
+    child_offset = offsets[0].as_py()
+    child_length = offsets[-1].as_py() - child_offset
+    # Create new offsets aligned to 0 for the copied data buffer slice.
+    offsets = pac.subtract(offsets, child_offset)
+    if pa.types.is_int32(offset_type):
+        # We need to cast the resulting Int64Array back down to an Int32Array.
+        offsets = offsets.cast(offset_type, safe=False)
+    buf = offsets.buffers()[1]
+    return buf, child_offset, child_length
+
+
+def _bytes_for_bits(n: int) -> int:
+    """Round up n to the nearest multiple of 8.
+    This is used to get the byte-padded number of bits for n bits.
+    """
+    return (n + 7) & (-8)
+
+
+def _align_bit_offset(
+    buf: "pyarrow.Buffer",
+    bit_offset: int,
+    byte_length: int,
+) -> "pyarrow.Buffer":
+    """Align the bit offset into the buffer with the front of the buffer by shifting
+    the buffer and eliminating the offset.
+    """
+    import pyarrow as pa
+
+    bytes_ = buf.to_pybytes()
+    bytes_as_int = int.from_bytes(bytes_, sys.byteorder)
+    bytes_as_int >>= bit_offset
+    bytes_ = bytes_as_int.to_bytes(byte_length, sys.byteorder)
+    return pa.py_buffer(bytes_)
+
+
+def _copy_tensor_array_if_needed(a: "ArrowTensorArray") -> "ArrowTensorArray":
+    """Copy tensor array if it's a zero-copy slice. This is to circumvent an Arrow
+    serialization bug, where a zero-copy slice serializes the entire underlying array
+    buffer.
+    """
+    import pyarrow as pa
+    from ray.data.extensions import ArrowTensorType
+
+    # Offset is propagated to storage array, and the storage array items align with the
+    # tensor elements, so we only need to do the straightforward copy of the storage
+    # array.
+    storage = _copy_array_if_needed(a.storage)
+    type_ = ArrowTensorType(a.type.shape, storage.type.value_type)
+    return pa.ExtensionArray.from_storage(type_, storage)
+
+
+def _copy_variable_shaped_tensor_array_if_needed(
+    a: "ArrowVariableShapedTensorArray",
+) -> "ArrowVariableShapedTensorArray":
+    """Copy variable-shaped tensor array if it's a zero-copy slice. This is to
+    circumvent an Arrow serialization bug, where a zero-copy slice serializes the entire
+    underlying array buffer.
+    """
+    import pyarrow as pa
+    from ray.data.extensions import ArrowVariableShapedTensorType
+
+    # Offset is propagated to storage struct array, and both the data and shape fields
+    # items align with tensor elements, so we only need to do the straightforward copy
+    # of the storage array.
+    storage = _copy_array_if_needed(a.storage)
+    type_ = ArrowVariableShapedTensorType(
+        storage.field("data").type.value_type, a.type.ndim
+    )
+    return pa.ExtensionArray.from_storage(type_, storage)

--- a/python/ray/data/tests/test_arrow_serialization.py
+++ b/python/ray/data/tests/test_arrow_serialization.py
@@ -125,8 +125,15 @@ pytest_custom_serialization_arrays = [
     (pa.array([True, False] * 500), 0.8),
     # String array
     (pa.array(["foo", "bar", "bz", None, "quux"] * 200), 0.1),
+    # Large string array
+    (pa.array(["foo", "bar", "bz", None, "quux"] * 200, type=pa.large_string()), 0.1),
     # Binary array
     (pa.array([b"foo", b"bar", b"bz", None, b"quux"] * 200), 0.1),
+    # Large binary array
+    (
+        pa.array([b"foo", b"bar", b"bz", None, b"quux"] * 200, type=pa.large_binary()),
+        0.1,
+    ),
     # List array with nulls
     (pa.array(([None] + [list(range(9)) + [None]] * 9) * 100), 0.1),
     # Large list array with nulls

--- a/python/ray/data/tests/test_arrow_serialization.py
+++ b/python/ray/data/tests/test_arrow_serialization.py
@@ -1,4 +1,6 @@
 import os
+import sys
+from unittest import mock
 
 from pkg_resources._vendor.packaging.version import parse as parse_version
 import pytest
@@ -10,10 +12,104 @@ import ray
 import ray.cloudpickle as pickle
 from ray._private.utils import _get_pyarrow_version
 from ray.tests.conftest import *  # noqa
+from ray.data._internal.arrow_serialization import (
+    _get_arrow_array_types,
+    _bytes_for_bits,
+    _align_bit_offset,
+    _copy_buffer_if_needed,
+    _copy_normal_buffer_if_needed,
+    _copy_bitpacked_buffer_if_needed,
+)
 from ray.data.extensions.tensor_extension import (
     ArrowTensorArray,
     ArrowVariableShapedTensorArray,
 )
+
+
+def test_bytes_for_bits():
+    M = 128
+    expected = [((n - 1) // 8 + 1) * 8 for n in range(M)]
+    for n, e in enumerate(expected):
+        assert _bytes_for_bits(n) == e, n
+
+
+def test_align_bit_offset():
+    M = 10
+    n = M * (2**8 - 1)
+    # Represent an integer as a Pyarrow buffer of bytes.
+    bytes_ = n.to_bytes(M, sys.byteorder)
+    buf = pa.py_buffer(bytes_)
+    for slice_len in range(1, M):
+        for bit_offset in range(1, n - slice_len * 8):
+            byte_length = _bytes_for_bits(bit_offset + slice_len * 8) // 8
+            # Shift the buffer to eliminate the offset.
+            out_buf = _align_bit_offset(buf, bit_offset, byte_length)
+            # Check that shifted buffer is equivalent to our base int shifted by the
+            # same number of bits.
+            assert int.from_bytes(out_buf.to_pybytes(), sys.byteorder) == (
+                n >> bit_offset
+            )
+
+
+@mock.patch("ray.data._internal.arrow_serialization._copy_normal_buffer_if_needed")
+@mock.patch("ray.data._internal.arrow_serialization._copy_bitpacked_buffer_if_needed")
+def test_copy_buffer_if_needed(mock_bitpacked, mock_normal):
+    # Test that type-based buffer copy dispatch works as expected.
+    bytes_ = b"abcd"
+    buf = pa.py_buffer(bytes_)
+    offset = 1
+    length = 2
+
+    # Normal (non-boolean) buffer copy path.
+    type_ = pa.int32()
+    _copy_buffer_if_needed(buf, type_, offset, length)
+    expected_byte_width = 4
+    mock_normal.assert_called_once_with(buf, expected_byte_width, offset, length)
+    mock_normal.reset_mock()
+
+    type_ = pa.int64()
+    _copy_buffer_if_needed(buf, type_, offset, length)
+    expected_byte_width = 8
+    mock_normal.assert_called_once_with(buf, expected_byte_width, offset, length)
+    mock_normal.reset_mock()
+
+    # Boolean buffer copy path.
+    type_ = pa.bool_()
+    _copy_buffer_if_needed(buf, type_, offset, length)
+    mock_bitpacked.assert_called_once_with(buf, offset, length)
+    mock_bitpacked.reset_mock()
+
+
+def test_copy_normal_buffer_if_needed():
+    bytes_ = b"abcd"
+    buf = pa.py_buffer(bytes_)
+    byte_width = 1
+    uncopied_buf = _copy_normal_buffer_if_needed(buf, byte_width, 0, len(bytes_))
+    assert uncopied_buf.address == buf.address
+    assert uncopied_buf.size == len(bytes_)
+    for offset in range(1, len(bytes_) - 1):
+        for length in range(1, len(bytes_) - offset):
+            copied_buf = _copy_normal_buffer_if_needed(buf, byte_width, offset, length)
+            assert copied_buf.address != buf.address
+            assert copied_buf.size == length
+
+
+def test_copy_bitpacked_buffer_if_needed():
+    M = 20
+    n = M * 8
+    # Represent an integer as a pyarrow buffer of bytes.
+    bytes_ = (n * 8).to_bytes(M, sys.byteorder)
+    buf = pa.py_buffer(bytes_)
+    for offset in range(0, n - 1):
+        for length in range(1, n - offset):
+            copied_buf = _copy_bitpacked_buffer_if_needed(buf, offset, length)
+            if offset > 0:
+                assert copied_buf.address != buf.address
+            else:
+                assert copied_buf.address == buf.address
+            # Buffer needs to include bits remaining in byte after adjusting for bit
+            # offset..
+            assert copied_buf.size == ((length + (offset % 8) - 1) // 8) + 1
 
 
 pytest_custom_serialization_arrays = [
@@ -70,17 +166,22 @@ pytest_custom_serialization_arrays = [
         ),
         0.1,
     ),
-    # Union array (dense)
-    (
-        pa.UnionArray.from_dense(
-            pa.array([0, 1] * 500, type=pa.int8()),
-            pa.array(
-                [i if i % 2 == 0 else (i % 3) % 2 for i in range(1000)], type=pa.int32()
-            ),
-            [pa.array(list(range(1000))), pa.array([True, False])],
-        ),
-        0.1,
-    ),
+    # # Union array (dense)
+    # (
+    #     pa.UnionArray.from_dense(
+    #         pa.array([0, 1] * 500, type=pa.int8()),
+    #         pa.array(
+    #             [
+    #                 i
+    #                 if i % 2 == 0 else (i % 3) % 2
+    #                 for i in range(1000)
+    #             ],
+    #             type=pa.int32()
+    #         ),
+    #         [pa.array(list(range(1000))), pa.array([True, False])],
+    #     ),
+    #     0.1,
+    # ),
     # Dictionary array
     (
         pa.DictionaryArray.from_arrays(
@@ -234,8 +335,10 @@ def test_custom_arrow_data_serializer_parquet_roundtrip(
 
 def test_custom_arrow_data_serializer_disable(shutdown_only):
     ray.shutdown()
+    ray.worker._post_init_hooks = []
     context = ray.worker.global_worker.get_serialization_context()
-    context._unregister_cloudpickle_reducer(pa.Table)
+    for array_type in _get_arrow_array_types():
+        context._unregister_cloudpickle_reducer(array_type)
     # Disable custom Arrow array serialization.
     os.environ["RAY_DISABLE_CUSTOM_ARROW_ARRAY_SERIALIZATION"] = "1"
     ray.init()

--- a/python/ray/data/tests/test_arrow_serialization.py
+++ b/python/ray/data/tests/test_arrow_serialization.py
@@ -346,10 +346,12 @@ def test_custom_arrow_data_serializer(ray_start_regular_shared, data, cap_mult):
     assert view.equals(post_slice), post_slice
     # Check that the slice view was truncated upon serialization.
     assert len(s_view) <= cap_mult * len(s_arr)
-    # Check that offset was reset on slice.
-    for column in post_slice.columns:
+    for column, pre_column in zip(post_slice.columns, view.columns):
+        # Check that offset was reset on slice.
         if column.num_chunks > 0:
             assert column.chunk(0).offset == 0
+        # Check that null count was either properly cached or recomputed.
+        assert column.null_count == pre_column.null_count
     if pyarrow_version >= parse_version("7.0.0"):
         # Check that slice buffer only contains slice data.
         slice_buf_size = post_slice.get_total_buffer_size()
@@ -418,10 +420,12 @@ def test_custom_arrow_data_serializer_fallback(
     assert view.equals(post_slice), post_slice
     # Check that the slice view was truncated upon serialization.
     assert len(s_view) <= cap_mult * len(s_arr)
-    # Check that offset was reset on slice.
-    for column in post_slice.columns:
+    for column, pre_column in zip(post_slice.columns, view.columns):
+        # Check that offset was reset on slice.
         if column.num_chunks > 0:
             assert column.chunk(0).offset == 0
+        # Check that null count was either properly cached or recomputed.
+        assert column.null_count == pre_column.null_count
     if pyarrow_version >= parse_version("7.0.0"):
         # Check that slice buffer only contains slice data.
         slice_buf_size = post_slice.get_total_buffer_size()

--- a/python/ray/data/tests/test_arrow_serialization.py
+++ b/python/ray/data/tests/test_arrow_serialization.py
@@ -13,7 +13,6 @@ import ray.cloudpickle as pickle
 from ray._private.utils import _get_pyarrow_version
 from ray.tests.conftest import *  # noqa
 from ray.data._internal.arrow_serialization import (
-    _get_arrow_array_types,
     _bytes_for_bits,
     _align_bit_offset,
     _copy_buffer_if_needed,
@@ -337,8 +336,7 @@ def test_custom_arrow_data_serializer_disable(shutdown_only):
     ray.shutdown()
     ray.worker._post_init_hooks = []
     context = ray.worker.global_worker.get_serialization_context()
-    for array_type in _get_arrow_array_types():
-        context._unregister_cloudpickle_reducer(array_type)
+    context._unregister_cloudpickle_reducer(pa.ChunkedArray)
     # Disable custom Arrow array serialization.
     os.environ["RAY_DISABLE_CUSTOM_ARROW_ARRAY_SERIALIZATION"] = "1"
     ray.init()


### PR DESCRIPTION
Reverts custom Arrow serialization path to manual buffer copying, since using the Arrow IPC format currently breaks zero-copy pickle serialization for Arrow tables.

## TODOs

- [x] Confirm that ingest regression is fixed
- [x] Refactor to `pa.ChunkedArray` serializer instead of array serializer to (1) reduce scope of serializers, and (2) avoid an eager Pandas import via registering extension types.
- [x] Fix large string/binary handling.
- [x] (Optional) Preserve null count (if already computed) during serialization.
- [ ] (Future PR) Add dense union support to manual buffer truncation method (currently using IPC fallback).
- [ ] ~(Optional) Refactor nested array traversal to mimic existing recursive Arrow Array reducer so we only do a single traversal (current solution does 2 traversals: one to propagate slices to buffers in order to trigger a copy, and one to recursively reduce the arrays for final serialization).~ Determined to be too complex.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
