### PR TITLE
[Autoscaler] Allow GPU upscaling for non-GPU workloads, with lowest priority

### DIFF
--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -209,10 +209,12 @@ class ResourceDemandScheduler:
             Dict of count to add for each node type, and residual of resources
             that still cannot be fulfilled.
         """
-        # Does every node type have gpus?
+        # Does every worker node type have gpus?
+        # (More precisely, does every non-head node type have gpus?)
         all_gpu_node_types = all(
             node_type_config.get("resources").get("GPU", 0) != 0
-            for node_type_config in self.node_types.values()
+            for node_type, node_type_config in self.node_types.items()
+            if node_type != self.head_node_type
         )
         utilization_scorer = partial(
             self.utilization_scorer,

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -209,6 +209,8 @@ class ResourceDemandScheduler:
             Dict of count to add for each node type, and residual of resources
             that still cannot be fulfilled.
         """
+        # The following function mutates self.node_types.
+        self._update_node_resources_from_runtime(nodes, max_resources_by_ip)
         # Does every worker node type have gpus?
         # (More precisely, does every non-head node type have gpus?)
         all_gpu_node_types = all(
@@ -221,7 +223,6 @@ class ResourceDemandScheduler:
             node_availability_summary=node_availability_summary,
             all_gpu_node_types=all_gpu_node_types,
         )
