### PR TITLE
[RLlib] Make ComplexInputNet use ModuleDict to register sub-modules

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2495,7 +2495,7 @@ py_test(
 py_test(
      name = "tests/test_supported_spaces_pg",
      main = "tests/test_supported_spaces.py",
-     tags = ["team:rllib", "tests_dir"],
+     tags = ["team:rllib", "tests_dir", "gpu"], # (Artur) gpu tag is for test_ppo_no_preprocessors_gpu
      size = "large",
      srcs = ["tests/test_supported_spaces.py"],
      args = ["TestSupportedSpacesPG"]

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2032,7 +2032,7 @@ py_test(
 
 py_test(
     name = "policy/tests/test_sample_batch",
-    tags = ["team:rllib", "policy", "gpu"],
+    tags = ["team:rllib", "policy", "multi-gpu"],
     size = "small",
     srcs = ["policy/tests/test_sample_batch.py"]
 )

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -48,7 +48,7 @@
 # - "needs_gpu": Indicating that a test needs to have a GPU in order to run.
 # - "gpu": Indicating that a test may (but doesn't have to) be run in the GPU
 #   pipeline, defined in .buildkite/pipeline.gpu.yml.
-# - "multi-gpu": Indicating that a test will definitely be run in the Large GPU
+# - "multi_gpu": Indicating that a test will definitely be run in the Large GPU
 #   pipeline, defined in .buildkite/pipeline.gpu.large.yml.
 # - "no_gpu": Indicating that a test should not be run in the GPU pipeline due
 #   to certain incompatibilities.
@@ -2495,7 +2495,7 @@ py_test(
 py_test(
      name = "tests/test_supported_spaces_pg",
      main = "tests/test_supported_spaces.py",
-     tags = ["team:rllib", "tests_dir", "multi-gpu"],
+     tags = ["team:rllib", "tests_dir", "multi_gpu"],
      size = "large",
      srcs = ["tests/test_supported_spaces.py"],
      args = ["TestSupportedSpacesPG"]

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2032,7 +2032,7 @@ py_test(
 
 py_test(
     name = "policy/tests/test_sample_batch",
-    tags = ["team:rllib", "policy", "multi-gpu"],
+    tags = ["team:rllib", "policy", "gpu"],
     size = "small",
     srcs = ["policy/tests/test_sample_batch.py"]
 )
@@ -2495,7 +2495,7 @@ py_test(
 py_test(
      name = "tests/test_supported_spaces_pg",
      main = "tests/test_supported_spaces.py",
-     tags = ["team:rllib", "tests_dir", "gpu"], # (Artur) gpu tag is for test_ppo_no_preprocessors_gpu
+     tags = ["team:rllib", "tests_dir", "multi-gpu"],
      size = "large",
      srcs = ["tests/test_supported_spaces.py"],
      args = ["TestSupportedSpacesPG"]

--- a/rllib/models/torch/complex_input_net.py
+++ b/rllib/models/torch/complex_input_net.py
@@ -60,12 +60,13 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
         #     "conv_type", "atari")
 
         # Build the CNN(s) given obs_space's image components.
-        self.cnns = {}
-        self.one_hot = {}
+        self.cnns = nn.ModuleDict()
+        self.one_hot = nn.ModuleDict()
         self.flatten_dims = {}
-        self.flatten = {}
+        self.flatten = nn.ModuleDict()
         concat_size = 0
         for i, component in enumerate(self.flattened_input_space):
+            i = str(i)
             # Image space.
             if len(component.shape) == 3:
                 config = {
@@ -185,6 +186,7 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
         # (CNNs, one-hot + FC, etc..).
         outs = []
         for i, component in enumerate(tree.flatten(orig_obs)):
+            i = str(i)
             if i in self.cnns:
                 cnn_out, _ = self.cnns[i](SampleBatch({SampleBatch.OBS: component}))
                 outs.append(cnn_out)
@@ -198,7 +200,7 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
                 ]:
                     one_hot_in = {
                         SampleBatch.OBS: one_hot(
-                            component, self.flattened_input_space[i]
+                            component, self.flattened_input_space[int(i)]
                         )
                     }
                 else:

--- a/rllib/tests/test_supported_spaces.py
+++ b/rllib/tests/test_supported_spaces.py
@@ -198,7 +198,9 @@ class TestSupportedSpacesPG(unittest.TestCase):
 
     def test_ppo_no_preprocessors_gpu(self):
         # Same test as test_ppo, but also test if we are able to move models and tensors
-        # on the same device when also no using preprocessors.
+        # on the same device when not using preprocessors.
+        # This covers a superposition of these edge cases that can lead to obscure
+        # errors
         config = (
             PPOConfig()
             .rollouts(num_rollout_workers=0, rollout_fragment_length=50)

--- a/rllib/tests/test_supported_spaces.py
+++ b/rllib/tests/test_supported_spaces.py
@@ -144,7 +144,7 @@ def check_support(alg, config, train=True, check_bounds=False, tf2=False):
 class TestSupportedSpacesPG(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        ray.init()
+        ray.init(num_gpus=1)
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/rllib/tests/test_supported_spaces.py
+++ b/rllib/tests/test_supported_spaces.py
@@ -199,8 +199,8 @@ class TestSupportedSpacesPG(unittest.TestCase):
     def test_ppo_no_preprocessors_gpu(self):
         # Same test as test_ppo, but also test if we are able to move models and tensors
         # on the same device when not using preprocessors.
-        # This covers a superposition of these edge cases that can lead to obscure
-        # errors
+        # (Artur) This covers a superposition of these edge cases that can lead to
+        # obscure errors.
         config = (
             PPOConfig()
             .rollouts(num_rollout_workers=0, rollout_fragment_length=50)

--- a/rllib/tests/test_supported_spaces.py
+++ b/rllib/tests/test_supported_spaces.py
@@ -212,9 +212,9 @@ class TestSupportedSpacesPG(unittest.TestCase):
                     "fcnet_hiddens": [10],
                 },
             )
+            .experimental(_disable_preprocessor_api=True)
+            .resources(num_gpus=1)
         )
-        config["_disable_preprocessor_api"] = True
-        config["num_gpus"] = 1
         check_support("PPO", config, check_bounds=True, tf2=True)
 
 

--- a/rllib/tests/test_supported_spaces.py
+++ b/rllib/tests/test_supported_spaces.py
@@ -196,6 +196,25 @@ class TestSupportedSpacesPG(unittest.TestCase):
         )
         check_support("PPO", config, check_bounds=True, tf2=True)
 
+    def test_ppo_no_preprocessors_gpu(self):
+        # Same test as test_ppo, but also test if we are able to move models and tensors
+        # on the same device when also no using preprocessors.
+        config = (
+            PPOConfig()
+            .rollouts(num_rollout_workers=0, rollout_fragment_length=50)
+            .training(
+                train_batch_size=100,
+                num_sgd_iter=1,
+                sgd_minibatch_size=50,
+                model={
+                    "fcnet_hiddens": [10],
+                },
+            )
+        )
+        config["_disable_preprocessor_api"] = True
+        config["num_gpus"] = 1
+        check_support("PPO", config, check_bounds=True, tf2=True)
+
 
 class TestSupportedSpacesOffPolicy(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

When calling ComplexInputNet.to() in order to move it to a device, this currently does not result in moving the models.
This is in torch, ComplexInputNet's "sub-models" are not registered as nn.Modules.
In order to properly deal with this, we can use ModuleDict.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
