### PR TITLE
[AIR] fixes bug passing 'raise' to FailureConfig

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -476,8 +476,8 @@ class FailureConfig:
         if self.fail_fast and self.max_failures != 0:
             raise ValueError("max_failures must be 0 if fail_fast=True.")
 
-        # Same check as in TrialRunner
-        if not (isinstance(self.fail_fast, bool) or self.fail_fast.upper() != "RAISE"):
+        # Similar check as in TrialRunner
+        if not (isinstance(self.fail_fast, bool) or self.fail_fast.upper() == "RAISE"):
             raise ValueError(
                 "fail_fast must be one of {bool, 'raise'}. " f"Got {self.fail_fast}."
             )

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -476,7 +476,7 @@ class FailureConfig:
         if self.fail_fast and self.max_failures != 0:
             raise ValueError("max_failures must be 0 if fail_fast=True.")
 
-        # Similar check as in TrialRunner
+        # Same check as in TrialRunner
         if not (isinstance(self.fail_fast, bool) or self.fail_fast.upper() == "RAISE"):
             raise ValueError(
                 "fail_fast must be one of {bool, 'raise'}. " f"Got {self.fail_fast}."

--- a/python/ray/air/tests/test_configs.py
+++ b/python/ray/air/tests/test_configs.py
@@ -33,6 +33,19 @@ def test_repr(config):
     assert len(representation) < MAX_REPR_LENGTH
 
 
+def test_failure_config_init():
+    FailureConfig(fail_fast=True)
+    FailureConfig(fail_fast=False)
+    FailureConfig(fail_fast="raise")
+
+    with pytest.raises(ValueError):
+        FailureConfig(fail_fast="fail")
+
+    FailureConfig(fail_fast=True, max_failures=0)
+    with pytest.raises(ValueError):
+        FailureConfig(fail_fast=True, max_failures=1)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -13,7 +13,7 @@ from sklearn.utils import shuffle
 
 from ray import tune
 from ray.air import session
-from ray.air.config import RunConfig, ScalingConfig
+from ray.air.config import RunConfig, ScalingConfig, FailureConfig
 from ray.train.examples.pytorch.torch_linear_example import (
     train_func as linear_train_func,
 )
@@ -233,6 +233,46 @@ class TunerTest(unittest.TestCase):
         assert len(results) == 2
         for i in range(2):
             assert results[i].error
+
+    def test_tuner_fail_fast_true(self):
+        trainer = FailingTrainer()
+        param_space = {
+            "scaling_config": ScalingConfig(num_workers=tune.grid_search([1, 2]))
+        }
+
+        failure_config = FailureConfig(fail_fast=True)
+
+        tuner = Tuner(
+            trainable=trainer,
+            run_config=RunConfig(
+                name="test_tuner_trainer_fail", failure_config=failure_config
+            ),
+            param_space=param_space,
+            tune_config=TuneConfig(mode="max", metric="iteration"),
+        )
+        with self.assertRaises(TuneError):
+            results = tuner.fit()
+            errors = [result.error for result in results if result.error]
+            assert len(errors) == 1
+
+    def test_tuner_fail_fast_raise(self):
+        trainer = FailingTrainer()
+        param_space = {
+            "scaling_config": ScalingConfig(num_workers=tune.grid_search([1, 2]))
+        }
+
+        failure_config = FailureConfig(fail_fast="raise")
+
+        tuner = Tuner(
+            trainable=trainer,
+            run_config=RunConfig(
+                name="test_tuner_trainer_fail", failure_config=failure_config
+            ),
+            param_space=param_space,
+            tune_config=TuneConfig(mode="max", metric="iteration"),
+        )
+        with self.assertRaises(RuntimeError):
+            tuner.fit()
 
     def test_tuner_with_torch_trainer(self):
         """Test a successful run using torch trainer."""

--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -13,7 +13,7 @@ from sklearn.utils import shuffle
 
 from ray import tune
 from ray.air import session
-from ray.air.config import RunConfig, ScalingConfig, FailureConfig
+from ray.air.config import RunConfig, ScalingConfig
 from ray.train.examples.pytorch.torch_linear_example import (
     train_func as linear_train_func,
 )
@@ -233,46 +233,6 @@ class TunerTest(unittest.TestCase):
         assert len(results) == 2
         for i in range(2):
             assert results[i].error
-
-    def test_tuner_fail_fast_true(self):
-        trainer = FailingTrainer()
-        param_space = {
-            "scaling_config": ScalingConfig(num_workers=tune.grid_search([1, 2]))
-        }
-
-        failure_config = FailureConfig(fail_fast=True)
-
-        tuner = Tuner(
-            trainable=trainer,
-            run_config=RunConfig(
-                name="test_tuner_trainer_fail", failure_config=failure_config
-            ),
-            param_space=param_space,
-            tune_config=TuneConfig(mode="max", metric="iteration"),
-        )
-        with self.assertRaises(TuneError):
-            results = tuner.fit()
-            errors = [result.error for result in results if result.error]
-            assert len(errors) == 1
-
-    def test_tuner_fail_fast_raise(self):
-        trainer = FailingTrainer()
-        param_space = {
-            "scaling_config": ScalingConfig(num_workers=tune.grid_search([1, 2]))
-        }
-
-        failure_config = FailureConfig(fail_fast="raise")
-
-        tuner = Tuner(
-            trainable=trainer,
-            run_config=RunConfig(
-                name="test_tuner_trainer_fail", failure_config=failure_config
-            ),
-            param_space=param_space,
-            tune_config=TuneConfig(mode="max", metric="iteration"),
-        )
-        with self.assertRaises(RuntimeError):
-            tuner.fit()
 
     def test_tuner_with_torch_trainer(self):
         """Test a successful run using torch trainer."""


### PR DESCRIPTION

## Why are these changes needed?

fixes bug where passing `fail_fast='raise` to `FailureConfig` raises `ValueError: fail_fast must be one of {bool, 'raise'}. Got raise.`

Closes #30813 

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X, sorry] This PR is not tested :(
