### PR TITLE
[Train] Fix bad case in ScalingConfig->RayParams

### DIFF
--- a/python/ray/train/gbdt_trainer.py
+++ b/python/ray/train/gbdt_trainer.py
@@ -74,9 +74,6 @@ def _convert_scaling_config_to_ray_params(
             def get_tune_resources(self) -> PlacementGroupFactory:
                 pgf = super().get_tune_resources()
                 placement_options = self.placement_options.copy()
-                # Special case, same as in ScalingConfig.as_placement_group_factory
-                if placement_options.get("_max_cpu_fraction_per_node", None) is None:
-                    placement_options.pop("_max_cpu_fraction_per_node", None)
                 extended_pgf = PlacementGroupFactory(
                     pgf.bundles,
                     **placement_options,
@@ -88,11 +85,16 @@ def _convert_scaling_config_to_ray_params(
     else:
         ray_params_cls_extended = ray_params_cls
 
+    placement_options = {
+        "strategy": scaling_config.placement_strategy,
+    }
+    # Special case, same as in ScalingConfig.as_placement_group_factory
+    if scaling_config._max_cpu_fraction_per_node is not None:
+        placement_options[
+            "_max_cpu_fraction_per_node"
+        ] = scaling_config._max_cpu_fraction_per_node
     ray_params = ray_params_cls_extended(
-        placement_options={
-            "strategy": scaling_config.placement_strategy,
-            "_max_cpu_fraction_per_node": scaling_config._max_cpu_fraction_per_node,
-        },
+        placement_options=placement_options,
         **ray_params_kwargs,
     )
 


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/xgboost_ray/commit/ecca2c63385841a0a1938f5edc349893e5ac63fc (unreleases as of time of writing) upstreams the logic we have in `_convert_scaling_config_to_ray_params` to `xgboost_ray`. However, the implementation of that logic in `xgboost_ray` doesn't guard against the case where `_max_cpu_fraction_per_node` is None, which will throw an exception when a placement group is created. This PR ensures that this case is guarded against on the AIR side.

This doesn't cause any issues right now, but without this PR, the next xgboost-ray update will cause exceptions.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
