### PR TITLE
[Core] Do not print the stacktrace when the worker exits due to GCS termination. 

### DIFF
--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -543,10 +543,18 @@ class GcsRpcClient {
       if (!gcs_is_down_) {
         gcs_is_down_ = true;
       } else {
-        RAY_CHECK(absl::ToInt64Seconds(absl::Now() - gcs_last_alive_time_) <
-                  ::RayConfig::instance().gcs_rpc_server_reconnect_timeout_s())
-            << "Failed to connect to GCS within "
-            << ::RayConfig::instance().gcs_rpc_server_reconnect_timeout_s() << " seconds";
+        if (absl::ToInt64Seconds(absl::Now() - gcs_last_alive_time_) >=
+                  ::RayConfig::instance().gcs_rpc_server_reconnect_timeout_s()) {
+            RAY_LOG(ERROR)
+              << "Failed to connect to GCS within "
+              << ::RayConfig::instance().gcs_rpc_server_reconnect_timeout_s() << " seconds. "
+              << "GCS may have been killed. It's either GCS is terminated by `ray stop` or "
+              << "is killed unexpectedly. If it is killed unexpectedly, "
+              << "see the log file gcs_server.out. "
+              << "https://docs.ray.io/en/master/ray-observability/ray-logging.html#logging-directory-structure. "
+              << "The program will terminate.";
+            std::_Exit(EXIT_FAILURE);
+        }
       }
       break;
     case GRPC_CHANNEL_SHUTDOWN:

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -544,16 +544,18 @@ class GcsRpcClient {
         gcs_is_down_ = true;
       } else {
         if (absl::ToInt64Seconds(absl::Now() - gcs_last_alive_time_) >=
-                  ::RayConfig::instance().gcs_rpc_server_reconnect_timeout_s()) {
-            RAY_LOG(ERROR)
-              << "Failed to connect to GCS within "
-              << ::RayConfig::instance().gcs_rpc_server_reconnect_timeout_s() << " seconds. "
-              << "GCS may have been killed. It's either GCS is terminated by `ray stop` or "
-              << "is killed unexpectedly. If it is killed unexpectedly, "
-              << "see the log file gcs_server.out. "
-              << "https://docs.ray.io/en/master/ray-observability/ray-logging.html#logging-directory-structure. "
-              << "The program will terminate.";
-            std::_Exit(EXIT_FAILURE);
+            ::RayConfig::instance().gcs_rpc_server_reconnect_timeout_s()) {
+          RAY_LOG(ERROR) << "Failed to connect to GCS within "
+                         << ::RayConfig::instance().gcs_rpc_server_reconnect_timeout_s()
+                         << " seconds. "
+                         << "GCS may have been killed. It's either GCS is terminated by "
+                            "`ray stop` or "
+                         << "is killed unexpectedly. If it is killed unexpectedly, "
+                         << "see the log file gcs_server.out. "
+                         << "https://docs.ray.io/en/master/ray-observability/"
+                            "ray-logging.html#logging-directory-structure. "
+                         << "The program will terminate.";
+          std::_Exit(EXIT_FAILURE);
         }
       }
       break;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Right now, the error message upon GCS termination is scary because it includes cpp stacktrace. This PR fixes the issue by just printing the clearer error message and exit the process using std::_Exit

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
