### PR TITLE
[Draft] [Core] Prefetching objects in `ray.wait`, while only blocking on `num_returns` objects.

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -729,4 +729,4 @@ RAY_CONFIG(bool, raylet_core_dump_exclude_plasma_store, true)
 
 RAY_CONFIG(bool, core_worker_use_old_path, true)
 RAY_CONFIG(int64_t, core_worker_new_path, 0)
-RAY_CONFIG(bool, core_worker_prefetch_waits, false)
+RAY_CONFIG(bool, core_worker_prefetch_waits, true)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -729,3 +729,4 @@ RAY_CONFIG(bool, raylet_core_dump_exclude_plasma_store, true)
 
 RAY_CONFIG(bool, core_worker_use_old_path, true)
 RAY_CONFIG(int64_t, core_worker_new_path, 0)
+RAY_CONFIG(bool, core_worker_prefetch_waits, false)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -727,6 +727,5 @@ RAY_CONFIG(int64_t, health_check_failure_threshold, 5)
 RAY_CONFIG(bool, worker_core_dump_exclude_plasma_store, true)
 RAY_CONFIG(bool, raylet_core_dump_exclude_plasma_store, true)
 
-RAY_CONFIG(bool, core_worker_use_old_path, true)
 RAY_CONFIG(int64_t, core_worker_new_path, 0)
-RAY_CONFIG(bool, core_worker_prefetch_waits, true)
+RAY_CONFIG(int64_t, core_worker_metrics_to_print, 0)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -728,3 +728,4 @@ RAY_CONFIG(bool, worker_core_dump_exclude_plasma_store, true)
 RAY_CONFIG(bool, raylet_core_dump_exclude_plasma_store, true)
 
 RAY_CONFIG(bool, core_worker_use_old_path, true)
+RAY_CONFIG(int64_t, core_worker_new_path, 0)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -726,3 +726,5 @@ RAY_CONFIG(int64_t, health_check_failure_threshold, 5)
 /// the mapped plasma pages.
 RAY_CONFIG(bool, worker_core_dump_exclude_plasma_store, true)
 RAY_CONFIG(bool, raylet_core_dump_exclude_plasma_store, true)
+
+RAY_CONFIG(bool, core_worker_use_old_path, true)

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1339,7 +1339,8 @@ Status CoreWorker::Wait(const std::vector<ObjectID> &ids,
         "Number of objects to wait for must be between 1 and the number of ids.");
   }
 
