### PR TITLE
[2.2 Release] Revert "[Core] RetryObjectInPlasmaErrors tries to fetch all objects, not just ready ones. (#30756)"

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1259,11 +1259,20 @@ void RetryObjectInPlasmaErrors(std::shared_ptr<CoreWorkerMemoryStore> &memory_st
   for (auto iter = memory_object_ids.begin(); iter != memory_object_ids.end();) {
     auto current = iter++;
     const auto &mem_id = *current;
-    auto found = memory_store->GetIfExists(mem_id);
-    if (found != nullptr && found->IsInPlasmaError()) {
-      plasma_object_ids.insert(mem_id);
-      ready.erase(mem_id);
-      memory_object_ids.erase(current);
+    auto ready_iter = ready.find(mem_id);
+    if (ready_iter != ready.end()) {
+      std::vector<std::shared_ptr<RayObject>> found;
+      RAY_CHECK_OK(memory_store->Get({mem_id},
+                                     /*num_objects=*/1,
+                                     /*timeout=*/0,
+                                     worker_context,
+                                     /*remote_after_get=*/false,
+                                     &found));
+      if (found.size() == 1 && found[0]->IsInPlasmaError()) {
+        plasma_object_ids.insert(mem_id);
+        ready.erase(ready_iter);
+        memory_object_ids.erase(current);
+      }
     }
   }
 }


### PR DESCRIPTION
Per comment https://github.com/ray-project/ray/issues/30694#issuecomment-1334954184, reverting the ray.wait prefetching change #30756.

This reverts commit 7bccdb777cf3a8d9d3696144c0e97ef3792d6083.

This PR is for the release branch -- I will create an issue to fix the performance regression in the master branch.

I'm not sure whether the performance regression is worse than the bug it was trying to fix in the beginning -- will leave up to @ericl to decide whether to revert or not.