### PR TITLE
[RLlib] Make convert_to_torch tensor adhere to docstring

### DIFF
--- a/rllib/utils/tests/test_torch_utils.py
+++ b/rllib/utils/tests/test_torch_utils.py
@@ -19,6 +19,9 @@ class TestTorchUtils(unittest.TestCase):
     def test_convert_to_torch_tensor(self):
         # Tests whether convert_to_torch_tensor works as expected
 
+        # Test None
+        self.assertTrue(convert_to_torch_tensor(None) is None)
+
         # Test single array
         array = np.array([1, 2, 3])
         tensor = torch.from_numpy(array)
@@ -32,10 +35,13 @@ class TestTorchUtils(unittest.TestCase):
         self.assertTrue(convert_to_torch_tensor(tensor_2).dtype is torch.float32)
 
         # Test nested structure with objects tested above
-        converted = convert_to_torch_tensor({"a": (array, tensor), "b": tensor_2})
+        converted = convert_to_torch_tensor(
+            {"a": (array, tensor), "b": tensor_2, "c": None}
+        )
         self.assertTrue(all(convert_to_torch_tensor(converted["a"][0]) == tensor))
-        self.assertTrue(convert_to_torch_tensor(converted["a"][1]) is tensor)
-        self.assertTrue(convert_to_torch_tensor(converted["b"]).dtype is torch.float32)
+        self.assertTrue(converted["a"][1] is tensor)
+        self.assertTrue(converted["b"].dtype is torch.float32)
+        self.assertTrue(converted["c"] is None)
 
 
 if __name__ == "__main__":

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -127,13 +127,14 @@ def convert_to_torch_tensor(x: TensorStructType, device: Optional[str] = None):
 
     Returns:
         Any: A new struct with the same structure as `x`, but with all
-            values converted to torch Tensor types.
+            values converted to torch Tensor types. This does not convert possibly
+            nested elements that are None because torch has no representation for that.
     """
 
     def mapping(item):
         if item is None:
             # Returns an empty torch tensor
-            return torch.empty([0])
+            return item
 
         # Special handling of "Repeated" values.
         if isinstance(item, RepeatedValues):

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -133,7 +133,7 @@ def convert_to_torch_tensor(x: TensorStructType, device: Optional[str] = None):
 
     def mapping(item):
         if item is None:
-            # Returns an empty torch tensor
+            # Torch has no representation for `None`, so we return None
             return item
 
         # Special handling of "Repeated" values.

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -132,8 +132,8 @@ def convert_to_torch_tensor(x: TensorStructType, device: Optional[str] = None):
 
     def mapping(item):
         if item is None:
-            # returns None with dtype=np.obj
-            return np.asarray(item)
+            # Returns an empty torch tensor
+            return torch.empty([0])
 
         # Special handling of "Repeated" values.
         if isinstance(item, RepeatedValues):
@@ -141,7 +141,6 @@ def convert_to_torch_tensor(x: TensorStructType, device: Optional[str] = None):
                 tree.map_structure(mapping, item.values), item.lengths, item.max_len
             )
 
-        tensor = None
         # Already torch tensor -> make sure it's on right device.
         if torch.is_tensor(item):
             tensor = item


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

convert_to_torch tensor says that it will return all inputs to torch tensors, while infact it convets Nones into np arrays.
Not only is the docstring quiet about it, the behavior is also not intuitive since one must know that torch is not as lax with Nones as numpy but instead offers torch.empty. torch.empty has a shape, so I'm refraining from converting to torch.empty in this PR so that we don't introduce shapes where there are none. Rather, the docstring should document the sensible behavior, which is not converting at all.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
