### PR TITLE
[OOM] Fix OOM deadlock tests

### DIFF
--- a/python/ray/tests/test_memory_deadlock.py
+++ b/python/ray/tests/test_memory_deadlock.py
@@ -17,7 +17,7 @@ from ray.tests.test_memory_pressure import (
 @pytest.fixture
 def ray_with_memory_monitor(shutdown_only):
     with ray.init(
-        address='local',
+        address="local",
         num_cpus=1,
         object_store_memory=100 * 1024 * 1024,
         _system_config={


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Each unit test in this file currently passes when run independently. But for some reason when running the whole file, the test that gets run after `test_churn_long_running` hangs and gives the error `This worker was asked to execute a function that it does not have registered. You may have to restart Ray.`. It likely has to do with some weird behavior in the teardown happening on Ray between tests.

By moving `test_churn_long_running` to the end, all the tests now pass when run at once.

The other change in this PR is using `address=local` inside `ray.init()`, that way the tests always start a local ray cluster. This needed due to the custom OOM configuration.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

  All these unit tests now pass
