### PR TITLE
Offline dataset refactor

### DIFF
--- a/python/requirements/ml/requirements_rllib.txt
+++ b/python/requirements/ml/requirements_rllib.txt
@@ -42,5 +42,3 @@ onnxruntime==1.12.0
 tf2onnx==1.12.1
 typer==0.6.1
 rich==12.0.1
-# For using Ray Datasets in Offline API.
-pyarrow==6.0.1

--- a/python/requirements/ml/requirements_rllib.txt
+++ b/python/requirements/ml/requirements_rllib.txt
@@ -42,3 +42,5 @@ onnxruntime==1.12.0
 tf2onnx==1.12.1
 typer==0.6.1
 rich==12.0.1
+# For using Ray Datasets in Offline API.
+pyarrow==6.0.1

--- a/rllib/offline/dataset_reader.py
+++ b/rllib/offline/dataset_reader.py
@@ -41,10 +41,10 @@ def _unzip_if_needed(paths: List[str], format: str):
             try:
                 _unzip_this_path(str(path), extract_path)
             except FileNotFoundError:
-                # intrepreted as a relative path to rllib folder
+                # interpreted as a relative path to rllib folder
                 try:
                     # TODO: remove this later when we replace all tests with s3 paths
-                    _unzip_this_path(Path(__file__).parent.parent / path, extract_path)
+                    _unzip_this_path(Path(__file__).parents[1] / path, extract_path)
                 except FileNotFoundError:
                     raise FileNotFoundError(f"File not found: {path}")
 
@@ -58,10 +58,10 @@ def _unzip_if_needed(paths: List[str], format: str):
                 ret_paths.append(path)
             else:
                 if not Path(path).exists():
-                    relative_path = str(Path(__file__).parent.parent / path)
-                    if not Path(relative_path).exists():
+                    relative_path = Path(__file__).parents[1] / path
+                    if not relative_path.exists():
                         raise FileNotFoundError(f"File not found: {path}")
-                    path = relative_path
+                    path = str(relative_path)
                 ret_paths.append(path)
     return ret_paths
 

--- a/rllib/offline/dataset_writer.py
+++ b/rllib/offline/dataset_writer.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 pa = try_import_arrow()
 
+
 @PublicAPI
 class DatasetWriter(OutputWriter):
     """Writer object that saves experiences using Datasets."""

--- a/rllib/offline/dataset_writer.py
+++ b/rllib/offline/dataset_writer.py
@@ -52,7 +52,7 @@ class DatasetWriter(OutputWriter):
 
         self.format = output_config["format"]
         parsed_path = urllib.parse.urlparse(output_config["path"])
-        self.is_filepath = self.parsed_path.scheme == ""
+        self.is_filepath = parsed_path.scheme == ""
         if self.is_filepath:
             # In case of a true file path resolve it.
             self.path = pathlib.Path(parsed_path.path).expanduser().resolve()

--- a/rllib/offline/dataset_writer.py
+++ b/rllib/offline/dataset_writer.py
@@ -51,7 +51,7 @@ class DatasetWriter(OutputWriter):
         ), "output_config.path must be specified when using Dataset output."
 
         self.format = output_config["format"]
-        parsed_path = urllib.urlparse(output_config["path"])
+        parsed_path = urllib.parse.urlparse(output_config["path"])
         self.is_filepath = self.parsed_path.scheme == ""
         if self.is_filepath:
             # In case of a true file path resolve it.

--- a/rllib/offline/dataset_writer.py
+++ b/rllib/offline/dataset_writer.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import pathlib
 import time
 
@@ -51,7 +50,7 @@ class DatasetWriter(OutputWriter):
         ), "output_config.path must be specified when using Dataset output."
 
         self.format = output_config["format"]
-        self.path = pathlib.Path(output_config["path"]).expanduser().resolve()
+        self.path = pathlib.Path(output_config["path"]).expanduser().resolve()      
         self.max_num_samples_per_file = (
             output_config["max_num_samples_per_file"]
             if "max_num_samples_per_file" in output_config

--- a/rllib/offline/dataset_writer.py
+++ b/rllib/offline/dataset_writer.py
@@ -50,7 +50,7 @@ class DatasetWriter(OutputWriter):
         ), "output_config.path must be specified when using Dataset output."
 
         self.format = output_config["format"]
-        self.path = pathlib.Path(output_config["path"]).expanduser().resolve()      
+        self.path = pathlib.Path(output_config["path"]).expanduser().resolve()
         self.max_num_samples_per_file = (
             output_config["max_num_samples_per_file"]
             if "max_num_samples_per_file" in output_config

--- a/rllib/offline/dataset_writer.py
+++ b/rllib/offline/dataset_writer.py
@@ -8,11 +8,13 @@ from ray.rllib.offline.io_context import IOContext
 from ray.rllib.offline.json_writer import _to_json_dict
 from ray.rllib.offline.output_writer import OutputWriter
 from ray.rllib.utils.annotations import override, PublicAPI
+from ray.rllib.utils.offline import try_import_arrow
 from ray.rllib.utils.typing import SampleBatchType
 from typing import Dict, List
 
 logger = logging.getLogger(__name__)
 
+pa = try_import_arrow()
 
 @PublicAPI
 class DatasetWriter(OutputWriter):

--- a/rllib/offline/dataset_writer.py
+++ b/rllib/offline/dataset_writer.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 import time
 
 from ray import data
@@ -50,7 +51,7 @@ class DatasetWriter(OutputWriter):
         ), "output_config.path must be specified when using Dataset output."
 
         self.format = output_config["format"]
