### PR TITLE
[RLlib] Fix tensorflow probability imports

### DIFF
--- a/rllib/algorithms/bandit/bandit_tf_model.py
+++ b/rllib/algorithms/bandit/bandit_tf_model.py
@@ -1,17 +1,25 @@
 import gymnasium as gym
-import tensorflow_probability as tfp
 
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.models.tf.tf_modelv2 import TFModelV2
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_tf
+from ray.rllib.utils.framework import try_import_tfp
 from ray.rllib.utils.typing import TensorType
 
 tf1, tf, tfv = try_import_tf()
+tfp = try_import_tfp()
 
 
 class OnlineLinearRegression(tf.Module if tf else object):
     def __init__(self, feature_dim, alpha=1, lambda_=1):
+        if not tfp:
+            raise ImportError(
+                "Could not import TensorFlow Probabilty! OnlineLinearRegression "
+                "requires you to install Tensorflow Probabilty. You can install it "
+                "with `pip install tensorflow_probability`."
+            )
+
         super(OnlineLinearRegression, self).__init__()
 
         self.d = feature_dim

--- a/rllib/algorithms/bandit/bandit_tf_model.py
+++ b/rllib/algorithms/bandit/bandit_tf_model.py
@@ -13,12 +13,8 @@ tfp = try_import_tfp()
 
 class OnlineLinearRegression(tf.Module if tf else object):
     def __init__(self, feature_dim, alpha=1, lambda_=1):
-        if not tfp:
-            raise ImportError(
-                "Could not import TensorFlow Probabilty! OnlineLinearRegression "
-                "requires you to install Tensorflow Probabilty. You can install it "
-                "with `pip install tensorflow_probability`."
-            )
+        try_import_tf(error=True)
+        try_import_tfp(error=True)
 
         super(OnlineLinearRegression, self).__init__()
 

--- a/rllib/core/optim/tests/test_rl_optimizer_tf.py
+++ b/rllib/core/optim/tests/test_rl_optimizer_tf.py
@@ -1,6 +1,7 @@
 # TODO (avnishn): Merge with the torch version of this test once the
 # RLTrainer has been merged.
 import gymnasium as gym
+import tensorflow as tf
 from typing import Any, Mapping, Union
 import unittest
 
