### PR TITLE
[RLlib, Tune] Make `Algorithm.train()` return Tune-style config dict (instead of AlgorithmConfig object).

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2233,6 +2233,21 @@ class Algorithm(Trainable):
             f"The config of this Algorithm is: {config}"
         )
 
+    @override(Trainable)
+    def get_auto_filled_metrics(
+        self,
+        now: Optional[datetime] = None,
+        time_this_iter: Optional[float] = None,
+        debug_metrics_only: bool = False,
+    ) -> dict:
+        autofilled = super().get_auto_filled_metrics(
+            now, time_this_iter, debug_metrics_only
+        )
+        if not isinstance(autofilled["config"], dict):
+            assert isinstance(autofilled["config"], AlgorithmConfig)
+            autofilled["config"] = autofilled["config"].to_dict()
+        return autofilled
+
     @classmethod
     def merge_trainer_configs(
         cls,

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2240,15 +2240,20 @@ class Algorithm(Trainable):
         time_this_iter: Optional[float] = None,
         debug_metrics_only: bool = False,
     ) -> dict:
-        autofilled = super().get_auto_filled_metrics(
+        # Override this method to make sure, the `config` key of the returned results
+        # contains the proper Tune config dict (instead of an AlgorithmConfig object).
+        auto_filled = super().get_auto_filled_metrics(
             now, time_this_iter, debug_metrics_only
         )
+        if "config" not in auto_filled:
+            raise KeyError("`config` key not found in auto-filled results dict!")
+
         # If `config` key is no dict (but AlgorithmConfig object) ->
         # make sure, it's a dict to not break Tune APIs.
-        if not isinstance(autofilled["config"], dict):
-            assert isinstance(autofilled["config"], AlgorithmConfig)
-            autofilled["config"] = autofilled["config"].to_dict()
-        return autofilled
+        if not isinstance(auto_filled["config"], dict):
+            assert isinstance(auto_filled["config"], AlgorithmConfig)
+            auto_filled["config"] = auto_filled["config"].to_dict()
+        return auto_filled
 
     @classmethod
     def merge_trainer_configs(

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2243,6 +2243,8 @@ class Algorithm(Trainable):
         autofilled = super().get_auto_filled_metrics(
             now, time_this_iter, debug_metrics_only
         )
+        # If `config` key is no dict (but AlgorithmConfig object) ->
+        # make sure, it's a dict to not break Tune APIs.
         if not isinstance(autofilled["config"], dict):
             assert isinstance(autofilled["config"], AlgorithmConfig)
             autofilled["config"] = autofilled["config"].to_dict()

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -267,7 +267,6 @@ class AlgorithmConfig:
         }
 
         # `self.multi_agent()`
-        self._is_multi_agent = False
         self.policies = {DEFAULT_POLICY_ID: PolicySpec()}
         self.policy_map_capacity = 100
         self.policy_map_cache = None
@@ -1726,12 +1725,6 @@ class AlgorithmConfig:
                     )
             self.policies_to_train = policies_to_train
 
-        # Is this a multi-agent setup? True, iff DEFAULT_POLICY_ID is only
-        # PolicyID found in policies dict.
-        self._is_multi_agent = (
-            len(self.policies) > 1 or DEFAULT_POLICY_ID not in self.policies
-        )
-
         return self
 
     def is_multi_agent(self) -> bool:
