### PR TITLE
[KubeRay] Update KubeRay operator version in CI

### DIFF
--- a/python/ray/autoscaler/kuberay/init-config.sh
+++ b/python/ray/autoscaler/kuberay/init-config.sh
@@ -2,8 +2,8 @@
 
 # Clone pinned Kuberay commit to temporary directory, copy the CRD definitions
 # into the autoscaler folder.
-KUBERAY_COMMIT="v0.3.0-rc.2"
-OPERATOR_TAG="v0.3.0-rc.2"
+KUBERAY_COMMIT="7940407"
+OPERATOR_TAG="7940407"
 
 # Requires Kustomize
 if ! command -v kustomize &> /dev/null


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR updates the KubeRay operator version in the test of KubeRay / Ray Autoscaler integration.

The KubeRay commit tested (current master) should be similar enough in terms of autoscaling to the upcoming KubeRay 0.4.0 release. 
Current Ray master should be similar enough in terms of autoscaling to the upcoming Ray 2.2.0 release.

It's a potential to-do to systematize the way in which the operator commit used in this test is updated.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
