### PR TITLE
[ci] Raise exception when db put failure when uploading release results. 

### DIFF
--- a/release/ray_release/reporter/db.py
+++ b/release/ray_release/reporter/db.py
@@ -44,7 +44,10 @@ class DBReporter(Reporter):
                 DeliveryStreamName="ray-ci-results",
                 Record={"Data": json.dumps(result_json)},
             )
-        except Exception:
-            logger.exception("Failed to persist result to the databricks delta lake")
+        except Exception as e:
+            logger.exception(
+                f"Failed to persist result to the databricks delta lake: {json.dumps(result_json)}"
+            )
+            raise e
         else:
             logger.info("Result has been persisted to the databricks delta lake")


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We have not had release test results being reported for a month when they ran but failed to report results to DB. 
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/11676094/206046444-d3ba57aa-8064-4943-b908-981ae64da010.png">

But there are successful runs which failed to upload results, and are not recorded silently: 
<img width="998" alt="image" src="https://user-images.githubusercontent.com/11676094/206046585-0f40122c-9e00-412c-afb1-bb0b77978490.png">



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
