### PR TITLE
[Doc] Move accelerator type doc from miscellaneous to gpu doc

### DIFF
--- a/doc/source/ray-core/doc_code/gpus.py
+++ b/doc/source/ray-core/doc_code/gpus.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 # __get_gpu_ids_start__
 import os
 import ray
@@ -93,3 +95,23 @@ def leak_gpus():
 
 
 # __leak_gpus_end__
+
+ray.shutdown()
+import ray.util.accelerators
+import ray._private.ray_constants as ray_constants
+
+v100_resource_name = f"{ray_constants.RESOURCE_CONSTRAINT_PREFIX}{ray.util.accelerators.NVIDIA_TESLA_V100}"
+ray.init(num_gpus=4, resources={v100_resource_name: 1})
+
+
+# __accelerator_type_start__
+from ray.util.accelerators import NVIDIA_TESLA_V100
+
+
+@ray.remote(num_gpus=1, accelerator_type=NVIDIA_TESLA_V100)
+def train(data):
+    return "This function was run on a node with a Tesla V100 GPU"
+
+
+ray.get(train.remote(1))
+# __accelerator_type_end__

--- a/doc/source/ray-core/miscellaneous.rst
+++ b/doc/source/ray-core/miscellaneous.rst
@@ -75,24 +75,6 @@ appear as the task name in the logs.
 .. image:: images/task_name_dashboard.png
 
 
-.. _accelerator-types:
-
-Accelerator Types
-------------------
-
-Ray supports resource specific accelerator types. The `accelerator_type` field can be used to force to a task to run on a node with a specific type of accelerator. Under the hood, the accelerator type option is implemented as a custom resource demand of ``"accelerator_type:<type>": 0.001``. This forces the task to be placed on a node with that particular accelerator type available. This also lets the multi-node-type autoscaler know that there is demand for that type of resource, potentially triggering the launch of new nodes providing that accelerator.
-
-.. code-block:: python
-
-    from ray.accelerators import NVIDIA_TESLA_V100
-
-    @ray.remote(num_gpus=1, accelerator_type=NVIDIA_TESLA_V100)
-    def train(data):
-        return "This function was run on a node with a Tesla V100 GPU"
-
-See `ray.util.accelerators` to see available accelerator types. Current automatically detected accelerator types include Nvidia GPUs.
-
-
 Overloaded Functions
 --------------------
 Ray Java API supports calling overloaded java functions remotely. However, due to the limitation of Java compiler type inference, one must explicitly cast the method reference to the correct function type. For example, consider the following.
@@ -236,7 +218,7 @@ Maximum open files
 The OS has to be configured to support opening many TCP connections since every
 worker and raylet connects to the GCS. In POSIX systems, the current limit can
 be checked by ``ulimit -n`` and if it's small, it should be increased according to
-the OS manual. 
+the OS manual.
 
 ARP cache
 *********
@@ -249,7 +231,7 @@ Failure to do this will result in the head node hanging. When this happens,
 ``dmesg`` will show errors like ``neighbor table overflow message``.
 
 In Ubuntu, the ARP cache size can be tuned in ``/etc/sysctl.conf`` by increasing
-the value of ``net.ipv4.neigh.default.gc_thresh1`` - ``net.ipv4.neigh.default.gc_thresh3``. 
+the value of ``net.ipv4.neigh.default.gc_thresh1`` - ``net.ipv4.neigh.default.gc_thresh3``.
 For more details, please refer to the OS manual.
 
 Tuning Ray Settings
@@ -274,7 +256,7 @@ available resources of each other in the Ray cluster. Each raylet is going to
 push its local available resource to GCS and GCS will broadcast it to all the
 raylet periodically. The time complexity is O(N^2). In a large Ray cluster, this
 is going to be an issue, since most of the time is spent on broadcasting the
-resources. There are several settings we can use to tune this: 
+resources. There are several settings we can use to tune this:
 
 - ``RAY_resource_broadcast_batch_size`` The maximum number of nodes in a single
   request sent by GCS, by default 512.
