### PR TITLE
[RLlib; RELEASE BLOCKER] Fix RLlib CLI: e.g. `rllib example run cartpole-ppo` raises an error.

### DIFF
--- a/rllib/common.py
+++ b/rllib/common.py
@@ -36,7 +36,7 @@ def get_file_type(config_file: str) -> SupportedFileType:
         raise ValueError(
             "Unknown file type for config "
             "file: {}. Supported extensions: .py, "
-            "yml, yaml.".format(config_file)
+            ".yml, .yaml".format(config_file)
         )
     return file_type
 

--- a/rllib/common.py
+++ b/rllib/common.py
@@ -28,9 +28,9 @@ class SupportedFileType(str, Enum):
 
 
 def get_file_type(config_file: str) -> SupportedFileType:
-    if ".py" in config_file:
+    if config_file.endswith(".py"):
         file_type = SupportedFileType.python
-    elif ".yaml" in config_file or ".yml" in config_file:
+    elif config_file.endswith(".yaml") or config_file.endswith(".yml"):
         file_type = SupportedFileType.yaml
     else:
         raise ValueError(
@@ -77,7 +77,14 @@ def download_example_file(
         example_url = base_url + example_file if base_url else example_file
         print(f">>> Attempting to download example file {example_url}...")
 
-        temp_file = tempfile.NamedTemporaryFile()
+        file_type = get_file_type(example_url)
+        if file_type == SupportedFileType.yaml:
+            temp_file = tempfile.NamedTemporaryFile(suffix=".yaml")
+        else:
+            assert (
+                file_type == SupportedFileType.python
+            ), f"`example_url` ({example_url}) must be a python or yaml file!"
+            temp_file = tempfile.NamedTemporaryFile(suffix=".py")
 
         r = requests.get(example_url)
         with open(temp_file.name, "wb") as f:

--- a/rllib/scripts.py
+++ b/rllib/scripts.py
@@ -100,7 +100,7 @@ def run(example_id: str = typer.Argument(..., help="Example ID to run.")):
     example = EXAMPLES[example_id]
     example_file = get_example_file(example_id)
     example_file, temp_file = download_example_file(example_file)
-    stop = example.get("stop", "{}")
+    stop = example.get("stop")
 
     train_module.file(
         config_file=example_file,

--- a/rllib/tests/test_rllib_train_and_evaluate.py
+++ b/rllib/tests/test_rllib_train_and_evaluate.py
@@ -283,7 +283,7 @@ class TestCLISmokeTests(unittest.TestCase):
         assert os.popen(f"python {rllib_dir}/scripts.py example list -f=ppo").read()
         assert os.popen(f"python {rllib_dir}/scripts.py example get atari-a2c").read()
         assert os.popen(
-            f"python {rllib_dir}/scripts.py example run cartpole-ppo"
+            f"python {rllib_dir}/scripts.py example run cartpole-simpleq-test"
         ).read()
 
     def test_yaml_run(self):

--- a/rllib/tests/test_rllib_train_and_evaluate.py
+++ b/rllib/tests/test_rllib_train_and_evaluate.py
@@ -282,6 +282,9 @@ class TestCLISmokeTests(unittest.TestCase):
         assert os.popen(f"python {rllib_dir}/scripts.py example list").read()
         assert os.popen(f"python {rllib_dir}/scripts.py example list -f=ppo").read()
         assert os.popen(f"python {rllib_dir}/scripts.py example get atari-a2c").read()
+        assert os.popen(
+            f"python {rllib_dir}/scripts.py example run cartpole-ppo"
+        ).read()
 
     def test_yaml_run(self):
         assert os.popen(

--- a/rllib/train.py
+++ b/rllib/train.py
@@ -79,7 +79,7 @@ def load_experiments_from_file(
         The experiments dict ready to be passed into `tune.run_experiments()`.
     """
 
-    #
+    # Yaml file
     if file_type == SupportedFileType.yaml:
         with open(config_file) as f:
             experiments = yaml.safe_load(f)
@@ -127,7 +127,7 @@ def file(
     # File-based arguments.
     config_file: str = cli.ConfigFile,
     # stopping conditions
-    stop: str = cli.Stop,
+    stop: Optional[str] = cli.Stop,
     # Checkpointing
     checkpoint_freq: int = cli.CheckpointFreq,
     checkpoint_at_end: bool = cli.CheckpointAtEnd,

--- a/rllib/tuned_examples/simple_q/cartpole-simpleq-test.yaml
+++ b/rllib/tuned_examples/simple_q/cartpole-simpleq-test.yaml
@@ -2,7 +2,7 @@ cartpole-simpleq-test:
     env: CartPole-v1
     run: SimpleQ
     stop:
-        episode_reward_mean: 150
-        timesteps_total: 50000
+        episode_reward_mean: 50.0
+        timesteps_total: 10000
     config:
         framework: tf


### PR DESCRIPTION
Signed-off-by: sven1977 <svenmika1977@gmail.com>

Fix RLlib CLI: e.g. `rllib example run cartpole-ppo` raises an error.

The fix is to give a proper file extension to temporary RLlib example config files downloaded from our github repo (instead of leaving these temp files w/o any extension). This way, our CLI code can properly detect whether the downloaded file is py or yaml.

Added a test case for this scenario.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
