### PR TITLE
Make gpu.processes nullable

### DIFF
--- a/dashboard/client/src/pages/node/GRAMColumn.tsx
+++ b/dashboard/client/src/pages/node/GRAMColumn.tsx
@@ -40,7 +40,7 @@ export const WorkerGRAM = ({
 }) => {
   const workerGRAMEntries = (node.gpus ?? [])
     .map((gpu, i) => {
-      const process = gpu.processes.find(
+      const process = gpu.processes?.find(
         (process) => process.pid === worker.pid,
       );
       if (!process) {

--- a/dashboard/client/src/type/node.d.ts
+++ b/dashboard/client/src/type/node.d.ts
@@ -66,7 +66,7 @@ export type GPUStats = {
   enforcedPowerLimit: number;
   memoryUsed: number;
   memoryTotal: number;
-  processes: GPUProcessStats[];
+  processes?: GPUProcessStats[];
 };
 
 export type NodeDetailExtend = {


### PR DESCRIPTION
gpu_stat can have null processes field. UI should be able to handle this without crashing 

Signed-off-by: Alan Guo <aguo@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
fixes #30854

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
