### PR TITLE
Fix duration formatter to show number of days and beyond 

### DIFF
--- a/dashboard/client/src/common/DurationText/DurationText.component.test.tsx
+++ b/dashboard/client/src/common/DurationText/DurationText.component.test.tsx
@@ -23,6 +23,34 @@ describe("DurationText", () => {
       <DurationText startTime={new Date(100000)} endTime={new Date(5000000)} />,
     );
     expect(await screen.findByText("1h 21m")).toBeInTheDocument();
+    // > 1 day
+    rerender(
+      <DurationText
+        startTime={new Date(100000)}
+        endTime={new Date(100000 + 1000 * 60 * 60 * 24 + 1000 * 60 * 60 * 13)}
+      />,
+    );
+    expect(await screen.findByText("1d 13h")).toBeInTheDocument();
+
+    // > 1 month
+    rerender(
+      <DurationText
+        startTime={new Date(100000)}
+        endTime={
+          new Date(100000 + 1000 * 60 * 60 * 24 * 30 + 1000 * 60 * 60 * 24 * 4)
+        }
+      />,
+    );
+    expect(await screen.findByText("1M 4d")).toBeInTheDocument();
+
+    // > 1 year
+    rerender(
+      <DurationText
+        startTime={new Date(100000)}
+        endTime={new Date(100000 + 1000 * 60 * 60 * 24 * 405)}
+      />,
+    );
+    expect(await screen.findByText("1y 1M 10d")).toBeInTheDocument();
   });
 
   it("automatically re-renders when endTime is null", async () => {

--- a/dashboard/client/src/common/DurationText/DurationText.tsx
+++ b/dashboard/client/src/common/DurationText/DurationText.tsx
@@ -23,14 +23,26 @@ export const DurationText = ({ startTime, endTime }: DurationTextProps) => {
 
   let durationText: string;
   let refreshInterval = 1000;
-  if (duration.asSeconds() < 60) {
+  if (duration.asMinutes() < 1) {
     durationText = duration.format("s[s]");
-  } else if (duration.asSeconds() < 3600) {
+  } else if (duration.asHours() < 1) {
     durationText = duration.format("m[m] s[s]");
-  } else {
+  } else if (duration.asDays() < 1) {
     // Only refresh once per minute
     durationText = duration.format("H[h] m[m]");
-    refreshInterval = 60000;
+    refreshInterval = 1000 * 60;
+  } else if (duration.asMonths() < 1) {
+    // Only refresh once per minute
+    durationText = duration.format("D[d] H[h]");
+    refreshInterval = 1000 * 60;
+  } else if (duration.asYears() < 1) {
+    // Only refresh once per hour
+    durationText = duration.format("M[M] D[d]");
+    refreshInterval = 1000 * 60 * 60;
+  } else {
+    // Only refresh once per hour
+    durationText = duration.format("Y[y] M[M] D[d]");
+    refreshInterval = 1000 * 60 * 60;
   }
 
   useEffect(() => {


### PR DESCRIPTION
This fixes a bug where the duration of a job only shows the number of hours. So if a job took 3 days and 5 hours, it would only show "5h" instead of "3d 5h".

<img width="1545" alt="Screen Shot 2022-12-02 at 11 49 26 AM" src="https://user-images.githubusercontent.com/711935/205374534-eebd1c5a-d794-4766-83df-c4a711139013.png">

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Cherry-pick of #30862
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
