### PR TITLE
Fix typing for `explore` argument

### DIFF
--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -494,7 +494,7 @@ class Policy(metaclass=ABCMeta):
     def compute_actions_from_input_dict(
         self,
         input_dict: Union[SampleBatch, Dict[str, TensorStructType]],
-        explore: bool = None,
+        explore: Optional[bool] = None,
         timestep: Optional[int] = None,
         episodes: Optional[List["Episode"]] = None,
         **kwargs,


### PR DESCRIPTION
Signed-off-by: Ram Rachum <ram@rachum.com>

Since the `explore` argument can accept the value `None`, it can't be just `bool`. I fixed it to `Optional[bool]`.