### PR TITLE
[Serve] Return 400 response code for malformed Serve configs sent via REST API

### DIFF
--- a/dashboard/modules/serve/serve_agent.py
+++ b/dashboard/modules/serve/serve_agent.py
@@ -115,8 +115,15 @@ class ServeAgent(dashboard_utils.DashboardAgentModule):
     async def put_all_deployments(self, req: Request) -> Response:
         from ray.serve.schema import ServeApplicationSchema
         from ray.serve._private.api import serve_start
+        from pydantic import ValidationError
 
-        config = ServeApplicationSchema.parse_obj(await req.json())
+        try:
+            config = ServeApplicationSchema.parse_obj(await req.json())
+        except ValidationError as e:
+            return Response(
+                status=400,
+                text=repr(e),
+            )
 
         client = serve_start(
             detached=True,

--- a/dashboard/modules/serve/tests/test_serve_agent.py
+++ b/dashboard/modules/serve/tests/test_serve_agent.py
@@ -94,6 +94,14 @@ def test_put_get(ray_start_stop):
 
 
 @pytest.mark.skipif(sys.platform == "darwin", reason="Flaky on OSX.")
+def test_put_bad_schema(ray_start_stop):
+    config = {"not_a_real_field": "value"}
+
+    put_response = requests.put(GET_OR_PUT_URL, json=config, timeout=5)
+    assert put_response.status_code == 400
+
+
+@pytest.mark.skipif(sys.platform == "darwin", reason="Flaky on OSX.")
 def test_delete(ray_start_stop):
     config = {
         "import_path": "dir.subdir.a.add_and_sub.serve_dag",


### PR DESCRIPTION
Signed-off-by: Shreyas Krishnaswamy <shrekris@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When users submit a malformed Serve config (e.g. with invalid fields) via `PUT` request, they receive a 500 error. This change makes the REST API return a 400 (unretryable) error instead.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #31370

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
     - New unit tests are added to `test_serve_agent.py`.
