### PR TITLE
[Core] Add `six` as dependency

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -17,6 +17,7 @@ pyyaml
 aiosignal
 frozenlist
 requests
+six
 virtualenv>=20.0.24
 
 # Python version-specific requirements

--- a/python/setup.py
+++ b/python/setup.py
@@ -317,6 +317,7 @@ if setup_spec.type == SetupType.RAY:
         "aiosignal",
         "frozenlist",
         "requests",
+        "six",
         # Light weight requirement, can be replaced with "typing" once
         # we deprecate Python 3.7 (this will take a while).
         "typing_extensions; python_version < '3.8'",


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As of recently (< 2-3 days ago), `six` is no longer being automatically installed with Ray, likely due to some change somewhere in the dependency tree.  This causes `ray start` and `ray.init()` to not work out of the box, see the linked issue for the traceback.  This PR explicitly includes `six` as a dependency.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/30810
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
