### PR TITLE
[Test Only Dont Land] ray2 upgrade raydata remote resouce args commit with remote_storage.p…

### DIFF
--- a/python/ray/air/_internal/remote_storage.py
+++ b/python/ray/air/_internal/remote_storage.py
@@ -107,7 +107,7 @@ def get_fs_and_path(
         _cached_fs[cache_key] = fs
         print(f'get_fs_and_path 2 {time.time()} uri:{uri} parsed:{parsed} path:{path} cache_key:{cache_key} _cached_fs:{_cached_fs} fs:{fs}')
         return fs, path
-    except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowNotImplementedError, Exception):
+    except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowNotImplementedError, Exception) as e:
         print(f'get_fs_and_path pyarrow.fs.FileSystem.from_uri throw e:{e} of type_e:{type(e)} for uri:{uri} ')
         # Raised when URI not recognized
         if not fsspec:

--- a/python/ray/air/_internal/remote_storage.py
+++ b/python/ray/air/_internal/remote_storage.py
@@ -34,7 +34,8 @@ except (ImportError, ModuleNotFoundError):
     _CustomGCSHandler = None
 
 from ray import logger
-
+import time
+FILE_READING_RETRY = 5
 
 def _assert_pyarrow_installed():
     if pyarrow is None:
@@ -82,6 +83,8 @@ _cached_fs = {}
 def get_fs_and_path(
     uri: str,
 ) -> Tuple[Optional["pyarrow.fs.FileSystem"], Optional[str]]:
+
+    print(f'get_fs_and_path 0 {time.time()} uri:{uri}')
     if not pyarrow:
         return None, None
 
@@ -89,31 +92,23 @@ def get_fs_and_path(
     path = parsed.netloc + parsed.path
 
     cache_key = (parsed.scheme, parsed.netloc)
-
     if cache_key in _cached_fs:
         fs = _cached_fs[cache_key]
+        print(f'get_fs_and_path 1 {time.time()}  uri:{uri} parsed:{parsed} path:{path} cache_key:{cache_key} _cached_fs:{_cached_fs} fs:{fs}')
         return fs, path
 
     try:
         # in case of hdfs filesystem, if uri don't have the netloc part below will
         # failed with hdfs access error.  For example 'hdfs:///user_folder/...' will
         # fail, while only 'hdfs://namenode_server/user_foler/...' will work
-        if parsed.scheme == "hdfs" and parsed.netloc == "":
-            raise Exception(
-                "pyarrow.fs.FileSystem.from_uri(uri) require uri to specify netloc"
-            )
+        if parsed.scheme=='hdfs' and parsed.netloc=='':
+            raise Exception('pyarrow.fs.FileSystem.from_uri(uri) require uri to specify netloc')
         fs, path = pyarrow.fs.FileSystem.from_uri(uri)
         _cached_fs[cache_key] = fs
+        print(f'get_fs_and_path 2 {time.time()} uri:{uri} parsed:{parsed} path:{path} cache_key:{cache_key} _cached_fs:{_cached_fs} fs:{fs}')
         return fs, path
-    except (
-        pyarrow.lib.ArrowInvalid,
-        pyarrow.lib.ArrowNotImplementedError,
-        Exception,
-    ) as e:
-        print(
-            f"get_fs_and_path pyarrow.fs.FileSystem.from_uri "
-            f"throw e:{e} of type:{type(e)} for uri:{uri}."
-        )
+    except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowNotImplementedError, Exception):
+        print(f'get_fs_and_path pyarrow.fs.FileSystem.from_uri throw e:{e} of type_e:{type(e)} for uri:{uri} ')
         # Raised when URI not recognized
         if not fsspec:
             # Only return if fsspec is not installed
