### PR TITLE
[Datasets] Unrevert "Fix ndarray representation of single-element ragged tensor slices. (#30514)"

### DIFF
--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -178,7 +178,14 @@ def test_arrow_variable_shaped_tensor_array_slice():
         slice(0, 3),
     ]
     for slice_ in slices:
-        for o, e in zip(ata[slice_], arr[slice_]):
+        ata_slice = ata[slice_]
+        ata_slice_np = ata_slice.to_numpy()
+        arr_slice = arr[slice_]
+        # Check for equivalent dtypes and shapes.
+        assert ata_slice_np.dtype == arr_slice.dtype
+        assert ata_slice_np.shape == arr_slice.shape
+        # Iteration over tensor array slices triggers NumPy conversion.
+        for o, e in zip(ata_slice, arr_slice):
             np.testing.assert_array_equal(o, e)
 
 

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 
 
@@ -20,3 +22,23 @@ def _is_ndarray_variable_shaped_tensor(arr: np.ndarray) -> bool:
         if a.shape != shape:
             return True
     return True
+
+
+def _create_strict_ragged_ndarray(values: Any) -> np.ndarray:
+    """Create a ragged ndarray; the representation will be ragged (1D array of
+    subndarray pointers) even if it's possible to represent it as a non-ragged ndarray.
+    """
+    # Use the create-empty-and-fill method. This avoids the following pitfalls of the
+    # np.array constructor - np.array(values, dtype=object):
+    #  1. It will fail to construct an ndarray if the first element dimension is
+    #  uniform, e.g. for imagery whose first element dimension is the channel.
+    #  2. It will construct the wrong representation for a single-row column (i.e. unit
+    #  outer dimension). Namely, it will consolidate it into a single multi-dimensional
+    #  ndarray rather than a 1D array of subndarray pointers, resulting in the single
+    #  row not being well-typed (having object dtype).
+
+    # Create an empty object-dtyped 1D array.
+    arr = np.empty(len(values), dtype=object)
+    # Try to fill the 1D array of pointers with the (ragged) tensors.
+    arr[:] = list(values)
+    return arr

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -142,7 +142,8 @@ def test_arrow_concat_tensor_extension_uniform_and_variable_shaped():
     # consolidation).
     assert out["a"].num_chunks == 2
     # Check content.
-    np.testing.assert_array_equal(out["a"].chunk(0).to_numpy(), a1)
+    for o, e in zip(out["a"].chunk(0).to_numpy(), a1):
+        np.testing.assert_array_equal(o, e)
     for o, e in zip(out["a"].chunk(1).to_numpy(), a2):
         np.testing.assert_array_equal(o, e)
     # NOTE: We don't check equivalence with pyarrow.concat_tables since it currently
@@ -167,8 +168,10 @@ def test_arrow_concat_tensor_extension_uniform_but_different():
     # consolidation).
     assert out["a"].num_chunks == 2
     # Check content.
-    np.testing.assert_array_equal(out["a"].chunk(0).to_numpy(), a1)
-    np.testing.assert_array_equal(out["a"].chunk(1).to_numpy(), a2)
+    for o, e in zip(out["a"].chunk(0).to_numpy(), a1):
+        np.testing.assert_array_equal(o, e)
+    for o, e in zip(out["a"].chunk(1).to_numpy(), a2):
+        np.testing.assert_array_equal(o, e)
     # NOTE: We don't check equivalence with pyarrow.concat_tables since it currently
     # fails for this case.
 


### PR DESCRIPTION
This unreverts #30514 by reverting commit 579770ad0f7caabccb5ac94b9bd4645af15e480f.

A test was merged into master while the original PR was open, which then broke when the original PR was merged. This wasn't caught in pre-merge checks since the PR was merged without having rebased onto latest master.

## Related Issues

Closes https://github.com/ray-project/ray/issues/30690

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
