### PR TITLE
Limiting numpy version to below 1.24.0

### DIFF
--- a/ci/env/install-minimal.sh
+++ b/ci/env/install-minimal.sh
@@ -25,7 +25,7 @@ echo "Python version is ${PYTHON_VERSION}"
 ROOT_DIR=$(cd "$(dirname "$0")/$(dirname "$(test -L "$0" && readlink "$0" || echo "/")")" || exit; pwd)
 WORKSPACE_DIR="${ROOT_DIR}/../.."
 
-# Installs conda and python 3.7
+# Installs conda and the specified python version.
 MINIMAL_INSTALL=1 PYTHON=${PYTHON_VERSION} "${WORKSPACE_DIR}/ci/env/install-dependencies.sh"
 
 # Re-install Ray wheels
@@ -35,8 +35,7 @@ eval "${WORKSPACE_DIR}/ci/ci.sh build"
 
 # Install test requirements
 python -m pip install -U \
-  pytest==7.0.1 \
-  numpy
+  pytest==7.0.1
 
 # Train requirements.
 # TODO: make this dynamic

--- a/doc/source/ray-air/getting-started.rst
+++ b/doc/source/ray-air/getting-started.rst
@@ -68,7 +68,7 @@ Get started by installing Ray AIR:
     # Consider running the following to ensure that the code below runs properly:
     pip install -U pandas>=1.3.5
     pip install -U torch>=1.12
-    pip install -U numpy>=1.19.5
+    pip install -U "numpy>=1.19.5,<1.24.0"
     pip install -U tensorflow>=2.6.2
     pip install -U pyarrow>=6.0.1
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -26,8 +26,8 @@ grpcio >= 1.32.0, <= 1.49.1; python_version < '3.10' and sys_platform == 'darwin
 grpcio >= 1.42.0, <= 1.49.1; python_version >= '3.10' and sys_platform == 'darwin'
 grpcio >= 1.32.0; python_version < '3.10' and sys_platform != 'darwin'
 grpcio >= 1.42.0; python_version >= '3.10' and sys_platform != 'darwin'
-numpy>=1.16; python_version < '3.9'
-numpy>=1.19.3; python_version >= '3.9'
+numpy>=1.16, < 1.24.0; python_version < '3.9'
+numpy>=1.19.3, < 1.24.0; python_version >= '3.9'
 packaging; python_version >= '3.10'
 typing_extensions; python_version < '3.8'
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -216,7 +216,7 @@ if setup_spec.type == SetupType.RAY:
         # Pandas dropped python 3.6 support in 1.2.
         pandas_dep = "pandas >= 1.0.5"
         # NumPy dropped python 3.6 support in 1.20.
-        numpy_dep = "numpy >= 1.19, numpy < 1.24.0"
+        numpy_dep = "numpy >= 1.19, < 1.24.0"
     if sys.version_info >= (3, 7) and sys.platform != "win32":
         pyarrow_dep = "pyarrow >= 6.0.1"
     else:
@@ -312,8 +312,8 @@ if setup_spec.type == SetupType.RAY:
         "grpcio >= 1.42.0; python_version >= '3.10' and sys_platform != 'darwin'",
         "jsonschema",
         "msgpack >= 1.0.0, < 2.0.0",
-        "numpy >= 1.16, numpy < 1.24.0; python_version < '3.9'",
-        "numpy >= 1.19.3; numpy < 1.24.0; python_version >= '3.9'",
+        "numpy >= 1.16, < 1.24.0; python_version < '3.9'",
+        "numpy >= 1.19.3, < 1.24.0; python_version >= '3.9'",
         "packaging; python_version >= '3.10'",
         "protobuf >= 3.15.3, != 3.19.5",
         "pyyaml",

--- a/python/setup.py
+++ b/python/setup.py
@@ -211,12 +211,12 @@ ray_files += [
 if setup_spec.type == SetupType.RAY:
     if sys.version_info >= (3, 7):
         pandas_dep = "pandas >= 1.3"
-        numpy_dep = "numpy >= 1.20"
+        numpy_dep = "numpy >= 1.20, < 1.24.0"
     else:
         # Pandas dropped python 3.6 support in 1.2.
         pandas_dep = "pandas >= 1.0.5"
         # NumPy dropped python 3.6 support in 1.20.
-        numpy_dep = "numpy >= 1.19"
+        numpy_dep = "numpy >= 1.19, numpy < 1.24.0"
     if sys.version_info >= (3, 7) and sys.platform != "win32":
         pyarrow_dep = "pyarrow >= 6.0.1"
     else:
@@ -312,8 +312,8 @@ if setup_spec.type == SetupType.RAY:
         "grpcio >= 1.42.0; python_version >= '3.10' and sys_platform != 'darwin'",
         "jsonschema",
         "msgpack >= 1.0.0, < 2.0.0",
-        "numpy >= 1.16; python_version < '3.9'",
-        "numpy >= 1.19.3; python_version >= '3.9'",
+        "numpy >= 1.16, numpy < 1.24.0; python_version < '3.9'",
+        "numpy >= 1.19.3; numpy < 1.24.0; python_version >= '3.9'",
         "packaging; python_version >= '3.10'",
         "protobuf >= 3.15.3, != 3.19.5",
         "pyyaml",

--- a/release/nightly_tests/dataset/app_config.yaml
+++ b/release/nightly_tests/dataset/app_config.yaml
@@ -13,5 +13,5 @@ post_build_cmds:
   # tensorflow=2.6, which requires numpy~=1.19.2. This is ok because the test
   # doesn't actually use tensorflow, but in the long term, but we should
   # consider upgrading to tensorflow 2.7 as a long term solution.
-  - pip install -U numpy>=1.20
+  - pip install -U "numpy>=1.20,<1.24.0"
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}


### PR DESCRIPTION
numpy 1.24.0 [expires some existing deprecations](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations), which cause existing datasets code to fail. Until https://github.com/ray-project/ray/issues/31182 is fixed and we verify all tests pass with the newest numpy, we need to limit the numpy version to <1.24.0.

Closes https://github.com/ray-project/ray/issues/31193
Closes https://github.com/ray-project/ray/issues/31194