### PR TITLE
[docs] [core] Fixing deadlock in Queue example

### DIFF
--- a/doc/source/ray-core/actors/actor-utils.rst
+++ b/doc/source/ray-core/actors/actor-utils.rst
@@ -29,4 +29,4 @@ actors, you can use :ref:`ray.util.queue.Queue <ray-queue-ref>`.
 
 .. literalinclude:: ../doc_code/actor-queue.py
 
-Ray's Queue API has similar API as Python's ``asyncio.Queue`` and ``queue.Queue``.
+Ray's Queue API has a similar API to Python's ``asyncio.Queue`` and ``queue.Queue``.


### PR DESCRIPTION
User Nemo brought this up in a Discuss question: https://discuss.ray.io/t/ray-util-queue-deadlock/8688

I reproduced the deadlock and fixed it:
```
Put work 1 - 10 to queue...
(consumer pid=284065) consumer 1 got work 0
(consumer pid=284065) consumer 1 got work 2
(consumer pid=284065) consumer 1 got work 5
(consumer pid=284065) consumer 1 got work 6
(consumer pid=284065) consumer 1 got work 8
(consumer pid=284064) consumer 0 got work 1
(consumer pid=284064) consumer 0 got work 3
(consumer pid=284064) consumer 0 got work 4
(consumer pid=284064) consumer 0 got work 7
(consumer pid=284064) consumer 0 got work 9
```