### PR TITLE
[RLlib] Enhance input readers to handle complex combinations of trained policies vs offline data

### DIFF
--- a/rllib/offline/input_reader.py
+++ b/rllib/offline/input_reader.py
@@ -28,6 +28,25 @@ class InputReader(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    def select_policy_data_build_ma_batch(self, batch: SampleBatchType,
+                                          policy_ids: List = None) -> MultiAgentBatch:
+        """Select what policy's data from the batch we read to operate on.
+
+        When reading data from a multi-agent file for a single agent, we want to
+        select only the policy data we want to train on. Vice versa, in a multi-agent
+        case, only a subset of trained policies may need offline data from the input
+        reader.
+
+        Args:
+            batch: SampleBatch or MultiAgent batch to select policy data from and
+                build a new MultiAgent batch from.
+            policy_ids: Policy IDs to select
+
+        Returns:
+            A MultiAgentBatch containing the policy ID's data.
+        """
+        pass
+
     @PublicAPI
     def tf_input_ops(self, queue_size: int = 1) -> Dict[str, TensorType]:
         """Returns TensorFlow queue ops for reading inputs from this reader.


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Our input readers today simply throw an error if we want to ingest single agent data in a multi-policy training workflow that combines offline and online training. While the case is not super compelling just like that, we should still support evaluating offline policies in a multi-agent setting and therefore support offline training with a policy_map of length > 1.

Related Issue:
https://github.com/ray-project/ray/issues/30676

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
