### PR TITLE
Better UI behavior when prometheus is not running

### DIFF
--- a/dashboard/client/src/pages/job/JobDetail.tsx
+++ b/dashboard/client/src/pages/job/JobDetail.tsx
@@ -1,4 +1,5 @@
 import { makeStyles } from "@material-ui/core";
+import { Alert } from "@material-ui/lab";
 import dayjs from "dayjs";
 import React from "react";
 import { DurationText } from "../../common/DurationText";
@@ -25,7 +26,7 @@ const JobDetailPage = () => {
   const classes = useStyle();
   const { job, msg, params } = useJobDetail();
   const jobId = params.id;
-  const { progress } = useJobProgress(jobId);
+  const { progress, error, driverExists } = useJobProgress(jobId);
 
   if (!job) {
     return (
@@ -39,6 +40,54 @@ const JobDetailPage = () => {
       </div>
     );
   }
+
+  const tasksSectionContents = (() => {
+    if (!driverExists) {
+      return <TaskProgressBar />;
+    }
+    const { status } = job;
+    if (!progress || error) {
+      return (
+        <Alert severity="warning">
+          No tasks visualizations because prometheus is not detected. Please
+          make sure prometheus is running and refresh this page. See:{" "}
+          <a
+            href="https://docs.ray.io/en/latest/ray-observability/ray-metrics.html"
+            target="_blank"
+            rel="noreferrer"
+          >
+            https://docs.ray.io/en/latest/ray-observability/ray-metrics.html
+          </a>
+          .
+          <br />
+          If you are hosting prometheus on a separate machine or using a
+          non-default port, please set the RAY_PROMETHEUS_HOST env var to point
+          to your prometheus server when launching ray.
+        </Alert>
+      );
+    }
+    if (status === "SUCCEEDED" || status === "FAILED") {
+      return (
+        <React.Fragment>
+          <TaskProgressBar {...progress} showAsComplete />
+          <JobTaskNameProgressTable
+            className={classes.taskProgressTable}
+            jobId={jobId}
+          />
+        </React.Fragment>
+      );
+    } else {
+      return (
+        <React.Fragment>
+          <TaskProgressBar {...progress} />
+          <JobTaskNameProgressTable
+            className={classes.taskProgressTable}
+            jobId={jobId}
+          />
+        </React.Fragment>
+      );
+    }
+  })();
 
   return (
     <div className={classes.root}>
@@ -108,16 +157,7 @@ const JobDetailPage = () => {
           ]}
         />
       </TitleCard>
-      <TitleCard title="Tasks">
-        <TaskProgressBar
-          {...progress}
-          showAsComplete={job.status === "SUCCEEDED" || job.status === "FAILED"}
-        />
-        <JobTaskNameProgressTable
-          className={classes.taskProgressTable}
-          jobId={jobId}
-        />
-      </TitleCard>
+      <TitleCard title="Tasks">{tasksSectionContents}</TitleCard>
     </div>
   );
 };

--- a/dashboard/client/src/pages/job/JobRow.tsx
+++ b/dashboard/client/src/pages/job/JobRow.tsx
@@ -41,15 +41,10 @@ export const JobRow = ({
 
   const progressBar = (() => {
     if (!driverExists) {
-      return "-";
+      return <MiniTaskProgressBar />;
     }
     if (!progress || error) {
-      if (status === "SUCCEEDED" || status === "FAILED") {
-        // Show a fake all-green progress bar.
-        return <MiniTaskProgressBar numFinished={1} showTooltip={false} />;
-      } else {
-        return "unavailable";
-      }
+      return "unavailable";
     }
     if (status === "SUCCEEDED" || status === "FAILED") {
       // TODO(aguo): Show failed tasks in progress bar once supported.

--- a/dashboard/client/src/pages/job/TaskProgressBar.tsx
+++ b/dashboard/client/src/pages/job/TaskProgressBar.tsx
@@ -6,6 +6,7 @@ import { TaskProgress } from "../../type/job";
 
 export type TaskProgressBarProps = TaskProgress & {
   showAsComplete?: boolean;
+  showTooltip?: boolean;
 };
 
 export const TaskProgressBar = ({
@@ -17,6 +18,7 @@ export const TaskProgressBar = ({
   numFailed = 0,
   numUnknown = 0,
   showAsComplete = false,
+  showTooltip = true,
 }: TaskProgressBarProps) => {
   const theme = useTheme<Theme>();
   if (showAsComplete) {
@@ -42,6 +44,7 @@ export const TaskProgressBar = ({
             color: theme.palette.error.main,
           },
         ]}
+        showTooltip={showTooltip}
       />
     );
   } else {


### PR DESCRIPTION
Signed-off-by: Alan Guo <aguo@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
1. When prometheus is not running, we used to show a empty progress bar in the job details page. This is confusing because it looks like there are 0 tasks instead of no data. Now we show a banner that explains why it isn't working and point the to documentation
<img width="1573" alt="Screen Shot 2022-11-29 at 2 26 44 PM" src="https://user-images.githubusercontent.com/711935/204662580-ff282c67-6c48-47f5-8156-e3509100f94d.png">

2. When there is a job with no driver, we show a "-" instead of the mini progress bar. I changed this to be an empty progress bar with 0 tasks since that is more accurate.
<img width="1533" alt="Screen Shot 2022-11-29 at 2 26 55 PM" src="https://user-images.githubusercontent.com/711935/204662686-d00b0414-6ce8-4054-8233-ab2879ca1b69.png">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
