### PR TITLE
[Datasets] Add separate cluster_env file for TFRecord read benchmark

### DIFF
--- a/release/nightly_tests/dataset/read_tfrecords_benchmark_app.yaml
+++ b/release/nightly_tests/dataset/read_tfrecords_benchmark_app.yaml
@@ -1,0 +1,14 @@
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+env_vars: {}
+debian_packages:
+  - curl
+
+python:
+  pip_packages:
+    - pytest
+  conda_packages: []
+
+post_build_cmds:
+  - pip3 uninstall ray -y || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 install crc32c
+  - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4469,7 +4469,7 @@
   frequency: nightly
   team: data
   cluster:
-    cluster_env: app_config.yaml
+    cluster_env: read_tfrecords_benchmark_app.yaml
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The TFRecord read benchmark nightly test is failed with lack of crc32c package ([nightly test failure](https://buildkite.com/ray-project/release-tests-branch/builds/1219#0184b0d6-4c5c-4425-b238-0144092fbdaa))

```
(write_block pid=643) Traceback (most recent call last):
(write_block pid=643)   File "python/ray/_raylet.pyx", line 830, in ray._raylet.execute_task
(write_block pid=643)   File "python/ray/_raylet.pyx", line 834, in ray._raylet.execute_task
(write_block pid=643)   File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/data/datasource/file_based_datasource.py", line 306, in write_block
(write_block pid=643)     **write_args,
(write_block pid=643)   File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/data/datasource/tfrecords_datasource.py", line 49, in _write_block
(write_block pid=643)     _check_import(self, module="crc32c", package="crc32c")
(write_block pid=643)   File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/data/_internal/util.py", line 194, in _check_import
(write_block pid=643)     f"`{obj.__class__.__name__}` depends on '{package}', but '{package}' "
(write_block pid=643) ImportError: `TFRecordDatasource` depends on 'crc32c', but 'crc32c' couldn't be imported. You can install 'crc32c' by running `pip install crc32c`.
```

The package is installed optinally for writing TFRecord file. Add a separate yaml file for the benchmark to install the package properly.

## Related issue number

<!-- For example: "Closes #1234" -->
Fixing the nightly test failure.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
