### PR TITLE
[core] OOM killer: 2.2 readiness (#30682)

### DIFF
--- a/doc/source/ray-core/doc_code/ray_oom_prevention.py
+++ b/doc/source/ray-core/doc_code/ray_oom_prevention.py
@@ -3,16 +3,14 @@ import ray
 
 ray.init(
     _system_config={
-        "memory_monitor_interval_ms": 100,
-        "memory_usage_threshold_fraction": 0.4,
-        "min_memory_free_bytes": -1,
+        "memory_usage_threshold": 0.4,
     },
 )
 # fmt: off
 # __oom_start__
 import ray
 
-@ray.remote
+@ray.remote(max_retries=0)
 def allocate_memory():
     chunks = []
     bits_to_allocate = 8 * 100 * 1024 * 1024  # ~0.1 GiB

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -783,7 +783,7 @@ cdef void execute_task(
         try:
             if (not (<int>task_type == <int>TASK_TYPE_ACTOR_TASK
                      and function_name == "__ray_terminate__") and
-                    ray._config.memory_monitor_interval_ms() == 0):
+                    ray._config.memory_monitor_refresh_ms() == 0):
                 worker.memory_monitor.raise_if_low_memory()
 
             with core_worker.profile_event(b"task:deserialize_arguments"):

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -91,4 +91,4 @@ cdef extern from "ray/common/ray_config.h" nogil:
 
         int64_t health_check_failure_threshold() const
 
-        uint64_t memory_monitor_interval_ms() const
+        uint64_t memory_monitor_refresh_ms() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -158,6 +158,5 @@ cdef class Config:
         return RayConfig.instance().health_check_failure_threshold()
 
     @staticmethod
-    def memory_monitor_interval_ms():
-        return (RayConfig.instance()
-                .memory_monitor_interval_ms())
+    def memory_monitor_refresh_ms():
+        return (RayConfig.instance().memory_monitor_refresh_ms())

--- a/release/nightly_tests/shuffle/shuffle_app_config_oom_disabled.yaml
+++ b/release/nightly_tests/shuffle/shuffle_app_config_oom_disabled.yaml
@@ -1,5 +1,5 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
-env_vars: {"RAY_memory_monitor_interval_ms": "0"}
+env_vars: {"RAY_memory_monitor_refresh_ms": "0"}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/stress_tests/stress_tests_single_node_oom_app_config.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_single_node_oom_app_config.yaml
@@ -1,5 +1,4 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
-env_vars: {"RAY_task_oom_retries": "30", "RAY_min_memory_free_bytes": "1000000000", "RAY_memory_usage_threshold_fraction": "0.9"}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
+++ b/release/nightly_tests/stress_tests/test_parallel_tasks_memory_pressure.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--mem-pct-per-task",
         help="memory to allocate per task as a fraction of the node's available memory",
-        default="0.4",
+        default="0.45",
         type=float,
     )
 

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -53,9 +53,6 @@ class ClusterManager(abc.ABC):
         self.cluster_env["env_vars"]["RAY_USAGE_STATS_ENABLED"] = "1"
         self.cluster_env["env_vars"]["RAY_USAGE_STATS_SOURCE"] = "nightly-tests"
         self.cluster_env["env_vars"][
-            "RAY_memory_monitor_interval_ms"
-        ] = self.cluster_env["env_vars"].get("RAY_memory_monitor_interval_ms", "250")
-        self.cluster_env["env_vars"][
             "RAY_USAGE_STATS_EXTRA_TAGS"
         ] = f"test_name={self.test_name};smoke_test={self.smoke_test}"
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3935,7 +3935,7 @@
 
   run:
     timeout: 500
-    script: python stress_tests/test_parallel_tasks_memory_pressure.py --num-tasks 20 --mem-pct-per-task 0.5
+    script: python stress_tests/test_parallel_tasks_memory_pressure.py --num-tasks 20
 
     type: sdk_command
     file_manager: sdk
@@ -4812,12 +4812,12 @@
   frequency: nightly
   team: core
   cluster:
-    cluster_env: shuffle/shuffle_app_config.yaml
+    cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml
     cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
 
   run:
     timeout: 7200
-    prepare: ' python setup_chaos.py --node-kill-interval 900 --max-nodes-to-kill 3'
+    prepare: 'python setup_chaos.py --node-kill-interval 900 --max-nodes-to-kill 3'
     script: python dataset/sort.py --num-partitions=1000 --partition-size=1e9
     wait_for_nodes:
       num_nodes: 20

--- a/src/ray/common/memory_monitor.cc
+++ b/src/ray/common/memory_monitor.cc
@@ -69,7 +69,7 @@ MemoryMonitor::MemoryMonitor(instrumented_io_context &io_service,
 #endif
   } else {
     RAY_LOG(INFO) << "MemoryMonitor disabled. Specify "
-                  << "`memory_monitor_interval_ms` > 0 to enable the monitor.";
+                  << "`memory_monitor_refresh_ms` > 0 to enable the monitor.";
   }
 }
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -81,23 +81,23 @@ RAY_CONFIG(uint64_t, raylet_report_resources_period_milliseconds, 100)
 RAY_CONFIG(uint64_t, raylet_check_gc_period_milliseconds, 100)
 
 /// Threshold when the node is beyond the memory capacity. If the memory is above the
