### PR TITLE
[WIP][prototype] Serve gRPC support using `Any` type

### DIFF
--- a/src/ray/protobuf/BUILD
+++ b/src/ray/protobuf/BUILD
@@ -310,6 +310,7 @@ cc_proto_library(
 proto_library(
     name = "serve_proto",
     srcs = ["serve.proto"],
+    deps = ["@com_google_protobuf//:any_proto"],
     visibility = ["//java:__subpackages__"],
 )
 

--- a/src/ray/protobuf/client.py
+++ b/src/ray/protobuf/client.py
@@ -1,0 +1,17 @@
+import grpc
+from google.protobuf.any_pb2 import Any
+
+from ray.serve.generated import serve_pb2, serve_pb2_grpc
+
+channel = grpc.insecure_channel("localhost:8000")
+stub = serve_pb2_grpc.PredictAPIsServiceStub(channel)
+
+test_in = Any()
+test_in.Pack(serve_pb2.TestIn(name="eoakes"))
+response = stub.Predict(serve_pb2.PredictRequest(target="test-name", input=test_in))
+print("Output type:", type(response.output))
+print("Full output:", response.output)
+
+test_out = serve_pb2.TestOut()
+response.output.Unpack(test_out)
+print("Output greeting field:", test_out.greeting)

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -23,6 +23,8 @@ option java_outer_classname = "ServeProtos";
 
 option java_multiple_files = true;
 
+import "google/protobuf/any.proto";
+
 // Configuration options for Serve's replica autoscaler.
 message AutoscalingConfig {
   // Minimal number of replicas, must be a non-negative integer.
@@ -218,13 +220,22 @@ message StatusOverview {
 
 // RPC Schema
 message PredictRequest {
-  map<string, bytes> input = 2;
+  string target = 1;
+  google.protobuf.Any input = 2;
 }
 
 message PredictResponse {
-  bytes prediction = 1;
+  google.protobuf.Any output = 1;
 }
 
 service PredictAPIsService {
   rpc Predict(PredictRequest) returns (PredictResponse);
+}
+
+message TestIn {
+  string name = 1;
+}
+
+message TestOut {
+  string greeting = 1;
 }

--- a/src/ray/protobuf/test.py
+++ b/src/ray/protobuf/test.py
@@ -1,0 +1,25 @@
+from google.protobuf.any_pb2 import Any
+
+from ray.serve.generated import serve_pb2
+
+from ray import serve
+
+
+@serve.deployment
+class Hi:
+    def __call__(self, any_input: Any):
+        # Everything done here can be transparently performed in the Serve replica
+        # (assuming they use type annotations for the input type).
+        request = serve_pb2.TestIn()
+        any_input.Unpack(request)
+        output = self.call(request)
+        any_output = Any()
+        any_output.Pack(output)
+        return any_output
+
+    # This is what a user-defined method would look like.
+    def call(self, request: serve_pb2.TestIn) -> serve_pb2.TestOut:
+        return serve_pb2.TestOut(greeting=f"Hello {request.name}")
+
+
+h = Hi.options(name="test-name").bind()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Uses the grpc `Any` field type to support generic gRPC message types.
This means we could support gRPC with an identical architecture to our current HTTP support (does not require "direct ingress.")

See `test.py` and `client.py` for an indication of what usage would look like.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
