### PR TITLE
[RLlib] [Tune] [Autoscaler] Remove `six` dependency

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -3,6 +3,7 @@ import logging
 import math
 import operator
 import os
+import queue
 import subprocess
 import threading
 import time
@@ -13,7 +14,6 @@ from typing import Any, Callable, Dict, FrozenSet, List, Optional, Set, Tuple, U
 
 import grpc
 import yaml
-from six.moves import queue
 
 from ray.autoscaler._private.constants import (
     AUTOSCALER_HEARTBEAT_TIMEOUT_S,

--- a/python/ray/tune/experiment/config_parser.py
+++ b/python/ray/tune/experiment/config_parser.py
@@ -5,7 +5,6 @@ import os
 # For compatibility under py2 to consider unicode as str
 from ray.air import CheckpointConfig
 from ray.tune.utils.serialization import TuneFunctionEncoder
-from six import string_types
 
 from ray.tune import TuneError
 from ray.tune.experiment import Trial
@@ -156,7 +155,7 @@ def _to_argv(config):
             continue
         if not isinstance(v, bool) or v:  # for argparse flags
             argv.append("--{}".format(k.replace("_", "-")))
-        if isinstance(v, string_types):
+        if isinstance(v, str):
             argv.append(v)
         elif isinstance(v, bool):
             pass

--- a/python/ray/tune/resources.py
+++ b/python/ray/tune/resources.py
@@ -7,7 +7,6 @@ from numbers import Number
 from typing import Optional
 
 from ray.util.annotations import Deprecated, DeveloperAPI
-from six import string_types
 
 from ray._private.resource_spec import NODE_ID_PREFIX
 from ray.tune import TuneError
@@ -231,7 +230,7 @@ class Resources(
 def json_to_resources(data: Optional[str]):
     if data is None or data == "null":
         return None
-    if isinstance(data, string_types):
+    if isinstance(data, str):
         data = json.loads(data)
 
     for k in data:

--- a/python/ray/tune/trainable/function_trainable.py
+++ b/python/ray/tune/trainable/function_trainable.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Dict, Optional, Type, Union
 
 from ray.air._internal.util import StartTraceback, RunnerThread
 from ray.tune.resources import Resources
-from six.moves import queue
+import queue
 
 from ray.air.checkpoint import Checkpoint
 from ray.air.constants import _ERROR_FETCH_TIMEOUT, _RESULT_FETCH_TIMEOUT

--- a/rllib/env/external_env.py
+++ b/rllib/env/external_env.py
@@ -1,4 +1,4 @@
-from six.moves import queue
+import queue
 import gym
 import threading
 import uuid

--- a/rllib/execution/learner_thread.py
+++ b/rllib/execution/learner_thread.py
@@ -1,5 +1,5 @@
 import copy
-from six.moves import queue
+import queue
 import threading
 from typing import Dict, Optional
 

--- a/rllib/execution/multi_gpu_learner_thread.py
+++ b/rllib/execution/multi_gpu_learner_thread.py
@@ -1,5 +1,5 @@
 import logging
-from six.moves import queue
+import queue
 import threading
 
 from ray.util.timer import _Timer

--- a/rllib/offline/json_writer.py
+++ b/rllib/offline/json_writer.py
@@ -3,7 +3,7 @@ import json
 import logging
 import numpy as np
 import os
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 import time
 
 try:

--- a/rllib/utils/compression.py
+++ b/rllib/utils/compression.py
@@ -5,7 +5,6 @@ import time
 import base64
 import numpy as np
 from ray import cloudpickle as pickle
-from six import string_types
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +62,7 @@ def unpack_if_needed(data):
 
 @DeveloperAPI
 def is_compressed(data):
-    return isinstance(data, bytes) or isinstance(data, string_types)
+    return isinstance(data, bytes) or isinstance(data, str)
 
 
 # Intel(R) Core(TM) i7-4600U CPU @ 2.10GHz


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`six` is a compatiblity library for Python 2 and Python 3 which is no longer needed because Ray doesn't support Python 2.

This PR removes all imports from `six`.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/30810
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
