### PR TITLE
Revert "Revert "[AIR] Change ScalingConfig to be optional for `DataParallelTrainer`s if already in Tuner `param_space`"" (#30918)

### DIFF
--- a/python/ray/train/data_parallel_trainer.py
+++ b/python/ray/train/data_parallel_trainer.py
@@ -282,23 +282,6 @@ class DataParallelTrainer(BaseTrainer):
     def _validate_attributes(self):
         super()._validate_attributes()
 
-        if not self.scaling_config.use_gpu and "GPU" in ray.available_resources():
-            logger.info(
-                "GPUs are detected in your Ray cluster, but GPU "
-                "training is not enabled for this trainer. To enable "
-                "GPU training, make sure to set `use_gpu` to True "
-                "in your scaling config."
-            )
-
-        if self.scaling_config.num_workers is None:
-            raise ValueError("You must specify the 'num_workers' in scaling_config.")
-
-        if self.scaling_config.num_workers <= 0:
-            raise ValueError(
-                "'num_workers' in `scaling_config` must be a positive "
-                f"integer. Received {self.scaling_config.num_workers}"
-            )
-
         self._validate_train_loop_per_worker(
             self._train_loop_per_worker, "train_loop_per_worker"
         )
@@ -319,6 +302,37 @@ class DataParallelTrainer(BaseTrainer):
                 f"{fn_name} should take in 0 or 1 arguments, "
                 f"but it accepts {num_params} arguments instead."
             )
+
+    @classmethod
+    def _validate_scaling_config(cls, scaling_config: ScalingConfig) -> ScalingConfig:
+        scaling_config = super(DataParallelTrainer, cls)._validate_scaling_config(
+            scaling_config
+        )
+
+        # This validation happens after the scaling config is updated from
+        # its specification in the Tuner `param_space`
+        if not scaling_config.use_gpu and "GPU" in ray.available_resources():
+            logger.info(
+                "GPUs are detected in your Ray cluster, but GPU "
+                "training is not enabled for this trainer. To enable "
+                "GPU training, make sure to set `use_gpu` to True "
+                "in your scaling config."
+            )
+
+        if scaling_config.num_workers is None:
+            raise ValueError(
+                "You must specify the 'num_workers' in `scaling_config` as either an "
+                f"argument of `{cls.__name__}` or through the `param_space` of a "
+                "`Tuner` (if performing hyperparameter tuning)."
+            )
+
+        if scaling_config.num_workers <= 0:
+            raise ValueError(
+                "'num_workers' in `scaling_config` must be a positive "
+                f"integer. Received {scaling_config.num_workers}"
+            )
+
+        return scaling_config
 
     def _report(self, training_iterator: TrainingIterator) -> None:
         for results in training_iterator:

--- a/python/ray/train/tests/test_data_parallel_trainer.py
+++ b/python/ray/train/tests/test_data_parallel_trainer.py
@@ -268,13 +268,13 @@ def test_scaling_config_validation(ray_start_4_cpus):
         train_loop_per_worker=train_func,
         train_loop_config={"x": 100},
     )
-    with pytest.raises(tune.TuneError):
+    with pytest.raises(ValueError):
         trainer.fit()
 
     # Scaling config must be passed in through Tuner param space if not
     # included in the initial trainer
     tuner = Tuner(trainer)
-    with pytest.raises(tune.TuneError):
+    with pytest.raises(ValueError):
         tuner.fit()
 
     tuner = Tuner(trainer, param_space={"scaling_config": ScalingConfig(num_workers=1)})

--- a/python/ray/train/tests/test_data_parallel_trainer.py
+++ b/python/ray/train/tests/test_data_parallel_trainer.py
@@ -258,6 +258,30 @@ def test_tune(ray_start_4_cpus):
     assert trainer._train_loop_config["x"] == 100
 
 
+def test_scaling_config_validation(ray_start_4_cpus):
+    def train_func(config):
+        session.report({"loss": config["x"]})
+
+    # Should be able to create a DataParallelTrainer w/o scaling_config,
+    # but it should fail on fit
+    trainer = DataParallelTrainer(
+        train_loop_per_worker=train_func,
+        train_loop_config={"x": 100},
+    )
+    with pytest.raises(tune.TuneError):
+        trainer.fit()
+
+    # Scaling config must be passed in through Tuner param space if not
+    # included in the initial trainer
+    tuner = Tuner(trainer)
+    with pytest.raises(tune.TuneError):
+        tuner.fit()
+
+    tuner = Tuner(trainer, param_space={"scaling_config": ScalingConfig(num_workers=1)})
+    results = tuner.fit()
+    assert not results.errors
+
+
 def test_fast_slow(ray_start_4_cpus):
     def train_func():
         for i in range(2):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

This reverts commit https://github.com/ray-project/ray/commit/df3628e9b682339b02cf0d6e10956f26f18066c6.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
https://github.com/ray-project/ray/pull/30715 introduced a test that was failing due to a change in master, and this PR wasn't fully up to date with master when the CI tests were all passing.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
