### PR TITLE
[release] Use more powerful instance type to deflake `serve_failure` test

### DIFF
--- a/release/long_running_tests/tpl_cpu_1_c5.yaml
+++ b/release/long_running_tests/tpl_cpu_1_c5.yaml
@@ -5,11 +5,11 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: c5.2xlarge
+    instance_type: c5.4xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: c5.2xlarge
+      instance_type: c5.4xlarge
       min_workers: 0
       max_workers: 0
       use_spot: false


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The `serve_failure` long running test is flaky.  Looking at the logs for one of the failures, we see that the cause is that a node died:

```
[2022-12-04 22:45:39,836 I 1085 1085] (raylet) accessor.cc:612: Received notification for node id = bdd88ecf794b240b1317c23e6fcafd3ba6193f74acaf0a63f6ca784b, IsAlive = 0
[2022-12-04 22:45:39,836 I 1085 1085] (raylet) node_manager.cc:1142: Owner node bdd88ecf794b240b1317c23e6fcafd3ba6193f74acaf0a63f6ca784b died, killing leased worker fd3d86888462ba9d2de5c6e00b5993fca5420fe1fd2ba61d04bbd463
```

I couldn't find any details about why the node died.  The memory was not growing.  This is not a physical node, just a "virtual" node created using Ray's `cluster_utils`.

In the past we were able to deflake a long running serve test by using a machine with more CPUs. This PR bumps the number of CPUs from 4 to 8 in an attempt to make this failure happen less.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
