### PR TITLE
Support cpp worker get java actor by name

### DIFF
--- a/cpp/include/ray/api/actor_handle.h
+++ b/cpp/include/ray/api/actor_handle.h
@@ -88,4 +88,5 @@ class ActorHandle {
   std::string id_;
 };
 
+typedef ActorHandle<void, true> ActorHandleXlang;
 }  // namespace ray

--- a/cpp/include/ray/api/function_manager.h
+++ b/cpp/include/ray/api/function_manager.h
@@ -284,6 +284,25 @@ class FunctionManager {
     return &it->second;
   }
 
+  static std::string GetClassNameByFuncName(const std::string &func_name) {
+    if (func_name.empty()) {
+      return "";
+    }
+
+    const std::string &prefix = "RAY_FUNC(";
+    size_t start_pos = 0;
+    auto pos = func_name.find(prefix);
+    if (pos != func_name.npos) {
+      start_pos = pos + prefix.size();
+    }
+    auto end_pod = func_name.find_last_of("::");
+    if (end_pod == func_name.npos || end_pod <= start_pos) {
+      return "";
+    }
+
+    return func_name.substr(start_pos, (end_pod - start_pos - 1));
+  }
+
  private:
   FunctionManager() = default;
   ~FunctionManager() = default;

--- a/cpp/include/ray/api/object_ref.h
+++ b/cpp/include/ray/api/object_ref.h
@@ -70,8 +70,10 @@ class ObjectRef {
     }
 
     SubReference(id_);
-    SubReference(rhs.id_);
     CopyAndAddReference(id_, rhs.id_);
+    // Rvalues need to be sub after add. Otherwise, the reference_count will become 0 and
+    // be deleted. Cause information such as owner to be deleted.
+    SubReference(rhs.id_);
     rhs.id_ = {};
     return *this;
   }

