### PR TITLE
Fix numpy int/bool dtype references

### DIFF
--- a/doc/source/data/doc_code/tensor.py
+++ b/doc/source/data/doc_code/tensor.py
@@ -146,7 +146,7 @@ ds.write_parquet(path)
 # Read the Parquet files into a new Dataset, with the serialized tensors
 # automatically cast to our tensor column extension type.
 ds = ray.data.read_parquet(
-    path, tensor_column_schema={"two": (np.int, (2, 2, 2))})
+    path, tensor_column_schema={"two": (np.int_, (2, 2, 2))})
 
 # The new column is represented with as a Tensor extension type.
 print(ds.schema())

--- a/python/ray/experimental/tf_utils.py
+++ b/python/ray/experimental/tf_utils.py
@@ -12,7 +12,7 @@ def unflatten(vector, shapes):
     i = 0
     arrays = []
     for shape in shapes:
-        size = np.prod(shape, dtype=np.int)
+        size = np.prod(shape, dtype=np.int_)
         array = vector[i : (i + size)].reshape(shape)
         arrays.append(array)
         i += size

--- a/python/ray/util/collective/collective_group/gloo_util.py
+++ b/python/ray/util/collective/collective_group/gloo_util.py
@@ -28,7 +28,7 @@ GLOO_REDUCE_OP_MAP = {
 
 NUMPY_GLOO_DTYPE_MAP = {
     # INT types
-    numpy.int: pygloo.glooDataType_t.glooInt64,
+    numpy.int_: pygloo.glooDataType_t.glooInt64,
     numpy.uint8: pygloo.glooDataType_t.glooUint8,
     numpy.uint32: pygloo.glooDataType_t.glooUint32,
     numpy.uint64: pygloo.glooDataType_t.glooUint64,

--- a/python/ray/util/collective/collective_group/nccl_util.py
+++ b/python/ray/util/collective/collective_group/nccl_util.py
@@ -25,7 +25,7 @@ NCCL_REDUCE_OP_MAP = {
 # cupy types are the same with numpy types
 NUMPY_NCCL_DTYPE_MAP = {
     # INT types
-    numpy.int: nccl.NCCL_INT64,
+    numpy.int_: nccl.NCCL_INT64,
     numpy.uint8: nccl.NCCL_UINT8,
     numpy.uint32: nccl.NCCL_UINT32,
     numpy.uint64: nccl.NCCL_UINT64,

--- a/release/nightly_tests/dataset/dataset_shuffle_data_loader.py
+++ b/release/nightly_tests/dataset/dataset_shuffle_data_loader.py
@@ -35,7 +35,7 @@ def create_torch_iterator(split, batch_size, rank=None):
         f"{batch_size} batch size."
     )
     numpy_to_torch_dtype = {
-        np.bool: torch.bool,
+        np.bool_: torch.bool,
         np.uint8: torch.uint8,
         np.int8: torch.int8,
         np.int16: torch.int16,

--- a/release/nightly_tests/dataset/pipelined_training.py
+++ b/release/nightly_tests/dataset/pipelined_training.py
@@ -182,7 +182,7 @@ def train_main(args, splits):
 ######################################################
 
 numpy_to_torch_dtype = {
-    np.bool: torch.bool,
+    np.bool_: torch.bool,
     np.uint8: torch.uint8,
     np.int8: torch.int8,
     np.int16: torch.int16,

--- a/rllib/algorithms/alpha_zero/mcts.py
+++ b/rllib/algorithms/alpha_zero/mcts.py
@@ -25,7 +25,7 @@ class Node:
         self.child_number_visits = np.zeros(
             [self.action_space_size], dtype=np.float32
         )  # N
-        self.valid_actions = obs["action_mask"].astype(np.bool)
+        self.valid_actions = obs["action_mask"].astype(np.bool_)
 
         self.reward = reward
         self.done = done

--- a/rllib/algorithms/dt/tests/test_dt_model.py
+++ b/rllib/algorithms/dt/tests/test_dt_model.py
@@ -274,7 +274,7 @@ class TestDTModel(unittest.TestCase):
         )
 
         # used to select the causal padded element of each attention tensor
-        select_mask = np.triu(np.ones((3 * T, 3 * T), dtype=np.bool), k=1)
+        select_mask = np.triu(np.ones((3 * T, 3 * T), dtype=np.bool_), k=1)
         select_mask = np.tile(select_mask, (B, model_config["num_heads"], 1, 1))
 
         for attention in attentions:

--- a/rllib/env/wrappers/dm_control_wrapper.py
+++ b/rllib/env/wrappers/dm_control_wrapper.py
@@ -46,7 +46,7 @@ from ray.rllib.utils.annotations import PublicAPI
 def _spec_to_box(spec):
     def extract_min_max(s):
         assert s.dtype == np.float64 or s.dtype == np.float32
-        dim = np.int(np.prod(s.shape))
+        dim = np.int_(np.prod(s.shape))
         if type(s) == specs.Array:
             bound = np.inf * np.ones(dim, dtype=np.float32)
             return -bound, bound

--- a/rllib/utils/numpy.py
+++ b/rllib/utils/numpy.py
@@ -468,7 +468,7 @@ def one_hot(
 
     # Handle bool arrays correctly.
     if x.dtype == np.bool_:
-        x = x.astype(np.int)
+        x = x.astype(np.int_)
         depth = 2
 
     # If depth is not given, try to infer it from the values in the array.

--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -668,7 +668,7 @@ def _check_done_and_truncated(done, truncated, base_env=False, agent_ids=None):
         if base_env:
             for _, multi_agent_dict in data.items():
                 for agent_id, done_ in multi_agent_dict.items():
-                    if not isinstance(done_, (bool, np.bool, np.bool_)):
+                    if not isinstance(done_, (bool, np.bool_)):
                         raise ValueError(
                             f"Your step function must return `{what}s` that are "
                             f"boolean. But instead was a {type(data)}"


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Numpy version 1.24.0 removed aliases for `numpy.int` and `numpy.bool` to `numpy.int_` and `numpy.bool_`, respectively. We are using these deprecated aliases in our code. This PR updates the Ray repo to use the underscore properties/methods instead.

This will resolve some of the incompatibilities we currently experience with numpy >= 1.24

## Related issue number

Related to #31240

Closes #31258

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
