### PR TITLE
[RLlib] Terminated/Truncated in Quickstart Script

### DIFF
--- a/rllib/examples/documentation/rllib_on_ray_readme.py
+++ b/rllib/examples/documentation/rllib_on_ray_readme.py
@@ -45,7 +45,7 @@ class SimpleCorridor(gym.Env):
         # Walk right.
         elif action == 1:
             self.cur_pos += 1
-        # Set `terminated` flag when end of corridor (goal) reached.
+        # Set `terminated` and `truncated` flag when end of corridor (goal) reached.
         terminated = truncated = self.cur_pos >= self.end_pos
         # +1 when goal reached, otherwise -1.
         reward = 1.0 if terminated else -0.1

--- a/rllib/examples/documentation/rllib_on_ray_readme.py
+++ b/rllib/examples/documentation/rllib_on_ray_readme.py
@@ -1,3 +1,4 @@
+# __quick_start_begin__
 import gymnasium as gym
 from ray.rllib.algorithms.ppo import PPOConfig
 

--- a/rllib/examples/documentation/rllib_on_ray_readme.py
+++ b/rllib/examples/documentation/rllib_on_ray_readme.py
@@ -27,7 +27,7 @@ class SimpleCorridor(gym.Env):
         """Resets the episode.
 
         Returns:
-           Initial observation of the new episode and an info dict
+           Initial observation of the new episode and an info dict.
         """
         self.cur_pos = 0
         # Return initial observation.

--- a/rllib/examples/documentation/rllib_on_ray_readme.py
+++ b/rllib/examples/documentation/rllib_on_ray_readme.py
@@ -82,10 +82,10 @@ for i in range(5):
 env = SimpleCorridor({"corridor_length": 10})
 # Get the initial observation (should be: [0.0] for the starting position).
 obs, info = env.reset()
-terminated = False
+terminated = truncated = False
 total_reward = 0.0
 # Play one episode.
-while not terminated:
+while not terminated and not truncated:
     # Compute a single action, given the current observation
     # from the environment.
     action = algo.compute_single_action(obs)

--- a/rllib/examples/documentation/rllib_on_ray_readme.py
+++ b/rllib/examples/documentation/rllib_on_ray_readme.py
@@ -1,4 +1,3 @@
-# __quick_start_begin__
 import gymnasium as gym
 from ray.rllib.algorithms.ppo import PPOConfig
 
@@ -41,11 +40,11 @@ class SimpleCorridor(gym.Env):
         # Walk right.
         elif action == 1:
             self.cur_pos += 1
-        # Set `done` and `truncated` flags when end of corridor (goal) reached.
-        done = truncated = self.cur_pos >= self.end_pos
+        # Set `done` flag when end of corridor (goal) reached.
+        terminated = self.cur_pos >= self.end_pos
         # +1 when goal reached, otherwise -1.
-        reward = 1.0 if done else -0.1
-        return [self.cur_pos], reward, done, truncated, {}
+        reward = 1.0 if terminated else -0.1
+        return [self.cur_pos], reward, terminated, False, {}
 
 
 # Create an RLlib Algorithm instance from a PPOConfig object.
@@ -77,7 +76,7 @@ for i in range(5):
 # to "just always walk right!"
 env = SimpleCorridor({"corridor_length": 10})
 # Get the initial observation (should be: [0.0] for the starting position).
-obs, info = env.reset()
+obs = env.reset()
 done = False
 total_reward = 0.0
 # Play one episode.
@@ -86,9 +85,8 @@ while not done:
     # from the environment.
     action = algo.compute_single_action(obs)
     # Apply the computed action in the environment.
-    obs, reward, done, truncated, info = env.step(action)
+    obs, reward, done, info = env.step(action)
     # Sum up rewards for reporting purposes.
     total_reward += reward
 # Report results.
 print(f"Played 1 episode; total-reward={total_reward}")
-# __quick_start_end__

--- a/rllib/examples/documentation/rllib_on_ray_readme.py
+++ b/rllib/examples/documentation/rllib_on_ray_readme.py
@@ -26,8 +26,8 @@ class SimpleCorridor(gym.Env):
     def reset(self, *, seed=None, options=None):
         """Resets the episode.
 
-         Returns:
-            Initial observation of the new episode and an info dict
+        Returns:
+           Initial observation of the new episode and an info dict
         """
         self.cur_pos = 0
         # Return initial observation.

