### PR TITLE
[core] Improve operator== for task spec SchedulingStrategy

### DIFF
--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -36,7 +36,30 @@ extern "C" {
 namespace ray {
 inline bool operator==(const ray::rpc::SchedulingStrategy &lhs,
                        const ray::rpc::SchedulingStrategy &rhs) {
-  return google::protobuf::util::MessageDifferencer::Equals(lhs, rhs);
+  if (lhs.scheduling_strategy_case() != rhs.scheduling_strategy_case()) {
+    return false;
+  }
+
+  switch (lhs.scheduling_strategy_case()) {
+  case ray::rpc::SchedulingStrategy::kNodeAffinitySchedulingStrategy: {
+    return (lhs.node_affinity_scheduling_strategy().node_id() ==
+            rhs.node_affinity_scheduling_strategy().node_id()) &&
+           (lhs.node_affinity_scheduling_strategy().soft() ==
+            rhs.node_affinity_scheduling_strategy().soft());
+  }
+  case ray::rpc::SchedulingStrategy::kPlacementGroupSchedulingStrategy: {
+    return (lhs.placement_group_scheduling_strategy().placement_group_id() ==
+            rhs.placement_group_scheduling_strategy().placement_group_id()) &&
+           (lhs.placement_group_scheduling_strategy().placement_group_bundle_index() ==
+            rhs.placement_group_scheduling_strategy().placement_group_bundle_index()) &&
+           (lhs.placement_group_scheduling_strategy()
+                .placement_group_capture_child_tasks() ==
+            rhs.placement_group_scheduling_strategy()
+                .placement_group_capture_child_tasks());
+  }
+  default:
+    return true;
+  }
 }
 
 typedef int SchedulingClass;

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -67,7 +67,8 @@ message DefaultSchedulingStrategy {}
 
 message SpreadSchedulingStrategy {}
 
-// Update std::hash<SchedulingStrategy> in task_spec.h when this is changed.
+// Update std::hash<SchedulingStrategy> and operator== in task_spec.h when this is
+// changed.
 message SchedulingStrategy {
   oneof scheduling_strategy {
     // Default hybrid scheduling strategy.


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There was substantial amount of CPU time spent in comparing `SchedulingStrategy` while comparing `SchedulingClassDescriptor` as shown in one of the micorbenchmark for `multi client tasks async`:

<img width="1724" alt="image" src="https://user-images.githubusercontent.com/11676094/207710569-66550c22-eaa0-45cf-928c-e35201115f81.png">


<!-- Please give a short summary of the change and the problem this solves. -->

After using customized comparison for `SchedulingStrategy`: 
<img width="1714" alt="image" src="https://user-images.githubusercontent.com/11676094/207710698-3ae1d53e-885d-4781-b169-3cb1b32f98e4.png">


## Related issue number
Closes #30872 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
