### PR TITLE
[RLlib] Clean up some signatures for compute_actions

### DIFF
--- a/rllib/algorithms/ars/ars_tf_policy.py
+++ b/rllib/algorithms/ars/ars_tf_policy.py
@@ -11,6 +11,7 @@ from ray.rllib.algorithms.es.es_tf_policy import make_session
 from ray.rllib.models import ModelCatalog
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.utils import deprecation_warning
 from ray.rllib.utils.filter import get_filter
 from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.spaces.space_utils import unbatch
@@ -86,10 +87,23 @@ class ARSTFPolicy(Policy):
             for _, variable in self.variables.variables.items()
         )
 
-    def compute_actions(self, observation, add_noise=False, update=True, **kwargs):
+    def compute_actions(self, obs_batch=None, add_noise=False, update=True, **kwargs):
+        if "observation" in kwargs:
+            assert obs_batch is None, (
+                "You can not use both arguments, "
+                "`observation` and `obs_batch`. `observation` "
+                "is deprecated."
+            )
+            deprecation_warning(
+                old="ARSTFPolicy.compute_actions(observation=...)`",
+                new="ARSTFPolicy.compute_actions(obs_batch=...)",
+            )
+            obs_batch = kwargs["observation"]
+        else:
+            assert obs_batch is not None
         # Squeeze batch dimension (we always calculate actions for only a
         # single obs).
-        observation = observation[0]
+        observation = obs_batch[0]
         observation = self.preprocessor.transform(observation)
         observation = self.observation_filter(observation[None], update=update)
 

--- a/rllib/algorithms/dt/dt_torch_policy.py
+++ b/rllib/algorithms/dt/dt_torch_policy.py
@@ -326,7 +326,7 @@ class DTTorchPolicy(LearningRateSchedule, TorchPolicyV2):
     @override(TorchPolicyV2)
     def compute_actions_from_input_dict(
         self,
-        input_dict: SampleBatch,
+        input_dict: Union[SampleBatch, Dict[str, TensorStructType]],
         explore: bool = None,
         timestep: Optional[int] = None,
         **kwargs,

--- a/rllib/algorithms/es/es_tf_policy.py
+++ b/rllib/algorithms/es/es_tf_policy.py
@@ -11,6 +11,7 @@ import ray.experimental.tf_utils
 from ray.rllib.models import ModelCatalog
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.utils import deprecation_warning
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.filter import get_filter
 from ray.rllib.utils.framework import try_import_tf
@@ -148,10 +149,23 @@ class ESTFPolicy(Policy):
         )
 
     @override(Policy)
-    def compute_actions(self, observation, add_noise=False, update=True, **kwargs):
+    def compute_actions(self, obs_batch=None, add_noise=False, update=True, **kwargs):
+        if "observation" in kwargs:
+            assert obs_batch is None, (
+                "You can not use both arguments, "
+                "`observation` and `obs_batch`. `observation` "
+                "is deprecated."
+            )
+            deprecation_warning(
+                old="ESTFPolicy.compute_actions(observation=...)`",
+                new="ESTFPolicy.compute_actions(obs_batch=...)",
+            )
+            obs_batch = kwargs["observation"]
+        else:
+            assert obs_batch is not None
         # Squeeze batch dimension (we always calculate actions for only a
         # single obs).
-        observation = observation[0]
+        observation = obs_batch[0]
         observation = self.preprocessor.transform(observation)
         observation = self.observation_filter(observation[None], update=update)
         # `actions` is a list of (component) batches.

--- a/rllib/evaluation/tests/test_episode.py
+++ b/rllib/evaluation/tests/test_episode.py
@@ -1,13 +1,16 @@
 import ray
 import unittest
+from typing import Dict, List, Optional, Union, Tuple
 import numpy as np
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.env.multi_agent_env import MultiAgentEnv
 from ray.rllib.evaluation.rollout_worker import RolloutWorker
+from ray.rllib.evaluation.episode import Episode
 from ray.rllib.examples.env.mock_env import MockEnv3
 from ray.rllib.policy import Policy
 from ray.rllib.utils import override
+from ray.rllib.utils.typing import TensorStructType, TensorType
 
 NUM_STEPS = 25
 NUM_AGENTS = 4
