### PR TITLE
Revert "Revert "[air/wandb] Use Ray actors instead of multiprocessing for WandbLoggerCallback"" (#30845)

### DIFF
--- a/python/ray/air/integrations/wandb.py
+++ b/python/ray/air/integrations/wandb.py
@@ -525,8 +525,14 @@ class WandbLoggerCallback(LoggerCallback):
         self, trial: "Trial", exclude_results: List[str], **wandb_init_kwargs
     ):
         if not self._remote_logger_class:
+            env_vars = {}
+            # API key env variable is not set if authenticating through `wandb login`
+            if WANDB_ENV_VAR in os.environ:
+                env_vars[WANDB_ENV_VAR] = os.environ[WANDB_ENV_VAR]
             self._remote_logger_class = ray.remote(
-                num_cpus=0, **_force_on_current_node()
+                num_cpus=0,
+                **_force_on_current_node(),
+                runtime_env={"env_vars": env_vars},
             )(self._logger_actor_cls)
 
         self._trial_queues[trial] = Queue(

--- a/python/ray/air/integrations/wandb.py
+++ b/python/ray/air/integrations/wandb.py
@@ -3,14 +3,13 @@ import os
 import pickle
 import urllib
 
-from multiprocessing import Process, Queue
-
 import numpy as np
 from numbers import Number
 
 from types import ModuleType
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
+import ray
 from ray import logger
 from ray.air import session
 
@@ -19,7 +18,9 @@ from ray.tune.utils import flatten_dict
 from ray.tune.experiment import Trial
 
 from ray._private.storage import _load_class
+from ray.tune.utils.node import _force_on_current_node
 from ray.util import PublicAPI
+from ray.util.queue import Queue
 
 try:
     import wandb
@@ -265,10 +266,12 @@ class _QueueItem(enum.Enum):
     CHECKPOINT = enum.auto()
 
 
-class _WandbLoggingProcess(Process):
+class _WandbLoggingActor:
     """
-    We need a `multiprocessing.Process` to allow multiple concurrent
-    wandb logging instances locally.
+    We need a separate process to allow multiple concurrent
+    wandb logging instances locally. We use Ray actors as forking multiprocessing
+    processes is not supported by Ray and spawn processes run into pickling
+    problems.
 
     We use a queue for the driver to communicate with the logging process.
     The queue accepts the following items:
@@ -287,8 +290,6 @@ class _WandbLoggingProcess(Process):
         *args,
         **kwargs,
     ):
-        super(_WandbLoggingProcess, self).__init__()
-
         import wandb
 
         self._wandb = wandb
@@ -363,9 +364,6 @@ class _WandbLoggingProcess(Process):
         config_update.pop("callbacks", None)  # Remove callbacks
         return log, config_update
 
-    def __reduce__(self):
-        raise RuntimeError("_WandbLoggingProcess is not pickleable.")
-
 
 class WandbLoggerCallback(LoggerCallback):
     """WandbLoggerCallback
@@ -434,7 +432,7 @@ class WandbLoggerCallback(LoggerCallback):
         "date",
     ]
 
-    _logger_process_cls = _WandbLoggingProcess
+    _logger_actor_cls = _WandbLoggingActor
 
     def __init__(
         self,
@@ -456,7 +454,12 @@ class WandbLoggerCallback(LoggerCallback):
         self.save_checkpoints = save_checkpoints
         self.kwargs = kwargs
 
-        self._trial_processes: Dict["Trial", _WandbLoggingProcess] = {}
+        self._remote_logger_class = None
+
+        self._trial_logging_actors: Dict[
+            "Trial", ray.actor.ActorHandle[_WandbLoggingActor]
+        ] = {}
+        self._trial_logging_futures: Dict["Trial", ray.ObjectRef] = {}
         self._trial_queues: Dict["Trial", Queue] = {}
 
     def setup(self, *args, **kwargs):
@@ -516,18 +519,44 @@ class WandbLoggerCallback(LoggerCallback):
         )
         wandb_init_kwargs.update(self.kwargs)
 
-        self._trial_queues[trial] = Queue()
-        self._trial_processes[trial] = self._logger_process_cls(
+        self._start_logging_actor(trial, exclude_results, **wandb_init_kwargs)
+
+    def _start_logging_actor(
+        self, trial: "Trial", exclude_results: List[str], **wandb_init_kwargs
+    ):
+        if not self._remote_logger_class:
+            self._remote_logger_class = ray.remote(
+                num_cpus=0, **_force_on_current_node()
+            )(self._logger_actor_cls)
+
+        self._trial_queues[trial] = Queue(
+            actor_options={"num_cpus": 0, **_force_on_current_node()}
+        )
+        self._trial_logging_actors[trial] = self._remote_logger_class.remote(
             logdir=trial.logdir,
             queue=self._trial_queues[trial],
             exclude=exclude_results,
             to_config=self._config_results,
             **wandb_init_kwargs,
         )
-        self._trial_processes[trial].start()
+        self._trial_logging_futures[trial] = self._trial_logging_actors[
+            trial
+        ].run.remote()
+
+    def _stop_logging_actor(self, trial: "Trial", timeout: int = 10):
+        self._trial_queues[trial].put((_QueueItem.END, None))
+
+        try:
+            ray.get(self._trial_logging_futures[trial], timeout=timeout)
+        except TimeoutError:
+            ray.kill(self._trial_logging_actors[trial])
+
+        del self._trial_queues[trial]
+        del self._trial_logging_actors[trial]
+        del self._trial_logging_futures[trial]
 
     def log_trial_result(self, iteration: int, trial: "Trial", result: Dict):
-        if trial not in self._trial_processes:
+        if trial not in self._trial_logging_actors:
             self.log_trial_start(trial)
 
         result = _clean_log(result)
@@ -540,23 +569,12 @@ class WandbLoggerCallback(LoggerCallback):
             )
 
     def log_trial_end(self, trial: "Trial", failed: bool = False):
