### PR TITLE
[Data] Fix Discretizers transforming ignored cols

### DIFF
--- a/python/ray/data/preprocessors/discretizer.py
+++ b/python/ray/data/preprocessors/discretizer.py
@@ -20,6 +20,8 @@ class _AbstractKBinsDiscretizer(Preprocessor):
 
     def _transform_pandas(self, df: pd.DataFrame):
         def bin_values(s: pd.Series) -> pd.Series:
+            if s.name not in self.columns:
+                return s
             labels = self.dtypes.get(s.name) if self.dtypes else False
             ordered = True
             if labels:

--- a/python/ray/data/tests/preprocessors/test_discretizer.py
+++ b/python/ray/data/tests/preprocessors/test_discretizer.py
@@ -25,8 +25,9 @@ def test_uniform_kbins_discretizer(
     """Tests basic UniformKBinsDiscretizer functionality."""
 
     col_a = [0.2, 1.4, 2.5, 6.2, 9.7, 2.1]
-    col_b = [0.2, 1.4, 2.5, 6.2, 9.7, 2.1]
-    in_df = pd.DataFrame.from_dict({"A": col_a, "B": col_b})
+    col_b = col_a.copy()
+    col_c = col_a.copy()
+    in_df = pd.DataFrame.from_dict({"A": col_a, "B": col_b, "C": col_c})
     ds = ray.data.from_pandas(in_df).repartition(2)
 
     discretizer = UniformKBinsDiscretizer(
@@ -74,6 +75,8 @@ def test_uniform_kbins_discretizer(
             include_lowest=include_lowest,
         )
     )
+    # Check that the remaining column was not modified
+    assert out_df["C"].equals(in_df["C"])
 
 
 @pytest.mark.parametrize(
@@ -98,8 +101,9 @@ def test_custom_kbins_discretizer(
     """Tests basic CustomKBinsDiscretizer functionality."""
 
     col_a = [0.2, 1.4, 2.5, 6.2, 9.7, 2.1]
-    col_b = [0.2, 1.4, 2.5, 6.2, 9.7, 2.1]
-    in_df = pd.DataFrame.from_dict({"A": col_a, "B": col_b})
+    col_b = col_a.copy()
+    col_c = col_a.copy()
+    in_df = pd.DataFrame.from_dict({"A": col_a, "B": col_b, "C": col_c})
     ds = ray.data.from_pandas(in_df).repartition(2)
 
     discretizer = CustomKBinsDiscretizer(
@@ -147,6 +151,8 @@ def test_custom_kbins_discretizer(
             include_lowest=include_lowest,
         )
     )
+    # Check that the remaining column was not modified
+    assert out_df["C"].equals(in_df["C"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes a bug in Discretizer Preprocessors where all of the columns in a Dataset would be transformed instead of just the specified ones. This lead to exceptions due to KeyErrors later.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
