### PR TITLE
[AIR] Deal with nested Chain in BatchPredictor

### DIFF
--- a/python/ray/data/preprocessors/chain.py
+++ b/python/ray/data/preprocessors/chain.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING
+from ray.air.util.data_batch_conversion import BatchFormat, BlockFormat
 from ray.data import Dataset
 from ray.data.preprocessor import Preprocessor
 from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
-    from ray.air.util.data_batch_conversion import BatchFormat, BlockFormat
     from ray.air.data_batch_type import DataBatchType
 
 
@@ -96,7 +96,7 @@ class Chain(Preprocessor):
         arguments = ", ".join(repr(preprocessor) for preprocessor in self.preprocessors)
         return f"{self.__class__.__name__}({arguments})"
 
-    def _determine_transform_to_use(self, data_format: "BlockFormat") -> "BatchFormat":
+    def _determine_transform_to_use(self, data_format: BlockFormat) -> BatchFormat:
         # This is relevant for BatchPrediction.
         # For Chain preprocessor, we picked the first one as entry point.
         # TODO (jiaodong): We should revisit if our Chain preprocessor is

--- a/python/ray/data/preprocessors/chain.py
+++ b/python/ray/data/preprocessors/chain.py
@@ -4,6 +4,7 @@ from ray.data.preprocessor import Preprocessor
 from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
+    from ray.air.util.data_batch_conversion import BatchFormat, BlockFormat
     from ray.air.data_batch_type import DataBatchType
 
 
@@ -94,3 +95,10 @@ class Chain(Preprocessor):
     def __repr__(self):
         arguments = ", ".join(repr(preprocessor) for preprocessor in self.preprocessors)
         return f"{self.__class__.__name__}({arguments})"
+
+    def _determine_transform_to_use(self, data_format: "BlockFormat") -> "BatchFormat":
+        # This is relevant for BatchPrediction.
+        # For Chain preprocessor, we picked the first one as entry point.
+        # TODO (jiaodong): We should revisit if our Chain preprocessor is
+        # still optimal with context of lazy execution.
+        return self.preprocessors[0]._determine_transform_to_use(data_format)

--- a/python/ray/data/tests/preprocessors/test_chain.py
+++ b/python/ray/data/tests/preprocessors/test_chain.py
@@ -206,8 +206,10 @@ def test_determine_transform_to_use(block_format):
         chain._determine_transform_to_use(block_format)
 
     # Should have no errors from here on
-    chain1 = Chain(SimpleImputer(["A"]))
+    preprocessor = SimpleImputer(["A"])
+    chain1 = Chain(preprocessor)
     format1 = chain1._determine_transform_to_use(block_format)
+    assert format1 == preprocessor._determine_transform_to_use(block_format)
 
     chain2 = Chain(chain1)
     format2 = chain2._determine_transform_to_use(block_format)

--- a/python/ray/train/batch_predictor.py
+++ b/python/ray/train/batch_predictor.py
@@ -444,11 +444,13 @@ class BatchPredictor:
         if preprocessor is None:
             # No preprocessor, just use the predictor format.
             return self._predictor_cls._batch_format_to_use()
-        elif hasattr(preprocessor, "preprocessors"):
-            # For Chain preprocessor, we picked the first one as entry point.
-            # TODO (jiaodong): We should revisit if our Chain preprocessor is
-            # still optimal with context of lazy execution.
-            preprocessor = preprocessor.preprocessors[0]
+        else:
+            # Use while to deal with nested Chain case
+            while hasattr(preprocessor, "preprocessors"):
+                # For Chain preprocessor, we picked the first one as entry point.
+                # TODO (jiaodong): We should revisit if our Chain preprocessor is
+                # still optimal with context of lazy execution.
+                preprocessor = preprocessor.preprocessors[0]
 
         # Use same batch format as first preprocessor to minimize data copies.
         return preprocessor._determine_transform_to_use(dataset_block_format)

--- a/python/ray/train/batch_predictor.py
+++ b/python/ray/train/batch_predictor.py
@@ -444,13 +444,7 @@ class BatchPredictor:
         if preprocessor is None:
             # No preprocessor, just use the predictor format.
             return self._predictor_cls._batch_format_to_use()
