### PR TITLE
[AIR] Place predictor kwargs in object store

### DIFF
--- a/python/ray/train/batch_predictor.py
+++ b/python/ray/train/batch_predictor.py
@@ -36,7 +36,6 @@ class BatchPredictor:
         self._checkpoint_ref = ray.put(checkpoint)
         self._predictor_cls = predictor_cls
         self._predictor_kwargs = predictor_kwargs
-        self._predictor_kwargs_ref = ray.put(predictor_kwargs)
         self._override_preprocessor: Optional[Preprocessor] = None
 
     def __repr__(self):
@@ -173,7 +172,6 @@ class BatchPredictor:
 
         predictor_cls = self._predictor_cls
         checkpoint_ref = self._checkpoint_ref
-        predictor_kwargs_ref = self._predictor_kwargs_ref
         override_prep = self._override_preprocessor
         # Automatic set use_gpu in predictor constructor if user provided
         # explicit GPU resources
@@ -187,7 +185,9 @@ class BatchPredictor:
                 "Automatically enabling GPU prediction for this predictor. To "
                 "disable set `use_gpu` to `False` in `BatchPredictor.predict`."
             )
-        self._predictor_kwargs["use_gpu"] = True
+            self._predictor_kwargs["use_gpu"] = True
+
+        predictor_kwargs_ref = ray.put(self._predictor_kwargs)
 
         # In case of [arrow block] -> [X] -> [Pandas UDF] -> [Y] -> [TorchPredictor]
         # We have two places where we can chose data format with less conversion cost.

--- a/python/ray/train/batch_predictor.py
+++ b/python/ray/train/batch_predictor.py
@@ -36,6 +36,7 @@ class BatchPredictor:
         self._checkpoint_ref = ray.put(checkpoint)
         self._predictor_cls = predictor_cls
         self._predictor_kwargs = predictor_kwargs
+        self._predictor_kwargs_ref = ray.put(predictor_kwargs)
         self._override_preprocessor: Optional[Preprocessor] = None
 
     def __repr__(self):
@@ -172,13 +173,13 @@ class BatchPredictor:
 
         predictor_cls = self._predictor_cls
         checkpoint_ref = self._checkpoint_ref
-        predictor_kwargs = self._predictor_kwargs
+        predictor_kwargs_ref = self._predictor_kwargs_ref
         override_prep = self._override_preprocessor
         # Automatic set use_gpu in predictor constructor if user provided
         # explicit GPU resources
         if (
             "use_gpu" in inspect.signature(predictor_cls.from_checkpoint).parameters
-            and "use_gpu" not in predictor_kwargs
+            and "use_gpu" not in self._predictor_kwargs
             and num_gpus_per_worker > 0
         ):
             logger.info(
@@ -186,7 +187,7 @@ class BatchPredictor:
                 "Automatically enabling GPU prediction for this predictor. To "
                 "disable set `use_gpu` to `False` in `BatchPredictor.predict`."
             )
-            predictor_kwargs["use_gpu"] = True
+        self._predictor_kwargs["use_gpu"] = True
 
         # In case of [arrow block] -> [X] -> [Pandas UDF] -> [Y] -> [TorchPredictor]
         # We have two places where we can chose data format with less conversion cost.
@@ -204,6 +205,7 @@ class BatchPredictor:
         class ScoringWrapper:
             def __init__(self):
                 checkpoint = ray.get(checkpoint_ref)
+                predictor_kwargs = ray.get(predictor_kwargs_ref)
                 self._predictor = predictor_cls.from_checkpoint(
                     checkpoint, **predictor_kwargs
                 )

--- a/python/ray/train/tests/test_torch_predictor.py
+++ b/python/ray/train/tests/test_torch_predictor.py
@@ -281,6 +281,19 @@ def test_multi_modal_real_model(use_gpu):
         ).is_cuda, "Model should not be on GPU if use_gpu is False"
 
 
+def test_batch_prediction_with_large_model():
+    # This model is 763MB large
+    model = torch.nn.Linear(1, int(1e8))
+    checkpoint = TorchCheckpoint.from_state_dict(model.state_dict())
+    predictor = BatchPredictor(
+        checkpoint,
+        TorchPredictor,
+        model=model,
+    )
+    dataset = ray.data.range(1)
+    predictor.predict(dataset, dtype=torch.float)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/tests/test_torch_predictor.py
+++ b/python/ray/train/tests/test_torch_predictor.py
@@ -281,19 +281,6 @@ def test_multi_modal_real_model(use_gpu):
         ).is_cuda, "Model should not be on GPU if use_gpu is False"
 
 
-def test_batch_prediction_with_large_model():
-    # This model is 763MB large
-    model = torch.nn.Linear(1, int(1e8))
-    checkpoint = TorchCheckpoint.from_state_dict(model.state_dict())
-    predictor = BatchPredictor(
-        checkpoint,
-        TorchPredictor,
-        model=model,
-    )
-    dataset = ray.data.range(1)
-    predictor.predict(dataset, dtype=torch.float)
-
-
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you pass predictor kwargs to `BatchPredictor`, they get pickled. As a result, if you pass a large object (for example, a large model definition), you get a value error. This PR fixes the issue by instead placing predictor kwargs in the object store.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/30926

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
