### PR TITLE
[Doc] [Kuberay] Tell user to set resource limits in docker

### DIFF
--- a/doc/source/cluster/kubernetes/getting-started.ipynb
+++ b/doc/source/cluster/kubernetes/getting-started.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "source": [
     "To run the example in this guide, make sure your Kubernetes cluster (or local Kind cluster) can accomodate\n",
-    "additional resource requests of 3 CPU and 3Gi memory. Also, make sure your Kubernetes cluster and Kubectl are both at version at least 1.19.\n",
+    "additional resource requests of 3 CPU and 3Gi memory (for example, by setting your Docker resource limits high enough). Also, make sure your Kubernetes cluster and Kubectl are both at version at least 1.19.\n",
     "\n",
     "(kuberay-operator-deploy)=\n",
     "## Deploying the KubeRay operator\n",
@@ -226,6 +226,14 @@
     "# If you're on MacOS, first `brew install watch`.\n",
     "# Run in a separate shell:\n",
     "! watch -n 1 kubectl get pod"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a01c9a9",
+   "metadata": {},
+   "source": [
+    "If your pods are stuck in the Pending state, you can check for errors via `kubectl describe pod raycluster-autoscaler-xxxx-xxxxx` and ensure that your Docker resource limits are set high enough."
    ]
   },
   {
@@ -456,7 +464,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.11 ('ray-py38')",
    "language": "python",
    "name": "python3"
   },
@@ -470,7 +478,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.11"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "250a0c8ad49f9e0ab80d6ffa587b8bd67c2b62f7c5238d34c3fd259cc7d4f5bf"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The Kuberay quickstart does not work out of the box on a recent intel Macbook with default settings due to pods being stuck in PENDING because of insufficient memory.  This is a quick PR to help unblock users who run into the error, and to prevent them from running into the error.
- Tell the user to adjust the docker resource limits
- Show the user how to debug pod stuck in "PENDING"

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
