### PR TITLE
[core][state] Task events backend - worker task event buffer implementation [1/n]

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1055,6 +1055,19 @@ cc_test(
 )
 
 cc_test(
+    name = "task_event_buffer_test",
+    size = "small",
+    srcs = ["src/ray/core_worker/test/task_event_buffer_test.cc"],
+    copts = COPTS,
+    tags = ["team:core"],
+    deps = [
+        ":core_worker_lib",
+        ":ray_mock",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "actor_creator_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/actor_creator_test.cc"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1050,6 +1050,7 @@ cc_test(
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
+        ":ray_mock",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/mock/ray/gcs/gcs_client/accessor.h
+++ b/src/mock/ray/gcs/gcs_client/accessor.h
@@ -212,6 +212,20 @@ class MockErrorInfoAccessor : public ErrorInfoAccessor {
 namespace ray {
 namespace gcs {
 
+class MockTaskInfoAccessor : public TaskInfoAccessor {
+ public:
+  MOCK_METHOD(Status,
+              AsyncAddTaskEventData,
+              (std::unique_ptr<rpc::TaskEventData> data_ptr, StatusCallback callback),
+              (override));
+};
+
+}  // namespace gcs
+}  // namespace ray
+
+namespace ray {
+namespace gcs {
+
 class MockStatsInfoAccessor : public StatsInfoAccessor {
  public:
   MOCK_METHOD(Status,

--- a/src/mock/ray/gcs/gcs_client/gcs_client.h
+++ b/src/mock/ray/gcs/gcs_client/gcs_client.h
@@ -46,6 +46,7 @@ class MockGcsClient : public GcsClient {
     mock_worker_accessor = new MockWorkerInfoAccessor();
     mock_placement_group_accessor = new MockPlacementGroupInfoAccessor();
     mock_internal_kv_accessor = new MockInternalKVAccessor();
+    mock_task_accessor = new MockTaskInfoAccessor();
 
     GcsClient::job_accessor_.reset(mock_job_accessor);
     GcsClient::actor_accessor_.reset(mock_actor_accessor);
@@ -55,6 +56,7 @@ class MockGcsClient : public GcsClient {
     GcsClient::error_accessor_.reset(mock_error_accessor);
     GcsClient::worker_accessor_.reset(mock_worker_accessor);
     GcsClient::placement_group_accessor_.reset(mock_placement_group_accessor);
+    GcsClient::task_accessor_.reset(mock_task_accessor);
   }
   MockActorInfoAccessor *mock_actor_accessor;
   MockJobInfoAccessor *mock_job_accessor;
@@ -65,6 +67,7 @@ class MockGcsClient : public GcsClient {
   MockWorkerInfoAccessor *mock_worker_accessor;
   MockPlacementGroupInfoAccessor *mock_placement_group_accessor;
   MockInternalKVAccessor *mock_internal_kv_accessor;
+  MockTaskInfoAccessor *mock_task_accessor;
 };
 
 }  // namespace gcs

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -159,7 +159,7 @@ static inline rpc::ObjectReference GetReferenceForActorDummyObject(
 class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
  public:
   /// Construct an empty task specification. This should not be used directly.
-  TaskSpecification() {}
+  TaskSpecification() { ComputeResources(); }
 
   /// Construct from a protobuf message object.
   /// The input message will be copied/moved into this object.

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -232,7 +232,7 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
   if (RayConfig::instance().task_events_report_interval_ms() > 0) {
     auto task_event_gcs_client = std::make_unique<gcs::GcsClient>(options_.gcs_options);
     task_event_buffer_ =
-        std::make_shared<worker::TaskEventBufferImpl>(std::move(task_event_gcs_client));
+        std::make_unique<worker::TaskEventBufferImpl>(std::move(task_event_gcs_client));
     if (!task_event_buffer_->Start().ok()) {
       task_event_buffer_.reset();
     }
@@ -353,7 +353,7 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
       },
       push_error_callback,
       RayConfig::instance().max_lineage_bytes(),
-      task_event_buffer_));
+      task_event_buffer_.get()));
 
   // Create an entry for the driver task in the task table. This task is
   // added immediately with status RUNNING. This allows us to push errors

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -229,10 +229,10 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
       worker_context_, options_.node_ip_address, io_service_, gcs_client_);
 
   // Initialize the task state event buffer.
+  auto task_event_gcs_client = std::make_unique<gcs::GcsClient>(options_.gcs_options);
+  task_event_buffer_ =
+      std::make_unique<worker::TaskEventBufferImpl>(std::move(task_event_gcs_client));
   if (RayConfig::instance().task_events_report_interval_ms() > 0) {
-    auto task_event_gcs_client = std::make_unique<gcs::GcsClient>(options_.gcs_options);
-    task_event_buffer_ =
-        std::make_unique<worker::TaskEventBufferImpl>(std::move(task_event_gcs_client));
     if (!task_event_buffer_->Start().ok()) {
       RAY_CHECK(!task_event_buffer_->Enabled()) << "TaskEventBuffer should be disabled.";
     }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2276,7 +2276,7 @@ Status CoreWorker::ExecuteTask(
       task_event.set_attempt_number(task_spec.AttemptNumber());
       auto state_updates = task_event.mutable_state_updates();
       state_updates->set_running_ts(absl::GetCurrentTimeNanos());
-      task_event_buffer_->AddTaskEvents(std::move(task_event));
+      task_event_buffer_->AddTaskEvent(std::move(task_event));
     }
 
     worker_context_.SetCurrentTask(task_spec);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -229,9 +229,14 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
       worker_context_, options_.node_ip_address, io_service_, gcs_client_);
 
   // Initialize the task state event buffer.
-  auto task_event_gcs_client = std::make_unique<gcs::GcsClient>(options_.gcs_options);
-  task_event_buffer_ =
-      std::make_shared<worker::TaskEventBufferImpl>(std::move(task_event_gcs_client));
+  if (RayConfig::instance().task_events_report_interval_ms() > 0) {
+    auto task_event_gcs_client = std::make_unique<gcs::GcsClient>(options_.gcs_options);
+    task_event_buffer_ =
+        std::make_shared<worker::TaskEventBufferImpl>(std::move(task_event_gcs_client));
+    if (!task_event_buffer_->Start().ok()) {
+      task_event_buffer_.reset();
+    }
+  }
 
   core_worker_client_pool_ =
       std::make_shared<rpc::CoreWorkerClientPool>(*client_call_manager_);
@@ -602,7 +607,9 @@ void CoreWorker::Shutdown() {
     // Running in a main thread.
     options_.on_worker_shutdown(GetWorkerID());
   }
-  task_event_buffer_->Stop();
+  if (task_event_buffer_) {
+    task_event_buffer_->Stop();
+  }
 
   if (gcs_client_) {
     // We should disconnect gcs client first otherwise because it contains
@@ -641,7 +648,9 @@ void CoreWorker::Disconnect(
   RecordMetrics();
 
   // Force task state events push before exiting the worker.
-  task_event_buffer_->FlushEvents(/* forced */ true);
+  if (task_event_buffer_) {
+    task_event_buffer_->FlushEvents(/* forced */ true);
+  }
 
   opencensus::stats::StatsExporter::ExportNow();
   if (connected_) {
@@ -1157,7 +1166,6 @@ Status CoreWorker::Get(const std::vector<ObjectID> &ids,
                        std::vector<std::shared_ptr<RayObject>> *results) {
   ScopedTaskMetricSetter state(
       worker_context_, task_counter_, rpc::TaskStatus::RUNNING_IN_RAY_GET);
-
   results->resize(ids.size(), nullptr);
 
   absl::flat_hash_set<ObjectID> plasma_object_ids;
@@ -2260,9 +2268,17 @@ Status CoreWorker::ExecuteTask(
   std::string func_name = task_spec.FunctionDescriptor()->CallString();
   if (!options_.is_local_mode) {
     task_counter_.MovePendingToRunning(func_name, task_spec.IsRetry());
-  }
 
-  if (!options_.is_local_mode) {
+    // Make task event
+    if (task_event_buffer_) {
+      rpc::TaskEvents task_event;
+      task_event.set_task_id(task_spec.TaskId().Binary());
+      task_event.set_attempt_number(task_spec.AttemptNumber());
+      auto state_updates = task_event.mutable_state_updates();
+      state_updates->set_running_ts(absl::GetCurrentTimeNanos());
+      task_event_buffer_->AddTaskEvents(std::move(task_event));
+    }
+
     worker_context_.SetCurrentTask(task_spec);
     SetCurrentTaskId(task_spec.TaskId(), task_spec.AttemptNumber(), task_spec.GetName());
   }

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1505,7 +1505,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
 
   /// A shared pointer between various components that emitting task state events.
   /// e.g. CoreWorker, TaskManager.
-  std::shared_ptr<worker::TaskEventBuffer> task_event_buffer_;
+  std::unique_ptr<worker::TaskEventBuffer> task_event_buffer_ = nullptr;
 };
 
 }  // namespace core

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -32,6 +32,7 @@
 #include "ray/core_worker/reference_count.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/core_worker/store_provider/plasma_store_provider.h"
+#include "ray/core_worker/task_event_buffer.h"
 #include "ray/core_worker/transport/direct_actor_transport.h"
 #include "ray/core_worker/transport/direct_task_transport.h"
 #include "ray/gcs/gcs_client/gcs_client.h"
@@ -1501,6 +1502,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// the checking and increasing of backpressure pending calls counter
   /// is not atomic, which may lead to under counting or over counting.
   absl::Mutex actor_task_mutex_;
+
+  /// A shared pointer between various components that emitting task state events.
+  /// e.g. CoreWorker, TaskManager.
+  std::shared_ptr<worker::TaskEventBuffer> task_event_buffer_;
 };
 
 }  // namespace core

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -1,0 +1,212 @@
+// Copyright 2022 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/core_worker/task_event_buffer.h"
+
+namespace ray {
+namespace core {
+
+namespace worker {
+
+TaskEventBufferImpl::TaskEventBufferImpl(std::unique_ptr<gcs::GcsClient> gcs_client,
+                                         bool manual_flush)
+    : work_guard_(boost::asio::make_work_guard(io_service_)),
+      periodical_runner_(io_service_),
+      gcs_client_(std::move(gcs_client)) {
+  auto report_interval_ms = RayConfig::instance().task_events_report_interval_ms();
+  if (report_interval_ms <= 0) {
+    gcs_client_.reset();
+    return;
+  }
+  recording_on_ = true;
+
+  buffer_.reserve(RayConfig::instance().task_events_max_num_task_events_in_buffer());
+
+  io_thread_ = std::thread([this]() {
+#ifndef _WIN32
+    // Block SIGINT and SIGTERM so they will be handled by the main thread.
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGINT);
+    sigaddset(&mask, SIGTERM);
+    pthread_sigmask(SIG_BLOCK, &mask, NULL);
+#endif
+    SetThreadName("task_event_buffer.io");
+    io_service_.run();
+    RAY_LOG(INFO) << "Task event buffer io service stopped.";
+  });
+
+  // Reporting to GCS, set up gcs client and and events flushing.
+  auto status = gcs_client_->Connect(io_service_);
+  if (!status.ok()) {
+    RAY_LOG(ERROR)
+        << "Failed to connect to GCS, TaskEventBuffer will not report to GCS. [status="
+        << status.ToString() << "].";
+
+    recording_on_ = false;
+
+    // Early clean up resources.
+    gcs_client_.reset();
+    Stop();
+    return;
+  }
+
+  if (manual_flush) {
+    return;
+  }
+
+  RAY_LOG(INFO) << "Reporting task events to GCS every " << report_interval_ms << "ms.";
+  periodical_runner_.RunFnPeriodically([this] { FlushEvents(/* forced */ false); },
+                                       report_interval_ms,
+                                       "CoreWorker.deadline_timer.flush_task_events");
+}
+
+void TaskEventBufferImpl::Stop() {
+  RAY_LOG(INFO) << "Shutting down TaskEventBuffer.";
+
+  // Shutting down the io service to exit the io_thread. This should prevent
+  // any other callbacks to be run on the io thread.
+  io_service_.stop();
+  if (io_thread_.joinable()) {
+    RAY_LOG(DEBUG) << "Joining io thread from TaskEventBuffer";
+    io_thread_.join();
+  }
+
+  {
+    absl::MutexLock lock(&mutex_);
+    // It's now safe to disconnect the GCS client since it will not be used by any
+    // callbacks.
+    if (gcs_client_) {
+      // Stop GCS client
+      gcs_client_->Disconnect();
+    }
+
+    gcs_client_.reset();
+  }
+}
+
+void TaskEventBufferImpl::AddTaskEvents(rpc::TaskEvents task_events) {
+  absl::MutexLock lock(&mutex_);
+  if (!recording_on_) {
+    return;
+  }
+
+  auto limit = RayConfig::instance().task_events_max_num_task_events_in_buffer();
+  if (limit > 0 && buffer_.size() >= static_cast<size_t>(limit)) {
+    // Too many task events, start overriding older ones.
+
+    // Delay GCing
+    gc_queue_.push_back(std::move(task_events));
+    std::swap(buffer_[iter_], gc_queue_.back());
+    iter_ = (iter_ + 1) % limit;
+    num_task_events_dropped_++;
+    return;
+  }
+  buffer_.push_back(std::move(task_events));
+}
+
+void TaskEventBufferImpl::FlushEvents(bool forced) {
+  if (!recording_on_) {
+    return;
+  }
+
+  std::vector<rpc::TaskEvents> task_events;
+  // Will be GC when function returns.
+  std::vector<rpc::TaskEvents> gc_swap;
+  size_t num_task_events_dropped = 0;
+  {
+    absl::MutexLock lock(&mutex_);
+
+    gc_queue_.swap(gc_swap);
+
+    // TODO(rickyx): change this interval
+    RAY_LOG_EVERY_MS(INFO, 5000)
+        << "Pushed task state events to GCS. [total_bytes="
+        << (1.0 * total_events_bytes_) / 1024 / 1024
+        << "MiB][total_count=" << total_num_events_
+        << "][total_task_events_dropped=" << num_task_events_dropped_
+        << "][cur_buffer_size=" << buffer_.size() << "].";
+
+    // Skip if GCS hasn't finished processing the previous message.
+    if (grpc_in_progress_ && !forced) {
+      RAY_LOG_EVERY_N_OR_DEBUG(WARNING, 100)
+          << "GCS hasn't replied to the previous flush events call (likely overloaded). "
+             "Skipping reporting task state events and retry later."
+          << "[cur_buffer_size=" << buffer_.size() << "].";
+      return;
+    }
+
+    if (buffer_.size() == 0) {
+      return;
+    }
+
+    task_events.reserve(
+        RayConfig::instance().task_events_max_num_task_events_in_buffer());
+    buffer_.swap(task_events);
+    iter_ = 0;
+    num_task_events_dropped = num_task_events_dropped_;
+    num_task_events_dropped_ = 0;
+  }
+  // mutex released. Below operations should be lock-free.
+
+  // Merge multiple events from a single task attempt run into one task event.
+  absl::flat_hash_map<std::pair<std::string, int>, rpc::TaskEvents> task_events_map;
+  for (auto events : task_events) {
+    auto &task_events_itr =
+        task_events_map[std::make_pair(events.task_id(), events.attempt_number())];
+    task_events_itr.MergeFrom(events);
+  }
+
+  // Convert to rpc::TaskEventsData
+  auto data = std::make_unique<rpc::TaskEventData>();
+  data->set_num_task_events_dropped(num_task_events_dropped);
+  auto num_task_events = task_events_map.size();
+  for (auto itr : task_events_map) {
+    auto events_by_task = data->add_events_by_task();
+    events_by_task->Swap(&itr.second);
+  }
+
+  // Some debug tracking.
+  total_num_events_ += num_task_events;
+  total_events_bytes_ += data->ByteSizeLong();
+
+  auto on_complete = [this, num_task_events](const Status &status) {
+    if (!status.ok()) {
+      RAY_LOG(WARNING) << "Failed to push " << num_task_events
+                       << " task state events to GCS. Data will be lost. [status="
+                       << status.ToString() << "]";
+    } else {
+      RAY_LOG(DEBUG) << "Push " << num_task_events << " task state events to GCS.";
+    }
+    grpc_in_progress_ = false;
+  };
+
+  // The flag should be unset when on_complete is invoked.
+  grpc_in_progress_ = true;
+  auto status = gcs_client_->Tasks().AsyncAddTaskEventData(std::move(data), on_complete);
+  if (!status.ok()) {
+    // If we couldn't even send the data by invoking client side callbacks, there's
+    // something seriously wrong, and losing data in this case should not be too
+    // worse. So we will silently drop these task events.
+    RAY_LOG(WARNING)
+        << "Failed to push task state events to GCS. Data will be lost. [status="
+        << status.ToString() << "]";
+    grpc_in_progress_ = false;
+  }
+}
+
+}  // namespace worker
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -112,8 +112,7 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
   {
     absl::MutexLock lock(&mutex_);
 
-    // TODO(rickyx): change this interval
-    RAY_LOG_EVERY_MS(INFO, 5000)
+    RAY_LOG_EVERY_MS(INFO, 15000)
         << "Pushed task state events to GCS. [total_bytes="
         << (1.0 * total_events_bytes_) / 1024 / 1024
         << "MiB][total_count=" << total_num_events_

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -25,11 +25,21 @@ TaskEventBufferImpl::TaskEventBufferImpl(std::unique_ptr<gcs::GcsClient> gcs_cli
       gcs_client_(std::move(gcs_client)) {}
 
 Status TaskEventBufferImpl::Start(bool auto_flush) {
+  absl::MutexLock lock(&mutex_);
   auto report_interval_ms = RayConfig::instance().task_events_report_interval_ms();
   RAY_CHECK(report_interval_ms > 0)
       << "RAY_task_events_report_interval_ms should be > 0 to use TaskEventBuffer.";
 
   buffer_.reserve(RayConfig::instance().task_events_max_num_task_events_in_buffer());
+
+  // Reporting to GCS, set up gcs client and and events flushing.
+  auto status = gcs_client_->Connect(io_service_);
+  if (!status.ok()) {
+    RAY_LOG(ERROR) << "Failed to connect to GCS, TaskEventBuffer will stop now. [status="
+                   << status.ToString() << "].";
+
+    return status;
+  }
 
   io_thread_ = std::thread([this]() {
 #ifndef _WIN32
@@ -44,18 +54,6 @@ Status TaskEventBufferImpl::Start(bool auto_flush) {
     io_service_.run();
     RAY_LOG(INFO) << "Task event buffer io service stopped.";
   });
-
-  // Reporting to GCS, set up gcs client and and events flushing.
-  auto status = gcs_client_->Connect(io_service_);
-  if (!status.ok()) {
-    RAY_LOG(ERROR) << "Failed to connect to GCS, TaskEventBuffer will stop now. [status="
-                   << status.ToString() << "].";
-
-    // Early clean up resources.
-    gcs_client_.reset();
-    Stop();
-    return status;
-  }
 
   if (!auto_flush) {
     return Status::OK();
@@ -83,12 +81,7 @@ void TaskEventBufferImpl::Stop() {
     absl::MutexLock lock(&mutex_);
     // It's now safe to disconnect the GCS client since it will not be used by any
     // callbacks.
-    if (gcs_client_) {
-      // Stop GCS client
-      gcs_client_->Disconnect();
-    }
-
-    gcs_client_.reset();
+    gcs_client_->Disconnect();
   }
 }
 
@@ -139,7 +132,6 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
     num_task_events_dropped = num_task_events_dropped_;
     num_task_events_dropped_ = 0;
   }
-  // mutex released. Below operations should be lock-free.
 
   // Merge multiple events from a single task attempt run into one task event.
   absl::flat_hash_map<std::pair<std::string, int>, rpc::TaskEvents> task_events_map;
@@ -158,32 +150,38 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
     events_by_task->Swap(&itr.second);
   }
 
-  // Some debug tracking.
-  total_num_events_ += num_task_events;
-  total_events_bytes_ += data->ByteSizeLong();
+  {
+    // Sending the protobuf to GCS.
+    absl::MutexLock lock(&mutex_);
+    // Some debug tracking.
+    total_num_events_ += num_task_events;
+    total_events_bytes_ += data->ByteSizeLong();
 
-  auto on_complete = [this, num_task_events](const Status &status) {
+    auto on_complete = [this, num_task_events](const Status &status) {
+      absl::MutexLock lock(&mutex_);
+      if (!status.ok()) {
+        RAY_LOG(WARNING) << "Failed to push " << num_task_events
+                         << " task state events to GCS. Data will be lost. [status="
+                         << status.ToString() << "]";
+      } else {
+        RAY_LOG(DEBUG) << "Push " << num_task_events << " task state events to GCS.";
+      }
+      grpc_in_progress_ = false;
+    };
+
+    // The flag should be unset when on_complete is invoked.
+    grpc_in_progress_ = true;
+    auto status =
+        gcs_client_->Tasks().AsyncAddTaskEventData(std::move(data), on_complete);
     if (!status.ok()) {
-      RAY_LOG(WARNING) << "Failed to push " << num_task_events
-                       << " task state events to GCS. Data will be lost. [status="
-                       << status.ToString() << "]";
-    } else {
-      RAY_LOG(DEBUG) << "Push " << num_task_events << " task state events to GCS.";
+      // If we couldn't even send the data by invoking client side callbacks, there's
+      // something seriously wrong, and losing data in this case should not be too
+      // worse. So we will silently drop these task events.
+      RAY_LOG(WARNING)
+          << "Failed to push task state events to GCS. Data will be lost. [status="
+          << status.ToString() << "]";
+      grpc_in_progress_ = false;
     }
-    grpc_in_progress_ = false;
-  };
-
-  // The flag should be unset when on_complete is invoked.
-  grpc_in_progress_ = true;
-  auto status = gcs_client_->Tasks().AsyncAddTaskEventData(std::move(data), on_complete);
-  if (!status.ok()) {
-    // If we couldn't even send the data by invoking client side callbacks, there's
-    // something seriously wrong, and losing data in this case should not be too
-    // worse. So we will silently drop these task events.
-    RAY_LOG(WARNING)
-        << "Failed to push task state events to GCS. Data will be lost. [status="
-        << status.ToString() << "]";
-    grpc_in_progress_ = false;
   }
 }
 

--- a/src/ray/core_worker/task_event_buffer.h
+++ b/src/ray/core_worker/task_event_buffer.h
@@ -122,6 +122,12 @@ class TaskEventBufferImpl : public TaskEventBuffer {
     return num_task_events_dropped_;
   }
 
+  /// Test only functions.
+  gcs::GcsClient *GetGcsClient() {
+    absl::MutexLock lock(&mutex_);
+    return gcs_client_.get();
+  }
+
   /// Mutex guarding task_events_data_.
   absl::Mutex mutex_;
 

--- a/src/ray/core_worker/task_event_buffer.h
+++ b/src/ray/core_worker/task_event_buffer.h
@@ -91,7 +91,7 @@ class TaskEventBuffer {
   /// Return true if recording and reporting of task events is enabled.
   ///
   /// The TaskEventBuffer will be disabled if Start() returns not ok.
-  virtual bool Enabled() = 0;
+  virtual bool Enabled() const = 0;
 };
 
 /// Implementation of TaskEventBuffer.
@@ -115,7 +115,7 @@ class TaskEventBufferImpl : public TaskEventBuffer {
 
   void Stop() LOCKS_EXCLUDED(mutex_) override;
 
-  bool Enabled() LOCKS_EXCLUDED(mutex_) override;
+  bool Enabled() const override;
 
  private:
   /// Test only functions.
@@ -156,7 +156,7 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   std::unique_ptr<gcs::GcsClient> gcs_client_ GUARDED_BY(mutex_);
 
   /// True if the TaskEventBuffer is enabled.
-  bool enabled_ GUARDED_BY(mutex_) = false;
+  std::atomic<bool> enabled_ = false;
 
   /// Buffered task events.
   std::vector<rpc::TaskEvents> buffer_ GUARDED_BY(mutex_);

--- a/src/ray/core_worker/task_event_buffer.h
+++ b/src/ray/core_worker/task_event_buffer.h
@@ -140,20 +140,19 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   /// A iterator into buffer_ that determines which element to be overwritten.
   size_t next_idx_to_overwrite_ GUARDED_BY(mutex_) = 0;
 
+  /// Number of task events dropped since the last report flush.
   size_t num_task_events_dropped_ GUARDED_BY(mutex_) = 0;
-
-  /// Thread local fields accessed only in io_thread_.
 
   /// True if there's a pending gRPC call. It's a simple way to prevent overloading
   /// GCS with too many calls. There is no point sending more events if GCS could not
   /// process them quick enough.
-  bool grpc_in_progress_ = false;
+  bool grpc_in_progress_ GUARDED_BY(mutex_) = false;
 
-  /// Stats tracking for debugging and monitoring.
-  uint64_t total_events_bytes_ = 0;
-  uint64_t total_num_events_ = 0;
+  /// Debug stats: total number of bytes of task events sent so far to GCS.
+  uint64_t total_events_bytes_ GUARDED_BY(mutex_) = 0;
 
-  /// Thread local fields accessed in io_thread_ ENDS.
+  /// Debug stats: total number of task events sent so far to GCS.
+  uint64_t total_num_events_ GUARDED_BY(mutex_) = 0;
 
   FRIEND_TEST(TaskEventBufferTestManualStart, TestGcsClientFail);
   FRIEND_TEST(TaskEventBufferTest, TestAddEvent);

--- a/src/ray/core_worker/task_event_buffer.h
+++ b/src/ray/core_worker/task_event_buffer.h
@@ -77,8 +77,10 @@ class TaskEventBuffer {
   ///
   /// Connects the GCS client, starts its io_thread, and sets up periodical runner for
   /// flushing events to GCS.
+  ///
   /// \param auto_flush Test only flag to disable periodical flushing events if false.
-  /// \return If setup succeeds. When failure, events will not be reported.
+  /// \return Status code. When the status is not ok, events will not be recorded nor
+  /// reported.
   virtual Status Start(bool auto_flush = true) = 0;
 
   /// Stop the TaskEventBuffer and it's underlying IO, disconnecting GCS clients.
@@ -104,16 +106,17 @@ class TaskEventBufferImpl : public TaskEventBuffer {
 
   Status Start(bool auto_flush = true) LOCKS_EXCLUDED(mutex_) override;
 
-  /// Stop the TaskEventBuffer and it's underlying IO, disconnecting GCS clients.
   void Stop() LOCKS_EXCLUDED(mutex_) override;
 
  private:
+  /// Test only functions.
   std::vector<rpc::TaskEvents> GetAllTaskEvents() LOCKS_EXCLUDED(mutex_) {
     absl::MutexLock lock(&mutex_);
     std::vector<rpc::TaskEvents> copy(buffer_);
     return copy;
   }
 
+  /// Test only functions.
   size_t GetNumTaskEventsDropped() LOCKS_EXCLUDED(mutex_) {
     absl::MutexLock lock(&mutex_);
     return num_task_events_dropped_;

--- a/src/ray/core_worker/task_event_buffer.h
+++ b/src/ray/core_worker/task_event_buffer.h
@@ -53,10 +53,10 @@ class TaskEventBuffer {
  public:
   virtual ~TaskEventBuffer() = default;
 
-  /// Add a task event to be reported..
+  /// Add a task event to be reported.
   ///
   /// \param task_events Task events.
-  virtual void AddTaskEvents(rpc::TaskEvents task_events) = 0;
+  virtual void AddTaskEvent(rpc::TaskEvents task_events) = 0;
 
   /// Flush all task events stored in the buffer to GCS.
   ///
@@ -64,6 +64,9 @@ class TaskEventBuffer {
   /// `RAY_task_events_report_interval_ms`, and send task events stored in a buffer to
   /// GCS. If GCS has not responded to a previous flush, it will defer the flushing to
   /// the next interval (if not forced.)
+  ///
+  /// Before flushing to GCS, events from a single task attempt will also be coalesced
+  /// into one rpc::TaskEvents as an optimization.
   ///
   /// \param forced When set to true, buffered events will be sent to GCS even if GCS has
   ///       not responded to the previous flush. A forced flush will be called before
@@ -95,7 +98,7 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   /// \param gcs_client GCS client
   TaskEventBufferImpl(std::unique_ptr<gcs::GcsClient> gcs_client);
 
-  void AddTaskEvents(rpc::TaskEvents task_events) LOCKS_EXCLUDED(mutex_) override;
+  void AddTaskEvent(rpc::TaskEvents task_events) LOCKS_EXCLUDED(mutex_) override;
 
   void FlushEvents(bool forced) LOCKS_EXCLUDED(mutex_) override;
 

--- a/src/ray/core_worker/task_event_buffer.h
+++ b/src/ray/core_worker/task_event_buffer.h
@@ -181,6 +181,7 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   FRIEND_TEST(TaskEventBufferTestManualStart, TestGcsClientFail);
   FRIEND_TEST(TaskEventBufferTest, TestAddEvent);
   FRIEND_TEST(TaskEventBufferTest, TestFlushEvents);
+  FRIEND_TEST(TaskEventBufferTest, TestFailedFlush);
   FRIEND_TEST(TaskEventBufferTest, TestBackPressure);
   FRIEND_TEST(TaskEventBufferTest, TestForcedFlush);
   FRIEND_TEST(TaskEventBufferTest, TestBufferSizeLimit);

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -920,7 +920,8 @@ void TaskManager::RecordTaskStatusEvent(const TaskEntry &task_entry,
     break;
   }
   default: {
-    // Do nothing
+    // NOTE: Other task status (e.g. TaskStatus::RUNNING_IN_XXX), should not be set by the
+    // TaskManager.
     UNREACHABLE;
   }
   }

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -925,7 +925,7 @@ void TaskManager::RecordTaskStatusEvent(const TaskEntry &task_entry,
     // Do nothing
   }
   }
-  task_event_buffer_->AddTaskEvents(std::move(task_event));
+  task_event_buffer_->AddTaskEvent(std::move(task_event));
 }
 
 ObjectID TaskManager::TaskGeneratorId(const TaskID &task_id) const {

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -881,7 +881,7 @@ void TaskManager::RecordMetrics() {
 
 void TaskManager::RecordTaskStatusEvent(const TaskEntry &task_entry,
                                         rpc::TaskStatus status) {
-  if (!task_event_buffer_) {
+  if (!task_event_buffer_.Enabled()) {
     return;
   }
   // Make task event
@@ -925,7 +925,7 @@ void TaskManager::RecordTaskStatusEvent(const TaskEntry &task_entry,
     UNREACHABLE;
   }
   }
-  task_event_buffer_->AddTaskEvent(std::move(task_event));
+  task_event_buffer_.AddTaskEvent(std::move(task_event));
 }
 
 ObjectID TaskManager::TaskGeneratorId(const TaskID &task_id) const {

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -125,9 +125,8 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
 
     if (!it->second.IsPending()) {
       resubmit = true;
-      it->second.SetStatus(rpc::TaskStatus::PENDING_ARGS_AVAIL);
+      SetTaskStatus(it->second, rpc::TaskStatus::PENDING_ARGS_AVAIL);
       it->second.MarkRetryOnResubmit();
-      RecordTaskStatusEvent(it->second, rpc::TaskStatus::PENDING_ARGS_AVAIL);
       num_pending_tasks_++;
 
       // The task is pending again, so it's no longer counted as lineage. If
@@ -382,11 +381,9 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
     it->second.num_successful_executions++;
 
     if (is_application_error) {
-      it->second.SetStatus(rpc::TaskStatus::FAILED);
-      RecordTaskStatusEvent(it->second, rpc::TaskStatus::FAILED);
+      SetTaskStatus(it->second, rpc::TaskStatus::FAILED);
     } else {
-      it->second.SetStatus(rpc::TaskStatus::FINISHED);
-      RecordTaskStatusEvent(it->second, rpc::TaskStatus::FINISHED);
+      SetTaskStatus(it->second, rpc::TaskStatus::FINISHED);
     }
     num_pending_tasks_--;
 
@@ -454,8 +451,7 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
       }
     }
     if (will_retry) {
-      it->second.SetStatus(rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
-      RecordTaskStatusEvent(it->second, rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
+      SetTaskStatus(it->second, rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
       it->second.MarkRetryOnFailed();
     }
   }
@@ -506,8 +502,7 @@ void TaskManager::FailPendingTask(const TaskID &task_id,
     RAY_CHECK(it->second.IsPending())
         << "Tried to fail task that was not pending " << task_id;
     spec = it->second.spec;
-    it->second.SetStatus(rpc::TaskStatus::FAILED);
-    RecordTaskStatusEvent(it->second, rpc::TaskStatus::FAILED);
+    SetTaskStatus(it->second, rpc::TaskStatus::FAILED);
     submissible_tasks_.erase(it);
     num_pending_tasks_--;
 
@@ -778,8 +773,7 @@ void TaskManager::MarkDependenciesResolved(const TaskID &task_id) {
     return;
   }
   if (it->second.GetStatus() == rpc::TaskStatus::PENDING_ARGS_AVAIL) {
-    it->second.SetStatus(rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
-    RecordTaskStatusEvent(it->second, rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
+    SetTaskStatus(it->second, rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
   }
 }
 
@@ -791,9 +785,13 @@ void TaskManager::MarkTaskWaitingForExecution(const TaskID &task_id,
     return;
   }
   RAY_CHECK(it->second.GetStatus() == rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
-  it->second.SetStatus(rpc::TaskStatus::SUBMITTED_TO_WORKER);
   it->second.SetNodeId(node_id);
-  RecordTaskStatusEvent(it->second, rpc::TaskStatus::SUBMITTED_TO_WORKER);
+  SetTaskStatus(it->second, rpc::TaskStatus::SUBMITTED_TO_WORKER);
+}
+
+void TaskManager::SetTaskStatus(TaskEntry &task_entry, rpc::TaskStatus status) {
+  task_entry.SetStatus(status);
+  RecordTaskStatusEvent(task_entry, status);
 }
 
 rpc::TaskInfoEntry TaskManager::MakeTaskInfoEntry(
@@ -923,6 +921,7 @@ void TaskManager::RecordTaskStatusEvent(const TaskEntry &task_entry,
   }
   default: {
     // Do nothing
+    UNREACHABLE;
   }
   }
   task_event_buffer_->AddTaskEvent(std::move(task_event));

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -104,6 +104,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
         spec.TaskId(), spec, max_retries, num_returns, task_counter_, max_oom_retries);
     RAY_CHECK(inserted.second);
     num_pending_tasks_++;
+    RecordTaskStatusEvent(inserted.first->second, rpc::TaskStatus::PENDING_ARGS_AVAIL);
   }
 
   return returned_refs;
@@ -126,6 +127,7 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
       resubmit = true;
       it->second.SetStatus(rpc::TaskStatus::PENDING_ARGS_AVAIL);
       it->second.MarkRetryOnResubmit();
+      RecordTaskStatusEvent(it->second, rpc::TaskStatus::PENDING_ARGS_AVAIL);
       num_pending_tasks_++;
 
       // The task is pending again, so it's no longer counted as lineage. If
@@ -381,8 +383,10 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
 
     if (is_application_error) {
       it->second.SetStatus(rpc::TaskStatus::FAILED);
+      RecordTaskStatusEvent(it->second, rpc::TaskStatus::FAILED);
     } else {
       it->second.SetStatus(rpc::TaskStatus::FINISHED);
+      RecordTaskStatusEvent(it->second, rpc::TaskStatus::FINISHED);
     }
     num_pending_tasks_--;
 
@@ -451,6 +455,7 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
     }
     if (will_retry) {
       it->second.SetStatus(rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
+      RecordTaskStatusEvent(it->second, rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
       it->second.MarkRetryOnFailed();
     }
   }
@@ -502,6 +507,7 @@ void TaskManager::FailPendingTask(const TaskID &task_id,
         << "Tried to fail task that was not pending " << task_id;
     spec = it->second.spec;
     it->second.SetStatus(rpc::TaskStatus::FAILED);
+    RecordTaskStatusEvent(it->second, rpc::TaskStatus::FAILED);
     submissible_tasks_.erase(it);
     num_pending_tasks_--;
 
@@ -773,7 +779,42 @@ void TaskManager::MarkDependenciesResolved(const TaskID &task_id) {
   }
   if (it->second.GetStatus() == rpc::TaskStatus::PENDING_ARGS_AVAIL) {
     it->second.SetStatus(rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
+    RecordTaskStatusEvent(it->second, rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
   }
+}
+
+rpc::TaskInfoEntry TaskManager::MakeTaskInfoEntry(
+    const TaskSpecification &task_spec) const {
+  rpc::TaskInfoEntry task_info;
+  return task_info;
+
+  rpc::TaskType type;
+  if (task_spec.IsNormalTask()) {
+    type = rpc::TaskType::NORMAL_TASK;
+  } else if (task_spec.IsActorCreationTask()) {
+    type = rpc::TaskType::ACTOR_CREATION_TASK;
+    task_info.set_actor_id(task_spec.ActorCreationId().Binary());
+  } else {
+    RAY_CHECK(task_spec.IsActorTask());
+    type = rpc::TaskType::ACTOR_TASK;
+    task_info.set_actor_id(task_spec.ActorId().Binary());
+  }
+  task_info.set_type(type);
+  task_info.set_name(task_spec.GetName());
+  task_info.set_language(task_spec.GetLanguage());
+  task_info.set_func_or_class_name(task_spec.FunctionDescriptor()->CallString());
+  // NOTE(rickyx): we will have scheduling states recorded in the events list.
+  task_info.set_scheduling_state(rpc::TaskStatus::NIL);
+  task_info.set_job_id(task_spec.JobId().Binary());
+
+  task_info.set_task_id(task_spec.TaskId().Binary());
+  task_info.set_parent_task_id(task_spec.ParentTaskId().Binary());
+  const auto &resources_map = task_spec.GetRequiredResources().GetResourceMap();
+  task_info.mutable_required_resources()->insert(resources_map.begin(),
+                                                 resources_map.end());
+  task_info.mutable_runtime_env_info()->CopyFrom(task_spec.RuntimeEnvInfo());
+
+  return task_info;
 }
 
 void TaskManager::MarkTaskWaitingForExecution(const TaskID &task_id,
@@ -786,6 +827,7 @@ void TaskManager::MarkTaskWaitingForExecution(const TaskID &task_id,
   RAY_CHECK(it->second.GetStatus() == rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
   it->second.SetStatus(rpc::TaskStatus::SUBMITTED_TO_WORKER);
   it->second.SetNodeId(node_id);
+  RecordTaskStatusEvent(it->second, rpc::TaskStatus::SUBMITTED_TO_WORKER);
 }
 
 void TaskManager::FillTaskInfo(rpc::GetCoreWorkerStatsReply *reply,
@@ -837,6 +879,50 @@ void TaskManager::FillTaskInfo(rpc::GetCoreWorkerStatsReply *reply,
 void TaskManager::RecordMetrics() {
   absl::MutexLock lock(&mu_);
   task_counter_.FlushOnChangeCallbacks();
+}
+
+void TaskManager::RecordTaskStatusEvent(const TaskEntry &task_entry,
+                                        rpc::TaskStatus status) {
+  // Make task event
+  rpc::TaskEvents task_event;
+  task_event.set_task_id(task_entry.spec.TaskId().Binary());
+  task_event.set_attempt_number(task_entry.spec.AttemptNumber());
+  auto state_updates = task_event.mutable_state_updates();
+  switch (status) {
+  case rpc::TaskStatus::PENDING_ARGS_AVAIL: {
+    // Initialize a new TaskInfoEntry
+    auto task_info = MakeTaskInfoEntry(task_entry.spec);
+    task_event.mutable_task_info()->Swap(&task_info);
+    state_updates->set_pending_args_avail_ts(absl::GetCurrentTimeNanos());
+    break;
+  }
+  case rpc::TaskStatus::SUBMITTED_TO_WORKER: {
+    RAY_CHECK(!task_entry.GetNodeId().IsNil())
+        << "Node ID should have been set on the TaskEntry before updating it's status "
+           "to "
+           "SUBMITTED_TO_WORKER.";
+    // Update the node id
+    state_updates->set_node_id(task_entry.GetNodeId().Binary());
+    state_updates->set_submitted_to_worker_ts(absl::GetCurrentTimeNanos());
+    break;
+  }
+  case rpc::TaskStatus::PENDING_NODE_ASSIGNMENT: {
+    state_updates->set_pending_node_assignment_ts(absl::GetCurrentTimeNanos());
+    break;
+  }
+  case rpc::TaskStatus::FINISHED: {
+    state_updates->set_finished_ts(absl::GetCurrentTimeNanos());
+    break;
+  }
+  case rpc::TaskStatus::FAILED: {
+    state_updates->set_failed_ts(absl::GetCurrentTimeNanos());
+    break;
+  }
+  default: {
+    // Do nothing
+  }
+  }
+  task_event_buffer_->AddTaskEvents(std::move(task_event));
 }
 
 ObjectID TaskManager::TaskGeneratorId(const TaskID &task_id) const {

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -20,6 +20,7 @@
 #include "ray/common/id.h"
 #include "ray/common/task/task.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
+#include "ray/core_worker/task_event_buffer.h"
 #include "ray/stats/metric_defs.h"
 #include "ray/util/counter_map.h"
 #include "src/ray/protobuf/common.pb.h"
@@ -91,13 +92,15 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
               PutInLocalPlasmaCallback put_in_local_plasma_callback,
               RetryTaskCallback retry_task_callback,
               PushErrorCallback push_error_callback,
-              int64_t max_lineage_bytes)
+              int64_t max_lineage_bytes,
+              std::shared_ptr<worker::TaskEventBuffer> task_event_buffer)
       : in_memory_store_(in_memory_store),
         reference_counter_(reference_counter),
         put_in_local_plasma_callback_(put_in_local_plasma_callback),
         retry_task_callback_(retry_task_callback),
         push_error_callback_(push_error_callback),
-        max_lineage_bytes_(max_lineage_bytes) {
+        max_lineage_bytes_(max_lineage_bytes),
+        task_event_buffer_(task_event_buffer) {
     task_counter_.SetOnChangeCallback(
         [this](const std::tuple<std::string, rpc::TaskStatus, bool> key)
             EXCLUSIVE_LOCKS_REQUIRED(&mu_) {
@@ -293,6 +296,12 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// Fill every task information of the current worker to GetCoreWorkerStatsReply.
   void FillTaskInfo(rpc::GetCoreWorkerStatsReply *reply, const int64_t limit) const;
 
+  /// Make a rpc::TaskInfoEntry based on the TaskSpecification.
+  ///
+  /// \param[in] task_spec TaskSpecification of the task.
+  /// \return TaskInfoEntry based on the spec.
+  rpc::TaskInfoEntry MakeTaskInfoEntry(const TaskSpecification &task_spec) const;
+
   /// Returns the generator ID that contains the dynamically allocated
   /// ObjectRefs, if the task is dynamic. Else, returns Nil.
   ObjectID TaskGeneratorId(const TaskID &task_id) const;
@@ -452,6 +461,12 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// Shutdown if all tasks are finished and shutdown is scheduled.
   void ShutdownIfNeeded() LOCKS_EXCLUDED(mu_);
 
+  /// Update task status change.
+  ///
+  /// \param task_entry corresponding TaskEntry of a task to record the event.
+  /// \param status the changed status.
+  void RecordTaskStatusEvent(const TaskEntry &task_entry, rpc::TaskStatus status);
+
   /// Used to store task results.
   std::shared_ptr<CoreWorkerMemoryStore> in_memory_store_;
 
@@ -501,6 +516,9 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
 
   /// Optional shutdown hook to call when pending tasks all finish.
   std::function<void()> shutdown_hook_ GUARDED_BY(mu_) = nullptr;
+
+  /// A task state events buffer initialized from the CoreWorker.
+  std::shared_ptr<worker::TaskEventBuffer> task_event_buffer_;
 
   friend class TaskManagerTest;
 };

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -93,7 +93,7 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
               RetryTaskCallback retry_task_callback,
               PushErrorCallback push_error_callback,
               int64_t max_lineage_bytes,
-              worker::TaskEventBuffer *task_event_buffer)
+              worker::TaskEventBuffer &task_event_buffer)
       : in_memory_store_(in_memory_store),
         reference_counter_(reference_counter),
         put_in_local_plasma_callback_(put_in_local_plasma_callback),
@@ -526,10 +526,10 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// Optional shutdown hook to call when pending tasks all finish.
   std::function<void()> shutdown_hook_ GUARDED_BY(mu_) = nullptr;
 
-  /// A task state events buffer initialized managed by the CoreWorker. It will be nullptr
-  /// if TaskEventBuffer is not initialized when recording is turned off (either due to
-  /// config or set-up error.)
-  worker::TaskEventBuffer *task_event_buffer_ = nullptr;
+  /// A task state events buffer initialized managed by the CoreWorker.
+  /// task_event_buffer_.Enabled() will return false if disabled (due to config or set-up
+  /// error).
+  worker::TaskEventBuffer &task_event_buffer_;
 
   friend class TaskManagerTest;
 };

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -461,7 +461,16 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// Shutdown if all tasks are finished and shutdown is scheduled.
   void ShutdownIfNeeded() LOCKS_EXCLUDED(mu_);
 
-  /// Update task status change.
+  /// Set the TaskStatus
+  ///
+  /// Sets the task status on the TaskEntry, and record the task status change events in
+  /// the TaskEventBuffer if enabled.
+  ///
+  /// \param task_entry corresponding TaskEntry of a task to record the event.
+  /// \param status the changed status.
+  void SetTaskStatus(TaskEntry &task_entry, rpc::TaskStatus status);
+
+  /// Update task status change in TaskEventBuffer
   ///
   /// \param task_entry corresponding TaskEntry of a task to record the event.
   /// \param status the changed status.

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -526,7 +526,9 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// Optional shutdown hook to call when pending tasks all finish.
   std::function<void()> shutdown_hook_ GUARDED_BY(mu_) = nullptr;
 
-  /// A task state events buffer initialized managed by the CoreWorker.
+  /// A task state events buffer initialized managed by the CoreWorker. It will be nullptr
+  /// if TaskEventBuffer is not initialized when recording is turned off (either due to
+  /// config or set-up error.)
   worker::TaskEventBuffer *task_event_buffer_ = nullptr;
 
   friend class TaskManagerTest;

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -93,7 +93,7 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
               RetryTaskCallback retry_task_callback,
               PushErrorCallback push_error_callback,
               int64_t max_lineage_bytes,
-              std::shared_ptr<worker::TaskEventBuffer> task_event_buffer)
+              worker::TaskEventBuffer *task_event_buffer)
       : in_memory_store_(in_memory_store),
         reference_counter_(reference_counter),
         put_in_local_plasma_callback_(put_in_local_plasma_callback),
@@ -517,8 +517,8 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// Optional shutdown hook to call when pending tasks all finish.
   std::function<void()> shutdown_hook_ GUARDED_BY(mu_) = nullptr;
 
-  /// A task state events buffer initialized from the CoreWorker.
-  std::shared_ptr<worker::TaskEventBuffer> task_event_buffer_;
+  /// A task state events buffer initialized managed by the CoreWorker.
+  worker::TaskEventBuffer *task_event_buffer_ = nullptr;
 
   friend class TaskManagerTest;
 };

--- a/src/ray/core_worker/test/task_event_buffer_test.cc
+++ b/src/ray/core_worker/test/task_event_buffer_test.cc
@@ -20,6 +20,8 @@
 #include "ray/common/task/task_spec.h"
 #include "ray/common/test_util.h"
 
+using ::testing::Return;
+
 namespace ray {
 
 namespace core {
@@ -32,16 +34,26 @@ class TaskEventBufferTest : public ::testing::Test {
     RayConfig::instance().initialize(
         R"(
 {
-  "task_events_report_interval_ms": 1000
+  "task_events_report_interval_ms": 1000,
+  "task_events_max_num_task_events_in_buffer": 100
 }
   )");
 
-    task_event_buffer_ =
-        std::make_unique<TaskEventBufferImpl>(std::make_unique<ray::gcs::MockGcsClient>(),
-                                              /*manual_flush*/ true);
+    task_event_buffer_ = std::make_unique<TaskEventBufferImpl>(
+        std::make_unique<ray::gcs::MockGcsClient>());
   }
 
+  virtual void SetUp() { RAY_CHECK_OK(task_event_buffer_->Start(/*auto_flush*/ false)); }
+
   virtual void TearDown() { task_event_buffer_->Stop(); };
+
+  std::vector<TaskID> GenTaskIDs(size_t num_tasks) {
+    std::vector<TaskID> task_ids;
+    for (size_t i = 0; i < num_tasks; ++i) {
+      task_ids.push_back(RandomTaskId());
+    }
+    return task_ids;
+  }
 
   rpc::TaskEvents GenTaskEvents(TaskID task_id, uint64_t attempt_num) {
     rpc::TaskEvents task_events;
@@ -52,6 +64,31 @@ class TaskEventBufferTest : public ::testing::Test {
 
   std::unique_ptr<TaskEventBufferImpl> task_event_buffer_ = nullptr;
 };
+
+class TaskEventBufferTestManualStart : public TaskEventBufferTest {
+  void SetUp() override {}
+};
+
+TEST_F(TaskEventBufferTestManualStart, TestGcsClientFail) {
+  ASSERT_NE(task_event_buffer_, nullptr);
+
+  // Mock GCS connect fail.
+  auto gcs_client =
+      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->gcs_client_.get());
+  EXPECT_CALL(*gcs_client, Connect)
+      .Times(1)
+      .WillOnce(Return(Status::UnknownError("error")));
+
+  // Expect no flushing even if auto flush is on since start fails.
+  auto task_gcs_accessor =
+      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->gcs_client_.get())
+          ->mock_task_accessor;
+  EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData).Times(0);
+
+  ASSERT_TRUE(task_event_buffer_->Start(/*auto_flush*/ true).IsUnknownError());
+  // Resources cleared.
+  EXPECT_EQ(task_event_buffer_->gcs_client_, nullptr);
+}
 
 TEST_F(TaskEventBufferTest, TestAddEvent) {
   ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), 0);
@@ -135,6 +172,35 @@ TEST_F(TaskEventBufferTest, TestForcedFlush) {
   auto task_id_2 = RandomTaskId();
   task_event_buffer_->AddTaskEvents(GenTaskEvents(task_id_2, 0));
   task_event_buffer_->FlushEvents(true);
+}
+
+TEST_F(TaskEventBufferTest, TestBufferSizeLimit) {
+  size_t num_limit = 100;  // Synced with test setup
+  size_t num_batch1 = 100;
+  size_t num_batch2 = 100;
+
+  auto task_ids1 = GenTaskIDs(num_batch1);
+  auto task_ids2 = GenTaskIDs(num_batch2);
+
+  // Adding them
+  for (auto &task_id : task_ids1) {
+    task_event_buffer_->AddTaskEvents(GenTaskEvents(task_id, 0));
+  }
+
+  for (auto &task_id : task_ids2) {
+    task_event_buffer_->AddTaskEvents(GenTaskEvents(task_id, 0));
+  }
+
+  // Expect only limit.
+  ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), num_limit);
+
+  // Expect task events match.
+  std::unordered_set<TaskID> task_ids2_set(task_ids2.begin(), task_ids2.end());
+  for (auto &task_event : task_event_buffer_->GetAllTaskEvents()) {
+    auto task_id = TaskID::FromBinary(task_event.task_id());
+    EXPECT_EQ(task_ids2_set.count(task_id), 1);
+  }
+  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsDropped(), num_batch1);
 }
 
 }  // namespace worker

--- a/src/ray/core_worker/test/task_event_buffer_test.cc
+++ b/src/ray/core_worker/test/task_event_buffer_test.cc
@@ -86,8 +86,6 @@ TEST_F(TaskEventBufferTestManualStart, TestGcsClientFail) {
   EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData).Times(0);
 
   ASSERT_TRUE(task_event_buffer_->Start(/*auto_flush*/ true).IsUnknownError());
-  // Resources cleared.
-  EXPECT_EQ(task_event_buffer_->gcs_client_, nullptr);
 }
 
 TEST_F(TaskEventBufferTest, TestAddEvent) {

--- a/src/ray/core_worker/test/task_event_buffer_test.cc
+++ b/src/ray/core_worker/test/task_event_buffer_test.cc
@@ -22,6 +22,7 @@
 #include "ray/common/task/task_spec.h"
 #include "ray/common/test_util.h"
 
+using ::testing::_;
 using ::testing::Return;
 
 namespace ray {
@@ -76,14 +77,14 @@ TEST_F(TaskEventBufferTestManualStart, TestGcsClientFail) {
 
   // Mock GCS connect fail.
   auto gcs_client =
-      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->gcs_client_.get());
+      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->GetGcsClient());
   EXPECT_CALL(*gcs_client, Connect)
       .Times(1)
       .WillOnce(Return(Status::UnknownError("error")));
 
   // Expect no flushing even if auto flush is on since start fails.
   auto task_gcs_accessor =
-      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->gcs_client_.get())
+      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->GetGcsClient())
           ->mock_task_accessor;
   EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData).Times(0);
 
@@ -115,7 +116,7 @@ TEST_F(TaskEventBufferTest, TestFlushEvents) {
 
   // Manually call flush should call GCS client's flushing grpc.
   auto task_gcs_accessor =
-      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->gcs_client_.get())
+      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->GetGcsClient())
           ->mock_task_accessor;
 
   // Expect data flushed match
@@ -152,7 +153,7 @@ TEST_F(TaskEventBufferTest, TestBackPressure) {
   }
 
   auto task_gcs_accessor =
-      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->gcs_client_.get())
+      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->GetGcsClient())
           ->mock_task_accessor;
   // Multiple flush calls should only result in 1 grpc call if not forced flush.
   EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData).Times(1);
@@ -177,7 +178,7 @@ TEST_F(TaskEventBufferTest, TestForcedFlush) {
   }
 
   auto task_gcs_accessor =
-      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->gcs_client_.get())
+      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->GetGcsClient())
           ->mock_task_accessor;
 
   // Multiple flush calls with forced should result in same number of grpc call.
@@ -222,7 +223,7 @@ TEST_F(TaskEventBufferTest, TestBufferSizeLimit) {
 
   // Expect the reported data to contain number of dropped events.
   auto task_gcs_accessor =
-      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->gcs_client_.get())
+      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->GetGcsClient())
           ->mock_task_accessor;
 
   rpc::TaskEventData expected_data;

--- a/src/ray/core_worker/test/task_event_buffer_test.cc
+++ b/src/ray/core_worker/test/task_event_buffer_test.cc
@@ -1,0 +1,144 @@
+// Copyright 2022 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/core_worker/task_event_buffer.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "mock/ray/gcs/gcs_client/gcs_client.h"
+#include "ray/common/task/task_spec.h"
+#include "ray/common/test_util.h"
+
+namespace ray {
+
+namespace core {
+
+namespace worker {
+
+class TaskEventBufferTest : public ::testing::Test {
+ public:
+  TaskEventBufferTest() {
+    RayConfig::instance().initialize(
+        R"(
+{
+  "task_events_report_interval_ms": 1000
+}
+  )");
+
+    task_event_buffer_ =
+        std::make_unique<TaskEventBufferImpl>(std::make_unique<ray::gcs::MockGcsClient>(),
+                                              /*manual_flush*/ true);
+  }
+
+  virtual void TearDown() { task_event_buffer_->Stop(); };
+
+  rpc::TaskEvents GenTaskEvents(TaskID task_id, uint64_t attempt_num) {
+    rpc::TaskEvents task_events;
+    task_events.set_task_id(task_id.Binary());
+    task_events.set_attempt_number(attempt_num);
+    return task_events;
+  }
+
+  std::unique_ptr<TaskEventBufferImpl> task_event_buffer_ = nullptr;
+};
+
+TEST_F(TaskEventBufferTest, TestAddEvent) {
+  ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), 0);
+
+  // Test add status event
+  auto task_id_1 = RandomTaskId();
+  task_event_buffer_->AddTaskEvents(GenTaskEvents(task_id_1, 0));
+
+  ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), 1);
+
+  task_event_buffer_->AddTaskEvents(GenTaskEvents(task_id_1, 1));
+  ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), 2);
+}
+
+TEST_F(TaskEventBufferTest, TestFlushEvents) {
+  size_t num_events = 20;
+  // Adding some events
+  for (size_t i = 0; i < num_events; ++i) {
+    auto task_id = RandomTaskId();
+    task_event_buffer_->AddTaskEvents(GenTaskEvents(task_id, 0));
+  }
+
+  ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), num_events);
+
+  // Manually call flush should call GCS client's flushing grpc.
+  auto task_gcs_accessor =
+      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->gcs_client_.get())
+          ->mock_task_accessor;
+  EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData).Times(1);
+
+  task_event_buffer_->FlushEvents(false);
+
+  // Expect no more events.
+  ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), 0);
+}
+
+TEST_F(TaskEventBufferTest, TestBackPressure) {
+  size_t num_events = 20;
+  // Adding some events
+  for (size_t i = 0; i < num_events; ++i) {
+    auto task_id = RandomTaskId();
+    task_event_buffer_->AddTaskEvents(GenTaskEvents(task_id, 0));
+  }
+
+  auto task_gcs_accessor =
+      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->gcs_client_.get())
+          ->mock_task_accessor;
+  // Multiple flush calls should only result in 1 grpc call if not forced flush.
+  EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData).Times(1);
+
+  task_event_buffer_->FlushEvents(false);
+
+  auto task_id_1 = RandomTaskId();
+  task_event_buffer_->AddTaskEvents(GenTaskEvents(task_id_1, 0));
+  task_event_buffer_->FlushEvents(false);
+
+  auto task_id_2 = RandomTaskId();
+  task_event_buffer_->AddTaskEvents(GenTaskEvents(task_id_2, 0));
+  task_event_buffer_->FlushEvents(false);
+}
+
+TEST_F(TaskEventBufferTest, TestForcedFlush) {
+  size_t num_events = 20;
+  // Adding some events
+  for (size_t i = 0; i < num_events; ++i) {
+    auto task_id = RandomTaskId();
+    task_event_buffer_->AddTaskEvents(GenTaskEvents(task_id, 0));
+  }
+
+  auto task_gcs_accessor =
+      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->gcs_client_.get())
+          ->mock_task_accessor;
+
+  // Multiple flush calls with forced should result in same number of grpc call.
+  EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData).Times(2);
+
+  auto task_id_1 = RandomTaskId();
+  task_event_buffer_->AddTaskEvents(GenTaskEvents(task_id_1, 0));
+  task_event_buffer_->FlushEvents(false);
+
+  auto task_id_2 = RandomTaskId();
+  task_event_buffer_->AddTaskEvents(GenTaskEvents(task_id_2, 0));
+  task_event_buffer_->FlushEvents(true);
+}
+
+}  // namespace worker
+
+}  // namespace core
+
+}  // namespace ray

