### PR TITLE
[Train] Force `GBDTTrainer` to use distributed loading for Ray Datasets

### DIFF
--- a/python/ray/train/gbdt_trainer.py
+++ b/python/ray/train/gbdt_trainer.py
@@ -158,8 +158,10 @@ class GBDTTrainer(BaseTrainer):
     ):
         self.label_column = label_column
         self.params = params
-        self.dmatrix_params = dmatrix_params or {}
+
         self.train_kwargs = train_kwargs
+        self.dmatrix_params = dmatrix_params or {}
+
         super().__init__(
             scaling_config=scaling_config,
             run_config=run_config,
@@ -167,6 +169,12 @@ class GBDTTrainer(BaseTrainer):
             preprocessor=preprocessor,
             resume_from_checkpoint=resume_from_checkpoint,
         )
+
+        # Ray Datasets should always use distributed loading.
+        for dataset_name in self.datasets.keys():
+            dataset_params = self.dmatrix_params.get(dataset_name, {})
+            dataset_params["distributed"] = True
+            self.dmatrix_params[dataset_name] = dataset_params
 
     def _validate_attributes(self):
         super()._validate_attributes()


### PR DESCRIPTION
Signed-off-by: amogkam <amogkamsetty@yahoo.com>

Closes https://github.com/ray-project/ray/issues/31068

`xgboost_ray` has 2 modes for data loading:
1. A centralized mode where the driver first loads in all the data and then partitions it for the remote training actors to load.
2. A distributed mode where the remote training actors load in the data partitions directly.

When using Ray Datasets with `xgboost_ray`, we should always do distributed data loading (option 2). However, this is no longer the case after https://github.com/ray-project/ray/pull/30575 is merged.

https://github.com/ray-project/ray/pull/30575 adds an `__iter__` method to Ray Datasets causing `isinstance(dataset, Iterable)` to return True. 

This causes Ray Dataset inputs to enter this if statement: https://github.com/ray-project/xgboost_ray/blob/v0.1.12/xgboost_ray/matrix.py#L943-L949, causing `xgboost-ray` to think that Ray Datasets are not distributed and therefore going with option 1 for loading.

This centralized loading leads to excessive object spilling and ultimately crashes large scale xgboost training.

In this PR, we force distributed data loading when using the AIR GBDTTrainers. 

In a follow up, we should clean up the distributed detection logic directly in xgboost-ray, removing input formats that are no longer supported, and then do a new release.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
