### PR TITLE
[RFC] [AIR] Update `DLPredictor` interface

### DIFF
--- a/python/ray/train/_internal/dl_predictor.py
+++ b/python/ray/train/_internal/dl_predictor.py
@@ -37,19 +37,6 @@ class DLPredictor(Predictor):
 
     @abc.abstractmethod
     @DeveloperAPI
-    def call_model(self, inputs: Any) -> Any:
-        """Inputs the tensor to the model for this Predictor and returns the result.
-
-        Args:
-            inputs: The tensor to input to the model.
-
-        Returns:
-            A tensor or dictionary of tensors containing the model output.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    @DeveloperAPI
     def tensor_to_array(self, tensor: TensorType) -> np.ndarray:
         """Converts tensor framework-specific tensor to a NumPy array.
 
@@ -58,6 +45,19 @@ class DLPredictor(Predictor):
 
         Returns:
             A NumPy array representing the input tensor.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    @DeveloperAPI
+    def call_model(self, inputs: Any) -> Any:
+        """Inputs the tensor to the model for this Predictor and returns the result.
+
+        Args:
+            inputs: The tensor to input to the model.
+
+        Returns:
+            A tensor or dictionary of tensors containing the model output.
         """
         raise NotImplementedError
 

--- a/python/ray/train/_internal/dl_predictor.py
+++ b/python/ray/train/_internal/dl_predictor.py
@@ -38,7 +38,7 @@ class DLPredictor(Predictor):
     @abc.abstractmethod
     @DeveloperAPI
     def tensor_to_array(self, tensor: TensorType) -> np.ndarray:
-        """Converts tensor framework specific tensor to a NumPy array.
+        """Converts tensor framework specific tensor to a numpy array.
 
         Args:
             tensor: A framework specific tensor.
@@ -46,6 +46,7 @@ class DLPredictor(Predictor):
         Returns:
             A numpy array representing the input tensor.
         """
+
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -84,12 +85,19 @@ class DLPredictor(Predictor):
     def outputs_to_arrays(
         self, outputs: Any
     ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
-        # TODO (jiaodong): Investigate perf implication of this.
-        # Move DL Tensor to CPU and convert to numpy.
-        if isinstance(outputs, dict):
-            return {k: self.tensor_to_array(v) for k, v in outputs.items()}
-        else:
-            return {"predictions": self.tensor_to_array(outputs)}
+
+        try:
+            # TODO (jiaodong): Investigate perf implication of this.
+            # Move DL Tensor to CPU and convert to numpy.
+            if isinstance(outputs, dict):
+                return {k: self.tensor_to_array(v) for k, v in outputs.items()}
+            else:
+                return {"predictions": self.tensor_to_array(outputs)}
+        except Exception:
+            raise ValueError(
+                "Your model returned a non-standard output. Implement a custom "
+                "predictor and override `outputs_to_arrays`."
+            )
 
     @classmethod
     @DeveloperAPI

--- a/python/ray/train/_internal/dl_predictor.py
+++ b/python/ray/train/_internal/dl_predictor.py
@@ -24,10 +24,10 @@ class DLPredictor(Predictor):
         array: np.ndarray,
         dtype: TensorDtype,
     ) -> TensorType:
-        """Converts a NumPy array batch to the tensor type for the DL framework.
+        """Converts a NumPy ndarray batch to the tensor type for the DL framework.
 
         Args:
-            array: The NumPy array to convert to a tensor.
+            array: The numpy array to convert to a tensor.
             dtype: The tensor dtype to use when creating the DL tensor.
 
         Returns:
@@ -38,13 +38,13 @@ class DLPredictor(Predictor):
     @abc.abstractmethod
     @DeveloperAPI
     def tensor_to_array(self, tensor: TensorType) -> np.ndarray:
-        """Converts tensor framework-specific tensor to a NumPy array.
+        """Converts tensor framework specific tensor to a NumPy array.
 
         Args:
-            tensor: A framework-specific tensor.
+            tensor: A framework specific tensor.
 
         Returns:
-            A NumPy array representing the input tensor.
+            A numpy array representing the input tensor.
         """
         raise NotImplementedError
 

