### PR TITLE
[RLlib] Convert PolicySpec to a readable format when converting to_dict()

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -490,7 +490,20 @@ class AlgorithmConfig:
         # Setup legacy multi-agent sub-dict:
         config["multiagent"] = {}
         for k in self.multiagent.keys():
-            config["multiagent"][k] = config.pop(k)
+            # convert policies dict to something human-readable
+            if k == "policies":
+                policies_dict = {}
+                for policy_id, policy_spec in self.multiagent[k].items():
+                    if isinstance(policy_spec, PolicySpec):
+                        policies_dict[policy_id] = (
+                            policy_spec.policy_class,
+                            policy_spec.observation_space,
+                            policy_spec.action_space,
+                            policy_spec.config,
+                        )
+                config["multiagent"][k] = policies_dict
+            else:
+                config["multiagent"][k] = config.pop(k)
 
         # Switch out deprecated vs new config keys.
         config["callbacks"] = config.pop("callbacks_class", DefaultCallbacks)

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -491,7 +491,7 @@ class AlgorithmConfig:
         config["multiagent"] = {}
         for k in self.multiagent.keys():
             # convert policies dict to something human-readable
-            if k == "policies":
+            if k == "policies" and isinstance(self.multiagent[k], dict):
                 policies_dict = {}
                 for policy_id, policy_spec in self.multiagent[k].items():
                     if isinstance(policy_spec, PolicySpec):
@@ -501,6 +501,8 @@ class AlgorithmConfig:
                             policy_spec.action_space,
                             policy_spec.config,
                         )
+                    else:
+                        policies_dict[policy_id] = policy_spec
                 config["multiagent"][k] = policies_dict
             else:
                 config["multiagent"][k] = config.pop(k)


### PR DESCRIPTION
Signed-off-by: Kourosh Hakhamaneshi <kourosh@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This is needed mainly so that when you log configs back to your wandb you can read the policy_spec content in a multi-agent scenario. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
