### PR TITLE
Revert "[RLlib] Fix `tensorflow_probability` imports. (#31331)"

### DIFF
--- a/rllib/algorithms/bandit/bandit_tf_model.py
+++ b/rllib/algorithms/bandit/bandit_tf_model.py
@@ -1,21 +1,17 @@
 import gymnasium as gym
+import tensorflow_probability as tfp
 
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.models.tf.tf_modelv2 import TFModelV2
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_tf
-from ray.rllib.utils.framework import try_import_tfp
 from ray.rllib.utils.typing import TensorType
 
 tf1, tf, tfv = try_import_tf()
-tfp = try_import_tfp()
 
 
 class OnlineLinearRegression(tf.Module if tf else object):
     def __init__(self, feature_dim, alpha=1, lambda_=1):
-        try_import_tf(error=True)
-        try_import_tfp(error=True)
-
         super(OnlineLinearRegression, self).__init__()
 
         self.d = feature_dim

--- a/rllib/core/optim/tests/test_rl_optimizer_tf.py
+++ b/rllib/core/optim/tests/test_rl_optimizer_tf.py
@@ -1,7 +1,7 @@
 # TODO (avnishn): Merge with the torch version of this test once the
 # RLTrainer has been merged.
 import gymnasium as gym
-import tensorflow as tf  # TODO (Artur): Use try_import_tf here (leads to error)
+import tensorflow as tf
 from typing import Any, Mapping, Union
 import unittest
 

--- a/rllib/core/rl_module/tf/tests/test_tf_rl_module.py
+++ b/rllib/core/rl_module/tf/tests/test_tf_rl_module.py
@@ -1,15 +1,13 @@
+import gymnasium as gym
+import tensorflow as tf
+import tensorflow_probability as tfp
 import unittest
 from typing import Mapping
 
-import gymnasium as gym
-
 from ray.rllib.core.rl_module.tf.tf_rl_module import TfRLModule
 from ray.rllib.core.testing.tf.bc_module import DiscreteBCTFModule
-from ray.rllib.utils.framework import try_import_tfp, try_import_tf
-from ray.rllib.utils.test_utils import check
 
-_, tf, _ = try_import_tf(error=True)
-tfp = try_import_tfp(error=True)
+from ray.rllib.utils.test_utils import check
 
 
 class TestRLModule(unittest.TestCase):

--- a/rllib/core/testing/tf/bc_module.py
+++ b/rllib/core/testing/tf/bc_module.py
@@ -1,4 +1,6 @@
 import gymnasium as gym
+import tensorflow as tf
+import tensorflow_probability as tfp
 from typing import Any, Mapping, Union
 
 from ray.rllib.core.rl_module.rl_module import RLModule
@@ -7,12 +9,8 @@ from ray.rllib.models.specs.specs_dict import SpecDict
 from ray.rllib.models.specs.typing import SpecType
 from ray.rllib.models.specs.specs_tf import TFTensorSpecs
 from ray.rllib.policy.sample_batch import SampleBatch
-from ray.rllib.utils.framework import try_import_tf, try_import_tfp
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.nested_dict import NestedDict
-
-_, tf, _ = try_import_tf()
-tfp = try_import_tfp()
 
 
 class DiscreteBCTFModule(TfRLModule):

--- a/rllib/core/testing/tf/bc_optimizer.py
+++ b/rllib/core/testing/tf/bc_optimizer.py
@@ -1,12 +1,9 @@
+import tensorflow as tf
 from typing import Any, Mapping
 
 from ray.rllib.core.optim.rl_optimizer import RLOptimizer
 from ray.rllib.policy.sample_batch import SampleBatch
-from ray.rllib.utils.framework import try_import_tf, try_import_tfp
 from ray.rllib.utils.nested_dict import NestedDict
-
-_, tf, _ = try_import_tf()
-tfp = try_import_tfp()
 
 
 class BCTFOptimizer(RLOptimizer):

--- a/rllib/models/specs/tests/test_tensor_spec.py
+++ b/rllib/models/specs/tests/test_tensor_spec.py
@@ -1,16 +1,13 @@
 import itertools
 import unittest
+import torch
 import numpy as np
+import tensorflow as tf
 
 from ray.rllib.utils.test_utils import check
 from ray.rllib.models.specs.specs_torch import TorchTensorSpec
 from ray.rllib.models.specs.specs_np import NPTensorSpec
 from ray.rllib.models.specs.specs_tf import TFTensorSpecs
-from ray.rllib.utils.framework import try_import_tf, try_import_tfp, try_import_torch
-
-torch = try_import_torch()
-_, tf, _ = try_import_tf()
-tfp = try_import_tfp()
 
 # TODO: add jax tests
 

--- a/rllib/utils/framework.py
+++ b/rllib/utils/framework.py
@@ -146,13 +146,9 @@ def try_import_tfp(error: bool = False):
         import tensorflow_probability as tfp
 
         return tfp
-    except ImportError:
+    except ImportError as e:
         if error:
-            raise ImportError(
-                "Could not import TensorFlow Probabilty! RLlib does not come with "
-                "TensorFlow Probabilty as a dependency. You can install it with "
-                "`pip install tensorflow_probability`."
-            )
+            raise e
         return None
 
 

--- a/rllib/utils/tf_utils.py
+++ b/rllib/utils/tf_utils.py
@@ -246,8 +246,8 @@ def get_tf_eager_cls_if_necessary(
     cls = orig_cls
     framework = config.get("framework", "tf")
 
-    if framework in ["tf2", "tf"]:
-        try_import_tf(error=True)
+    if framework in ["tf2", "tf"] and not tf1:
+        raise ImportError("Could not import tensorflow!")
 
     if framework == "tf2":
         if not tf1.executing_eagerly():


### PR DESCRIPTION
This reverts commit f6da3f3be479a537c49a82b67b2503484256c7ca.

## Why are these changes needed?

As @krfricke noted, there seems to be something wrong with this PR:

<img width="1061" alt="Screenshot 2023-01-03 at 12 40 27" src="https://user-images.githubusercontent.com/9356806/210350413-f9eb8262-0ef8-45b2-955f-27d83875469f.png">