@@ -1741,7 +1734,7 @@ class AlgorithmConfig:
             True, if a) >1 policies defined OR b) 1 policy defined, but its ID is NOT
             DEFAULT_POLICY_ID.
         """
-        return self._is_multi_agent
+        return len(self.policies) > 1 or DEFAULT_POLICY_ID not in self.policies
 
     def reporting(
         self,

--- a/rllib/algorithms/dt/dt.py
+++ b/rllib/algorithms/dt/dt.py
@@ -38,8 +38,6 @@ class DTConfig(AlgorithmConfig):
         # Required settings during training and evaluation:
         # Initial return to go used as target during rollout.
         self.target_return = None
-        # Rollout horizon/maximum episode length.
-        self.horizon = None
 
         # Model settings:
         self.model = {

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -648,6 +648,7 @@ def check_train_results(train_results):
         "`config` in results not a python dict!",
     )
 
+    from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
     is_multi_agent = (
         AlgorithmConfig().from_dict(train_results["config"]).is_multi_agent()
     )

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -597,7 +597,7 @@ def check_off_policyness(
     return off_policy_ness
 
 
-def check_train_results(train_results):
+def check_train_results(train_results: PartialAlgorithmConfigDict) -> ResultDict:
     """Checks proper structure of a Algorithm.train() returned dict.
 
     Args:
@@ -649,9 +649,9 @@ def check_train_results(train_results):
     )
 
     from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
-    is_multi_agent = (
-        AlgorithmConfig().from_dict(train_results["config"]).is_multi_agent()
-    )
+    is_multi_agent = AlgorithmConfig().update_from_dict(
+        train_results["config"]["multiagent"]
+    ).is_multi_agent()
 
     # Check in particular the "info" dict.
     info = train_results["info"]

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -643,14 +643,16 @@ def check_train_results(train_results: PartialAlgorithmConfigDict) -> ResultDict
         ), f"'{key}' not found in `train_results` ({train_results})!"
 
     # Make sure, `config` is an actual dict, not an AlgorithmConfig object.
-    assert (
-        isinstance(train_results["config"], dict)
+    assert isinstance(
+        train_results["config"], dict
     ), "`config` in results not a python dict!"
 
     from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
-    is_multi_agent = AlgorithmConfig().update_from_dict(
-        train_results["config"]["multiagent"]
-    ).is_multi_agent()
+    is_multi_agent = (
+        AlgorithmConfig()
+        .update_from_dict(train_results["config"]["multiagent"])
+        .is_multi_agent()
+    )
 
     # Check in particular the "info" dict.
     info = train_results["info"]

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -648,6 +648,7 @@ def check_train_results(train_results: PartialAlgorithmConfigDict) -> ResultDict
     ), "`config` in results not a python dict!"
 
     from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
+
     is_multi_agent = (
         AlgorithmConfig()
         .update_from_dict(train_results["config"]["multiagent"])

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -648,7 +648,9 @@ def check_train_results(train_results):
         "`config` in results not a python dict!",
     )
 
-    is_multi_agent = train_results["config"].is_multi_agent()
+    is_multi_agent = (
+        AlgorithmConfig().from_dict(train_results["config"]).is_multi_agent()
+    )
 
     # Check in particular the "info" dict.
     info = train_results["info"]

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -642,6 +642,12 @@ def check_train_results(train_results):
             key in train_results
         ), f"'{key}' not found in `train_results` ({train_results})!"
 
+    # Make sure, `config` is an actual dict, not an AlgorithmConfig object.
+    assert (
+        isinstance(train_results["config"], dict),
+        "`config` in results not a python dict!",
+    )
+
     is_multi_agent = train_results["config"].is_multi_agent()
 
     # Check in particular the "info" dict.

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -644,9 +644,8 @@ def check_train_results(train_results: PartialAlgorithmConfigDict) -> ResultDict
 
     # Make sure, `config` is an actual dict, not an AlgorithmConfig object.
     assert (
-        isinstance(train_results["config"], dict),
-        "`config` in results not a python dict!",
-    )
+        isinstance(train_results["config"], dict)
+    ), "`config` in results not a python dict!"
 
     from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
     is_multi_agent = AlgorithmConfig().update_from_dict(


### PR DESCRIPTION
Signed-off-by: sven1977 <svenmika1977@gmail.com>

Make `Algorithm.train()` return Tune-style config dict (instead of AlgorithmConfig object).

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
