### PR TITLE
[Data] dataset repartition by col with hash func

### DIFF
--- a/python/ray/data/_internal/shuffle.py
+++ b/python/ray/data/_internal/shuffle.py
@@ -61,6 +61,7 @@ class SimpleShufflePlan(ShuffleOp):
         *,
         map_ray_remote_args: Optional[Dict[str, Any]] = None,
         reduce_ray_remote_args: Optional[Dict[str, Any]] = None,
+        shuffle_col=None,
     ) -> Tuple[BlockList, Dict[str, List[BlockMetadata]]]:
         input_blocks_list = input_blocks.get_blocks()
         input_num_blocks = len(input_blocks_list)
@@ -82,7 +83,7 @@ class SimpleShufflePlan(ShuffleOp):
             shuffle_map.options(
                 **map_ray_remote_args,
                 num_returns=1 + output_num_blocks,
-            ).remote(i, block, output_num_blocks, *self._map_args)
+            ).remote(i, block, output_num_blocks, *self._map_args, shuffle_col)
             for i, block in enumerate(input_blocks_list)
         ]
 

--- a/python/ray/data/_internal/stage_impl.py
+++ b/python/ray/data/_internal/stage_impl.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 class RepartitionStage(AllToAllStage):
     """Implementation of `Dataset.repartition()`."""
 
-    def __init__(self, num_blocks: int, shuffle: bool):
+    def __init__(self, num_blocks: int, shuffle: bool, col=None):
         if shuffle:
 
             def do_shuffle(
@@ -50,6 +50,7 @@ class RepartitionStage(AllToAllStage):
                     clear_input_blocks,
                     map_ray_remote_args=remote_args,
                     reduce_ray_remote_args=remote_args,
+                    shuffle_col=col
                 )
 
             super().__init__(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -935,7 +935,7 @@ class Dataset(Generic[T]):
             >>> data = [{'a': 1, 'b': 2}, {'a': 5, 'b': 20, 'c': 21}]
             >>> df = pd.DataFrame(data)
             >>> ds = ray.data.from_pandas(df)
-            >>> ds.repartition(10,col='a').write_csv(path="/tmp/test")
+            >>> ds.repartition(10 ,shuffle=True, col='a').write_csv(path="/tmp/test")
 
         Time complexity: O(dataset size / parallelism)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Dataset repartition according to the specified col.
such as ：
            >>> data = [{'a': 1, 'b': 2}, {'a': 5, 'b': 20, 'c': 21}]
            >>> df = pd.DataFrame(data)
            >>> ds = ray.data.from_pandas(df)
            >>> ds.repartition(10, shuffle=True,col='a').write_csv(path="/tmp/test")
