### PR TITLE
[ci] Fix issues with PS1 with conda activate

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -46,7 +46,8 @@ steps:
     - export MAC_WHEELS=1
     - export MAC_JARS=1
     - export RAY_INSTALL_JAVA=1
-    - . ./ci/ci.sh init && source ~/.zshrc
+    - . ./ci/ci.sh init 
+    - source ~/.zshrc
     - ./ci/ci.sh build
     # Test wheels
     - ./ci/ci.sh test_wheels


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
With some searching, seems to be a similar issue (https://github.com/conda/conda/issues/8186) with activating conda in bash script. However, it could also be unrelated. The major correlation is from where this error is thrown. I believe the error is raised when initializing conda when doing `source ~/.zshrc`, and we did change some of the scripting options in this PR(https://github.com/ray-project/ray/pull/27495) and its original revert. 

**So the hypothesis is because `ci.sh` changes some of the scripting options, and with `&&`, it also interferes with `source ~/.zshrc` which initializes conda.** 

<img width="1020" alt="image" src="https://user-images.githubusercontent.com/11676094/205784734-c59fd68b-521b-4815-a696-f9ef3ac22627.png">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/30686
Closes https://github.com/ray-project/ray/issues/26194

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
