### PR TITLE
    [core] Fix a corner case where GCS will crash when actor is deleted (#30563)

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -408,6 +408,11 @@ void GcsActorScheduler::HandleWorkerLeaseGrantedReply(
                                       actor->GetActorTableData(),
                                       [this, actor, leased_worker](Status status) {
                                         RAY_CHECK_OK(status);
+                                        if (actor->GetState() ==
+                                            rpc::ActorTableData::DEAD) {
+                                          // Actor has already been killed.
+                                          return;
+                                        }
                                         CreateActorOnWorker(actor, leased_worker);
                                       }));
   }


### PR DESCRIPTION
[core] Fix a corner case where GCS will crash when actor is deleted (#30563)

When the lease is granted and writing to the table, if the actor is deleted, GCS is going to crash. This PR fix it by check the actor status first before creating the actor.
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
