### PR TITLE
[ci][metrics] Skip task metric test_actor_task_retry on windows

### DIFF
--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -367,6 +367,7 @@ time.sleep(999)
     proc.kill()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows. Timing out.")
 def test_actor_task_retry(shutdown_only):
     info = ray.init(num_cpus=2, **METRIC_CONFIG)
 


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I believe the task_metric suite is just being slow on windows again e.g. [this](https://buildkite.com/ray-project/oss-ci-build-branch/builds/1426#0184e66c-c599-411e-8203-6ab568499b8d). Wondering if we want to split the test or simply skipping more advanced tests in the same test file. 

I skipped this since it was the most recently added test I believe. 

<img width="974" alt="image" src="https://user-images.githubusercontent.com/11676094/206278125-52acc646-4721-446c-915d-9fc105e65b08.png">



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
