### PR TITLE
[Tune] Replace `"model_state_dict"` key with `"model"` in PBT examples

### DIFF
--- a/python/ray/train/examples/pytorch/tune_cifar_torch_pbt_example.py
+++ b/python/ray/train/examples/pytorch/tune_cifar_torch_pbt_example.py
@@ -83,7 +83,7 @@ def train_func(config):
         checkpoint_dict = session.get_checkpoint().to_dict()
 
         # Load in model
-        model_state = checkpoint_dict["model_state_dict"]
+        model_state = checkpoint_dict["model"]
         model.load_state_dict(model_state)
 
         # Load in optimizer
@@ -146,7 +146,7 @@ def train_func(config):
         checkpoint = Checkpoint.from_dict(
             {
                 "epoch": epoch,
-                "model_state_dict": model.state_dict(),
+                "model": model.state_dict(),
                 "optimizer_state_dict": optimizer.state_dict(),
             }
         )

--- a/python/ray/tune/examples/pbt_convnet_function_example.py
+++ b/python/ray/tune/examples/pbt_convnet_function_example.py
@@ -36,7 +36,7 @@ def train_convnet(config):
         with loaded_checkpoint.as_directory() as loaded_checkpoint_dir:
             path = os.path.join(loaded_checkpoint_dir, "checkpoint.pt")
             checkpoint = torch.load(path)
-            model.load_state_dict(checkpoint["model_state_dict"])
+            model.load_state_dict(checkpoint["model"])
             step = checkpoint["step"]
 
     while True:
@@ -52,7 +52,7 @@ def train_convnet(config):
             torch.save(
                 {
                     "step": step,
-                    "model_state_dict": model.state_dict(),
+                    "model": model.state_dict(),
                 },
                 "my_model/checkpoint.pt",
             )
@@ -72,7 +72,7 @@ def test_best_model(results: tune.ResultGrid):
         best_checkpoint = torch.load(
             os.path.join(best_checkpoint_path, "checkpoint.pt")
         )
-        best_model.load_state_dict(best_checkpoint["model_state_dict"])
+        best_model.load_state_dict(best_checkpoint["model"])
         # Note that test only runs on a small random set of the test data, thus the
         # accuracy may be different from metrics shown in tuning process.
         test_acc = test(best_model, get_data_loaders()[1])


### PR DESCRIPTION
Signed-off-by: Balaji <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If don't save your model with the `"model"` key, `TorchPredictor.from_checkpoint` errors. To avoid this gotcha, this PR updates the `tune_cifar_torch_pbt_example` and replaces the `"model_state_dict"` key with `"model"`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
