### PR TITLE
[AIR] Rename `DLPredictor.call_model` `tensor` parameter to `inputs`

### DIFF
--- a/python/ray/train/_internal/dl_predictor.py
+++ b/python/ray/train/_internal/dl_predictor.py
@@ -52,6 +52,7 @@ class DLPredictor(Predictor):
         raise NotImplementedError
 
     @abc.abstractmethod
+    @DeveloperAPI
     def call_model(
         self, inputs: Union[TensorType, Dict[str, TensorType]]
     ) -> Union[TensorType, Dict[str, TensorType]]:

--- a/python/ray/train/_internal/dl_predictor.py
+++ b/python/ray/train/_internal/dl_predictor.py
@@ -53,12 +53,12 @@ class DLPredictor(Predictor):
 
     @abc.abstractmethod
     def call_model(
-        self, tensor: Union[TensorType, Dict[str, TensorType]]
+        self, inputs: Union[TensorType, Dict[str, TensorType]]
     ) -> Union[TensorType, Dict[str, TensorType]]:
         """Inputs the tensor to the model for this Predictor and returns the result.
 
         Args:
-            tensor: The tensor to input to the model.
+            inputs: The tensor to input to the model.
 
         Returns:
             A tensor or dictionary of tensors containing the model output.

--- a/python/ray/train/tensorflow/tensorflow_predictor.py
+++ b/python/ray/train/tensorflow/tensorflow_predictor.py
@@ -108,7 +108,7 @@ class TensorflowPredictor(DLPredictor):
         )
 
     def call_model(
-        self, tensor: Union[tf.Tensor, Dict[str, tf.Tensor]]
+        self, inputs: Union[tf.Tensor, Dict[str, tf.Tensor]]
     ) -> Union[tf.Tensor, Dict[str, tf.Tensor]]:
         """Runs inference on a single batch of tensor data.
 
@@ -130,8 +130,8 @@ class TensorflowPredictor(DLPredictor):
 
                 # Use a custom predictor to format model output as a dict.
                 class CustomPredictor(TensorflowPredictor):
-                    def call_model(self, tensor):
-                        model_output = super().call_model(tensor)
+                    def call_model(self, inputs):
+                        model_output = super().call_model(inputs)
                         return {
                             str(i): model_output[i] for i in range(len(model_output))
                         }
@@ -140,8 +140,8 @@ class TensorflowPredictor(DLPredictor):
                 predictions = predictor.predict(data_batch)
 
         Args:
-            tensor: A batch of data to predict on, represented as either a single
-                PyTorch tensor or for multi-input models, a dictionary of tensors.
+            inputs: A batch of data to predict on, represented as either a single
+                TensorFlow tensor or for multi-input models, a dictionary of tensors.
 
         Returns:
             The model outputs, either as a single tensor or a dictionary of tensors.
@@ -149,9 +149,9 @@ class TensorflowPredictor(DLPredictor):
         """
         if self.use_gpu:
             with tf.device("GPU:0"):
-                return self._model(tensor)
+                return self._model(inputs)
         else:
-            return self._model(tensor)
+            return self._model(inputs)
 
     def predict(
         self,

--- a/python/ray/train/tensorflow/tensorflow_predictor.py
+++ b/python/ray/train/tensorflow/tensorflow_predictor.py
@@ -10,7 +10,7 @@ from ray.air.checkpoint import Checkpoint
 from ray.air._internal.tensorflow_utils import convert_ndarray_batch_to_tf_tensor_batch
 from ray.train._internal.dl_predictor import DLPredictor
 from ray.train.tensorflow.tensorflow_checkpoint import TensorflowCheckpoint
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:
     from ray.data.preprocessor import Preprocessor
@@ -107,6 +107,7 @@ class TensorflowPredictor(DLPredictor):
             use_gpu=use_gpu,
         )
 
+    @DeveloperAPI
     def call_model(
         self, inputs: Union[tf.Tensor, Dict[str, tf.Tensor]]
     ) -> Union[tf.Tensor, Dict[str, tf.Tensor]]:

--- a/python/ray/train/torch/torch_predictor.py
+++ b/python/ray/train/torch/torch_predictor.py
@@ -95,7 +95,7 @@ class TorchPredictor(DLPredictor):
         return cls(model=model, preprocessor=preprocessor, use_gpu=use_gpu)
 
     def call_model(
-        self, tensor: Union[torch.Tensor, Dict[str, torch.Tensor]]
+        self, inputs: Union[torch.Tensor, Dict[str, torch.Tensor]]
     ) -> Union[torch.Tensor, Dict[str, torch.Tensor]]:
         """Runs inference on a single batch of tensor data.
 
@@ -106,7 +106,7 @@ class TorchPredictor(DLPredictor):
         output.
 
         Args:
-            tensor: A batch of data to predict on, represented as either a single
+            inputs: A batch of data to predict on, represented as either a single
                 PyTorch tensor or for multi-input models, a dictionary of tensors.
 
         Returns:
@@ -124,8 +124,8 @@ class TorchPredictor(DLPredictor):
 
                 # Use a custom predictor to format model output as a dict.
                 class CustomPredictor(TorchPredictor):
-                    def call_model(self, tensor):
-                        model_output = super().call_model(tensor)
+                    def call_model(self, inputs):
+                        model_output = super().call_model(inputs)
                         return {
                             str(i): model_output[i] for i in range(len(model_output))
                         }
@@ -142,7 +142,7 @@ class TorchPredictor(DLPredictor):
                 Predictions: [1 2], [1 2]
         """
         with torch.no_grad():
-            output = self.model(tensor)
+            output = self.model(inputs)
         return output
 
     def predict(

--- a/python/ray/train/torch/torch_predictor.py
+++ b/python/ray/train/torch/torch_predictor.py
@@ -10,7 +10,7 @@ from ray.air.checkpoint import Checkpoint
 from ray.air._internal.torch_utils import convert_ndarray_batch_to_torch_tensor_batch
 from ray.train.torch.torch_checkpoint import TorchCheckpoint
 from ray.train._internal.dl_predictor import DLPredictor
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:
     from ray.data.preprocessor import Preprocessor
@@ -94,6 +94,7 @@ class TorchPredictor(DLPredictor):
         preprocessor = checkpoint.get_preprocessor()
         return cls(model=model, preprocessor=preprocessor, use_gpu=use_gpu)
 
+    @DeveloperAPI
     def call_model(
         self, inputs: Union[torch.Tensor, Dict[str, torch.Tensor]]
     ) -> Union[torch.Tensor, Dict[str, torch.Tensor]]:


### PR DESCRIPTION
Signed-off-by: Balaji <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Some people get confused what the `tensor` argument represents. The name's ambiguous. This PR addressees the issue by renaming the parameter `inputs`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
