### PR TITLE
[core][microbenchmark] Microbenchmark run with test filters TESTS_TO_RUN

### DIFF
--- a/python/ray/_private/ray_microbenchmark_helpers.py
+++ b/python/ray/_private/ray_microbenchmark_helpers.py
@@ -14,7 +14,7 @@ filter_pattern = os.environ.get("TESTS_TO_RUN", "")
 def timeit(
     name, fn, multiplier=1, warmup_time_sec=10
 ) -> List[Optional[Tuple[str, float, float]]]:
-    if filter_pattern not in name:
+    if filter_pattern and name not in filter_pattern:
         return [None]
     # sleep for a while to avoid noisy neigbhors.
     # related issue: https://github.com/ray-project/ray/issues/22045

--- a/python/ray/_private/ray_perf.py
+++ b/python/ray/_private/ray_perf.py
@@ -95,7 +95,10 @@ def main(results=None):
 
     check_optimized_build()
 
-    print("Tip: set TESTS_TO_RUN='pattern' to run a subset of benchmarks")
+    print(
+        "Tip: set TESTS_TO_RUN='<test_name_1> | ...' to run a subset of benchmarks. \n"
+        "E.g. TESTS_TO_RUN='single client put gigabytes | multi client put gigabytes'"
+    )
 
     ray.init()
 


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, `TESTS_TO_RUN` has a limited filtering logic where it's not possible to run a subset of microbenchmarks w/o common test names. 

This allows one to run an arbitrary set of tests as long as the test names are in the `TESTS_TO_RUN` string. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
