### PR TITLE
[Core] Fix graceful task cancellation of queued tasks.

### DIFF
--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -66,7 +66,7 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
   bool ReplyPushTask(Status status = Status::OK(),
                      bool exit = false,
                      bool is_retryable_error = false,
-                     bool is_cancelled_before_running = false) {
+                     bool was_cancelled_before_running = false) {
     if (callbacks.size() == 0) {
       return false;
     }
@@ -78,8 +78,8 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
     if (is_retryable_error) {
       reply.set_is_retryable_error(true);
     }
-    if (is_cancelled_before_running) {
-      reply.set_is_cancelled_before_running(true);
+    if (was_cancelled_before_running) {
+      reply.set_was_cancelled_before_running(true);
     }
     callback(status, reply);
     callbacks.pop_front();

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -65,7 +65,8 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
 
   bool ReplyPushTask(Status status = Status::OK(),
                      bool exit = false,
-                     bool is_retryable_error = false) {
+                     bool is_retryable_error = false,
+                     bool is_cancelled_before_running = false) {
     if (callbacks.size() == 0) {
       return false;
     }
@@ -76,6 +77,9 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
     }
     if (is_retryable_error) {
       reply.set_is_retryable_error(true);
+    }
+    if (is_cancelled_before_running) {
+      reply.set_is_cancelled_before_running(true);
     }
     callback(status, reply);
     callbacks.pop_front();
@@ -1748,15 +1752,15 @@ TEST(DirectTaskTransportTest, TestKillExecutingTask) {
 
   // Try non-force kill, worker returns normally
   ASSERT_TRUE(submitter.CancelTask(task, false, false).ok());
-  ASSERT_TRUE(worker_client->ReplyPushTask());
+  ASSERT_TRUE(worker_client->ReplyPushTask(Status::OK(), false, false, true));
   ASSERT_EQ(worker_client->kill_requests.front().intended_task_id(),
             task.TaskId().Binary());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 1);
   ASSERT_EQ(raylet_client->num_workers_returned_exiting, 0);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 1);
-  ASSERT_EQ(task_finisher->num_tasks_complete, 1);
-  ASSERT_EQ(task_finisher->num_tasks_failed, 1);
+  ASSERT_EQ(task_finisher->num_tasks_complete, 0);
+  ASSERT_EQ(task_finisher->num_fail_pending_task_calls, 1);
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
@@ -1788,14 +1792,35 @@ TEST(DirectTaskTransportTest, TestKillPendingTask) {
   TaskSpecification task = BuildEmptyTaskSpec();
 
   ASSERT_TRUE(submitter.SubmitTask(task).ok());
+
+  // Try force kill
   ASSERT_TRUE(submitter.CancelTask(task, true, false).ok());
   ASSERT_EQ(worker_client->kill_requests.size(), 0);
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
   ASSERT_EQ(task_finisher->num_tasks_complete, 0);
-  ASSERT_EQ(task_finisher->num_tasks_failed, 1);
+  ASSERT_EQ(task_finisher->num_tasks_failed, 0);
+  ASSERT_EQ(task_finisher->num_fail_pending_task_calls, 1);
   ASSERT_EQ(raylet_client->num_leases_canceled, 1);
+  ASSERT_TRUE(raylet_client->ReplyCancelWorkerLease());
+
+  // Trigger reply to RequestWorkerLease to remove the canceled pending lease request
+  ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1000, NodeID::Nil(), true));
+
+  task.GetMutableMessage().set_task_id(
+      TaskID::ForNormalTask(JobID::Nil(), TaskID::Nil(), 1).Binary());
+  ASSERT_TRUE(submitter.SubmitTask(task).ok());
+
+  // Try non-force kill
+  ASSERT_TRUE(submitter.CancelTask(task, false, false).ok());
+  ASSERT_EQ(worker_client->kill_requests.size(), 0);
+  ASSERT_EQ(worker_client->callbacks.size(), 0);
+  ASSERT_EQ(raylet_client->num_workers_returned, 0);
+  ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
+  ASSERT_EQ(task_finisher->num_tasks_complete, 0);
+  ASSERT_EQ(task_finisher->num_fail_pending_task_calls, 2);
+  ASSERT_EQ(raylet_client->num_leases_canceled, 2);
   ASSERT_TRUE(raylet_client->ReplyCancelWorkerLease());
 
   // Trigger reply to RequestWorkerLease to remove the canceled pending lease request

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -208,7 +208,7 @@ void CoreWorkerDirectTaskReceiver::HandleTask(
     } else {
       // We consider cancellation of normal tasks to be an in-band cancellation of a
       // successful RPC.
-      reply->set_is_cancelled_before_running(true);
+      reply->set_was_cancelled_before_running(true);
       send_reply_callback(Status::OK(), nullptr, nullptr);
     }
   };

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -622,7 +622,7 @@ void CoreWorkerDirectTaskSubmitter::PushNormalTask(
           }
         }
         if (status.ok()) {
-          if (reply.is_cancelled_before_running()) {
+          if (reply.was_cancelled_before_running()) {
             RAY_LOG(DEBUG) << "Task " << task_id
                            << " was cancelled before it started running.";
             RAY_UNUSED(

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -609,7 +609,7 @@ void CoreWorkerDirectTaskSubmitter::PushNormalTask(
                 };
             auto &lease_entry = worker_to_lease_entry_[addr];
             RAY_CHECK(lease_entry.lease_client);
-            lease_entry.lease_client->GetTaskFailureCause(lease_entry.task_id, callback);
+            lease_entry.lease_client->GetTaskFailureCause(task_id, callback);
           }
 
           if (!status.ok() || !is_actor_creation || reply.worker_exiting()) {
@@ -622,9 +622,16 @@ void CoreWorkerDirectTaskSubmitter::PushNormalTask(
           }
         }
         if (status.ok()) {
-          if (!task_spec.GetMessage().retry_exceptions() || !reply.is_retryable_error() ||
-              !task_finisher_->RetryTaskIfPossible(task_id,
-                                                   /*task_failed_due_to_oom*/ false)) {
+          if (reply.is_cancelled_before_running()) {
+            RAY_LOG(DEBUG) << "Task " << task_id
+                           << " was cancelled before it started running.";
+            RAY_UNUSED(
+                task_finisher_->FailPendingTask(task_id, rpc::ErrorType::TASK_CANCELLED));
+          } else if (!task_spec.GetMessage().retry_exceptions() ||
+                     !reply.is_retryable_error() ||
+                     !task_finisher_->RetryTaskIfPossible(
+                         task_id,
+                         /*task_failed_due_to_oom*/ false)) {
             task_finisher_->CompletePendingTask(
                 task_id, reply, addr.ToProto(), reply.is_application_error());
           }
@@ -642,7 +649,7 @@ void CoreWorkerDirectTaskSubmitter::HandleGetTaskFailureCause(
   rpc::ErrorType task_error_type = rpc::ErrorType::WORKER_DIED;
   std::unique_ptr<rpc::RayErrorInfo> error_info;
   if (get_task_failure_cause_reply_status.ok()) {
-    RAY_LOG(DEBUG) << "Task failure cause "
+    RAY_LOG(DEBUG) << "Task failure cause for task " << task_id << ": "
                    << ray::gcs::RayErrorInfoToString(
                           get_task_failure_cause_reply.failure_cause());
     if (get_task_failure_cause_reply.has_failure_cause()) {
@@ -705,8 +712,8 @@ Status CoreWorkerDirectTaskSubmitter::CancelTask(TaskSpecification task_spec,
           if (scheduling_tasks.empty()) {
             CancelWorkerLeaseIfNeeded(scheduling_key);
           }
-          RAY_UNUSED(task_finisher_->FailOrRetryPendingTask(
-              task_spec.TaskId(), rpc::ErrorType::TASK_CANCELLED, nullptr));
+          RAY_UNUSED(task_finisher_->FailPendingTask(task_spec.TaskId(),
+                                                     rpc::ErrorType::TASK_CANCELLED));
           return Status::OK();
         }
       }

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -609,7 +609,7 @@ void CoreWorkerDirectTaskSubmitter::PushNormalTask(
                 };
             auto &lease_entry = worker_to_lease_entry_[addr];
             RAY_CHECK(lease_entry.lease_client);
-            lease_entry.lease_client->GetTaskFailureCause(task_id, callback);
+            lease_entry.lease_client->GetTaskFailureCause(lease_entry.task_id, callback);
           }
 
           if (!status.ok() || !is_actor_creation || reply.worker_exiting()) {

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -135,6 +135,8 @@ message PushTaskReply {
   bool is_retryable_error = 5;
   // Whether the result contains an application-level error.
   bool is_application_error = 6;
+  // Whether the task was cancelled before it started running (i.e. while queued).
+  bool is_cancelled_before_running = 7;
 }
 
 message DirectActorCallArgWaitCompleteRequest {

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -136,7 +136,7 @@ message PushTaskReply {
   // Whether the result contains an application-level error.
   bool is_application_error = 6;
   // Whether the task was cancelled before it started running (i.e. while queued).
-  bool is_cancelled_before_running = 7;
+  bool was_cancelled_before_running = 7;
 }
 
 message DirectActorCallArgWaitCompleteRequest {


### PR DESCRIPTION
Graceful task cancellation of queued tasks currently kills the underlying worker, which causes a `WorkerCrashedError` to be raised instead of a `TaskCancelledError`. This PR fixes this by ensuring that the worker isn't killed, and that the `TaskCancelledError` is eventually raised.

In particular, this PR:
- adds an `is_cancelled_before_running` field to the task push RPC reply,
- sets that field in the executing worker if the task is cancelled before it starts running,
- ensures that the task is marked as cancelled in the submitting worker if that field is set.

## Related issue number

Closes https://github.com/ray-project/ray/issues/30760

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
