### PR TITLE
[Core] Loosened click versioning to encompass 8.*

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@
 
 ## setup.py install_requires
 attrs
-click>=7.0
+click>=7.0, >=8.0
 filelock
 jsonschema
 msgpack<2.0.0,>=1.0.0


### PR DESCRIPTION
## Why are these changes needed?

Due to semantic versioning constraints, projects using more recent versions of `click` can't coexist with Ray when using certain package managers such as `poetry` which implicitly sets `ray` to use `click` >=7.0, <8.0.4

Thus projects that use click > 8.0 can't use ray.

This PR loosens the click versioning

## Related issue number


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
