### PR TITLE
Revert "[air/wandb] Use Ray actors instead of multiprocessing for WandbLoggerCallback"

### DIFF
--- a/python/ray/air/integrations/wandb.py
+++ b/python/ray/air/integrations/wandb.py
@@ -3,13 +3,14 @@ import os
 import pickle
 import urllib
 
+from multiprocessing import Process, Queue
+
 import numpy as np
 from numbers import Number
 
 from types import ModuleType
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
-import ray
 from ray import logger
 from ray.air import session
 
@@ -18,9 +19,7 @@ from ray.tune.utils import flatten_dict
 from ray.tune.experiment import Trial
 
 from ray._private.storage import _load_class
-from ray.tune.utils.node import _force_on_current_node
 from ray.util import PublicAPI
-from ray.util.queue import Queue
 
 try:
     import wandb
@@ -266,12 +265,10 @@ class _QueueItem(enum.Enum):
     CHECKPOINT = enum.auto()
 
 
-class _WandbLoggingActor:
+class _WandbLoggingProcess(Process):
     """
-    We need a separate process to allow multiple concurrent
-    wandb logging instances locally. We use Ray actors as forking multiprocessing
-    processes is not supported by Ray and spawn processes run into pickling
-    problems.
+    We need a `multiprocessing.Process` to allow multiple concurrent
+    wandb logging instances locally.
 
     We use a queue for the driver to communicate with the logging process.
     The queue accepts the following items:
@@ -290,6 +287,8 @@ class _WandbLoggingActor:
         *args,
         **kwargs,
     ):
+        super(_WandbLoggingProcess, self).__init__()
+
         import wandb
 
         self._wandb = wandb
@@ -364,6 +363,9 @@ class _WandbLoggingActor:
         config_update.pop("callbacks", None)  # Remove callbacks
         return log, config_update
 
+    def __reduce__(self):
+        raise RuntimeError("_WandbLoggingProcess is not pickleable.")
+
 
 class WandbLoggerCallback(LoggerCallback):
     """WandbLoggerCallback
@@ -432,7 +434,7 @@ class WandbLoggerCallback(LoggerCallback):
         "date",
     ]
 
-    _logger_actor_cls = _WandbLoggingActor
+    _logger_process_cls = _WandbLoggingProcess
 
     def __init__(
         self,
@@ -454,12 +456,7 @@ class WandbLoggerCallback(LoggerCallback):
         self.save_checkpoints = save_checkpoints
         self.kwargs = kwargs
 
-        self._remote_logger_class = None
-
-        self._trial_logging_actors: Dict[
-            "Trial", ray.actor.ActorHandle[_WandbLoggingActor]
-        ] = {}
-        self._trial_logging_futures: Dict["Trial", ray.ObjectRef] = {}
+        self._trial_processes: Dict["Trial", _WandbLoggingProcess] = {}
         self._trial_queues: Dict["Trial", Queue] = {}
 
     def setup(self, *args, **kwargs):
@@ -519,44 +516,18 @@ class WandbLoggerCallback(LoggerCallback):
         )
         wandb_init_kwargs.update(self.kwargs)
 
-        self._start_logging_actor(trial, exclude_results, **wandb_init_kwargs)
-
-    def _start_logging_actor(
-        self, trial: "Trial", exclude_results: List[str], **wandb_init_kwargs
-    ):
-        if not self._remote_logger_class:
-            self._remote_logger_class = ray.remote(
-                num_cpus=0, **_force_on_current_node()
-            )(self._logger_actor_cls)
-
-        self._trial_queues[trial] = Queue(
-            actor_options={"num_cpus": 0, **_force_on_current_node()}
-        )
-        self._trial_logging_actors[trial] = self._remote_logger_class.remote(
+        self._trial_queues[trial] = Queue()
+        self._trial_processes[trial] = self._logger_process_cls(
             logdir=trial.logdir,
             queue=self._trial_queues[trial],
             exclude=exclude_results,
             to_config=self._config_results,
             **wandb_init_kwargs,
         )
-        self._trial_logging_futures[trial] = self._trial_logging_actors[
-            trial
-        ].run.remote()
-
-    def _stop_logging_actor(self, trial: "Trial", timeout: int = 10):
-        self._trial_queues[trial].put((_QueueItem.END, None))
-
-        try:
-            ray.get(self._trial_logging_futures[trial], timeout=timeout)
-        except TimeoutError:
-            ray.kill(self._trial_logging_actors[trial])
-
-        del self._trial_queues[trial]
-        del self._trial_logging_actors[trial]
-        del self._trial_logging_futures[trial]
+        self._trial_processes[trial].start()
 
     def log_trial_result(self, iteration: int, trial: "Trial", result: Dict):
-        if trial not in self._trial_logging_actors:
+        if trial not in self._trial_processes:
             self.log_trial_start(trial)
 
         result = _clean_log(result)
@@ -569,12 +540,23 @@ class WandbLoggerCallback(LoggerCallback):
             )
 
     def log_trial_end(self, trial: "Trial", failed: bool = False):
