### PR TITLE
[Jobs] Increase timeout in unit test for stop job

### DIFF
--- a/dashboard/modules/job/tests/test_job_manager.py
+++ b/dashboard/modules/job/tests/test_job_manager.py
@@ -848,7 +848,7 @@ while True:
         check_job_stopped,
         job_manager=job_manager,
         job_id=job_id,
-        timeout=JobSupervisor.WAIT_FOR_JOB_TERMINATION_S + 1,
+        timeout=JobSupervisor.WAIT_FOR_JOB_TERMINATION_S + 10,
     )
 
 

--- a/dashboard/modules/job/tests/test_job_manager.py
+++ b/dashboard/modules/job/tests/test_job_manager.py
@@ -848,7 +848,7 @@ while True:
         check_job_stopped,
         job_manager=job_manager,
         job_id=job_id,
-        timeout=JobSupervisor.WAIT_FOR_JOB_TERMINATION_S,
+        timeout=JobSupervisor.WAIT_FOR_JOB_TERMINATION_S + 1,
     )
 
 


### PR DESCRIPTION
Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test_stop_job_timeout` is flaky. My guess is `asyncio.wait_for` (used [here](https://github.com/ray-project/ray/blob/master/dashboard/modules/job/job_manager.py#L392-L394)) is not necessarily exact, it is possible for that code to block for more than the specified time because the event loop is executing other coroutines. Adding 10 seconds to timeout in unit test, which should be plenty of leeway for occasional longer blocks (if it still fails, then it should be a problem).

## Related issue number

"Closes #31215"

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
