### PR TITLE
[Datasets] Check if using Ray client in DatasetContext

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -176,6 +176,10 @@ class DatasetContext:
                     enable_auto_log_stats=DEFAULT_AUTO_LOG_STATS,
                 )
 
+            # Check if using Ray client and disable dynamic block splitting.
+            if ray.util.client.ray.is_connected():
+                _default_context.block_splitting_enabled = False
+
             return _default_context
 
     @staticmethod


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Found dynamic block splitting is still enabled even in Ray client mode - https://github.com/ray-project/ray/issues/31077 .  The reason is some import statements trigger the import of `ray.data.context` module, and the `ray.data.context.DEFAULT_BLOCK_SPLITTING_ENABLED` is set to true, before Ray client is used. Verified this PR fixed the issue with another user.

small repro looks like:

```py
from ray_lightning import RayStrategy <-- "ray.data.context" is imported and DEFAULT_BLOCK_SPLITTING_ENABLED is set to true

ray.init(...)  <-- Ray client is used

ds.map_batches(...) <-- Failure happens because dynamic block splitting is not working with Ray client.
```

`DatasetContext` is a singleton object, so here fix to always check if in Ray client mode in real-time when accessing `DatasetContext`.

## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/issues/31077
## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
