### PR TITLE
[Core] make ray.__all__ work again for static analyzers such as mypy

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -193,11 +193,6 @@ serialization = _DeprecationWrapper("serialization", ray._private.serialization)
 state = _DeprecationWrapper("state", ray._private.state)
 
 
-_subpackages = [
-    "data",
-    "workflow",
-]
-
 __all__ = [
     "__version__",
     "_config",
@@ -233,7 +228,13 @@ __all__ = [
     "LOCAL_MODE",
     "SCRIPT_MODE",
     "WORKER_MODE",
-] + _subpackages
+]
+
+# Subpackages
+__all__ += [
+    "data",
+    "workflow",
+]
 
 # ID types
 __all__ += [
@@ -260,7 +261,7 @@ else:
     def __getattr__(name: str):
         import importlib
 
-        if name in _subpackages:
+        if name in ["data", "workflow"]:
             return importlib.import_module("." + name, __name__)
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray 2.2.0 breaks static analyzers such as mypy because of how `ray.__all__` is defined. See https://github.com/tianyicui-tsy/ray-220-mypy-regression for a reproduction.

## Related issue number

I cannot find one. It looks like I might be the first to report and fix this. Let me know if creating an issue is necessary.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
