### PR TITLE
Make pandas dataframe keep the index when concat them

### DIFF
--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -106,7 +106,6 @@ class PandasBlockBuilder(TableBlockBuilder[T]):
             df = pandas.concat(tables, ignore_index=True)
         else:
             df = tables[0]
-        df.reset_index(drop=True, inplace=True)
         ctx = DatasetContext.get_current()
         if ctx.enable_tensor_extension_casting:
             df = _cast_ndarray_columns_to_tensor_extension(df)

--- a/python/ray/data/tests/test_dataset_pandas.py
+++ b/python/ray/data/tests/test_dataset_pandas.py
@@ -103,6 +103,10 @@ def test_pandas_roundtrip(ray_start_regular_shared, tmp_path):
     dfds = ds.to_pandas()
     assert pd.concat([df1, df2], ignore_index=True).equals(dfds)
 
+    df3 = df1.set_index("one")
+    ds = ray.data.from_pandas(df3)
+    assert ds.to_pandas().equals(df3)
+
 
 def test_to_pandas_tensor_column_cast_pandas(ray_start_regular_shared):
     # Check that tensor column casting occurs when converting a Dataset to a Pandas


### PR DESCRIPTION
Signed-off-by: jianoaix <iamjianxiao@gmail.com>

## Why are these changes needed?
The dataframe index is lost when having a roundtrip with `.from_pandas()` and then `.to_pandas()`.

## Related issue number
#30261

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
