### PR TITLE
Fix read_tfrecords_benchmark nightly test

### DIFF
--- a/release/nightly_tests/dataset/read_tfrecords_benchmark.py
+++ b/release/nightly_tests/dataset/read_tfrecords_benchmark.py
@@ -25,7 +25,7 @@ def generate_tfrecords_from_images(
 
         # Convert images from NumPy to bytes
         def images_to_bytes(batch):
-            images_as_bytes = [image.tobytes() for image in batch]
+            images_as_bytes = [image.tobytes() for image in batch.values()]
             return pa.table({"image": images_as_bytes})
 
         ds = ds.map_batches(images_to_bytes, batch_format="numpy")


### PR DESCRIPTION
Signed-off-by: jianoaix <iamjianxiao@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The test has been broken since https://github.com/ray-project/ray/commit/d560b88d398eef1d4f002d7576d3c12fa28a39be
with a column added.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#30971
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
