### PR TITLE
[Core] disable obj store pages in raylet coredump

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -715,6 +715,7 @@ RAY_CONFIG(int64_t, health_check_period_ms, 3000)
 RAY_CONFIG(int64_t, health_check_timeout_ms, 10000)
 RAY_CONFIG(int64_t, health_check_failure_threshold, 5)
 
-/// Use madvise to prevent worker coredump from including the mapped plasma pages
-/// in the worker processes.
+/// Use madvise to prevent worker/raylet coredumps from including
+/// the mapped plasma pages.
 RAY_CONFIG(bool, worker_core_dump_exclude_plasma_store, true)
+RAY_CONFIG(bool, raylet_core_dump_exclude_plasma_store, true)

--- a/src/ray/object_manager/plasma/shared_memory.cc
+++ b/src/ray/object_manager/plasma/shared_memory.cc
@@ -43,8 +43,7 @@ ClientMmapTableEntry::ClientMmapTableEntry(MEMFD_TYPE fd, int64_t map_size)
 void ClientMmapTableEntry::MaybeMadviseDontdump() {
   if (!RayConfig::instance().worker_core_dump_exclude_plasma_store()) {
     RAY_LOG(DEBUG) << "worker_core_dump_exclude_plasma_store disabled, worker coredumps "
-                      "will contain "
-                   << "the object store mappings.";
+                      "will contain the object store mappings.";
     return;
   }
 


### PR DESCRIPTION
Disable object store pages from appearing in Raylet coredumps using `madvise(MADV_DONTDUMP)`. See https://github.com/ray-project/ray/pull/30150 for more context.