### PR TITLE
[Release] Reenable release metrics with fallback

### DIFF
--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -298,7 +298,11 @@ def run_release_test(
             )
 
         try:
-            command_runner.save_metrics(start_time_unix)
+            # Timeout is the time the test took divided by 200
+            # (~7 minutes for a 24h test) but no less than 30s
+            # and no more than 900s
+            metrics_timeout = max(30, min((time.time() - start_time_unix) / 200, 900))
+            command_runner.save_metrics(start_time_unix, timeout=metrics_timeout)
             metrics = command_runner.fetch_metrics()
         except Exception as e:
             logger.exception(f"Could not fetch metrics for test command: {e}")


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR reenables prometheus metrics reporting disabled in https://github.com/ray-project/ray/pull/30849 by adding a fallback to not report them to database in case of any exception, thus allowing us to persist other fields in case metrics are too big. A more comprehensive solution is being worked on.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
