### PR TITLE
[Tune] Fix AxSearch save and nan/inf result handling

### DIFF
--- a/python/ray/tune/search/ax/ax_search.py
+++ b/python/ray/tune/search/ax/ax_search.py
@@ -1,5 +1,4 @@
 import copy
-import pickle
 import numpy as np
 from typing import Dict, List, Optional, Union
 
@@ -153,7 +152,7 @@ class AxSearch(Searcher):
         parameter_constraints: Optional[List] = None,
         outcome_constraints: Optional[List] = None,
         ax_client: Optional[AxClient] = None,
-        **ax_kwargs
+        **ax_kwargs,
     ):
         assert (
             ax is not None
@@ -337,7 +336,7 @@ class AxSearch(Searcher):
                 # Don't report trials with NaN metrics to Ax
                 self._ax.abandon_trial(
                     trial_index=ax_trial_index,
-                    reason=f"nan/inf metrics reported by {trial_id}"
+                    reason=f"nan/inf metrics reported by {trial_id}",
                 )
                 return
             metric_dict[key] = (val, None)

--- a/python/ray/tune/search/ax/ax_search.py
+++ b/python/ray/tune/search/ax/ax_search.py
@@ -3,6 +3,7 @@ import pickle
 import numpy as np
 from typing import Dict, List, Optional, Union
 
+from ray import cloudpickle
 from ray.tune.result import DEFAULT_METRIC
 from ray.tune.search.sample import (
     Categorical,
@@ -425,9 +426,9 @@ class AxSearch(Searcher):
     def save(self, checkpoint_path: str):
         save_object = self.__dict__
         with open(checkpoint_path, "wb") as outputFile:
-            pickle.dump(save_object, outputFile)
+            cloudpickle.dump(save_object, outputFile)
 
     def restore(self, checkpoint_path: str):
         with open(checkpoint_path, "rb") as inputFile:
-            save_object = pickle.load(inputFile)
+            save_object = cloudpickle.load(inputFile)
         self.__dict__.update(save_object)

--- a/python/ray/tune/tests/test_searchers.py
+++ b/python/ray/tune/tests/test_searchers.py
@@ -77,7 +77,7 @@ class InvalidValuesTest(unittest.TestCase):
         assert not any(
             "Trial Runner checkpointing failed: Can't pickle local object" in x
             for x in buffer
-        ), f"Searcher checkpointing failed (unable to serialize)."
+        ), "Searcher checkpointing failed (unable to serialize)."
 
     def testAxManualSetup(self):
         from ray.tune.search.ax import AxSearch

--- a/python/ray/tune/tests/test_searchers.py
+++ b/python/ray/tune/tests/test_searchers.py
@@ -1,14 +1,16 @@
-import unittest
-import tempfile
-import shutil
-import os
+import contextlib
 from copy import deepcopy
-
 import numpy as np
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
 
 import ray
 from ray import tune
 from ray.tune.result import TRAINING_ITERATION
+from ray.tune.search import ConcurrencyLimiter
 
 
 def _invalid_objective(config):
@@ -38,6 +40,8 @@ class InvalidValuesTest(unittest.TestCase):
     Test searcher handling of invalid values (NaN, -inf, inf).
     Implicitly tests automatic config conversion and default (anonymous)
     mode handling.
+    Also tests that searcher save doesn't throw any errors during
+    experiment checkpointing.
     """
 
     def setUp(self):
@@ -61,6 +65,19 @@ class InvalidValuesTest(unittest.TestCase):
         # Hyperopt converts lists to tuples, so check for either
         self.assertIn(best_trial.config["list"], ([1, 2, 3], (1, 2, 3)))
         self.assertEqual(best_trial.config["num"], 4)
+
+    @contextlib.contextmanager
+    def check_searcher_checkpoint_errors_scope(self):
+        buffer = []
+        from ray.tune.execution.trial_runner import logger
+
+        with patch.object(logger, "warning", lambda x: buffer.append(x)):
+            yield
+
+        assert not any(
+            "Trial Runner checkpointing failed: Can't pickle local object" in x
+            for x in buffer
+        ), f"Searcher checkpointing failed (unable to serialize)."
 
     def testAxManualSetup(self):
         from ray.tune.search.ax import AxSearch
@@ -93,67 +110,74 @@ class InvalidValuesTest(unittest.TestCase):
     def testAx(self):
         from ray.tune.search.ax import AxSearch
 
-        searcher = AxSearch(random_seed=4321)
+        searcher = ConcurrencyLimiter(AxSearch(random_seed=4321), max_concurrent=2)
 
-        out = tune.run(
-            _invalid_objective,
-            search_alg=searcher,
-            metric="_metric",
-            mode="max",
-            num_samples=4,
-            reuse_actors=False,
-            config=self.config,
-        )
+        with self.check_searcher_checkpoint_errors_scope():
+            # Make sure enough samples are used so that Ax actually fits a model
+            # for config suggestion
+            out = tune.run(
+                _invalid_objective,
+                search_alg=searcher,
+                metric="_metric",
+                mode="max",
+                num_samples=16,
+                reuse_actors=False,
+                config=self.config,
+            )
+
         self.assertCorrectExperimentOutput(out)
 
     def testBayesOpt(self):
         from ray.tune.search.bayesopt import BayesOptSearch
 
-        out = tune.run(
-            _invalid_objective,
-            # At least one nan, inf, -inf and float
-            search_alg=BayesOptSearch(random_state=1234),
-            config=self.config,
-            metric="_metric",
-            mode="max",
-            num_samples=8,
-            reuse_actors=False,
-        )
+        with self.check_searcher_checkpoint_errors_scope():
+            out = tune.run(
+                _invalid_objective,
+                # At least one nan, inf, -inf and float
+                search_alg=BayesOptSearch(random_state=1234),
+                config=self.config,
+                metric="_metric",
+                mode="max",
+                num_samples=8,
+                reuse_actors=False,
+            )
         self.assertCorrectExperimentOutput(out)
 
     def testBlendSearch(self):
         from ray.tune.search.flaml import BlendSearch
 
-        out = tune.run(
-            _invalid_objective,
-            search_alg=BlendSearch(
-                points_to_evaluate=[
-                    {"report": 1.0},
-                    {"report": 2.1},
-                    {"report": 3.1},
-                    {"report": 4.1},
-                ]
-            ),
-            config=self.config,
-            metric="_metric",
-            mode="max",
-            num_samples=16,
-            reuse_actors=False,
-        )
+        with self.check_searcher_checkpoint_errors_scope():
+            out = tune.run(
+                _invalid_objective,
+                search_alg=BlendSearch(
+                    points_to_evaluate=[
+                        {"report": 1.0},
+                        {"report": 2.1},
+                        {"report": 3.1},
+                        {"report": 4.1},
+                    ]
+                ),
+                config=self.config,
+                metric="_metric",
+                mode="max",
+                num_samples=16,
+                reuse_actors=False,
+            )
         self.assertCorrectExperimentOutput(out)
 
     def testBOHB(self):
         from ray.tune.search.bohb import TuneBOHB
 
-        out = tune.run(
-            _invalid_objective,
-            search_alg=TuneBOHB(seed=1000),
-            config=self.config,
-            metric="_metric",
-            mode="max",
-            num_samples=8,
-            reuse_actors=False,
-        )
+        with self.check_searcher_checkpoint_errors_scope():
+            out = tune.run(
+                _invalid_objective,
+                search_alg=TuneBOHB(seed=1000),
+                config=self.config,
+                metric="_metric",
+                mode="max",
+                num_samples=8,
+                reuse_actors=False,
+            )
         self.assertCorrectExperimentOutput(out)
 
     def testCFO(self):
@@ -163,22 +187,23 @@ class InvalidValuesTest(unittest.TestCase):
         )
         from ray.tune.search.flaml import CFO
 
-        out = tune.run(
-            _invalid_objective,
-            search_alg=CFO(
-                points_to_evaluate=[
-                    {"report": 1.0},
-                    {"report": 2.1},
-                    {"report": 3.1},
-                    {"report": 4.1},
-                ]
-            ),
-            config=self.config,
-            metric="_metric",
-            mode="max",
-            num_samples=16,
-            reuse_actors=False,
-        )
+        with self.check_searcher_checkpoint_errors_scope():
+            out = tune.run(
+                _invalid_objective,
+                search_alg=CFO(
+                    points_to_evaluate=[
+                        {"report": 1.0},
+                        {"report": 2.1},
+                        {"report": 3.1},
+                        {"report": 4.1},
+                    ]
+                ),
+                config=self.config,
+                metric="_metric",
+                mode="max",
+                num_samples=16,
+                reuse_actors=False,
+            )
         self.assertCorrectExperimentOutput(out)
 
     def testDragonfly(self):
@@ -186,45 +211,48 @@ class InvalidValuesTest(unittest.TestCase):
 
         np.random.seed(1000)  # At least one nan, inf, -inf and float
 
-        out = tune.run(
-            _invalid_objective,
-            search_alg=DragonflySearch(domain="euclidean", optimizer="random"),
-            config=self.config,
-            metric="_metric",
-            mode="max",
-            num_samples=8,
-            reuse_actors=False,
-        )
+        with self.check_searcher_checkpoint_errors_scope():
+            out = tune.run(
+                _invalid_objective,
+                search_alg=DragonflySearch(domain="euclidean", optimizer="random"),
+                config=self.config,
+                metric="_metric",
+                mode="max",
+                num_samples=8,
+                reuse_actors=False,
+            )
         self.assertCorrectExperimentOutput(out)
 
     def testHEBO(self):
         from ray.tune.search.hebo import HEBOSearch
 
-        out = tune.run(
-            _invalid_objective,
-            # At least one nan, inf, -inf and float
-            search_alg=HEBOSearch(random_state_seed=123),
-            config=self.config,
-            metric="_metric",
-            mode="max",
-            num_samples=8,
-            reuse_actors=False,
-        )
+        with self.check_searcher_checkpoint_errors_scope():
+            out = tune.run(
+                _invalid_objective,
+                # At least one nan, inf, -inf and float
+                search_alg=HEBOSearch(random_state_seed=123),
+                config=self.config,
+                metric="_metric",
+                mode="max",
+                num_samples=8,
+                reuse_actors=False,
+            )
         self.assertCorrectExperimentOutput(out)
 
     def testHyperopt(self):
         from ray.tune.search.hyperopt import HyperOptSearch
 
-        out = tune.run(
-            _invalid_objective,
-            # At least one nan, inf, -inf and float
-            search_alg=HyperOptSearch(random_state_seed=1234),
-            config=self.config,
-            metric="_metric",
-            mode="max",
-            num_samples=8,
-            reuse_actors=False,
-        )
+        with self.check_searcher_checkpoint_errors_scope():
+            out = tune.run(
+                _invalid_objective,
+                # At least one nan, inf, -inf and float
+                search_alg=HyperOptSearch(random_state_seed=1234),
+                config=self.config,
+                metric="_metric",
+                mode="max",
+                num_samples=8,
+                reuse_actors=False,
+            )
         self.assertCorrectExperimentOutput(out)
 
     def testNevergrad(self):
@@ -233,14 +261,15 @@ class InvalidValuesTest(unittest.TestCase):
 
         np.random.seed(2020)  # At least one nan, inf, -inf and float
 
-        out = tune.run(
-            _invalid_objective,
-            search_alg=NevergradSearch(optimizer=ng.optimizers.RandomSearch),
-            config=self.config,
-            mode="max",
-            num_samples=16,
-            reuse_actors=False,
-        )
+        with self.check_searcher_checkpoint_errors_scope():
+            out = tune.run(
+                _invalid_objective,
+                search_alg=NevergradSearch(optimizer=ng.optimizers.RandomSearch),
+                config=self.config,
+                mode="max",
+                num_samples=16,
+                reuse_actors=False,
+            )
         self.assertCorrectExperimentOutput(out)
 
     def testOptuna(self):
@@ -249,15 +278,16 @@ class InvalidValuesTest(unittest.TestCase):
 
         np.random.seed(1000)  # At least one nan, inf, -inf and float
 
-        out = tune.run(
-            _invalid_objective,
-            search_alg=OptunaSearch(sampler=RandomSampler(seed=1234)),
-            config=self.config,
-            metric="_metric",
-            mode="max",
-            num_samples=8,
-            reuse_actors=False,
-        )
+        with self.check_searcher_checkpoint_errors_scope():
+            out = tune.run(
+                _invalid_objective,
+                search_alg=OptunaSearch(sampler=RandomSampler(seed=1234)),
+                config=self.config,
+                metric="_metric",
+                mode="max",
+                num_samples=8,
+                reuse_actors=False,
+            )
         self.assertCorrectExperimentOutput(out)
 
     def testOptunaReportTooOften(self):
@@ -284,35 +314,33 @@ class InvalidValuesTest(unittest.TestCase):
 
         np.random.seed(1234)  # At least one nan, inf, -inf and float
 
-        out = tune.run(
-            _invalid_objective,
-            search_alg=SkOptSearch(),
-            config=self.config,
-            metric="_metric",
-            mode="max",
-            num_samples=8,
-            reuse_actors=False,
-        )
+        with self.check_searcher_checkpoint_errors_scope():
+            out = tune.run(
+                _invalid_objective,
+                search_alg=SkOptSearch(),
+                config=self.config,
+                metric="_metric",
+                mode="max",
+                num_samples=8,
+                reuse_actors=False,
+            )
         self.assertCorrectExperimentOutput(out)
 
     def testZOOpt(self):
-        self.skipTest(
-            "Recent ZOOpt versions fail handling invalid values gracefully. "
-            "Skipping until we or they found a workaround. "
-        )
         from ray.tune.search.zoopt import ZOOptSearch
 
         np.random.seed(1000)  # At least one nan, inf, -inf and float
 
-        out = tune.run(
-            _invalid_objective,
-            search_alg=ZOOptSearch(budget=100, parallel_num=4),
-            config=self.config,
-            metric="_metric",
-            mode="max",
-            num_samples=8,
-            reuse_actors=False,
-        )
+        with self.check_searcher_checkpoint_errors_scope():
+            out = tune.run(
+                _invalid_objective,
+                search_alg=ZOOptSearch(budget=100, parallel_num=4),
+                config=self.config,
+                metric="_metric",
+                mode="max",
+                num_samples=8,
+                reuse_actors=False,
+            )
         self.assertCorrectExperimentOutput(out)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

This PR fixes AxSearch saving and handles trials that produce nan/inf metrics properly.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. --> 

### Issues

1. The `AxSearch` saving fails during experiment checkpointing. This wasn't caught because it's (1) just a warning, and (2) the unit test didn't actually start fitting/saving any models for config suggestion, since `num_samples` was too low. This is fixed by using cloudpickle during AxSearch save.
```
2022-12-15 17:31:07,148 WARNING tune.py:740 -- Trial Runner checkpointing failed: Can't pickle local object '_HomoskedasticNoiseBase.__init__.<locals>.<lambda>
```
2. `AxSearch` doesn't handle nan/inf metric values (will raise an input error on both of these). This PR screens these out and uses `AxClient.abandon_trial` to complete this trial without adding its result as data to fit on. This wasn't caught for a similar reason to above.

```
InputDataError: Input data contains NaN values.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
