### PR TITLE
[data] New executor backend [2/n]--- Add allocation tracing util

### DIFF
--- a/python/ray/data/_internal/memory_tracing.py
+++ b/python/ray/data/_internal/memory_tracing.py
@@ -1,0 +1,110 @@
+from typing import Dict
+
+import ray
+
+
+@ray.remote
+class _MemActor:
+    def __init__(self):
+        self.allocated: Dict[ray.ObjectRef, dict] = {}
+        self.deallocated: Dict[ray.ObjectRef, dict] = {}
+        self.skip_dealloc: Dict[ray.ObjectRef, str] = {}
+        self.peak_mem = 0
+        self.cur_mem = 0
+
+    def trace_alloc(self, ref, loc):
+        ref = ref[0]
+        if ref not in self.allocated:
+            meta = ray.experimental.get_object_locations([ref])
+            size_bytes = meta.get("object_size", 0)
+            if not size_bytes:
+                size_bytes = -1
+                from ray import cloudpickle as pickle
+
+                try:
+                    obj = ray.get(ref, timeout=5.0)
+                    size_bytes = len(pickle.dumps(obj))
+                except Exception:
+                    print("[mem_tracing] ERROR getting size")
+                    size_bytes = -1
+            print(f"[mem_tracing] Allocated {size_bytes} bytes at {loc}: {ref}")
+            entry = {
+                "size_bytes": size_bytes,
+                "loc": loc,
+            }
+            self.allocated[ref] = entry
+            self.cur_mem += size_bytes
+            self.peak_mem = max(self.cur_mem, self.peak_mem)
+
+    def trace_dealloc(self, ref, loc, freed):
+        ref = ref[0]
+        size_bytes = self.allocated.get(ref, {}).get("size_bytes", 0)
+        if freed:
+            print(f"[mem_tracing] Freed {size_bytes} bytes at {loc}: {ref}")
+            if ref in self.allocated:
+                self.cur_mem -= size_bytes
+                self.deallocated[ref] = self.allocated[ref]
+                self.deallocated[ref]["dealloc_loc"] = loc
+                del self.allocated[ref]
+            else:
+                print(f"[mem_tracing] WARNING: allocation of {ref} was not traced!")
+        else:
+            print(f"[mem_tracing] Skipped freeing {size_bytes} bytes at {loc}: {ref}")
+            self.skip_dealloc[ref] = loc
+
+    def leak_report(self):
+        print("[mem_tracing] ===== Leaked objects =====")
+        for ref in self.allocated:
+            size_bytes = self.allocated[ref].get("size_bytes")
+            loc = self.allocated[ref].get("loc")
+            if ref in self.skip_dealloc:
+                dealloc_loc = self.skip_dealloc[ref]
+                print(
+                    f"[mem_tracing] Leaked object, created at {loc}, size "
+                    f"{size_bytes}, skipped dealloc at {dealloc_loc}: {ref}"
+                )
+            else:
+                print(
+                    f"[mem_tracing] Leaked object, created at {loc}, "
+                    f"size {size_bytes}: {ref}"
+                )
+        print("[mem_tracing] ===== End leaked objects =====")
+        print("[mem_tracing] ===== Freed objects =====")
+        for ref in self.deallocated:
+            size_bytes = self.deallocated[ref].get("size_bytes")
+            loc = self.deallocated[ref].get("loc")
+            dealloc_loc = self.deallocated[ref].get("dealloc_loc")
+            print(
+                f"[mem_tracing] Freed obj from {loc} at {dealloc_loc}, "
+                f"size {size_bytes}: {ref}"
+            )
+        print("[mem_tracing] ===== End freed objects =====")
+        print(f"[mem_tracing] Peak size bytes {self.peak_mem}")
+        print(f"[mem_tracing] Current size bytes {self.cur_mem}")
+
+
+def _get_mem_actor():
+    return _MemActor.options(
+        name="mem_tracing_actor", get_if_exists=True, lifetime="detached"
+    ).remote()
+
+
+def _trace_allocation(ref: ray.ObjectRef, loc: str) -> None:
+    ctx = DatasetContext.get_current()
+    if ctx.trace_allocations:
+        tracer = _get_mem_actor()
+        ray.get(tracer.trace_alloc.remote([ref], loc))
+
+
+def _trace_deallocation(ref: ray.ObjectRef, loc: str, freed: bool = True) -> None:
+    if freed:
+        ray._private.internal_api.free(ref, local_only=False)
+    ctx = DatasetContext.get_current()
+    if ctx.trace_allocations:
+        tracer = _get_mem_actor()
+        ray.get(tracer.trace_dealloc.remote([ref], loc, freed))
+
+
+def _leak_report() -> None:
+    tracer = _get_mem_actor()
+    ray.get(tracer.leak_report.remote())

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -1,6 +1,13 @@
 import pytest
+import ray
+import numpy as np
 
 from ray.data._internal.util import _check_pyarrow_version
+from ray.data._internal.memory_tracing import (
+    trace_allocation,
+    trace_deallocation,
+    leak_report,
+)
 from ray.data.tests.conftest import *  # noqa: F401, F403
 
 
@@ -32,6 +39,37 @@ def test_check_pyarrow_version_supported():
         _check_pyarrow_version()
     except ImportError as e:
         pytest.fail(f"_check_pyarrow_version failed unexpectedly: {e}")
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_memory_tracing(enabled):
+    ctx = ray.data.context.DatasetContext.get_current()
+    ctx.trace_allocations = enabled
+    ref1 = ray.put(np.zeros(1024 * 1024))
+    ref2 = ray.put(np.zeros(1024 * 1024))
+    ref3 = ray.put(np.zeros(1024 * 1024))
+    trace_allocation(ref1, "test1")
+    trace_allocation(ref2, "test2")
+    trace_allocation(ref3, "test5")
+    trace_deallocation(ref1, "test3", free=False)
+    trace_deallocation(ref2, "test4", free=True)
+    ray.get(ref1)
+    with pytest.raises(ray.exceptions.ObjectFreedError):
+        ray.get(ref2)
+    report = leak_report()
+    print(report)
+
+    if enabled:
+        assert "Leaked object, created at test1" in report, report
+        assert "Leaked object, created at test5" in report, report
+        assert "Freed object from test2 at test4" in report, report
+        assert "skipped dealloc at test3" in report, report
+    else:
+        assert "test1" not in report, report
+        assert "test2" not in report, report
+        assert "test3" not in report, report
+        assert "test4" not in report, report
+        assert "test5" not in report, report
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add a utility class for tracing object allocation / freeing. This makes it a lot easier to debug memory allocation / freeing issues.

This is split out from https://github.com/ray-project/ray/pull/30903

Sample output:
```
[mem_tracing] ===== Leaked objects =====
[mem_tracing] Leaked object, created at test1, size 8388742, skipped dealloc at test3: ObjectRef(00ffffffffffffffffffffffffffffffffffffff0100000004000000)
[mem_tracing] Leaked object, created at test5, size 8388742: ObjectRef(00ffffffffffffffffffffffffffffffffffffff0100000006000000)
[mem_tracing] ===== End leaked objects =====
[mem_tracing] ===== Freed objects =====
[mem_tracing] Freed object from test2 at test4, size 8388742: ObjectRef(00ffffffffffffffffffffffffffffffffffffff0100000005000000)
[mem_tracing] ===== End freed objects =====
[mem_tracing] Peak size bytes 25166226
[mem_tracing] Current size bytes 16777484
```