-        self._update_node_resources_from_runtime(nodes, max_resources_by_ip)
 
         node_resources: List[ResourceDict]
         node_type_counts: Dict[NodeType, int]

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -815,7 +815,8 @@ def _resource_based_utilization_scorer(
     # if there *is* a GPU task, then CPU tasks can be scheduled as well.
     if AUTOSCALER_CONSERVE_GPU_NODES:
         if is_gpu_node and not any_gpu_task:
-            return None
+            # The lowest possible score.
+            return (-float("inf"), -float("inf"), -float("inf"))
 
     fittable = []
     resource_types = set()

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -209,20 +209,10 @@ class ResourceDemandScheduler:
             Dict of count to add for each node type, and residual of resources
             that still cannot be fulfilled.
         """
-        # The following function mutates self.node_types.
-        self._update_node_resources_from_runtime(nodes, max_resources_by_ip)
-        # Does every worker node type have gpus?
-        # (More precisely, does every non-head node type have gpus?)
-        all_gpu_node_types = all(
-            node_type_config.get("resources").get("GPU", 0) != 0
-            for node_type, node_type_config in self.node_types.items()
-            if node_type != self.head_node_type
-        )
         utilization_scorer = partial(
-            self.utilization_scorer,
-            node_availability_summary=node_availability_summary,
-            all_gpu_node_types=all_gpu_node_types,
+            self.utilization_scorer, node_availability_summary=node_availability_summary
         )
+        self._update_node_resources_from_runtime(nodes, max_resources_by_ip)
 
         node_resources: List[ResourceDict]
         node_type_counts: Dict[NodeType, int]
@@ -816,7 +806,6 @@ def _resource_based_utilization_scorer(
     resources: List[ResourceDict],
     *,
     node_availability_summary: NodeAvailabilitySummary,
-    all_gpu_node_types: bool = False,
 ) -> Optional[Tuple[float, float]]:
     remaining = copy.deepcopy(node_resources)
     is_gpu_node = "GPU" in node_resources and node_resources["GPU"] > 0
@@ -824,15 +813,9 @@ def _resource_based_utilization_scorer(
 
     # Avoid launching GPU nodes if there aren't any GPU tasks at all. Note that
     # if there *is* a GPU task, then CPU tasks can be scheduled as well.
-    if not AUTOSCALER_CONSERVE_GPU_NODES:
-        # Skip GPU node avoidance if this is explicitly disabled.
-        pass
-    elif all_gpu_node_types:
-        # If ALL available non-head node types have GPUs, don't avoid upscaling.
-        pass
-    elif is_gpu_node and not any_gpu_task:
-        # Avoid upscaling the gpu node if the workload does not require GPUs.
-        return None
+    if AUTOSCALER_CONSERVE_GPU_NODES:
+        if is_gpu_node and not any_gpu_task:
+            return None
 
     fittable = []
     resource_types = set()
@@ -879,13 +862,9 @@ def _default_utilization_scorer(
     node_type: str,
     *,
     node_availability_summary: NodeAvailabilitySummary,
-    all_gpu_node_types: bool = False,
 ):
     return _resource_based_utilization_scorer(
-        node_resources,
-        resources,
-        node_availability_summary=node_availability_summary,
-        all_gpu_node_types=all_gpu_node_types,
+        node_resources, resources, node_availability_summary=node_availability_summary
     )
 
 

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -815,7 +815,7 @@ def _resource_based_utilization_scorer(
     resources: List[ResourceDict],
     *,
     node_availability_summary: NodeAvailabilitySummary,
-    all_gpu_node_types: bool = False
+    all_gpu_node_types: bool = False,
 ) -> Optional[Tuple[float, float]]:
     remaining = copy.deepcopy(node_resources)
     is_gpu_node = "GPU" in node_resources and node_resources["GPU"] > 0
@@ -875,11 +875,13 @@ def _default_utilization_scorer(
     node_type: str,
     *,
     node_availability_summary: NodeAvailabilitySummary,
-    all_gpu_node_types: bool = False
+    all_gpu_node_types: bool = False,
 ):
     return _resource_based_utilization_scorer(
-        node_resources, resources, node_availability_summary=node_availability_summary,
-        all_gpu_node_types=all_gpu_node_types
+        node_resources,
+        resources,
+        node_availability_summary=node_availability_summary,
+        all_gpu_node_types=all_gpu_node_types,
     )
 
 

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -811,8 +811,8 @@ def _resource_based_utilization_scorer(
     is_gpu_node = "GPU" in node_resources and node_resources["GPU"] > 0
     any_gpu_task = any("GPU" in r for r in resources)
 
-    # Avoid launching GPU nodes if there aren't any GPU tasks at all. Note that
-    # if there *is* a GPU task, then CPU tasks can be scheduled as well.
+    # Prefer not to launch a GPU node if there aren't any GPU requirements in the
+    # resource bundle.
     if AUTOSCALER_CONSERVE_GPU_NODES:
         if is_gpu_node and not any_gpu_task:
             # The lowest possible score.

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -847,7 +847,7 @@ def _resource_based_utilization_scorer(
             gpu_ok = False
 
     # Prioritize avoiding gpu nodes for non-gpu workloads first,
-    # then matching multiple resource types,
+    # then prioritize matching multiple resource types,
     # then prioritize using all resources,
     # then prioritize overall balance of multiple resources.
     return (

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -806,7 +806,7 @@ def _resource_based_utilization_scorer(
     resources: List[ResourceDict],
     *,
     node_availability_summary: NodeAvailabilitySummary,
-) -> Optional[Tuple[float, float]]:
+) -> Optional[Tuple[int, float, float]]:
     remaining = copy.deepcopy(node_resources)
     is_gpu_node = "GPU" in node_resources and node_resources["GPU"] > 0
     any_gpu_task = any("GPU" in r for r in resources)
@@ -816,7 +816,7 @@ def _resource_based_utilization_scorer(
     if AUTOSCALER_CONSERVE_GPU_NODES:
         if is_gpu_node and not any_gpu_task:
             # The lowest possible score.
-            return (-float("inf"), -float("inf"), -float("inf"))
+            return (-1, -float("inf"), -float("inf"))
 
     fittable = []
     resource_types = set()

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -824,12 +824,15 @@ def _resource_based_utilization_scorer(
 
     # Avoid launching GPU nodes if there aren't any GPU tasks at all. Note that
     # if there *is* a GPU task, then CPU tasks can be scheduled as well.
-    if AUTOSCALER_CONSERVE_GPU_NODES:
-        # If all available node types have GPUs, don't avoid upscaling.
-        if all_gpu_node_types:
-            pass
-        elif is_gpu_node and not any_gpu_task:
-            return None
+    if not AUTOSCALER_CONSERVE_GPU_NODES:
+        # Skip GPU node avoidance if this is explicitly disabled.
+        pass
+    elif all_gpu_node_types:
+        # If ALL available non-head node types have GPUs, don't avoid upscaling.
+        pass
+    elif is_gpu_node and not any_gpu_task:
+        # Avoid upscaling the gpu node if the workload does not require GPUs.
+        return None
 
     fittable = []
     resource_types = set()

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -1,4 +1,3 @@
-import copy
 import pytest
 import platform
 
@@ -91,24 +90,18 @@ def test_autoscaler_all_gpu_node_types():
     """Validates that CPU tasks can trigger GPU upscaling.
     See https://github.com/ray-project/ray/pull/31202.
     """
-    gpu_node_type_1 = (
-        {
-            "resources": {
-                "CPU": 1,
-                "GPU": 1,
-            },
-            "node_config": {},
-            "min_workers": 0,
-            "max_workers": 1,
-        },
-    )
-    gpu_node_type_2 = copy.deepcopy(gpu_node_type_1)
-
     cluster = AutoscalingCluster(
         head_resources={"CPU": 0},
         worker_node_types={
-            "gpu_node_type_1": gpu_node_type_1,
-            "gpu_node_type_2": gpu_node_type_2,
+            "gpu_node_type": {
+                "resources": {
+                    "CPU": 1,
+                    "GPU": 1,
+                },
+                "node_config": {},
+                "min_workers": 0,
+                "max_workers": 1,
+            },
         },
     )
 

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -91,15 +91,17 @@ def test_autoscaler_all_gpu_node_types():
     """Validates that CPU tasks still trigger upscaling
     when all available node types have GPUs.
     """
-    gpu_node_type_1 = {
-        "resources": {
-            "CPU": 1,
-            "GPU": 1,
+    gpu_node_type_1 = (
+        {
+            "resources": {
+                "CPU": 1,
+                "GPU": 1,
+            },
+            "node_config": {},
+            "min_workers": 0,
+            "max_workers": 1,
         },
-        "node_config": {},
-        "min_workers": 0,
-        "max_workers": 1,
-    },
+    )
     gpu_node_type_2 = copy.deepcopy(gpu_node_type_1)
 
     cluster = AutoscalingCluster(
@@ -107,7 +109,7 @@ def test_autoscaler_all_gpu_node_types():
         worker_node_types={
             "gpu_node_type_1": gpu_node_type_1,
             "gpu_node_type_2": gpu_node_type_2,
-        }
+        },
     )
 
     try:

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -88,8 +88,8 @@ def test_zero_cpu_default_actor():
 
 
 def test_autoscaler_all_gpu_node_types():
-    """Validates that CPU tasks still trigger upscaling
-    when all available non-head node types have GPUs.
+    """Validates that CPU tasks can trigger GPU upscaling.
+    See https://github.com/ray-project/ray/pull/31202.
     """
     gpu_node_type_1 = (
         {

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -113,7 +113,9 @@ def test_autoscaler_all_gpu_node_types():
         def task():
             return True
 
-        assert ray.get(task.remote(), timeout=60), "Failed to schedule CPU task."
+        # Make sure the task can be scheduled.
+        # Since the head has 0 CPUs, this requires upscaling a GPU worker.
+        ray.get(task.remote(), timeout=60)
         ray.shutdown()
 
     finally:

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -115,7 +115,7 @@ def test_autoscaler_all_gpu_node_types():
 
         # Make sure the task can be scheduled.
         # Since the head has 0 CPUs, this requires upscaling a GPU worker.
-        ray.get(task.remote(), timeout=60)
+        ray.get(task.remote(), timeout=30)
         ray.shutdown()
 
     finally:

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -89,7 +89,7 @@ def test_zero_cpu_default_actor():
 
 def test_autoscaler_all_gpu_node_types():
     """Validates that CPU tasks still trigger upscaling
-    when all available node types have GPUs.
+    when all available non-head node types have GPUs.
     """
     gpu_node_type_1 = (
         {

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -86,7 +86,7 @@ def test_zero_cpu_default_actor():
         cluster.shutdown()
 
 
-def test_autoscaler_all_gpu_node_types():
+def test_autoscaler_cpu_task_gpu_node_up():
     """Validates that CPU tasks can trigger GPU upscaling.
     See https://github.com/ray-project/ray/pull/31202.
     """

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -103,7 +103,7 @@ def test_autoscaler_all_gpu_node_types():
     gpu_node_type_2 = copy.deepcopy(gpu_node_type_1)
 
     cluster = AutoscalingCluster(
-        head_resources={"CPU": 0, "GPU": 1},
+        head_resources={"CPU": 0},
         worker_node_types={
             "gpu_node_type_1": gpu_node_type_1,
             "gpu_node_type_2": gpu_node_type_2,

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -142,7 +142,9 @@ def test_gpu_node_util_score():
         [{"CPU": 1}],
         node_availability_summary=EMPTY_AVAILABILITY_SUMMARY,
     )
-    import pdb; pdb.set_trace()
+    import pdb
+
+    pdb.set_trace()
     gpu_ok = utilization_score[0]
     assert gpu_ok is False
     assert _resource_based_utilization_scorer(

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -313,13 +313,23 @@ def test_gpu_node_avoid_cpu_task():
         },
     }
     r1 = [{"CPU": 1}] * 100
+    # max_to_add ten nodes allowed. All chosen to be "cpu".
     assert get_nodes_for(
         types,
         {},
         "empty_node",
-        100,
+        10,
         r1,
     ) == {"cpu": 10}
+    # max_to_add eleven nodes allowed. First ten chosen to be "cpu",
+    # last chosen to be "gpu" due max_workers constraint on "cpu".
+    assert get_nodes_for(
+        types,
+        {},
+        "empty_node",
+        11,
+        r1,
+    ) == {"cpu": 10, "gpu": 1}
     r2 = [{"GPU": 1}] + [{"CPU": 1}] * 100
     assert get_nodes_for(
         types,

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -93,7 +93,7 @@ def test_util_score():
     )
     assert _resource_based_utilization_scorer(
         {"GPU": 4}, [{"GPU": 2}], node_availability_summary=EMPTY_AVAILABILITY_SUMMARY
-    ) == (1, 0.5, 0.5)
+    ) == (True, 1, 0.5, 0.5)
     assert _resource_based_utilization_scorer(
         {"GPU": 4},
         [{"GPU": 1}, {"GPU": 1}],

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -142,9 +142,6 @@ def test_gpu_node_util_score():
         [{"CPU": 1}],
         node_availability_summary=EMPTY_AVAILABILITY_SUMMARY,
     )
-    import pdb
-
-    pdb.set_trace()
     gpu_ok = utilization_score[0]
     assert gpu_ok is False
     assert _resource_based_utilization_scorer(

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -98,71 +98,63 @@ def test_util_score():
         {"GPU": 4},
         [{"GPU": 1}, {"GPU": 1}],
         node_availability_summary=EMPTY_AVAILABILITY_SUMMARY,
-    ) == (1, 0.5, 0.5)
+    ) == (True, 1, 0.5, 0.5)
     assert _resource_based_utilization_scorer(
         {"GPU": 2}, [{"GPU": 2}], node_availability_summary=EMPTY_AVAILABILITY_SUMMARY
-    ) == (1, 2, 2)
+    ) == (True, 1, 2, 2)
     assert _resource_based_utilization_scorer(
         {"GPU": 2},
         [{"GPU": 1}, {"GPU": 1}],
         node_availability_summary=EMPTY_AVAILABILITY_SUMMARY,
-    ) == (1, 2, 2)
+    ) == (True, 1, 2, 2)
     assert _resource_based_utilization_scorer(
         {"GPU": 1},
         [{"GPU": 1, "CPU": 1}, {"GPU": 1}],
         node_availability_summary=EMPTY_AVAILABILITY_SUMMARY,
-    ) == (
-        1,
-        1,
-        1,
-    )
+    ) == (True, 1, 1, 1)
     assert _resource_based_utilization_scorer(
         {"GPU": 1, "CPU": 1},
         [{"GPU": 1, "CPU": 1}, {"GPU": 1}],
         node_availability_summary=EMPTY_AVAILABILITY_SUMMARY,
-    ) == (2, 1, 1)
+    ) == (True, 2, 1, 1)
     assert _resource_based_utilization_scorer(
         {"GPU": 2, "TPU": 1},
         [{"GPU": 2}],
         node_availability_summary=EMPTY_AVAILABILITY_SUMMARY,
-    ) == (1, 0, 1)
+    ) == (True, 1, 0, 1)
     assert _resource_based_utilization_scorer(
         {"CPU": 64}, [{"CPU": 64}], node_availability_summary=EMPTY_AVAILABILITY_SUMMARY
-    ) == (1, 64, 64)
+    ) == (True, 1, 64, 64)
     assert _resource_based_utilization_scorer(
         {"CPU": 64}, [{"CPU": 32}], node_availability_summary=EMPTY_AVAILABILITY_SUMMARY
-    ) == (1, 8, 8)
+    ) == (True, 1, 8, 8)
     assert _resource_based_utilization_scorer(
         {"CPU": 64},
         [{"CPU": 16}, {"CPU": 16}],
         node_availability_summary=EMPTY_AVAILABILITY_SUMMARY,
-    ) == (1, 8, 8)
+    ) == (True, 1, 8, 8)
 
 
 def test_gpu_node_util_score():
     # Avoid scheduling CPU tasks on GPU node.
