### PR TITLE
[RLlib] Fix using yaml files with empty stopping conditions

### DIFF
--- a/rllib/train.py
+++ b/rllib/train.py
@@ -83,7 +83,7 @@ def load_experiments_from_file(
     if file_type == SupportedFileType.yaml:
         with open(config_file) as f:
             experiments = yaml.safe_load(f)
-            if stop is not None:
+            if stop is not None and stop != "{}":
                 raise ValueError("`stop` criteria only supported for python files.")
     # Python file case (ensured by file type enum)
     else:


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Fixes an issue I introduced in https://github.com/ray-project/ray/pull/31078/commits/dea8c7e4f6f17de54755051392afb6ed905df2f1 
The issue arises when running for example "rllib train file <...>.yaml" with an empty stopping condition.
Since rllib train defaults to `stop="{}"`,  which translates to no stopping condition since the mentioned PR, the changed line will trigger and render us unable to run such yaml files even if they don't have a stopping condition.

https://github.com/ray-project/ray/pull/31078/commits/dea8c7e4f6f17de54755051392afb6ed905df2f1

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
