### PR TITLE
[Docs] Prevent ">>>" from getting copied

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -81,7 +81,11 @@ external_toc_path = "_toc.yml"
 
 html_extra_path = ["robots.txt"]
 
-# Omit prompt when using copy button
+# This pattern matches:
+# - Python Repl prompts (">>> ") and it's continuation ("... ")
+# - Bash prompts ("$ ") 
+# - IPython prompts ("In []: ", "In [999]: ") and it's continuations 
+#   ("  ...: ", "     : ")
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
 copybutton_prompt_is_regexp = True
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -82,7 +82,7 @@ external_toc_path = "_toc.yml"
 html_extra_path = ["robots.txt"]
 
 # Omit prompt when using copy button
-copybutton_prompt_text = r"\$ "
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
 copybutton_prompt_is_regexp = True
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -83,8 +83,8 @@ html_extra_path = ["robots.txt"]
 
 # This pattern matches:
 # - Python Repl prompts (">>> ") and it's continuation ("... ")
-# - Bash prompts ("$ ") 
-# - IPython prompts ("In []: ", "In [999]: ") and it's continuations 
+# - Bash prompts ("$ ")
+# - IPython prompts ("In []: ", "In [999]: ") and it's continuations
 #   ("  ...: ", "     : ")
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
 copybutton_prompt_is_regexp = True


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR updates the `sphinx_copybutton` config so that interactive prompts like ">>>" aren't copied. 

If you click the copy button, interactive prompts are copied. This makes the copy button hard to use, because the interactive prompts aren't valid Python, and your code won't run.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
