### PR TITLE
[RFC] [data] New executor [4/n]--- Add resource management interfaces

### DIFF
--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -306,11 +306,3 @@ class Executor:
         while iterating over `execute` results for streaming execution.
         """
         raise NotImplementedError
-
-    def get_resource_usage(self) -> ExecutionResources:
-        """Return the current resource usage of the executor.
-
-        This is the sum of resource usage for each operator being executed. If
-        execution has completed, the resource usages will be None.
-        """
-        raise NotImplementedError

--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -268,15 +268,9 @@ class PhysicalOperator:
         This method is called by the executor to allocate resources between different
         operators. Operators should ensure they make forward progress even if the limit
         is set to zero (i.e., should run at least one task).
-        """
-        pass
 
-    def release_unused_resources(self) -> None:
-        """Tell the operator to release unused resources, if possible.
-
-        For example, an ActorPool operator may remove idle actors from its internal
-        pool when this is called. This method is called by the executor to allocate
-        resources between different operators.
+        If this is called and the operator is currently using more than the specified
+        resource limit, it should gracefully scale down (i.e., when tasks complete).
         """
         pass
 


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds resource management interfaces for operators. These are interfaces to be used by the `StreamingExecutor` implementation to control the scale-up/down of individual operators.

This will be part of https://github.com/ray-project/ray/pull/30903