### PR TITLE
In TorchScript all Tracer Warnings should be sorted out in order to b…

### DIFF
--- a/rllib/utils/torch_ops.py
+++ b/rllib/utils/torch_ops.py
@@ -209,10 +209,10 @@ def sequence_mask(lengths, maxlen=None, dtype=None, time_major=False):
     39036).
     """
     if maxlen is None:
-        maxlen = int(lengths.max())
+        maxlen = lengths.max()
 
     mask = ~(torch.ones(
-        (len(lengths), maxlen)).to(lengths.device).cumsum(dim=1).t() > lengths)
+        (lengths.shape[0], maxlen)).to(lengths.device).cumsum(dim=1).t() > lengths)
     if not time_major:
         mask = mask.t()
     mask.type(dtype or torch.bool)


### PR DESCRIPTION
…e sure to avoid bad generalization.

Two statements were slightly adapted in order to get rid of the following TracerWarnings raised by torch.jit.trace:

1. TracerWarning: Converting a tensor to a Python integer might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs! maxlen = int(lengths.max())

2. TracerWarning: Using len to get tensor shape might cause the trace to be incorrect. Recommended usage would be tensor.shape[0]. Passing a tensor of different shape might lead to errors or silently give incorrect results. (len(lengths), maxlen)).to(lengths.device).cumsum(dim=1).t() > lengths)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