@@ -15,13 +16,10 @@ from ray.rllib.offline.dataset_reader import (
 from ray.rllib.core.testing.tf.bc_module import DiscreteBCTFModule
 from ray.rllib.core.testing.tf.bc_optimizer import BCTFOptimizer
 from ray.rllib.policy.sample_batch import SampleBatch
-from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.nested_dict import NestedDict
 from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.test_utils import check
 from ray.rllib.utils.typing import TensorType
-
-_, tf, _ = try_import_tf()
 
 
 class BCTFTrainer:

--- a/rllib/core/optim/tests/test_rl_optimizer_tf.py
+++ b/rllib/core/optim/tests/test_rl_optimizer_tf.py
@@ -1,7 +1,6 @@
 # TODO (avnishn): Merge with the torch version of this test once the
 # RLTrainer has been merged.
 import gymnasium as gym
-import tensorflow as tf
 from typing import Any, Mapping, Union
 import unittest
 
@@ -16,10 +15,13 @@ from ray.rllib.offline.dataset_reader import (
 from ray.rllib.core.testing.tf.bc_module import DiscreteBCTFModule
 from ray.rllib.core.testing.tf.bc_optimizer import BCTFOptimizer
 from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.nested_dict import NestedDict
 from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.test_utils import check
 from ray.rllib.utils.typing import TensorType
+
+_, tf, _ = try_import_tf()
 
 
 class BCTFTrainer:

--- a/rllib/core/optim/tests/test_rl_optimizer_tf.py
+++ b/rllib/core/optim/tests/test_rl_optimizer_tf.py
@@ -1,7 +1,7 @@
 # TODO (avnishn): Merge with the torch version of this test once the
 # RLTrainer has been merged.
 import gymnasium as gym
-import tensorflow as tf
+import tensorflow as tf  # TODO (Artur): Use try_import_tf here (leads to error)
 from typing import Any, Mapping, Union
 import unittest
 

--- a/rllib/core/rl_module/tf/tests/test_tf_rl_module.py
+++ b/rllib/core/rl_module/tf/tests/test_tf_rl_module.py
@@ -2,13 +2,13 @@ import unittest
 from typing import Mapping
 
 import gymnasium as gym
-import tensorflow as tf
 
 from ray.rllib.core.rl_module.tf.tf_rl_module import TfRLModule
 from ray.rllib.core.testing.tf.bc_module import DiscreteBCTFModule
-from ray.rllib.utils.framework import try_import_tfp
+from ray.rllib.utils.framework import try_import_tfp, try_import_tf
 from ray.rllib.utils.test_utils import check
 
+_, tf, _ = try_import_tf(error=True)
 tfp = try_import_tfp(error=True)
 
 

--- a/rllib/core/rl_module/tf/tests/test_tf_rl_module.py
+++ b/rllib/core/rl_module/tf/tests/test_tf_rl_module.py
@@ -1,13 +1,15 @@
-import gymnasium as gym
-import tensorflow as tf
-import tensorflow_probability as tfp
 import unittest
 from typing import Mapping
 
+import gymnasium as gym
+import tensorflow as tf
+
 from ray.rllib.core.rl_module.tf.tf_rl_module import TfRLModule
 from ray.rllib.core.testing.tf.bc_module import DiscreteBCTFModule
-
+from ray.rllib.utils.framework import try_import_tfp
 from ray.rllib.utils.test_utils import check
+
+tfp = try_import_tfp(error=True)
 
 
 class TestRLModule(unittest.TestCase):

--- a/rllib/core/testing/tf/bc_module.py
+++ b/rllib/core/testing/tf/bc_module.py
@@ -1,6 +1,4 @@
 import gymnasium as gym
-import tensorflow as tf
-import tensorflow_probability as tfp
 from typing import Any, Mapping, Union
 
 from ray.rllib.core.rl_module.rl_module import RLModule
@@ -9,8 +7,12 @@ from ray.rllib.models.specs.specs_dict import SpecDict
 from ray.rllib.models.specs.typing import SpecType
 from ray.rllib.models.specs.specs_tf import TFTensorSpecs
 from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.utils.framework import try_import_tf, try_import_tfp
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.nested_dict import NestedDict
+
+_, tf, _ = try_import_tf()
+tfp = try_import_tfp()
 
 
 class DiscreteBCTFModule(TfRLModule):

--- a/rllib/core/testing/tf/bc_optimizer.py
+++ b/rllib/core/testing/tf/bc_optimizer.py
@@ -1,9 +1,12 @@
-import tensorflow as tf
 from typing import Any, Mapping
 
 from ray.rllib.core.optim.rl_optimizer import RLOptimizer
 from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.utils.framework import try_import_tf, try_import_tfp
 from ray.rllib.utils.nested_dict import NestedDict
+
+_, tf, _ = try_import_tf()
+tfp = try_import_tfp()
 
 
 class BCTFOptimizer(RLOptimizer):

--- a/rllib/models/specs/tests/test_tensor_spec.py
+++ b/rllib/models/specs/tests/test_tensor_spec.py
@@ -1,13 +1,16 @@
 import itertools
 import unittest
-import torch
 import numpy as np
-import tensorflow as tf
 
 from ray.rllib.utils.test_utils import check
 from ray.rllib.models.specs.specs_torch import TorchTensorSpec
 from ray.rllib.models.specs.specs_np import NPTensorSpec
 from ray.rllib.models.specs.specs_tf import TFTensorSpecs
+from ray.rllib.utils.framework import try_import_tf, try_import_tfp, try_import_torch
+
+torch = try_import_torch()
+_, tf, _ = try_import_tf()
+tfp = try_import_tfp()
 
 # TODO: add jax tests
 

--- a/rllib/utils/framework.py
+++ b/rllib/utils/framework.py
@@ -1,8 +1,9 @@
 import logging
-import numpy as np
 import os
 import sys
 from typing import Any, Optional
+
+import numpy as np
 
 from ray.rllib.utils.annotations import DeveloperAPI, PublicAPI
 from ray.rllib.utils.deprecation import Deprecated
@@ -146,9 +147,13 @@ def try_import_tfp(error: bool = False):
         import tensorflow_probability as tfp
 
         return tfp
-    except ImportError as e:
+    except ImportError:
         if error:
-            raise e
+            raise ImportError(
+                "Could not import TensorFlow Probabilty! RLlib does not come with "
+                "TensorFlow Probabilty as a dependency. You can install it with "
+                "`pip install tensorflow_probability`."
+            )
         return None
 
 

--- a/rllib/utils/framework.py
+++ b/rllib/utils/framework.py
@@ -1,9 +1,8 @@
 import logging
+import numpy as np
 import os
 import sys
 from typing import Any, Optional
-
-import numpy as np
 
 from ray.rllib.utils.annotations import DeveloperAPI, PublicAPI
 from ray.rllib.utils.deprecation import Deprecated

--- a/rllib/utils/tf_utils.py
+++ b/rllib/utils/tf_utils.py
@@ -246,8 +246,8 @@ def get_tf_eager_cls_if_necessary(
     cls = orig_cls
     framework = config.get("framework", "tf")
 
-    if framework in ["tf2", "tf"] and not tf1:
-        raise ImportError("Could not import tensorflow!")
+    if framework in ["tf2", "tf"]:
+        try_import_tf(error=True)
 
     if framework == "tf2":
         if not tf1.executing_eagerly():


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Makes it so that we don't error out without informing user about TFP not being a dependecy when import of tfp fails.
This is related to issues users have been reporting when using tune + RLLib without having all frameworks installed.

## Related issue number

#31327 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
