### PR TITLE
[release] Post process fetched result earlier

### DIFF
--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -291,6 +291,12 @@ def run_release_test(
             logger.exception(e)
             command_results = {}
 
+        # Postprocess result:
+        if "last_update" in command_results:
+            command_results["last_update_diff"] = time.time() - command_results.get(
+                "last_update", 0.0
+            )
+
         try:
             command_runner.save_metrics(start_time_unix)
             metrics = command_runner.fetch_metrics()
@@ -298,11 +304,6 @@ def run_release_test(
             logger.exception(f"Could not fetch metrics for test command: {e}")
             metrics = {}
 
-        # Postprocess result:
-        if "last_update" in command_results:
-            command_results["last_update_diff"] = time.time() - command_results.get(
-                "last_update", 0.0
-            )
         if smoke_test:
             command_results["smoke_test"] = True
 


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We postprocess results for long running tests by calculating the difference between the current timestamp and the timestamp of the last file update on the server.

However, in #30075 we also collect and fetch prometheus metrics. This is done before collecting the current timestamp. Thus, if collecting and downloading the metrics takes a long time, the difference is inaccurate and can lead to test failures due to too long updates.

This PR moves the calculation to an earlier point.

Generally, the comparison between a local and a remote timestamp is not ideal and we may want to think about better ways to do this in the future.




## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
