### PR TITLE
[RLlib] Issue 28289: When resuming from checkpoint, global "timestep" value on policies initially 0 (wrong)

### DIFF
--- a/rllib/algorithms/tests/test_algorithm.py
+++ b/rllib/algorithms/tests/test_algorithm.py
@@ -420,25 +420,6 @@ class TestAlgorithm(unittest.TestCase):
         bc.train()
         bc.stop()
 
-    def test_counters_after_checkpoint(self):
-        # We expect algorithm to no start counters from zero after loading a
-        # checkpoint on a fresh Algorithm instance
-        config = pg.PGConfig().environment(env="CartPole-v1")
-        algo = config.build()
-
-        self.assertTrue(all(c == 0 for c in algo._counters.values()))
-        algo.step()
-        self.assertTrue((all(c != 0 for c in algo._counters.values())))
-        counter_values = list(algo._counters.values())
-        state = algo.__getstate__()
-        algo.stop()
-
-        algo2 = config.build()
-        self.assertTrue(all(c == 0 for c in algo2._counters.values()))
-        algo2.__setstate__(state)
-        counter_values2 = list(algo2._counters.values())
-        self.assertEqual(counter_values, counter_values2)
-
 
 if __name__ == "__main__":
     import pytest

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -1630,6 +1630,8 @@ class RolloutWorker(ParallelIteratorWorker, FaultAwareApply):
             "is_policy_to_train": self.is_policy_to_train,
             # TODO: Filters will be replaced by connectors.
             "filters": filters,
+            # Global variables.
+            "global_vars": self.get_global_vars(),
         }
 
     @DeveloperAPI
@@ -1698,6 +1700,10 @@ class RolloutWorker(ParallelIteratorWorker, FaultAwareApply):
             self.set_policy_mapping_fn(state["policy_mapping_fn"])
         if state.get("is_policy_to_train") is not None:
             self.set_is_policy_to_train(state["is_policy_to_train"])
+
+        # Also restore global vars for this worker.
+        if state.get("global_vars") is not None:
+            self.set_global_vars(state["global_vars"])
 
     @DeveloperAPI
     def get_weights(


### PR DESCRIPTION
Signed-off-by: sven1977 <svenmika1977@gmail.com>

Issue 28289: When resuming from checkpoint, global "timestep" value on policies initially 0 (wrong)

Only after another training round will have correct value again (due to `Algorithm._counters` being correctly handled).

Closes #28289

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
