### PR TITLE
[RLlib] Fix EnvRunnerV2 creation of fake observations

### DIFF
--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import numpy as np
-import tree  # pip install dm_tree
 
 from ray.rllib.env.base_env import ASYNC_RESET_RETURN, BaseEnv
 from ray.rllib.env.external_env import ExternalEnvWrapper
@@ -18,7 +17,7 @@ from ray.rllib.policy.sample_batch import MultiAgentBatch, SampleBatch, concat_s
 from ray.rllib.utils.annotations import DeveloperAPI
 from ray.rllib.utils.filter import Filter
 from ray.rllib.utils.numpy import convert_to_numpy
-from ray.rllib.utils.spaces.space_utils import unbatch
+from ray.rllib.utils.spaces.space_utils import unbatch, get_original_space
 from ray.rllib.utils.typing import (
     ActionConnectorDataType,
     AgentConnectorDataType,
@@ -637,9 +636,9 @@ class EnvRunnerV2:
                     policy_id: PolicyID = episode.policy_for(agent_id)
                     policy = self._worker.policy_map[policy_id]
 
-                    # Create a fake (all-0s) observation.
-                    obs_space = policy.observation_space
-                    obs_space = getattr(obs_space, "original_space", obs_space)
+                    # Create a fake observation by sampling the original env
+                    # observation space.
+                    obs_space = get_original_space(policy.observation_space)
                     values_dict = {
                         SampleBatch.T: episode.length,
                         SampleBatch.ENV_ID: env_id,
@@ -647,9 +646,7 @@ class EnvRunnerV2:
                         SampleBatch.REWARDS: 0.0,
                         SampleBatch.DONES: True,
                         SampleBatch.INFOS: {},
-                        SampleBatch.NEXT_OBS: tree.map_structure(
-                            np.zeros_like, obs_space.sample()
-                        ),
+                        SampleBatch.NEXT_OBS: obs_space.sample(),
                     }
 
                     # Queue these fake obs for connector preprocessing too.

--- a/rllib/utils/spaces/space_utils.py
+++ b/rllib/utils/spaces/space_utils.py
@@ -7,6 +7,25 @@ from typing import Any, List, Optional, Union
 
 
 @DeveloperAPI
+def get_original_space(space: gym.Space) -> gym.Space:
+    """Returns the original space of a space, if any.
+
+    This function recursively traverses the given space and returns the original space
+    at the very end of the chain.
+
+    Args:
+        space: The space to get the original space for.
+
+    Returns:
+        The original space or the given space itself if no original space is found.
+    """
+    if hasattr(space, "original_space"):
+        return get_original_space(space.original_space)
+    else:
+        return space
+
+
+@DeveloperAPI
 def flatten_space(space: gym.Space) -> List[gym.Space]:
     """Flattens a gym.Space into its primitive components.
 


### PR DESCRIPTION
Recursively look up the original space from obs_space to get the very original space that environment outputs. We should use that to create fake samples for the input of the agent connector chain to match what the environment outputs.

Signed-off-by: Kourosh Hakhamaneshi <kourosh@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
