### PR TITLE
[AIR] fixes bug passing 'raise' to FailureConfig (#30814)

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -475,7 +475,7 @@ class FailureConfig:
             raise ValueError("max_failures must be 0 if fail_fast=True.")
 
         # Same check as in TrialRunner
-        if not (isinstance(self.fail_fast, bool) or self.fail_fast.upper() != "RAISE"):
+        if not (isinstance(self.fail_fast, bool) or self.fail_fast.upper() == "RAISE"):
             raise ValueError(
                 "fail_fast must be one of {bool, 'raise'}. " f"Got {self.fail_fast}."
             )

--- a/python/ray/air/tests/test_configs.py
+++ b/python/ray/air/tests/test_configs.py
@@ -33,6 +33,19 @@ def test_repr(config):
     assert len(representation) < MAX_REPR_LENGTH
 
 
+def test_failure_config_init():
+    FailureConfig(fail_fast=True)
+    FailureConfig(fail_fast=False)
+    FailureConfig(fail_fast="raise")
+
+    with pytest.raises(ValueError):
+        FailureConfig(fail_fast="fail")
+
+    FailureConfig(fail_fast=True, max_failures=0)
+    with pytest.raises(ValueError):
+        FailureConfig(fail_fast=True, max_failures=1)
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
cherry-picks https://github.com/ray-project/ray/pull/30814

original message
===============

fixes bug where passing fail_fast='raise to FailureConfig raises ValueError: fail_fast must be one of {bool, 'raise'}. Got raise.

Closes #30813

Signed-off-by: Richard Decal <richard.decal@ncf.edu>
Signed-off-by: amogkam <amogkamsetty@yahoo.com>
Co-authored-by: amogkam <amogkamsetty@yahoo.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
