### PR TITLE
[release] Do not send prometheus logs to db to avoid HTTP 413

### DIFF
--- a/release/ray_release/reporter/db.py
+++ b/release/ray_release/reporter/db.py
@@ -32,7 +32,9 @@ class DBReporter(Reporter):
             "stable": result.stable,
             "return_code": result.return_code,
             "smoke_test": result.smoke_test,
-            "prometheus_metrics": result.prometheus_metrics or {},
+            # Todo: Activate again once we thinned these out a bit or find another
+            # way to reduce the size.
+            "prometheus_metrics": {},  # result.prometheus_metrics or {},
         }
 
         logger.debug(f"Result json: {json.dumps(result_json)}")


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/ray/pull/30075 introduced collecting and sendign prometheus metrics to databricks. However, for some tests these metrics are too large, e.g. here: https://buildkite.com/ray-project/release-tests-branch/builds/1233#0184cfc2-f577-4946-964b-6fd1dfeabecd (38 MB). This then leads to HTTP 413 errors (payload too large) and no metrics are reported at all.

This PR deactivates sending any prometheus metrics to databricks. Instead we should collect a summary or find a different way to persist large metrics.

There have been subsequent changes to the metrics reporting, which prevents a simple revert.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
