### PR TITLE
[Core] RetryObjectInPlasmaErrors tries to fetch all objects, not just ready ones.

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1260,20 +1260,11 @@ void RetryObjectInPlasmaErrors(std::shared_ptr<CoreWorkerMemoryStore> &memory_st
   for (auto iter = memory_object_ids.begin(); iter != memory_object_ids.end();) {
     auto current = iter++;
     const auto &mem_id = *current;
-    auto ready_iter = ready.find(mem_id);
-    if (ready_iter != ready.end()) {
-      std::vector<std::shared_ptr<RayObject>> found;
-      RAY_CHECK_OK(memory_store->Get({mem_id},
-                                     /*num_objects=*/1,
-                                     /*timeout=*/0,
-                                     worker_context,
-                                     /*remote_after_get=*/false,
-                                     &found));
-      if (found.size() == 1 && found[0]->IsInPlasmaError()) {
-        plasma_object_ids.insert(mem_id);
-        ready.erase(ready_iter);
-        memory_object_ids.erase(current);
-      }
+    auto found = memory_store->GetIfExists(mem_id);
+    if (found != nullptr && found->IsInPlasmaError()) {
+      plasma_object_ids.insert(mem_id);
+      ready.erase(mem_id);
+      memory_object_ids.erase(current);
     }
   }
 }


### PR DESCRIPTION
Eric root-caused a bug in Datasets prefetching that was impacting performance. The TL;DR is that a bug in core_worker.cc was causing `ray.wait(objrefs, num_returns=N, fetch_local=True)` to only fetch N objects locally, instead of `len(objrefs)`.

Eric's patch fixes this by having core_worker.cc fetch `len(objrefs)` objects locally. In the case where `len(objrefs)` > N, there should now be more prefetching 🎉 .

Closes https://github.com/ray-project/ray/issues/30375.


### Testing
Steps followed:
1. Create Workspace with two nodes.
2. Start Ray on latest on each node, each with 20GB object store size.
3. Run a modified version of Eric's script (see below) that creates a 15GB dataset on the worker node, and streams it to the head node using `prefetch_blocks=10`.
4. Compile Ray with latest + this PR / start Ray on each node
5. Run the same script

#### Results
`after` indicates a test run including this change, `before` indicates a test run without this change.
```
$ grep 'In ray.wait' *prefetch*
after_prefetch10_1:* In ray.wait(): 138.7ms
after_prefetch10_2:* In ray.wait(): 400.36ms
after_prefetch10_3:* In ray.wait(): 54.53ms
after_prefetch10_4:* In ray.wait(): 350.69ms
before_prefetch_10_1:* In ray.wait(): 2.44s
before_prefetch_10_2:* In ray.wait(): 1.57s
before_prefetch_10_3:* In ray.wait(): 1.6s
before_prefetch_10_4:* In ray.wait(): 1.34s
```

#### Test script
```python3
#!/usr/bin/env python3

import ray
import time
import numpy as np


@ray.remote
def create_ds():
    # 15 GB
    ds = ray.data.range_tensor(100000, shape=(80, 80, 3), parallelism=200)

    return ray.put(ds)

# Create ds on worker node
ref = ray.get(create_ds.options(resources={'node:172.31.181.44': 0.001}).remote())
ds = ray.get(ref)
print(ds.size_bytes() / 1e9, "GB")

context = ray.data.context.DatasetContext.get_current()
context.actor_prefetcher_enabled = False

start = time.time()
latencies = []
for _ in ds.iter_batches(batch_size=None, prefetch_blocks=10):
    latencies.append(time.time() - start)
    start = time.time()
    if len(latencies) % 10 == 0:
            print("Latencies (mean/50/90)", np.mean(latencies), np.median(latencies), np.quantile(latencies, 0.9))

print(ds.stats())
```