### PR TITLE
[RLlib] return zeroed initial states for attention

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -223,7 +223,7 @@ class AlgorithmConfig:
         self.sample_collector = SimpleListCollector
         self.create_env_on_local_worker = False
         self.sample_async = False
-        self.enable_connectors = True
+        self.enable_connectors = False
         self.rollout_fragment_length = 200
         self.batch_mode = "truncate_episodes"
         self.remote_worker_envs = False

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -223,7 +223,7 @@ class AlgorithmConfig:
         self.sample_collector = SimpleListCollector
         self.create_env_on_local_worker = False
         self.sample_async = False
-        self.enable_connectors = False
+        self.enable_connectors = True
         self.rollout_fragment_length = 200
         self.batch_mode = "truncate_episodes"
         self.remote_worker_envs = False

--- a/rllib/models/tf/attention_net.py
+++ b/rllib/models/tf/attention_net.py
@@ -551,7 +551,10 @@ class AttentionWrapper(TFModelV2):
 
     @override(ModelV2)
     def get_initial_state(self) -> Union[List[np.ndarray], List[TensorType]]:
-        return []
+        return [
+            np.zeros(self.gtrxl.view_requirements["state_in_{}".format(i)].space.shape)
+            for i in range(self.gtrxl.num_transformer_units)
+        ]
 
     @override(ModelV2)
     def value_function(self) -> TensorType:

--- a/rllib/models/torch/attention_net.py
+++ b/rllib/models/torch/attention_net.py
@@ -439,7 +439,12 @@ class AttentionWrapper(TorchModelV2, nn.Module):
 
     @override(ModelV2)
     def get_initial_state(self) -> Union[List[np.ndarray], List[TensorType]]:
-        return []
+        return [
+            torch.zeros(
+                self.gtrxl.view_requirements["state_in_{}".format(i)].space.shape
+            )
+            for i in range(self.gtrxl.num_transformer_units)
+        ]
 
     @override(ModelV2)
     def value_function(self) -> TensorType:


### PR DESCRIPTION

<img width="796" alt="image" src="https://user-images.githubusercontent.com/31483498/204402457-a7a60d51-5345-4906-8640-428ef423d679.png">

Signed-off-by: Kourosh Hakhamaneshi <kourosh@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This fixes the unittests for `policy_inference_after_training_with_attention_torch/tf` when `enable_connectors=True`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
