### PR TITLE
[RLlib; RELEASE BLOCKER] Fix RLlib CLI: e.g. `rllib example run cartpole-ppo` fails.

### DIFF
--- a/doc/source/ray-overview/doc_test/ray_rllib.py
+++ b/doc/source/ray-overview/doc_test/ray_rllib.py
@@ -6,6 +6,6 @@ tuner = tune.Tuner(
     run_config=air.RunConfig(
         stop={"episode_len_mean": 20},
     ),
-    param_space={"env": "CartPole-v0", "framework": "torch", "log_level": "INFO"},
+    param_space={"env": "CartPole-v1", "framework": "torch", "log_level": "INFO"},
 )
 tuner.fit()

--- a/doc/source/rllib/core-concepts.rst
+++ b/doc/source/rllib/core-concepts.rst
@@ -69,7 +69,7 @@ which implements the proximal policy optimization algorithm in RLlib.
 
         # Configure.
         from ray.rllib.algorithms.ppo import PPOConfig
-        config = PPOConfig().environment(env="CartPole-v0").training(train_batch_size=4000)
+        config = PPOConfig().environment(env="CartPole-v1").training(train_batch_size=4000)
 
         # Build.
         algo = config.build()
@@ -87,7 +87,7 @@ which implements the proximal policy optimization algorithm in RLlib.
 
         # Configure.
         from ray.rllib.algorithms.ppo import PPOConfig
-        config = PPOConfig().environment(env="CartPole-v0").training(train_batch_size=4000)
+        config = PPOConfig().environment(env="CartPole-v1").training(train_batch_size=4000)
 
         # Train via Ray Tune.
         tune.run("PPO", config=config)
@@ -97,7 +97,7 @@ which implements the proximal policy optimization algorithm in RLlib.
 
     .. code-block:: bash
 
-        rllib train --run=PPO --env=CartPole-v0 --config='{"train_batch_size": 4000}'
+        rllib train --run=PPO --env=CartPole-v1 --config='{"train_batch_size": 4000}'
 
 
 RLlib `Algorithm classes <rllib-concepts.html#algorithms>`__ coordinate the distributed workflow of running rollouts and optimizing policies.
@@ -160,11 +160,11 @@ Here is an example of creating a set of rollout workers and using them gather ex
 .. code-block:: python
 
     # Setup policy and rollout workers.
-    env = gym.make("CartPole-v0")
+    env = gym.make("CartPole-v1")
     policy = CustomPolicy(env.observation_space, env.action_space, {})
     workers = WorkerSet(
         policy_class=CustomPolicy,
-        env_creator=lambda c: gym.make("CartPole-v0"),
+        env_creator=lambda c: gym.make("CartPole-v1"),
         num_workers=10)
 
     while True:

--- a/doc/source/rllib/rllib-algorithms.rst
+++ b/doc/source/rllib/rllib-algorithms.rst
@@ -93,7 +93,7 @@ with the only difference being the ``beta`` parameter force-set to 0.0. This mak
 BC try to match the behavior policy, which generated the offline data, disregarding any resulting rewards.
 BC requires the `offline datasets API <rllib-offline.html>`__ to be used.
 
-Tuned examples: `CartPole-v0 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/bc/cartpole-bc.yaml>`__
+Tuned examples: `CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/bc/cartpole-bc.yaml>`__
 
 **BC-specific configs** (see also `common configs <rllib-training.html#common-parameters>`__):
 
@@ -113,7 +113,7 @@ The latter becomes increasingly important during bootstrapping in the bellman eq
 To mitigate these issues, CRR implements a simple and yet powerful idea of "value-filtered regression".
 The key idea is to use a learned critic to filter-out the non-promising transitions from the replay dataset. For more details, please refer to the paper (see link above).
 
-Tuned examples: `CartPole-v0 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/crr/cartpole-v0-crr.yaml>`__, `Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/crr/pendulum-v1-crr.yaml>`__
+Tuned examples: `CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/crr/cartpole-v1-crr.yaml>`__, `Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/crr/pendulum-v1-crr.yaml>`__
 
 .. autoclass:: ray.rllib.algorithms.crr.crr.CRRConfig
    :members: training
