### PR TITLE
[Tune] Move `validate_upload_dir` to Syncer

### DIFF
--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -120,6 +120,20 @@ class SyncConfig:
             max_height="none",
         )
 
+    def validate_upload_dir(self) -> bool:
+        """Checks if ``upload_dir`` is supported by ``syncer``.
+
+        Returns True if ``upload_dir`` is valid, otherwise raises
+        ``ValueError``.
+
+        Args:
+            upload_dir: Path to validate.
+        """
+        if hasattr(self.syncer, "validate_upload_dir"):
+            return self.syncer.validate_upload_dir(self.upload_dir)
+        else:
+            return Syncer.validate_upload_dir(self.upload_dir)
+
 
 class _BackgroundProcess:
     def __init__(self, fn: Callable):
@@ -341,7 +355,7 @@ class Syncer(abc.ABC):
     @classmethod
     def validate_upload_dir(cls, upload_dir: str) -> bool:
         """Checks if ``upload_dir`` is supported by the Syncer.
-        
+
         Returns True if ``upload_dir`` is valid, otherwise raises
         ``ValueError``.
 

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -51,21 +51,6 @@ _EXCLUDE_FROM_SYNC = [
 ]
 
 
-def _validate_upload_dir(sync_config: "SyncConfig") -> bool:
-    if not sync_config.upload_dir:
-        return True
-
-    if sync_config.upload_dir.startswith("file://"):
-        return True
-
-    if not is_non_local_path_uri(sync_config.upload_dir):
-        raise ValueError(
-            f"Could not identify external storage filesystem for "
-            f"upload dir `{sync_config.upload_dir}`. "
-            f"Hint: {fs_hint(sync_config.upload_dir)}"
-        )
-
-
 @PublicAPI
 @dataclass
 class SyncConfig:
@@ -352,6 +337,29 @@ class Syncer(abc.ABC):
 
     def _repr_html_(self) -> str:
         return
+
+    @classmethod
+    def validate_upload_dir(cls, upload_dir: str) -> bool:
+        """Checks if ``upload_dir`` is supported by the Syncer.
+        
+        Returns True if ``upload_dir`` is valid, otherwise raises
+        ``ValueError``.
+
+        Args:
+            upload_dir: Path to validate.
+        """
+        if not upload_dir:
+            return True
+
+        if upload_dir.startswith("file://"):
+            return True
+
+        if not is_non_local_path_uri(upload_dir):
+            raise ValueError(
+                f"Could not identify external storage filesystem for "
+                f"upload dir `{upload_dir}`. "
+                f"Hint: {fs_hint(upload_dir)}"
+            )
 
 
 class _BackgroundSyncer(Syncer):

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -129,7 +129,7 @@ class SyncConfig:
         Args:
             upload_dir: Path to validate.
         """
-        if hasattr(self.syncer, "validate_upload_dir"):
+        if isinstance(self.syncer, Syncer):
             return self.syncer.validate_upload_dir(self.upload_dir)
         else:
             return Syncer.validate_upload_dir(self.upload_dir)

--- a/python/ray/tune/tests/test_syncer.py
+++ b/python/ray/tune/tests/test_syncer.py
@@ -166,20 +166,39 @@ class CustomCommandSyncer(Syncer):
 
 def test_sync_string_invalid_uri():
     with pytest.raises(ValueError):
-        Syncer.validate_upload_dir("invalid://some/url")
+        sync_config = tune.SyncConfig(upload_dir="invalid://some/url")
+        sync_config.validate_upload_dir()
 
 
 def test_sync_string_invalid_local():
     with pytest.raises(ValueError):
-        Syncer.validate_upload_dir("/invalid/dir")
+        sync_config = tune.SyncConfig(upload_dir="/invalid/dir")
+        sync_config.validate_upload_dir()
 
 
 def test_sync_string_valid_local():
-    Syncer.validate_upload_dir("file:///valid/dir")
+    sync_config = tune.SyncConfig(upload_dir="file:///valid/dir")
+    sync_config.validate_upload_dir()
 
 
 def test_sync_string_valid_s3():
-    Syncer.validate_upload_dir("s3://valid/bucket")
+    sync_config = tune.SyncConfig(upload_dir="s3://valid/bucket")
+    sync_config.validate_upload_dir()
+
+
+def test_sync_config_validate():
+    sync_config = tune.SyncConfig()
+    sync_config.validate_upload_dir()
+
+
+def test_sync_config_validate_custom_syncer():
+    class CustomSyncer(_DefaultSyncer):
+        @classmethod
+        def validate_upload_dir(cls, upload_dir: str) -> bool:
+            return True
+
+    sync_config = tune.SyncConfig(upload_dir="/invalid/dir", syncer=CustomSyncer())
+    sync_config.validate_upload_dir()
 
 
 def test_syncer_sync_up_down(temp_data_dirs):

