### PR TITLE
[Jobs] [Job Status refactor 1/n] Use JSON for JobInfo instead of pickled Python class

### DIFF
--- a/dashboard/modules/job/common.py
+++ b/dashboard/modules/job/common.py
@@ -93,6 +93,8 @@ class JobInfo:
     driver_node_id: Optional[str] = None
 
     def __post_init__(self):
+        if isinstance(self.status, str):
+            self.status = JobStatus(self.status)
         if self.message is None:
             if self.status == JobStatus.PENDING:
                 self.message = "Job has not started yet."
@@ -146,6 +148,9 @@ class JobInfo:
         Args:
             json_dict: A JSON dictionary to use to initialize the JobInfo object.
         """
+        # Convert enum values to enum objects.
+        json_dict["status"] = JobStatus(json_dict["status"])
+
         return cls(**json_dict)
 
 

--- a/dashboard/modules/job/common.py
+++ b/dashboard/modules/job/common.py
@@ -1,7 +1,7 @@
 import asyncio
-import pickle
+import json
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, asdict
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Union
@@ -105,8 +105,10 @@ class JobInfo:
                         self.entrypoint_resources not in [None, {}],
                     ]
                 ):
-                    self.message += " It may be waiting for resources "
-                    "(CPUs, GPUs, custom resources) to become available."
+                    self.message += (
+                        " It may be waiting for resources "
+                        "(CPUs, GPUs, custom resources) to become available."
+                    )
                 if self.runtime_env not in [None, {}]:
                     self.message += (
                         " It may be waiting for the runtime environment to be set up."
@@ -119,6 +121,32 @@ class JobInfo:
                 self.message = "Job finished successfully."
             elif self.status == JobStatus.FAILED:
                 self.message = "Job failed."
+
+    def to_json(self) -> Dict[str, Any]:
+        """Convert this object to a JSON-serializable dictionary.
+
+        Returns:
+            A JSON-serializable dictionary representing the JobInfo object.
+        """
+
+        json_dict = asdict(self)
+
+        # Convert enum values to strings.
+        json_dict["status"] = str(json_dict["status"])
+
+        # Assert that the dictionary is JSON-serializable.
+        json.dumps(json_dict)
+
+        return json_dict
+
+    @classmethod
+    def from_json(cls, json_dict: Dict[str, Any]) -> None:
+        """Initialize this object from a JSON dictionary.
+
+        Args:
+            json_dict: A JSON dictionary to use to initialize the JobInfo object.
+        """
+        return cls(**json_dict)
 
 
 class JobInfoStorageClient:
@@ -133,24 +161,24 @@ class JobInfoStorageClient:
         self._gcs_aio_client = gcs_aio_client
         assert _internal_kv_initialized()
 
-    async def put_info(self, job_id: str, data: JobInfo):
+    async def put_info(self, job_id: str, job_info: JobInfo):
         await self._gcs_aio_client.internal_kv_put(
             self.JOB_DATA_KEY.format(job_id=job_id).encode(),
-            pickle.dumps(data),
+            json.dumps(job_info.to_json()).encode(),
             True,
             namespace=ray_constants.KV_NAMESPACE_JOB,
         )
 
     async def get_info(self, job_id: str, timeout: int = 30) -> Optional[JobInfo]:
-        pickled_info = await self._gcs_aio_client.internal_kv_get(
+        serialized_info = await self._gcs_aio_client.internal_kv_get(
             self.JOB_DATA_KEY.format(job_id=job_id).encode(),
             namespace=ray_constants.KV_NAMESPACE_JOB,
             timeout=timeout,
         )
-        if pickled_info is None:
+        if serialized_info is None:
             return None
         else:
-            return pickle.loads(pickled_info)
+            return JobInfo.from_json(json.loads(serialized_info))
 
     async def delete_info(self, job_id: str, timeout: int = 30):
         await self._gcs_aio_client.internal_kv_del(

--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -303,7 +303,7 @@ class JobSupervisor:
             "PYTHONUNBUFFERED": "1",
         }
 
-    async def _polling(self, child_process) -> int:
+    async def _polling(self, child_process: subprocess.Popen) -> int:
         try:
             while child_process is not None:
                 return_code = child_process.poll()

--- a/dashboard/modules/job/tests/test_common.py
+++ b/dashboard/modules/job/tests/test_common.py
@@ -131,6 +131,35 @@ def test_dynamic_status_message():
     assert "may be waiting for the runtime environment" in info.message
 
 
+def test_job_info_to_json():
+    info = JobInfo(
+        status=JobStatus.PENDING,
+        entrypoint="echo hi",
+        entrypoint_num_cpus=1,
+        entrypoint_num_gpus=1,
+        entrypoint_resources={"Custom": 1},
+        runtime_env={"pip": ["pkg"]},
+    )
+    expected_items = {
+        "status": "PENDING",
+        "message": (
+            "Job has not started yet. It may be waiting for resources "
+            "(CPUs, GPUs, custom resources) to become available. "
+            "It may be waiting for the runtime environment to be set up."
+        ),
+        "entrypoint": "echo hi",
+        "entrypoint_num_cpus": 1,
+        "entrypoint_num_gpus": 1,
+        "entrypoint_resources": {"Custom": 1},
+        "runtime_env": {"pip": ["pkg"]},
+    }
+
+    # Check expected items are a subset of the info
+    assert expected_items.items() <= info.to_json().items()
+
+    assert JobInfo.from_json(info.to_json()) == info
+
+
 if __name__ == "__main__":
     import sys
 

--- a/dashboard/modules/job/tests/test_common.py
+++ b/dashboard/modules/job/tests/test_common.py
@@ -154,7 +154,7 @@ def test_job_info_to_json():
         "runtime_env": {"pip": ["pkg"]},
     }
 
-    # Check expected items are a subset of the info
+    # Check that the expected items are in the JSON.
     assert expected_items.items() <= info.to_json().items()
 
     assert JobInfo.from_json(info.to_json()) == info

--- a/dashboard/modules/job/tests/test_common.py
+++ b/dashboard/modules/job/tests/test_common.py
@@ -157,7 +157,12 @@ def test_job_info_to_json():
     # Check that the expected items are in the JSON.
     assert expected_items.items() <= info.to_json().items()
 
-    assert JobInfo.from_json(info.to_json()) == info
+    new_job_info = JobInfo.from_json(info.to_json())
+    assert new_job_info == info
+
+    # If `status` is just a string, then operations like status.is_terminal()
+    # would fail, so we should make sure that it's a JobStatus.
+    assert isinstance(new_job_info.status, JobStatus)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Updates the JobInfo storage to use JSON instead of a pickled Python class. This allows it to be read by the GCS (which is in C++).  


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
This a first step towards resolving https://github.com/ray-project/ray/issues/29621. The goal is to unify the GCS APIs and Ray Jobs API for getting the status of jobs. Plan copied from that issue:

1. [This PR] Have the job server store extended JobInfo in a proto or JSON form, instead of pickled Python data. The proto/JSON JobInfo can still be stored in the internal KV.
2. Enhance `ListAllJobs` to pre-join the data from `job_submission_id` in the internal KV. This means that GCS will need to lookup the extended JobInfo for jobs that have `job_submission_id` defined.
3. Add a `limit` field to ListAllJobs to bound the number of returned jobs.
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
