### PR TITLE
[Jobs] Track real job process

### DIFF
--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -412,11 +412,11 @@ class JobSupervisor:
                             "job with SIGTERM."
                         )
                         stop_signal = "SIGTERM"
-                    
+
                     job_process = psutil.Process(child_pid)
                     proc_to_kill = [job_process] + job_process.children(recursive=True)
 
-                    # Send stop signal and wait for job to terminate gracefully, 
+                    # Send stop signal and wait for job to terminate gracefully,
                     # otherwise SIGKILL job forcefully after timeout.
                     self._kill_processes(proc_to_kill, getattr(signal, stop_signal))
                     try:

--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -336,7 +336,7 @@ class JobSupervisor:
                 await asyncio.sleep(self.SUBPROCESS_POLL_PERIOD_S)
 
     def _kill_processes(self, processes: List[psutil.Process], sig: signal.Signals):
-        """Ensures each process is already finished or send a kill signal."""
+        """Ensure each process is already finished or send a kill signal."""
         for proc in processes:
             try:
                 os.kill(proc.pid, sig)

--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -341,7 +341,7 @@ class JobSupervisor:
             try:
                 if os.getpgid(proc.pid) == pgid:
                     process_group.append(proc)
-            except:
+            except ProcessLookupError:
                 pass
 
         while True:

--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -437,7 +437,7 @@ class JobSupervisor:
                             f"Attempt to gracefully terminate job {self._job_id} "
                             f"through {stop_signal} has timed out after "
                             f"{stop_job_wait_time} seconds. Job is now being "
-                            "force-killed."
+                            "force-killed with SIGKILL."
                         )
                         self._kill_processes(proc_to_kill, signal.SIGKILL)
                 await self._job_info_client.put_status(self._job_id, JobStatus.STOPPED)

--- a/dashboard/modules/job/tests/test_job_manager.py
+++ b/dashboard/modules/job/tests/test_job_manager.py
@@ -850,6 +850,14 @@ while True:
 
     assert job_manager.stop_job(job_id) is True
 
+    with pytest.raises(RuntimeError):
+        await async_wait_for_condition_async_predicate(
+            check_job_stopped,
+            job_manager=job_manager,
+            job_id=job_id,
+            timeout=stop_timeout - 1,
+        )
+
     await async_wait_for_condition(
         lambda: "SIGTERM signal handled!" in job_manager.get_job_logs(job_id)
     )
@@ -858,7 +866,7 @@ while True:
         check_job_stopped,
         job_manager=job_manager,
         job_id=job_id,
-        timeout=stop_timeout + 10,
+        timeout=10,
     )
 
 

--- a/dashboard/modules/job/tests/test_job_manager.py
+++ b/dashboard/modules/job/tests/test_job_manager.py
@@ -774,7 +774,10 @@ class TestTailLogs:
             job_manager.stop_job(job_id)
 
             async for lines in job_manager.tail_job_logs(job_id):
-                assert all(s == "Waiting..." for s in lines.strip().split("\n"))
+                assert all(
+                    s == "Waiting..." or s == "Terminated"
+                    for s in lines.strip().split("\n")
+                )
                 print(lines, end="")
 
             await async_wait_for_condition_async_predicate(


### PR DESCRIPTION
Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Resolves the issue described in https://github.com/ray-project/ray/issues/31274. On Linux systems, when a stop signal is sent, instead of killing + waiting on only the shell process (which starts the actual job as a child process), we want to kill all the children of the shell process along with the shell process itself, and poll all processes until they exit or send a force SIGKILL on timeout. (This change is compatible with Mac OSX systems as well)

## Related issue number

"Closes #31274"

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
