### PR TITLE
[Datasets] Add more debugging info when failing to read TFRecord file

### DIFF
--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -240,14 +240,14 @@ def _read_records(
 
             row_count += 1
             data_length = None
-        except Exception:
+        except Exception as e:
             error_message = (
-                f"Failed to read TFRecord file {path}. Please check the TFRecord file "
-                f"has correct format. Already read {row_count} rows."
+                f"Failed to read TFRecord file {path}. Please ensure that the "
+                f"TFRecord file has correct format. Already read {row_count} rows."
             )
             if data_length is not None:
-                error_message += f" Bytes size of current record data is {data_length}."
-            raise Exception(error_message)
+                error_message += f" Byte size of current record data is {data_length}."
+            raise RuntimeError(error_message) from e
 
 
 # Adapted from https://github.com/vahidk/tfrecord/blob/74b2d24a838081356d993ec0e147eaf59ccd4c84/tfrecord/writer.py#L57-L72  # noqa: E501

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -202,16 +202,16 @@ def _read_records(
                 break
             elif num_length_bytes_read != 8:
                 raise ValueError(
-                    "Failed to read the length of record data. Expect 8 bytes but get "
-                    f"{num_length_bytes_read} bytes."
+                    "Failed to read the length of record data. Expected 8 bytes but "
+                    "got {num_length_bytes_read} bytes."
                 )
 
             # Read "masked_crc32_of_length" field.
             num_length_crc_bytes_read = file.readinto(crc_bytes)
             if num_length_crc_bytes_read != 4:
                 raise ValueError(
-                    "Failed to read the length of CRC-32C hashes. Expect 4 bytes but "
-                    "get {num_length_crc_bytes_read} bytes."
+                    "Failed to read the length of CRC-32C hashes. Expected 4 bytes "
+                    "but got {num_length_crc_bytes_read} bytes."
                 )
 
             # Read "data[length]" field.
@@ -222,7 +222,7 @@ def _read_records(
             num_datum_bytes_read = file.readinto(datum_bytes_view)
             if num_datum_bytes_read != data_length:
                 raise ValueError(
-                    f"Failed to read the record. Exepct {data_length} bytes but get "
+                    f"Failed to read the record. Exepcted {data_length} bytes but got "
                     f"{num_datum_bytes_read} bytes."
                 )
 
@@ -231,7 +231,7 @@ def _read_records(
             num_crc_bytes_read = file.readinto(crc_bytes)
             if num_crc_bytes_read != 4:
                 raise ValueError(
-                    "Failed to read the CRC-32C hashes. Expect 4 bytes but get "
+                    "Failed to read the CRC-32C hashes. Expected 4 bytes but got "
                     f"{num_crc_bytes_read} bytes."
                 )
 

--- a/python/ray/data/tests/test_dataset_tfrecords.py
+++ b/python/ray/data/tests/test_dataset_tfrecords.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import numpy as np
@@ -211,6 +212,16 @@ def test_write_invalid_tfrecords(ray_start_regular_shared, tmp_path):
 
     with pytest.raises(ValueError):
         ds.write_tfrecords(tmp_path)
+
+
+def test_read_invalid_tfrecords(ray_start_regular_shared, tmp_path):
+    file_path = os.path.join(tmp_path, "file.json")
+    with open(file_path, "w") as file:
+        json.dump({"number": 0, "string": "foo"}, file)
+
+    # Expect exception raised when reading JSON as TFRecord file.
+    with pytest.raises(Exception, match="Failed to read TFRecord file"):
+        ray.data.read_tfrecords(file_path)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_dataset_tfrecords.py
+++ b/python/ray/data/tests/test_dataset_tfrecords.py
@@ -219,8 +219,8 @@ def test_read_invalid_tfrecords(ray_start_regular_shared, tmp_path):
     with open(file_path, "w") as file:
         json.dump({"number": 0, "string": "foo"}, file)
 
-    # Expect exception raised when reading JSON as TFRecord file.
-    with pytest.raises(Exception, match="Failed to read TFRecord file"):
+    # Expect RuntimeError raised when reading JSON as TFRecord file.
+    with pytest.raises(RuntimeError, match="Failed to read TFRecord file"):
         ray.data.read_tfrecords(file_path)
 
 


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
User found difficulty to debug when failing to read TFRecord files. It turns out inside input files directory, some of the files are not in TFRecord format. It's very hard to figure out which file has issue to read, and there's no useful debugging information in exception error message. So in this PR, we enrich the error message when failing to read TFRecord file (already verified with user, this PR helped them find the issue and unblocked them).

Example error message when reading JSON file as TFRecord file:

After this PR:
```
(_execute_read_task_split pid=27793) Traceback (most recent call last):
(_execute_read_task_split pid=27793)   File "/tmp/ray/session_2022-12-16_11-11-57_627589_180/runtime_resources/py_modules_files/_ray_pkg_3fc85d5930c8e93a/ray/data/datasource/tfrecords_datasource.py", line 220, in _read_records
(_execute_read_task_split pid=27793)     datum_bytes = datum_bytes.zfill(int(data_length * 1.5))
(_execute_read_task_split pid=27793) OverflowError: Python int too large to convert to C ssize_t
(_execute_read_task_split pid=27793) 
(_execute_read_task_split pid=27793) During handling of the above exception, another exception occurred:
(_execute_read_task_split pid=27793) 
(_execute_read_task_split pid=27793) Traceback (most recent call last):
(_execute_read_task_split pid=27793)   File "python/ray/_raylet.pyx", line 620, in ray._raylet.execute_dynamic_generator_and_store_task_outputs
(_execute_read_task_split pid=27793)     core_worker.store_task_outputs(
(_execute_read_task_split pid=27793)   File "python/ray/_raylet.pyx", line 2435, in ray._raylet.CoreWorker.store_task_outputs
(_execute_read_task_split pid=27793)     for i, output in enumerate(outputs):
(_execute_read_task_split pid=27793)   File "/tmp/ray/session_2022-12-16_11-11-57_627589_180/runtime_resources/py_modules_files/_ray_pkg_3fc85d5930c8e93a/ray/data/_internal/lazy_block_list.py", line 678, in _execute_read_task_split
(_execute_read_task_split pid=27793)     for block in blocks:
(_execute_read_task_split pid=27793)   File "/tmp/ray/session_2022-12-16_11-11-57_627589_180/runtime_resources/py_modules_files/_ray_pkg_3fc85d5930c8e93a/ray/data/datasource/datasource.py", line 185, in __call__
(_execute_read_task_split pid=27793)     for block in result:
(_execute_read_task_split pid=27793)   File "/tmp/ray/session_2022-12-16_11-11-57_627589_180/runtime_resources/py_modules_files/_ray_pkg_3fc85d5930c8e93a/ray/data/datasource/file_based_datasource.py", line 466, in read_files
(_execute_read_task_split pid=27793)     for data in read_stream(f, read_path, **reader_args):
(_execute_read_task_split pid=27793)   File "/tmp/ray/session_2022-12-16_11-11-57_627589_180/runtime_resources/py_modules_files/_ray_pkg_3fc85d5930c8e93a/ray/data/datasource/tfrecords_datasource.py", line 28, in _read_stream
(_execute_read_task_split pid=27793)     for record in _read_records(f, path):
(_execute_read_task_split pid=27793)   File "/tmp/ray/session_2022-12-16_11-11-57_627589_180/runtime_resources/py_modules_files/_ray_pkg_3fc85d5930c8e93a/ray/data/datasource/tfrecords_datasource.py", line 250, in _read_records
(_execute_read_task_split pid=27793)     raise Exception(error_message)
(_execute_read_task_split pid=27793) Exception: Failed to read TFRecord file ./country=us/file1.json. Please check the TFRecord file has correct format. Already read 0 rows. Bytes size of current record data is 8243102915232670331.
```

Before this PR:

```
Traceback (most recent call last):
  File "/root/.local/lib/python3.8/site-packages/ray/data/read_api.py", line 950, in read_tfrecords
    return read_datasource(
  File "/root/.local/lib/python3.8/site-packages/ray/data/read_api.py", line 317, in read_datasource
    block_list.ensure_metadata_for_first_block()
  File "/root/.local/lib/python3.8/site-packages/ray/data/_internal/lazy_block_list.py", line 392, in ensure_metadata_for_first_block
    metadata = ray.get(metadata_ref)
  File "/root/.local/lib/python3.8/site-packages/ray/_private/client_mode_hook.py", line 105, in wrapper
    return func(*args, **kwargs)
  File "/root/.local/lib/python3.8/site-packages/ray/_private/worker.py", line 2289, in get
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(OverflowError): ray::_execute_read_task_nosplit()
  File "/root/.local/lib/python3.8/site-packages/ray/data/_internal/lazy_block_list.py", line 636, in _execute_read_task_nosplit
    blocks = list(task())
  File "/root/.local/lib/python3.8/site-packages/ray/data/datasource/datasource.py", line 192, in __call__
    for block in result:
  File "/root/.local/lib/python3.8/site-packages/ray/data/datasource/file_based_datasource.py", line 475, in read_files
    for data in read_stream(f, read_path, **reader_args):
  File "/root/.local/lib/python3.8/site-packages/ray/data/datasource/tfrecords_datasource.py", line 25, in _read_stream
    for record in _read_records(f):
  File "/root/.local/lib/python3.8/site-packages/ray/data/datasource/tfrecords_datasource.py", line 109, in _read_records
    datum_bytes = datum_bytes.zfill(int(length * 1.5))
OverflowError: Python int too large to convert to C ssize_t
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
