### PR TITLE
[Datasets] Add `map_batches()` benchmark

### DIFF
--- a/release/nightly_tests/dataset/map_batches_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_benchmark.py
@@ -106,7 +106,7 @@ def run_map_batches_benchmark(benchmark: Benchmark):
             )
 
     # Test different batch formats of map_batches.
-    for current_format in ["pyarrow", "pandas", "numpy"]:
+    for current_format in ["pyarrow", "pandas"]:
         new_input_ds = input_ds.map_batches(
             lambda ds: ds, batch_format=current_format, batch_size=None
         ).fully_executed()

--- a/release/nightly_tests/dataset/map_batches_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_benchmark.py
@@ -18,7 +18,7 @@ def map_batches(
     ds = input_ds
     for _ in range(num_calls):
         ds = ds.map_batches(
-            lambda ds: ds,
+            lambda x: x,
             batch_format=batch_format,
             batch_size=batch_size,
             compute=compute,
@@ -39,8 +39,9 @@ def run_map_batches_benchmark(benchmark: Benchmark):
     # Test different batch_size of map_batches.
     for batch_format in batch_formats:
         for batch_size in batch_sizes:
-            # TODO(chengsu): Investigate why NumPy with batch_size being 1024,
-            # took much longer to finish.
+            # TODO(chengsu): https://github.com/ray-project/ray/issues/31108
+            # Investigate why NumPy with batch_size being 1024, took much longer
+            # to finish.
             if (
                 batch_format == "numpy"
                 and batch_size is not None
@@ -127,7 +128,7 @@ def run_map_batches_benchmark(benchmark: Benchmark):
     )
     for batch_format in batch_formats:
         for compute in ["tasks", "actors"]:
-            test_name = f"map-batches-{batch_format}-{compute}-default"
+            test_name = f"map-batches-{batch_format}-{compute}-multi-files"
             benchmark.run(
                 test_name,
                 map_batches,

--- a/release/nightly_tests/dataset/map_batches_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_benchmark.py
@@ -1,0 +1,93 @@
+from typing import Literal
+
+import ray
+from ray.data.dataset import Dataset
+
+from benchmark import Benchmark
+
+
+def map_batches(
+    input_ds: Dataset,
+    batch_size: int,
+    batch_format: Literal["default", "pandas", "pyarrow", "numpy"],
+    num_calls: int,
+) -> Dataset:
+
+    ds = input_ds
+    for _ in range(num_calls):
+        ds = ds.map_batches(
+            lambda ds: ds, batch_format=batch_format, batch_size=batch_size
+        )
+    return ds
+
+
+def run_map_batches_benchmark(benchmark: Benchmark):
+    input_ds = ray.data.read_parquet(
+        "s3://shuffling-data-loader-benchmarks/data/input_data_0.parquet.snappy"
+    )
+    lazy_input_ds = input_ds.lazy()
+
+    batch_formats = ["pandas", "numpy"]
+    batch_sizes = [64, 128, 256, 512, 1024, 2048, 4096, None]
+    num_calls_list = [1, 2, 4, 8, 16]
+
+    # Test different batch_size of map_batches.
+    for batch_format in batch_formats:
+        for batch_size in batch_sizes:
+            # TODO(chengsu): Investigate why NumPy with batch_size less than 512,
+            # took forever to finish.
+            if batch_format == "numpy" and batch_size is not None and batch_size < 512:
+                continue
+
+            num_calls = 2
+            test_name = f"map-batches-{batch_format}-{batch_size}-{num_calls}-default"
+            benchmark.run(
+                test_name,
+                map_batches,
+                input_ds=input_ds,
+                batch_format=batch_format,
+                batch_size=batch_size,
+                num_calls=num_calls,
+            )
+            test_name = f"map-batches-{batch_format}-{batch_size}-{num_calls}-lazy"
+            benchmark.run(
+                test_name,
+                map_batches,
+                input_ds=lazy_input_ds,
+                batch_format=batch_format,
+                batch_size=batch_size,
+                num_calls=num_calls,
+            )
+
+    # Test multiple calls of map_batches.
+    for batch_format in batch_formats:
+        for num_calls in num_calls_list:
+            batch_size = 4096
+            test_name = f"map-batches-{batch_format}-{batch_size}-{num_calls}-default"
+            benchmark.run(
+                test_name,
+                map_batches,
+                input_ds=input_ds,
+                batch_format=batch_format,
+                batch_size=batch_size,
+                num_calls=num_calls,
+            )
+            test_name = f"map-batches-{batch_format}-{batch_size}-{num_calls}-lazy"
+            benchmark.run(
+                test_name,
+                map_batches,
+                input_ds=lazy_input_ds,
+                batch_format=batch_format,
+                batch_size=batch_size,
+                num_calls=num_calls,
+            )
+
+
+if __name__ == "__main__":
+    ray.init()
+
+    benchmark = Benchmark("map-batches")
+
+    run_map_batches_benchmark(benchmark)
+
+    benchmark.write_result()

--- a/release/nightly_tests/dataset/map_batches_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_benchmark.py
@@ -1,6 +1,7 @@
-from typing import Literal
+from typing import Literal, Optional, Union
 
 import ray
+from ray.data._internal.compute import ActorPoolStrategy, ComputeStrategy
 from ray.data.dataset import Dataset
 
 from benchmark import Benchmark
@@ -10,13 +11,17 @@ def map_batches(
     input_ds: Dataset,
     batch_size: int,
     batch_format: Literal["default", "pandas", "pyarrow", "numpy"],
-    num_calls: int,
+    compute: Optional[Union[str, ComputeStrategy]] = None,
+    num_calls: Optional[int] = 1,
 ) -> Dataset:
 
     ds = input_ds
     for _ in range(num_calls):
         ds = ds.map_batches(
-            lambda ds: ds, batch_format=batch_format, batch_size=batch_size
+            lambda ds: ds,
+            batch_format=batch_format,
+            batch_size=batch_size,
+            compute=compute,
         )
     return ds
 
@@ -62,24 +67,54 @@ def run_map_batches_benchmark(benchmark: Benchmark):
     # Test multiple calls of map_batches.
     for batch_format in batch_formats:
         for num_calls in num_calls_list:
-            batch_size = 4096
-            test_name = f"map-batches-{batch_format}-{batch_size}-{num_calls}-default"
+            for compute in ["tasks", ActorPoolStrategy(1, 1)]:
+                batch_size = 4096
+                if compute == "tasks":
+                    compute_strategy = "task"
+                else:
+                    compute_strategy = "actor"
+
+                test_name = (
+                    f"map-batches-{batch_format}-{batch_size}-{num_calls}-"
+                    f"{compute_strategy}-default"
+                )
+                benchmark.run(
+                    test_name,
+                    map_batches,
+                    input_ds=input_ds,
+                    batch_format=batch_format,
+                    batch_size=batch_size,
+                    compute=compute,
+                    num_calls=num_calls,
+                )
+                test_name = (
+                    f"map-batches-{batch_format}-{batch_size}-{num_calls}-"
+                    f"{compute_strategy}-lazy"
+                )
+                benchmark.run(
+                    test_name,
+                    map_batches,
+                    input_ds=lazy_input_ds,
+                    batch_format=batch_format,
+                    batch_size=batch_size,
+                    compute=compute,
+                    num_calls=num_calls,
+                )
+
+    # Test different batch formats of map_batches.
+    for current_format in ["pyarrow", "pandas", "numpy"]:
+        new_input_ds = input_ds.map_batches(
+            lambda ds: ds, batch_format=current_format, batch_size=None
+        ).fully_executed()
+        for new_format in ["pyarrow", "pandas", "numpy"]:
+            test_name = f"map-batches-{current_format}-to-{new_format}"
             benchmark.run(
                 test_name,
                 map_batches,
-                input_ds=input_ds,
-                batch_format=batch_format,
-                batch_size=batch_size,
-                num_calls=num_calls,
-            )
-            test_name = f"map-batches-{batch_format}-{batch_size}-{num_calls}-lazy"
-            benchmark.run(
-                test_name,
-                map_batches,
-                input_ds=lazy_input_ds,
-                batch_format=batch_format,
-                batch_size=batch_size,
-                num_calls=num_calls,
+                input_ds=new_input_ds,
+                batch_format=new_format,
+                batch_size=None,
+                num_calls=1,
             )
 
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4491,8 +4491,8 @@
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
-    # Expect the benchmark to finish around 20 minutes.
-    timeout: 1800
+    # Expect the benchmark to finish around 30 minutes.
+    timeout: 2400
     script: python map_batches_benchmark.py
 
     type: sdk_command

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4491,7 +4491,7 @@
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
-    # Expect the benchmark to finish around 17 minutes.
+    # Expect the benchmark to finish around 20 minutes.
     timeout: 1800
     script: python map_batches_benchmark.py
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4480,6 +4480,24 @@
     type: sdk_command
     file_manager: sdk
 
+- name: map_batches_benchmark_single_node
+  group: core-dataset-tests
+  working_dir: nightly_tests/dataset
+
+  frequency: nightly
+  team: data
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: single_node_benchmark_compute.yaml
+
+  run:
+    # Expect the benchmark to finish around 17 minutes.
+    timeout: 1800
+    script: python map_batches_benchmark.py
+
+    type: sdk_command
+    file_manager: sdk
+
 - name: pipelined_training_50_gb
   group: core-dataset-tests
   working_dir: nightly_tests/dataset


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is to add benchmark for `map_batches`. It focus on benchmarking the internal overhead of `map_batches` from Ray Data, but not the cost of user code. So it uses a dummy identity function - `map_batches(lambda ds: ds)`.

This benchmark focus on testing:
* Different batch formats
* Different batch sizes
* Multiple `map_batches` calls
* Lazy vs eager execution
* Task vs actor

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
