### PR TITLE
[release] Move the release tests that are originally on prod back to prod

### DIFF
--- a/release/cluster_tests/aws_compute.yaml
+++ b/release/cluster_tests/aws_compute.yaml
@@ -1,5 +1,4 @@
-# cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
 region: us-west-2
 
 aws:

--- a/release/nightly_tests/chaos_test/compute_template.yaml
+++ b/release/nightly_tests/chaos_test/compute_template.yaml
@@ -1,5 +1,5 @@
-# cloud_id: cld_4F7k8814aZzGG8TNUGPKnc
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+cloud_id: cld_4F7k8814aZzGG8TNUGPKnc
+
 region: us-west-2
 
 head_node_type:

--- a/release/nightly_tests/dask_on_ray/1tb_sort_compute.yaml
+++ b/release/nightly_tests/dask_on_ray/1tb_sort_compute.yaml
@@ -1,5 +1,4 @@
-# cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
 region: us-west-2
 
 aws:

--- a/release/nightly_tests/dataset/dataset_ingest_400G_compute.yaml
+++ b/release/nightly_tests/dataset/dataset_ingest_400G_compute.yaml
@@ -1,5 +1,4 @@
-# cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
 region: us-west-2
 
 max_workers: 0

--- a/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
@@ -1,5 +1,4 @@
-# cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
 region: us-west-2
 
 max_workers: 999

--- a/release/nightly_tests/dataset/pipelined_training_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_training_compute.yaml
@@ -1,5 +1,4 @@
-# cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
 region: us-west-2
 allowed_azs:
   - us-west-2a

--- a/release/nightly_tests/dataset/ray_sgd_training_compute_no_gpu.yaml
+++ b/release/nightly_tests/dataset/ray_sgd_training_compute_no_gpu.yaml
@@ -1,5 +1,4 @@
-# cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
 region: us-west-2
 allowed_azs:
   - us-west-2a

--- a/release/nightly_tests/dataset/shuffle_compute.yaml
+++ b/release/nightly_tests/dataset/shuffle_compute.yaml
@@ -1,5 +1,4 @@
-# cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
 region: us-west-2
 
 max_workers: 999

--- a/release/nightly_tests/many_nodes_tests/compute_config.yaml
+++ b/release/nightly_tests/many_nodes_tests/compute_config.yaml
@@ -1,5 +1,5 @@
-# cloud_id: cld_4F7k8814aZzGG8TNUGPKnc
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+cloud_id: cld_4F7k8814aZzGG8TNUGPKnc
+
 region: us-west-2
 
 head_node_type:

--- a/release/ray_release/env.py
+++ b/release/ray_release/env.py
@@ -3,7 +3,7 @@ from typing import Dict
 
 from ray_release.exception import ReleaseTestConfigError
 
-DEFAULT_ENVIRONMENT = "staging"
+DEFAULT_ENVIRONMENT = "prod"
 
 
 def load_environment(environment_name: str) -> Dict[str, str]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Move the release tests that are originally on prod back to prod

revert the following 3 commits:
https://github.com/ray-project/ray/commit/6fd684bbdb186a73732f6113a83a12b63200f170
https://github.com/ray-project/ray/commit/faf628067b8cb776d5fd796c34472acc69a5cfca
https://github.com/ray-project/ray/commit/116b6f74ef920b4b062025dff45e0cd0ae574018

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
