### PR TITLE
[ci/release] Rewrite tests to use pytest instead of unittest

### DIFF
--- a/release/ray_release/tests/test_alerts.py
+++ b/release/ray_release/tests/test_alerts.py
@@ -1,5 +1,5 @@
 import sys
-import unittest
+import pytest
 
 from ray_release.alerts import (
     handle,
@@ -14,35 +14,31 @@ from ray_release.exception import ReleaseTestConfigError, ResultsAlert
 from ray_release.result import Result
 
 
-class AlertsTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.test = Test(name="unit_alert_test", alert="default")
-
-    def testHandleAlert(self):
-        # Unknown test suite
-        with self.assertRaises(ReleaseTestConfigError):
-            handle.handle_result(
-                Test(name="unit_alert_test", alert="invalid"), Result(status="finished")
-            )
-
-        # Alert raised
-        with self.assertRaises(ResultsAlert):
-            handle.handle_result(
-                Test(name="unit_alert_test", alert="default"),
-                Result(status="unsuccessful"),
-            )
-
-        # Everything fine
+def test_handle_alert():
+    # Unknown test suite
+    with pytest.raises(ReleaseTestConfigError):
         handle.handle_result(
-            Test(name="unit_alert_test", alert="default"), Result(status="finished")
+            Test(name="unit_alert_test", alert="invalid"), Result(status="finished")
         )
 
-    def testDefaultAlert(self):
-        self.assertTrue(default.handle_result(self.test, Result(status="timeout")))
-        self.assertFalse(default.handle_result(self.test, Result(status="finished")))
+    # Alert raised
+    with pytest.raises(ResultsAlert):
+        handle.handle_result(
+            Test(name="unit_alert_test", alert="default"),
+            Result(status="unsuccessful"),
+        )
+
+    # Everything fine
+    handle.handle_result(
+        Test(name="unit_alert_test", alert="default"), Result(status="finished")
+    )
+
+
+def test_default_alert():
+    test = Test(name="unit_alert_test", alert="default")
+    assert default.handle_result(test, Result(status="timeout"))
+    assert not default.handle_result(test, Result(status="finished"))
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_run_script.py
+++ b/release/ray_release/tests/test_run_script.py
@@ -4,105 +4,131 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import unittest
+import pytest
 
 from ray_release.result import ExitCode
 
 
-class RunScriptTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.tempdir = tempfile.mkdtemp()
-        self.state_file = os.path.join(self.tempdir, "state.txt")
-        self.test_script = os.path.join(
-            os.path.dirname(__file__), "..", "..", "run_release_test.sh"
-        )
+@pytest.fixture
+def setup(tmpdir):
+    state_file = os.path.join(tmpdir, "state.txt")
+    test_script = os.path.join(
+        os.path.dirname(__file__), "..", "..", "run_release_test.sh"
+    )
 
-        os.environ["NO_INSTALL"] = "1"
-        os.environ["NO_CLONE"] = "1"
-        os.environ["NO_ARTIFACTS"] = "1"
-        os.environ["RAY_TEST_SCRIPT"] = "ray_release/tests/_test_run_release_test_sh.py"
-        os.environ["OVERRIDE_SLEEP_TIME"] = "0"
-        os.environ["MAX_RETRIES"] = "3"
+    os.environ["NO_INSTALL"] = "1"
+    os.environ["NO_CLONE"] = "1"
+    os.environ["NO_ARTIFACTS"] = "1"
+    os.environ["RAY_TEST_SCRIPT"] = "ray_release/tests/_test_run_release_test_sh.py"
+    os.environ["OVERRIDE_SLEEP_TIME"] = "0"
+    os.environ["MAX_RETRIES"] = "3"
 
-    def tearDown(self) -> None:
-        shutil.rmtree(self.tempdir)
+    yield state_file, test_script
 
-    def _read_state(self):
-        with open(self.state_file, "rt") as f:
-            return int(f.read())
 
-    def _run(self, *exits) -> int:
-        assert len(exits) == 3
+def _read_state(state_file):
+    with open(state_file, "rt") as f:
+        return int(f.read())
 
-        if os.path.exists(self.state_file):
-            os.unlink(self.state_file)
 
-        try:
-            return subprocess.check_call(
-                f"{self.test_script} "
-                f"{self.state_file} "
-                f"{' '.join(str(e.value) for e in exits)}",
-                shell=True,
-            )
-        except subprocess.CalledProcessError as e:
-            return e.returncode
+def _run_script(test_script, state_file, *exits):
+    assert len(exits) == 3
 
-    def testRepeat(self):
-        self.assertEquals(
-            self._run(ExitCode.SUCCESS, ExitCode.SUCCESS, ExitCode.SUCCESS),
-            ExitCode.SUCCESS.value,
-        )
-        self.assertEquals(self._read_state(), 1)
+    if os.path.exists(state_file):
+        os.unlink(state_file)
 
-        self.assertEquals(
-            self._run(ExitCode.RAY_WHEELS_TIMEOUT, ExitCode.SUCCESS, ExitCode.SUCCESS),
-            ExitCode.SUCCESS.value,
-        )
-        self.assertEquals(self._read_state(), 2)
-
-        self.assertEquals(
-            self._run(
-                ExitCode.RAY_WHEELS_TIMEOUT,
-                ExitCode.CLUSTER_ENV_BUILD_TIMEOUT,
-                ExitCode.SUCCESS,
-            ),
-            ExitCode.SUCCESS.value,
-        )
-        self.assertEquals(self._read_state(), 3)
-
-        self.assertEquals(
-            self._run(
-                ExitCode.CLUSTER_STARTUP_TIMEOUT,
-                ExitCode.CLUSTER_WAIT_TIMEOUT,
-                ExitCode.RAY_WHEELS_TIMEOUT,
-            ),
-            ExitCode.RAY_WHEELS_TIMEOUT.value,
-        )
-        self.assertEquals(self._read_state(), 3)
-
-        self.assertEquals(
-            self._run(
-                ExitCode.RAY_WHEELS_TIMEOUT, ExitCode.COMMAND_ALERT, ExitCode.SUCCESS
-            ),
-            ExitCode.COMMAND_ALERT.value,
-        )
-        self.assertEquals(self._read_state(), 2)
-
-    def testParameters(self):
-        os.environ["RAY_TEST_SCRIPT"] = "ray_release/tests/_test_catch_args.py"
-        argv_file = tempfile.mktemp()
-
-        subprocess.check_call(
-            f"{self.test_script} " f"{argv_file} " f"--smoke-test",
+    try:
+        return subprocess.check_call(
+            f"{test_script} "
+            f"{state_file} "
+            f"{' '.join(str(e.value) for e in exits)}",
             shell=True,
         )
+    except subprocess.CalledProcessError as e:
+        return e.returncode
 
-        with open(argv_file, "rt") as fp:
-            data = json.load(fp)
 
-        os.unlink(argv_file)
+def test_repeat(setup):
+    state_file, test_script = setup
 
-        self.assertIn("--smoke-test", data)
+    assert (
+        _run_script(
+            test_script,
+            state_file,
+            ExitCode.SUCCESS,
+            ExitCode.SUCCESS,
+            ExitCode.SUCCESS,
+        )
+        == ExitCode.SUCCESS.value
+    )
+    assert _read_state(state_file) == 1
+
+    assert (
+        _run_script(
+            test_script,
+            state_file,
+            ExitCode.RAY_WHEELS_TIMEOUT,
+            ExitCode.SUCCESS,
+            ExitCode.SUCCESS,
+        )
+        == ExitCode.SUCCESS.value
+    )
+    assert _read_state(state_file) == 2
+
+    assert (
+        _run_script(
+            test_script,
+            state_file,
+            ExitCode.RAY_WHEELS_TIMEOUT,
+            ExitCode.CLUSTER_ENV_BUILD_TIMEOUT,
+            ExitCode.SUCCESS,
+        )
+        == ExitCode.SUCCESS.value
+    )
+    assert _read_state(state_file) == 3
+
+    assert (
+        _run_script(
+            test_script,
+            state_file,
+            ExitCode.CLUSTER_STARTUP_TIMEOUT,
+            ExitCode.CLUSTER_WAIT_TIMEOUT,
+            ExitCode.RAY_WHEELS_TIMEOUT,
+        )
+        == ExitCode.RAY_WHEELS_TIMEOUT.value
+    )
+    assert _read_state(state_file) == 3
+
+    assert (
+        _run_script(
+            test_script,
+            state_file,
+            ExitCode.RAY_WHEELS_TIMEOUT,
+            ExitCode.COMMAND_ALERT,
+            ExitCode.SUCCESS,
+        )
+        == ExitCode.COMMAND_ALERT.value
+    )
+    assert _read_state(state_file) == 2
+
+
+def test_parameters(setup):
+    state_file, test_script = setup
+
+    os.environ["RAY_TEST_SCRIPT"] = "ray_release/tests/_test_catch_args.py"
+    argv_file = tempfile.mktemp()
+
+    subprocess.check_call(
+        f"{test_script} " f"{argv_file} " f"--smoke-test",
+        shell=True,
+    )
+
+    with open(argv_file, "rt") as fp:
+        data = json.load(fp)
+
+    os.unlink(argv_file)
+
+    assert "--smoke-test" in data
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_run_script.py
+++ b/release/ray_release/tests/test_run_script.py
@@ -1,6 +1,5 @@
 import json
 import os
-import shutil
 import subprocess
 import sys
 import tempfile

--- a/release/ray_release/tests/test_template.py
+++ b/release/ray_release/tests/test_template.py
@@ -1,5 +1,5 @@
+import pytest
 import sys
-import unittest
 
 from ray_release.config import Test
 from ray_release.exception import ReleaseTestConfigError
@@ -20,47 +20,48 @@ debian_packages:
 """  # noqa: E501
 
 
-class TemplateTest(unittest.TestCase):
-    def testPythonVersionDefaultCPU(self):
-        test = Test()
+def test_python_version_default_cpu():
+    test = Test()
 
-        env = populate_cluster_env_variables(test, ray_wheels_url="")
-        result = render_yaml_template(TEST_APP_CONFIG_CPU, env=env)
+    env = populate_cluster_env_variables(test, ray_wheels_url="")
+    result = render_yaml_template(TEST_APP_CONFIG_CPU, env=env)
 
-        assert result["base_image"] == "anyscale/ray:nightly-py37"
+    assert result["base_image"] == "anyscale/ray:nightly-py37"
 
-    def testPythonVersion39CPU(self):
-        test = Test(python="3.9")
 
-        env = populate_cluster_env_variables(test, ray_wheels_url="")
-        result = render_yaml_template(TEST_APP_CONFIG_CPU, env=env)
+def test_python_version_39_cpu():
+    test = Test(python="3.9")
 
-        assert result["base_image"] == "anyscale/ray:nightly-py39"
+    env = populate_cluster_env_variables(test, ray_wheels_url="")
+    result = render_yaml_template(TEST_APP_CONFIG_CPU, env=env)
 
-    def testPythonVersionDefaultGPU(self):
-        test = Test()
+    assert result["base_image"] == "anyscale/ray:nightly-py39"
 
-        env = populate_cluster_env_variables(test, ray_wheels_url="")
-        result = render_yaml_template(TEST_APP_CONFIG_GPU, env=env)
 
-        assert result["base_image"] == "anyscale/ray-ml:nightly-py37-gpu"
+def test_python_version_default_gpu():
+    test = Test()
 
-    def testPythonVersion39GPU(self):
-        test = Test(python="3.9")
+    env = populate_cluster_env_variables(test, ray_wheels_url="")
+    result = render_yaml_template(TEST_APP_CONFIG_GPU, env=env)
 
-        env = populate_cluster_env_variables(test, ray_wheels_url="")
-        result = render_yaml_template(TEST_APP_CONFIG_GPU, env=env)
+    assert result["base_image"] == "anyscale/ray-ml:nightly-py37-gpu"
 
-        assert result["base_image"] == "anyscale/ray-ml:nightly-py39-gpu"
 
-    def testPythonVersionInvalid(self):
-        test = Test(python="3.x")
+def test_python_version_39_gpu():
+    test = Test(python="3.9")
 
-        with self.assertRaises(ReleaseTestConfigError):
-            populate_cluster_env_variables(test, ray_wheels_url="")
+    env = populate_cluster_env_variables(test, ray_wheels_url="")
+    result = render_yaml_template(TEST_APP_CONFIG_GPU, env=env)
+
+    assert result["base_image"] == "anyscale/ray-ml:nightly-py39-gpu"
+
+
+def test_python_version_invalid():
+    test = Test(python="3.x")
+
+    with pytest.raises(ReleaseTestConfigError):
+        populate_cluster_env_variables(test, ray_wheels_url="")
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_wheels.py
+++ b/release/ray_release/tests/test_wheels.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import time
-import unittest
+import pytest
 from unittest.mock import patch
 
 from freezegun import freeze_time
@@ -22,226 +22,229 @@ from ray_release.wheels import (
 )
 
 
-class WheelsFinderTest(unittest.TestCase):
-    def setUp(self) -> None:
-        for key in os.environ:
-            if key.startswith("BUILDKITE"):
-                os.environ.pop(key)
+@pytest.fixture
+def remove_buildkite_env():
+    for key in os.environ:
+        if key.startswith("BUILDKITE"):
+            os.environ.pop(key)
 
-    def testGetRayVersion(self):
-        init_file = os.path.join(
-            os.path.dirname(__file__), "..", "..", "..", "python", "ray", "__init__.py"
-        )
-        with open(init_file, "rt") as fp:
-            content = [line.encode() for line in fp.readlines()]
 
-        with patch("urllib.request.urlopen", lambda _: content):
-            version = get_ray_version(DEFAULT_REPO, commit="fake")
-            self.assertTrue(version)
+def test_get_ray_version(remove_buildkite_env):
+    init_file = os.path.join(
+        os.path.dirname(__file__), "..", "..", "..", "python", "ray", "__init__.py"
+    )
+    with open(init_file, "rt") as fp:
+        content = [line.encode() for line in fp.readlines()]
 
-        with patch("urllib.request.urlopen", lambda _: []), self.assertRaises(
-            RayWheelsNotFoundError
-        ):
-            get_ray_version(DEFAULT_REPO, commit="fake")
+    with patch("urllib.request.urlopen", lambda _: content):
+        version = get_ray_version(DEFAULT_REPO, commit="fake")
+        assert version
 
-    def testGetRayWheelsURL(self):
-        url = get_ray_wheels_url(
-            repo_url="https://github.com/ray-project/ray.git",
-            branch="master",
-            commit="1234",
-            ray_version="3.0.0.dev0",
-        )
-        self.assertEqual(
-            url,
-            "https://s3-us-west-2.amazonaws.com/ray-wheels/"
-            "master/1234/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl",
-        )
+    with patch("urllib.request.urlopen", lambda _: []), pytest.raises(
+        RayWheelsNotFoundError
+    ):
+        get_ray_version(DEFAULT_REPO, commit="fake")
 
-    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
-    def testFindRayWheelsBuildkite(self):
-        repo = DEFAULT_REPO
-        branch = "master"
-        commit = "1234" * 10
-        version = "3.0.0.dev0"
 
-        os.environ["BUILDKITE_COMMIT"] = commit
+def test_get_ray_wheels_url(remove_buildkite_env):
+    url = get_ray_wheels_url(
+        repo_url="https://github.com/ray-project/ray.git",
+        branch="master",
+        commit="1234",
+        ray_version="3.0.0.dev0",
+    )
+    assert (
+        url == "https://s3-us-west-2.amazonaws.com/ray-wheels/master/1234/"
+        "ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl"
+    )
 
-        url = find_ray_wheels_url()
 
-        self.assertEqual(url, get_ray_wheels_url(repo, branch, commit, version))
+@patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
+def test_find_ray_wheels_buildkite(remove_buildkite_env):
+    repo = DEFAULT_REPO
+    branch = "master"
+    commit = "1234" * 10
+    version = "3.0.0.dev0"
 
-        branch = "branched"
-        os.environ["BUILDKITE_BRANCH"] = branch
+    os.environ["BUILDKITE_COMMIT"] = commit
 
-        url = find_ray_wheels_url()
+    url = find_ray_wheels_url()
 
-        self.assertEqual(url, get_ray_wheels_url(repo, branch, commit, version))
+    assert url == get_ray_wheels_url(repo, branch, commit, version)
 
-    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
-    def testFindRayWheelsCommitOnly(self):
-        repo = DEFAULT_REPO
-        branch = "master"
-        commit = "1234" * 10
-        version = "3.0.0.dev0"
+    branch = "branched"
+    os.environ["BUILDKITE_BRANCH"] = branch
 
-        search_str = commit
+    url = find_ray_wheels_url()
 
+    assert url == get_ray_wheels_url(repo, branch, commit, version)
+
+
+@patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
+def test_find_ray_wheels_commit_only(remove_buildkite_env):
+    repo = DEFAULT_REPO
+    branch = "master"
+    commit = "1234" * 10
+    version = "3.0.0.dev0"
+
+    search_str = commit
+
+    url = find_ray_wheels_url(search_str)
+
+    assert url == get_ray_wheels_url(repo, branch, commit, version)
+
+
+def _test_find_ray_wheels_checkout(
+    repo: str, branch: str, commit: str, version: str, search_str: str
+):
+    with patch(
+        "ray_release.wheels.get_latest_commits", lambda *a, **kw: [commit]
+    ), patch("ray_release.wheels.url_exists", lambda *a, **kw: False), pytest.raises(
+        RayWheelsNotFoundError
+    ):
+        # Fails because URL does not exist
+        find_ray_wheels_url(search_str)
+
+    with patch(
+        "ray_release.wheels.get_latest_commits", lambda *a, **kw: [commit]
+    ), patch("ray_release.wheels.url_exists", lambda *a, **kw: True):
+        # Succeeds
         url = find_ray_wheels_url(search_str)
 
-        self.assertEqual(url, get_ray_wheels_url(repo, branch, commit, version))
+        assert url == get_ray_wheels_url(repo, branch, commit, version)
 
-    def _testFindRayWheelsCheckout(
-        self, repo: str, branch: str, commit: str, version: str, search_str: str
-    ):
-        with patch(
-            "ray_release.wheels.get_latest_commits", lambda *a, **kw: [commit]
-        ), patch(
-            "ray_release.wheels.url_exists", lambda *a, **kw: False
-        ), self.assertRaises(
-            RayWheelsNotFoundError
-        ):
-            # Fails because URL does not exist
-            find_ray_wheels_url(search_str)
 
-        with patch(
-            "ray_release.wheels.get_latest_commits", lambda *a, **kw: [commit]
-        ), patch("ray_release.wheels.url_exists", lambda *a, **kw: True):
-            # Succeeds
-            url = find_ray_wheels_url(search_str)
+@patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
+def test_find_ray_wheels_branch(remove_buildkite_env):
+    repo = DEFAULT_REPO
+    branch = "master"
+    commit = "1234" * 10
+    version = "3.0.0.dev0"
 
-            self.assertEqual(url, get_ray_wheels_url(repo, branch, commit, version))
+    search_str = "master"
 
-    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
-    def testFindRayWheelsBranch(self):
-        repo = DEFAULT_REPO
-        branch = "master"
-        commit = "1234" * 10
-        version = "3.0.0.dev0"
+    _test_find_ray_wheels_checkout(repo, branch, commit, version, search_str)
 
-        self._testFindRayWheelsCheckout(
-            repo, branch, commit, version, search_str="master"
-        )
 
-    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
-    def testFindRayWheelsRepoBranch(self):
-        repo = DEFAULT_REPO
-        branch = "master"
-        commit = "1234" * 10
-        version = "3.0.0.dev0"
+@patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
+def test_find_ray_wheels_repo_branch(remove_buildkite_env):
+    repo = DEFAULT_REPO
+    branch = "master"
+    commit = "1234" * 10
+    version = "3.0.0.dev0"
 
-        self._testFindRayWheelsCheckout(
-            repo, branch, commit, version, search_str="ray-project:master"
-        )
+    search_str = "ray-project:master"
 
-    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
-    def testFindRayWheelsPRRepoBranch(self):
-        repo = "user"
-        branch = "dev-branch"
-        commit = "1234" * 10
-        version = "3.0.0.dev0"
+    _test_find_ray_wheels_checkout(repo, branch, commit, version, search_str)
 
-        self._testFindRayWheelsCheckout(
-            repo, branch, commit, version, search_str="user:dev-branch"
-        )
-        self._testFindRayWheelsCheckout(
-            f"https://github.com/{repo}/ray-fork.git",
-            branch,
-            commit,
-            version,
-            search_str="user:dev-branch",
-        )
 
-    @patch("time.sleep", lambda *a, **kw: None)
-    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
-    def testFindAndWaitWheels(self):
-        repo = DEFAULT_REPO
-        branch = "master"
-        commit = "1234" * 10
-        version = "3.0.0.dev0"
+@patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
+def test_find_ray_wheels_pr_repo_branch(remove_buildkite_env):
+    repo = "user"
+    branch = "dev-branch"
+    commit = "1234" * 10
+    version = "3.0.0.dev0"
 
-        class TrueAfter:
-            def __init__(self, after: float):
-                self.available_at = time.monotonic() + after
+    search_str = "user:dev-branch"
+    _test_find_ray_wheels_checkout(repo, branch, commit, version, search_str)
 
-            def __call__(self, *args, **kwargs):
-                if time.monotonic() > self.available_at:
-                    return True
-                return False
+    search_str = "user:dev-branch"
+    _test_find_ray_wheels_checkout(
+        f"https://github.com/{repo}/ray-fork.git", branch, commit, version, search_str
+    )
 
-        with freeze_time(auto_tick_seconds=10):
-            with patch(
-                "ray_release.wheels.url_exists", TrueAfter(400)
-            ), self.assertRaises(RayWheelsTimeoutError):
+
+@patch("time.sleep", lambda *a, **kw: None)
+@patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
+def test_find_and_wait_wheels(remove_buildkite_env):
+    repo = DEFAULT_REPO
+    branch = "master"
+    commit = "1234" * 10
+    version = "3.0.0.dev0"
+
+    class TrueAfter:
+        def __init__(self, after: float):
+            self.available_at = time.monotonic() + after
+
+        def __call__(self, *args, **kwargs):
+            if time.monotonic() > self.available_at:
+                return True
+            return False
+
+    with freeze_time(auto_tick_seconds=10):
+        with patch("ray_release.wheels.url_exists", TrueAfter(400)):
+            with pytest.raises(RayWheelsTimeoutError):
                 find_and_wait_for_ray_wheels_url(commit, timeout=300.0)
 
-        with freeze_time(auto_tick_seconds=10):
-            with patch("ray_release.wheels.url_exists", TrueAfter(200)):
-                url = find_and_wait_for_ray_wheels_url(commit, timeout=300.0)
+    with freeze_time(auto_tick_seconds=10):
+        with patch("ray_release.wheels.url_exists", TrueAfter(200)):
+            url = find_and_wait_for_ray_wheels_url(commit, timeout=300.0)
 
-            self.assertEqual(url, get_ray_wheels_url(repo, branch, commit, version))
+        assert url == get_ray_wheels_url(repo, branch, commit, version)
 
-    def testMatchingRayWheelsURL(self):
-        assert not is_wheels_url_matching_ray_verison(
-            f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 8))}", (3, 7)
+
+def test_matching_ray_wheels_url():
+    assert not is_wheels_url_matching_ray_verison(
+        f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 8))}", (3, 7)
+    )
+
+    assert not is_wheels_url_matching_ray_verison(
+        f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 7))}", (3, 8)
+    )
+
+    assert is_wheels_url_matching_ray_verison(
+        f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 7))}", (3, 7)
+    )
+
+
+@patch("ray_release.wheels.resolve_url", lambda url: url)
+def test_rewrite_wheels_url(remove_buildkite_env):
+    # Do not rewrite if versions match
+    assert (
+        maybe_rewrite_wheels_url(
+            f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 7))}",
+            (3, 7),
         )
+        == f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 7))}"
+    )
 
-        assert not is_wheels_url_matching_ray_verison(
-            f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 7))}", (3, 8)
+    # Do not rewrite if version can't be parsed
+    assert (
+        maybe_rewrite_wheels_url("http://some/location/unknown.whl", (3, 7))
+        == "http://some/location/unknown.whl"
+    )
+
+    # Rewrite when version can be parsed
+    assert (
+        maybe_rewrite_wheels_url(
+            f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 8))}",
+            (3, 7),
         )
+        == f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 7))}"
+    )
 
-        assert is_wheels_url_matching_ray_verison(
-            f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 7))}", (3, 7)
+
+def test_wheels_sanity_string(remove_buildkite_env):
+    this_env = {"env": None}
+
+    def override_env(path, env):
+        this_env["env"] = env
+
+    with patch(
+        "ray_release.template.load_and_render_yaml_template", override_env
+    ), patch("ray_release.template.get_test_environment", lambda: {}):
+        load_test_cluster_env(
+            Test(cluster=dict(cluster_env="invalid")),
+            ray_wheels_url="https://no-commit-url",
         )
+        assert "No commit sanity check" in this_env["env"]["RAY_WHEELS_SANITY_CHECK"]
 
-    @patch("ray_release.wheels.resolve_url", lambda url: url)
-    def testRewriteWheelsURL(self):
-        # Do not rewrite if versions match
-        assert (
-            maybe_rewrite_wheels_url(
-                f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 7))}",
-                (3, 7),
-            )
-            == f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 7))}"
+        sha = "abcdef1234abcdef1234abcdef1234abcdef1234"
+        load_test_cluster_env(
+            Test(cluster=dict(cluster_env="invalid")),
+            ray_wheels_url=f"https://some/{sha}/binary.whl",
         )
-
-        # Do not rewrite if version can't be parsed
-        assert (
-            maybe_rewrite_wheels_url("http://some/location/unknown.whl", (3, 7))
-            == "http://some/location/unknown.whl"
-        )
-
-        # Rewrite when version can be parsed
-        assert (
-            maybe_rewrite_wheels_url(
-                f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 8))}",
-                (3, 7),
-            )
-            == f"http://some/location/{get_wheels_filename('3.0.0dev0', (3, 7))}"
-        )
-
-    def testWheelsSanityString(self):
-        this_env = {"env": None}
-
-        def override_env(path, env):
-            this_env["env"] = env
-
-        with patch(
-            "ray_release.template.load_and_render_yaml_template", override_env
-        ), patch("ray_release.template.get_test_environment", lambda: {}):
-            load_test_cluster_env(
-                Test(cluster=dict(cluster_env="invalid")),
-                ray_wheels_url="https://no-commit-url",
-            )
-            assert (
-                "No commit sanity check" in this_env["env"]["RAY_WHEELS_SANITY_CHECK"]
-            )
-
-            sha = "abcdef1234abcdef1234abcdef1234abcdef1234"
-            load_test_cluster_env(
-                Test(cluster=dict(cluster_env="invalid")),
-                ray_wheels_url=f"https://some/{sha}/binary.whl",
-            )
-            assert sha in this_env["env"]["RAY_WHEELS_SANITY_CHECK"]
+        assert sha in this_env["env"]["RAY_WHEELS_SANITY_CHECK"]
 
 
 def test_url_exist():
@@ -250,6 +253,4 @@ def test_url_exist():
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We centralized on pytest, so we should move some of our `unittest` tests to `pytest`. Luckily, we have a capable automated junior dev to help us with that: ChatGPT.

Powered by ChatGPT:

<img width="770" alt="Screen Shot 2022-12-21 at 2 21 09 PM" src="https://user-images.githubusercontent.com/14904111/208927027-71d101ac-dbc2-4c35-a52a-25fb9b27defe.png">

<img width="742" alt="Screen Shot 2022-12-21 at 2 21 21 PM" src="https://user-images.githubusercontent.com/14904111/208927065-134e5f7e-f9b6-4b98-ac41-ca3af3acdb35.png">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
