### PR TITLE
[Doc] Limit search engine crawler indexing to latest and master

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -81,6 +81,8 @@ external_toc_path = "_toc.yml"
 
 html_extra_path = ["robots.txt"]
 
+html_baseurl = "https://docs.ray.io/en/latest"
+
 # This pattern matches:
 # - Python Repl prompts (">>> ") and it's continuation ("... ")
 # - Bash prompts ("$ ")

--- a/doc/source/robots.txt
+++ b/doc/source/robots.txt
@@ -1,6 +1,6 @@
 # Algolia-Crawler-Verif: C37A60AFB138256B
 User-agent: *
-Allow: /
+Disallow: /
 Allow: /*/latest/
 Allow: /en/latest/   # Fallback for bots that don't understand wildcards
 Allow: /*/master/


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The documentation `robots.txt` currently allows web crawlers (Google) access to all Ray versions, leading to outdated and sometimes redundant links showing up in search results. This PR limits the crawlers to only index `latest` and `master`.

Some examples of search results from old ray versions:

<img width="500" alt="Screen Shot 2022-12-19 at 5 04 36 PM" src="https://user-images.githubusercontent.com/3887863/208557366-4e76ed03-1c4c-4d93-8b65-7988ac44a123.png">

<img width="500" alt="Screen Shot 2022-12-19 at 5 05 23 PM" src="https://user-images.githubusercontent.com/3887863/208557501-51065a89-3dbf-4bab-9942-5b1e5e9ede17.png">

This PR also sets the [canonical URL](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls) to the latest release docs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
