### PR TITLE
[Core][deprecate run_on_all_workers 1/n] set worker's sys.path through JobConfig._py_driver_sys_path

### DIFF
--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -356,7 +356,7 @@ class FunctionActorManager:
         )
 
         object = self.load_function_or_class_from_local(module_name, function_name)
-        if object is not None:
+        if object is not None and hasattr(object, "_function"):
             function = object._function
             self._function_execution_info[function_id] = FunctionExecutionInfo(
                 function=function,

--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -138,10 +138,10 @@ class FunctionActorManager:
 
     def load_function_or_class_from_local(self, module_name, function_or_class_name):
         """Try to load a function or class in the module from local."""
+        module = importlib.import_module(module_name)
+        parts = [part for part in function_or_class_name.split(".") if part]
+        object = module
         try:
-            module = importlib.import_module(module_name)
-            parts = [part for part in function_or_class_name.split(".") if part]
-            object = module
             for part in parts:
                 object = getattr(object, part)
             return object
@@ -356,7 +356,7 @@ class FunctionActorManager:
         )
 
         object = self.load_function_or_class_from_local(module_name, function_name)
-        if object is not None and hasattr(object, "_function"):
+        if object is not None:
             function = object._function
             self._function_execution_info[function_id] = FunctionExecutionInfo(
                 function=function,

--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -138,10 +138,10 @@ class FunctionActorManager:
 
     def load_function_or_class_from_local(self, module_name, function_or_class_name):
         """Try to load a function or class in the module from local."""
-        module = importlib.import_module(module_name)
-        parts = [part for part in function_or_class_name.split(".") if part]
-        object = module
         try:
+            module = importlib.import_module(module_name)
+            parts = [part for part in function_or_class_name.split(".") if part]
+            object = module
             for part in parts:
                 object = getattr(object, part)
             return object

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2048,7 +2048,7 @@ def connect(
             current_directory = os.path.abspath(os.path.curdir)
             code_paths.append(current_directory)
         if len(code_paths) != 0:
-            job_config.code_search_path.extend(code_paths)
+            job_config._py_sys_path.extend(code_paths)
 
     serialized_job_config = job_config.serialize()
     if not node.should_redirect_logs():

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2027,6 +2027,29 @@ def connect(
         runtime_env.pop("excludes", None)
         job_config.set_runtime_env(runtime_env)
 
+    if mode == SCRIPT_MODE:
+        # Add the directory containing the script that is running to the Python
+        # paths of the workers. Also add the current directory. Note that this
+        # assumes that the directory structures on the machines in the clusters
+        # are the same.
+        # When using an interactive shell, there is no script directory.
+        code_paths = []
+        if not interactive_mode:
+            script_directory = os.path.dirname(os.path.realpath(sys.argv[0]))
+            # If driver's sys.path doesn't include the script directory
+            # (e.g driver is started via `python -m`,
+            # see https://peps.python.org/pep-0338/),
+            # then we shouldn't add it to the workers.
+            if script_directory in sys.path:
+                code_paths.append(script_directory)
+        # In client mode, if we use runtime envs with "working_dir", then
+        # it'll be handled automatically.  Otherwise, add the current dir.
+        if not job_config.client_job and not job_config.runtime_env_has_working_dir():
+            current_directory = os.path.abspath(os.path.curdir)
+            code_paths.append(current_directory)
+        if len(code_paths) != 0:
+            job_config.code_search_path.extend(code_paths)
+
     serialized_job_config = job_config.serialize()
     if not node.should_redirect_logs():
         # Logging to stderr, so give core worker empty logs directory.
@@ -2097,29 +2120,6 @@ def connect(
             worker.logger_thread.start()
 
     if mode == SCRIPT_MODE:
-        # Add the directory containing the script that is running to the Python
-        # paths of the workers. Also add the current directory. Note that this
-        # assumes that the directory structures on the machines in the clusters
-        # are the same.
-        # When using an interactive shell, there is no script directory.
-        code_paths = []
-        if not interactive_mode:
-            script_directory = os.path.dirname(os.path.realpath(sys.argv[0]))
-            # If driver's sys.path doesn't include the script directory
-            # (e.g driver is started via `python -m`,
-            # see https://peps.python.org/pep-0338/),
-            # then we shouldn't add it to the workers.
-            if script_directory in sys.path:
-                code_paths.append(script_directory)
-        # In client mode, if we use runtime envs with "working_dir", then
-        # it'll be handled automatically.  Otherwise, add the current dir.
-        if not job_config.client_job and not job_config.runtime_env_has_working_dir():
-            current_directory = os.path.abspath(os.path.curdir)
-            code_paths.append(current_directory)
-        if len(code_paths) != 0:
-            worker.run_function_on_all_workers(
-                lambda worker_info: [sys.path.insert(1, path) for path in code_paths]
-            )
         # TODO(rkn): Here we first export functions to run, then remote
         # functions. The order matters. For example, one of the functions to
         # run may set the Python path, which is needed to import a module used

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2048,7 +2048,7 @@ def connect(
             current_directory = os.path.abspath(os.path.curdir)
             code_paths.append(current_directory)
         if len(code_paths) != 0:
-            job_config._py_driver_sys_path.extend(code_paths)
+            job_config.py_driver_sys_path.extend(code_paths)
 
     serialized_job_config = job_config.serialize()
     if not node.should_redirect_logs():

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2048,7 +2048,7 @@ def connect(
             current_directory = os.path.abspath(os.path.curdir)
             code_paths.append(current_directory)
         if len(code_paths) != 0:
-            job_config._py_sys_path.extend(code_paths)
+            job_config._py_driver_sys_path.extend(code_paths)
 
     serialized_job_config = job_config.serialize()
     if not node.should_redirect_logs():

--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -230,10 +230,10 @@ if __name__ == "__main__":
             sys.path.insert(0, p)
     ray._private.worker.global_worker.set_load_code_from_local(load_code_from_local)
 
-    # Add driver sys path to sys.path
-    py_sys_path = core_worker.get_job_config()._py_sys_path
-    if py_sys_path:
-        for p in py_sys_path:
+    # Add driver's system path to sys.path
+    _py_driver_sys_path = core_worker.get_job_config()._py_driver_sys_path
+    if _py_driver_sys_path:
+        for p in _py_driver_sys_path:
             sys.path.insert(0, p)
 
     # Setup log file.

--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -223,12 +223,18 @@ if __name__ == "__main__":
     code_search_path = core_worker.get_job_config().code_search_path
     load_code_from_local = False
     if code_search_path:
-        #load_code_from_local = True
+        load_code_from_local = True
         for p in code_search_path:
             if os.path.isfile(p):
                 p = os.path.dirname(p)
             sys.path.insert(0, p)
     ray._private.worker.global_worker.set_load_code_from_local(load_code_from_local)
+
+    # Add driver sys path to sys.path
+    py_sys_path = core_worker.get_job_config()._py_sys_path
+    if py_sys_path:
+        for p in py_sys_path:
+            sys.path.insert(0, p)
 
     # Setup log file.
     out_file, err_file = node.get_log_file_handles(

--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -231,9 +231,9 @@ if __name__ == "__main__":
     ray._private.worker.global_worker.set_load_code_from_local(load_code_from_local)
 
     # Add driver's system path to sys.path
-    _py_driver_sys_path = core_worker.get_job_config()._py_driver_sys_path
-    if _py_driver_sys_path:
-        for p in _py_driver_sys_path:
+    py_driver_sys_path = core_worker.get_job_config().py_driver_sys_path
+    if py_driver_sys_path:
+        for p in py_driver_sys_path:
             sys.path.insert(0, p)
 
     # Setup log file.

--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -223,7 +223,7 @@ if __name__ == "__main__":
     code_search_path = core_worker.get_job_config().code_search_path
     load_code_from_local = False
     if code_search_path:
-        load_code_from_local = True
+        #load_code_from_local = True
         for p in code_search_path:
             if os.path.isfile(p):
                 p = os.path.dirname(p)

--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -18,7 +18,7 @@ class JobConfig:
             ``runtime_env.py`` for detailed documentation).
         client_job: A boolean represent the source of the job.
         default_actor_lifetime: The default value of actor lifetime.
-        _py_driver_sys_path: A list of directories that
+        py_driver_sys_path: A list of directories that
             specify the search path for python workers.
     """
 
@@ -31,7 +31,7 @@ class JobConfig:
         metadata: Optional[dict] = None,
         ray_namespace: Optional[str] = None,
         default_actor_lifetime: str = "non_detached",
-        _py_driver_sys_path: List[str] = None,
+        py_driver_sys_path: List[str] = None,
     ):
         self.jvm_options = jvm_options or []
         self.code_search_path = code_search_path or []
@@ -45,7 +45,7 @@ class JobConfig:
         self.ray_namespace = ray_namespace
         self.set_runtime_env(runtime_env)
         self.set_default_actor_lifetime(default_actor_lifetime)
-        self._py_driver_sys_path = _py_driver_sys_path or []
+        self.py_driver_sys_path = py_driver_sys_path or []
 
     def set_metadata(self, key: str, value: str) -> None:
         self.metadata[key] = value
@@ -112,6 +112,7 @@ class JobConfig:
                 pb.ray_namespace = self.ray_namespace
             pb.jvm_options.extend(self.jvm_options)
             pb.code_search_path.extend(self.code_search_path)
+            pb.py_driver_sys_path.extend(self.py_driver_sys_path)
             for k, v in self.metadata.items():
                 pb.metadata[k] = v
 
@@ -153,5 +154,5 @@ class JobConfig:
             client_job=job_config_json.get("client_job", False),
             metadata=job_config_json.get("metadata", None),
             ray_namespace=job_config_json.get("ray_namespace", None),
-            _py_driver_sys_path=job_config_json.get("_py_driver_sys_path", None),
+            py_driver_sys_path=job_config_json.get("py_driver_sys_path", None),
         )

--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -29,6 +29,7 @@ class JobConfig:
         metadata: Optional[dict] = None,
         ray_namespace: Optional[str] = None,
         default_actor_lifetime: str = "non_detached",
+        _py_sys_path: List[str] = None,
     ):
         self.jvm_options = jvm_options or []
         self.code_search_path = code_search_path or []
@@ -42,6 +43,7 @@ class JobConfig:
         self.ray_namespace = ray_namespace
         self.set_runtime_env(runtime_env)
         self.set_default_actor_lifetime(default_actor_lifetime)
+        self._py_sys_path = _py_sys_path or []
 
     def set_metadata(self, key: str, value: str) -> None:
         self.metadata[key] = value
@@ -149,4 +151,5 @@ class JobConfig:
             client_job=job_config_json.get("client_job", False),
             metadata=job_config_json.get("metadata", None),
             ray_namespace=job_config_json.get("ray_namespace", None),
+            _py_sys_path=job_config_json.get("_py_sys_path", None),
         )

--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -18,6 +18,8 @@ class JobConfig:
             ``runtime_env.py`` for detailed documentation).
         client_job: A boolean represent the source of the job.
         default_actor_lifetime: The default value of actor lifetime.
+        _py_driver_sys_path: A list of directories that
+            specify the search path for python workers.
     """
 
     def __init__(
@@ -29,7 +31,7 @@ class JobConfig:
         metadata: Optional[dict] = None,
         ray_namespace: Optional[str] = None,
         default_actor_lifetime: str = "non_detached",
-        _py_sys_path: List[str] = None,
+        _py_driver_sys_path: List[str] = None,
     ):
         self.jvm_options = jvm_options or []
         self.code_search_path = code_search_path or []
@@ -43,7 +45,7 @@ class JobConfig:
         self.ray_namespace = ray_namespace
         self.set_runtime_env(runtime_env)
         self.set_default_actor_lifetime(default_actor_lifetime)
-        self._py_sys_path = _py_sys_path or []
+        self._py_driver_sys_path = _py_driver_sys_path or []
 
     def set_metadata(self, key: str, value: str) -> None:
         self.metadata[key] = value
@@ -151,5 +153,5 @@ class JobConfig:
             client_job=job_config_json.get("client_job", False),
             metadata=job_config_json.get("metadata", None),
             ray_namespace=job_config_json.get("ray_namespace", None),
-            _py_sys_path=job_config_json.get("_py_sys_path", None),
+            _py_driver_sys_path=job_config_json.get("_py_driver_sys_path", None),
         )

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -238,7 +238,6 @@ def test_worker_kv_calls(monkeypatch, shutdown_only):
     # So far we have the following gets
     """
     b'fun' b'IsolatedExports:01000000:\x00\x00\x00\x00\x00\x00\x00\x01'
-    b'fun' b'FunctionsToRun:01000000:\x12\x9b\xea\xa39\x01...'
     b'fun' b'IsolatedExports:01000000:\x00\x00\x00\x00\x00\x00\x00\x02'
     b'cluster' b'CLUSTER_METADATA'
     b'fun' b'IsolatedExports:01000000:\x00\x00\x00\x00\x00\x00\x00\x01'
@@ -247,7 +246,7 @@ def test_worker_kv_calls(monkeypatch, shutdown_only):
     ???? # unknown
     """
     # !!!If you want to increase this number, please let ray-core knows this!!!
-    assert freqs["internal_kv_get"] == 8
+    assert freqs["internal_kv_get"] == 5
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -247,7 +247,7 @@ def test_worker_kv_calls(monkeypatch, shutdown_only):
     ???? # unknown
     """
     # !!!If you want to increase this number, please let ray-core knows this!!!
-    assert freqs["internal_kv_get"] == 5
+    assert freqs["internal_kv_get"] == 8
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -247,7 +247,7 @@ def test_worker_kv_calls(monkeypatch, shutdown_only):
     ???? # unknown
     """
     # !!!If you want to increase this number, please let ray-core knows this!!!
-    assert freqs["internal_kv_get"] == 8
+    assert freqs["internal_kv_get"] == 5
 
 
 if __name__ == "__main__":

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -324,7 +324,7 @@ message JobConfig {
   ActorLifetime default_actor_lifetime = 7;
   // System paths of the driver scripts. Python workers need to search
   // these paths to load modules.
-  repeated string _py_driver_sys_path = 8;
+  repeated string py_driver_sys_path = 8;
 }
 
 message JobTableData {

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -322,6 +322,8 @@ message JobConfig {
   // If the lifetime of an actor is not specified explicitly at runtime, this
   // default value will be applied.
   ActorLifetime default_actor_lifetime = 7;
+  // Python worker should first try to load modules from local code path.
+  repeated string _py_sys_path= 8;
 }
 
 message JobTableData {

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -322,8 +322,9 @@ message JobConfig {
   // If the lifetime of an actor is not specified explicitly at runtime, this
   // default value will be applied.
   ActorLifetime default_actor_lifetime = 7;
-  // Python worker should first try to load modules from local code path.
-  repeated string _py_sys_path= 8;
+  // System paths of the driver scripts. Python workers need to search
+  // these paths to load modules.
+  repeated string _py_driver_sys_path = 8;
 }
 
 message JobTableData {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Today we use `run_on_all_workers` to set worker's system path, where the `run_on_all_workers` suffers from weak ordering guarantees and will be deprecated.

Instead, we should use JobConfig._py_driver_sys_path to set worker's system path, where the worker will add these paths into its sys.path on startup.

Note we have JobConfig.code_search_path which servers similar functionality, however it uses a different `load_code_from_local` code path and behaves differently and introduced bugs that failed tests (https://github.com/ray-project/ray/pull/17605#discussion_r684890177). 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