--- a/src/ray/core_worker/test/task_event_buffer_test.cc
+++ b/src/ray/core_worker/test/task_event_buffer_test.cc
@@ -145,6 +145,41 @@ TEST_F(TaskEventBufferTest, TestFlushEvents) {
   ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), 0);
 }
 
+TEST_F(TaskEventBufferTest, TestFailedFlush) {
+  size_t num_events = 20;
+  // Adding some events
+  for (size_t i = 0; i < num_events; ++i) {
+    auto task_id = RandomTaskId();
+    task_event_buffer_->AddTaskEvent(GenTaskEvents(task_id, 0));
+  }
+
+  auto task_gcs_accessor =
+      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->GetGcsClient())
+          ->mock_task_accessor;
+
+  // Mock gRPC sent failure.
+  EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData)
+      .Times(2)
+      .WillOnce(Return(Status::GrpcUnknown("grpc error")))
+      .WillOnce(Return(Status::OK()));
+
+  // Flush
+  task_event_buffer_->FlushEvents(false);
+
+  // Expect the number of dropped events incremented.
+  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsDropped(), num_events);
+
+  // Adding some more events
+  for (size_t i = 0; i < num_events; ++i) {
+    auto task_id = RandomTaskId();
+    task_event_buffer_->AddTaskEvent(GenTaskEvents(task_id, 0));
+  }
+
+  // Flush successfully will reset the num events dropped.
+  task_event_buffer_->FlushEvents(false);
+  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsDropped(), 0);
+}
+
 TEST_F(TaskEventBufferTest, TestBackPressure) {
   size_t num_events = 20;
   // Adding some events

--- a/src/ray/core_worker/test/task_event_buffer_test.cc
+++ b/src/ray/core_worker/test/task_event_buffer_test.cc
@@ -89,6 +89,7 @@ TEST_F(TaskEventBufferTestManualStart, TestGcsClientFail) {
   EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData).Times(0);
 
   ASSERT_TRUE(task_event_buffer_->Start(/*auto_flush*/ true).IsUnknownError());
+  ASSERT_FALSE(task_event_buffer_->Enabled());
 }
 
 TEST_F(TaskEventBufferTest, TestAddEvent) {

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -57,7 +57,7 @@ class MockTaskEventBuffer : public worker::TaskEventBuffer {
 
   MOCK_METHOD(void, FlushEvents, (bool forced), (override));
 
-  MOCK_METHOD(bool, Start, (bool manual_flush), (override));
+  MOCK_METHOD(Status, Start, (bool manual_flush), (override));
 
   MOCK_METHOD(void, Stop, (), (override));
 };
@@ -69,6 +69,7 @@ class TaskManagerTest : public ::testing::Test {
       : addr_(GetRandomWorkerAddr()),
         publisher_(std::make_shared<mock_pubsub::MockPublisher>()),
         subscriber_(std::make_shared<mock_pubsub::MockSubscriber>()),
+        task_event_buffer_mock_(std::make_unique<MockTaskEventBuffer>()),
         reference_counter_(std::shared_ptr<ReferenceCounter>(new ReferenceCounter(
             addr_,
             publisher_.get(),
@@ -94,7 +95,7 @@ class TaskManagerTest : public ::testing::Test {
                const std::string &error_message,
                double timestamp) { return Status::OK(); },
             max_lineage_bytes,
-            std::make_shared<MockTaskEventBuffer>()) {}
+            task_event_buffer_mock_.get()) {}
 
   virtual void TearDown() { AssertNoLeaks(); }
 
@@ -108,6 +109,7 @@ class TaskManagerTest : public ::testing::Test {
   rpc::Address addr_;
   std::shared_ptr<mock_pubsub::MockPublisher> publisher_;
   std::shared_ptr<mock_pubsub::MockSubscriber> subscriber_;
+  std::unique_ptr<MockTaskEventBuffer> task_event_buffer_mock_;
   std::shared_ptr<ReferenceCounter> reference_counter_;
   std::shared_ptr<CoreWorkerMemoryStore> store_;
   bool all_nodes_alive_ = true;

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -57,6 +57,8 @@ class MockTaskEventBuffer : public worker::TaskEventBuffer {
 
   MOCK_METHOD(void, FlushEvents, (bool forced), (override));
 
+  MOCK_METHOD(bool, Start, (bool manual_flush), (override));
+
   MOCK_METHOD(void, Stop, (), (override));
 };
 

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -61,7 +61,7 @@ class MockTaskEventBuffer : public worker::TaskEventBuffer {
 
   MOCK_METHOD(void, Stop, (), (override));
 
-  MOCK_METHOD(bool, Enabled, (), (override));
+  MOCK_METHOD(bool, Enabled, (), (const, override));
 };
 
 class TaskManagerTest : public ::testing::Test {

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -53,7 +53,7 @@ rpc::Address GetRandomWorkerAddr() {
 
 class MockTaskEventBuffer : public worker::TaskEventBuffer {
  public:
-  MOCK_METHOD(void, AddTaskEvents, (rpc::TaskEvents task_events), (override));
+  MOCK_METHOD(void, AddTaskEvent, (rpc::TaskEvents task_events), (override));
 
   MOCK_METHOD(void, FlushEvents, (bool forced), (override));
 

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -60,6 +60,8 @@ class MockTaskEventBuffer : public worker::TaskEventBuffer {
   MOCK_METHOD(Status, Start, (bool manual_flush), (override));
 
   MOCK_METHOD(void, Stop, (), (override));
+
+  MOCK_METHOD(bool, Enabled, (), (override));
 };
 
 class TaskManagerTest : public ::testing::Test {
@@ -95,7 +97,7 @@ class TaskManagerTest : public ::testing::Test {
                const std::string &error_message,
                double timestamp) { return Status::OK(); },
             max_lineage_bytes,
-            task_event_buffer_mock_.get()) {}
+            *task_event_buffer_mock_.get()) {}
 
   virtual void TearDown() { AssertNoLeaks(); }
 

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -817,6 +817,22 @@ Status StatsInfoAccessor::AsyncGetAll(
   return Status::OK();
 }
 
+Status TaskInfoAccessor::AsyncAddTaskEventData(
+    std::unique_ptr<rpc::TaskEventData> data_ptr, StatusCallback callback) {
+  RAY_LOG(DEBUG) << "Adding task events." << data_ptr->DebugString();
+  rpc::AddTaskEventDataRequest request;
+  // Prevent copy here
+  request.mutable_data()->Swap(data_ptr.get());
+  client_impl_->GetGcsRpcClient().AddTaskEventData(
+      request, [callback](const Status &status, const rpc::AddTaskEventDataReply &reply) {
+        if (callback) {
+          callback(status);
+        }
+        RAY_LOG(DEBUG) << "Accessor added task events grpc OK";
+      });
+  return Status::OK();
+}
+
 ErrorInfoAccessor::ErrorInfoAccessor(GcsClient *client_impl)
     : client_impl_(client_impl) {}
 

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -526,6 +526,27 @@ class ErrorInfoAccessor {
   GcsClient *client_impl_;
 };
 
+/// \class TaskInfoAccessor
+/// `TaskInfoAccessor` is a sub-interface of `GcsClient`.
+/// This class includes all the methods that are related to accessing
+/// task info in the GCS.
+class TaskInfoAccessor {
+ public:
+  TaskInfoAccessor() = default;
+  explicit TaskInfoAccessor(GcsClient *client_impl) : client_impl_(client_impl) {}
+  virtual ~TaskInfoAccessor() = default;
+  /// Add task event data to GCS asynchronously.
+  ///
+  /// \param data_ptr The task states event data that will be added to GCS.
+  /// \param callback Callback that will be called when add is complete.
+  /// \return Status
+  virtual Status AsyncAddTaskEventData(std::unique_ptr<rpc::TaskEventData> data_ptr,
+                                       StatusCallback callback);
+
+ private:
+  GcsClient *client_impl_;
+};
+
 /// \class StatsInfoAccessor
 /// `StatsInfoAccessor` is a sub-interface of `GcsClient`.
 /// This class includes all the methods that are related to accessing

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -123,6 +123,7 @@ Status GcsClient::Connect(instrumented_io_context &io_service) {
   worker_accessor_ = std::make_unique<WorkerInfoAccessor>(this);
   placement_group_accessor_ = std::make_unique<PlacementGroupInfoAccessor>(this);
   internal_kv_accessor_ = std::make_unique<InternalKVAccessor>(this);
+  task_accessor_ = std::make_unique<TaskInfoAccessor>(this);
 
   RAY_LOG(DEBUG) << "GcsClient connected.";
   return Status::OK();

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -136,6 +136,11 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
     return *stats_accessor_;
   }
 
+  TaskInfoAccessor &Tasks() {
+    RAY_CHECK(task_accessor_ != nullptr);
+    return *task_accessor_;
+  }
+
   /// Get the sub-interface for accessing worker information in GCS.
   /// This function is thread safe.
   WorkerInfoAccessor &Workers() {
@@ -170,6 +175,7 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
   std::unique_ptr<WorkerInfoAccessor> worker_accessor_;
   std::unique_ptr<PlacementGroupInfoAccessor> placement_group_accessor_;
   std::unique_ptr<InternalKVAccessor> internal_kv_accessor_;
+  std::unique_ptr<TaskInfoAccessor> task_accessor_;
 
  private:
   const UniqueID gcs_client_id_ = UniqueID::FromRandom();

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -233,7 +233,7 @@ message TaskStateUpdate {
   // Timestamp when status changes to PENDING_ARGS_AVAIL.
   optional int64 pending_args_avail_ts = 2;
   // Timestamp when status changes to PENDING_NODE_ASSIGNMENT.
-  optional int64 pending_node_assignment = 3;
+  optional int64 pending_node_assignment_ts = 3;
   // Timestamp when status changes to SUBMITTED_TO_WORKER.
   optional int64 submitted_to_worker_ts = 4;
   // Timestamp when status changes to RUNNING.

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -231,6 +231,9 @@ class GcsRpcClient {
     internal_pubsub_grpc_client_ = std::make_unique<GrpcClient<InternalPubSubGcsService>>(
         channel_, client_call_manager);
 
+    task_info_grpc_client_ =
+        std::make_unique<GrpcClient<TaskInfoGcsService>>(channel_, client_call_manager);
+
     SetupCheckTimer();
   }
 
@@ -376,6 +379,12 @@ class GcsRpcClient {
   VOID_GCS_RPC_CLIENT_METHOD(StatsGcsService,
                              GetAllProfileInfo,
                              stats_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+
+  /// Add task events info to GCS Service.
+  VOID_GCS_RPC_CLIENT_METHOD(TaskInfoGcsService,
+                             AddTaskEventData,
+                             task_info_grpc_client_,
                              /*method_timeout_ms*/ -1, )
 
   /// Report a worker failure to GCS Service.
@@ -582,6 +591,8 @@ class GcsRpcClient {
       placement_group_info_grpc_client_;
   std::unique_ptr<GrpcClient<InternalKVGcsService>> internal_kv_grpc_client_;
   std::unique_ptr<GrpcClient<InternalPubSubGcsService>> internal_pubsub_grpc_client_;
+
+  std::unique_ptr<GrpcClient<TaskInfoGcsService>> task_info_grpc_client_;
 
   std::shared_ptr<grpc::Channel> channel_;
   bool gcs_is_down_ = false;

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -36,6 +36,11 @@ namespace rpc {
                       HANDLER,                 \
                       RayConfig::instance().gcs_max_active_rpcs_per_handler())
 
+#define TASK_INFO_SERVICE_RPC_HANDLER(HANDLER) \
+  RPC_SERVICE_HANDLER(TaskInfoGcsService,      \
+                      HANDLER,                 \
+                      RayConfig::instance().gcs_max_active_rpcs_per_handler())
+
 #define HEARTBEAT_INFO_SERVICE_RPC_HANDLER(HANDLER) \
   RPC_SERVICE_HANDLER(HeartbeatInfoGcsService, HANDLER, -1)
 
@@ -571,6 +576,42 @@ class RuntimeEnvGrpcService : public GrpcService {
  private:
   RuntimeEnvGcsService::AsyncService service_;
   RuntimeEnvGcsServiceHandler &service_handler_;
+};
+
+class TaskInfoGcsServiceHandler {
+ public:
+  virtual ~TaskInfoGcsServiceHandler() = default;
+
+  virtual void HandleAddTaskEventData(AddTaskEventDataRequest request,
+                                      AddTaskEventDataReply *reply,
+                                      SendReplyCallback send_reply_callback) = 0;
+};
+
+/// The `GrpcService` for `TaskInfoGcsService`.
+class TaskInfoGrpcService : public GrpcService {
+ public:
+  /// Constructor.
+  ///
+  /// \param[in] io_service IO service to run the handler.
+  /// \param[in] handler The service handler that actually handle the requests.
+  explicit TaskInfoGrpcService(instrumented_io_context &io_service,
+                               TaskInfoGcsServiceHandler &handler)
+      : GrpcService(io_service), service_handler_(handler){};
+
+ protected:
+  grpc::Service &GetGrpcService() override { return service_; }
+
+  void InitServerCallFactories(
+      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
+      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+    TASK_INFO_SERVICE_RPC_HANDLER(AddTaskEventData);
+  }
+
+ private:
+  /// The grpc async service object.
+  TaskInfoGcsService::AsyncService service_;
+  /// The service handler that actually handle the requests.
+  TaskInfoGcsServiceHandler &service_handler_;
 };
 
 class InternalPubSubGcsServiceHandler {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For details of the design and background see this [doc](https://docs.google.com/document/d/1l7GAbEoVbZszWOS2V1voSq5YiPzTgblK9dmtmnWb_tM/edit)

Previous PRs:
 - https://github.com/ray-project/ray/pull/30829: Interface and protobuf definitions. 

In this PR: 
- Added a TaskEventBuffer class which serves as an abstraction to store task events, and push those events to GCS in batches periodically. 
- Each CoreWorker will own one single TaskEventBuffer, and events (both task status change events and profiling events) will be added to a local in-memory buffer. 
- The TaskEventBuffer also owns its own GCS client and io thread, which is independent from the main io_contexts.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