-        self._trial_queues[trial].put((_QueueItem.END, None))
-        self._trial_processes[trial].join(timeout=10)
-
-        if self._trial_processes[trial].is_alive():
-            self._trial_processes[trial].kill()
-
-        del self._trial_queues[trial]
-        del self._trial_processes[trial]
+        self._stop_logging_actor(trial=trial, timeout=10)
 
     def __del__(self):
-        for trial in self._trial_processes:
-            if trial in self._trial_queues:
-                self._trial_queues[trial].put((_QueueItem.END, None))
-            self._trial_processes[trial].join(timeout=2)
+        for trial in list(self._trial_logging_actors):
+            self._stop_logging_actor(trial=trial, timeout=2)
 
-            if self._trial_processes[trial].is_alive():
-                self._trial_processes[trial].kill()
-
-        self._trial_processes = {}
+        self._trial_logging_actors = {}
+        self._trial_logging_futures = {}
         self._trial_queues = {}

--- a/python/ray/tune/tests/test_integration_wandb.py
+++ b/python/ray/tune/tests/test_integration_wandb.py
@@ -1,8 +1,9 @@
 import os
 import tempfile
+import threading
 from collections import namedtuple
 from dataclasses import dataclass
-from multiprocessing import Queue
+from queue import Queue
 from typing import Tuple, Dict
 from unittest.mock import (
     Mock,
@@ -21,8 +22,8 @@ from ray.tune.integration.wandb import (
 )
 from ray.air.integrations.wandb import (
     WandbLoggerCallback,
-    _WandbLoggingProcess,
     _QueueItem,
+    _WandbLoggingActor,
 )
 from ray.air.integrations.wandb import (
     WANDB_ENV_VAR,
@@ -88,20 +89,41 @@ class _MockWandbAPI:
         return Mock()
 
 
-class _MockWandbLoggingProcess(_WandbLoggingProcess):
+class _MockWandbLoggingActor(_WandbLoggingActor):
     def __init__(self, logdir, queue, exclude, to_config, *args, **kwargs):
-        super(_MockWandbLoggingProcess, self).__init__(
+        super(_MockWandbLoggingActor, self).__init__(
             logdir, queue, exclude, to_config, *args, **kwargs
         )
         self._wandb = _MockWandbAPI()
 
 
 class WandbTestExperimentLogger(WandbLoggerCallback):
-    _logger_process_cls = _MockWandbLoggingProcess
-
     @property
     def trial_processes(self):
-        return self._trial_processes
+        return self._trial_logging_actors
+
+    def _start_logging_actor(self, trial, exclude_results, **wandb_init_kwargs):
+        self._trial_queues[trial] = Queue()
+        local_actor = _MockWandbLoggingActor(
+            logdir=trial.logdir,
+            queue=self._trial_queues[trial],
+            exclude=exclude_results,
+            to_config=self._config_results,
+            **wandb_init_kwargs,
+        )
+        self._trial_logging_actors[trial] = local_actor
+
+        thread = threading.Thread(target=local_actor.run)
+        self._trial_logging_futures[trial] = thread
+        thread.start()
+
+    def _stop_logging_actor(self, trial: "Trial", timeout: int = 10):
+        self._trial_queues[trial].put((_QueueItem.END, None))
+
+        del self._trial_queues[trial]
+        del self._trial_logging_actors[trial]
+        self._trial_logging_futures[trial].join(timeout=2)
+        del self._trial_logging_futures[trial]
 
 
 class _MockWandbTrainableMixin(WandbTrainableMixin):
@@ -405,8 +427,8 @@ class TestWandbMixinDecorator:
 
 def test_wandb_logging_process_run_info_hook(monkeypatch):
     """
-    Test WANDB_PROCESS_RUN_INFO_HOOK in _WandbLoggingProcess is
-    correctly called by calling _WandbLoggingProcess.run() mocking
+    Test WANDB_PROCESS_RUN_INFO_HOOK in _WandbLoggingActor is
+    correctly called by calling _WandbLoggingActor.run() mocking
     out calls to wandb.
     """
     mock_queue = Mock(get=Mock(return_value=(_QueueItem.END, None)))
@@ -415,7 +437,7 @@ def test_wandb_logging_process_run_info_hook(monkeypatch):
     )
 
     with patch.object(ray.air.integrations.wandb, "_load_class") as mock_load_class:
-        logging_process = _WandbLoggingProcess(
+        logging_process = _WandbLoggingActor(
             logdir="/tmp", queue=mock_queue, exclude=[], to_config=[]
         )
         logging_process._wandb = Mock()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This reverts commit https://github.com/ray-project/ray/commit/45340b51f83395661689c2fbb97eab7a3b812f76.

Adds a fix to propagate wandb API key environment variable to the logging actors, if the API key is specified through `api_key` or `api_key_file` in the `WandbLoggerCallback`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
