### PR TITLE
[Datasets] Raise error message if user calls `Dataset.__iter__`

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4205,8 +4205,9 @@ class Dataset(Generic[T]):
 
     def __iter__(self):
         raise TypeError(
-            "`Dataset` objects aren't iterable. If you want to inspect records, call "
-            "`ds.take()`. If you want to transform records, call `ds.map_batches()`."
+            "`Dataset` objects aren't iterable. To iterate records, call "
+            "`ds.iter_rows()` or `ds.iter_batches()`. For more information, read "
+            "https://docs.ray.io/en/latest/data/consuming-datasets.html."
         )
 
     def _block_num_rows(self) -> List[int]:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4203,6 +4203,12 @@ class Dataset(Generic[T]):
             "This may be an expensive operation."
         )
 
+    def __iter__(self):
+        raise TypeError(
+            "`Dataset` objects aren't iterable. If you want to inspect records, call "
+            "`ds.take()`. If you want to transform records, call `ds.map_batches()`."
+        )
+
     def _block_num_rows(self) -> List[int]:
         get_num_rows = cached_remote_fn(_get_num_rows)
         return ray.get([get_num_rows.remote(b) for b in self.get_internal_block_refs()])


### PR DESCRIPTION
Signed-off-by: Balaji <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

New users might try `for item in dataset` and get confused when they receive the default error message. This PR adds a more descriptive error that points users towards `Dataset.take` or `Dataset.map_batches`.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #30399 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
