### PR TITLE
[Temporary] change the default env to staging

### DIFF
--- a/release/ray_release/env.py
+++ b/release/ray_release/env.py
@@ -3,7 +3,7 @@ from typing import Dict
 
 from ray_release.exception import ReleaseTestConfigError
 
-DEFAULT_ENVIRONMENT = "prod"
+DEFAULT_ENVIRONMENT = "staging"
 
 
 def load_environment(environment_name: str) -> Dict[str, str]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

prod is unstable due to load. We will move release tests to staging temporarily to relieve the load. We will revert this back in a few days until the staging env stability is ensured. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