-  absl::flat_hash_set<ObjectID> plasma_object_ids;
+  //absl::flat_hash_set<ObjectID> plasma_object_ids;
+  absl::flat_hash_set<ObjectID> plasma_object_ids(ids.begin(), ids.end());
   absl::flat_hash_set<ObjectID> memory_object_ids(ids.begin(), ids.end());
 
   if (memory_object_ids.size() != ids.size()) {
@@ -1375,19 +1376,21 @@ Status CoreWorker::Wait(const std::vector<ObjectID> &ids,
     }
 
     if (RayConfig::instance().core_worker_prefetch_waits()
-        && ids.size() > (9 * 1000)
-        && first_time_prefetch_
+        //&& ids.size() > (9 * 1000)
+        //&& first_time_prefetch_
         ) {
         // I might have to batch these if this is too large.
-        RAY_RETURN_NOT_OK(plasma_store_provider_->FetchFromPlasmaStore(
-            ids,
-            /*in_direct_call*/ worker_context_.CurrentTaskIsDirectCall(),
-            /*task_id*/ worker_context_.GetCurrentTaskID()
-        ));
+        //RAY_RETURN_NOT_OK(plasma_store_provider_->FetchFromPlasmaStore(
+        //    ids,
+        //    /*in_direct_call*/ worker_context_.CurrentTaskIsDirectCall(),
+        //    /*task_id*/ worker_context_.GetCurrentTaskID()
+        //));
+        RAY_LOG(WARNING) << "FetchFromPlasmaStore called first_time_prefetch_: " << first_time_prefetch_ << ", ids.size: " << ids.size() << ", core_worker_prefetch_waits: " << RayConfig::instance().core_worker_prefetch_waits()
+            << ", core_worker_new_path: " << RayConfig::instance().core_worker_new_path() << ", core_worker_use_old_path: " << RayConfig::instance().core_worker_use_old_path();
         first_time_prefetch_ = false;
-        RAY_LOG(WARNING) << "FetchFromPlasmaStore called first_time_prefetch_: " << first_time_prefetch_ << ", ids.size: " << ids.size() << ", core_worker_prefetch_waits: " << RayConfig::instance().core_worker_prefetch_waits();
     } else {
-        RAY_LOG(WARNING) << "FetchFromPlasmaStore skipped first_time_prefetch_: " << first_time_prefetch_ << ", ids.size: " << ids.size() << ", core_worker_prefetch_waits: " << RayConfig::instance().core_worker_prefetch_waits();
+        RAY_LOG(WARNING) << "FetchFromPlasmaStore skipped first_time_prefetch_: " << first_time_prefetch_ << ", ids.size: " << ids.size() << ", core_worker_prefetch_waits: " << RayConfig::instance().core_worker_prefetch_waits()
+            << ", core_worker_new_path: " << RayConfig::instance().core_worker_new_path() << ", core_worker_use_old_path: " << RayConfig::instance().core_worker_use_old_path();
     }
 
     if (static_cast<int>(ready.size()) < num_objects && plasma_object_ids.size() > 0) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1375,7 +1375,7 @@ Status CoreWorker::Wait(const std::vector<ObjectID> &ids,
     }
 
     if (RayConfig::instance().core_worker_prefetch_waits()
-        && ids.size() == 10 * 1000
+        && ids.size() > (9 * 1000)
         && first_time_prefetch_
         ) {
         // I might have to batch these if this is too large.
@@ -1385,6 +1385,9 @@ Status CoreWorker::Wait(const std::vector<ObjectID> &ids,
             /*task_id*/ worker_context_.GetCurrentTaskID()
         ));
         first_time_prefetch_ = false;
+        RAY_LOG(WARNING) << "FetchFromPlasmaStore called first_time_prefetch_: " << first_time_prefetch_ << ", ids.size: " << ids.size() << ", core_worker_prefetch_waits: " << RayConfig::instance().core_worker_prefetch_waits();
+    } else {
+        RAY_LOG(WARNING) << "FetchFromPlasmaStore skipped first_time_prefetch_: " << first_time_prefetch_ << ", ids.size: " << ids.size() << ", core_worker_prefetch_waits: " << RayConfig::instance().core_worker_prefetch_waits();
     }
 
     if (static_cast<int>(ready.size()) < num_objects && plasma_object_ids.size() > 0) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1259,12 +1259,32 @@ void RetryObjectInPlasmaErrors(std::shared_ptr<CoreWorkerMemoryStore> &memory_st
   for (auto iter = memory_object_ids.begin(); iter != memory_object_ids.end();) {
     auto current = iter++;
     const auto &mem_id = *current;
-    auto found = memory_store->GetIfExists(mem_id);
-    if (found != nullptr && found->IsInPlasmaError()) {
-      plasma_object_ids.insert(mem_id);
-      ready.erase(mem_id);
-      memory_object_ids.erase(current);
+    
+    if (RayConfig::instance().core_worker_use_old_path()) {
+      auto ready_iter = ready.find(mem_id);
+      if (ready_iter != ready.end()) {
+        std::vector<std::shared_ptr<RayObject>> found;
+        RAY_CHECK_OK(memory_store->Get({mem_id},
+                                       /*num_objects=*/1,
+                                       /*timeout=*/0,
+                                       worker_context,
+                                       /*remote_after_get=*/false,
+                                       &found));
+        if (found.size() == 1 && found[0]->IsInPlasmaError()) {
+          plasma_object_ids.insert(mem_id);
+          ready.erase(ready_iter);
+          memory_object_ids.erase(current);
+        }
+      }
+    } else {
+      auto found = memory_store->GetIfExists(mem_id);
+      if (found != nullptr && found->IsInPlasmaError()) {
+        plasma_object_ids.insert(mem_id);
+        ready.erase(mem_id);
+        memory_object_ids.erase(current);
+      }
     }
+
   }
 }
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1035,7 +1035,6 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   std::unordered_map<std::string, std::vector<int64_t>> GetActorCallStats() const;
 
  private:
-
   bool first_time_prefetch_;
 
   static json OverrideRuntimeEnv(json &child, const std::shared_ptr<json> parent);

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1035,6 +1035,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   std::unordered_map<std::string, std::vector<int64_t>> GetActorCallStats() const;
 
  private:
+
+  bool first_time_prefetch_;
+
   static json OverrideRuntimeEnv(json &child, const std::shared_ptr<json> parent);
 
   /// The following tests will use `OverrideRuntimeEnv` function.

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -199,26 +199,24 @@ std::shared_ptr<RayObject> CoreWorkerMemoryStore::GetIfExists(const ObjectID &ob
 void CoreWorkerMemoryStore::GetIfExistsBatch(
     absl::flat_hash_set<ObjectID> &memory_object_ids,
     absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>> &existing) {
-
   {
     absl::MutexLock lock(&mu_);
 
     for (auto iter = memory_object_ids.begin(); iter != memory_object_ids.end();) {
-        auto current = iter++;
-        const auto &mem_id = *current;
+      auto current = iter++;
+      const auto &mem_id = *current;
 
-        auto iter_obj = objects_.find(mem_id);
-        if (iter_obj == objects_.end()) {
-          continue;
-        }
+      auto iter_obj = objects_.find(mem_id);
+      if (iter_obj == objects_.end()) {
+        continue;
+      }
 
-        std::shared_ptr<RayObject> ptr = iter_obj->second;
+      std::shared_ptr<RayObject> ptr = iter_obj->second;
 
-        if (ptr != nullptr) {
-          ptr->SetAccessed();
-          existing.emplace(mem_id, ptr);
-        }
-
+      if (ptr != nullptr) {
+        ptr->SetAccessed();
+        existing.emplace(mem_id, ptr);
+      }
     }
   }
 }

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -196,6 +196,33 @@ std::shared_ptr<RayObject> CoreWorkerMemoryStore::GetIfExists(const ObjectID &ob
   return ptr;
 }
 
+void CoreWorkerMemoryStore::GetIfExistsBatch(
+    absl::flat_hash_set<ObjectID> &memory_object_ids,
+    absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>> &existing) {
+
+  {
+    absl::MutexLock lock(&mu_);
+
+    for (auto iter = memory_object_ids.begin(); iter != memory_object_ids.end();) {
+        auto current = iter++;
+        const auto &mem_id = *current;
+
+        auto iter_obj = objects_.find(mem_id);
+        if (iter_obj == objects_.end()) {
+          continue;
+        }
+
+        std::shared_ptr<RayObject> ptr = iter_obj->second;
+
+        if (ptr != nullptr) {
+          ptr->SetAccessed();
+          existing.emplace(mem_id, ptr);
+        }
+
+    }
+  }
+}
+
 bool CoreWorkerMemoryStore::Put(const RayObject &object, const ObjectID &object_id) {
   std::vector<std::function<void(std::shared_ptr<RayObject>)>> async_callbacks;
   RAY_LOG(DEBUG) << "Putting object into memory store. objectid is " << object_id;

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -102,7 +102,9 @@ class CoreWorkerMemoryStore {
   /// \return Pointer to the object if it exists, otherwise nullptr.
   std::shared_ptr<RayObject> GetIfExists(const ObjectID &object_id);
 
-  void GetIfExistsBatch(absl::flat_hash_set<ObjectID> &memory_object_ids, absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>> &existing);
+  void GetIfExistsBatch(
+      absl::flat_hash_set<ObjectID> &memory_object_ids,
+      absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>> &existing);
 
   /// Asynchronously get an object from the object store. The object will not be removed
   /// from storage after GetAsync (TODO(ekl): integrate this with object GC).

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -102,6 +102,8 @@ class CoreWorkerMemoryStore {
   /// \return Pointer to the object if it exists, otherwise nullptr.
   std::shared_ptr<RayObject> GetIfExists(const ObjectID &object_id);
 
+  void GetIfExistsBatch(absl::flat_hash_set<ObjectID> &memory_object_ids, absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>> &existing);
+
   /// Asynchronously get an object from the object store. The object will not be removed
   /// from storage after GetAsync (TODO(ekl): integrate this with object GC).
   ///

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -161,16 +161,17 @@ Status CoreWorkerPlasmaStoreProvider::Release(const ObjectID &object_id) {
   return store_client_.Release(object_id);
 }
 
-Status CoreWorkerPlasmaStoreProvider::FetchFromPlasmaStore(const std::vector<ObjectID> &batch_ids, bool in_direct_call, const TaskID &task_id) {
-    const auto owner_addresses = reference_counter_->GetOwnerAddresses(batch_ids);
-    RAY_RETURN_NOT_OK(
-        raylet_client_->FetchOrReconstruct(batch_ids,
-                                           owner_addresses,
-                                           /*fetch_only*/true,
-                                           /*mark_worker_blocked*/ !in_direct_call,
-                                           task_id));
+Status CoreWorkerPlasmaStoreProvider::FetchFromPlasmaStore(
+    const std::vector<ObjectID> &batch_ids, bool in_direct_call, const TaskID &task_id) {
+  const auto owner_addresses = reference_counter_->GetOwnerAddresses(batch_ids);
+  RAY_RETURN_NOT_OK(
+      raylet_client_->FetchOrReconstruct(batch_ids,
+                                         owner_addresses,
+                                         /*fetch_only*/ true,
+                                         /*mark_worker_blocked*/ !in_direct_call,
+                                         task_id));
 
-    return Status::OK();
+  return Status::OK();
 }
 
 Status CoreWorkerPlasmaStoreProvider::FetchAndGetFromPlasmaStore(

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -161,6 +161,18 @@ Status CoreWorkerPlasmaStoreProvider::Release(const ObjectID &object_id) {
   return store_client_.Release(object_id);
 }
 
+Status CoreWorkerPlasmaStoreProvider::FetchFromPlasmaStore(const std::vector<ObjectID> &batch_ids, bool in_direct_call, const TaskID &task_id) {
+    const auto owner_addresses = reference_counter_->GetOwnerAddresses(batch_ids);
+    RAY_RETURN_NOT_OK(
+        raylet_client_->FetchOrReconstruct(batch_ids,
+                                           owner_addresses,
+                                           /*fetch_only*/true,
+                                           /*mark_worker_blocked*/ !in_direct_call,
+                                           task_id));
+
+    return Status::OK();
+}
+
 Status CoreWorkerPlasmaStoreProvider::FetchAndGetFromPlasmaStore(
     absl::flat_hash_set<ObjectID> &remaining,
     const std::vector<ObjectID> &batch_ids,

--- a/src/ray/core_worker/store_provider/plasma_store_provider.h
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.h
@@ -180,6 +180,8 @@ class CoreWorkerPlasmaStoreProvider {
 
   std::string MemoryUsageString();
 
+  Status FetchFromPlasmaStore(const std::vector<ObjectID> &batch_ids, bool in_direct_call, const TaskID &task_id);
+
  private:
   /// Ask the raylet to fetch a set of objects and then attempt to get them
   /// from the local plasma store. Successfully fetched objects will be removed

--- a/src/ray/core_worker/store_provider/plasma_store_provider.h
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.h
@@ -180,7 +180,9 @@ class CoreWorkerPlasmaStoreProvider {
 
   std::string MemoryUsageString();
 
-  Status FetchFromPlasmaStore(const std::vector<ObjectID> &batch_ids, bool in_direct_call, const TaskID &task_id);
+  Status FetchFromPlasmaStore(const std::vector<ObjectID> &batch_ids,
+                              bool in_direct_call,
+                              const TaskID &task_id);
 
  private:
   /// Ask the raylet to fetch a set of objects and then attempt to get them


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/ray-project/ray/pull/30724

This PR needs cleaning up but I validated that it fixes the issue:
```
Requesting 10k objects in ray.wait without fix: 10.59s
Requesting 10k objects in ray.wait with this fix: 10.56
```

### Cleanup items:
* Write microbenchmark that validates prefetching.
* Do we need to dedup fetch requests sent?
* Batch fetch request?
* Remove debugging code

### Closes
Closes https://github.com/ray-project/ray/issues/30694

### Test code
https://github.com/cadedaniel/cadelabs/blob/master/ray-wait-perf-regression/script.py