### PR TITLE
[ci][nightly] no ray.wait in a loop for many_actors test

### DIFF
--- a/release/benchmarks/distributed/test_many_actors.py
+++ b/release/benchmarks/distributed/test_many_actors.py
@@ -29,11 +29,9 @@ def test_max_actors():
         for _ in tqdm.trange(MAX_ACTORS_IN_CLUSTER, desc="Launching actors")
     ]
 
-    not_ready = [actor.foo.remote() for actor in actors]
-
-    for _ in tqdm.trange(len(actors)):
-        ready, not_ready = ray.wait(not_ready)
-        assert ray.get(*ready) is None
+    done = ray.get([actor.foo.remote() for actor in actors])
+    for result in done:
+        assert result is None
 
 
 def no_resource_leaks():


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`many_actors` regressed since `ray.wait` regresses, which could be non-related to what `many_actors` is testing. 

See more in https://github.com/ray-project/ray/issues/31284 for detailed root-cause. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Mitigates https://github.com/ray-project/ray/issues/31284
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