@@ -296,9 +278,9 @@ By default, only one gRPC thread is used for server and client polling from the
 completion queue. This might become the bottleneck if QPS is too high.
 
 - ``RAY_gcs_server_rpc_server_thread_num`` Control the number of threads in GCS
-  polling from the server completion queue, by default, 1. 
+  polling from the server completion queue, by default, 1.
 - ``RAY_gcs_server_rpc_client_thread_num`` Control the number of threads in GCS
-  polling from the client completion queue, by default, 1. 
+  polling from the client completion queue, by default, 1.
 
 
 Benchmark

--- a/doc/source/ray-core/tasks/using-ray-with-gpus.rst
+++ b/doc/source/ray-core/tasks/using-ray-with-gpus.rst
@@ -121,4 +121,4 @@ This also lets the multi-node-type autoscaler know that there is demand for that
     :start-after: __accelerator_type_start__
     :end-before: __accelerator_type_end__
 
-See :py:mod:`~ray.util.accelerators` for available accelerator types. Current automatically detected accelerator types include Nvidia GPUs.
+See ``ray.util.accelerators`` for available accelerator types. Current automatically detected accelerator types include Nvidia GPUs.

--- a/doc/source/ray-core/tasks/using-ray-with-gpus.rst
+++ b/doc/source/ray-core/tasks/using-ray-with-gpus.rst
@@ -105,3 +105,20 @@ in the :ref:`ray.remote <ray-remote-ref>` decorator.
     :language: python
     :start-after: __leak_gpus_start__
     :end-before: __leak_gpus_end__
+
+.. _accelerator-types:
+
+Accelerator Types
+-----------------
+
+Ray supports resource specific accelerator types. The `accelerator_type` option can be used to force to a task or actor to run on a node with a specific type of accelerator.
+Under the hood, the accelerator type option is implemented as a :ref:`custom resource requirement <custom-resources>` of ``"accelerator_type:<type>": 0.001``.
+This forces the task or actor to be placed on a node with that particular accelerator type available.
+This also lets the multi-node-type autoscaler know that there is demand for that type of resource, potentially triggering the launch of new nodes providing that accelerator.
+
+.. literalinclude:: ../doc_code/gpus.py
+    :language: python
+    :start-after: __accelerator_type_start__
+    :end-before: __accelerator_type_end__
+
+See :py:mod:`~ray.util.accelerators` for available accelerator types. Current automatically detected accelerator types include Nvidia GPUs.

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2932,7 +2932,7 @@ def remote(
             This is a dictionary mapping strings (resource names) to floats.
         accelerator_type: If specified, requires that the task or actor run
             on a node with the specified type of accelerator.
-            See `ray.accelerators` for accelerator types.
+            See `ray.util.accelerators` for accelerator types.
         memory: The heap memory request in bytes for this task/actor,
             rounded down to the nearest integer.
         max_calls: Only for *remote functions*. This specifies the

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -544,7 +544,7 @@ class ActorClass:
                 This is a dictionary mapping strings (resource names) to floats.
             accelerator_type: If specified, requires that the task or actor run
                 on a node with the specified type of accelerator.
-                See `ray.accelerators` for accelerator types.
+                See `ray.util.accelerators` for accelerator types.
             memory: The heap memory request in bytes for this task/actor,
                 rounded down to the nearest integer.
             object_store_memory: The object store memory request for actors only.

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -155,7 +155,7 @@ class RemoteFunction:
                 This is a dictionary mapping strings (resource names) to floats.
             accelerator_type: If specified, requires that the task or actor run
                 on a node with the specified type of accelerator.
-                See `ray.accelerators` for accelerator types.
+                See `ray.util.accelerators` for accelerator types.
             memory: The heap memory request in bytes for this task/actor,
                 rounded down to the nearest integer.
             object_store_memory: The object store memory request for actors only.


### PR DESCRIPTION
Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Move accelerator type doc from miscellaneous to gpu doc
- Make the code snippet testable
- Fix the reference from ray.accelerators to ray.util.accelerators
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