-        self._stop_logging_actor(trial=trial, timeout=10)
+        self._trial_queues[trial].put((_QueueItem.END, None))
+        self._trial_processes[trial].join(timeout=10)
+
+        if self._trial_processes[trial].is_alive():
+            self._trial_processes[trial].kill()
+
+        del self._trial_queues[trial]
+        del self._trial_processes[trial]
 
     def __del__(self):
-        for trial in list(self._trial_logging_actors):
-            self._stop_logging_actor(trial=trial, timeout=2)
+        for trial in self._trial_processes:
+            if trial in self._trial_queues:
+                self._trial_queues[trial].put((_QueueItem.END, None))
+            self._trial_processes[trial].join(timeout=2)
 
-        self._trial_logging_actors = {}
-        self._trial_logging_futures = {}
+            if self._trial_processes[trial].is_alive():
+                self._trial_processes[trial].kill()
+
+        self._trial_processes = {}
         self._trial_queues = {}

--- a/python/ray/tune/tests/test_integration_wandb.py
+++ b/python/ray/tune/tests/test_integration_wandb.py
@@ -1,9 +1,8 @@
 import os
 import tempfile
-import threading
 from collections import namedtuple
 from dataclasses import dataclass
-from queue import Queue
+from multiprocessing import Queue
 from typing import Tuple, Dict
 from unittest.mock import (
     Mock,
@@ -22,8 +21,8 @@ from ray.tune.integration.wandb import (
 )
 from ray.air.integrations.wandb import (
     WandbLoggerCallback,
+    _WandbLoggingProcess,
     _QueueItem,
-    _WandbLoggingActor,
 )
 from ray.air.integrations.wandb import (
     WANDB_ENV_VAR,
@@ -89,41 +88,20 @@ class _MockWandbAPI:
         return Mock()
 
 
-class _MockWandbLoggingActor(_WandbLoggingActor):
+class _MockWandbLoggingProcess(_WandbLoggingProcess):
     def __init__(self, logdir, queue, exclude, to_config, *args, **kwargs):
-        super(_MockWandbLoggingActor, self).__init__(
+        super(_MockWandbLoggingProcess, self).__init__(
             logdir, queue, exclude, to_config, *args, **kwargs
         )
         self._wandb = _MockWandbAPI()
 
 
 class WandbTestExperimentLogger(WandbLoggerCallback):
+    _logger_process_cls = _MockWandbLoggingProcess
+
     @property
     def trial_processes(self):
-        return self._trial_logging_actors
-
-    def _start_logging_actor(self, trial, exclude_results, **wandb_init_kwargs):
-        self._trial_queues[trial] = Queue()
-        local_actor = _MockWandbLoggingActor(
-            logdir=trial.logdir,
-            queue=self._trial_queues[trial],
-            exclude=exclude_results,
-            to_config=self._config_results,
-            **wandb_init_kwargs,
-        )
-        self._trial_logging_actors[trial] = local_actor
-
-        thread = threading.Thread(target=local_actor.run)
-        self._trial_logging_futures[trial] = thread
-        thread.start()
-
-    def _stop_logging_actor(self, trial: "Trial", timeout: int = 10):
-        self._trial_queues[trial].put((_QueueItem.END, None))
-
-        del self._trial_queues[trial]
-        del self._trial_logging_actors[trial]
-        self._trial_logging_futures[trial].join(timeout=2)
-        del self._trial_logging_futures[trial]
+        return self._trial_processes
 
 
 class _MockWandbTrainableMixin(WandbTrainableMixin):
@@ -427,8 +405,8 @@ class TestWandbMixinDecorator:
 
 def test_wandb_logging_process_run_info_hook(monkeypatch):
     """
-    Test WANDB_PROCESS_RUN_INFO_HOOK in _WandbLoggingActor is
-    correctly called by calling _WandbLoggingActor.run() mocking
+    Test WANDB_PROCESS_RUN_INFO_HOOK in _WandbLoggingProcess is
+    correctly called by calling _WandbLoggingProcess.run() mocking
     out calls to wandb.
     """
     mock_queue = Mock(get=Mock(return_value=(_QueueItem.END, None)))
@@ -437,7 +415,7 @@ def test_wandb_logging_process_run_info_hook(monkeypatch):
     )
 
     with patch.object(ray.air.integrations.wandb, "_load_class") as mock_load_class:
-        logging_process = _WandbLoggingActor(
+        logging_process = _WandbLoggingProcess(
             logdir="/tmp", queue=mock_queue, exclude=[], to_config=[]
         )
         logging_process._wandb = Mock()


### PR DESCRIPTION
Reverts ray-project/ray#30165

The WANDB_ENV_VAR is not being propagated to the actors causing them to not be able to find the API key.