-        self.path = os.path.abspath(os.path.expanduser(output_config["path"]))
+        self.path = pathlib.Path(output_config["path"]).expanduser().resolve()
         self.max_num_samples_per_file = (
             output_config["max_num_samples_per_file"]
             if "max_num_samples_per_file" in output_config

--- a/rllib/offline/tests/test_dataset_reader.py
+++ b/rllib/offline/tests/test_dataset_reader.py
@@ -23,7 +23,10 @@ class TestDatasetReader(unittest.TestCase):
         #  credentials issues, using a local file instead for now.
 
         # cls.dset_path = "s3://air-example-data/rllib/cartpole/large.json"
-        cls.dset_path = "tests/data/pendulum/large.json"
+        Path(__file__).parents[2] / "tests/data/pendulum/large.json"
+        cls.dset_path = (
+            Path("rllib/tests/data/pendulum/large.json").resolve().as_posix()
+        )
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -162,9 +165,7 @@ class TestUnzipIfNeeded(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.s3_path = "s3://air-example-data/rllib/pendulum"
         cls.relative_path = "tests/data/pendulum"
-        cls.absolute_path = str(
-            Path(__file__).parent.parent.parent / "tests" / "data" / "pendulum"
-        )
+        cls.absolute_path = str(Path(__file__).parents[2] / cls.relative_path)
 
     # @TODO: unskip when this is fixed
     @pytest.mark.skip(reason="Shouldn't hit S3 in CI")
@@ -236,7 +237,7 @@ class TestUnzipIfNeeded(unittest.TestCase):
     def test_relative_json(self):
         """Tests whether the unzip_if_needed function works correctly on relative json
         files"""
-        # this should work regardless of where th current working directory is.
+        # this should work regardless of where the current working directory is.
         with tempfile.TemporaryDirectory() as tmp_dir:
             cwdir = os.getcwd()
             os.chdir(tmp_dir)
@@ -244,14 +245,10 @@ class TestUnzipIfNeeded(unittest.TestCase):
                 [str(Path(self.relative_path) / "large.json")], "json"
             )
             self.assertEqual(
-                os.path.realpath(str(Path(unzipped_paths[0]).absolute())),
-                os.path.realpath(
-                    str(
-                        Path(__file__).parent.parent.parent
-                        / self.relative_path
-                        / "large.json"
-                    )
-                ),
+                Path(unzipped_paths[0]).resolve(),
+                (
+                    Path(__file__).parents[2] / self.relative_path / "large.json"
+                ).resolve(),
             )
 
             assert all(Path(fpath).exists() for fpath in unzipped_paths)

--- a/rllib/utils/offline.py
+++ b/rllib/utils/offline.py
@@ -1,0 +1,34 @@
+import logging
+import os
+
+from ray.rllib.utils.annotations import PublicAPI
+
+logger = logging.getLogger(__name__)
+
+@PublicAPI
+def try_import_arrow(error: bool = False):
+    """Tries importing Arrow and returns the module.
+    
+    Args: 
+        error: Whether to raise an error if pyarrow cannot be
+               imported.
+
+    Returns:
+        The pyarrow module
+          
+    Raises:
+        ImportError: If error=True and pyarrow is not insntalled.        
+    """
+    if "RLLIB_TEST_NO_ARROW_IMPORT" in os.environ:
+        logger.warning("Not importing Arrow for test purposes.")
+        return None
+
+    try:
+        # TODO: Might need pyarrow==6.0.1
+        import pyarrow as pa
+
+        return pa
+    except ImportError as e:
+        if error:
+            raise e
+        return None

--- a/rllib/utils/offline.py
+++ b/rllib/utils/offline.py
@@ -5,19 +5,20 @@ from ray.rllib.utils.annotations import PublicAPI
 
 logger = logging.getLogger(__name__)
 
+
 @PublicAPI
 def try_import_arrow(error: bool = False):
     """Tries importing Arrow and returns the module.
-    
-    Args: 
+
+    Args:
         error: Whether to raise an error if pyarrow cannot be
                imported.
 
     Returns:
         The pyarrow module
-          
+
     Raises:
-        ImportError: If error=True and pyarrow is not insntalled.        
+        ImportError: If error=True and pyarrow is not insntalled.
     """
     if "RLLIB_TEST_NO_ARROW_IMPORT" in os.environ:
         logger.warning("Not importing Arrow for test purposes.")


### PR DESCRIPTION
## Why are these changes needed?

I ran into problems when using the `Offline API` with the older `JsonWriter` setup when trying to use the `output_config` with a custom output directory in `path`. I saw the recommended `DatasetReader` and ran with this and immediately into an error as `pyarrow` was not installed. So I added `pyarrow` to the `requirements_rllib.txt` to get automatically installed for a user when installing "ray[rllib]". 

I further saw that `DataWriter` could simply use `pathlib` and work more safely with objects instead of strings. 

There is no test for the `DatasetWriter` - we should write one. So I ran the `test_dataset_reader.py`. That had problems with `_unzip_if_needed()` using relative paths. I fixed this again with using `pathlib` and refactored some further lines in `test_dataset_reader.py`. 

IMO we should use for the complete code in `DatasetReader` the `pathlib` module. Take a string path from a user and convert it to a `Path` object and only when returning a path it should be converted back to a string path again.
 
## Related issue number
None

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
