### PR TITLE
[core][cluster] handle file deleted case when trying to re-open file

### DIFF
--- a/python/ray/_private/log_monitor.py
+++ b/python/ray/_private/log_monitor.py
@@ -73,11 +73,11 @@ class LogFileInfo:
         would have different inodes, such as log rotation or file syncing
         semantics.
         """
-        open_inode = None
-        if self.file_handle and not self.file_handle.closed:
-            open_inode = os.fstat(self.file_handle.fileno()).st_ino
-
         try:
+            open_inode = None
+            if self.file_handle and not self.file_handle.closed:
+                open_inode = os.fstat(self.file_handle.fileno()).st_ino
+
             new_inode = os.stat(self.filename).st_ino
             if open_inode != new_inode:
                 self.file_handle = open(self.filename, "rb")

--- a/python/ray/_private/log_monitor.py
+++ b/python/ray/_private/log_monitor.py
@@ -84,7 +84,6 @@ class LogFileInfo:
                 self.file_handle.seek(self.file_position)
         except Exception:
             logger.debug(f"file no longer exists, skip re-opening of {self.filename}")
-            pass
 
     def __repr__(self):
         return (

--- a/python/ray/_private/log_monitor.py
+++ b/python/ray/_private/log_monitor.py
@@ -76,10 +76,15 @@ class LogFileInfo:
         open_inode = None
         if self.file_handle and not self.file_handle.closed:
             open_inode = os.fstat(self.file_handle.fileno()).st_ino
-        new_inode = os.stat(self.filename).st_ino
-        if open_inode != new_inode:
-            self.file_handle = open(self.filename, "rb")
-            self.file_handle.seek(self.file_position)
+
+        try:
+            new_inode = os.stat(self.filename).st_ino
+            if open_inode != new_inode:
+                self.file_handle = open(self.filename, "rb")
+                self.file_handle.seek(self.file_position)
+        except Exception as _:
+            logger.debug(f"file no longer exists, skip re-opening of {self.filename}")
+            pass
 
     def __repr__(self):
         return (

--- a/python/ray/_private/log_monitor.py
+++ b/python/ray/_private/log_monitor.py
@@ -82,7 +82,7 @@ class LogFileInfo:
             if open_inode != new_inode:
                 self.file_handle = open(self.filename, "rb")
                 self.file_handle.seek(self.file_position)
-        except Exception as _:
+        except Exception:
             logger.debug(f"file no longer exists, skip re-opening of {self.filename}")
             pass
 

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -79,6 +79,27 @@ def test_reopen_changed_inode(tmp_path):
     assert file_info.file_handle.tell() == orig_file_pos
 
 
+def test_file_rename_does_not_throw_error(tmp_path):
+    filename = tmp_path / "file"
+
+    Path(filename).touch()
+
+    file_info = LogFileInfo(
+        filename=filename,
+        size_when_last_opened=0,
+        file_position=0,
+        file_handle=None,
+        is_err_file=False,
+        job_id=None,
+        worker_pid=None,
+    )
+
+    file_info.reopen_if_necessary()
+
+    os.rename(filename, f"{filename}.1")
+
+    file_info.reopen_if_necessary()
+
 def test_log_rotation_config(ray_start_cluster, monkeypatch):
     cluster = ray_start_cluster
     max_bytes = 100

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -79,7 +79,7 @@ def test_reopen_changed_inode(tmp_path):
     assert file_info.file_handle.tell() == orig_file_pos
 
 
-def test_file_rename_does_not_throw_error(tmp_path):
+def test_deleted_file_does_not_throw_error(tmp_path):
     filename = tmp_path / "file"
 
     Path(filename).touch()
@@ -96,7 +96,7 @@ def test_file_rename_does_not_throw_error(tmp_path):
 
     file_info.reopen_if_necessary()
 
-    os.rename(filename, f"{filename}.1")
+    os.remove(filename)
 
     file_info.reopen_if_necessary()
 

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -100,6 +100,7 @@ def test_file_rename_does_not_throw_error(tmp_path):
 
     file_info.reopen_if_necessary()
 
+
 def test_log_rotation_config(ray_start_cluster, monkeypatch):
     cluster = ray_start_cluster
     max_bytes = 100


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

We are getting errors in log monitor when the file it is monitoring is deleted, which could happen during rotation

## Related issue number

https://github.com/ray-project/ray/issues/31119

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