@@ -153,7 +148,7 @@ def get_fs_and_path(
 
     fs = pyarrow.fs.PyFileSystem(fsspec_handler(fsspec_fs))
     _cached_fs[cache_key] = fs
-
+    print(f'get_fs_and_path 3 {time.time()} uri:{uri} parsed:{parsed} path:{path} cache_key:{cache_key} _cached_fs:{_cached_fs} fs:{fs}')
     return fs, path
 
 
@@ -189,6 +184,67 @@ def read_file_from_uri(uri: str) -> bytes:
         return file.read()
 
 
+# Visible for test mocking.
+def _copy_files(src, des, source_filesystem=None, destination_filesystem=None):
+    pyarrow.fs.copy_files(
+        src,
+        des,
+        source_filesystem=source_filesystem,
+        destination_filesystem=destination_filesystem,
+    )
+
+
+# This retry helps when the upstream datasource is not able to handle
+# overloaded write request or failed with some retriable failures.
+# For example when copying data from HA hdfs service to local disk or vice versa,
+# hdfs might lose connection for some unknown reason expecially when
+# simutaneously running many ray tuning jobs
+# Such failure can be restored with some waiting and retry.
+def _copy_files_with_retry(src, des, source_filesystem=None, destination_filesystem=None):
+    min_interval = 0
+    final_exception = None
+    for i in range(FILE_READING_RETRY):
+        try:
+            return _copy_files(
+                src,
+                des,
+                source_filesystem=source_filesystem,
+                destination_filesystem=destination_filesystem,
+            )
+        except Exception as e:
+            import random
+            import time
+            retry_timing = (
+                ""
+                if i == FILE_READING_RETRY - 1
+                else (f"Retry after {min_interval} sec. ")
+            )
+            log_only_show_in_1st_retry = (
+                ""
+                if i
+                else (
+                    f"If earlier read attempt threw certain Exception"
+                    f", it may or may not be an issue depends on these retries "
+                    f"succeed or not."
+                )
+            )
+            logger.exception(
+                f"{i + 1}th attempt to pyarrow.fs.copy_files failed "
+                f"{retry_timing}"
+                f"{log_only_show_in_1st_retry}"
+            )
+            if not min_interval:
+                # to make retries of different process hit hdfs server
+                # at slightly different time
+                min_interval = (1 + random.random()) * 10
+            # exponential backoff at
+            # 10, 20, 40, 80, 160 seconds
+            time.sleep(min_interval)
+            min_interval = min_interval * 2
+            final_exception = e
+    raise final_exception
+
+
 def download_from_uri(uri: str, local_path: str, filelock: bool = True):
     _assert_pyarrow_installed()
 
@@ -199,35 +255,65 @@ def download_from_uri(uri: str, local_path: str, filelock: bool = True):
             f"URI `{uri}` is not a valid or supported cloud target. "
             f"Hint: {fs_hint(uri)}"
         )
-
+    file_infos = fs.get_file_info(pyarrow.fs.FileSelector(bucket_path, allow_not_found=True, recursive=True))
+    print(f'download_from_uri get_file_info remote location  {time.time()} file_infos:{file_infos}')
     if filelock:
         with TempFileLock(f"{os.path.normpath(local_path)}.lock"):
-            pyarrow.fs.copy_files(bucket_path, local_path, source_filesystem=fs)
+            # pyarrow.fs.copy_files(bucket_path, local_path, source_filesystem=fs)
+            _copy_files_with_retry(bucket_path, local_path, source_filesystem=fs)
     else:
-        pyarrow.fs.copy_files(bucket_path, local_path, source_filesystem=fs)
+        # pyarrow.fs.copy_files(bucket_path, local_path, source_filesystem=fs)
+        _copy_files_with_retry(bucket_path, local_path, source_filesystem=fs)
 
 
 def upload_to_uri(
     local_path: str, uri: str, exclude: Optional[List[str]] = None
 ) -> None:
+    import os
+    print(f'upload_to_uri 0 {time.time()} uri:{uri} local_path:{local_path} pyarrow.__version__:{pyarrow.__version__} pyarrow.__file__:{pyarrow.__file__}')
     _assert_pyarrow_installed()
 
+    # from remote_pdb import RemotePdb
+    # RemotePdb('localhost', 4445).set_trace()
+
     fs, bucket_path = get_fs_and_path(uri)
+    #time.sleep(10)
     if not fs:
         raise ValueError(
             f"Could not upload to URI: "
             f"URI `{uri}` is not a valid or supported cloud target. "
             f"Hint: {fs_hint(uri)}"
         )
