### PR TITLE
[Serve][Doc] Add back reconfigure documentation 

### DIFF
--- a/doc/source/serve/production-guide/config.md
+++ b/doc/source/serve/production-guide/config.md
@@ -178,7 +178,7 @@ The `user_config` field can be used to supply structured configuration for your 
 - adjust traffic splitting percentage for your model composition graph.
 - configure any feature flag, A/B tests, and hyper-parameters for your deployments.
 
-The enable your deployment supports the user configuration feature, you just need to implement a `reconfigure` method that takes one argument:
+To enable the `user_config` feature, you need to implement a `reconfigure` method that takes a dictionary as its only argument:
 
 ```python
 @serve.deployment
@@ -187,7 +187,7 @@ class Model:
         self.threshold = config["threshold"]
 ```
 
-The reconfigure method is called when the class is created if user_config is set. In particular, it's also called when new replicas are created in the future if scale up your deployment later. The reconfigure method is also called each time user_config is updated.
+If the `user_config` is set when the deployment is created (e.g. in the decorator or the Serve config file), this `reconfigure` method is called right after the deployment's `__init__` method, and the `user_config` is passed in as an argument. You can also trigger the `reconfigure` method by updating your Serve config file with a new `user_config` and reapplying it to your Ray cluster.
 
 The corresponding YAML snippet is
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The documentation about `reconfigure` was removed during the 2.x doc refactor. This PR adds it back to the right location (config file). 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
