### PR TITLE
fixes bug passing 'raise' to FailureConfig

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -476,8 +476,8 @@ class FailureConfig:
         if self.fail_fast and self.max_failures != 0:
             raise ValueError("max_failures must be 0 if fail_fast=True.")
 
-        # Same check as in TrialRunner
-        if not (isinstance(self.fail_fast, bool) or self.fail_fast.upper() != "RAISE"):
+        # Similar check as in TrialRunner
+        if not (isinstance(self.fail_fast, bool) or self.fail_fast.upper() == "RAISE"):
             raise ValueError(
                 "fail_fast must be one of {bool, 'raise'}. " f"Got {self.fail_fast}."
             )


### PR DESCRIPTION



## Why are these changes needed?

fixes bug where passing `fail_fast='raise` to `FailureConfig` raises `ValueError: fail_fast must be one of {bool, 'raise'}. Got raise.`

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X, sorry] This PR is not tested :(