--- a/python/ray/train/_internal/dl_predictor.py
+++ b/python/ray/train/_internal/dl_predictor.py
@@ -85,7 +85,6 @@ class DLPredictor(Predictor):
     def outputs_to_arrays(
         self, outputs: Any
     ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
-
         try:
             # TODO (jiaodong): Investigate perf implication of this.
             # Move DL Tensor to CPU and convert to numpy.

--- a/python/ray/train/tensorflow/tensorflow_predictor.py
+++ b/python/ray/train/tensorflow/tensorflow_predictor.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 from ray.util import log_once
 from ray.train.predictor import DataBatchType
 from ray.air.checkpoint import Checkpoint
-from ray.air._internal.tensorflow_utils import convert_ndarray_batch_to_tf_tensor_batch
+from ray.air._internal.tensorflow_utils import convert_ndarray_to_tf_tensor
 from ray.train._internal.dl_predictor import DLPredictor
 from ray.train.tensorflow.tensorflow_checkpoint import TensorflowCheckpoint
 from ray.util.annotations import DeveloperAPI, PublicAPI
@@ -222,14 +222,14 @@ class TensorflowPredictor(DLPredictor):
         """
         return super(TensorflowPredictor, self).predict(data=data, dtype=dtype)
 
-    def _arrays_to_tensors(
+    def array_to_tensor(
         self,
-        numpy_arrays: Union[np.ndarray, Dict[str, np.ndarray]],
-        dtypes: Union[tf.dtypes.DType, Dict[str, tf.dtypes.DType]],
-    ) -> Union[tf.Tensor, Dict[str, tf.Tensor]]:
-        return convert_ndarray_batch_to_tf_tensor_batch(numpy_arrays, dtypes=dtypes)
+        array: np.ndarray,
+        dtype: tf.dtypes.DType,
+    ) -> tf.Tensor:
+        return convert_ndarray_to_tf_tensor(array, dtypes=dtype)
 
-    def _tensor_to_array(self, tensor: tf.Tensor) -> np.ndarray:
+    def tensor_to_array(self, tensor: tf.Tensor) -> np.ndarray:
         if not isinstance(tensor, tf.Tensor):
             raise ValueError(
                 "Expected the model to return either a tf.Tensor or a "

--- a/python/ray/train/torch/torch_predictor.py
+++ b/python/ray/train/torch/torch_predictor.py
@@ -7,7 +7,7 @@ import torch
 from ray.util import log_once
 from ray.train.predictor import DataBatchType
 from ray.air.checkpoint import Checkpoint
-from ray.air._internal.torch_utils import convert_ndarray_batch_to_torch_tensor_batch
+from ray.air._internal.torch_utils import convert_ndarray_to_torch_tensor
 from ray.train.torch.torch_checkpoint import TorchCheckpoint
 from ray.train._internal.dl_predictor import DLPredictor
 from ray.util.annotations import DeveloperAPI, PublicAPI
@@ -223,18 +223,18 @@ class TorchPredictor(DLPredictor):
         """
         return super(TorchPredictor, self).predict(data=data, dtype=dtype)
 
-    def _arrays_to_tensors(
+    def array_to_tensor(
         self,
-        numpy_arrays: Union[np.ndarray, Dict[str, np.ndarray]],
-        dtypes: Union[torch.dtype, Dict[str, torch.dtype]],
-    ) -> Union[torch.Tensor, Dict[str, torch.Tensor]]:
-        return convert_ndarray_batch_to_torch_tensor_batch(
-            numpy_arrays,
-            dtypes=dtypes,
+        array: np.ndarray,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        return convert_ndarray_to_torch_tensor(
+            array,
+            dtypes=dtype,
             device="cuda" if self.use_gpu else None,
         )
 
-    def _tensor_to_array(self, tensor: torch.Tensor) -> np.ndarray:
+    def tensor_to_array(self, tensor: torch.Tensor) -> np.ndarray:
         if not isinstance(tensor, torch.Tensor):
             raise ValueError(
                 "Expected the model to return either a torch.Tensor or a "


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

**tl;dr** The `DLPredictor` interface is inflexible, and you have to override private methods to implement subclasses. This PR updates the interface to address the aforementioned problems.

### Change 1: Make `DLPredictor` and its required methods public

If you want to subclass `DLPredictor`, you need to override the private `_arrays_to_tensors`  and `_tensor_to_array` methods. You also need to import `DLPredictor` from the internal `ray.train._internal` subpackage.

**Before**
```python
from ray.train._internal.dl_predictor import DLPredictor

class MXNetPredictor(DLPredictor):
    def _arrays_to_tensors(...):
        ...
    def _tensor_to_array(...):
        ...
```

**After**
```python
from ray.train.dl_predictor import DLPredictor

class MXNetPredictor(DLPredictor):
    def array_to_tensor(...):  # This is now marked as a `DeveloperAPI`
        ...
    def tensor_to_array(...):  # This is now marked as a `DeveloperAPI`
        ...
```
   

### Change 2: Simplify `_arrays_to_tensors` interface 

`_arrays_to_tensors` requires boilerplate to handle `dict`s. We can simplify `DLPredictor` implementations by handling 
`dict`s elsewhere.

**Before**
```python
def _arrays_to_tensor(
    self,
    numpy_arrays: Union[np.ndarray, Dict[str, np.ndarray]],
    dtype: Union[np.dtype, Dict[str, np.dtype]],
) -> Union[mx.ndarray, Dict[str, mx.ndarray]]:
    if isinstance(numpy_arrays, dict):
        return {key, mx.ndarray(array) for key, array in numpy_arrays.items()}
    else:
        return mx.ndarray(numpy_arrays)
```

**After**
```python
def array_to_tensor(
    self,
    array: np.ndarray,
    dtype: np.dtype,
) -> mx.ndarray:
    return mx.ndarray(array)
```

### Change 3: Add `arrays_to_inputs` and `outputs_to_arrays`

The current `DLPredictor` interface assumes that models return tensors, but this isn't always the case. For example, Torch object detection models return lists of dicts. In this case, there's no easy way to override `DLPredictor`; you have to override `_predict_numpy`. 

`arrays_to_inputs` and `outputs_to_arrays` address this issue by giving you the flexibility to handle non-standard model inputs and outputs.  

**Before**
```python
class DLPredictor(Predictor):
    ...

    def _predict_numpy(
        self,
        data: Union[np.ndarray, Dict[str, np.ndarray]],
        dtype: Union[TensorDtype, Dict[str, TensorDtype]],
    ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
        if isinstance(data, dict) and len(data) == 1:
            data = next(iter(data.values()))
        model_input = self._arrays_to_tensors(data, dtype)

        model_output = self.call_model(model_input)

        # NOTE: We're assuming that the model outputs a tensor or a dict that maps
        # strings to tensors.
        if isinstance(model_output, dict):
            return {k: self._tensor_to_array(v) for k, v in model_output.items()}
        else:
            return {"predictions": self._tensor_to_array(model_output)}
```

**After**
```python
class DLPredictor(Predictor):
    ...

    @DeveloperAPI
    def arrays_to_inputs(self, arrays: Union[np.ndarray, Dict[str, np.ndarray]]):
        ...  # Default implementation

    @DeveloperAPI
    def outputs_to_arrays(
        self, outputs: Any
    ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
        ...  # Default implementation

    def _predict_numpy(
        self,
        data: Union[np.ndarray, Dict[str, np.ndarray]],
        dtype: Union[TensorDtype, Dict[str, TensorDtype]],
    ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
        # NOTE: We make the same assumptions here, but now subclasses can 
        # override `arrays_to_inputs` and `outputs_to_arrays` if our assumptions
        # don't hold.
        model_inputs = self.arrays_to_inputs(data)
        model_outputs = self.call_model(model_inputs)
        return self.outputs_to_arrays(model_outputs)
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
