### PR TITLE
[Datasets] Hide `TableRow` implementation in `_repr_pretty_`

### DIFF
--- a/python/ray/data/row.py
+++ b/python/ray/data/row.py
@@ -41,5 +41,5 @@ class TableRow(Mapping):
     def _repr_pretty_(self, p, cycle):
         from IPython.lib.pretty import _dict_pprinter_factory
 
-        pprinter = _dict_pprinter_factory(f"{type(self).__name__}({{", "})")
+        pprinter = _dict_pprinter_factory("{", "}")
         return pprinter(self, p, cycle)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you represent a `TableRow` in a Jupyter notebook (for example, by calling `dataset.take`), you see an implementation like `ArrowRow`. This PR updates `_repr_pretty_` so that the implementation is hidden.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #30400 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
