### PR TITLE
[core][state] Task events backend - split drop count on worker

### DIFF
--- a/src/ray/core_worker/task_event_buffer.h
+++ b/src/ray/core_worker/task_event_buffer.h
@@ -126,9 +126,15 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   }
 
   /// Test only functions.
-  size_t GetNumTaskEventsDropped() LOCKS_EXCLUDED(mutex_) {
+  size_t GetNumStatusTaskEventsDropped() LOCKS_EXCLUDED(mutex_) {
     absl::MutexLock lock(&mutex_);
-    return num_task_events_dropped_;
+    return num_status_task_events_dropped_;
+  }
+
+  /// Test only functions.
+  size_t GetNumProfileTaskEventsDropped() LOCKS_EXCLUDED(mutex_) {
+    absl::MutexLock lock(&mutex_);
+    return num_profile_task_events_dropped_;
   }
 
   /// Test only functions.
@@ -164,8 +170,11 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   /// A iterator into buffer_ that determines which element to be overwritten.
   size_t next_idx_to_overwrite_ GUARDED_BY(mutex_) = 0;
 
-  /// Number of task events dropped since the last report flush.
-  size_t num_task_events_dropped_ GUARDED_BY(mutex_) = 0;
+  /// Number of profile task events dropped since the last report flush.
+  size_t num_profile_task_events_dropped_ GUARDED_BY(mutex_) = 0;
+
+  /// Number of status task events dropped since the last report flush.
+  size_t num_status_task_events_dropped_ GUARDED_BY(mutex_) = 0;
 
   /// True if there's a pending gRPC call. It's a simple way to prevent overloading
   /// GCS with too many calls. There is no point sending more events if GCS could not

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -263,8 +263,10 @@ message TaskEvents {
 message TaskEventData {
   // A batch of task state change events.
   repeated TaskEvents events_by_task = 1;
-  // Number of dropped task events due to buffer size limit on workers.
-  int32 num_task_events_dropped = 2;
+  // Number of dropped profile task events due to buffer size limit on workers.
+  int32 num_profile_task_events_dropped = 3;
+  // Number of dropped status task events due to buffer size limit on workers.
+  int32 num_status_task_events_dropped = 4;
 }
 
 message ResourceTableData {


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- We were reporting dropped task event count as a single value. When queried for a specific kind of events, e.g. profile events, the number of dropped events for status updates should not interfere the profile events results. 
- Fix testing: task events in exported `rpc::TaskEventData`' has non-deterministic order due to an intermediate merge with `flat_hash_map`. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
