### PR TITLE
[cherry-pick][core] Fix a corner case where raylet started at the same ip addr + port leads to node removal failure. (#30841)

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -194,7 +194,7 @@ py_test_module_list(
   files = [
     "test_gcs_ha_e2e.py",
   ],
-  size = "small",
+  size = "medium",
   tags = ["exclusive", "ray_ha", "team:core"],
   deps = ["//:ray_lib", ":conftest"],
 )

--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -1,4 +1,5 @@
 import sys
+import time
 
 import pytest
 
@@ -180,6 +181,20 @@ def test_function_table_gc_actor(call_ray_start):
     ray.shutdown()
     ray.init(address="auto", namespace="c")
     wait_for_condition(lambda: function_entry_num(job_id) == 0)
+
+
+def test_node_liveness_after_restart(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node()
+    ray.init(cluster.address)
+    worker = cluster.add_node(node_manager_port=9037)
+    wait_for_condition(lambda: len([n for n in ray.nodes() if n["Alive"]]) == 2)
+
+    cluster.remove_node(worker)
+    worker = cluster.add_node(node_manager_port=9037)
+    for _ in range(10):
+        wait_for_condition(lambda: len([n for n in ray.nodes() if n["Alive"]]) == 2)
+        time.sleep(1)
 
 
 @pytest.mark.skipif(

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.h
@@ -94,6 +94,7 @@ class GcsHealthCheckManager {
           stopped_(std::make_shared<bool>(false)),
           timer_(manager->io_service_),
           health_check_remaining_(manager->failure_threshold_) {
+      request_.set_service(node_id.Hex());
       stub_ = grpc::health::v1::Health::NewStub(channel);
       timer_.expires_from_now(
           boost::posix_time::milliseconds(manager_->initial_delay_ms_));

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -445,7 +445,10 @@ NodeManager::NodeManager(instrumented_io_context &io_service,
     node_manager_server_.RegisterService(ray_syncer_service_);
   }
   node_manager_server_.Run();
-
+  // GCS will check the health of the service named with the node id.
+  // Fail to setup this will lead to the health check failure.
+  node_manager_server_.GetServer().GetHealthCheckService()->SetServingStatus(
+      self_node_id_.Hex(), true);
   worker_pool_.SetNodeManagerPort(GetServerPort());
 
   auto agent_command_line = ParseCommandLine(config.agent_command);


### PR DESCRIPTION
    Right now, GCS will ping the raylet to check their liveness, but the raylet can be dead and started at the same address as before. In this case, GCS will still consider the old raylet alive and this will make things broken.

    The fix add the node id as the service name and thus fix this issue.