### PR TITLE
[core] delete duplicate nightly tests

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3251,69 +3251,6 @@
 # Core Nightly Tests
 ########################
 
-- name: shuffle_10gb
-  group: core-multi-test
-
-  team: core
-  frequency: nightly
-  working_dir: nightly_tests
-  env: staging
-
-  legacy:
-    test_name: shuffle_10gb
-    test_suite: nightly_tests
-
-  cluster:
-    cluster_env: shuffle/shuffle_app_config.yaml
-    cluster_compute: shuffle/shuffle_compute_single.yaml
-
-  run:
-    timeout: 3000
-    script: python shuffle/shuffle_test.py --num-partitions=50 --partition-size=200e6
-
-    type: job
-    file_manager: job
-
-- name: shuffle_50gb
-  group: core-multi-test
-  working_dir: nightly_tests
-  legacy:
-    test_name: shuffle_50gb
-    test_suite: nightly_tests
-
-  frequency: nightly
-  team: core
-  env: staging
-  cluster:
-    cluster_env: shuffle/shuffle_app_config.yaml
-    cluster_compute: shuffle/shuffle_compute_single.yaml
-
-  run:
-    timeout: 3000
-    script: python shuffle/shuffle_test.py --num-partitions=50 --partition-size=1e9
-    type: sdk_command
-    file_manager: sdk
-
-- name: shuffle_50gb_large_partition
-  group: core-multi-test
-  working_dir: nightly_tests
-  legacy:
-    test_name: shuffle_50gb_large_partition
-    test_suite: nightly_tests
-
-  frequency: nightly
-  team: core
-  env: staging
-  cluster:
-    cluster_env: shuffle/shuffle_app_config.yaml
-    cluster_compute: shuffle/shuffle_compute_single.yaml
-
-  run:
-    timeout: 3000
-    script: python shuffle/shuffle_test.py --num-partitions=500 --partition-size=100e6
-    type: sdk_command
-    file_manager: sdk
-
 - name: shuffle_100gb
   group: core-multi-test
   working_dir: nightly_tests
@@ -3333,75 +3270,6 @@
     script: python shuffle/shuffle_test.py --num-partitions=200 --partition-size=500e6
     wait_for_nodes:
       num_nodes: 4
-
-    type: sdk_command
-    file_manager: sdk
-
-- name: non_streaming_shuffle_100gb
-  group: core-multi-test
-  working_dir: nightly_tests
-  legacy:
-    test_name: non_streaming_shuffle_100gb
-    test_suite: nightly_tests
-
-  frequency: nightly
-  team: core
-  env: staging
-  cluster:
-    cluster_env: shuffle/shuffle_app_config.yaml
-    cluster_compute: shuffle/shuffle_compute_multi.yaml
-
-  run:
-    timeout: 3000
-    script: python shuffle/shuffle_test.py --num-partitions=200 --partition-size=500e6
-      --no-streaming
-
-    wait_for_nodes:
-      num_nodes: 4
-
-    type: sdk_command
-    file_manager: sdk
-
-- name: non_streaming_shuffle_50gb_large_partition
-  group: core-multi-test
-  working_dir: nightly_tests
-  legacy:
-    test_name: non_streaming_shuffle_50gb_large_partition
-    test_suite: nightly_tests
-
-  frequency: nightly
-  team: core
-  env: staging
-  cluster:
-    cluster_env: shuffle/shuffle_app_config.yaml
-    cluster_compute: shuffle/shuffle_compute_single.yaml
-
-  run:
-    timeout: 3000
-    script: python shuffle/shuffle_test.py --num-partitions=500 --partition-size=100e6
-      --no-streaming
-
-    type: sdk_command
-    file_manager: sdk
-
-- name: non_streaming_shuffle_50gb
-  group: core-multi-test
-  working_dir: nightly_tests
-  legacy:
-    test_name: non_streaming_shuffle_50gb
-    test_suite: nightly_tests
-
-  frequency: nightly
-  team: core
-  env: staging
-  cluster:
-    cluster_env: shuffle/shuffle_app_config.yaml
-    cluster_compute: shuffle/shuffle_compute_single.yaml
-
-  run:
-    timeout: 3000
-    script: python shuffle/shuffle_test.py --num-partitions=50 --partition-size=1e9
-      --no-streaming
 
     type: sdk_command
     file_manager: sdk
@@ -3426,29 +3294,6 @@
     type: sdk_command
     file_manager: sdk
 
-- name: shuffle_1tb_1000_partition
-  group: core-multi-test
-  working_dir: nightly_tests
-  legacy:
-    test_name: shuffle_1tb_1000_partition
-    test_suite: nightly_tests
-
-  frequency: nightly
-  team: core
-  env: staging
-  cluster:
-    cluster_env: shuffle/shuffle_app_config.yaml
-    cluster_compute: shuffle/shuffle_compute_large_scale.yaml
-
-  run:
-    timeout: 3000
-    script: python shuffle/shuffle_test.py --num-partitions=1000 --partition-size=1e9
-    wait_for_nodes:
-      num_nodes: 20
-
-    type: sdk_command
-    file_manager: sdk
-
 - name: shuffle_1tb_5000_partitions
   group: core-multi-test
   working_dir: nightly_tests
@@ -3469,25 +3314,6 @@
     wait_for_nodes:
       num_nodes: 20
 
