### PR TITLE
[ci/release] Move all release tests to use Ray jobs instead of SDK commands

### DIFF
--- a/release/ray_release/command_runner/job_runner.py
+++ b/release/ray_release/command_runner/job_runner.py
@@ -115,7 +115,7 @@ class JobRunner(CommandRunner):
         )
 
         status_code, time_taken = self.job_manager.run_and_wait(
-            full_command, full_env, timeout=timeout
+            full_command, full_env, timeout=int(timeout)
         )
 
         if status_code != 0:

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -66,7 +66,7 @@ file_manager_str_to_file_manager = {
 command_runner_to_file_manager = {
     SDKRunner: SessionControllerFileManager,
     ClientRunner: RemoteTaskFileManager,
-    JobFileManager: JobFileManager,
+    JobRunner: JobFileManager,
 }
 
 

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -69,7 +69,8 @@ command_runner_to_file_manager = {
     JobFileManager: JobFileManager,
 }
 
-uploader_str_to_uploader = {"client": None, "s3": None, "command_runner": None}
+
+DEFAULT_RUN_TYPE = "job"
 
 
 def run_release_test(
@@ -104,7 +105,7 @@ def run_release_test(
 
     start_time = time.monotonic()
 
-    run_type = test["run"].get("type", "sdk_command")
+    run_type = test["run"].get("type", DEFAULT_RUN_TYPE)
 
     command_runner_cls = type_str_to_command_runner.get(run_type)
     if not command_runner_cls:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -46,14 +46,14 @@
 #
 #  # Run configuration for the test
 #  run:
-#    # Type of test. Can be sdk_command or client (job to be implemented soon).
-#    # Uses either Anyscale SDK commands or the Ray client to run the actual
+#    # Type of test. Can be job, sdk_command or client.
+#    # Uses either Ray jobs, anyscale SDK commands or the Ray client to run the actual
 #    # release test.
-#    type: sdk_command
+#    type: job
 #
 #    # File manager to use to transfer files to and from the cluster.
 #    # Can be any of [sdk, client, job].
-#    file_manager: sdk
+#    file_manager: job
 #
 #    # If you want to wait for nodes to be ready, you can specify this here:
 #    wait_for_nodes:
@@ -115,8 +115,6 @@
     wait_for_nodes:
       num_nodes: 0
 
-    type: sdk_command
-
   alert: default
 
 
@@ -142,8 +140,6 @@
     wait_for_nodes:
       num_nodes: 2
 
-    type: sdk_command
-    file_manager: job
 
   smoke_test:
     frequency: disabled
@@ -173,8 +169,6 @@
     wait_for_nodes:
       num_nodes: 20
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -198,8 +192,6 @@
     wait_for_nodes:
       num_nodes: 11
 
-    type: sdk_command
-    file_manager: job
 
   smoke_test:
     frequency: disabled
@@ -229,8 +221,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -253,8 +243,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   smoke_test:
     frequency: nightly
@@ -288,8 +276,6 @@
     timeout: 3600
     script: python workloads/torch_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 2
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -310,8 +296,6 @@
     timeout: 3600
     script: python workloads/gpu_batch_prediction.py --data-size-gb 20
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -334,8 +318,6 @@
     timeout: 10800
     script: python workloads/gpu_batch_prediction.py --data-size-gb 100
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -359,8 +341,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -384,8 +364,6 @@
     wait_for_nodes:
       num_nodes: 8
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -408,8 +386,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -433,8 +409,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -455,8 +429,6 @@
     timeout: 5400
     script: python workloads/tensorflow_benchmark.py run --num-runs 3 --num-epochs 20 --num-workers 4 --cpus-per-worker 2
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -482,8 +454,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -509,8 +479,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   smoke_test:
     frequency: nightly
@@ -543,8 +511,6 @@
     timeout: 3600
     script: python workloads/pytorch_training_e2e.py --data-size-gb 20
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -570,8 +536,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -592,8 +556,6 @@
   run:
     timeout: 3600
     script: bash file_size_benchmark.sh
-    type: sdk_command
-    file_manager: sdk
 
 # Test dataset larger than object store memory.
 - name: ray-data-bulk-ingest-out-of-core-benchmark
@@ -612,8 +574,6 @@
   run:
     timeout: 3600
     script: bash out_of_core_benchmark.sh
-    type: sdk_command
-    file_manager: sdk
 
 # Test additional CPU nodes for preprocessing.
 - name: ray-data-bulk-ingest-heterogeneity-benchmark
@@ -635,8 +595,6 @@
 
     timeout: 1800
     script: bash heterogeneity_benchmark.sh 2
-    type: sdk_command
-    file_manager: sdk
 
 #######################
 # XGBoost release tests
@@ -691,8 +649,6 @@
     wait_for_nodes:
       num_nodes: 32
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: xgboost_tests
 
@@ -719,8 +675,6 @@
     wait_for_nodes:
       num_nodes: 5
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: xgboost_tests
 
@@ -746,8 +700,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: xgboost_tests
 
@@ -774,8 +726,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: xgboost_tests
 
@@ -802,8 +752,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: xgboost_tests
 
@@ -830,8 +778,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: xgboost_tests
 
@@ -858,8 +804,6 @@
     wait_for_nodes:
       num_nodes: 32
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: xgboost_tests
 
@@ -886,8 +830,6 @@
     wait_for_nodes:
       num_nodes: 32
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: xgboost_tests
 
@@ -942,8 +884,6 @@
     wait_for_nodes:
       num_nodes: 32
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -970,8 +910,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -998,8 +936,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -1025,8 +961,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -1052,8 +986,6 @@
     wait_for_nodes:
       num_nodes: 32
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -1079,8 +1011,6 @@
     wait_for_nodes:
       num_nodes: 32
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -1348,8 +1278,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: tune_tests
 
@@ -1378,8 +1306,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: tune_tests
 
@@ -1408,8 +1334,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: tune_tests
 
@@ -1440,8 +1364,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: tune_tests
 
@@ -1471,8 +1393,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: tune_tests
 
@@ -1590,8 +1510,6 @@
   run:
     timeout: 1200
     script: python workloads/test_bookkeeping_overhead.py
-    type: sdk_command
-    file_manager: sdk
 
   alert: tune_tests
 
@@ -1617,8 +1535,6 @@
     wait_for_nodes:
       num_nodes: 16
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: tune_tests
 
@@ -1642,8 +1558,6 @@
     timeout: 86400
     script: python workloads/test_long_running_large_checkpoints.py
     long_running: true
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -1674,9 +1588,6 @@
     script: python workloads/test_network_overhead.py
     wait_for_nodes:
       num_nodes: 100
-
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -1715,8 +1626,6 @@
     wait_for_nodes:
       num_nodes: 16
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: tune_tests
 
@@ -1739,8 +1648,6 @@
   run:
     timeout: 600
     script: python workloads/test_result_throughput_single_node.py
-    type: sdk_command
-    file_manager: sdk
 
   alert: tune_tests
 
@@ -1767,8 +1674,6 @@
     wait_for_nodes:
       num_nodes: 16
 
-    type: sdk_command
-    file_manager: sdk
 
   alert: tune_tests
 
@@ -1824,8 +1729,6 @@
     prepare: ray stop
     script: python workloads/actor_deaths.py
     long_running: true
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -1856,8 +1759,6 @@
     wait_for_nodes:
       num_nodes: 3
 
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -1885,8 +1786,6 @@
     timeout: 86400
     script: python workloads/impala.py
     long_running: true
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -1914,8 +1813,6 @@
     prepare: ray stop
     script: python workloads/many_actor_tasks.py
     long_running: true
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -1943,8 +1840,6 @@
     prepare: ray stop
     script: python workloads/many_drivers.py --iteration-num=4000
     long_running: true
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -1977,8 +1872,6 @@
     wait_for_nodes:
       num_nodes: 1
 
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -2006,8 +1899,6 @@
     prepare: ray stop
     script: python workloads/many_tasks.py
     long_running: true
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -2035,8 +1926,6 @@
     prepare: ray stop
     script: python workloads/many_tasks_serialized_ids.py
     long_running: true
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -2064,8 +1953,6 @@
     prepare: ray stop
     script: python workloads/node_failures.py
     long_running: true
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -2094,8 +1981,6 @@
     prepare: ray stop
     script: python workloads/pbt.py
     long_running: true
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -2123,8 +2008,6 @@
     prepare: ray stop
     script: python workloads/serve.py
     long_running: true
-    type: sdk_command
-    file_manager: job
 
   smoke_test:
     frequency: nightly
@@ -2155,8 +2038,6 @@
     prepare: ray stop
     script: python workloads/serve_failure.py
     long_running: true
-    type: sdk_command
-    file_manager: job
 
   smoke_test:
     frequency: nightly
@@ -2186,8 +2067,6 @@
     timeout: 86400
     script: python workloads/long_running_many_jobs.py --num-clients=1
     long_running: true
-    type: sdk_command
-    file_manager: job
 
   smoke_test:
     frequency: nightly
@@ -2216,8 +2095,6 @@
     timeout: 86400
     script: python workloads/pytorch_pbt_failure.py
     long_running: true
-    type: sdk_command
-    file_manager: job
 
   smoke_test:
     frequency: disabled
@@ -2251,8 +2128,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2277,8 +2152,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2300,7 +2173,6 @@
       num_nodes: 4
 
     type: job
-    file_manager: job
 
 - name: jobs_check_cuda_available
   group: Jobs tests
@@ -2319,7 +2191,6 @@
     wait_for_nodes:
       num_nodes: 2
     type: job
-    file_manager: job
 
 - name: jobs_specify_num_gpus
   group: Jobs tests
@@ -2338,8 +2209,6 @@
     wait_for_nodes:
       num_nodes: 2
 
-    type: sdk_command
-    file_manager: job
 
 ########################
 # Runtime env tests
@@ -2365,8 +2234,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2391,8 +2258,6 @@
     wait_for_nodes:
       num_nodes: 1
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2445,8 +2310,6 @@
     timeout: 7200
     long_running: false
     script: python workloads/single_deployment_1k_noop_replica.py
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2469,8 +2332,6 @@
     timeout: 7200
     long_running: false
     script: python workloads/multi_deployment_1k_noop_replica.py
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2493,8 +2354,6 @@
     timeout: 7200
     long_running: false
     script: python workloads/autoscaling_single_deployment.py
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2517,8 +2376,6 @@
     timeout: 7200
     long_running: false
     script: python workloads/autoscaling_multi_deployment.py
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2541,8 +2398,6 @@
     timeout: 7200
     long_running: false
     script: python workloads/serve_micro_benchmark.py
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2566,8 +2421,6 @@
     timeout: 7200
     long_running: false
     script: python workloads/serve_micro_benchmark.py
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2591,8 +2444,6 @@
     timeout: 3600
     long_running: false
     script: python workloads/deployment_graph_long_chain.py --chain-length=10 --num-clients=4 --local-test=False
-    type: sdk_command
-    file_manager: job
 
   alert: default
   stable: False
@@ -2616,8 +2467,6 @@
     timeout: 3600
     long_running: false
     script: python workloads/deployment_graph_wide_ensemble.py --fanout-degree=10 --num-clients=4 --local-test=False
-    type: sdk_command
-    file_manager: job
 
   alert: default
   stable: False
@@ -2641,8 +2490,6 @@
     timeout: 3600
     long_running: false
     script: python workloads/serve_handle_long_chain.py --chain-length=10 --num-clients=4 --local-test=False
-    type: sdk_command
-    file_manager: job
 
   alert: default
   stable: False
@@ -2666,8 +2513,6 @@
     timeout: 3600
     long_running: false
     script: python workloads/serve_handle_wide_ensemble.py --fanout-degree=10 --num-clients=4 --local-test=False
-    type: sdk_command
-    file_manager: job
 
   alert: default
   stable: False
@@ -2692,8 +2537,6 @@
     timeout: 7200
     long_running: false
     script: python workloads/serve_protocol_benchmark.py --data-size=1048576
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2716,8 +2559,6 @@
     timeout: 7200
     long_running: false
     script: python workloads/serve_protocol_benchmark.py --data-size=1048576 --http-test
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2741,8 +2582,6 @@
     timeout: 7200
     long_running: false
     script: python workloads/serve_resnet_benchmark.py --gpu-env
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2769,8 +2608,6 @@
     wait_for_nodes:
       num_nodes: 2
 
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2797,8 +2634,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=a2c
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2821,8 +2656,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=a3c
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2845,8 +2678,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=apex
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2869,8 +2700,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=appo
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2893,8 +2722,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=ppo
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2917,8 +2744,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=bc
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2941,8 +2766,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=cql
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2965,8 +2788,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=ddpg
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -2989,8 +2810,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=dqn
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -3013,8 +2832,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=es
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -3037,8 +2854,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=impala
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -3061,8 +2876,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=marwil
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -3086,8 +2899,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=sac
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -3110,8 +2921,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=slateq
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -3135,8 +2944,6 @@
   run:
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=td3
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -3160,8 +2967,6 @@
   run:
     timeout: 7200
     script: python multi_gpu_learning_tests/run.py
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -3184,8 +2989,6 @@
   run:
     timeout: 7200
     script: python multi_gpu_with_lstm_learning_tests/run.py
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -3208,8 +3011,6 @@
   run:
     timeout: 7200
     script: python multi_gpu_with_attention_learning_tests/run.py
-    type: sdk_command
-    file_manager: job
 
   alert: default
 
@@ -3236,8 +3037,6 @@
     wait_for_nodes:
       num_nodes: 6
 
-    type: sdk_command
-    file_manager: job
 
   smoke_test:
     frequency: nightly
@@ -3272,7 +3071,6 @@
     script: python shuffle/shuffle_test.py --num-partitions=50 --partition-size=200e6
 
     type: job
-    file_manager: job
 
 - name: shuffle_50gb
   group: core-multi-test
@@ -3291,8 +3089,6 @@
   run:
     timeout: 3000
     script: python shuffle/shuffle_test.py --num-partitions=50 --partition-size=1e9
-    type: sdk_command
-    file_manager: sdk
 
 - name: shuffle_50gb_large_partition
   group: core-multi-test
@@ -3311,8 +3107,6 @@
   run:
     timeout: 3000
     script: python shuffle/shuffle_test.py --num-partitions=500 --partition-size=100e6
-    type: sdk_command
-    file_manager: sdk
 
 - name: shuffle_100gb
   group: core-multi-test
@@ -3334,8 +3128,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: non_streaming_shuffle_100gb
   group: core-multi-test
@@ -3359,8 +3151,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: non_streaming_shuffle_50gb_large_partition
   group: core-multi-test
@@ -3381,8 +3171,6 @@
     script: python shuffle/shuffle_test.py --num-partitions=500 --partition-size=100e6
       --no-streaming
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: non_streaming_shuffle_50gb
   group: core-multi-test
@@ -3403,8 +3191,6 @@
     script: python shuffle/shuffle_test.py --num-partitions=50 --partition-size=1e9
       --no-streaming
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: stress_test_placement_group
   group: core-multi-test
@@ -3423,8 +3209,6 @@
   run:
     timeout: 7200
     script: python stress_tests/test_placement_group.py
-    type: sdk_command
-    file_manager: sdk
 
 - name: shuffle_1tb_1000_partition
   group: core-multi-test
@@ -3446,8 +3230,6 @@
     wait_for_nodes:
       num_nodes: 20
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: shuffle_1tb_5000_partitions
   group: core-multi-test
@@ -3469,8 +3251,6 @@
     wait_for_nodes:
       num_nodes: 20
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: decision_tree_autoscaling
   group: core-multi-test
@@ -3488,8 +3268,6 @@
   run:
     timeout: 3000
     script: python decision_tree/cart_with_tree.py
-    type: sdk_command
-    file_manager: sdk
 
 - name: decision_tree_autoscaling_20_runs
   group: core-multi-test
@@ -3508,8 +3286,6 @@
   run:
     timeout: 9600
     script: python decision_tree/cart_with_tree.py --concurrency=20
-    type: sdk_command
-    file_manager: sdk
 
 - name: autoscaling_shuffle_1tb_1000_partitions
   group: core-multi-test
@@ -3530,8 +3306,6 @@
     script: python shuffle/shuffle_test.py --num-partitions=1000 --partition-size=1e9
       --no-streaming
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: pg_long_running_performance_test
   group: core-multi-test
@@ -3554,8 +3328,6 @@
     wait_for_nodes:
       num_nodes: 2
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: microbenchmark
   group: core-daily-test
@@ -3631,8 +3403,6 @@
     script: python dask_on_ray/dask_on_ray_sort.py --nbytes 10_000_000_000 --npartitions
       50 --num-nodes 1 --ray --data-dir /tmp/ray --file-path /tmp/ray
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: dask_on_ray_100gb_sort
   group: core-daily-test
@@ -3652,8 +3422,6 @@
     script: python dask_on_ray/dask_on_ray_sort.py --nbytes 100_000_000_000 --npartitions
       200 --num-nodes 1 --ray --data-dir /tmp/ray --file-path /tmp/ray
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: dask_on_ray_large_scale_test_no_spilling
   group: core-daily-test
@@ -3676,8 +3444,6 @@
     wait_for_nodes:
       num_nodes: 21
 
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -3714,8 +3480,6 @@
     wait_for_nodes:
       num_nodes: 21
 
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -3750,8 +3514,6 @@
     script: python stress_tests/test_state_api_scale.py
     wait_for_nodes:
       num_nodes: 7
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -3784,8 +3546,6 @@
     script: python stress_tests/test_state_api_with_other_tests.py
       nightly_tests/shuffle/shuffle_test.py --test-args="--num-partitions=100 --partition-size=200e6"
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: stress_test_many_tasks
   group: core-daily-test
@@ -3806,8 +3566,6 @@
       num_nodes: 101
 
     script: python stress_tests/test_many_tasks.py
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -3841,8 +3599,6 @@
       num_nodes: 101
 
     script: python stress_tests/test_dead_actors.py
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -3902,9 +3658,6 @@
 #       num_nodes: 201
 #       timeout: 600
 #
-#     type: sdk_command
-#     file_manager: sdk
-#
 #   smoke_test:
 #     frequency: nightly
 #     cluster:
@@ -3937,8 +3690,6 @@
     timeout: 500
     script: python stress_tests/test_parallel_tasks_memory_pressure.py --num-tasks 20
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: dask_on_ray_1tb_sort
   group: core-daily-test
@@ -3961,8 +3712,6 @@
     wait_for_nodes:
       num_nodes: 32
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: many_nodes_actor_test
   group: core-daily-test
@@ -3983,8 +3732,6 @@
     wait_for_nodes:
       num_nodes: 251
 
-    type: sdk_command
-    file_manager: sdk
 
 
 - name: pg_autoscaling_regression_test
@@ -4003,8 +3750,6 @@
   run:
     timeout: 1200
     script: python placement_group_tests/pg_run.py
-    type: sdk_command
-    file_manager: sdk
 
 - name: placement_group_performance_test
   group: core-daily-test
@@ -4025,8 +3770,6 @@
     wait_for_nodes:
       num_nodes: 5
 
-    type: sdk_command
-    file_manager: sdk
 
 
 #########################
@@ -4051,8 +3794,6 @@
     timeout: 12000
     prepare: sleep 0
     script: python single_node/test_single_node.py
-    type: sdk_command
-    file_manager: sdk
 
 - name: object_store
   group: core-scalability-test
@@ -4073,8 +3814,6 @@
     wait_for_nodes:
       num_nodes: 50
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: many_actors
   group: core-scalability-test
@@ -4095,8 +3834,6 @@
     wait_for_nodes:
       num_nodes: 65
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: many_actors_smoke_test
   group: core-scalability-test
@@ -4117,8 +3854,6 @@
     wait_for_nodes:
       num_nodes: 2
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: many_tasks
   group: core-scalability-test
@@ -4139,8 +3874,6 @@
     wait_for_nodes:
       num_nodes: 65
 
-    type: sdk_command
-    file_manager: sdk
 
   smoke_test:
     frequency: nightly
@@ -4173,8 +3906,6 @@
     wait_for_nodes:
       num_nodes: 65
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: many_pgs_smoke_test
   group: core-scalability-test
@@ -4195,8 +3926,6 @@
     wait_for_nodes:
       num_nodes: 2
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: many_nodes
   group: core-scalability-test
@@ -4219,8 +3948,6 @@
     wait_for_nodes:
       num_nodes: 250
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: scheduling_test_many_0s_tasks_single_node
   group: core-scalability-test
@@ -4243,8 +3970,6 @@
     wait_for_nodes:
       num_nodes: 32
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: scheduling_test_many_0s_tasks_many_nodes
   group: core-scalability-test
@@ -4267,8 +3992,6 @@
     wait_for_nodes:
       num_nodes: 32
 
-    type: sdk_command
-    file_manager: sdk
 
 # - name: scheduling_test_many_5s_tasks_single_node
 #   group: core-scalability-test
@@ -4292,8 +4015,6 @@
 #       num_nodes: 32
 #       timeout: 600
 
-#     type: sdk_command
-#     file_manager: sdk
 #   stable: false
 
 # - name: scheduling_test_many_5s_tasks_many_nodes
@@ -4318,8 +4039,6 @@
 #       num_nodes: 32
 #       timeout: 600
 
-#     type: sdk_command
-#     file_manager: sdk
 #   stable: false
 
 ###############
@@ -4345,8 +4064,6 @@
     wait_for_nodes:
       num_nodes: 2
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: shuffle_data_loader
   group: core-dataset-tests
@@ -4364,8 +4081,6 @@
   run:
     timeout: 1800
     script: python dataset_shuffle_data_loader.py
-    type: sdk_command
-    file_manager: sdk
 
 - name: parquet_metadata_resolution
   group: core-dataset-tests
@@ -4386,8 +4101,6 @@
     wait_for_nodes:
       num_nodes: 15
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: dataset_random_access
   group: core-dataset-tests
@@ -4406,8 +4119,6 @@
     wait_for_nodes:
       num_nodes: 15
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: pipelined_data_ingest_benchmark
   group: core-dataset-tests
@@ -4425,8 +4136,6 @@
     wait_for_nodes:
       num_nodes: 20
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: aggregate_benchmark
   group: core-dataset-tests
@@ -4442,8 +4151,6 @@
     timeout: 1800
     script: python aggregate_benchmark.py
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: read_images_benchmark_single_node
   group: core-dataset-tests
@@ -4459,8 +4166,6 @@
     timeout: 1800
     script: python read_images_benchmark.py
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: read_tfrecords_benchmark_single_node
   group: core-dataset-tests
@@ -4477,8 +4182,6 @@
     timeout: 1800
     script: python read_tfrecords_benchmark.py
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: pipelined_training_50_gb
   group: core-dataset-tests
@@ -4499,8 +4202,6 @@
     wait_for_nodes:
       num_nodes: 15
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: pipelined_ingestion_1500_gb
   group: core-dataset-tests
@@ -4523,8 +4224,6 @@
     wait_for_nodes:
       num_nodes: 21
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: datasets_preprocess_ingest
   group: core-dataset-tests
@@ -4547,8 +4246,6 @@
     wait_for_nodes:
       num_nodes: 17
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: datasets_ingest_400G
   group: core-dataset-tests
@@ -4566,8 +4263,6 @@
   run:
     timeout: 7200
     script: python ray_sgd_runner.py --address auto --use-gpu --num-epochs 1
-    type: sdk_command
-    file_manager: sdk
 
 - name: dataset_shuffle_random_shuffle_1tb
   group: core-dataset-tests
@@ -4587,8 +4282,6 @@
     script: python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
-    type: sdk_command
-    file_manager: sdk
 
 - name: dataset_shuffle_sort_1tb
   group: core-dataset-tests
@@ -4608,8 +4301,6 @@
     script: python dataset/sort.py --num-partitions=1000 --partition-size=1e9
     wait_for_nodes:
       num_nodes: 20
-    type: sdk_command
-    file_manager: sdk
 
 - name: dataset_shuffle_push_based_random_shuffle_1tb
   group: core-dataset-tests
@@ -4629,8 +4320,6 @@
     script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
-    type: sdk_command
-    file_manager: sdk
 
 - name: dataset_shuffle_push_based_sort_1tb
   group: core-dataset-tests
@@ -4650,8 +4339,6 @@
     script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9
     wait_for_nodes:
       num_nodes: 20
-    type: sdk_command
-    file_manager: sdk
 
 - name: dataset_shuffle_push_based_random_shuffle_100tb
   group: core-dataset-tests
@@ -4671,8 +4358,6 @@
     script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=100000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 100
-    type: sdk_command
-    file_manager: sdk
 
 ##################
 # Core Chaos tests
@@ -4698,8 +4383,6 @@
     prepare: python setup_chaos.py --no-start
     script: python chaos_test/test_chaos_basic.py --workload=tasks
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: chaos_many_actors
   group: core-dataset-tests
@@ -4721,8 +4404,6 @@
     prepare: python setup_chaos.py --no-start
     script: python chaos_test/test_chaos_basic.py --workload=actors
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: chaos_dask_on_ray_large_scale_test_no_spilling
   group: core-dataset-tests
@@ -4745,8 +4426,6 @@
     script: python dask_on_ray/large_scale_test.py --num_workers 20 --worker_obj_store_size_in_gb
       20 --error_rate 0  --data_save_path /tmp/ray
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: chaos_dask_on_ray_large_scale_test_spilling
   group: core-dataset-tests
@@ -4769,8 +4448,6 @@
     script: python dask_on_ray/large_scale_test.py --num_workers 150 --worker_obj_store_size_in_gb
       70 --error_rate 0  --data_save_path /tmp/ray
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: chaos_pipelined_ingestion_1500_gb_15_windows
   group: core-dataset-tests
@@ -4793,8 +4470,6 @@
     script: python dataset/pipelined_training.py --epochs 1 --num-windows 15  --num-files
       915 --debug
 
-    type: sdk_command
-    file_manager: sdk
 
 - name: chaos_dataset_shuffle_push_based_sort_1tb
   group: core-dataset-tests
@@ -4817,8 +4492,6 @@
     script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9
     wait_for_nodes:
       num_nodes: 20
-    type: sdk_command
-    file_manager: sdk
 
 - name: chaos_dataset_shuffle_sort_1tb
   group: core-dataset-tests
@@ -4839,8 +4512,6 @@
     script: python dataset/sort.py --num-partitions=1000 --partition-size=1e9
     wait_for_nodes:
       num_nodes: 20
-    type: sdk_command
-    file_manager: sdk
 
 - name: chaos_dataset_shuffle_random_shuffle_1tb
   group: core-dataset-tests
@@ -4864,8 +4535,6 @@
     script: python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
-    type: sdk_command
-    file_manager: sdk
 
 - name: chaos_dataset_shuffle_push_based_random_shuffle_1tb
   group: core-dataset-tests
@@ -4889,8 +4558,6 @@
     script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
-    type: sdk_command
-    file_manager: sdk
 
 #####################
 # Observability tests
@@ -4910,8 +4577,6 @@
   run:
     timeout: 14400
     script: python mem_check.py
-    type: sdk_command
-    file_manager: sdk
 
 - name: k8s_serve_ha_test
   group: k8s-test
@@ -4932,8 +4597,6 @@
     timeout: 28800 # 8h
     prepare: bash prepare.sh
     script: python run_gcs_ft_on_k8s.py
-    type: sdk_command
-    file_manager: sdk
 
 - name: aws_cluster_launcher
   group: cluster-launcher-test
@@ -4953,5 +4616,3 @@
   run:
     timeout: 1200
     script: bash test_aws_cluster_launcher.sh
-    type: sdk_command
-    file_manager: sdk

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1491,24 +1491,6 @@
 # Tune scalability tests
 ########################
 
-
-- name: tune_failing_due_to_timeout
-  group: Tune scalability tests
-  working_dir: tune_tests/scalability_tests
-
-  frequency: nightly
-  team: ml
-  env: staging
-
-  cluster:
-    cluster_env: app_config.yaml
-    cluster_compute: tpl_1x16.yaml
-
-  run:
-    timeout: 30
-    script: python workloads/test_bookkeeping_overhead.py
-
-
 - name: tune_scalability_bookkeeping_overhead
   group: Tune scalability tests
   working_dir: tune_tests/scalability_tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1491,6 +1491,24 @@
 # Tune scalability tests
 ########################
 
+
+- name: tune_failing_due_to_timeout
+  group: Tune scalability tests
+  working_dir: tune_tests/scalability_tests
+
+  frequency: nightly
+  team: ml
+  env: staging
+
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: tpl_1x16.yaml
+
+  run:
+    timeout: 30
+    script: python workloads/test_bookkeeping_overhead.py
+
+
 - name: tune_scalability_bookkeeping_overhead
   group: Tune scalability tests
   working_dir: tune_tests/scalability_tests

--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -69,7 +69,7 @@ if [ -z "${NO_CLONE}" ]; then
 fi
 
 if [ -z "${NO_INSTALL}" ]; then
-  pip install -e .
+  pip install --use-deprecated=legacy-resolver -c requirements.txt -e .
 fi
 
 RETRY_NUM=0


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The Anyscale command API has been deprecated in favor of Ray jobs and Anyscale jobs. Support is not thoroughly tested and may be deprecated or removed soon.

This PR moves all release tests to use Ray jobs for command submission in the future. For testing, we will run a subset of affected release tests with the new configuration.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
