### PR TITLE
[Jobs] [release tests] Use "SPREAD" scheduling strategy for tasks in multinode test

### DIFF
--- a/release/jobs_tests/workloads/jobs_check_cuda_available.py
+++ b/release/jobs_tests/workloads/jobs_check_cuda_available.py
@@ -35,7 +35,7 @@ assert ray.get(f.remote()) == [0]
 NUM_NODES = 2
 
 
-@ray.remote(num_cpus=1)
+@ray.remote(num_cpus=1, scheduling_strategy="SPREAD")
 def get_node_id():
     return ray.get_runtime_context().node_id
 


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previously a Jobs release test assumed that Ray tasks would be spread across nodes by default.  This seems to not always be the case; sometimes all tasks would be scheduled on a single node (despite both nodes being up), causing the test to fail.

This PR uses the scheduling strategy "SPREAD" to ensure that tasks are scheduled on different nodes.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #30688 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
