### PR TITLE
[all_tests][ci] Use .zshenv to avoid conda setting up breaks the pipeline

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -47,7 +47,6 @@ steps:
     - export MAC_JARS=1
     - export RAY_INSTALL_JAVA=1
     - . ./ci/ci.sh init 
-    - source ~/.zshrc
     - ./ci/ci.sh build
     # Test wheels
     - ./ci/ci.sh test_wheels

--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -14,7 +14,7 @@ prelude_commands: &prelude_commands |-
   rm -rf /tmp/bazel_event_logs
   cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
   (which bazel && bazel clean) || true;
-  . ./ci/ci.sh init && source ~/.zshrc
+  . ./ci/ci.sh init && source ~/.zshenv
   ./ci/ci.sh build
   ./ci/env/install-dependencies.sh
   ./ci/env/env_info.sh
@@ -46,7 +46,7 @@ steps:
     - export MAC_WHEELS=1
     - export MAC_JARS=1
     - export RAY_INSTALL_JAVA=1
-    - . ./ci/ci.sh init 
+    - . ./ci/ci.sh init && source ~/.zshenv
     - ./ci/ci.sh build
     # Test wheels
     - ./ci/ci.sh test_wheels

--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -59,9 +59,9 @@ if [ "${BAZEL_CONFIG_ONLY-}" != "1" ]; then
       "${target}" --user
       # Add bazel to the path.
       # shellcheck disable=SC2016
-      printf '\nexport PATH="$HOME/bin:$PATH"\n' >> ~/.zshrc
+      printf '\nexport PATH="$HOME/bin:$PATH"\n' >> ~/.zshenv
       # shellcheck disable=SC1090
-      source ~/.zshrc
+      source ~/.zshenv
     elif [ "${CI-}" = true ] || [ "${arg1-}" = "--system" ]; then
       "$(command -v sudo || echo command)" "${target}" > /dev/null  # system-wide install for CI
     else


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We have seen mac wheel build failures like when setting up the environment. 
<img width="1010" alt="image" src="https://user-images.githubusercontent.com/11676094/207124572-511fa9bf-6df5-4e59-9559-4507ed4b342f.png">

The error was raised when doing `source ~/.zshrc` which contains 
- an export PATH to include bazel that `ci.sh init` puts in
- default conda activation code comes with the sandbox. 

We don't use condas for the mac builds and tests I believe, and this PR moves the PATH export to `.zshenv` for environment.

(This also reverts the PR: https://github.com/ray-project/ray/pull/30911) 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/26194

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
