### PR TITLE
[minor][kuberay][ci] Delete nil metadata field in test RayCluster CR

### DIFF
--- a/python/ray/tests/kuberay/setup/raycluster_test.yaml
+++ b/python/ray/tests/kuberay/setup/raycluster_test.yaml
@@ -9,7 +9,6 @@ spec:
     replicas: 1
     rayStartParams: {}
     template:
-      metadata:
       spec:
         containers:
           - name: ray-test


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The KubeRay autoscaling test creates sample RayCluster CR with a nil metadata field, which causes the test to fail against K8s 1.19. 
This PR gets rid of the metadata field.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
