### PR TITLE
[ci][core] Remove cython version pin in release tests

### DIFF
--- a/release/nightly_tests/stress_tests/state_api_app_config.yaml
+++ b/release/nightly_tests/stress_tests/state_api_app_config.yaml
@@ -6,7 +6,7 @@ python:
   pip_packages:
     - terminado
     - boto3
-    - cython==0.29.26
+    - cython
   conda_packages: []
 
 post_build_cmds:

--- a/release/nightly_tests/stress_tests/stress_tests_app_config.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_app_config.yaml
@@ -5,7 +5,7 @@ python:
   pip_packages:
     - terminado
     - boto3
-    - cython==0.29.26
+    - cython
   conda_packages: []
 
 post_build_cmds:


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The cyphon version usually gets upgraded with new python version, so this shows up in PR like https://github.com/ray-project/ray/pull/21244, removing the unnecesary pin as per https://github.com/ray-project/ray/pull/21244#discussion_r775312226

I believe this was first introduced in this PR https://github.com/ray-project/ray/pull/16469. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
