### PR TITLE
[Jobs] Spawn only one process when starting a Job

### DIFF
--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -219,8 +219,13 @@ class JobSupervisor:
                 terminated or killed upon user calling stop().
         """
         with open(logs_path, "w") as logs_file:
+            command = (
+                f"exec {self._entrypoint}"
+                if sys.platform != "win32"
+                else self._entrypoint
+            )
             child_process = subprocess.Popen(
-                self._entrypoint,
+                command,
                 shell=True,
                 start_new_session=True,
                 stdout=logs_file,

--- a/dashboard/modules/job/tests/test_job_manager.py
+++ b/dashboard/modules/job/tests/test_job_manager.py
@@ -841,14 +841,22 @@ while True:
 
     assert job_manager.stop_job(job_id) is True
 
+    with pytest.raises(RuntimeError):
+        await async_wait_for_condition_async_predicate(
+            check_job_stopped,
+            job_manager=job_manager,
+            job_id=job_id,
+            timeout=JobSupervisor.WAIT_FOR_JOB_TERMINATION_S - 1,
+        )
+
     await async_wait_for_condition(
         lambda: "SIGTERM signal handled!" in job_manager.get_job_logs(job_id)
     )
+
     await async_wait_for_condition_async_predicate(
         check_job_stopped,
         job_manager=job_manager,
         job_id=job_id,
-        timeout=JobSupervisor.WAIT_FOR_JOB_TERMINATION_S + 10,
     )
 
 


### PR DESCRIPTION
Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

On Linux systems, using `subprocess.Popen(cmd, shell=True)` will spawn two processes; one is the shell process, and the second is the actual process we want to run. 

Replacing the above with `subprocess.Popen("exec " + cmd, shell=True)` will cause the child process to take over the shell process.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
