### PR TITLE
`compute_actions` expects `observations` to be a `dict`

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -1555,7 +1555,7 @@ class Algorithm(Trainable):
     @PublicAPI
     def compute_actions(
         self,
-        observations: TensorStructType,
+        observations: dict,
         state: Optional[List[TensorStructType]] = None,
         *,
         prev_action: Optional[TensorStructType] = None,


### PR DESCRIPTION
Signed-off-by: Ram Rachum <ram@rachum.com>

Later in the function we see that `observations.items()` is accessed, which only makes sense if it's a `dict`.