### PR TITLE
[core] fix gcs_pubsub flakiness

### DIFF
--- a/python/ray/tests/test_gcs_pubsub.py
+++ b/python/ray/tests/test_gcs_pubsub.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 import threading
+import re
 
 from ray._private.gcs_pubsub import (
     GcsPublisher,
@@ -187,10 +188,13 @@ def test_two_subscribers(ray_start_regular):
     # Make sure subscription is registered before publishing starts.
     log_subscriber.subscribe()
 
+    log_str_pattern = re.compile("^log ([0-9]+)$")
+
     def receive_logs():
         while len(logs) < num_messages:
             log_batch = log_subscriber.poll()
-            logs.append(log_batch)
+            if log_str_pattern.match(log_batch["lines"][0]):
+                logs.append(log_batch)
 
     t2 = threading.Thread(target=receive_logs)
     t2.start()


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

fix test flakiness. The log subscriber could get logs of cluster startup, but the test assumes it does not see any of that.

Verifies this fixes the flakiness by running it 100 times (before that it would fail on every few runs)

## Related issue number

https://github.com/ray-project/ray/issues/31043

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
