### PR TITLE
[runtime_env] Fix failing `wheel_urls` release test

### DIFF
--- a/release/runtime_env_tests/workloads/wheel_urls.py
+++ b/release/runtime_env_tests/workloads/wheel_urls.py
@@ -48,14 +48,14 @@ if __name__ == "__main__":
                     ray_commit=ray.__commit__,
                     sys_platform=sys_platform,
                     ray_version=ray.__version__,
-                    py_version=(sys.version_info.major, sys.version_info.minor),
+                    py_version=py_version,
                 )
             else:
                 url = get_release_wheel_url(
                     ray_commit=ray.__commit__,
                     sys_platform=sys_platform,
                     ray_version=ray.__version__,
-                    py_version=(sys.version_info.major, sys.version_info.minor),
+                    py_version=py_version,
                 )
             if requests.head(url).status_code != 200:
                 print("URL not found (yet?):", url)

--- a/release/runtime_env_tests/workloads/wheel_urls.py
+++ b/release/runtime_env_tests/workloads/wheel_urls.py
@@ -20,7 +20,6 @@ import json
 import time
 import requests
 import pprint
-import sys
 
 import ray._private.runtime_env.constants as ray_constants
 from ray._private.utils import get_master_wheel_url, get_release_wheel_url

--- a/release/runtime_env_tests/workloads/wheel_urls.py
+++ b/release/runtime_env_tests/workloads/wheel_urls.py
@@ -20,7 +20,9 @@ import json
 import time
 import requests
 import pprint
+import sys
 
+import ray._private.runtime_env.constants as ray_constants
 from ray._private.utils import get_master_wheel_url, get_release_wheel_url
 
 
@@ -40,20 +42,20 @@ if __name__ == "__main__":
 
     retry = set()
     for sys_platform in ["darwin", "linux", "win32"]:
-        for py_version in ["36", "37", "38", "39", "310"]:
+        for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             if "dev" in ray.__version__:
                 url = get_master_wheel_url(
                     ray_commit=ray.__commit__,
                     sys_platform=sys_platform,
                     ray_version=ray.__version__,
-                    py_version=py_version,
+                    py_version=(sys.version_info.major, sys.version_info.minor),
                 )
             else:
                 url = get_release_wheel_url(
                     ray_commit=ray.__commit__,
                     sys_platform=sys_platform,
                     ray_version=ray.__version__,
-                    py_version=py_version,
+                    py_version=(sys.version_info.major, sys.version_info.minor),
                 )
             if requests.head(url).status_code != 200:
                 print("URL not found (yet?):", url)


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR updates the release tests `wheel_urls` to make it compatible with the internal API change in PR #30970. Previously the release test was breaking with 
```python-traceback
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/utils.py", line 1266, in get_wheel_filename
    assert py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS, py_version
AssertionError: 36
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
