### PR TITLE
[Docs] Fix plasma docs related to arrow

### DIFF
--- a/doc/source/ray-core/objects/serialization.rst
+++ b/doc/source/ray-core/objects/serialization.rst
@@ -17,7 +17,9 @@ Ray is currently compatible with Pickle protocol version 5, while Ray supports s
 Plasma Object Store
 ~~~~~~~~~~~~~~~~~~~
 
-Plasma is an in-memory object store that is being developed as part of Apache Arrow. Ray uses Plasma to efficiently transfer objects across different processes and different nodes. All objects in Plasma object store are **immutable** and held in shared memory. This is so that they can be accessed efficiently by many workers on the same node.
+Plasma is an in-memory object store. It has been originally developed as part of Apache Arrow. Prior to Ray's version 1.0.0 release, Ray forked Arrow's Plasma code into Ray's code base in order to disentangle and continue development with respect to Ray's architecture and performance needs.
+
+Plasma is used to efficiently transfer objects across different processes and different nodes. All objects in Plasma object store are **immutable** and held in shared memory. This is so that they can be accessed efficiently by many workers on the same node.
 
 Each node has its own object store. When data is put into the object store, it does not get automatically broadcasted to other nodes. Data remains local to the writer until requested by another task or actor on another node.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The current documentation states that Ray uses Arrow Plasma Object Store, which is incorrect for ~ 2 years now.

This PR corrects this, and adds a short historical note on Ray's in-memory object store and Arrow's plasma.

Note that as Arrow's Plasma will be deprecated in Arrow's version 10.0.0, this mistake is even more so misleading.

A related discussion for the "Arrow's fork into ray" can be found in https://github.com/ray-project/ray/pull/7901

I'd be happy if you can suggest a more accurate  description of the historical note added to the docs in this PR.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/issues/10858

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
