### PR TITLE
[CI] Skip Jobs portion of runtime_env test on Windows

### DIFF
--- a/python/ray/tests/test_runtime_env_2.py
+++ b/python/ray/tests/test_runtime_env_2.py
@@ -214,8 +214,13 @@ class TestNoUserInfoInLogs:
         using_ray_client = address.startswith("ray://")
 
         # Test Ray Jobs API codepath. Skip for ray_minimal because Ray Jobs API
-        # requires ray[default].
-        if not using_ray_client and os.environ.get("RAY_MINIMAL") != "1":
+        # requires ray[default]. Skip for Windows because Dashboard and Ray Jobs
+        # are not tested on Windows.
+        if (
+            not using_ray_client
+            and os.environ.get("RAY_MINIMAL") != "1"
+            and not sys.platform == "win32"
+        ):
             client = JobSubmissionClient()
             job_id_good_runtime_env = client.submit_job(
                 entrypoint="echo 'hello world'", runtime_env=runtime_env


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
CI is failing on a newly added jobs test `test_runtime_env_2.py::TestNoUserInfoInLogs`.  This PR skips the jobs portion of the test. Dashboard and Jobs are currently not tested on Windows, we should reenable the test when we have better Windows support. (See issue https://github.com/ray-project/ray/issues/28316)
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #31349 
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
