### PR TITLE
[air] Deflake resource manager bound resources tests

### DIFF
--- a/python/ray/air/tests/test_resource_manager_placement_group.py
+++ b/python/ray/air/tests/test_resource_manager_placement_group.py
@@ -200,15 +200,15 @@ def test_bind_two_bundles(ray_start_4_cpus):
 
     res1 = ray.get(av1.remote())
 
-    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0")) == 1
+    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0_")) == 1, res1
 
     [av1, av2] = acq.annotate_remote_entities(
         [get_assigned_resources, get_assigned_resources]
     )
 
     res1, res2 = ray.get([av1.remote(), av2.remote()])
-    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0")) == 1
-    assert sum(v for k, v in res2.items() if k.startswith("CPU_group_1")) == 2
+    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0_")) == 1, res1
+    assert sum(v for k, v in res2.items() if k.startswith("CPU_group_1_")) == 2, res2
 
 
 def test_bind_empty_head_bundle(ray_start_4_cpus):
@@ -234,15 +234,15 @@ def test_bind_empty_head_bundle(ray_start_4_cpus):
 
     res1 = ray.get(av1.remote())
 
-    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0")) == 0
+    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0_")) == 0
 
     [av1, av2] = acq.annotate_remote_entities(
         [get_assigned_resources, get_assigned_resources]
     )
 
     res1, res2 = ray.get([av1.remote(), av2.remote()])
-    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0")) == 0
-    assert sum(v for k, v in res2.items() if k.startswith("CPU_group_0")) == 2
+    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0_")) == 0
+    assert sum(v for k, v in res2.items() if k.startswith("CPU_group_0_")) == 2
 
 
 def test_capture_child_tasks(ray_start_4_cpus):

--- a/python/ray/air/tests/test_resource_manager_placement_group.py
+++ b/python/ray/air/tests/test_resource_manager_placement_group.py
@@ -234,15 +234,15 @@ def test_bind_empty_head_bundle(ray_start_4_cpus):
 
     res1 = ray.get(av1.remote())
 
-    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0_")) == 0
+    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0_")) == 0, res1
 
     [av1, av2] = acq.annotate_remote_entities(
         [get_assigned_resources, get_assigned_resources]
     )
 
     res1, res2 = ray.get([av1.remote(), av2.remote()])
-    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0_")) == 0
-    assert sum(v for k, v in res2.items() if k.startswith("CPU_group_0_")) == 2
+    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0_")) == 0, res1
+    assert sum(v for k, v in res2.items() if k.startswith("CPU_group_0_")) == 2, res2
 
 
 def test_capture_child_tasks(ray_start_4_cpus):


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In `test_bind_two_bundles` and `test_bind_empty_head_bundle` we test that the bound resources match our requested resources. In placement groups, bound resources are returned with a group prefix (`CPU_group_0_xyz`), see #28814.

`ray.get_runtime_context().get_assigned_resources()` returns resources twice (once for the whole PG, once for the PG bundle) like this: `{'CPU_group_06ae30121a2c541a43e3e529597c01000000': 1.0, 'CPU_group_0_06ae30121a2c541a43e3e529597c01000000': 1.0}`. Our previous check `sum(v for k, v in res1.items() if k.startswith("CPU_group_0"))` would match the resources twice if the placement group ID starts with a `0` (or a `1` in a different check, resulting in double counting.

Adding a `_` to the `startwith` clause should alleviate the flakiness of the test.

## Related issue number

Closes #31335

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
