### PR TITLE
[Datasets] Postpone Dataset logger initialization until first logging method call

### DIFF
--- a/python/ray/data/_internal/dataset_logger.py
+++ b/python/ray/data/_internal/dataset_logger.py
@@ -36,7 +36,7 @@ class DatasetLogger:
         # to stdout.
         self.log_name = log_name
         # Lazily initialized in self._initialize_logger()
-        self.logger = None
+        self._logger = None
 
     def _initialize_logger(self) -> logging.Logger:
         """Internal method to initialize the logger and the extra file handler
@@ -52,10 +52,10 @@ class DatasetLogger:
                 "DatasetLogger._initialize_logger() must be called after ray.init()."
             )
 
-        self.logger = logging.getLogger(f"{self.log_name}.logfile")
+        logger = logging.getLogger(f"{self.log_name}.logfile")
         # We need to set the log level again when explicitly
         # initializing a new logger (otherwise can have undesirable level).
-        self.logger.setLevel(LOGGER_LEVEL.upper())
+        logger.setLevel(LOGGER_LEVEL.upper())
 
         # Add log handler which writes to a separate Datasets log file
         # at `DatasetLogger.DEFAULT_DATASET_LOG_PATH`
@@ -69,8 +69,8 @@ class DatasetLogger:
         file_log_handler = logging.FileHandler(datasets_log_path)
         file_log_formatter = logging.Formatter(fmt=LOGGER_FORMAT)
         file_log_handler.setFormatter(file_log_formatter)
-        self.logger.addHandler(file_log_handler)
-        return self.logger
+        logger.addHandler(file_log_handler)
+        return logger
 
     def get_logger(self, log_to_stdout: bool = True) -> logging.Logger:
         """
@@ -86,7 +86,7 @@ class DatasetLogger:
         also removes the need for this getter method:
         `logger.info(msg="Hello world", stacklevel=2)`
         """
-        if self.logger is None:
-            self.logger = self._initialize_logger()
-        self.logger.propagate = log_to_stdout
-        return self.logger
+        if self._logger is None:
+            self._logger = self._initialize_logger()
+        self._logger.propagate = log_to_stdout
+        return self._logger

--- a/python/ray/data/_internal/dataset_logger.py
+++ b/python/ray/data/_internal/dataset_logger.py
@@ -36,7 +36,7 @@ class DatasetLogger:
         # to stdout.
         self.log_name = log_name
         # Lazily initialized in self._initialize_logger()
-        self._logger = None
+        self.logger = None
 
     def _initialize_logger(self) -> logging.Logger:
         """Internal method to initialize the logger and the extra file handler
@@ -46,10 +46,10 @@ class DatasetLogger:
         # after ray.init() is called. A less hacky way could potentially fix this
         global_node = ray._private.worker._global_node
         if global_node is not None:
-            self._logger = logging.getLogger(f"{self.log_name}.logfile")
+            self.logger = logging.getLogger(f"{self.log_name}.logfile")
             # We need to set the log level again when explicitly
             # initializing a new logger (otherwise can have undesirable level).
-            self._logger.setLevel(LOGGER_LEVEL.upper())
+            self.logger.setLevel(LOGGER_LEVEL.upper())
 
             # Add log handler which writes to a separate Datasets log file
             # at `DatasetLogger.DEFAULT_DATASET_LOG_PATH`
@@ -63,8 +63,8 @@ class DatasetLogger:
             file_log_handler = logging.FileHandler(datasets_log_path)
             file_log_formatter = logging.Formatter(fmt=LOGGER_FORMAT)
             file_log_handler.setFormatter(file_log_formatter)
-            self._logger.addHandler(file_log_handler)
-        return self._logger
+            self.logger.addHandler(file_log_handler)
+        return self.logger
 
     def get_logger(self, log_to_stdout: bool = True):
         """
@@ -80,7 +80,7 @@ class DatasetLogger:
         also removes the need for this getter method:
         `logger.info(msg="Hello world", stacklevel=2)`
         """
-        if not self._logger:
-            self._logger = self._initialize_logger()
-        self._logger.propagate = log_to_stdout
-        return self._logger
+        if not self.logger:
+            self.logger = self._initialize_logger()
+        self.logger.propagate = log_to_stdout
+        return self.logger

--- a/python/ray/data/_internal/dataset_logger.py
+++ b/python/ray/data/_internal/dataset_logger.py
@@ -39,9 +39,9 @@ class DatasetLogger:
         self._initialize_logger()
 
     def _initialize_logger(self):
-        """ Internal method to initialize the logger and the extra file handler
+        """Internal method to initialize the logger and the extra file handler
         for writing to the Dataset log file. Not intended (nor should it be necessary)
-        to call explicitly. """
+        to call explicitly."""
         # With current implementation, we can only get session_dir
         # after ray.init() is called. A less hacky way could potentially fix this
         global_node = ray._private.worker._global_node

