### PR TITLE
[all_tests][core] Ping grpcio to <= 1.49.1 due to thread pool hanging issue on mac

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -21,8 +21,7 @@ virtualenv>=20.0.24
 
 # Python version-specific requirements
 dataclasses; python_version < '3.7'
-# https://github.com/grpc/grpc/issues/31772
-# The commit is https://github.com/grpc/grpc/pull/30996
+# Tracking issue: https://github.com/ray-project/ray/issues/30984
 grpcio >= 1.32.0, <= 1.49.1; python_version < '3.10' and sys_platform == 'darwin'
 grpcio >= 1.42.0, <= 1.49.1; python_version >= '3.10' and sys_platform == 'darwin'
 grpcio >= 1.32.0; python_version < '3.10' and sys_platform != 'darwin'

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -21,8 +21,12 @@ virtualenv>=20.0.24
 
 # Python version-specific requirements
 dataclasses; python_version < '3.7'
-grpcio>=1.32.0, <= 1.49.1; python_version < '3.10'
-grpcio>=1.42.0, <= 1.49.1; python_version >= '3.10'
+# https://github.com/grpc/grpc/issues/31772
+# The commit is https://github.com/grpc/grpc/pull/30996
+grpcio >= 1.32.0, <= 1.49.1; python_version < '3.10' and sys_platform == 'darwin'
+grpcio >= 1.42.0, <= 1.49.1; python_version >= '3.10' and sys_platform == 'darwin'
+grpcio >= 1.32.0; python_version < '3.10' and sys_platform != 'darwin'
+grpcio >= 1.42.0; python_version >= '3.10' and sys_platform != 'darwin'
 numpy>=1.16; python_version < '3.9'
 numpy>=1.19.3; python_version >= '3.9'
 packaging; python_version >= '3.10'

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -21,8 +21,8 @@ virtualenv>=20.0.24
 
 # Python version-specific requirements
 dataclasses; python_version < '3.7'
-grpcio>=1.32.0; python_version < '3.10'
-grpcio>=1.42.0; python_version >= '3.10'
+grpcio>=1.32.0, <= 1.49.1; python_version < '3.10'
+grpcio>=1.42.0, <= 1.49.1; python_version >= '3.10'
 numpy>=1.16; python_version < '3.9'
 numpy>=1.19.3; python_version >= '3.9'
 packaging; python_version >= '3.10'

--- a/python/setup.py
+++ b/python/setup.py
@@ -305,8 +305,7 @@ if setup_spec.type == SetupType.RAY:
         "click >= 7.0",
         "dataclasses; python_version < '3.7'",
         "filelock",
-        # https://github.com/grpc/grpc/issues/31772
-        # The commit is https://github.com/grpc/grpc/pull/30996
+        # Tracking issue: https://github.com/ray-project/ray/issues/30984
         "grpcio >= 1.32.0, <= 1.49.1; python_version < '3.10' and sys_platform == 'darwin'",  # noqa
         "grpcio >= 1.42.0, <= 1.49.1; python_version >= '3.10' and sys_platform == 'darwin'",  # noqa
         "grpcio >= 1.32.0; python_version < '3.10' and sys_platform != 'darwin'",

--- a/python/setup.py
+++ b/python/setup.py
@@ -305,8 +305,10 @@ if setup_spec.type == SetupType.RAY:
         "click >= 7.0",
         "dataclasses; python_version < '3.7'",
         "filelock",
-        "grpcio >= 1.32.0; python_version < '3.10'",
-        "grpcio >= 1.42.0; python_version >= '3.10'",
+        # https://github.com/grpc/grpc/issues/31772
+        # The commit is https://github.com/grpc/grpc/pull/30996
+        "grpcio >= 1.32.0, <= 1.49.1; python_version < '3.10'",
+        "grpcio >= 1.42.0, <= 1.49.1; python_version >= '3.10'",
         "jsonschema",
         "msgpack >= 1.0.0, < 2.0.0",
         "numpy >= 1.16; python_version < '3.9'",

--- a/python/setup.py
+++ b/python/setup.py
@@ -307,8 +307,10 @@ if setup_spec.type == SetupType.RAY:
         "filelock",
         # https://github.com/grpc/grpc/issues/31772
         # The commit is https://github.com/grpc/grpc/pull/30996
-        "grpcio >= 1.32.0, <= 1.49.1; python_version < '3.10'",
-        "grpcio >= 1.42.0, <= 1.49.1; python_version >= '3.10'",
+        "grpcio >= 1.32.0, <= 1.49.1; python_version < '3.10' and sys_platform == 'darwin'",  # noqa
+        "grpcio >= 1.42.0, <= 1.49.1; python_version >= '3.10' and sys_platform == 'darwin'",  # noqa
+        "grpcio >= 1.32.0; python_version < '3.10' and sys_platform != 'darwin'",
+        "grpcio >= 1.42.0; python_version >= '3.10' and sys_platform != 'darwin'",
         "jsonschema",
         "msgpack >= 1.0.0, < 2.0.0",
         "numpy >= 1.16; python_version < '3.9'",


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
With grpcio >= 1.50.0, this PR is included: https://github.com/grpc/grpc/commit/6b95573959f4efd62c60a144b29b430e093d2813

Tracking issue on grpc repo: https://github.com/grpc/grpc/issues/31772

And this has caused hanging of tests on mac, leading to multiple flaky tests. 
E.g. 
- https://github.com/ray-project/ray/issues/30954
- [osx://python/ray/tests:test_reconstruction](https://buildkite.com/ray-project/oss-ci-build-branch/builds/1458#0184ef73-4ca6-4d21-ae7c-6fba362b0d05/2004-4542)
- [osx://python/ray/tests:test_placement_group](https://buildkite.com/ray-project/oss-ci-build-branch/builds/1465#0184f2f2-3288-43db-b2cb-2b53688c2fd7/943-2191)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
