### PR TITLE
[RLlib] Use get_model_v2 with MADDPG

### DIFF
--- a/rllib/algorithms/maddpg/maddpg_tf_policy.py
+++ b/rllib/algorithms/maddpg/maddpg_tf_policy.py
@@ -339,10 +339,7 @@ class MADDPGTFPolicy(MADDPGPostprocessing, TFPolicy):
         with tf1.variable_scope(scope, reuse=tf1.AUTO_REUSE) as scope:
             if use_state_preprocessor:
                 model_n = [
-                    ModelCatalog.get_model(
-                        SampleBatch(
-                            obs=obs, _is_training=self._get_is_training_placeholder()
-                        ),
+                    ModelCatalog.get_model_v2(
                         obs_space,
                         act_space,
                         1,
@@ -377,10 +374,7 @@ class MADDPGTFPolicy(MADDPGPostprocessing, TFPolicy):
     ):
         with tf1.variable_scope(scope, reuse=tf1.AUTO_REUSE) as scope:
             if use_state_preprocessor:
-                model = ModelCatalog.get_model(
-                    SampleBatch(
-                        obs=obs, _is_training=self._get_is_training_placeholder()
-                    ),
+                model = ModelCatalog.get_model_v2(
                     obs_space,
                     act_space,
                     1,


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Make MADDPG use get_model_v2 method.
I'm not sure at what point we diverged here exactly, but for reference here is the get_model() signature from 0.6.6 on which I base these changes.

```
def get_model(input_dict,
              obs_space,
              action_space,
              num_outputs,
              options,
              state_in=None,
              seq_lens=None):
    """Returns a suitable model conforming to given input and output specs.

    Args:
        input_dict (dict): Dict of input tensors to the model, including
            the observation under the "obs" key.
        obs_space (Space): Observation space of the target gym env.
        action_space (Space): Action space of the target gym env.
        num_outputs (int): The size of the output vector of the model.
        options (dict): Optional args to pass to the model constructor.
        state_in (list): Optional RNN state in tensors.
        seq_lens (Tensor): Optional RNN sequence length tensor.

    Returns:
        model (models.Model): Neural network model.
    """
```

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
