### PR TITLE
Fix pyarrow hdfs uri without namenode server issue

### DIFF
--- a/python/ray/air/_internal/remote_storage.py
+++ b/python/ray/air/_internal/remote_storage.py
@@ -146,7 +146,6 @@ def get_fs_and_path(
         return None, None
 
 
-
 def delete_at_uri(uri: str):
     _assert_pyarrow_installed()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

pyarrow can not resolve uri if uri is of the form hdfs:///user_folder/...  It only works with hdfs:///namenode-server/user_folder/...

This diff remove the format dependency of uri given fssspec is installed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
