### PR TITLE
[Serve] Address incremental memory leak due to _PyObjScanner

### DIFF
--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -175,6 +175,7 @@ class DAGNode(DAGNodeBase):
         ):
             if n not in children:
                 children.append(n)
+        scanner.clear()
         return children
 
     def _apply_and_replace_all_child_nodes(
@@ -210,6 +211,7 @@ class DAGNode(DAGNodeBase):
         new_args, new_kwargs, new_other_args_to_resolve = scanner.replace_nodes(
             replace_table
         )
+        scanner.clear()
 
         # Return updated copy of self.
         return self._copy(
@@ -288,6 +290,7 @@ class DAGNode(DAGNodeBase):
                 replace_table[node] = apply_fn(node)
 
         replaced_inputs = scanner.replace_nodes(replace_table)
+        scanner.clear()
 
         return replaced_inputs
 


### PR DESCRIPTION
Signed-off-by: simon-mo <simon.mo@hey.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Ray user @AbhishekBose reported a memory leak in Ray Serve and I was able to pin it down to the the leak in the `PyObjScanner` object. Previously we had to deal with this in other places. But it seems like the fix was incomplete.

This PR apply the same fix to the other places where _PyObjScanner is involved. Someone from the Ray Serve team should follow up with a release test.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://discuss.ray.io/t/dagdriver-memory-increasing-for-basic-dags/8758/1

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
