### PR TITLE
[Core/Python] Turn hardcoded forward slashes into os.path.join operations

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -137,7 +137,9 @@ class Node:
             resources={},
             temp_dir=ray._private.utils.get_ray_temp_dir(),
             worker_path=os.path.join(
-                os.path.dirname(os.path.abspath(__file__)), "workers/default_worker.py"
+                os.path.dirname(os.path.abspath(__file__)),
+                "workers",
+                "default_worker.py",
             ),
             setup_worker_path=os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -39,22 +39,24 @@ EXE_SUFFIX = ".exe" if sys.platform == "win32" else ""
 RUN_RAYLET_PROFILER = False
 
 # Location of the redis server.
-RAY_HOME = os.path.join(os.path.dirname(os.path.dirname(__file__)), "../..")
+RAY_HOME = os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "..")
 RAY_PATH = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 RAY_PRIVATE_DIR = "_private"
 AUTOSCALER_PRIVATE_DIR = "autoscaler/_private"
 
 # Location of the raylet executables.
-RAYLET_EXECUTABLE = os.path.join(RAY_PATH, "core/src/ray/raylet/raylet" + EXE_SUFFIX)
+RAYLET_EXECUTABLE = os.path.join(
+    RAY_PATH, "core", "src", "ray", "raylet", "raylet" + EXE_SUFFIX
+)
 GCS_SERVER_EXECUTABLE = os.path.join(
-    RAY_PATH, "core/src/ray/gcs/gcs_server" + EXE_SUFFIX
+    RAY_PATH, "core", "src", "ray", "gcs", "gcs_server" + EXE_SUFFIX
 )
 
 # Location of the cpp default worker executables.
-DEFAULT_WORKER_EXECUTABLE = os.path.join(RAY_PATH, "cpp/default_worker" + EXE_SUFFIX)
+DEFAULT_WORKER_EXECUTABLE = os.path.join(RAY_PATH, "cpp", "default_worker" + EXE_SUFFIX)
 
 # Location of the native libraries.
-DEFAULT_NATIVE_LIBRARY_PATH = os.path.join(RAY_PATH, "cpp/lib")
+DEFAULT_NATIVE_LIBRARY_PATH = os.path.join(RAY_PATH, "cpp", "lib")
 
 DASHBOARD_DEPENDENCY_ERROR_MESSAGE = (
     "Not all Ray Dashboard dependencies were "


### PR DESCRIPTION
Signed-off-by: Jeroen Bédorf <jeroen@bedorf.net>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The hardcoded usage of the forward slashes is problematic when Ray is run from special Windows folder paths. Specifically if Ray is run from a path that is preceded with `\\?\` . This type of prefix ([Win32 File Namespace](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces)) tells Windows to not parse the rest of the path name, so currently you end up with something like this:  `\\?\C:\python-location\ray\core/src/ray/raylet/raylet.exe`
This path does not get properly parsed and this results in Ray not being able to launch. 

This typically happens when Ray is used as a dependency in a Bazel build/test project. 

The changes made here ensure that the paths get properly set and can be used, e.g. you end up with the proper path, like this:
`\\\\?\\C:\\python-location\\ray\\core\\src\\ray\\raylet\\raylet.exe`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
