### PR TITLE
[RLlib] Better behavior if user does not specify stopping condition in RLLib CLI

### DIFF
--- a/rllib/common.py
+++ b/rllib/common.py
@@ -11,6 +11,8 @@ import requests
 from ray.tune.experiment.config_parser import _make_parser
 from ray.tune.result import DEFAULT_RESULTS_DIR
 
+STOP_ARG_NAMES = ["--stop", "-s"]
+
 
 class FrameworkEnum(str, Enum):
     """Supported frameworks for RLlib, used for CLI argument validation."""
@@ -216,7 +218,7 @@ class CLIArguments:
 
     # Train arguments
     # __cli_train_start__
-    Stop = typer.Option(None, "--stop", "-s", help=get_help("stop"))
+    Stop = typer.Option(None, *STOP_ARG_NAMES, help=get_help("stop"))
     ExperimentName = typer.Option(
         "default", "--experiment-name", "-n", help=train_help.get("experiment_name")
     )

--- a/rllib/common.py
+++ b/rllib/common.py
@@ -11,8 +11,6 @@ import requests
 from ray.tune.experiment.config_parser import _make_parser
 from ray.tune.result import DEFAULT_RESULTS_DIR
 
-STOP_ARG_NAMES = ["--stop", "-s"]
-
 
 class FrameworkEnum(str, Enum):
     """Supported frameworks for RLlib, used for CLI argument validation."""
@@ -218,7 +216,7 @@ class CLIArguments:
 
     # Train arguments
     # __cli_train_start__
-    Stop = typer.Option(None, *STOP_ARG_NAMES, help=get_help("stop"))
+    Stop = typer.Option("{}", "--stop", "-s", help=get_help("stop"))
     ExperimentName = typer.Option(
         "default", "--experiment-name", "-n", help=train_help.get("experiment_name")
     )

--- a/rllib/train.py
+++ b/rllib/train.py
@@ -14,7 +14,7 @@ from ray.tune.tune import run_experiments
 from ray.tune.schedulers import create_scheduler
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
 from ray.rllib.common import CLIArguments as cli
-from ray.rllib.common import FrameworkEnum, SupportedFileType
+from ray.rllib.common import FrameworkEnum, SupportedFileType, STOP_ARG_NAMES
 from ray.rllib.common import download_example_file, get_file_type
 
 
@@ -266,6 +266,15 @@ def run(
         config = json.loads(config)
         resources_per_trial = json_to_resources(resources_per_trial)
 
+        if stop is None:
+            print(
+                "\nNo stopping condition set. You can set one by specifying {"
+                "}.".format(STOP_ARG_NAMES[0])
+            )
+            stop = {}
+        else:
+            stop = json.loads(stop)
+
         # Load a single experiment from configuration
         experiments = {
             experiment_name: {  # i.e. log to ~/ray_results/default
@@ -280,7 +289,7 @@ def run(
                 "resources_per_trial": (
                     resources_per_trial and resources_to_json(resources_per_trial)
                 ),
-                "stop": json.loads(stop),
+                "stop": stop,
                 "config": dict(config, env=env),
                 "restore": restore,
                 "num_samples": num_samples,

--- a/rllib/train.py
+++ b/rllib/train.py
@@ -14,7 +14,7 @@ from ray.tune.tune import run_experiments
 from ray.tune.schedulers import create_scheduler
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
 from ray.rllib.common import CLIArguments as cli
-from ray.rllib.common import FrameworkEnum, SupportedFileType, STOP_ARG_NAMES
+from ray.rllib.common import FrameworkEnum, SupportedFileType
 from ray.rllib.common import download_example_file, get_file_type
 
 
@@ -266,15 +266,6 @@ def run(
         config = json.loads(config)
         resources_per_trial = json_to_resources(resources_per_trial)
 
-        if stop is None:
-            print(
-                "\nNo stopping condition set. You can set one by specifying {"
-                "}.".format(STOP_ARG_NAMES[0])
-            )
-            stop = {}
-        else:
-            stop = json.loads(stop)
-
         # Load a single experiment from configuration
         experiments = {
             experiment_name: {  # i.e. log to ~/ray_results/default
@@ -289,7 +280,7 @@ def run(
                 "resources_per_trial": (
                     resources_per_trial and resources_to_json(resources_per_trial)
                 ),
-                "stop": stop,
+                "stop": json.loads(stop),
                 "config": dict(config, env=env),
                 "restore": restore,
                 "num_samples": num_samples,


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

We have lots of examples inside RLlib of running ray CLI similar to `rllib train --env ... --config ...` that lack a stopping condition.
They error out with the following message.

<img width="705" alt="Screenshot 2022-12-13 at 23 06 18" src="https://user-images.githubusercontent.com/9356806/207454214-f86af816-5406-4dc8-b5e7-cec9e3aafdd0.png">

We should not error out, since a workflow to be expected from us is to quickly start an experiment from CLI, observe it and cancel it manually without caring for stopping condidations.

## Related issue number

https://discuss.ray.io/t/problem-with-rllib-configuration-by-command-line/8624

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