+    # path2 = 'hdfs:///user/yud/canvas/workspaces/platforms.maps.postprocessing.deepeta.pipelines.v6.prod/variables/72445241/value/value.parquet'
+    # path2 = '/user/yud/canvas/workspaces/platforms.uberai.michelangelo.ma_integration_test.pipelines.boston_housing.raytune_xgboost_base/operators/96ca6a8f/tmp/trainable_2022-11-21_02-11-23'
+    # print(f'upload_to_uri 1 {time.time()} bucket_path:{bucket_path} path2:{path2} fs:{fs}')
+
+    # time.sleep(15)
+    # file_infos = fs.get_file_info(pyarrow.fs.FileSelector(path2, allow_not_found=True, recursive=True))
+    # time.sleep(1)
+    # print(f'upload_to_uri 2 {time.time()} file_infos:{file_infos} now check fileinfo2')
+
+    time.sleep(15)
+    file_infos2 = fs.get_file_info(pyarrow.fs.FileSelector(bucket_path, allow_not_found=True, recursive=True))
+    time.sleep(1)
+    print(f'upload_to_uri 3 {time.time()} file_infos2:{file_infos2}')
 
     if not exclude:
-        pyarrow.fs.copy_files(local_path, bucket_path, destination_filesystem=fs)
+        print(f'upload_to_uri 10 {time.time()} fs:{fs} bucket_path:{bucket_path} uri:{uri} local_path:{local_path}')
+        time.sleep(15)
+        # pyarrow.fs.copy_files(local_path, bucket_path, destination_filesystem=fs)
+        _copy_files_with_retry(local_path, bucket_path, destination_filesystem=fs)
+        print(f'upload_to_uri 20 after pyarrow.fs.copy_files {time.time()} fs:{fs} bucket_path:{bucket_path} uri:{uri} local_path:{local_path}')
         return
 
     # Else, walk and upload
-    return _upload_to_uri_with_exclude(
+    print(f'upload_to_uri 30 {time.time()} fs:{fs} bucket_path:{bucket_path} uri:{uri} local_path:{local_path} exclude:{exclude}')
+    time.sleep(15)
+    _upload_to_uri_with_exclude(
         local_path=local_path, fs=fs, bucket_path=bucket_path, exclude=exclude
     )
+    print(f'upload_to_uri 40 after _upload_to_uri_with_exclude {time.time()} fs:{fs} bucket_path:{bucket_path} uri:{uri} local_path:{local_path} exclude:{exclude}')
+
 
 
 def _upload_to_uri_with_exclude(
@@ -240,6 +326,8 @@ def _upload_to_uri_with_exclude(
         return False
 
     for root, dirs, files in os.walk(local_path):
+        print(f'_upload_to_uri_with_exclude doing root:{root}  dirs:{dirs} files:{files}')
+
         rel_root = os.path.relpath(root, local_path)
         for file in files:
             candidate = os.path.join(rel_root, file)
@@ -249,10 +337,16 @@ def _upload_to_uri_with_exclude(
 
             full_source_path = os.path.normpath(os.path.join(local_path, candidate))
             full_target_path = os.path.normpath(os.path.join(bucket_path, candidate))
+            try:
+                print(f'_upload_to_uri_with_exclude copy full_source_path:{full_source_path} full_target_path:{full_target_path} candidate:{candidate} ')
+                # pyarrow.fs.copy_files(
+                #     full_source_path, full_target_path, destination_filesystem=fs
+                # )
+                _copy_files_with_retry(full_source_path, full_target_path, destination_filesystem=fs)
+            except Exception as e:
+                print(f'candidate:{candidate} failed with e:{e}')
 
-            pyarrow.fs.copy_files(
-                full_source_path, full_target_path, destination_filesystem=fs
-            )
+    print(f'_upload_to_uri_with_exclude 2 after copy {time.time()} fs:{fs} full_source_path:{full_source_path} full_target_path:{full_target_path} exclude:{exclude}')
 
 
 def list_at_uri(uri: str) -> List[str]:


### PR DESCRIPTION
ray2 upgrade raydata remote resouce args commit with remote_storage.py fix for e2e testing

Signed-off-by: Di Yu <yud@uber.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change contains the master up to the commit 
commit fcc0086154154847af9a26b8e09b60d678274ff6
Author: Jian Xiao <99709935+jianoaix@users.noreply.github.com>
Date:   Thu Oct 20 09:45:43 2022 -0700
    Support custom resource with remote args in random_shuffle_each_window() (#29482)
    Followup of #29276

and on top of this applied remote_storage.py fix to allow pyarrow avoid failing with short hdfs uri link.


<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
