### PR TITLE
[Java] Throw exception when subprocess is hang.

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
@@ -83,12 +83,12 @@ public class RunManager {
     ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true);
     Process p = builder.start();
     final boolean exited = p.waitFor(timeout, unit);
-    String output = IOUtils.toString(p.getInputStream(), Charset.defaultCharset());
-
     if (!exited) {
+      String output = IOUtils.toString(p.getInputStream(), Charset.defaultCharset());
       throw new RuntimeException("The process was not exited in time. output:\n" + output);
     }
 
+    String output = IOUtils.toString(p.getInputStream(), Charset.defaultCharset());
     if (p.exitValue() != 0) {
       String sb =
           "The exit value of the process is "

--- a/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
@@ -82,12 +82,10 @@ public class RunManager {
     ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true);
     Process p = builder.start();
     final boolean exited = p.waitFor(timeout, unit);
-    String errorOutput = IOUtils.toString(p.getErrorStream(), Charset.defaultCharset());
-    String stdOutput = IOUtils.toString(p.getInputStream(), Charset.defaultCharset());
+    String output = IOUtils.toString(p.getInputStream(), Charset.defaultCharset());
 
-    final String outputs = String.format("Error output:\n%s\nStd output:\n%s", errorOutput, stdOutput);
     if (!exited) {
-      throw new RuntimeException("The process was not exited in time.\n" + outputs);
+      throw new RuntimeException("The process was not exited in time. output:\n" + output);
     }
 
     if (p.exitValue() != 0) {
@@ -97,9 +95,10 @@ public class RunManager {
               + ". Command: "
               + Joiner.on(" ").join(command)
               + "\n"
-              + outputs;
+              + "output:\n"
+              + output;
       throw new RuntimeException(sb);
     }
-    return outputs;
+    return output;
   }
 }

--- a/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
@@ -76,7 +76,8 @@ public class RunManager {
     return runCommand(command, 30, TimeUnit.SECONDS);
   }
 
-  public static String runCommand(List<String> command, long timeout, TimeUnit unit) throws IOException, InterruptedException {
+  public static String runCommand(List<String> command, long timeout, TimeUnit unit)
+      throws IOException, InterruptedException {
     LOGGER.info("Starting process with command: {}", Joiner.on(" ").join(command));
 
     ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true);


### PR DESCRIPTION
Signed-off-by: Qing Wang <kingchin1218@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It will throw exception instead of block the main test process when `ray start --head xxx` subprocess is hang. This is very useful to help us figure out what happened in CI.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/30646
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
