### PR TITLE
[ci] Upgrade numba, remove windows-specific constraint

### DIFF
--- a/python/requirements_test.txt
+++ b/python/requirements_test.txt
@@ -37,8 +37,7 @@ lxml==4.9.1
 moto[s3,server]==4.0.7
 mypy==0.982
 networkx==2.6.3
-numba==0.56.3; platform_system != "Windows"
-numba==0.51.2; platform_system == "Windows"
+numba==0.56.4
 openpyxl==3.0.10
 opentelemetry-api==1.1.0
 opentelemetry-sdk==1.1.0

--- a/python/requirements_test.txt
+++ b/python/requirements_test.txt
@@ -30,9 +30,7 @@ google-cloud-storage==2.5.0
 gradio==3.5; platform_system != "Windows"
 jsonpatch==1.32
 kubernetes==24.2.0
-# higher version of llvmlite breaks windows
-llvmlite==0.39.1; platform_system != "Windows"
-llvmlite==0.34.0; platform_system == "Windows"
+llvmlite==0.39.1
 lxml==4.9.1
 moto[s3,server]==4.0.7
 mypy==0.982


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The latest release of numpy is incompatible with the currently pinned version of numba for windows. E.g. the `np.long` alias has been removed, leading to `AttributeError: module 'numpy' has no attribute 'long'`.

It's not clear if this separate numba pin is still needed, so this PR removes the OS-specific pin and upgrades numba to the latest patch release. If this fails, we can pin numpy for windows tests instead until we found a resolution.

## Related issue number

See #31258

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
