### PR TITLE
[Jobs] [Doc] Add doc sidebar that was inadvertently removed

### DIFF
--- a/doc/source/cluster/running-applications/job-submission/index.md
+++ b/doc/source/cluster/running-applications/job-submission/index.md
@@ -36,7 +36,7 @@ If you would like to run an application *interactively* and see the output in re
 
 Note that jobs started in these ways are not managed by the Ray Jobs API, so the Ray Jobs API will not be able to see them or interact with them (with the exception of `ray job list` and `JobSubmissionClient.list_jobs()`).
 
-# Contents
+## Contents
 
 ```{toctree}
 :maxdepth: '1'


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In https://github.com/ray-project/ray/pull/29608, including the Sphinx TOC underneath a level-1 header instead of a level-2 header somehow inadvertently caused an unexpected regression where the table of contents disappeared in the sidebar.

How it currently appears on master (bad, no sidebar even after clicking into the jobs overview):
<img width="421" alt="Screen Shot 2022-11-29 at 2 54 35 PM" src="https://user-images.githubusercontent.com/5459654/204666222-588db828-098b-4ac6-b451-d29bd6672852.png">

How it used to look, and how it looks in this PR:
<img width="376" alt="Screen Shot 2022-11-29 at 2 53 07 PM" src="https://user-images.githubusercontent.com/5459654/204666033-f1aa08b1-3cc0-4b62-9495-bb6b41e8a39e.png">

This PR adds back the sidebar by putting the TOC under the level-2 header.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
