### PR TITLE
[RLlib] Fix Policy map __del__

### DIFF
--- a/rllib/policy/policy_map.py
+++ b/rllib/policy/policy_map.py
@@ -166,6 +166,8 @@ class PolicyMap(dict):
     def __delitem__(self, key: PolicyID):
         # Make key invalid.
         self._valid_keys.remove(key)
+        # Remove policy from deque
+        self._deque.remove(key)
         # Remove policy from memory if currently cached.
         if key in self.cache:
             policy = self.cache[key]

--- a/rllib/policy/policy_map.py
+++ b/rllib/policy/policy_map.py
@@ -166,8 +166,9 @@ class PolicyMap(dict):
     def __delitem__(self, key: PolicyID):
         # Make key invalid.
         self._valid_keys.remove(key)
-        # Remove policy from deque
-        self._deque.remove(key)
+        # Remove policy from deque if contained
+        if key in self._deque:
+            self._deque.remove(key)
         # Remove policy from memory if currently cached.
         if key in self.cache:
             policy = self.cache[key]

--- a/rllib/policy/tests/test_policy_map.py
+++ b/rllib/policy/tests/test_policy_map.py
@@ -81,6 +81,32 @@ class TestPolicyMap(unittest.TestCase):
             time_total = time.time() - start
             print(f"Random access (swapping={use_swapping} took {time_total}sec.")
 
+        # Delete some policy entirely that is in the deque
+        policy_id = next(iter(policy_map._deque))
+        del policy_map[policy_id]
+        self.assertEqual(len(policy_map._deque), capacity - 1)
+        self.assertTrue(policy_id not in policy_map._deque)
+        self.assertEqual(len(policy_map.cache), capacity - 1)
+        self.assertTrue(policy_id not in policy_map._deque)
+        self.assertEqual(len(policy_map._valid_keys), num_policies - 1)
+        self.assertTrue(policy_id not in policy_map._deque)
+
+        # Add another policy and see if data structures behave as expected
+        config.training(lr=(i + 1) * 0.00001)
+        policy = cls(
+            observation_space=obs_space,
+            action_space=act_space,
+            config=config.to_dict(),
+        )
+        policy_id = f"pol{num_policies + 1}"
+        policy_map[policy_id] = policy
+        self.assertEqual(len(policy_map._deque), capacity)
+        self.assertTrue(policy_id in policy_map._deque)
+        self.assertEqual(len(policy_map.cache), capacity)
+        self.assertTrue(policy_id in policy_map._deque)
+        self.assertEqual(len(policy_map._valid_keys), num_policies)
+        self.assertTrue(policy_id in policy_map._deque)
+
 
 if __name__ == "__main__":
     import pytest


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

PolicyMap does not delete keys from it's deque. It only deletes from the other structures.

## Related issue number

https://github.com/ray-project/ray/issues/31351

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
