### PR TITLE
[Datasets] Fix import of Literal for `map_batches` benchmark w/ Python 3.7

### DIFF
--- a/release/nightly_tests/dataset/map_batches_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_benchmark.py
@@ -1,10 +1,16 @@
-from typing import Literal, Optional, Union
+import sys
+from typing import Optional, Union
 
 import ray
 from ray.data._internal.compute import ActorPoolStrategy, ComputeStrategy
 from ray.data.dataset import Dataset
 
 from benchmark import Benchmark
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 def map_batches(


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Seeing nightly test is failed because of 

```
Traceback (most recent call last):
  File "map_batches_benchmark.py", line 1, in <module>
    from typing import Literal, Optional, Union
ImportError: cannot import name 'Literal' from 'typing' (/home/ray/anaconda3/lib/python3.7/typing.py)
```

Change the import of `Literal` to work with Python 3.7 ([same as what we did in dataset.py](https://github.com/ray-project/ray/blob/master/python/ray/data/dataset.py#L108-L111)). Was running benchmark in workspace with Python 3.8, so didn't find this issue before merging the PR.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
