### PR TITLE
[Serve] [Serve-autoscaler] Change target_num_ongoing_requests_per_replica to positive float

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -44,7 +44,7 @@ class AutoscalingConfig(BaseModel):
     min_replicas: NonNegativeInt = 1
     initial_replicas: Optional[NonNegativeInt] = None
     max_replicas: PositiveInt = 1
-    target_num_ongoing_requests_per_replica: NonNegativeInt = 1
+    target_num_ongoing_requests_per_replica: PositiveFloat = 1.0
 
     # Private options below.
 

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -58,27 +58,41 @@ class TestCalculateDesiredNumReplicas:
             )
             assert min_replicas <= desired_num_replicas <= max_replicas
 
-    def test_scale_up(self):
+    @pytest.mark.parametrize("target_requests", [1.0, 1.5])
+    def test_scale_up(self, target_requests):
         config = AutoscalingConfig(
-            min_replicas=0, max_replicas=100, target_num_ongoing_requests_per_replica=1
+            min_replicas=0,
+            max_replicas=100,
+            target_num_ongoing_requests_per_replica=target_requests,
         )
         num_replicas = 10
-        num_ongoing_requests = [2.0] * num_replicas
+        num_ongoing_requests = [2 * target_requests] * num_replicas
         desired_num_replicas = calculate_desired_num_replicas(
             autoscaling_config=config, current_num_ongoing_requests=num_ongoing_requests
         )
-        assert 19 <= desired_num_replicas <= 21  # 10 * 2 = 20
+        assert (
+            2 * num_replicas * target_requests - 1
+            <= desired_num_replicas
+            <= 2 * num_replicas * target_requests + 1
+        )
 
-    def test_scale_down(self):
+    @pytest.mark.parametrize("target_requests", [1.0, 1.5])
+    def test_scale_down(self, target_requests):
         config = AutoscalingConfig(
-            min_replicas=0, max_replicas=100, target_num_ongoing_requests_per_replica=1
+            min_replicas=0,
+            max_replicas=100,
+            target_num_ongoing_requests_per_replica=target_requests,
         )
         num_replicas = 10
-        num_ongoing_requests = [0.5] * num_replicas
+        num_ongoing_requests = [0.5 * target_requests] * num_replicas
         desired_num_replicas = calculate_desired_num_replicas(
             autoscaling_config=config, current_num_ongoing_requests=num_ongoing_requests
         )
-        assert 4 <= desired_num_replicas <= 6  # 10 * 0.5 = 5
+        assert (
+            0.5 * num_replicas * target_requests - 1
+            <= desired_num_replicas
+            <= 0.5 * num_replicas * target_requests + 1
+        )
 
     def test_smoothing_factor(self):
         config = AutoscalingConfig(

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -58,7 +58,7 @@ class TestCalculateDesiredNumReplicas:
             )
             assert min_replicas <= desired_num_replicas <= max_replicas
 
-    @pytest.mark.parametrize("target_requests", [1.0, 1.5])
+    @pytest.mark.parametrize("target_requests", [0.5, 1.0, 1.5])
     def test_scale_up(self, target_requests):
         config = AutoscalingConfig(
             min_replicas=0,
@@ -72,7 +72,7 @@ class TestCalculateDesiredNumReplicas:
         )
         assert 19 <= desired_num_replicas <= 21  # 10 * 2 = 20
 
-    @pytest.mark.parametrize("target_requests", [1.0, 1.5])
+    @pytest.mark.parametrize("target_requests", [0.5, 1.0, 1.5])
     def test_scale_down(self, target_requests):
         config = AutoscalingConfig(
             min_replicas=0,

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -70,11 +70,7 @@ class TestCalculateDesiredNumReplicas:
         desired_num_replicas = calculate_desired_num_replicas(
             autoscaling_config=config, current_num_ongoing_requests=num_ongoing_requests
         )
-        assert (
-            2 * num_replicas * target_requests - 1
-            <= desired_num_replicas
-            <= 2 * num_replicas * target_requests + 1
-        )
+        assert 19 <= desired_num_replicas <= 21  # 10 * 2 = 20
 
     @pytest.mark.parametrize("target_requests", [1.0, 1.5])
     def test_scale_down(self, target_requests):
@@ -88,11 +84,7 @@ class TestCalculateDesiredNumReplicas:
         desired_num_replicas = calculate_desired_num_replicas(
             autoscaling_config=config, current_num_ongoing_requests=num_ongoing_requests
         )
-        assert (
-            0.5 * num_replicas * target_requests - 1
-            <= desired_num_replicas
-            <= 0.5 * num_replicas * target_requests + 1
-        )
+        assert 4 <= desired_num_replicas <= 6  # 10 * 0.5 = 5
 
     def test_smoothing_factor(self):
         config = AutoscalingConfig(

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -35,7 +35,7 @@ message AutoscalingConfig {
   // Target number of in flight requests per replicas. This is the primary configuration
   // knob for replica autoscaler. Lower the number, the more rapidly will the replicas
   // being scaled up. Must be a non-negative integer.
-  uint32 target_num_ongoing_requests_per_replica = 3;
+  double target_num_ongoing_requests_per_replica = 3;
 
   // The frequency of how long does each replica sending metrics to autoscaler.
   double metrics_interval_s = 4;


### PR DESCRIPTION
Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Allow for float values for `target_num_ongoing_requests_per_replica`.

## Related issue number

"Closes #31209"

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
