### PR TITLE
[runtime env] Support python 3.10 for runtime_env conda

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -364,4 +364,7 @@ def gcs_actor_scheduling_enabled():
 
 DEFAULT_RESOURCES = {"CPU", "GPU", "memory", "object_store_memory"}
 
-SUPPORTED_PYTHON_VERSIONS = [(3, 6), (3, 7), (3, 8), (3, 9), (3, 10)]
+# Supported Python versions for runtime env's "conda" field. Ray downloads
+# Ray wheels into the conda environment, so the Ray wheels for these Python
+# versions must be available online.
+RUNTIME_ENV_CONDA_PY_VERSIONS = [(3, 6), (3, 7), (3, 8), (3, 9), (3, 10)]

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -363,3 +363,5 @@ def gcs_actor_scheduling_enabled():
 
 
 DEFAULT_RESOURCES = {"CPU", "GPU", "memory", "object_store_memory"}
+
+SUPPORTED_PYTHON_VERSIONS = [(3, 6), (3, 7), (3, 8), (3, 9), (3, 10)]

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1262,7 +1262,7 @@ def get_wheel_filename(
         The wheel file name.  Examples:
             ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
     """
-    assert py_version in ray_constants.SUPPORTED_PYTHON_VERSIONS, py_version
+    assert py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS, py_version
 
     py_version_str = "".join(map(str, py_version))
     if py_version_str in ["36", "37"]:

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1247,7 +1247,7 @@ def import_attr(full_path: str):
 def get_wheel_filename(
     sys_platform: str = sys.platform,
     ray_version: str = ray.__version__,
-    py_version: Tuple[int, int] = sys.version_info[:2],
+    py_version: Tuple[int, int] = (sys.version_info.major, sys.version_info.minor),
 ) -> str:
     """Returns the filename used for the nightly Ray wheel.
 

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1262,7 +1262,7 @@ def get_wheel_filename(
         The wheel file name.  Examples:
             ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
     """
-    assert py_version in ray_constants.SUPPORTED_PY_VERSIONS, py_version
+    assert py_version in ray_constants.SUPPORTED_PYTHON_VERSIONS, py_version
 
     py_version_str = "".join(map(str, py_version))
     if py_version_str in ["36", "37"]:

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1266,9 +1266,9 @@ def get_wheel_filename(
     assert py_version in ["36", "37", "38", "39", "310"], py_version
 
     os_strings = {
-        "darwin": "macosx_10_15_x86_64"
-        if py_version in ["38", "39", "310"]
-        else "macosx_10_15_intel",
+        "darwin": "macosx_10_15_intel"
+        if py_version in ["36", "37"]
+        else "macosx_10_15_x86_64",
         "linux": "manylinux2014_x86_64",
         "win32": "win_amd64",
     }

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1263,11 +1263,11 @@ def get_wheel_filename(
         The wheel file name.  Examples:
             ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
     """
-    assert py_version in ["36", "37", "38", "39"], py_version
+    assert py_version in ["36", "37", "38", "39", "310"], py_version
 
     os_strings = {
         "darwin": "macosx_10_15_x86_64"
-        if py_version in ["38", "39"]
+        if py_version in ["38", "39", "310"]
         else "macosx_10_15_intel",
         "linux": "manylinux2014_x86_64",
         "win32": "win_amd64",

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -45,7 +45,7 @@ def test_get_wheel_filename():
     # NOTE: These should not be changed for releases.
     ray_version = "3.0.0.dev0"
     for sys_platform in ["darwin", "linux", "win32"]:
-        for py_version in [(3, 6), (3, 7), (3, 8), (3, 9), (3, 10)]:
+        for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             if sys_platform == "win32" and py_version == (3, 6):
                 # Windows wheels are not built for py3.6 anymore
                 continue
@@ -64,7 +64,7 @@ def test_get_master_wheel_url():
     # `s3://ray-wheels/master/<test_commit>/`.
     test_commit = "6fd684bbdb186a73732f6113a83a12b63200f170"
     for sys_platform in ["darwin", "linux", "win32"]:
-        for py_version in [(3, 6), (3, 7), (3, 8), (3, 9), (3, 10)]:
+        for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             if sys_platform == "win32" and py_version == (3, 6):
                 # Windows wheels are not built for py3.6 anymore
                 continue
@@ -81,7 +81,7 @@ def test_get_release_wheel_url():
     # `s3://ray-wheels/releases/2.2.0/<commit>/`.
     test_commits = {"2.2.0": "b6af0887ee5f2e460202133791ad941a41f15beb"}
     for sys_platform in ["darwin", "linux", "win32"]:
-        for py_version in [(3, 6), (3, 7), (3, 8), (3, 9), (3, 10)]:
+        for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             for version, commit in test_commits.items():
                 if sys_platform == "win32" and py_version == (3, 6):
                     # Windows wheels are not built for py3.6 anymore
@@ -99,14 +99,14 @@ def test_current_py_version_supported():
     the `conda` environment installation will fail.
 
     When a new python version is added to the Ray wheels, please update
-    `ray_constants.SUPPORTED_PYTHON_VERSIONS`.  In a subsequent commit,
+    `ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS`.  In a subsequent commit,
     once wheels have been built for the new python version, please update
     the tests test_get_wheel_filename, test_get_master_wheel_url, and
     (after the first Ray release with the new python version)
     test_get_release_wheel_url.
     """
     py_version = sys.version_info[:2]
-    assert py_version in ray_constants.SUPPORTED_PYTHON_VERSIONS
+    assert py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS
 
 
 def test_compatible_with_dataclasses():

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -42,7 +42,7 @@ def test_get_wheel_filename():
     # NOTE: These should not be changed for releases.
     ray_version = "3.0.0.dev0"
     for sys_platform in ["darwin", "linux", "win32"]:
-        for py_version in ["36", "37", "38", "39"]:
+        for py_version in ["36", "37", "38", "39", "310"]:
             if sys_platform == "win32" and py_version == "36":
                 # Windows wheels are not built for py3.6 anymore
                 continue
@@ -55,9 +55,12 @@ def test_get_wheel_filename():
 def test_get_master_wheel_url():
     # NOTE: These should not be changed for releases.
     ray_version = "3.0.0.dev0"
-    test_commit = "c3ac6fcf3fcc8cfe6930c9a820add0e187bff579"
+    # This should be a commit for which wheels have been built for
+    # all platforms and python versions at
+    # `s3://ray-wheels/master/<test_commit>/`.
+    test_commit = "6fd684bbdb186a73732f6113a83a12b63200f170"
     for sys_platform in ["darwin", "linux", "win32"]:
-        for py_version in ["36", "37", "38", "39"]:
+        for py_version in ["36", "37", "38", "39", "310"]:
             if sys_platform == "win32" and py_version == "36":
                 # Windows wheels are not built for py3.6 anymore
                 continue
@@ -68,9 +71,13 @@ def test_get_master_wheel_url():
 
 
 def test_get_release_wheel_url():
-    test_commits = {"1.6.0": "5052fe67d99f1d4bfc81b2a8694dbf2aa807bbdc"}
+    # This should be a commit for which wheels have been built for
+    # all platforms and python versions at
+    # `s3://ray-wheels/releases/2.2.0/<commit>/`.
+    # NOTE: These should not be changed for releases.
+    test_commits = {"2.2.0": "03de294293ab598da6e183f182b49b7003cceba8"}
     for sys_platform in ["darwin", "linux", "win32"]:
-        for py_version in ["36", "37", "38", "39"]:
+        for py_version in ["36", "37", "38", "39", "310"]:
             for version, commit in test_commits.items():
                 url = get_release_wheel_url(commit, sys_platform, version, py_version)
                 assert requests.head(url).status_code == 200, url

--- a/release/runtime_env_tests/workloads/wheel_urls.py
+++ b/release/runtime_env_tests/workloads/wheel_urls.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
 
     retry = set()
     for sys_platform in ["darwin", "linux", "win32"]:
-        for py_version in ["36", "37", "38", "39"]:
+        for py_version in ["36", "37", "38", "39", "310"]:
             if "dev" in ray.__version__:
                 url = get_master_wheel_url(
                     ray_commit=ray.__commit__,


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`conda` environments are isolated, so when `runtime_env` sets up a conda environment it must download the Ray wheel into the conda environment.  It must download the wheel that matches the current Python and Ray version running, otherwise there will be incompatibility issues between the workers that use this `runtime_env` and the other workers and Ray processes.

This PR updates the wheel name format logic to support Python 3.10.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #30929 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
