### PR TITLE
[Flaky]Try to fix flaky test: test_job_agent

### DIFF
--- a/dashboard/modules/job/tests/test_job_agent.py
+++ b/dashboard/modules/job/tests/test_job_agent.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 from functools import partial
 import pytest
+import psutil
 import yaml
 
 from ray._private.gcs_utils import GcsAioClient
@@ -45,7 +46,24 @@ EVENT_LOOP = get_or_create_event_loop()
 
 
 @pytest.fixture
-def job_sdk_client():
+def make_sure_dashboard_http_port_unused():
+    for process in psutil.process_iter():
+        should_kill = False
+        try:
+            for conn in process.connections():
+                if conn.laddr.port == DEFAULT_DASHBOARD_AGENT_LISTEN_PORT:
+                    should_kill = True
+                    break
+        except psutil.AccessDenied:
+            continue
+        if should_kill:
+            process.kill()
+            process.wait()
+    yield
+
+
+@pytest.fixture
+def job_sdk_client(make_sure_dashboard_http_port_unused):
     with _ray_start(include_dashboard=True, num_cpus=1) as ctx:
         ip, _ = ctx.address_info["webui_url"].split(":")
         agent_address = f"{ip}:{DEFAULT_DASHBOARD_AGENT_LISTEN_PORT}"
@@ -380,7 +398,10 @@ async def test_tail_job_logs_with_echo(job_sdk_client):
     indirect=True,
 )
 async def test_job_log_in_multiple_node(
-    enable_test_module, disable_aiohttp_cache, ray_start_cluster_head
+    make_sure_dashboard_http_port_unused,
+    enable_test_module,
+    disable_aiohttp_cache,
+    ray_start_cluster_head,
 ):
     cluster = ray_start_cluster_head
     assert wait_until_server_available(cluster.webui_url) is True

--- a/dashboard/modules/job/tests/test_job_agent.py
+++ b/dashboard/modules/job/tests/test_job_agent.py
@@ -54,11 +54,14 @@ def make_sure_dashboard_http_port_unused():
                 if conn.laddr.port == DEFAULT_DASHBOARD_AGENT_LISTEN_PORT:
                     should_kill = True
                     break
-        except psutil.AccessDenied:
+        except Exception:
             continue
         if should_kill:
-            process.kill()
-            process.wait()
+            try:
+                process.kill()
+                process.wait()
+            except Exception:
+                pass
     yield
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Since the agent process will listen to the fixed port DEFAULT_DASHBOARD_AGENT_LISTEN_PORT, but the agent process on the last test may not exit in time (this is killing itself by observing whether the raylet is dead)

fix: try to find the process which listens to port DEFAULT_DASHBOARD_AGENT_LISTEN_PORT and kills this process to make sure the next test's agent can listen to port DEFAULT_DASHBOARD_AGENT_LISTEN_PORT

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