--- a/rllib/examples/documentation/rllib_on_ray_readme.py
+++ b/rllib/examples/documentation/rllib_on_ray_readme.py
@@ -24,7 +24,11 @@ class SimpleCorridor(gym.Env):
         self.observation_space = gym.spaces.Box(0.0, self.end_pos, shape=(1,))
 
     def reset(self, *, seed=None, options=None):
-        """Resets the episode and returns the initial observation of the new one."""
+        """Resets the episode.
+
+         Returns:
+            Initial observation of the new episode and an info dict
+        ."""
         self.cur_pos = 0
         # Return initial observation.
         return [self.cur_pos], {}
@@ -33,7 +37,7 @@ class SimpleCorridor(gym.Env):
         """Takes a single step in the episode given `action`
 
         Returns:
-            New observation, reward, done-flag, info-dict (empty).
+            New observation, reward, terminated-flag, truncated-flag, info-dict (empty).
         """
         # Walk left.
         if action == 0 and self.cur_pos > 0:
@@ -41,7 +45,7 @@ class SimpleCorridor(gym.Env):
         # Walk right.
         elif action == 1:
             self.cur_pos += 1
-        # Set `done` flag when end of corridor (goal) reached.
+        # Set `terminated` flag when end of corridor (goal) reached.
         terminated = self.cur_pos >= self.end_pos
         # +1 when goal reached, otherwise -1.
         reward = 1.0 if terminated else -0.1
@@ -77,16 +81,16 @@ for i in range(5):
 # to "just always walk right!"
 env = SimpleCorridor({"corridor_length": 10})
 # Get the initial observation (should be: [0.0] for the starting position).
-obs = env.reset()
-done = False
+obs, info = env.reset()
+terminated = False
 total_reward = 0.0
 # Play one episode.
-while not done:
+while not terminated:
     # Compute a single action, given the current observation
     # from the environment.
     action = algo.compute_single_action(obs)
     # Apply the computed action in the environment.
-    obs, reward, done, info = env.step(action)
+    obs, reward, terminated, truncated, info = env.step(action)
     # Sum up rewards for reporting purposes.
     total_reward += reward
 # Report results.

--- a/rllib/examples/documentation/rllib_on_ray_readme.py
+++ b/rllib/examples/documentation/rllib_on_ray_readme.py
@@ -45,8 +45,9 @@ class SimpleCorridor(gym.Env):
         # Walk right.
         elif action == 1:
             self.cur_pos += 1
-        # Set `terminated` and `truncated` flag when end of corridor (goal) reached.
-        terminated = truncated = self.cur_pos >= self.end_pos
+        # Set `terminated` flag when end of corridor (goal) reached.
+        terminated = self.cur_pos >= self.end_pos
+        truncated = False
         # +1 when goal reached, otherwise -1.
         reward = 1.0 if terminated else -0.1
         return [self.cur_pos], reward, terminated, truncated, {}

--- a/rllib/examples/documentation/rllib_on_ray_readme.py
+++ b/rllib/examples/documentation/rllib_on_ray_readme.py
@@ -28,13 +28,13 @@ class SimpleCorridor(gym.Env):
 
          Returns:
             Initial observation of the new episode and an info dict
-        ."""
+        """
         self.cur_pos = 0
         # Return initial observation.
         return [self.cur_pos], {}
 
     def step(self, action):
-        """Takes a single step in the episode given `action`
+        """Takes a single step in the episode given `action`.
 
         Returns:
             New observation, reward, terminated-flag, truncated-flag, info-dict (empty).
@@ -46,10 +46,10 @@ class SimpleCorridor(gym.Env):
         elif action == 1:
             self.cur_pos += 1
         # Set `terminated` flag when end of corridor (goal) reached.
-        terminated = self.cur_pos >= self.end_pos
+        terminated = truncated = self.cur_pos >= self.end_pos
         # +1 when goal reached, otherwise -1.
         reward = 1.0 if terminated else -0.1
-        return [self.cur_pos], reward, terminated, False, {}
+        return [self.cur_pos], reward, terminated, truncated, {}
 
 
 # Create an RLlib Algorithm instance from a PPOConfig object.
@@ -95,3 +95,4 @@ while not terminated:
     total_reward += reward
 # Report results.
 print(f"Played 1 episode; total-reward={total_reward}")
+# __quick_start_end__


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Our quickstart example in the docs has been updated to fit gymnasium, but a docstring is missing the truncated flag and all terminated flags are still called done.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
