### PR TITLE
[Train] Mention threading in `TensorflowTrainer` doc

### DIFF
--- a/doc/source/train/dl_guide.rst
+++ b/doc/source/train/dl_guide.rst
@@ -196,6 +196,15 @@ with one of the following:
 
 .. tabbed:: TensorFlow
 
+    .. warning::
+        Ray will not automatically set any environment variables or configuration
+        related to local parallelism / threading
+        :ref:`aside from "OMP_NUM_THREADS" <omp-num-thread-note>`.
+        If you desire greater control over TensorFlow threading, use
+        the ``tf.config.threading`` module (eg.
+        ``tf.config.threading.set_inter_op_parallelism_threads(num_cpus)``)
+        at the beginning of your ``train_loop_per_worker`` function.
+
     .. code-block:: python
 
         from ray.air import ScalingConfig

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -79,14 +79,6 @@ def _repr_dataclass(obj, *, default_values: Optional[Dict[str, Any]] = None) -> 
 class ScalingConfig:
     """Configuration for scaling training.
 
-    .. warning::
-        Ray will not automatically set any environment variables or configuration
-        related to local (in-worker) parallelism / threading
-        :ref:`aside from "OMP_NUM_THREADS" <omp-num-thread-note>` in user
-        defined training / tuning functions (with eg. Tensorflow, PyTorch, Horovod).
-        Make sure you configure threading in your code according to the
-        framework you are using.
-
     Args:
         trainer_resources: Resources to allocate for the trainer. If None is provided,
             will default to 1 CPU.

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -79,6 +79,14 @@ def _repr_dataclass(obj, *, default_values: Optional[Dict[str, Any]] = None) -> 
 class ScalingConfig:
     """Configuration for scaling training.
 
+    .. warning::
+        Ray will not automatically set any environment variables or configuration
+        related to local (in-worker) parallelism / threading
+        :ref:`aside from "OMP_NUM_THREADS" <omp-num-thread-note>` in user
+        defined training / tuning functions (with eg. Tensorflow, PyTorch, Horovod).
+        Make sure you configure threading in your code according to the
+        framework you are using.
+
     Args:
         trainer_resources: Resources to allocate for the trainer. If None is provided,
             will default to 1 CPU.

--- a/python/ray/train/tensorflow/tensorflow_trainer.py
+++ b/python/ray/train/tensorflow/tensorflow_trainer.py
@@ -45,6 +45,16 @@ class TensorflowTrainer(DataParallelTrainer):
     Inside the ``train_loop_per_worker`` function, you can use any of the
     :ref:`Ray AIR session methods <air-session-ref>`.
 
+    .. warning::
+        Ray will not automatically set any environment variables or configuration
+        related to local parallelism / threading
+        :ref:`aside from "OMP_NUM_THREADS" <omp-num-thread-note>`.
+        If you desire greater control over TensorFlow threading, use
+        the ``tf.config.threading`` module (eg.
+        ``tf.config.threading.set_inter_op_parallelism_threads(num_cpus)``)
+        at the beginning of your ``train_loop_per_worker`` function.
+
+
     .. code-block:: python
 
         def train_loop_per_worker():


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Even though we allow users to set the number of CPUs per worker, we do not set Tensorflow threading configurations automatically. This PR mentions this explicitly in the docstring.

We may consider setting this automatically in the future, but the main concern is that there are multiple configuration options interacting with another, so just setting them all to the number of CPUs assigned to a worker may not give the best performance. Therefore, we leave it up to the user for now.

For more information, see
https://stackoverflow.com/questions/41233635/meaning-of-inter-op-parallelism-threads-and-intra-op-parallelism-threads
https://www.intel.com/content/www/us/en/developer/articles/technical/maximize-tensorflow-performance-on-cpu-considerations-and-recommendations-for-inference.html

Quote from the second link:

> The ConfigProto is used for configuration when creating a session. These two variables control number of cores to use.
> 
> intra_op_parallelism_threads
> This runtime setting controls parallelism inside an operation. For instance, if matrix multiplication or reduction is intended to be executed in several threads, this variable should be set. TensorFlow will schedule tasks in a thread pool that contains intra_op_parallelism_threads threads. As illustrated later in Figure 2, OpenMP* threads are bound to thread context as close as possible on different cores. Setting this environment variable to the number of available physical cores is recommended.
> 
> inter_op_parallelism_threads
> NOTE: This setting is highly dependent on hardware and topologies, so it’s best to empirically confirm the best setting on your workload.
> 
> This runtime setting controls parallelism among independent operations. Since these operations are not relevant to each other, TensorFlow will try to run them concurrently in the thread pool that contains inter_op_parallelism_threads threads. This variable should be set to the number of parallel paths where you want the code to run. For Intel® Optimization for TensorFlow, we recommend starting with the setting '2’, and adjusting after empirical testing.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/anyscale/product/issues/14817

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