--- a/python/ray/data/_internal/dataset_logger.py
+++ b/python/ray/data/_internal/dataset_logger.py
@@ -41,32 +41,38 @@ class DatasetLogger:
     def _initialize_logger(self) -> logging.Logger:
         """Internal method to initialize the logger and the extra file handler
         for writing to the Dataset log file. Not intended (nor should it be necessary)
-        to call explicitly."""
-        # With current implementation, we can only get session_dir
-        # after ray.init() is called. A less hacky way could potentially fix this
+        to call explicitly. Assumes that `ray.init()` has already been called prior
+        to calling this method; otherwise raises a `ValueError`."""
+        # With current implementation, we can only get the global node session
+        # directory path after ray.init() is called. A less hacky way could
+        # potentially fix this.
         global_node = ray._private.worker._global_node
-        if global_node is not None:
-            self.logger = logging.getLogger(f"{self.log_name}.logfile")
-            # We need to set the log level again when explicitly
-            # initializing a new logger (otherwise can have undesirable level).
-            self.logger.setLevel(LOGGER_LEVEL.upper())
-
-            # Add log handler which writes to a separate Datasets log file
-            # at `DatasetLogger.DEFAULT_DATASET_LOG_PATH`
-            session_dir = global_node.get_session_dir_path()
-            datasets_log_path = os.path.join(
-                session_dir,
-                DatasetLogger.DEFAULT_DATASET_LOG_PATH,
+        if global_node is None:
+            raise ValueError(
+                "DatasetLogger._initialize_logger() must be called after ray.init()."
             )
-            # Add a FileHandler to write to the specific Ray Datasets log file,
-            # using the standard default logger format used by the root logger
-            file_log_handler = logging.FileHandler(datasets_log_path)
-            file_log_formatter = logging.Formatter(fmt=LOGGER_FORMAT)
-            file_log_handler.setFormatter(file_log_formatter)
-            self.logger.addHandler(file_log_handler)
+
+        self.logger = logging.getLogger(f"{self.log_name}.logfile")
+        # We need to set the log level again when explicitly
+        # initializing a new logger (otherwise can have undesirable level).
+        self.logger.setLevel(LOGGER_LEVEL.upper())
+
+        # Add log handler which writes to a separate Datasets log file
+        # at `DatasetLogger.DEFAULT_DATASET_LOG_PATH`
+        session_dir = global_node.get_session_dir_path()
+        datasets_log_path = os.path.join(
+            session_dir,
+            DatasetLogger.DEFAULT_DATASET_LOG_PATH,
+        )
+        # Add a FileHandler to write to the specific Ray Datasets log file,
+        # using the standard default logger format used by the root logger
+        file_log_handler = logging.FileHandler(datasets_log_path)
+        file_log_formatter = logging.Formatter(fmt=LOGGER_FORMAT)
+        file_log_handler.setFormatter(file_log_formatter)
+        self.logger.addHandler(file_log_handler)
         return self.logger
 
-    def get_logger(self, log_to_stdout: bool = True):
+    def get_logger(self, log_to_stdout: bool = True) -> logging.Logger:
         """
         Returns the underlying Logger, with the `propagate` attribute set
         to the same value as `log_to_stdout`. For example, when
@@ -80,7 +86,7 @@ class DatasetLogger:
         also removes the need for this getter method:
         `logger.info(msg="Hello world", stacklevel=2)`
         """
-        if not self.logger:
+        if self.logger is None:
             self.logger = self._initialize_logger()
         self.logger.propagate = log_to_stdout
         return self.logger

--- a/python/ray/data/_internal/dataset_logger.py
+++ b/python/ray/data/_internal/dataset_logger.py
@@ -35,10 +35,10 @@ class DatasetLogger:
         # to `False` in order to prevent the root logger from writing the log
         # to stdout.
         self.log_name = log_name
-        self._logger = None  # initialized in self._initialize_logger()
-        self._initialize_logger()
+        # Lazily initialized in self._initialize_logger()
+        self._logger = None
 
-    def _initialize_logger(self):
+    def _initialize_logger(self) -> logging.Logger:
         """Internal method to initialize the logger and the extra file handler
         for writing to the Dataset log file. Not intended (nor should it be necessary)
         to call explicitly."""
@@ -54,16 +54,17 @@ class DatasetLogger:
             # Add log handler which writes to a separate Datasets log file
             # at `DatasetLogger.DEFAULT_DATASET_LOG_PATH`
             session_dir = global_node.get_session_dir_path()
-            self.datasets_log_path = os.path.join(
+            datasets_log_path = os.path.join(
                 session_dir,
                 DatasetLogger.DEFAULT_DATASET_LOG_PATH,
             )
             # Add a FileHandler to write to the specific Ray Datasets log file,
             # using the standard default logger format used by the root logger
-            file_log_handler = logging.FileHandler(self.datasets_log_path)
+            file_log_handler = logging.FileHandler(datasets_log_path)
             file_log_formatter = logging.Formatter(fmt=LOGGER_FORMAT)
             file_log_handler.setFormatter(file_log_formatter)
             self._logger.addHandler(file_log_handler)
+        return self._logger
 
     def get_logger(self, log_to_stdout: bool = True):
         """
@@ -80,6 +81,6 @@ class DatasetLogger:
         `logger.info(msg="Hello world", stacklevel=2)`
         """
         if not self._logger:
-            self._initialize_logger()
+            self._logger = self._initialize_logger()
         self._logger.propagate = log_to_stdout
         return self._logger


### PR DESCRIPTION
Signed-off-by: Scott Lee <sjl@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The [previous PR](https://github.com/ray-project/ray/pull/30557) for this issue does create the dataset-specific log file, but only in cases where the user calls `ray.init()` prior to using Ray Datasets. In the testing of the aforementioned PR, I did not account for cases where the user does not explicitly call `ray.init()`, which fails in logging due to the file directory of the global node not being available (`ray._private.worker._global_node`). In order to also correctly log to the extra file in this case, we can delay the initialization of the file logger until the first logger call, at which point we can attempt to get the log file path.

Confirmed that the fix worked by creating a workspace, and running the following in terminal:
```
import ray
ds = ray.data.range(20)
ds2 = ds.map_batches(lambda x:x*2)
```

<img width="1116" alt="Screenshot at Dec 19 12-43-27" src="https://user-images.githubusercontent.com/5122851/208517939-1a6db7ba-17b5-40bc-a2f4-899180c4ebb4.png">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #29575
## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
