### PR TITLE
[RLlib] Fix erroring our when tuning any algo without torch being installed

### DIFF
--- a/rllib/algorithms/qmix/qmix_policy.py
+++ b/rllib/algorithms/qmix/qmix_policy.py
@@ -22,7 +22,7 @@ from ray.rllib.utils.typing import TensorType
 from ray.rllib.utils.torch_utils import apply_grad_clipping
 
 # Torch must be installed.
-torch, nn = try_import_torch(error=True)
+torch, nn = try_import_torch(error=False)
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +167,12 @@ class QMixTorchPolicy(TorchPolicy):
     """
 
     def __init__(self, obs_space, action_space, config):
+        # We want to error out on instantiation and not on import, because tune
+        # imports all RLlib algorithms when registering them
+        # TODO (Artur): Find a way to only import algorithms when needed
+        if not torch:
+            raise ImportError("Could not import PyTorch, which QMix requires.")
+
         _validate(obs_space, action_space)
         config = dict(ray.rllib.algorithms.qmix.qmix.DEFAULT_CONFIG, **config)
         self.framework = "torch"


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Makes it so that tune can register QMix even though torch is not installed.
We don't error out on import for torch specific Algorithms in general, QMix should not be an exception.
This PR does not fix the root cause of this behaviour, which is that we import stuff that can not be used.
This PR goes the same way as other Algorithms that only work for torch.

## Related issue number

#31176 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