@@ -152,7 +152,7 @@ MARWIL is a hybrid imitation learning and policy gradient algorithm suitable for
 When the ``beta`` hyperparameter is set to zero, the MARWIL objective reduces to vanilla imitation learning (see `BC`_).
 MARWIL requires the `offline datasets API <rllib-offline.html>`__ to be used.
 
-Tuned examples: `CartPole-v0 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/marwil/cartpole-marwil.yaml>`__
+Tuned examples: `CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/marwil/cartpole-marwil.yaml>`__
 
 **MARWIL-specific configs** (see also `common configs <rllib-training.html#common-parameters>`__):
 
@@ -203,7 +203,7 @@ Unlike APPO or PPO, with DD-PPO policy improvement is no longer done centralized
 
     DD-PPO architecture (both sampling and learning are done on worker GPUs)
 
-Tuned examples: `CartPole-v0 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ddppo/cartpole-ddppo.yaml>`__, `BreakoutNoFrameskip-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ddppo/atari-ddppo.yaml>`__
+Tuned examples: `CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ddppo/cartpole-ddppo.yaml>`__, `BreakoutNoFrameskip-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ddppo/atari-ddppo.yaml>`__
 
 **DDPPO-specific configs** (see also `common configs <rllib-training.html#common-parameters>`__):
 
@@ -384,7 +384,7 @@ We include a vanilla policy gradients implementation as an example algorithm.
 
     Policy gradients architecture (same as A2C)
 
-Tuned examples: `CartPole-v0 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/pg/cartpole-pg.yaml>`__
+Tuned examples: `CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/pg/cartpole-pg.yaml>`__
 
 **PG-specific configs** (see also `common configs <rllib-training.html#common-parameters>`__):
 
@@ -466,7 +466,7 @@ Recurrent Replay Distributed DQN (R2D2)
 `[paper] <https://openreview.net/pdf?id=r1lyTjAqYX>`__ `[implementation] <https://github.com/ray-project/ray/blob/master/rllib/algorithms/r2d2/r2d2.py>`__
 R2D2 can be scaled by increasing the number of workers. All of the DQN improvements evaluated in `Rainbow <https://arxiv.org/abs/1710.02298>`__ are available, though not all are enabled by default.
 
-Tuned examples: `CartPole-v0 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/r2d2/stateless-cartpole-r2d2.yaml>`__
+Tuned examples: `Stateless CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/r2d2/stateless-cartpole-r2d2.yaml>`__
 
 .. _dqn:
 
@@ -567,7 +567,7 @@ Tuned examples (continuous actions):
 `Pendulum-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/sac/pendulum-sac.yaml>`__,
 `HalfCheetah-v3 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/sac/halfcheetah-sac.yaml>`__,
 Tuned examples (discrete actions):
-`CartPole-v0 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/sac/cartpole-sac.yaml>`__
+`CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/sac/cartpole-sac.yaml>`__
 
 **MuJoCo results @3M steps:** `more details <https://github.com/ray-project/rl-experiments>`__
 
@@ -628,7 +628,7 @@ Tuned examples (continuous actions):
 `HalfCheetah <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/mbmpo/halfcheetah-mbmpo.yaml>`__,
 `Hopper <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/mbmpo/hopper-mbmpo.yaml>`__,
 Tuned examples (discrete actions):
-`CartPole-v0 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/mbmpo/cartpole-mbmpo.yaml>`__
+`CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/mbmpo/cartpole-mbmpo.yaml>`__
 
 **MuJoCo results @100K steps:** `more details <https://github.com/ray-project/rl-experiments>`__
 
@@ -655,7 +655,7 @@ Augmented Random Search (ARS)
 `[paper] <https://arxiv.org/abs/1803.07055>`__ `[implementation] <https://github.com/ray-project/ray/blob/master/rllib/algorithms/ars/ars.py>`__
 ARS is a random search method for training linear policies for continuous control problems. Code here is adapted from https://github.com/modestyachts/ARS to integrate with RLlib APIs.
 
-Tuned examples: `CartPole-v0 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ars/cartpole-ars.yaml>`__, `Swimmer-v2 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ars/swimmer-ars.yaml>`__
+Tuned examples: `CartPole-v1 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ars/cartpole-ars.yaml>`__, `Swimmer-v2 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/ars/swimmer-ars.yaml>`__
 
 **ARS-specific configs** (see also `common configs <rllib-training.html#common-parameters>`__):
 