--- a/cpp/src/ray/runtime/task/native_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/native_task_submitter.cc
@@ -27,7 +27,9 @@ using ray::core::TaskOptions;
 RayFunction BuildRayFunction(InvocationSpec &invocation) {
   if (invocation.remote_function_holder.lang_type == LangType::CPP) {
     auto function_descriptor = FunctionDescriptorBuilder::BuildCpp(
-        invocation.remote_function_holder.function_name);
+        invocation.remote_function_holder.function_name,
+        "",
+        invocation.remote_function_holder.class_name);
     return RayFunction(ray::Language::CPP, function_descriptor);
   } else if (invocation.remote_function_holder.lang_type == LangType::PYTHON) {
     auto function_descriptor = FunctionDescriptorBuilder::BuildPython(

--- a/cpp/src/ray/test/cluster/cluster_mode_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_test.cc
@@ -68,8 +68,9 @@ TEST(RayClusterModeTest, FullTest) {
   if (absl::GetFlag<bool>(FLAGS_external_cluster)) {
     auto port = absl::GetFlag<int32_t>(FLAGS_redis_port);
     std::string password = absl::GetFlag<std::string>(FLAGS_redis_password);
-    ray::internal::ProcessHelper::GetInstance().StartRayNode(port, password);
-    config.address = "127.0.0.1:" + std::to_string(port);
+    std::string local_ip = ray::internal::GetNodeIpAddress();
+    ray::internal::ProcessHelper::GetInstance().StartRayNode(local_ip, port, password);
+    config.address = local_ip + ":" + std::to_string(port);
     config.redis_password_ = password;
   }
   ray::Init(config, cmd_argc, cmd_argv);

--- a/cpp/src/ray/test/cluster/cluster_mode_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_test.cc
@@ -252,10 +252,16 @@ TEST(RayClusterModeTest, ActorHandleTest) {
   auto child_actor =
       actor1.Task(&Counter::CreateChildActor).Remote(child_actor_name).Get();
   EXPECT_EQ(1, *child_actor->Task(&Counter::Plus1).Remote().Get());
+
+  auto named_actor_handle_optional = ray::GetActor<Counter>(child_actor_name);
+  EXPECT_TRUE(named_actor_handle_optional);
+  auto &named_actor_handle = *named_actor_handle_optional;
+  auto named_actor_obj1 = named_actor_handle.Task(&Counter::Plus1).Remote();
+  EXPECT_EQ(2, *named_actor_obj1.Get());
 }
 
 TEST(RayClusterModeTest, PythonInvocationTest) {
-  auto py_actor_handle =
+  ray::ActorHandleXlang py_actor_handle =
       ray::Actor(ray::PyActorClass{"test_cross_language_invocation", "Counter"})
           .Remote(1);
   EXPECT_TRUE(!py_actor_handle.ID().empty());

--- a/cpp/src/ray/test/cluster/cluster_mode_xlang_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_xlang_test.cc
@@ -15,19 +15,95 @@
 #include <gtest/gtest.h>
 #include <ray/api.h>
 
-TEST(RayClusterModeXLangTest, JavaInvocationTest) {
-  auto java_actor_handle =
-      ray::Actor(ray::JavaActorClass{"io.ray.test.Counter"}).Remote(1);
-  EXPECT_TRUE(!java_actor_handle.ID().empty());
-  auto java_actor_ret =
-      java_actor_handle.Task(ray::JavaActorMethod<int>{"increase"}).Remote(2);
-  EXPECT_EQ(3, *java_actor_ret.Get());
+#include "cpp/include/ray/api/actor_handle.h"
 
+TEST(RayClusterModeXLangTest, JavaInvocationTest) {
+  // Test java nested static class
+  ray::ActorHandleXlang java_nested_class_actor_handle =
+      ray::Actor(ray::JavaActorClass{"io.ray.test.Counter$NestedActor"}).Remote("hello");
+  EXPECT_TRUE(!java_nested_class_actor_handle.ID().empty());
+  auto java_actor_ret =
+      java_nested_class_actor_handle.Task(ray::JavaActorMethod<std::string>{"concat"})
+          .Remote("world");
+  EXPECT_EQ("helloworld", *java_actor_ret.Get());
+
+  // Test java static function
   auto java_task_ret =
       ray::Task(ray::JavaFunction<std::string>{"io.ray.test.CrossLanguageInvocationTest",
                                                "returnInputString"})
           .Remote("helloworld");
   EXPECT_EQ("helloworld", *java_task_ret.Get());
+
+  // Test java normal class
+  std::string actor_name = "java_actor";
+  auto java_class_actor_handle = ray::Actor(ray::JavaActorClass{"io.ray.test.Counter"})
+                                     .SetName(actor_name)
+                                     .Remote(0);
+  auto ref2 =
+      java_class_actor_handle.Task(ray::JavaActorMethod<int>{"getValue"}).Remote();
+  EXPECT_EQ(0, *ref2.Get());
+
+  // Test get java actor by actor name.
+  boost::optional<ray::ActorHandleXlang> named_actor_handle_optional =
+      ray::GetActor(actor_name);
+  EXPECT_TRUE(named_actor_handle_optional);
+  ray::ActorHandleXlang named_actor_handle = *named_actor_handle_optional;
+  auto named_actor_obj1 =
+      named_actor_handle.Task(ray::JavaActorMethod<int>{"getValue"}).Remote();
+  EXPECT_EQ(0, *named_actor_obj1.Get());
+
+  // Test get other java actor by actor name.
+  auto ref_1 =
+      java_class_actor_handle.Task(ray::JavaActorMethod<std::string>{"createChildActor"})
+          .Remote("child_actor");
+  EXPECT_EQ(*ref_1.Get(), "OK");
+  boost::optional<ray::ActorHandleXlang> child_actor_optional =
+      ray::GetActor("child_actor");
+  EXPECT_TRUE(child_actor_optional);
+  ray::ActorHandleXlang &child_actor = *child_actor_optional;
+  auto ref_2 = child_actor.Task(ray::JavaActorMethod<int>{"getValue"}).Remote();
+  EXPECT_EQ(0, *ref_2.Get());
+}
+
+TEST(RayClusterModeXLangTest, GetXLangActorByNameTest) {
+  // Create a named java actor in namespace `isolated_ns`.
+  std::string actor_name_in_isolated_ns = "named_actor_in_isolated_ns";
+  std::string isolated_ns_name = "isolated_ns";
+
+  auto java_actor_handle = ray::Actor(ray::JavaActorClass{"io.ray.test.Counter"})
+                               .SetName(actor_name_in_isolated_ns, isolated_ns_name)
+                               .Remote(0);
+  auto ref = java_actor_handle.Task(ray::JavaActorMethod<int>{"getValue"}).Remote();
+  EXPECT_EQ(0, *ref.Get());
+
+  // It is invisible to job default namespace.
+  boost::optional<ray::ActorHandleXlang> actor_optional =
+      ray::GetActor(actor_name_in_isolated_ns);
+  EXPECT_TRUE(!actor_optional);
+  // It is invisible to any other namespaces.
+  actor_optional = ray::GetActor(actor_name_in_isolated_ns, "other_ns");
+  EXPECT_TRUE(!actor_optional);
+  // It is visible to the namespace it belongs.
+  actor_optional = ray::GetActor(actor_name_in_isolated_ns, isolated_ns_name);
+  EXPECT_TRUE(actor_optional);
+  ref = (*actor_optional).Task(ray::JavaActorMethod<int>{"getValue"}).Remote();
+  EXPECT_EQ(0, *ref.Get());
+
+  // Create a named java actor in job default namespace.
+  std::string actor_name_in_default_ns = "actor_name_in_default_ns";
+  java_actor_handle = ray::Actor(ray::JavaActorClass{"io.ray.test.Counter"})
+                          .SetName(actor_name_in_default_ns)
+                          .Remote(0);
+  ref = java_actor_handle.Task(ray::JavaActorMethod<int>{"getValue"}).Remote();
+  EXPECT_EQ(0, *ref.Get());
+  // It is invisible to any other namespaces.
+  actor_optional = ray::GetActor(actor_name_in_default_ns, isolated_ns_name);
+  EXPECT_TRUE(!actor_optional);
+  // It is visible to job default namespace.
+  actor_optional = ray::GetActor(actor_name_in_default_ns);
+  EXPECT_TRUE(actor_optional);
+  ref = (*actor_optional).Task(ray::JavaActorMethod<int>{"getValue"}).Remote();
+  EXPECT_EQ(0, *ref.Get());
 }
 
 int main(int argc, char **argv) {

--- a/cpp/src/ray/test/cluster/counter.h
+++ b/cpp/src/ray/test/cluster/counter.h
@@ -31,6 +31,7 @@ class Counter {
   int Plus1();
   int Add(int x);
   int Exit();
+  int GetCount() { return count; }
   uint64_t GetPid();
   void ExceptionFunc() { throw std::invalid_argument("error"); }
   static bool IsProcessAlive(uint64_t pid);
@@ -38,11 +39,23 @@ class Counter {
   bool CheckRestartInActorCreationTask();
   bool CheckRestartInActorTask();
   ray::ActorHandle<Counter> CreateChildActor(std::string actor_name);
+  std::string CreateNestedChildActor(std::string actor_name);
   int Plus1ForActor(ray::ActorHandle<Counter> actor);
 
   std::string GetNamespaceInActor();
 
   std::string GetVal(ray::ObjectRef<std::string> obj) { return *obj.Get(); }
+
+  std::vector<std::byte> GetBytes(std::string s) {
+    std::vector<std::byte> bytes;
+    bytes.reserve(s.size());
+
+    std::transform(std::begin(s), std::end(s), std::back_inserter(bytes), [](char c) {
+      return std::byte(c);
+    });
+
+    return bytes;
+  }
 
   int GetIntVal(ray::ObjectRef<ray::ObjectRef<int>> obj) {
     auto val = *obj.Get();
@@ -59,6 +72,7 @@ class Counter {
  private:
   int count;
   bool is_restared = false;
+  ray::ActorHandle<Counter> child_actor;
 };
 
 std::string GetEnvVar(std::string key);

--- a/cpp/src/ray/test/ray_remote_test.cc
+++ b/cpp/src/ray/test/ray_remote_test.cc
@@ -220,3 +220,13 @@ TEST(RayApiTest, ExceptionTask) {
   auto r4 = ray::Task(ExceptionFunc).Remote(2);
   EXPECT_THROW(r4.Get(), ray::internal::RayTaskException);
 }
+
+TEST(RayApiTest, GetClassNameByFuncNameTest) {
+  using ray::internal::FunctionManager;
+  EXPECT_EQ(FunctionManager::GetClassNameByFuncName("RAY_FUNC(Counter::FactoryCreate)"),
+            "Counter");
+  EXPECT_EQ(FunctionManager::GetClassNameByFuncName("Counter::FactoryCreate"), "Counter");
+  EXPECT_EQ(FunctionManager::GetClassNameByFuncName("FactoryCreate"), "");
+  EXPECT_EQ(FunctionManager::GetClassNameByFuncName(""), "");
+  EXPECT_EQ(FunctionManager::GetClassNameByFuncName("::FactoryCreate"), "");
+}

--- a/cpp/src/ray/util/process_helper.cc
+++ b/cpp/src/ray/util/process_helper.cc
@@ -78,9 +78,6 @@ void ProcessHelper::RayStart(CoreWorkerOptions::TaskExecutionCallback callback) 
                  ConfigInternal::Instance().redis_password,
                  ConfigInternal::Instance().head_args);
   }
-  if (bootstrap_ip == "127.0.0.1") {
-    bootstrap_ip = GetNodeIpAddress();
-  }
 
   std::string bootstrap_address = bootstrap_ip + ":" + std::to_string(bootstrap_port);
   std::string node_ip = ConfigInternal::Instance().node_ip_address;

--- a/cpp/src/ray/util/process_helper.cc
+++ b/cpp/src/ray/util/process_helper.cc
@@ -15,6 +15,7 @@
 #include "process_helper.h"
 
 #include <boost/algorithm/string.hpp>
+#include <string>
 
 #include "ray/common/ray_config.h"
 #include "ray/util/process.h"
@@ -27,7 +28,8 @@ namespace internal {
 using ray::core::CoreWorkerProcess;
 using ray::core::WorkerType;
 
-void ProcessHelper::StartRayNode(const int port,
+void ProcessHelper::StartRayNode(const std::string node_id_address,
+                                 const int port,
                                  const std::string redis_password,
                                  const std::vector<std::string> &head_args) {
   std::vector<std::string> cmdargs({"ray",
@@ -38,7 +40,7 @@ void ProcessHelper::StartRayNode(const int port,
                                     "--redis-password",
                                     redis_password,
                                     "--node-ip-address",
-                                    GetNodeIpAddress()});
+                                    node_id_address});
   if (!head_args.empty()) {
     cmdargs.insert(cmdargs.end(), head_args.begin(), head_args.end());
   }
@@ -73,8 +75,9 @@ void ProcessHelper::RayStart(CoreWorkerOptions::TaskExecutionCallback callback) 
 
   if (ConfigInternal::Instance().worker_type == WorkerType::DRIVER &&
       bootstrap_ip.empty()) {
-    bootstrap_ip = "127.0.0.1";
-    StartRayNode(bootstrap_port,
+    bootstrap_ip = GetNodeIpAddress();
+    StartRayNode(bootstrap_ip,
+                 bootstrap_port,
                  ConfigInternal::Instance().redis_password,
                  ConfigInternal::Instance().head_args);
   }

--- a/cpp/src/ray/util/process_helper.h
+++ b/cpp/src/ray/util/process_helper.h
@@ -29,7 +29,8 @@ class ProcessHelper {
  public:
   void RayStart(CoreWorkerOptions::TaskExecutionCallback callback);
   void RayStop();
-  void StartRayNode(const int port,
+  void StartRayNode(const std::string node_id_address,
+                    const int port,
                     const std::string redis_password,
                     const std::vector<std::string> &head_args = {});
   void StopRayNode();

--- a/java/test/src/main/java/io/ray/test/Counter.java
+++ b/java/test/src/main/java/io/ray/test/Counter.java
@@ -1,15 +1,52 @@
 package io.ray.test;
 
+import io.ray.api.ActorHandle;
+import io.ray.api.Ray;
+import org.testng.Assert;
+
 public class Counter {
 
-  public Counter(int v) {
-    value = v;
+  private int value;
+
+  private ActorHandle<Counter> childActor;
+
+  public Counter(int initValue) {
+    this.value = initValue;
   }
 
-  public int increase(int delta) {
+  public int getValue() {
+    return value;
+  }
+
+  public void increase(int delta) {
+    value += delta;
+  }
+
+  public int increaseAndGet(int delta) {
     value += delta;
     return value;
   }
 
-  private int value;
+  public String echo(String str) {
+    return str;
+  }
+
+  public String createChildActor(String actorName) {
+    childActor = Ray.actor(Counter::new, 0).setName(actorName).remote();
+    Assert.assertEquals(Integer.valueOf(0), childActor.task(Counter::getValue).remote().get());
+    return "OK";
+  }
+
+  public static class NestedActor {
+
+    public NestedActor(String s) {
+      str = s;
+    }
+
+    public String concat(String s) {
+      return str + s;
+    }
+
+    private String str;
+  }
 }


### PR DESCRIPTION
## Why are these changes needed?

- [x] Cpp worker support get java actor by actor name.
- [x] Support Java worker get cpp actor which created by cpp worker.

1.  get java actor by actor name api:
```
boost::optional<ActorHandleXlang> GetActor(const std::string &actor_name,
                                                  const std::string &ray_namespce = "") ;
```
2. Support Java worker get cpp actor which created by cpp worker：
Now when java obtains the c++ worker created by the c++ worker through the actor name, an error will be reported. The reason for the error is that the c++ actor created by the c++ worker lacks the class_name parameter. So this modification plan is that the class_name parameter will be filled in when the c++ worker is created by the c++ worker.

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
