### PR TITLE
[core] dashboard client : migrate to createTheme 

### DIFF
--- a/dashboard/client/src/theme.ts
+++ b/dashboard/client/src/theme.ts
@@ -1,5 +1,5 @@
 import { blueGrey, grey, lightBlue } from "@material-ui/core/colors";
-import { createMuiTheme, ThemeOptions } from "@material-ui/core/styles";
+import { createTheme, ThemeOptions } from "@material-ui/core/styles";
 
 const basicTheme: ThemeOptions = {
   typography: {
@@ -27,7 +27,7 @@ const basicTheme: ThemeOptions = {
   },
 };
 
-export const lightTheme = createMuiTheme({
+export const lightTheme = createTheme({
   ...basicTheme,
   palette: {
     primary: {
@@ -53,7 +53,7 @@ export const lightTheme = createMuiTheme({
   },
 });
 
-export const darkTheme = createMuiTheme({
+export const darkTheme = createTheme({
   ...basicTheme,
   palette: {
     primary: {


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

Fix for Dashboard Tests.

Currently the build breaks unless we migrate from createMuiTheme to createTheme

## Related issue number

https://github.com/ray-project/ray/issues/30564

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
