### PR TITLE
Fix: proxy command not run for initialization commands

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -317,8 +317,12 @@ class SSHCommandRunner(CommandRunnerInterface):
     ):
         if shutdown_after_run:
             cmd += "; sudo shutdown -h now"
+
         if ssh_options_override_ssh_key:
-            ssh_options = SSHOptions(ssh_options_override_ssh_key, ProxyCommand=self.ssh_proxy_command)
+            if self.ssh_proxy_command:
+                ssh_options = SSHOptions(ssh_options_override_ssh_key, ProxyCommand=self.ssh_proxy_command)
+            else:
+                ssh_options = SSHOptions(ssh_options_override_ssh_key)
         else:
             ssh_options = self.ssh_options
 

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -320,7 +320,9 @@ class SSHCommandRunner(CommandRunnerInterface):
 
         if ssh_options_override_ssh_key:
             if self.ssh_proxy_command:
-                ssh_options = SSHOptions(ssh_options_override_ssh_key, ProxyCommand=self.ssh_proxy_command)
+                ssh_options = SSHOptions(
+                    ssh_options_override_ssh_key, ProxyCommand=self.ssh_proxy_command
+                )
             else:
                 ssh_options = SSHOptions(ssh_options_override_ssh_key)
         else:

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -318,7 +318,7 @@ class SSHCommandRunner(CommandRunnerInterface):
         if shutdown_after_run:
             cmd += "; sudo shutdown -h now"
         if ssh_options_override_ssh_key:
-            ssh_options = SSHOptions(ssh_options_override_ssh_key)
+            ssh_options = SSHOptions(ssh_options_override_ssh_key, ProxyCommand=self.ssh_proxy_command)
         else:
             ssh_options = self.ssh_options
 

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -276,7 +276,7 @@ class NodeUpdater:
 
                     try:
                         # Run outside of the container
-                        self.cmd_runner.run("uptime", timeout=5, run_env="host")
+                        self.cmd_runner.run("uptime", timeout=10, run_env="host")
                         cli_logger.success("Success.")
                         return True
                     except ProcessRunnerError as e:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We use a proxy, [gcloud iap tunnel](https://cloud.google.com/iap/docs/using-tcp-forwarding), to access ray clusters with private ips. SSH proxy command works well for everything except "initialization_commands" where proxy commands are not passed.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

These PR's have relevant context: https://github.com/ray-project/ray/pull/10014, https://github.com/ray-project/ray/pull/8833
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(