@@ -60,15 +63,16 @@ class EchoPolicy(Policy):
     @override(Policy)
     def compute_actions(
         self,
-        obs_batch,
-        state_batches=None,
-        prev_action_batch=None,
-        prev_reward_batch=None,
-        episodes=None,
-        explore=None,
-        timestep=None,
-        **kwargs
-    ):
+        obs_batch: Union[List[TensorStructType], TensorStructType],
+        state_batches: Optional[List[TensorType]] = None,
+        prev_action_batch: Union[List[TensorStructType], TensorStructType] = None,
+        prev_reward_batch: Union[List[TensorStructType], TensorStructType] = None,
+        info_batch: Optional[Dict[str, list]] = None,
+        episodes: Optional[List["Episode"]] = None,
+        explore: Optional[bool] = None,
+        timestep: Optional[int] = None,
+        **kwargs,
+    ) -> Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
         return obs_batch.argmax(axis=1), [], {}
 
 

--- a/rllib/examples/policy/random_policy.py
+++ b/rllib/examples/policy/random_policy.py
@@ -2,11 +2,16 @@ from gym.spaces import Box
 import numpy as np
 import random
 import tree  # pip install dm_tree
+from typing import (
+    List,
+    Optional,
+    Union,
+)
 
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import override
-from ray.rllib.utils.typing import ModelWeights
+from ray.rllib.utils.typing import ModelWeights, TensorStructType, TensorType
 
 
 class RandomPolicy(Policy):
@@ -42,10 +47,10 @@ class RandomPolicy(Policy):
     @override(Policy)
     def compute_actions(
         self,
-        obs_batch,
-        state_batches=None,
-        prev_action_batch=None,
-        prev_reward_batch=None,
+        obs_batch: Union[List[TensorStructType], TensorStructType],
+        state_batches: Optional[List[TensorType]] = None,
+        prev_action_batch: Union[List[TensorStructType], TensorStructType] = None,
+        prev_reward_batch: Union[List[TensorStructType], TensorStructType] = None,
         **kwargs
     ):
         # Alternatively, a numpy array would work here as well.

--- a/rllib/policy/eager_tf_policy.py
+++ b/rllib/policy/eager_tf_policy.py
@@ -7,7 +7,7 @@ import logging
 import os
 import threading
 import tree  # pip install dm_tree
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 from ray.rllib.evaluation.episode import Episode
 from ray.rllib.models.catalog import ModelCatalog
@@ -30,7 +30,12 @@ from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.spaces.space_utils import normalize_action
 from ray.rllib.utils.tf_utils import get_gpu_devices
 from ray.rllib.utils.threading import with_lock
-from ray.rllib.utils.typing import LocalOptimizer, ModelGradients, TensorType
+from ray.rllib.utils.typing import (
+    LocalOptimizer,
+    ModelGradients,
+    TensorType,
+    TensorStructType,
+)
 from ray.util.debug import log_once
 
 tf1, tf, tfv = try_import_tf()
@@ -503,16 +508,16 @@ def _build_eager_tf_policy(
         @override(Policy)
         def compute_actions(
             self,
-            obs_batch,
-            state_batches=None,
-            prev_action_batch=None,
-            prev_reward_batch=None,
-            info_batch=None,
-            episodes=None,
-            explore=None,
-            timestep=None,
+            obs_batch: Union[List[TensorStructType], TensorStructType],
+            state_batches: Optional[List[TensorType]] = None,
+            prev_action_batch: Union[List[TensorStructType], TensorStructType] = None,
+            prev_reward_batch: Union[List[TensorStructType], TensorStructType] = None,
+            info_batch: Optional[Dict[str, list]] = None,
+            episodes: Optional[List["Episode"]] = None,
+            explore: Optional[bool] = None,
+            timestep: Optional[int] = None,
             **kwargs,
-        ):
+        ) -> Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
             # Create input dict to simply pass the entire call to
             # self.compute_actions_from_input_dict().
             input_dict = SampleBatch(


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

These changes unify function signatures a little for compute_actions().
These changes where in #29205 before, which I'm trying to make a little smaller.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
