### PR TITLE
[core][state][telemetry] Add telemetry for top level state API usage …

### DIFF
--- a/dashboard/modules/state/state_head.py
+++ b/dashboard/modules/state/state_head.py
@@ -5,6 +5,7 @@ from typing import Callable, Optional
 
 import aiohttp.web
 from abc import ABC, abstractmethod
+from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
 from ray.dashboard.consts import (
@@ -261,11 +262,13 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
     @routes.get("/api/v0/actors")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_actors(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_ACTORS, "1")
         return await self._handle_list_api(self._state_api.list_actors, req)
 
     @routes.get("/api/v0/jobs")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_jobs(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_JOBS, "1")
         try:
             result = await self._state_api.list_jobs(option=self._options_from_req(req))
             return self._reply(
@@ -279,6 +282,7 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
     @routes.get("/api/v0/nodes")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_nodes(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_NODES, "1")
         return await self._handle_list_api(self._state_api.list_nodes, req)
 
     @routes.get("/api/v0/placement_groups")
@@ -286,26 +290,31 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
     async def list_placement_groups(
         self, req: aiohttp.web.Request
     ) -> aiohttp.web.Response:
+        record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_PLACEMENT_GROUPS, "1")
         return await self._handle_list_api(self._state_api.list_placement_groups, req)
 
     @routes.get("/api/v0/workers")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_workers(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_WORKERS, "1")
         return await self._handle_list_api(self._state_api.list_workers, req)
 
     @routes.get("/api/v0/tasks")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_tasks(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_TASKS, "1")
         return await self._handle_list_api(self._state_api.list_tasks, req)
 
     @routes.get("/api/v0/objects")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_objects(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_OBJECTS, "1")
         return await self._handle_list_api(self._state_api.list_objects, req)
 
     @routes.get("/api/v0/runtime_envs")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_runtime_envs(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_RUNTIME_ENVS, "1")
         return await self._handle_list_api(self._state_api.list_runtime_envs, req)
 
     @routes.get("/api/v0/cluster_events")
@@ -313,6 +322,7 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
     async def list_cluster_events(
         self, req: aiohttp.web.Request
     ) -> aiohttp.web.Response:
+        record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_CLUSTER_EVENTS, "1")
         return await self._handle_list_api(self._state_api.list_cluster_events, req)
 
     @routes.get("/api/v0/logs")
@@ -323,6 +333,7 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
         Unlike other list APIs that display all existing resources in the cluster,
         this API always require to specify node id and node ip.
         """
+        record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_LOGS, "1")
         glob_filter = req.query.get("glob", "*")
         node_id = req.query.get("node_id", None)
         node_ip = req.query.get("node_ip", None)
@@ -360,6 +371,7 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
     @routes.get("/api/v0/logs/{media_type}")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def get_logs(self, req: aiohttp.web.Request):
+        record_extra_usage_tag(TagKey.CORE_STATE_API_GET_LOG, "1")
         options = GetLogOptions(
             timeout=int(req.query.get("timeout", DEFAULT_RPC_TIMEOUT)),
             node_id=req.query.get("node_id", None),
@@ -419,16 +431,19 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
     @routes.get("/api/v0/tasks/summarize")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def summarize_tasks(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        record_extra_usage_tag(TagKey.CORE_STATE_API_SUMMARIZE_TASKS, "1")
         return await self._handle_summary_api(self._state_api.summarize_tasks, req)
 
     @routes.get("/api/v0/actors/summarize")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def summarize_actors(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        record_extra_usage_tag(TagKey.CORE_STATE_API_SUMMARIZE_ACTORS, "1")
         return await self._handle_summary_api(self._state_api.summarize_actors, req)
 
     @routes.get("/api/v0/objects/summarize")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def summarize_objects(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        record_extra_usage_tag(TagKey.CORE_STATE_API_SUMMARIZE_OBJECTS, "1")
         return await self._handle_summary_api(self._state_api.summarize_objects, req)
 
     @routes.get("/api/v0/delay/{delay_s}")

--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -1,7 +1,7 @@
 """This is the module that is in charge of Ray usage report (telemetry) APIs.
 
-NOTE: Ray's usage report is currently "off by default".
-      But we are planning to make it opt-in by default.
+NOTE: Ray's usage report is currently "on by default".
+      One could opt-out, see details at https://docs.ray.io/en/master/cluster/usage-stats.html. # noqa
 
 Ray usage report follows the specification from
 https://docs.google.com/document/d/1ZT-l9YbGHh-iWRUC91jS-ssQ5Qe2UQ43Lsoc1edCalc/edit#heading=h.17dss3b9evbj. # noqa
@@ -261,6 +261,24 @@ class TagKey(Enum):
 
     # The GCS storage type, which could be memory or redis.
     GCS_STORAGE = auto()
+
+    # Ray Core State API
+    # NOTE(rickyxx): Currently only setting "1" for tracking existence of
+    # invocations only.
+    CORE_STATE_API_LIST_ACTORS = auto()
+    CORE_STATE_API_LIST_TASKS = auto()
+    CORE_STATE_API_LIST_JOBS = auto()
+    CORE_STATE_API_LIST_NODES = auto()
+    CORE_STATE_API_LIST_PLACEMENT_GROUPS = auto()
+    CORE_STATE_API_LIST_WORKERS = auto()
+    CORE_STATE_API_LIST_OBJECTS = auto()
+    CORE_STATE_API_LIST_RUNTIME_ENVS = auto()
+    CORE_STATE_API_LIST_CLUSTER_EVENTS = auto()
+    CORE_STATE_API_LIST_LOGS = auto()
+    CORE_STATE_API_GET_LOG = auto()
+    CORE_STATE_API_SUMMARIZE_TASKS = auto()
+    CORE_STATE_API_SUMMARIZE_ACTORS = auto()
+    CORE_STATE_API_SUMMARIZE_OBJECTS = auto()
 
     # Dashboard
     # Whether a user is running ray with some third party metrics


### PR DESCRIPTION
…from python.  (#30231)

Signed-off-by: Ricky Xu <xuchen727@hotmail.com>

Adding telemetry for state api usage.

This should only be collecting what functions (e.g. listing tasks, listing actors) people are invoking. We will NOT collect any other info of those resources other than the invocations existence. This is to track the usage of state API, and help prioritize future improvements. This should at most trigger the number of added calls to GCS if all tracked APIs are called (since it doesn't override with same values). TODO:

We currently implement get based on list so we couldn't track from dashboard if get APIs are called. But this is probably fine for now.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
