### PR TITLE
[core] fix depth of threaded task

### DIFF
--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -57,6 +57,8 @@ class WorkerContext {
 
   void SetCurrentActorId(const ActorID &actor_id) LOCKS_EXCLUDED(mutex_);
 
+  void SetTaskDepth(int64_t depth);
+
   void SetCurrentTask(const TaskSpecification &task_spec) LOCKS_EXCLUDED(mutex_);
 
   void ResetCurrentTask();
@@ -103,6 +105,7 @@ class WorkerContext {
   const WorkerType worker_type_;
   const WorkerID worker_id_;
   const JobID current_job_id_;
+  int64_t task_depth_ GUARDED_BY(mutex_) = 0;
   ActorID current_actor_id_ GUARDED_BY(mutex_);
   int current_actor_max_concurrency_ GUARDED_BY(mutex_) = 1;
   bool current_actor_is_asyncio_ GUARDED_BY(mutex_) = false;

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -57,7 +57,7 @@ class WorkerContext {
 
   void SetCurrentActorId(const ActorID &actor_id) LOCKS_EXCLUDED(mutex_);
 
-  void SetTaskDepth(int64_t depth);
+  void SetTaskDepth(int64_t depth) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   void SetCurrentTask(const TaskSpecification &task_spec) LOCKS_EXCLUDED(mutex_);
 


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

AIR's runs training on a separate RunnerThread that is implemented with threading.Thread.

The current task spec and depth is thread-local, which breaks when a different thread such as the RunnerThread is the one that is starting the task. The RunnerThread starts the training worker and dataset. Without this fix, the depth is incorrectly set to 1. With the fix it is correctly set to 2.

Program this fixes: https://gist.github.com/clarng/50094104476080d1b2d04bded4e370b3

Going forward we should re-evaluate whether the worker context should be thread-local or whether we should clean this up and use something that is thread-safe

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
