### PR TITLE
[runtime env] Print the failed key or value type when env_vars validation fails

### DIFF
--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -231,18 +231,39 @@ def parse_and_validate_env_vars(env_vars: Dict[str, str]) -> Optional[Dict[str, 
     This is validated to verify that all keys and vals are strings.
 
     If an empty dictionary is passed, we return `None` for consistency.
+
+    Args:
+        env_vars: A dictionary of environment variables to set in the
+            runtime environment.
+
+    Returns:
+        The validated env_vars dictionary, or None if it was empty.
+
+    Raises:
+        TypeError: If the env_vars is not a dictionary of strings. The error message
+            will include the type of the invalid value.
     """
     assert env_vars is not None
     if len(env_vars) == 0:
         return None
 
-    if not (
-        isinstance(env_vars, dict)
-        and all(
-            isinstance(k, str) and isinstance(v, str) for (k, v) in env_vars.items()
+    if not isinstance(env_vars, dict):
+        raise TypeError(
+            "runtime_env['env_vars'] must be of type "
+            f"Dict[str, str], got {type(env_vars)}"
         )
-    ):
-        raise TypeError("runtime_env['env_vars'] must be of type Dict[str, str]")
+
+    for key, val in env_vars.items():
+        if not isinstance(key, str):
+            raise TypeError(
+                "runtime_env['env_vars'] must be of type "
+                f"Dict[str, str], but the key {key} is of type {type(key)}"
+            )
+        if not isinstance(val, str):
+            raise TypeError(
+                "runtime_env['env_vars'] must be of type "
+                f"Dict[str, str], but the value {val} is of type {type(val)}"
+            )
 
     return env_vars
 

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -223,7 +223,7 @@ class TestValidateEnvVars:
 
         with pytest.raises(TypeError, match=".*value True is of type <class 'bool'>*"):
             parse_and_validate_env_vars({"hi": True})
-        
+
         with pytest.raises(TypeError, match=".*key 1.23 is of type <class 'float'>*"):
             parse_and_validate_env_vars({1.23: "hi"})
 

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -218,6 +218,15 @@ class TestValidateEnvVars:
         with pytest.raises(TypeError, match=".*Dict[str, str]*"):
             parse_and_validate_env_vars({1: "hi"})
 
+        with pytest.raises(TypeError, match=".*value 123 is of type <class 'int'>*"):
+            parse_and_validate_env_vars({"hi": 123})
+
+        with pytest.raises(TypeError, match=".*value True is of type <class 'bool'>*"):
+            parse_and_validate_env_vars({"hi": True})
+        
+        with pytest.raises(TypeError, match=".*key 1.23 is of type <class 'float'>*"):
+            parse_and_validate_env_vars({1.23: "hi"})
+
 
 class TestParsedRuntimeEnv:
     def test_empty(self):


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The current `env_vars` validation currently doesn't show the key or value that violated the validation.  This PR prints the offending key or value and its type for easier debugging.  This came up in a UX study where a numeric value was passed instead of a `str` and it took a while to figure out the issue from the existing error message.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
