### PR TITLE
[CI] Increase target time for `test_result_throughput_cluster` 

### DIFF
--- a/release/ray_release/alerts/tune_tests.py
+++ b/release/ray_release/alerts/tune_tests.py
@@ -44,7 +44,7 @@ def handle_result(
         target_time = 900 if not was_smoke_test else 400
     elif test_name == "result_throughput_cluster":
         target_terminated = 1000
-        target_time = 130
+        target_time = 135
     elif test_name == "result_throughput_single_node":
         target_terminated = 96
         target_time = 120

--- a/release/tune_tests/scalability_tests/workloads/test_result_throughput_cluster.py
+++ b/release/tune_tests/scalability_tests/workloads/test_result_throughput_cluster.py
@@ -8,7 +8,7 @@ Cluster: cluster_16x64.yaml
 
 Test owner: krfricke
 
-Acceptance criteria: Should run faster than 130 seconds.
+Acceptance criteria: Should run faster than 135 seconds.
 
 Theoretical minimum time: 100 seconds
 """


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_result_throughput_cluster` failed because it took 2 seconds longer than expected. This PR increases the target time by 5 seconds to make the test less flaky.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/31337

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
