### PR TITLE
Fix percentage value for memory and object store memory in dashboard ui

### DIFF
--- a/dashboard/client/src/pages/node/NodeRow.component.test.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.component.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { NodeDetail } from "../../type/node";
+import { CoreWorkerStats, Worker } from "../../type/worker";
+import { NodeRow, WorkerRow } from "./NodeRow";
+
+describe("NodeRow", () => {
+  it("renders", async () => {
+    const node: NodeDetail = {
+      hostname: "test-hostname",
+      ip: "192.168.0.1",
+      cpu: 15,
+      mem: [100, 95, 5],
+      disk: {
+        "/": {
+          used: 20000000,
+          total: 200000000,
+          free: 180000000,
+          percent: 10,
+        },
+        "/tmp": {
+          used: 0,
+          total: 200,
+          free: 200,
+          percent: 0,
+        },
+      },
+      networkSpeed: [5, 10],
+      raylet: {
+        state: "ALIVE",
+        nodeId: "1234567890ab",
+        isHeadNode: true,
+        numWorkers: 0,
+        pid: 2345,
+        startTime: 100,
+        terminateTime: -1,
+        brpcPort: 3456,
+        nodeManagerPort: 5890,
+        objectStoreAvailableMemory: 40,
+        objectStoreUsedMemory: 10,
+      },
+      logUrl: "http://192.16.0.1/logs",
+    } as NodeDetail;
+    render(
+      <NodeRow
+        node={node}
+        expanded
+        onExpandButtonClick={() => {
+          /* purposefully empty */
+        }}
+      />,
+      {
+        wrapper: ({ children }) => (
+          <MemoryRouter>
+            <table>
+              <tbody>{children}</tbody>
+            </table>
+          </MemoryRouter>
+        ),
+      },
+    );
+
+    await screen.findByText("test-hostname");
+    expect(screen.getByText(/ALIVE/)).toBeVisible();
+    expect(screen.getByText(/1234567890ab/)).toBeVisible();
+    expect(screen.getByText(/192\.168\.0\.1.*\(Head\)/)).toBeVisible();
+    // CPU Usage
+    expect(screen.getByText(/15%/)).toBeVisible();
+    // Memory Usage
+    expect(screen.getByText(/5\.0000KB\/100\.0000KB\(5\.0%\)/)).toBeVisible();
+    // Disk Usage
+    expect(screen.getByText(/19\.07MB\/190\.73MB\(10\.0%\)/)).toBeVisible();
+    // Object store memory
+    expect(screen.getByText(/10\.0000KB\/50\.0000KB\(20\.0%\)/)).toBeVisible();
+    // Network usage
+    expect(screen.getByText(/5.0000KB\/s/)).toBeVisible();
+    expect(screen.getByText(/10.0000KB\/s/)).toBeVisible();
+  });
+});
+
+describe("WorkerRow", () => {
+  it("renders", async () => {
+    const node: NodeDetail = {
+      hostname: "test-hostname",
+      ip: "192.168.0.1",
+      cpu: 15,
+      mem: [100, 95, 5],
+      disk: {
+        "/": {
+          used: 20000000,
+          total: 200000000,
+          free: 180000000,
+          percent: 10,
+        },
+        "/tmp": {
+          used: 0,
+          total: 200,
+          free: 200,
+          percent: 0,
+        },
+      },
+      networkSpeed: [5, 10],
+      raylet: {
+        state: "ALIVE",
+        nodeId: "1234567890ab",
+        isHeadNode: true,
+        numWorkers: 0,
+        pid: 2345,
+        startTime: 100,
+        terminateTime: -1,
+        brpcPort: 3456,
+        nodeManagerPort: 5890,
+        objectStoreAvailableMemory: 40,
+        objectStoreUsedMemory: 10,
+      },
+      logUrl: "http://192.16.0.1/logs",
+    } as NodeDetail;
+
+    const worker: Worker = {
+      cmdline: ["echo hi"],
+      pid: 3456,
+      cpuPercent: 14,
+      memoryInfo: {
+        rss: 75,
+        vms: 0,
+        pageins: 0,
+        pfaults: 0,
+      },
+      coreWorkerStats: [
+        {
+          workerId: "worker-12345",
+        } as CoreWorkerStats,
+      ],
+    } as Worker;
+
+    render(<WorkerRow node={node} worker={worker} />, {
+      wrapper: ({ children }) => (
+        <MemoryRouter>
+          <table>
+            <tbody>{children}</tbody>
+          </table>
+        </MemoryRouter>
+      ),
+    });
+
+    await screen.findByText("echo hi");
+    expect(screen.getByText(/ALIVE/)).toBeVisible();
+    expect(screen.getByText(/worker-12345/)).toBeVisible();
+    expect(screen.getByText(/3456/)).toBeVisible();
+    // CPU Usage
+    expect(screen.getByText(/14%/)).toBeVisible();
+    // Memory Usage
+    expect(screen.getByText(/75\.0000KB\/100\.0000KB\(75\.0%\)/)).toBeVisible();
+  });
+});

--- a/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.tsx
@@ -40,7 +40,7 @@ type NodeRowProps = Pick<NodeRowsProps, "node"> & {
  * A single row that represents the node information only.
  * Does not show any data about the node's workers.
  */
-const NodeRow = ({
+export const NodeRow = ({
   node,
   expanded,
   onExpandButtonClick,
@@ -170,7 +170,7 @@ type WorkerRowProps = {
 /**
  * A single row that represents the data of a Worker
  */
-const WorkerRow = ({ node, worker, newIA = false }: WorkerRowProps) => {
+export const WorkerRow = ({ node, worker, newIA = false }: WorkerRowProps) => {
   const classes = rowStyles();
 
   const { ip, mem, logUrl } = node;

--- a/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.tsx
@@ -133,7 +133,10 @@ const NodeRow = ({
           >
             {memoryConverter(raylet.objectStoreUsedMemory)}/
             {memoryConverter(objectStoreTotalMemory)}(
-            {(raylet.objectStoreUsedMemory / objectStoreTotalMemory).toFixed(2)}
+            {(
+              (raylet.objectStoreUsedMemory / objectStoreTotalMemory) *
+              100
+            ).toFixed(1)}
             %)
           </PercentageBar>
         )}
@@ -236,7 +239,7 @@ const WorkerRow = ({ node, worker, newIA = false }: WorkerRowProps) => {
         {mem && (
           <PercentageBar num={memoryInfo.rss} total={mem[0]}>
             {memoryConverter(memoryInfo.rss)}/{memoryConverter(mem[0])}(
-            {(memoryInfo.rss / mem[0]).toFixed(1)}
+            {((memoryInfo.rss / mem[0]) * 100).toFixed(1)}
             %)
           </PercentageBar>
         )}


### PR DESCRIPTION
Signed-off-by: Alan Guo <aguo@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There was a bug previously where the the percentage value text was printed incorrectly.
Before: `10/100 (.1%)`
After: `10/100 (10.0%)`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
