### PR TITLE
[rllib] Fix test_placement_groups test

### DIFF
--- a/rllib/tests/test_placement_groups.py
+++ b/rllib/tests/test_placement_groups.py
@@ -63,7 +63,6 @@ class TestPlacementGroups(unittest.TestCase):
                 verbose=2,
                 callbacks=[_TestCallback()],
             ),
-            tune_config=tune.TuneConfig(reuse_actors=True),
         ).fit()
 
     def test_default_resource_request(self):


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test_overriding_default_resource_request` passes `reuse_actors=True`, but actor reuse is not supported for the `PG` algorithm (`reset_config()` is not implemented). This should have led to test failures before (a local run succeeded despite showing the errors), but it seems that 1510fb2cd631b2776092fb45ee4082e5e65f16f8 surfaced this in the CI.

The correct fix here is to not pass `reuse_actors` as this has been a misconfiguration before.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