-/// memory_usage_threshold_fraction and free space is below the min_memory_free_bytes then
+/// memory_usage_threshold and free space is below the min_memory_free_bytes then
 /// it will start killing processes to free up the space.
 /// Ranging from [0, 1]
-RAY_CONFIG(float, memory_usage_threshold_fraction, 0.98)
+RAY_CONFIG(float, memory_usage_threshold, 0.95)
 
 /// The interval between runs of the memory usage monitor.
 /// Monitor is disabled when this value is 0.
-RAY_CONFIG(uint64_t, memory_monitor_interval_ms, 250)
+RAY_CONFIG(uint64_t, memory_monitor_refresh_ms, 250)
 
 /// The minimum amount of free space. If the memory is above the
-/// memory_usage_threshold_fraction and free space is below min_memory_free_bytes then it
+/// memory_usage_threshold and free space is below min_memory_free_bytes then it
 /// will start killing processes to free up the space. Disabled if it is -1.
 ///
-/// This value is useful for larger host where the memory_usage_threshold_fraction could
+/// This value is useful for larger host where the memory_usage_threshold could
 /// represent a large chunk of memory, e.g. a host with 64GB of memory and 0.9 threshold
 /// means 6.4 GB of the memory will not be usable.
-RAY_CONFIG(int64_t, min_memory_free_bytes, (int64_t)512 * 1024 * 1024)
+RAY_CONFIG(int64_t, min_memory_free_bytes, (int64_t)-1)
 
 /// The TTL for when the task failure entry is considered
 /// eligble for garbage colletion.
@@ -106,7 +106,7 @@ RAY_CONFIG(uint64_t, task_failure_entry_ttl_ms, 15 * 60 * 1000)
 /// The number of retries for the task or actor when
 /// it fails due to the process being killed when the memory is running low on the node.
 /// The process killing is done by memory monitor, which is enabled via
-/// memory_monitor_interval_ms. If the task or actor is not retriable then this value is
+/// memory_monitor_refresh_ms. If the task or actor is not retriable then this value is
 /// ignored. This retry counter is only used when the process is killed due to memory, and
 /// the retry counter of the task or actor is only used when it fails in other ways
 /// that is not related to running out of memory. Note infinite retry (-1) is not
@@ -398,7 +398,7 @@ RAY_CONFIG(uint32_t, task_retry_delay_ms, 0)
 
 /// The base retry delay for exponential backoff when the task fails due to OOM.
 /// No delay if this value is zero.
-RAY_CONFIG(uint32_t, task_oom_retry_delay_base_ms, 0)
+RAY_CONFIG(uint32_t, task_oom_retry_delay_base_ms, 1000)
 
 /// Duration to wait between retrying to kill a task.
 RAY_CONFIG(uint32_t, cancellation_retry_ms, 2000)

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -338,9 +338,9 @@ NodeManager::NodeManager(instrumented_io_context &io_service,
       ray_syncer_service_(ray_syncer_),
       memory_monitor_(std::make_unique<MemoryMonitor>(
           io_service,
-          RayConfig::instance().memory_usage_threshold_fraction(),
+          RayConfig::instance().memory_usage_threshold(),
           RayConfig::instance().min_memory_free_bytes(),
-          RayConfig::instance().memory_monitor_interval_ms(),
+          RayConfig::instance().memory_monitor_refresh_ms(),
           CreateMemoryUsageRefreshCallback())) {
   RAY_LOG(INFO) << "Initializing NodeManager with ID " << self_node_id_;
   RAY_CHECK(RayConfig::instance().raylet_heartbeat_period_milliseconds() > 0);
@@ -3058,9 +3058,9 @@ const std::string NodeManager::CreateOomKillMessageSuggestions(
       << not_retriable_recommendation_ss.str()
       << "To adjust the kill "
          "threshold, set the environment variable "
-         "`RAY_memory_usage_threshold_fraction` when starting Ray. To disable "
+         "`RAY_memory_usage_threshold` when starting Ray. To disable "
          "worker killing, set the environment variable "
-         "`RAY_memory_monitor_interval_ms` to zero.";
+         "`RAY_memory_monitor_refresh_ms` to zero.";
   return oom_kill_suggestions_ss.str();
 }
 


### PR DESCRIPTION
Cherry pick https://github.com/ray-project/ray/pull/30682 to 2.2.0 release branch to resolve release blockers

https://github.com/ray-project/ray/issues/30704
https://github.com/ray-project/ray/issues/30433

---- https://github.com/ray-project/ray/pull/30682  commit message ---- 

Re-applying #30553 to adjust OOM killer defaults + clean up overrides. Also include a bunch of fixes

This fixes the doc test that was failing due to time out, that was caused by the exponential backoff added. We set "max_retries=0" so it doesn't trigger OOM retry, which also speeds up the example

This also adds an extra node for chaos_dataset_shuffle_sort_1tb. The original test has the memory threshold at 1.00. With this PR the memory threshold is 0.95. With the extra node (21) the memory available is 21 * 0.95 = 19.95, which is closer to the amount of memory given to the test previously. Ultimately, the test is unstable if we start killing tasks aggressively in addition to node failure, so we keep the amount of memory the same to maintain the previous behavior

The memory threshold was adjusted on the product side accidentally to 1.0 when we don't provide an override in the release test. This PR renames the variables so it won't accidentally override the default value in Ray. The configs have limited exposure so it is relatively safe to rename and not break users

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