--- a/doc/source/rllib/rllib-concepts.rst
+++ b/doc/source/rllib/rllib-concepts.rst
@@ -161,7 +161,7 @@ We can create an `Algorithm <#algorithms>`__ and try running this policy on a to
             return MyTFPolicy
 
     ray.init()
-    tune.Tuner(MyAlgo, param_space={"env": "CartPole-v0", "num_workers": 2}).fit()
+    tune.Tuner(MyAlgo, param_space={"env": "CartPole-v1", "num_workers": 2}).fit()
 
 
 If you run the above snippet `(runnable file here) <https://github.com/ray-project/ray/blob/master/rllib/examples/custom_tf_policy.py>`__, you'll probably notice that CartPole doesn't learn so well:

--- a/doc/source/rllib/rllib-dev.rst
+++ b/doc/source/rllib/rllib-dev.rst
@@ -99,7 +99,7 @@ After registration, you can run and visualize training progress using ``rllib tr
 
 .. code-block:: bash
 
-    rllib train --run=contrib/RandomAgent --env=CartPole-v0
+    rllib train --run=contrib/RandomAgent --env=CartPole-v1
     tensorboard --logdir=~/ray_results
 
 Debugging your Algorithms

--- a/doc/source/rllib/rllib-env.rst
+++ b/doc/source/rllib/rllib-env.rst
@@ -490,7 +490,7 @@ RLlib provides the `ExternalEnv <https://github.com/ray-project/ray/blob/master/
 Unlike other envs, ExternalEnv has its own thread of control. At any point, agents on that thread can query the current policy for decisions via ``self.get_action()`` and reports rewards, done-dicts, and infos via ``self.log_returns()``.
 This can be done for multiple concurrent episodes as well.
 
-Take a look at the examples here for a `simple "CartPole-v0" server <https://github.com/ray-project/ray/blob/master/rllib/examples/serving/cartpole_server.py>`__
+Take a look at the examples here for a `simple "CartPole-v1" server <https://github.com/ray-project/ray/blob/master/rllib/examples/serving/cartpole_server.py>`__
 and `n client(s) <https://github.com/ray-project/ray/blob/master/rllib/examples/serving/cartpole_client.py>`__
 scripts, in which we setup an RLlib policy server that listens on one or more ports for client connections
 and connect several clients to this server to learn the env.

--- a/doc/source/rllib/rllib-models.rst
+++ b/doc/source/rllib/rllib-models.rst
@@ -229,7 +229,7 @@ Once implemented, your TF model can then be registered and used in place of a bu
     ModelCatalog.register_custom_model("my_tf_model", MyModelClass)
 
     ray.init()