-    type: sdk_command
-    file_manager: sdk
-
-- name: decision_tree_autoscaling
-  group: core-multi-test
-  working_dir: nightly_tests
-  legacy:
-    test_name: decision_tree_autoscaling
-    test_suite: nightly_tests
-
-  frequency: nightly
-  team: core
-  cluster:
-    cluster_env: decision_tree/decision_tree_app_config.yaml
-    cluster_compute: decision_tree/autoscaling_compute.yaml
-
-  run:
-    timeout: 3000
-    script: python decision_tree/cart_with_tree.py
     type: sdk_command
     file_manager: sdk
 
@@ -3529,30 +3355,6 @@
     timeout: 4000
     script: python shuffle/shuffle_test.py --num-partitions=1000 --partition-size=1e9
       --no-streaming
-
-    type: sdk_command
-    file_manager: sdk
-
-- name: pg_long_running_performance_test
-  group: core-multi-test
-  working_dir: nightly_tests
-  legacy:
-    test_name: pg_long_running_performance_test
-    test_suite: nightly_tests
-
-  frequency: nightly
-  team: core
-  cluster:
-    cluster_env: placement_group_tests/app_config.yaml
-    cluster_compute: placement_group_tests/long_running_test_compute.yaml
-
-  run:
-    timeout: 3600
-    script: python placement_group_tests/long_running_performance_test.py --num-stages
-      2000
-
-    wait_for_nodes:
-      num_nodes: 2
 
     type: sdk_command
     file_manager: sdk
@@ -3613,27 +3415,6 @@
     timeout: 1800
     script: OMP_NUM_THREADS=64 RAY_ADDRESS=local python run_microbenchmark.py
 
-- name: dask_on_ray_10gb_sort
-  group: core-daily-test
-  working_dir: nightly_tests
-  legacy:
-    test_name: dask_on_ray_10gb_sort
-    test_suite: nightly_tests
-
-  frequency: nightly
-  team: core
-  cluster:
-    cluster_env: dask_on_ray/dask_on_ray_app_config.yaml
-    cluster_compute: dask_on_ray/dask_on_ray_sort_compute_template.yaml
-
-  run:
-    timeout: 7200
-    script: python dask_on_ray/dask_on_ray_sort.py --nbytes 10_000_000_000 --npartitions
-      50 --num-nodes 1 --ray --data-dir /tmp/ray --file-path /tmp/ray
-
-    type: sdk_command
-    file_manager: sdk
-
 - name: dask_on_ray_100gb_sort
   group: core-daily-test
   working_dir: nightly_tests
@@ -3654,44 +3435,6 @@
 
     type: sdk_command
     file_manager: sdk
-
-- name: dask_on_ray_large_scale_test_no_spilling
-  group: core-daily-test
-  working_dir: nightly_tests
-  legacy:
-    test_name: dask_on_ray_large_scale_test_no_spilling
-    test_suite: nightly_tests
-
-  frequency: nightly
-  team: core
-  cluster:
-    cluster_env: dask_on_ray/large_scale_dask_on_ray_app_config.yaml
-    cluster_compute: dask_on_ray/dask_on_ray_stress_compute.yaml
-
-  run:
-    timeout: 7200
-    script: python dask_on_ray/large_scale_test.py --num_workers 20 --worker_obj_store_size_in_gb
-      20 --error_rate 0  --data_save_path /tmp/ray
-
-    wait_for_nodes:
-      num_nodes: 21
-
-    type: sdk_command
-    file_manager: sdk
-
-  smoke_test:
-    frequency: nightly
-    cluster:
-      app_config: dask_on_ray/large_scale_dask_on_ray_app_config.yaml
-      cluster_compute: dask_on_ray/large_scale_dask_on_ray_compute_template.yaml
-
-    run:
-      timeout: 7200
-      script: python dask_on_ray/large_scale_test.py --num_workers 4 --worker_obj_store_size_in_gb
-        20 --error_rate 0  --data_save_path /tmp/ray
-
-      wait_for_nodes:
-        num_nodes: 5
 
 - name: dask_on_ray_large_scale_test_spilling
   group: core-daily-test
@@ -4218,30 +3961,6 @@
     script: python distributed/test_many_tasks.py --num-tasks=1000
     wait_for_nodes:
       num_nodes: 250
-
-    type: sdk_command
-    file_manager: sdk
-
-- name: scheduling_test_many_0s_tasks_single_node
-  group: core-scalability-test
-  working_dir: benchmarks
-  legacy:
-    test_name: scheduling_test_many_0s_tasks_single_node
-    test_suite: benchmark_tests
-
-  frequency: nightly
-  team: core
-  cluster:
-    cluster_env: app_config.yaml
-    cluster_compute: scheduling.yaml
-
-  run:
-    timeout: 3600
-    script: python distributed/test_scheduling.py --total-num-task=1984000 --num-cpu-per-task=1
-      --task-duration-s=0 --total-num-actors=1 --num-actors-per-nodes=1
-
-    wait_for_nodes:
-      num_nodes: 32
 
     type: sdk_command
     file_manager: sdk


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

Delete duplicate nightly tests per plan : https://docs.google.com/document/d/1dyxwOUNWqn8GEV0iy-onp55Tgy89jakvdxwBUM5VXAs/edit#

Only touched ones grouped under core. Tests deleted:

decision_tree_autoscaling
pg_long_running_performance_test
shuffle_1tb_1000_partition
shuffle_50gb_large_partition
non_streaming_shuffle_100gb
non_streaming_shuffle_50gb
shuffle_10gb
shuffle_50gb
dask_on_ray_large_scale_test_no_spilling

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