-    assert (
-        _resource_based_utilization_scorer(
-            {"GPU": 1, "CPU": 1},
-            [{"CPU": 1}],
-            node_availability_summary=EMPTY_AVAILABILITY_SUMMARY,
-        )
-        is None
+    utilization_score = _resource_based_utilization_scorer(
+        {"GPU": 1, "CPU": 1},
+        [{"CPU": 1}],
+        node_availability_summary=EMPTY_AVAILABILITY_SUMMARY,
     )
+    import pdb; pdb.set_trace()
+    gpu_ok = utilization_score[0]
+    assert gpu_ok is False
     assert _resource_based_utilization_scorer(
         {"GPU": 1, "CPU": 1},
         [{"CPU": 1, "GPU": 1}],
         node_availability_summary=EMPTY_AVAILABILITY_SUMMARY,
-    ) == (
-        2,
-        1.0,
-        1.0,
-    )
+    ) == (True, 2, 1.0, 1.0)
     assert _resource_based_utilization_scorer(
         {"GPU": 1, "CPU": 1},
         [{"GPU": 1}],
         node_availability_summary=EMPTY_AVAILABILITY_SUMMARY,
-    ) == (1, 0.0, 0.5)
+    ) == (True, 1, 0.0, 0.5)
 
 
 def test_zero_resource():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Closes https://github.com/ray-project/ray/issues/20476:
Instead of preventing GPU upscaling due to non-GPU tasks, **prefer non-GPU nodes** by assigning low utilization score to the GPU nodes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