-    algo = ppo.PPO(env="CartPole-v0", config={
+    algo = ppo.PPO(env="CartPole-v1", config={
         "model": {
             "custom_model": "my_tf_model",
             # Extra kwargs to be passed to your model's c'tor.
@@ -284,7 +284,7 @@ Once implemented, your PyTorch model can then be registered and used in place of
     ModelCatalog.register_custom_model("my_torch_model", CustomTorchModel)
 
     ray.init()
-    algo = ppo.PPO(env="CartPole-v0", config={
+    algo = ppo.PPO(env="CartPole-v1", config={
         "framework": "torch",
         "model": {
             "custom_model": "my_torch_model",
@@ -510,7 +510,7 @@ Similar to custom models and preprocessors, you can also specify a custom action
     ModelCatalog.register_custom_action_dist("my_dist", MyActionDist)
 
     ray.init()
-    algo = ppo.PPO(env="CartPole-v0", config={
+    algo = ppo.PPO(env="CartPole-v1", config={
         "model": {
             "custom_action_dist": "my_dist",
         },

--- a/doc/source/rllib/rllib-offline.rst
+++ b/doc/source/rllib/rllib-offline.rst
@@ -25,7 +25,7 @@ In this example, we will save batches of experiences generated during online tra
 
     $ rllib train \
         --run=PG \
-        --env=CartPole-v0 \
+        --env=CartPole-v1 \
         --config='{"output": "/tmp/cartpole-out", "output_max_file_size": 5000000}' \
         --stop='{"timesteps_total": 100000}'
 
@@ -45,7 +45,7 @@ Then, we can tell DQN to train using these previously generated experiences with
 
     $ rllib train \
         --run=DQN \
-        --env=CartPole-v0 \
+        --env=CartPole-v1 \
         --config='{
             "input": "/tmp/cartpole-out",
             "explore": false}'
@@ -89,7 +89,7 @@ As an example, we generate an evaluation dataset for off-policy estimation:
 
     $ rllib train \
         --run=PG \
-        --env=CartPole-v0 \
+        --env=CartPole-v1 \
         --config='{"output": "/tmp/cartpole-eval", "output_max_file_size": 5000000}' \
         --stop='{"timesteps_total": 10000}'
 
@@ -110,7 +110,7 @@ We can now train a DQN algorithm offline and evaluate it using OPE:
 
     config = (
         DQNConfig()
-        .environment(env="CartPole-v0")
+        .environment(env="CartPole-v1")
         .framework("torch")
         .offline_data(input_="/tmp/cartpole-out")
         .evaluation(
@@ -176,7 +176,7 @@ Example: Converting external experiences to batch format
 --------------------------------------------------------
 
 When the env does not support simulation (e.g., it is a web application), it is necessary to generate the ``*.json`` experience batch files outside of RLlib. This can be done by using the `JsonWriter <https://github.com/ray-project/ray/blob/master/rllib/offline/json_writer.py>`__ class to write out batches.
-This `runnable example <https://github.com/ray-project/ray/blob/master/rllib/examples/saving_experiences.py>`__ shows how to generate and save experience batches for CartPole-v0 to disk:
+This `runnable example <https://github.com/ray-project/ray/blob/master/rllib/examples/saving_experiences.py>`__ shows how to generate and save experience batches for CartPole-v1 to disk:
 
 .. literalinclude:: ../../../rllib/examples/saving_experiences.py
    :language: python
@@ -206,7 +206,7 @@ RLlib supports multiplexing inputs from multiple input sources, including simula
 
     $ rllib train \
         --run=DQN \
-        --env=CartPole-v0 \
+        --env=CartPole-v1 \
         --config='{
             "input": {
                 "/tmp/cartpole-out": 0.4,

--- a/doc/source/rllib/rllib-sample-collection.rst
+++ b/doc/source/rllib/rllib-sample-collection.rst
@@ -298,7 +298,7 @@ make these modifications to your batches in your postprocessing function:
         # Modify view_requirements in the Policy object.
         action_space = Discrete(2)
         rollout_worker = RolloutWorker(
-            env_creator=lambda _: gym.make("CartPole-v0"),
+            env_creator=lambda _: gym.make("CartPole-v1"),
             policy_config=ppo.DEFAULT_CONFIG,
             policy_spec=ppo.PPOTorchPolicy,
         )

--- a/doc/source/rllib/rllib-training.rst
+++ b/doc/source/rllib/rllib-training.rst
@@ -572,7 +572,7 @@ traces to ``/tmp/debug``.
 
 .. code-block:: bash
 
-    rllib train --run=PPO --env=CartPole-v0 \
+    rllib train --run=PPO --env=CartPole-v1 \
         --config='{"output": "/tmp/debug", "output_compress_columns": []}'
 
     # episode traces will be saved in /tmp/debug, for example

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -253,7 +253,7 @@ py_test(
    name = "learning_tests_pendulum_crr",
    main = "tests/run_regression_tests.py",
    tags = ["team:rllib", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
-   size = "medium",
+   size = "large",
    srcs = ["tests/run_regression_tests.py"],
    # Include an offline json data file as well.
    data = [
@@ -281,7 +281,7 @@ py_test(
     name = "learning_tests_cartpole_crr_expectation",
     main = "tests/run_regression_tests.py",
     tags = ["team:rllib", "torch_only", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
-    size = "medium",
+    size = "large",
     srcs = ["tests/run_regression_tests.py"],
     # Include an offline json data file as well.
     data = [

--- a/rllib/common.py
+++ b/rllib/common.py
@@ -36,7 +36,7 @@ def get_file_type(config_file: str) -> SupportedFileType:
         raise ValueError(
             "Unknown file type for config "
             "file: {}. Supported extensions: .py, "
-            "yml, yaml.".format(config_file)
+            ".yml, .yaml".format(config_file)
         )
     return file_type
 

--- a/rllib/common.py
+++ b/rllib/common.py
@@ -28,9 +28,9 @@ class SupportedFileType(str, Enum):
 
 
 def get_file_type(config_file: str) -> SupportedFileType:
-    if ".py" in config_file:
+    if config_file.endswith(".py"):
         file_type = SupportedFileType.python
-    elif ".yaml" in config_file or ".yml" in config_file:
+    elif config_file.endswith(".yaml") or config_file.endswith(".yml"):
         file_type = SupportedFileType.yaml
     else:
         raise ValueError(
@@ -77,7 +77,14 @@ def download_example_file(
         example_url = base_url + example_file if base_url else example_file
         print(f">>> Attempting to download example file {example_url}...")
 
-        temp_file = tempfile.NamedTemporaryFile()
+        file_type = get_file_type(example_url)
+        if file_type == SupportedFileType.yaml:
+            temp_file = tempfile.NamedTemporaryFile(suffix=".yaml")
+        else:
+            assert (
+                file_type == SupportedFileType.python
+            ), f"`example_url` ({example_url}) must be a python or yaml file!"
+            temp_file = tempfile.NamedTemporaryFile(suffix=".py")
 
         r = requests.get(example_url)
         with open(temp_file.name, "wb") as f:

--- a/rllib/scripts.py
+++ b/rllib/scripts.py
@@ -100,7 +100,7 @@ def run(example_id: str = typer.Argument(..., help="Example ID to run.")):
     example = EXAMPLES[example_id]
     example_file = get_example_file(example_id)
     example_file, temp_file = download_example_file(example_file)
-    stop = example.get("stop", "{}")
+    stop = example.get("stop")
 
     train_module.file(
         config_file=example_file,

--- a/rllib/tests/test_rllib_train_and_evaluate.py
+++ b/rllib/tests/test_rllib_train_and_evaluate.py
@@ -283,7 +283,7 @@ class TestCLISmokeTests(unittest.TestCase):
         assert os.popen(f"python {rllib_dir}/scripts.py example list -f=ppo").read()
         assert os.popen(f"python {rllib_dir}/scripts.py example get atari-a2c").read()
         assert os.popen(
-            f"python {rllib_dir}/scripts.py example run cartpole-ppo"
+            f"python {rllib_dir}/scripts.py example run cartpole-simpleq-test"
         ).read()
 
     def test_yaml_run(self):

--- a/rllib/tests/test_rllib_train_and_evaluate.py
+++ b/rllib/tests/test_rllib_train_and_evaluate.py
@@ -282,6 +282,9 @@ class TestCLISmokeTests(unittest.TestCase):
         assert os.popen(f"python {rllib_dir}/scripts.py example list").read()
         assert os.popen(f"python {rllib_dir}/scripts.py example list -f=ppo").read()
         assert os.popen(f"python {rllib_dir}/scripts.py example get atari-a2c").read()
+        assert os.popen(
+            f"python {rllib_dir}/scripts.py example run cartpole-ppo"
+        ).read()
 
     def test_yaml_run(self):
         assert os.popen(

--- a/rllib/train.py
+++ b/rllib/train.py
@@ -79,7 +79,7 @@ def load_experiments_from_file(
         The experiments dict ready to be passed into `tune.run_experiments()`.
     """
 
-    #
+    # Yaml file
     if file_type == SupportedFileType.yaml:
         with open(config_file) as f:
             experiments = yaml.safe_load(f)
@@ -127,7 +127,7 @@ def file(
     # File-based arguments.
     config_file: str = cli.ConfigFile,
     # stopping conditions
-    stop: str = cli.Stop,
+    stop: Optional[str] = cli.Stop,
     # Checkpointing
     checkpoint_freq: int = cli.CheckpointFreq,
     checkpoint_at_end: bool = cli.CheckpointAtEnd,

--- a/rllib/tuned_examples/simple_q/cartpole-simpleq-test.yaml
+++ b/rllib/tuned_examples/simple_q/cartpole-simpleq-test.yaml
@@ -2,7 +2,7 @@ cartpole-simpleq-test:
     env: CartPole-v1
     run: SimpleQ
     stop:
-        episode_reward_mean: 150
-        timesteps_total: 50000
+        episode_reward_mean: 50.0
+        timesteps_total: 10000
     config:
         framework: tf


### PR DESCRIPTION
Signed-off-by: sven1977 <svenmika1977@gmail.com>

Fix RLlib CLI: e.g. `rllib example run cartpole-ppo` fails.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
