### PR TITLE
[Datasets] Allow `MultiHotEncoder` to encode arrays

### DIFF
--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -2,6 +2,7 @@ from functools import partial
 from typing import List, Dict, Optional
 
 from collections import Counter, OrderedDict
+import numpy as np
 import pandas as pd
 import pandas.api.types
 
@@ -324,7 +325,9 @@ class MultiHotEncoder(Preprocessor):
         _validate_df(df, *self.columns)
 
         def encode_list(element: list, *, name: str):
-            if not isinstance(element, list):
+            if isinstance(element, np.ndarray):
+                element = element.tolist()
+            elif not isinstance(element, list):
                 element = [element]
             stats = self.stats_[f"unique_values({name})"]
             counter = Counter(element)
@@ -509,6 +512,7 @@ def _get_unique_value_indices(
     encode_lists: bool = True,
 ) -> Dict[str, Dict[str, int]]:
     """If drop_na_values is True, will silently drop NA values."""
+
     if max_categories is None:
         max_categories = {}
     for column in max_categories:
@@ -601,5 +605,5 @@ def _is_series_composed_of_lists(series: pd.Series) -> bool:
         (element for element in series if element is not None), None
     )
     return pandas.api.types.is_object_dtype(series.dtype) and isinstance(
-        first_not_none_element, list
+        first_not_none_element, (list, np.ndarray)
     )

--- a/python/ray/data/tests/preprocessors/test_encoder.py
+++ b/python/ray/data/tests/preprocessors/test_encoder.py
@@ -416,6 +416,14 @@ def test_multi_hot_encoder():
         null_encoder.transform_batch(null_df)
     null_encoder.transform_batch(nonnull_df)
 
+    # Verify that `fit` and `transform` work with ndarrays.
+    df = pd.DataFrame({"column": [np.array(["A"]), np.array(["A", "B"])]})
+    ds = ray.data.from_pandas(df)
+    encoder = MultiHotEncoder(["column"])
+    transformed = encoder.fit_transform(ds)
+    encodings = [record["column"] for record in transformed.take_all()]
+    assert encodings == [[1, 0], [1, 1]]
+
 
 def test_multi_hot_encoder_with_max_categories():
     """Tests basic MultiHotEncoder functionality with limit."""


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

**tl;dr**: `MultiHotEncoder` doesn't work with Arrow datasets. This PR updates the `MultiHotEncoder` implementation to fix the issue.

`MultiHotEncoder` implements the `_transform_pandas` method. So, when `MultiHotEncoder` transforms a dataset, it converts Arrow blocks to pandas DataFrames. During the conversion, lists are converted to ndarrays. This causes `MultiHotEncoder` to error, because `MultiHotEncoder` doesn't support ndarrays (only built-in lists).

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes #31353 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
