### PR TITLE
[Core] [release] Add num_cpus used for success many_tasks as well

### DIFF
--- a/release/benchmarks/distributed/test_many_tasks.py
+++ b/release/benchmarks/distributed/test_many_tasks.py
@@ -45,9 +45,11 @@ def test_max_running_tasks(num_tasks):
 
     # There are some relevant magic numbers in this check. 10k tasks each
     # require 1/4 cpus. Therefore, ideally 2.5k cpus will be used.
-    err_str = f"Only {max_cpus - min_cpus_available}/{max_cpus} cpus used."
+    used_cpus = max_cpus - min_cpus_available
+    err_str = f"Only {used_cpus}/{max_cpus} cpus used."
     threshold = num_tasks * cpus_per_task * 0.70
-    assert max_cpus - min_cpus_available > threshold, err_str
+    print(f"{used_cpus}/{max_cpus} used.")
+    assert used_cpus > threshold, err_str
 
     for _ in tqdm.trange(num_tasks, desc="Ensuring all tasks have finished"):
         done, refs = ray.wait(refs)


### PR DESCRIPTION
Signed-off-by: Ricky Xu <xuchen727@hotmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- For now,  the test failed at the first stage: waiting for at least 70% tasks (7000) to run within 300 seconds. This seems to be a stronger signal than the `num_tasks` to run e2e, so adding another perf metric `used_cpus_by_deadline`. 

- Also, we don't log the num cpus used when the test finishes. I suspect we are really close at the threshold for now. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
