### PR TITLE
[tune] Add hook to get project/group for W&B integration

### DIFF
--- a/doc/source/tune/examples/tune-wandb.ipynb
+++ b/doc/source/tune/examples/tune-wandb.ipynb
@@ -770,7 +770,7 @@
     "   :noindex:\n",
     "```\n",
     "\n",
-    "### Wandb-Mixin\n",
+    "### setup_wandb\n",
     "\n",
     "(air-wandb-setup)=\n",
     "\n",

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1744,5 +1744,7 @@ def wandb_populate_run_location_hook():
     Example external hook to populate W&B project and group env vars in
     WandbIntegrationTest.testWandbLoggerConfig
     """
-    os.environ["WANDB_PROJECT_NAME"] = "test_project"
-    os.environ["WANDB_GROUP_NAME"] = "test_group"
+    from ray.air.integrations.wandb import WANDB_GROUP_ENV_VAR, WANDB_PROJECT_ENV_VAR
+
+    os.environ[WANDB_PROJECT_ENV_VAR] = "test_project"
+    os.environ[WANDB_GROUP_ENV_VAR] = "test_group"

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -39,6 +39,7 @@ from ray._private.gcs_pubsub import GcsErrorSubscriber, GcsLogSubscriber
 from ray._private.internal_api import memory_summary
 from ray._private.tls_utils import generate_self_signed_tls_certs
 from ray._raylet import GcsClientOptions, GlobalStateAccessor
+from ray.air.integrations.wandb import WANDB_GROUP_ENV_VAR, WANDB_PROJECT_ENV_VAR
 from ray.core.generated import gcs_pb2, node_manager_pb2, node_manager_pb2_grpc
 from ray.scripts.scripts import main as ray_main
 from ray.util.queue import Empty, Queue, _QueueActor
@@ -1737,3 +1738,12 @@ def get_gcs_memory_used():
     }
     assert "gcs_server" in m
     return sum(m.values())
+
+
+def wandb_populate_run_location_hook():
+    """
+    Example external hook to populate W&B project and group env vars in
+    WandbIntegrationTest.testWandbLoggerConfig
+    """
+    os.environ[WANDB_PROJECT_ENV_VAR] = "test_project"
+    os.environ[WANDB_GROUP_ENV_VAR] = "test_group"

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -39,7 +39,6 @@ from ray._private.gcs_pubsub import GcsErrorSubscriber, GcsLogSubscriber
 from ray._private.internal_api import memory_summary
 from ray._private.tls_utils import generate_self_signed_tls_certs
 from ray._raylet import GcsClientOptions, GlobalStateAccessor
-from ray.air.integrations.wandb import WANDB_GROUP_ENV_VAR, WANDB_PROJECT_ENV_VAR
 from ray.core.generated import gcs_pb2, node_manager_pb2, node_manager_pb2_grpc
 from ray.scripts.scripts import main as ray_main
 from ray.util.queue import Empty, Queue, _QueueActor
@@ -1745,5 +1744,5 @@ def wandb_populate_run_location_hook():
     Example external hook to populate W&B project and group env vars in
     WandbIntegrationTest.testWandbLoggerConfig
     """
-    os.environ[WANDB_PROJECT_ENV_VAR] = "test_project"
-    os.environ[WANDB_GROUP_ENV_VAR] = "test_group"
+    os.environ["WANDB_PROJECT_NAME"] = "test_project"
+    os.environ["WANDB_GROUP_NAME"] = "test_group"

--- a/python/ray/tune/tests/test_integration_wandb.py
+++ b/python/ray/tune/tests/test_integration_wandb.py
@@ -28,6 +28,7 @@ from ray.air.integrations.wandb import (
 from ray.air.integrations.wandb import (
     WANDB_ENV_VAR,
     WANDB_GROUP_ENV_VAR,
+    WANDB_POPULATE_RUN_LOCATION_HOOK,
     WANDB_PROJECT_ENV_VAR,
     WANDB_SETUP_API_KEY_HOOK,
 )
@@ -221,6 +222,22 @@ class TestWandbLogger:
         logger = WandbTestExperimentLogger(project="test_project")
         logger.setup()
         assert os.environ[WANDB_ENV_VAR] == "abcd"
+
+    def test_wandb_logger_run_location_external_hook(self, monkeypatch):
+        # No project
+        with pytest.raises(ValueError):
+            logger = WandbTestExperimentLogger(api_key="1234")
+            logger.setup()
+
+        # Project and group env vars from external hook
+        monkeypatch.setenv(
+            WANDB_POPULATE_RUN_LOCATION_HOOK,
+            "ray._private.test_utils.wandb_populate_run_location_hook",
+        )
+        logger = WandbTestExperimentLogger(api_key="1234")
+        logger.setup()
+        assert os.environ[WANDB_PROJECT_ENV_VAR] == "test_project"
+        assert os.environ[WANDB_GROUP_ENV_VAR] == "test_group"
 
     def test_wandb_logger_start(self, monkeypatch, trial):
         monkeypatch.setenv(WANDB_ENV_VAR, "9012")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Allow setting the W&B project and group environment variables from an external hook if it is not already passed to the `WandbLoggerCallback` and `setup_wandb`
- Add remaining external hooks to `setup_wandb`
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
