### PR TITLE
[core][state] Task backend disable status by default

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -455,6 +455,12 @@ RAY_CONFIG(uint64_t, gcs_service_address_check_interval_milliseconds, 1000)
 /// The batch size for metrics export.
 RAY_CONFIG(int64_t, metrics_report_batch_size, 100)
 
+/// True if task status changes will be recorded and reported to GCS.
+/// When false, and `RAY_task_events_report_interval_ms > 0` and `RAY_enable_timeline=1`,
+/// only timeline events will be recorded and reported to GCS.
+/// TODO(rickyx): A temporary feature flag. Remove later.
+RAY_CONFIG(bool, task_events_report_status_events, false)
+
 /// The interval duration for which task state events will be reported to GCS.
 /// The reported data should only be used for observability.
 /// Setting the value to 0 disables the task event recording and reporting.

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2365,7 +2365,8 @@ Status CoreWorker::ExecuteTask(
     task_counter_.MovePendingToRunning(func_name, task_spec.IsRetry());
 
     // Make task event
-    if (task_event_buffer_->Enabled()) {
+    if (task_event_buffer_->Enabled() &&
+        RayConfig::instance().task_events_report_status_events()) {
       rpc::TaskEvents task_event;
       task_event.set_task_id(task_spec.TaskId().Binary());
       task_event.set_attempt_number(task_spec.AttemptNumber());

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -881,7 +881,8 @@ void TaskManager::RecordMetrics() {
 
 void TaskManager::RecordTaskStatusEvent(const TaskEntry &task_entry,
                                         rpc::TaskStatus status) {
-  if (!task_event_buffer_.Enabled()) {
+  if (!task_event_buffer_.Enabled() ||
+      !RayConfig::instance().task_events_report_status_events()) {
     return;
   }
   // Make task event

--- a/src/ray/core_worker/test/task_event_buffer_test.cc
+++ b/src/ray/core_worker/test/task_event_buffer_test.cc
@@ -38,7 +38,8 @@ class TaskEventBufferTest : public ::testing::Test {
         R"(
 {
   "task_events_report_interval_ms": 1000,
-  "task_events_max_num_task_events_in_buffer": 100
+  "task_events_max_num_task_events_in_buffer": 100,
+  "task_events_report_status_events": 1 
 }
   )");
 

--- a/src/ray/core_worker/test/task_event_buffer_test.cc
+++ b/src/ray/core_worker/test/task_event_buffer_test.cc
@@ -39,7 +39,7 @@ class TaskEventBufferTest : public ::testing::Test {
 {
   "task_events_report_interval_ms": 1000,
   "task_events_max_num_task_events_in_buffer": 100,
-  "task_events_report_status_events": 1 
+  "task_events_report_status_events": true
 }
   )");
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
See https://github.com/ray-project/ray/issues/31284

This PR disables the recording/reporting of status changes for a task (but keeps the profiling events on by default). 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
