### PR TITLE
[Datasets] Defaulting to wait-based prefetcher

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -53,7 +53,7 @@ DEFAULT_OPTIMIZE_FUSE_SHUFFLE_STAGES = True
 DEFAULT_MIN_PARALLELISM = 200
 
 # Wether to use actor based block prefetcher.
-DEFAULT_ACTOR_PREFETCHER_ENABLED = True
+DEFAULT_ACTOR_PREFETCHER_ENABLED = False
 
 # Whether to use push-based shuffle by default.
 DEFAULT_USE_PUSH_BASED_SHUFFLE = bool(


### PR DESCRIPTION
Given https://github.com/ray-project/ray/pull/30724, a performance issue was fixed in the `ray.wait`-based prefetcher. We can now use that for datasets.

Closes https://github.com/ray-project/ray/issues/30380

### Testing
TODO @cadedaniel need to run the script in https://github.com/ray-project/ray/pull/30724 and compare perf with actor-based vs. wait-based prefetchers.