### PR TITLE
[Datasets] [Hotfix] Remove Arrow 8 upper-bound in `ray[data]` extra

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -218,7 +218,7 @@ if setup_spec.type == SetupType.RAY:
         # NumPy dropped python 3.6 support in 1.20.
         numpy_dep = "numpy >= 1.19"
     if sys.version_info >= (3, 7) and sys.platform != "win32":
-        pyarrow_dep = "pyarrow >= 6.0.1, < 8.0.0"
+        pyarrow_dep = "pyarrow >= 6.0.1"
     else:
         # pyarrow dropped python 3.6 support in 7.0.0.
         # Serialization workaround for pyarrow 7.0.0+ doesn't work for Windows.


### PR DESCRIPTION
Removing the Arrow 8 upper-bound in the Arrow version constraint in the `ray[data]` extra was missed in [this PR](https://github.com/ray-project/ray/pull/29999#issuecomment-1357161838), meaning that `pip install ray[data]` will enforce `pyarrow < 8.0.0`. This wasn't caught in our Arrow 8+ CI jobs since we install Arrow _after_ Ray, bypassing this version constraint.

This PR removes that upper-bound.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
