### PR TITLE
[Spark][WIP] Handle SIGHUP signal on spark application termination

### DIFF
--- a/python/ray/tests/spark/test_basic.py
+++ b/python/ray/tests/spark/test_basic.py
@@ -160,12 +160,12 @@ def test_sighup_handling_on_spark_app_termination():
     )
     ray_temp_root_dir = tempfile.mkdtemp()
     init_ray_cluster(num_worker_nodes=1, ray_temp_root_dir=ray_temp_root_dir)
-    spark.stop()
+    spark.stop()  # terminate spark application
     time.sleep(10)
     # assert temp dir is removed.
-    assert len(os.listdir(ray_temp_root_dir)) == 1 and os.listdir(
-        ray_temp_root_dir
-    )[0].endswith(".lock")
+    assert len(os.listdir(ray_temp_root_dir)) == 1 and os.listdir(ray_temp_root_dir)[
+        0
+    ].endswith(".lock")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Handle SIGHUP signal on spark application termination:

When spark application is terminated, all pyspark task worker descendant
processes will receive SIGHUP signal, we need to handle it properly.
Otherwise the `start_ray_node.py` process might be killed quickly and cleanup code (including cleaning temp dir and collect logs to specified path) has no chance to run.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
