### PR TITLE
[Train] Report only once in `SklearnTrainer`

### DIFF
--- a/python/ray/train/sklearn/sklearn_trainer.py
+++ b/python/ray/train/sklearn/sklearn_trainer.py
@@ -433,5 +433,6 @@ class SklearnTrainer(BaseTrainer):
             **validation_set_scores,
             **cv_scores,
             "fit_time": fit_time,
+            "done": True,
         }
         self._report(results)


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Sets `"done": True` in the `SklearnTrainer` report so that it only print the results only once.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/29226

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