-        else:
-            # Use while to deal with nested Chain case
-            while hasattr(preprocessor, "preprocessors"):
-                # For Chain preprocessor, we picked the first one as entry point.
-                # TODO (jiaodong): We should revisit if our Chain preprocessor is
-                # still optimal with context of lazy execution.
-                preprocessor = preprocessor.preprocessors[0]
+        # Code dealing with Chain preprocessor is in Chain._determine_transform_to_use
 
         # Use same batch format as first preprocessor to minimize data copies.
         return preprocessor._determine_transform_to_use(dataset_block_format)

--- a/python/ray/train/tests/test_batch_predictor.py
+++ b/python/ray/train/tests/test_batch_predictor.py
@@ -13,7 +13,6 @@ import ray
 from ray.air.checkpoint import Checkpoint
 from ray.air.util.data_batch_conversion import BatchFormat
 from ray.data import Preprocessor
-from ray.data.preprocessors import Chain
 from ray.tests.conftest import *  # noqa
 from ray.train.batch_predictor import BatchPredictor
 from ray.train.predictor import Predictor
@@ -151,15 +150,9 @@ def test_automatic_enable_gpu_from_num_gpus_per_worker(shutdown_only):
         _ = batch_predictor.predict(test_dataset, num_gpus_per_worker=1)
 
 
-@pytest.mark.parametrize("use_nested_chain", (True,))
-def test_batch_prediction_simple(use_nested_chain):
-    # use_nested_chain is a special case to test _determine_preprocessor_batch_format
-    # being able to deal with a Chain nested inside a Chain
-    preprocessor = (
-        Chain(Chain(DummyPreprocessor())) if use_nested_chain else DummyPreprocessor()
-    )
+def test_batch_prediction_simple():
     batch_predictor = BatchPredictor.from_checkpoint(
-        Checkpoint.from_dict({"factor": 2.0, PREPROCESSOR_KEY: preprocessor}),
+        Checkpoint.from_dict({"factor": 2.0, PREPROCESSOR_KEY: DummyPreprocessor()}),
         DummyPredictor,
     )
 

--- a/python/ray/train/tests/test_batch_predictor.py
+++ b/python/ray/train/tests/test_batch_predictor.py
@@ -13,6 +13,7 @@ import ray
 from ray.air.checkpoint import Checkpoint
 from ray.air.util.data_batch_conversion import BatchFormat
 from ray.data import Preprocessor
+from ray.data.preprocessors import Chain
 from ray.tests.conftest import *  # noqa
 from ray.train.batch_predictor import BatchPredictor
 from ray.train.predictor import Predictor
@@ -150,9 +151,15 @@ def test_automatic_enable_gpu_from_num_gpus_per_worker(shutdown_only):
         _ = batch_predictor.predict(test_dataset, num_gpus_per_worker=1)
 
 
-def test_batch_prediction_simple():
+@pytest.mark.parametrize("use_nested_chain", (True,))
+def test_batch_prediction_simple(use_nested_chain):
+    # use_nested_chain is a special case to test _determine_preprocessor_batch_format
+    # being able to deal with a Chain nested inside a Chain
+    preprocessor = (
+        Chain(Chain(DummyPreprocessor())) if use_nested_chain else DummyPreprocessor()
+    )
     batch_predictor = BatchPredictor.from_checkpoint(
-        Checkpoint.from_dict({"factor": 2.0, PREPROCESSOR_KEY: DummyPreprocessor()}),
+        Checkpoint.from_dict({"factor": 2.0, PREPROCESSOR_KEY: preprocessor}),
         DummyPredictor,
     )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`BatchPredictor._determine_preprocessor_batch_format` has a special case for `Chain`, where it obtains the first preprocessor contained within `Chain` in order to determine which transformation function to use for the dataset (as `Chain` doesn't implement any). However, with https://github.com/ray-project/ray/pull/29706 allowing for nested `Chain`s, this check fails if the first preprocessor within a `Chain` is also a `Chain`.

This PR removes this special case from `BatchPredictor` and instead subclasses `_determine_transform_to_use` inside `Chain` itself, which allows us to both deal with the nested `Chain` case and improve code structure.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