--- a/python/ray/tune/tests/test_syncer.py
+++ b/python/ray/tune/tests/test_syncer.py
@@ -14,7 +14,7 @@ import ray.cloudpickle as pickle
 from ray import tune
 from ray.air import Checkpoint
 from ray.tune import TuneError
-from ray.tune.syncer import Syncer, _DefaultSyncer, _validate_upload_dir
+from ray.tune.syncer import Syncer, _DefaultSyncer
 from ray.tune.utils.file_transfer import _pack_dir, _unpack_dir
 
 
@@ -166,20 +166,20 @@ class CustomCommandSyncer(Syncer):
 
 def test_sync_string_invalid_uri():
     with pytest.raises(ValueError):
-        _validate_upload_dir(tune.SyncConfig(upload_dir="invalid://some/url"))
+        Syncer.validate_upload_dir("invalid://some/url")
 
 
 def test_sync_string_invalid_local():
     with pytest.raises(ValueError):
-        _validate_upload_dir(tune.SyncConfig(upload_dir="/invalid/dir"))
+        Syncer.validate_upload_dir("/invalid/dir")
 
 
 def test_sync_string_valid_local():
-    _validate_upload_dir(tune.SyncConfig(upload_dir="file:///valid/dir"))
+    Syncer.validate_upload_dir("file:///valid/dir")
 
 
 def test_sync_string_valid_s3():
-    _validate_upload_dir(tune.SyncConfig(upload_dir="s3://valid/bucket"))
+    Syncer.validate_upload_dir("s3://valid/bucket")
 
 
 def test_syncer_sync_up_down(temp_data_dirs):

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -48,7 +48,7 @@ from ray.tune.search.util import (
     _set_search_properties_backwards_compatible as searcher_set_search_props,
 )
 from ray.tune.search.variant_generator import _has_unresolved_values
-from ray.tune.syncer import SyncConfig, SyncerCallback, _validate_upload_dir
+from ray.tune.syncer import SyncConfig, Syncer, SyncerCallback
 from ray.tune.trainable import Trainable
 from ray.tune.experiment import Trial
 from ray.tune.execution.trial_runner import TrialRunner
@@ -425,7 +425,10 @@ def run(
 
     config = config or {}
     sync_config = sync_config or SyncConfig()
-    _validate_upload_dir(sync_config)
+    if hasattr(sync_config.syncer, "validate_upload_dir"):
+        sync_config.syncer.validate_upload_dir(sync_config.upload_dir)
+    else:
+        Syncer.validate_upload_dir(sync_config.upload_dir)
 
     checkpoint_score_attr = checkpoint_score_attr or ""
     if checkpoint_score_attr.startswith("min-"):

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -48,7 +48,7 @@ from ray.tune.search.util import (
     _set_search_properties_backwards_compatible as searcher_set_search_props,
 )
 from ray.tune.search.variant_generator import _has_unresolved_values
-from ray.tune.syncer import SyncConfig, Syncer, SyncerCallback
+from ray.tune.syncer import SyncConfig, SyncerCallback
 from ray.tune.trainable import Trainable
 from ray.tune.experiment import Trial
 from ray.tune.execution.trial_runner import TrialRunner
@@ -425,10 +425,7 @@ def run(
 
     config = config or {}
     sync_config = sync_config or SyncConfig()
-    if hasattr(sync_config.syncer, "validate_upload_dir"):
-        sync_config.syncer.validate_upload_dir(sync_config.upload_dir)
-    else:
-        Syncer.validate_upload_dir(sync_config.upload_dir)
+    sync_config.validate_upload_dir()
 
     checkpoint_score_attr = checkpoint_score_attr or ""
     if checkpoint_score_attr.startswith("min-"):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We run `_validate_upload_dir` when starting a `tune.run` in order to fail early if the `upload_dir` in sync config is invalid. However, this is too inflexible if a user creates their own Syncer which may support additional file systems (eg. MinIO). This PR makes that function a part of the `Syncer` class itself as a classmethod, allowing users to override it in their `Syncer` subclasses if needed. Logic is otherwise unchanged.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/30865

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
