### PR TITLE
[core] Fixing MemoryMonitorTest flakiness

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1649,6 +1649,7 @@ cc_test(
     deps = [
         ":ray_common",
         "@boost//:filesystem",
+        "@boost//:thread",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/ray/common/test/memory_monitor_test.cc
+++ b/src/ray/common/test/memory_monitor_test.cc
@@ -130,8 +130,8 @@ TEST_F(MemoryMonitorTest, TestMonitorPeriodSetMaxUsageThresholdCallbackExecuted)
                         -1 /*min_memory_free_bytes*/,
                         1 /*refresh_interval_ms*/,
                         [has_checked_once](bool is_usage_above_threshold,
-                                        MemorySnapshot system_memory,
-                                        float usage_threshold) {
+                                           MemorySnapshot system_memory,
+                                           float usage_threshold) {
                           ASSERT_EQ(1.0f, usage_threshold);
                           ASSERT_GT(system_memory.total_bytes, 0);
                           ASSERT_GT(system_memory.used_bytes, 0);
@@ -148,8 +148,8 @@ TEST_F(MemoryMonitorTest, TestMonitorPeriodDisableMinMemoryCallbackExecuted) {
                         -1 /*min_memory_free_bytes*/,
                         1 /*refresh_interval_ms*/,
                         [has_checked_once](bool is_usage_above_threshold,
-                                        MemorySnapshot system_memory,
-                                        float usage_threshold) {
+                                           MemorySnapshot system_memory,
+                                           float usage_threshold) {
                           ASSERT_EQ(0.4f, usage_threshold);
                           ASSERT_GT(system_memory.total_bytes, 0);
                           ASSERT_GT(system_memory.used_bytes, 0);
@@ -167,8 +167,8 @@ TEST_F(MemoryMonitorTest, TestMonitorMinFreeZeroThresholdIsOne) {
                         0 /*min_memory_free_bytes*/,
                         1 /*refresh_interval_ms*/,
                         [has_checked_once](bool is_usage_above_threshold,
-                                        MemorySnapshot system_memory,
-                                        float usage_threshold) {
+                                           MemorySnapshot system_memory,
+                                           float usage_threshold) {
                           ASSERT_EQ(1.0f, usage_threshold);
                           ASSERT_GT(system_memory.total_bytes, 0);
                           ASSERT_GT(system_memory.used_bytes, 0);


### PR DESCRIPTION
The tests copy a reference to a stack variable. When the memory monitor callback is invoked the second+ time, it will attempt to dereference this stack address, causing the mutex we're using to assert false because the mutex data is corrupted.

I fixed this by using a shared_ptr (move to heap) and a boost latch (abstracts away the thread safety for us).

Closes https://github.com/ray-project/ray/issues/29702