### PR TITLE
Allow tf and torch apex release tests to run in parallel

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2840,7 +2840,7 @@
 
   cluster:
     cluster_env: app_config.yaml
-    cluster_compute: 2gpu_32cpus.yaml
+    cluster_compute: 2gpus_32cpus.yaml
 
   run:
     timeout: 18000

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2840,7 +2840,7 @@
 
   cluster:
     cluster_env: app_config.yaml
-    cluster_compute: 2gpus_32cpus.yaml
+    cluster_compute: 2gpus_64cpus.yaml
 
   run:
     timeout: 18000

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2840,7 +2840,7 @@
 
   cluster:
     cluster_env: app_config.yaml
-    cluster_compute: 1gpu_24cpus.yaml
+    cluster_compute: 2gpu_32cpus.yaml
 
   run:
     timeout: 18000

--- a/release/rllib_tests/2gpus_64cpus.yaml
+++ b/release/rllib_tests/2gpus_64cpus.yaml
@@ -1,7 +1,7 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
-max_workers: 0
+max_workers: 1
 
 head_node_type:
     name: head_node

--- a/release/rllib_tests/2gpus_64cpus.yaml
+++ b/release/rllib_tests/2gpus_64cpus.yaml
@@ -1,0 +1,22 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: g3.8xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: m5.8xlarge
+      min_workers: 1
+      max_workers: 1
+      use_spot: false
+
+aws:
+    BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: true
+            VolumeSize: 500

--- a/release/rllib_tests/learning_tests/yaml_files/apex/apex-breakoutnoframeskip-v4.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/apex/apex-breakoutnoframeskip-v4.yaml
@@ -24,7 +24,7 @@ apex-breakoutnoframeskip-v4:
             epsilon_timesteps: 200000
             final_epsilon: 0.01
         num_gpus: 1
-        num_workers: 15
+        num_workers: 16
         num_envs_per_worker: 8
         rollout_fragment_length: 20
         train_batch_size: 512

--- a/release/rllib_tests/learning_tests/yaml_files/apex/apex-breakoutnoframeskip-v4.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/apex/apex-breakoutnoframeskip-v4.yaml
@@ -24,7 +24,7 @@ apex-breakoutnoframeskip-v4:
             epsilon_timesteps: 200000
             final_epsilon: 0.01
         num_gpus: 1
-        num_workers: 16
+        num_workers: 15
         num_envs_per_worker: 8
         rollout_fragment_length: 20
         train_batch_size: 512


### PR DESCRIPTION
Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

Curent instance is too small to run both trials in parallel
Each trial takes 2 hrs, and if any of them needs retry, the 5hr cluster timeout will kick in and fail everything.

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
