### PR TITLE
[Tune] Improve trainable serialization error

### DIFF
--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -382,6 +382,18 @@ def test_tuner_fn_trainable_checkpoint_at_end_none(shutdown_only):
     tuner.fit()
 
 
+def test_nonserializable_trainable(capsys):
+    import threading
+
+    lock = threading.Lock()
+    with pytest.raises(TypeError):
+        Tuner(lambda config: print(lock))
+
+    # Check that the `inspect_serializability` trace was printed
+    out, _ = capsys.readouterr()
+    assert "was found to be non-serializable." in out
+
+
 @pytest.mark.parametrize("runtime_env", [{}, {"working_dir": "."}])
 def test_tuner_no_chdir_to_trial_dir(shutdown_only, chdir_tmpdir, runtime_env):
     """Tests that setting `chdir_to_trial_dir=False` in `TuneConfig` allows for


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Improves the error message when Tune tries to serialize a non-serializable trainable to: 1) explain why serializability is a requirement for the trainable, and 2) provide the `inspect_serializability` trace to help debugging what needs to be fixed for the trainable to be serializable.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
When Tune pickles the trainable on Tuner initialization, the error message is not very descriptive: `TypeError: Cannot pickle X object.`.

### Example

```python
from ray import tune
import threading

lock = threading.Lock()
tuner = tune.Tuner(lambda config: print(lock))
```

```
==========================================================
Checking Serializability of <function test at 0x1035a11f0>
==========================================================
!!! FAIL serialization: cannot pickle '_thread.lock' object
Detected 1 global variables. Checking serializability...
    Serializing 'lock' <unlocked _thread.lock object at 0x1035c6cf0>...
    !!! FAIL serialization: cannot pickle '_thread.lock' object
    WARNING: Did not find non-serializable object in <unlocked _thread.lock object at 0x1035c6cf0>. This may be an oversight.
==========================================================
Variable:

        FailTuple(lock [obj=<unlocked _thread.lock object at 0x1035c6cf0>, parent=<function test at 0x1035a11f0>])

was found to be non-serializable. There may be multiple other undetected variables that were non-serializable.
Consider either removing the instantiation/imports of these variables or moving the instantiation into the scope of the function/class.
If you have any suggestions on how to improve this error message, please reach out to the Ray developers on github.com/ray-project/ray/issues/
==========================================================
Traceback (most recent call last):
  File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/impl/tuner_internal.py", line 133, in __init__
    pickle.dump(self.trainable, fp)
  File "/Users/justin/Developer/justinvyu-dev/python/ray/cloudpickle/cloudpickle_fast.py", line 55, in dump
    CloudPickler(
  File "/Users/justin/Developer/justinvyu-dev/python/ray/cloudpickle/cloudpickle_fast.py", line 627, in dump
    return Pickler.dump(self, obj)
TypeError: cannot pickle '_thread.lock' object

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "test/nonserializable_error.py", line 10, in <module>
    tuner = tune.Tuner(test)
  File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/tuner.py", line 152, in __init__
    self._local_tuner = TunerInternal(**kwargs)
  File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/impl/tuner_internal.py", line 142, in __init__
    raise TypeError(msg) from e
TypeError: The provided trainable is not serializable, which is a requirement since the trainable is serialized and deserialized when transferred to remote workers. See above for a trace of the non-serializable objects that were found in your trainable.
```

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/31059

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
