### PR TITLE
[RLlib] skip preprocessor connector if the preprocessor is a no op.

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -1493,27 +1493,28 @@ class Algorithm(Trainable):
                 assert len(pp) == 1, "Only one preprocessor should be in the pipeline"
                 pp = pp[0]
 
-                # Note(Kourosh): The connector will leave the policy's connector in eval
-                # mode. would that be a problem?
-                pp.in_eval()
-                if observation is not None:
-                    _input_dict = {SampleBatch.OBS: observation}
-                elif input_dict is not None:
-                    _input_dict = {SampleBatch.OBS: input_dict[SampleBatch.OBS]}
-                else:
-                    raise ValueError(
-                        "Either observation or input_dict must be provided."
-                    )
+                if not pp.is_identity():
+                    # Note(Kourosh): The connector will leave the policy's connector
+                    # in eval mode. would that be a problem?
+                    pp.in_eval()
+                    if observation is not None:
+                        _input_dict = {SampleBatch.OBS: observation}
+                    elif input_dict is not None:
+                        _input_dict = {SampleBatch.OBS: input_dict[SampleBatch.OBS]}
+                    else:
+                        raise ValueError(
+                            "Either observation or input_dict must be provided."
+                        )
 
-                # TODO (Kourosh): Create a new util method for algorithm that computes
-                # actions based on raw inputs from env and can keep track of its own
-                # internal state.
-                acd = AgentConnectorDataType("0", "0", _input_dict)
-                # make sure the state is reset since we are only applying the
-                # preprocessor
-                pp.reset(env_id="0")
-                ac_o = pp([acd])[0]
-                observation = ac_o.data[SampleBatch.OBS]
+                    # TODO (Kourosh): Create a new util method for algorithm that
+                    # computes actions based on raw inputs from env and can keep track
+                    # of its own internal state.
+                    acd = AgentConnectorDataType("0", "0", _input_dict)
+                    # make sure the state is reset since we are only applying the
+                    # preprocessor
+                    pp.reset(env_id="0")
+                    ac_o = pp([acd])[0]
+                    observation = ac_o.data[SampleBatch.OBS]
 
         # Input-dict.
         if input_dict is not None:

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -1494,7 +1494,7 @@ class Algorithm(Trainable):
                 pp = pp[0]
 
                 if not pp.is_identity():
-                    # Note(Kourosh): The connector will leave the policy's connector
+                    # Note(Kourosh): This call will leave the policy's connector
                     # in eval mode. would that be a problem?
                     pp.in_eval()
                     if observation is not None:

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -223,7 +223,7 @@ class AlgorithmConfig:
         self.sample_collector = SimpleListCollector
         self.create_env_on_local_worker = False
         self.sample_async = False
-        self.enable_connectors = True
+        self.enable_connectors = False
         self.rollout_fragment_length = 200
         self.batch_mode = "truncate_episodes"
         self.remote_worker_envs = False

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -223,7 +223,7 @@ class AlgorithmConfig:
         self.sample_collector = SimpleListCollector
         self.create_env_on_local_worker = False
         self.sample_async = False
-        self.enable_connectors = False
+        self.enable_connectors = True
         self.rollout_fragment_length = 200
         self.batch_mode = "truncate_episodes"
         self.remote_worker_envs = False

--- a/rllib/connectors/agent/obs_preproc.py
+++ b/rllib/connectors/agent/obs_preproc.py
@@ -42,7 +42,7 @@ class ObsPreprocessorConnector(AgentConnector):
         )
 
     def is_identity(self):
-        """Returns whether this preprocessor connector is an identity preprocessor."""
+        """Returns whether this preprocessor connector is a no-op preprocessor."""
         return isinstance(self._preprocessor, NoPreprocessor)
 
     def transform(self, ac_data: AgentConnectorDataType) -> AgentConnectorDataType:

--- a/rllib/connectors/agent/obs_preproc.py
+++ b/rllib/connectors/agent/obs_preproc.py
@@ -5,7 +5,7 @@ from ray.rllib.connectors.connector import (
     ConnectorContext,
     register_connector,
 )
-from ray.rllib.models.preprocessors import get_preprocessor
+from ray.rllib.models.preprocessors import get_preprocessor, NoPreprocessor
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.typing import AgentConnectorDataType
 from ray.util.annotations import PublicAPI
@@ -40,6 +40,10 @@ class ObsPreprocessorConnector(AgentConnector):
         self._preprocessor = get_preprocessor(obs_space)(
             obs_space, ctx.config.get("model", {})
         )
+
+    def is_identity(self):
+        """Returns whether this preprocessor connector is an identity preprocessor."""
+        return isinstance(self._preprocessor, NoPreprocessor)
 
     def transform(self, ac_data: AgentConnectorDataType) -> AgentConnectorDataType:
         d = ac_data.data


### PR DESCRIPTION
Signed-off-by: Kourosh Hakhamaneshi <kourosh@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fixes policy_inference_after_training_with_dt_torch unittests.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
