### PR TITLE
[kuberay][autoscaler] Update KubeRay version in autoscaler test

### DIFF
--- a/python/ray/autoscaler/kuberay/init-config.sh
+++ b/python/ray/autoscaler/kuberay/init-config.sh
@@ -2,8 +2,8 @@
 
 # Clone pinned Kuberay commit to temporary directory, copy the CRD definitions
 # into the autoscaler folder.
-KUBERAY_COMMIT="v0.3.0-rc.2"
-OPERATOR_TAG="v0.3.0-rc.2"
+KUBERAY_BRANCH="v0.4.0-rc.0"
+OPERATOR_TAG="v0.4.0-rc.0"
 
 # Requires Kustomize
 if ! command -v kustomize &> /dev/null
@@ -17,7 +17,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 DIR=$(mktemp -d -t "kuberay-XXXXXX")
 
 pushd "$DIR" || exit
-    git clone https://github.com/ray-project/kuberay/ --branch "$KUBERAY_COMMIT" --depth 1
+    git clone https://github.com/ray-project/kuberay/ --branch "$KUBERAY_BRANCH" --depth 1
     pushd kuberay/ray-operator/config/default || exit
         kustomize edit set image kuberay/operator=kuberay/operator:"$OPERATOR_TAG"
     popd || exit

--- a/python/ray/tests/kuberay/scripts/check_cpu_and_memory.py
+++ b/python/ray/tests/kuberay/scripts/check_cpu_and_memory.py
@@ -8,7 +8,7 @@ def main():
     cpu_limit = ray._private.utils.get_num_cpus()
     mem_limit_gb = round(ray._private.utils.get_system_memory() / 10**9, 2)
     assert cpu_limit == 1, cpu_limit
-    assert mem_limit_gb == 1.00, mem_limit_gb
+    assert mem_limit_gb == 2.00, mem_limit_gb
     print(f"Confirmed cpu limit {cpu_limit}.")
     print(f"Confirmed memory limit {mem_limit_gb} gigabyte.")
 

--- a/python/ray/tests/kuberay/test_autoscaling_e2e.py
+++ b/python/ray/tests/kuberay/test_autoscaling_e2e.py
@@ -110,7 +110,7 @@ class KubeRayAutoscalingTest(unittest.TestCase):
 
             ray_container = containers[0]
             # Confirm the first container in the example config is the Ray container.
-            assert ray_container["name"] in ["ray-head", "machine-learning"]
+            assert ray_container["name"] in ["ray-head", "ray-worker"]
             # ("machine-learning" is the name of the worker Ray container)
 
             ray_container["image"] = RAY_IMAGE


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR updates the the KubeRay version in the autoscaling integration test.

Theoretically, this should be picked into the Ray 2.2 branch. 
The lower overhead option that I will take will be to simply open a PR against the release branch to confirm once that the test passes with the updated operator.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
