### PR TITLE
Check numerics in environments at runtime

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -285,7 +285,7 @@ class AlgorithmConfig:
         self.clip_actions = False
         self.disable_env_checking = False
         # If environment should be checked for NaNs/Infs.
-        self.check_nan_env = (False,)
+        self.check_nan_env = False
         self.check_nan_env_config = {
             # If an NaN/Inf should raise an exception.
             "raise_exception": False,

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -284,6 +284,16 @@ class AlgorithmConfig:
         self.normalize_actions = True
         self.clip_actions = False
         self.disable_env_checking = False
+        # If environment should be checked for NaNs/Infs.
+        self.check_nan_env = False,
+        self.check_nan_env_config = {
+            # If an NaN/Inf should raise an exception.
+            "raise_exception": False,
+            # Also check for Inf values. Otherwise only NaNs.
+            "check_inf": True,
+            # Warn only at the first occurrence.
+            "warn_once": False,
+        }
         # Whether this env is an atari env (for atari-specific preprocessing).
         # If not specified, we will try to auto-detect this.
         self.is_atari = None
@@ -1125,6 +1135,8 @@ class AlgorithmConfig:
         normalize_actions: Optional[bool] = NotProvided,
         clip_actions: Optional[bool] = NotProvided,
         disable_env_checking: Optional[bool] = NotProvided,
+        check_nan_env: Optional[bool] = NotProvided,
+        check_nan_env_config: Optional[Dict] = NotProvided,
         is_atari: Optional[bool] = NotProvided,
         auto_wrap_old_gym_envs: Optional[bool] = NotProvided,
     ) -> "AlgorithmConfig":
@@ -1206,6 +1218,10 @@ class AlgorithmConfig:
             self.clip_actions = clip_actions
         if disable_env_checking is not NotProvided:
             self.disable_env_checking = disable_env_checking
+        if check_nan_env is not NotProvided:
+            self.check_nan_env = check_nan_env
+        if check_nan_env_config is not NotProvided:
+            self.check_nan_env_config = check_nan_env_config
         if is_atari is not NotProvided:
             self.is_atari = is_atari
         if auto_wrap_old_gym_envs is not NotProvided:
@@ -1225,7 +1241,7 @@ class AlgorithmConfig:
         rollout_fragment_length: Optional[Union[int, str]] = NotProvided,
         batch_mode: Optional[str] = NotProvided,
         remote_worker_envs: Optional[bool] = NotProvided,
-        remote_env_batch_wait_ms: Optional[float] = NotProvided,
+        remote_env_batch_wait_ms: Optional[float] =  NotProvided,
         validate_workers_after_construction: Optional[bool] = NotProvided,
         ignore_worker_failures: Optional[bool] = NotProvided,
         recreate_failed_workers: Optional[bool] = NotProvided,

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -285,7 +285,7 @@ class AlgorithmConfig:
         self.clip_actions = False
         self.disable_env_checking = False
         # If environment should be checked for NaNs/Infs.
-        self.check_nan_env = False,
+        self.check_nan_env = (False,)
         self.check_nan_env_config = {
             # If an NaN/Inf should raise an exception.
             "raise_exception": False,
@@ -1241,7 +1241,7 @@ class AlgorithmConfig:
         rollout_fragment_length: Optional[Union[int, str]] = NotProvided,
         batch_mode: Optional[str] = NotProvided,
         remote_worker_envs: Optional[bool] = NotProvided,
-        remote_env_batch_wait_ms: Optional[float] =  NotProvided,
+        remote_env_batch_wait_ms: Optional[float] = NotProvided,
         validate_workers_after_construction: Optional[bool] = NotProvided,
         ignore_worker_failures: Optional[bool] = NotProvided,
         recreate_failed_workers: Optional[bool] = NotProvided,

--- a/rllib/env/wrappers/check_nan_wrapper.py
+++ b/rllib/env/wrappers/check_nan_wrapper.py
@@ -93,23 +93,40 @@ class CheckNaNWrapper:
 
             # Check observations.
             for env_id, all_agent_obs in unfiltered_obs.items():
-                for agent_id, agent_obs in all_agent_obs.items():
-                    self._check_val(
-                        env_id=env_id,
-                        agent_id=agent_id,
-                        observation=agent_obs,
+                if not isinstance(all_agent_obs, Exception):
+                    for agent_id, agent_obs in all_agent_obs.items():
+                        self._check_val(
+                            env_id=env_id,
+                            agent_id=agent_id,
+                            observation=agent_obs,
+                        )
+                else:
+                    return (
+                        unfiltered_obs,
+                        rewards,
+                        terminateds,
+                        truncateds,
+                        infos,
+                        off_policy_actions,
                     )
             # Check rewards.
             for env_id, all_agent_rewards in rewards.items():
-                for agent_id, agent_reward in all_agent_rewards.items():
-                    self._check_val(
-                        env_id=env_id,
-                        agent_id=agent_id,
-                        reward=agent_reward,
+                if not isinstance(all_agent_rewards, Exception):
+                    for agent_id, agent_reward in all_agent_rewards.items():
+                        self._check_val(
+                            env_id=env_id,
+                            agent_id=agent_id,
+                            reward=agent_reward,
+                        )
+                else:
+                    return (
+                        unfiltered_obs,
+                        rewards,
+                        terminateds,
+                        truncateds,
+                        infos,
+                        off_policy_actions,
                     )
-
-        # If it was a reset it will not in the next iterations.
-        self._reset = False
 
         # Finally, return the polled results from the BaseEnv back to the
         # sampler.
@@ -179,12 +196,15 @@ class CheckNaNWrapper:
         if isinstance(resetted_obs, dict):
             # Check observations.
             for env_id, all_agent_obs in resetted_obs.items():
-                for agent_id, agent_obs in all_agent_obs.items():
-                    self._check_val(
-                        env_id=env_id,
-                        agent_id=agent_id,
-                        observation=agent_obs,
-                    )
+                if not isinstance(all_agent_obs, Exception):
+                    for agent_id, agent_obs in all_agent_obs.items():
+                        self._check_val(
+                            env_id=env_id,
+                            agent_id=agent_id,
+                            observation=agent_obs,
+                        )
+                else:
+                    return resetted_obs, resetted_infos
 
         # Reset is done.
         self._reset = False

--- a/rllib/env/wrappers/check_nan_wrapper.py
+++ b/rllib/env/wrappers/check_nan_wrapper.py
@@ -1,0 +1,257 @@
+import logging
+import numpy as np
+from typing import Optional, Tuple
+
+from ray.rllib.env.base_env import BaseEnv
+from ray.rllib.utils.spaces.space_utils import flatten_to_single_ndarray
+from ray.rllib.utils.typing import EnvID, MultiEnvDict
+
+logger = logging.getLogger(__name__)
+
+class CheckNaNWrapper:
+
+    def __init__(
+        self,
+        env: BaseEnv,
+        config: dict,
+    ):
+        # Only BaseEnvs should be wrapped.
+        assert isinstance(env, BaseEnv)
+        self.env = env
+
+        # Whether the wrapper should raise an exception when finding
+        # an NaN or Inf value.
+        self.raise_exception: bool = config.get("raise_exception", False)    
+        # Whether it should be checked also for Inf values. Otherwise only NaN
+        # values are checked for.
+        self.check_inf: bool = config.get("check_inf", True)
+        # Whether the user should be warned only once, if an NaN or Inf value
+        # was encountered.
+        self.warn_once: bool = config.get("warn_once", False)
+        self._user_warned: bool = False
+
+        # Records also the last action and observation for understanding the causes.
+        self._last_actions: MultiEnvDict = None
+        self._last_observations: MultiEnvDict = None
+        self._reset = True
+
+    def __getattr__(self, name):
+        """Uses all attributes of the wrapped environment.
+        
+        This ensures that all attributes of the BaseEnv are available 
+        upon calling.
+
+        Args: 
+            name: Name of the attribute.
+
+        Returns:
+            Class attribute of the wrapped BaseEnv.
+        """
+        if name.startswith("_"):
+            raise AttributeError(f"accessing private attribute '{name}' is prohibited")
+        return getattr(self.env, name)
+
+    def poll(
+        self,
+    ) -> Tuple[
+        MultiEnvDict,
+        MultiEnvDict,
+        MultiEnvDict,
+        MultiEnvDict,
+        MultiEnvDict,
+        MultiEnvDict,
+    ]:
+        """Checks for Nan and Inf values in observations and rewards.
+    
+        The `poll()` method of the BaseEnv is wrapped here.
+
+        Returns:
+            Tuple consisting of:
+            New observations for each ready agent.
+            Reward values for each ready agent. If the episode is just started,
+            the value will be None.
+            Terminated values for each ready agent. The special key "__all__" is used to
+            indicate episode termination.
+            Truncated values for each ready agent. The special key "__all__"
+            is used to indicate episode truncation.
+            Info values for each ready agent.
+            Agents may take off-policy actions, in which case, there will be an entry
+            in this dict that contains the taken action. There is no need to
+            `send_actions()` for agents that have already chosen off-policy actions.
+        """
+        (
+            unfiltered_obs,
+            rewards,
+            terminateds,
+            truncateds,
+            infos,
+            off_policy_actions,
+        ) = self.env.poll()
+
+        self._last_observations = unfiltered_obs
+
+        # Check observations.
+        for env_id, all_agent_obs in unfiltered_obs.items():
+            for agent_id, agent_obs in all_agent_obs.items():
+                self._check_val(
+                    env_id=env_id,
+                    agent_id=agent_id,                                 
+                    observation=agent_obs,        
+                )
+        # Check rewards.
+        for env_id, all_agent_rewards in rewards.items():
+            for agent_id, agent_reward in all_agent_rewards.items():
+                self._check_val(
+                    env_id = env_id,
+                    agent_id=agent_id,
+                    reward=agent_reward,
+                )
+
+        # If it was a reset it will not in the next iterations.
+        self._reset = False
+
+        # Finally, return the polled results from the BaseEnv back to the
+        # sampler.
+        return (
+            unfiltered_obs,
+            rewards,
+            terminateds,
+            truncateds,
+            infos,
+            off_policy_actions,
+        )
+
+    def send_actions(self, action_dict: MultiEnvDict) -> None:
+        """Checking for NaNs and Inf in actions. 
+        
+        The `send_actions()` of the BaseEnv is wrapped here.
+
+        Args:
+            action_dict: Actions values keyed by env_id and agent_id.
+        """
+        self._last_actions = action_dict
+
+        # Check actions.
+        for env_id, all_agent_actions in action_dict.items():
+            for agent_id, agent_actions in all_agent_actions.items():
+                self._check_val(
+                    env_id=env_id,
+                    agent_id=agent_id,
+                    action=agent_actions,
+                )
+
+        # Finally return the actions to the wrapped BaseEnv for evaluation.
+        return self.env.send_actions(action_dict)
+
+    def try_reset(
+        self,
+        env_id: Optional[EnvID] = None,
+        *,
+        seed: Optional[int] = None,
+        options: Optional[dict] = None,
+    ) -> Tuple[MultiEnvDict, MultiEnvDict]:
+        """Checks values from the environment at reset.
+        
+        The `try_reset()` of the BaseEnv is wrapped here.
+
+        Args:
+            env_id: The sub-environment's ID if applicable. If None, reset
+                the entire Env (i.e. all sub-environments).
+            seed: The seed to be passed to the sub-environment(s) when
+                resetting it. If None, will not reset any existing PRNG. If you pass an
+                integer, the PRNG will be reset even if it already exists.
+            options: An options dict to be passed to the sub-environment(s) when
+                resetting it.
+        
+        Returns:
+            The wrapped environment's reset observations and infos.
+        """
+        resetted_obs, resetted_infos = self.env.try_reset(
+            env_id=env_id, seed=seed, options=options,
+        )
+        self._last_observations = resetted_obs
+
+        # Check observations.
+        for env_id, all_agent_obs in resetted_obs.items():
+            for agent_id, agent_obs in all_agent_obs.items():
+                self._check_val(
+                    env_id=env_id,
+                    agent_id=agent_id,                                 
+                    observation=agent_obs,        
+                )
+
+        # Reset is done.
+        self._reset = False
+
+        # Finally return the BaseEnv's resetted observations and infos.
+        return resetted_obs, resetted_infos
+
+    def _check_val(self, env_id, agent_id,  **kwargs) -> None:
+        """Checks values from the environment for NaN or Inf.
+        
+        Values get assigned to their corresponding names and a 
+        message is printed that includes also the last intact action.
+
+        Args:
+            env_id: The sub-environment's ID, if applicable.
+            agent_id: The agent's ID, if applicable.
+
+        Returns:
+            A message containing information about the detected NaN/Inf values 
+            or None, if all values are proper numbers.                        
+        """
+
+        # Only execute value checking if False.
+        if not self.raise_exception and self.warn_once and self._user_warned:
+            return
+
+        found = []
+        for name, val in kwargs.items():
+            has_nan = np.any(
+                np.isnan(
+                    flatten_to_single_ndarray(val)
+                )
+            )
+            has_inf = self.check_inf and np.any(
+                np.isinf(
+                    flatten_to_single_ndarray(val)
+                )
+            )
+            if has_inf:
+                found.append((name, "inf"))
+            if has_nan:
+                found.append((name, "nan"))
+
+        if found:
+            self._user_warned = True
+            msg = "" if len(found) == 0 else "Sub-Env '{}', agent '{}': ".format(env_id, agent_id)
+            for i, (name, val) in enumerate(found):
+                msg += "found '{}' in '{}'".format(val, name)
+                if i != len(found) - 1:
+                    msg += ", "
+
+            msg += ".\r\nOriginated from the "
+            if self._reset:
+                # At reset no last action was recorded.
+                msg += "environment (at reset). Environment returned: \r\n'observation'={}.".format(
+                    self._last_observations[env_id]
+                )
+            elif found[0][0] == "observation":
+                msg += "environment. Last given value was: \r\n'action'={}.".format(
+                    self._last_actions[env_id]
+                )
+                msg += "\r\nStep result was: \r\n'observation'={}".format(
+                    self._last_observations[env_id]
+                )
+            else: 
+                msg += "Policy model. Last given value was: \r\n'observation'={}.".format(
+                    self._last_observations[env_id]
+                )                
+                msg += "\r\nResult was: \r\n'action'={}".format(
+                    self._last_action[env_id]
+                )
+
+            if self.raise_exception:
+                raise ValueError(msg)
+            else:
+                logger.warning(msg)

--- a/rllib/env/wrappers/check_nan_wrapper.py
+++ b/rllib/env/wrappers/check_nan_wrapper.py
@@ -169,16 +169,18 @@ class CheckNaNWrapper:
         resetted_obs, resetted_infos = self.env.try_reset(
             env_id=env_id, seed=seed, options=options,
         )
+        
         self._last_observations = resetted_obs
 
-        # Check observations.
-        for env_id, all_agent_obs in resetted_obs.items():
-            for agent_id, agent_obs in all_agent_obs.items():
-                self._check_val(
-                    env_id=env_id,
-                    agent_id=agent_id,                                 
-                    observation=agent_obs,        
-                )
+        if resetted_obs:
+            # Check observations.
+            for env_id, all_agent_obs in resetted_obs.items():
+                for agent_id, agent_obs in all_agent_obs.items():
+                    self._check_val(
+                        env_id=env_id,
+                        agent_id=agent_id,                                 
+                        observation=agent_obs,        
+                    )
 
         # Reset is done.
         self._reset = False

--- a/rllib/env/wrappers/check_nan_wrapper.py
+++ b/rllib/env/wrappers/check_nan_wrapper.py
@@ -88,24 +88,25 @@ class CheckNaNWrapper:
             off_policy_actions,
         ) = self.env.poll()
 
-        self._last_observations = unfiltered_obs
+        if isinstance(unfiltered_obs, dict):
+            self._last_observations = unfiltered_obs
 
-        # Check observations.
-        for env_id, all_agent_obs in unfiltered_obs.items():
-            for agent_id, agent_obs in all_agent_obs.items():
-                self._check_val(
-                    env_id=env_id,
-                    agent_id=agent_id,
-                    observation=agent_obs,
-                )
-        # Check rewards.
-        for env_id, all_agent_rewards in rewards.items():
-            for agent_id, agent_reward in all_agent_rewards.items():
-                self._check_val(
-                    env_id=env_id,
-                    agent_id=agent_id,
-                    reward=agent_reward,
-                )
+            # Check observations.
+            for env_id, all_agent_obs in unfiltered_obs.items():
+                for agent_id, agent_obs in all_agent_obs.items():
+                    self._check_val(
+                        env_id=env_id,
+                        agent_id=agent_id,
+                        observation=agent_obs,
+                    )
+            # Check rewards.
+            for env_id, all_agent_rewards in rewards.items():
+                for agent_id, agent_reward in all_agent_rewards.items():
+                    self._check_val(
+                        env_id=env_id,
+                        agent_id=agent_id,
+                        reward=agent_reward,
+                    )
 
         # If it was a reset it will not in the next iterations.
         self._reset = False
@@ -129,16 +130,17 @@ class CheckNaNWrapper:
         Args:
             action_dict: Actions values keyed by env_id and agent_id.
         """
-        self._last_actions = action_dict
+        if isinstance(action_dict, dict):
+            self._last_actions = action_dict
 
-        # Check actions.
-        for env_id, all_agent_actions in action_dict.items():
-            for agent_id, agent_actions in all_agent_actions.items():
-                self._check_val(
-                    env_id=env_id,
-                    agent_id=agent_id,
-                    action=agent_actions,
-                )
+            # Check actions.
+            for env_id, all_agent_actions in action_dict.items():
+                for agent_id, agent_actions in all_agent_actions.items():
+                    self._check_val(
+                        env_id=env_id,
+                        agent_id=agent_id,
+                        action=agent_actions,
+                    )
 
         # Finally return the actions to the wrapped BaseEnv for evaluation.
         return self.env.send_actions(action_dict)

--- a/rllib/env/wrappers/tests/test_check_nan_wrapper.py
+++ b/rllib/env/wrappers/tests/test_check_nan_wrapper.py
@@ -1,0 +1,169 @@
+import unittest
+import logging
+
+import gymnasium as gym
+import numpy as np
+import ray
+from ray import air, tune
+from ray.rllib.env.base_env import convert_to_base_env
+from ray.rllib.env.wrappers.check_nan_wrapper import CheckNaNWrapper
+
+class TestNaNEnv(gym.Env):
+    
+    def __init__(self, render_mode=None, check_inf=False):
+        self.check_inf = check_inf
+        self.action_space = gym.spaces.Discrete(10)
+        self.observation_space = gym.spaces.Box(-np.inf, np.inf, shape=(10,), dtype=np.float32)
+        self.counter = 0
+        self.max_episode_steps=1000
+
+    def step(self, action):
+        self.counter += 1
+        obs = np.random.rand(10)
+        reward = np.sum(obs) * action
+        if np.random.rand() > 0.0 and self.counter > 20:
+            if self.check_inf:
+                obs[2] = np.inf 
+            else:
+                obs[2] = np.nan
+            print("*****************************************")
+            print("=========================================")
+            print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+            print(f"Now its {obs[2]}.")
+        terminated = self.counter == 100                   
+        return obs.astype(np.float32), reward, terminated, False, {}
+    
+    def reset(self, *, seed=None, options=None):
+
+        obs = np.random.rand(10)
+        self.counter = 0
+
+        return obs.astype(np.float32), {}
+
+class TestCheckNaNWrapper(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        ray.init()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        ray.shutdown()
+
+    def test_check_nan_wrapper(self):
+        """Checks, if the Wrapper warns about NaNs."""
+        env = TestNaNEnv()
+        base_env = convert_to_base_env(env)
+        check_nan_env_config = {
+            "raise_exception": False,
+            "check_inf": True,
+            "warn_once": False,
+        }
+        wrapped_env = CheckNaNWrapper(base_env, check_nan_env_config)
+
+        obs, infos = wrapped_env.try_reset()
+
+        def run(iters):        
+            for i in range(iters):            
+                action = np.random.randint(0, 10)
+                action_to_send = {0: {"agent0": action}}            
+                wrapped_env.send_actions(action_to_send)
+                (
+                    obs, 
+                    rewards, 
+                    terminateds, 
+                    truncateds, 
+                    infos, 
+                    offpolicy_actions
+                ) = wrapped_env.poll()
+        
+        self.assertLogs("check_nan_wrapper", level="WARNING")
+
+    def test_check_nan_wrapper_inf(self):
+        """Checks if the Wrapper als warns about Inf values."""
+        env = TestNaNEnv(check_inf=True)
+        base_env = convert_to_base_env(env)
+        check_nan_env_config = {
+            "raise_exception": False,
+            "check_inf": True,
+            "warn_once": False,
+        }
+        wrapped_env = CheckNaNWrapper(base_env, check_nan_env_config)
+
+        obs, infos = wrapped_env.try_reset()
+
+        def run(iters):        
+            for i in range(iters):            
+                action = np.random.randint(0, 10)
+                action_to_send = {0: {"agent0": action}}            
+                wrapped_env.send_actions(action_to_send)
+                (
+                    obs, 
+                    rewards, 
+                    terminateds, 
+                    truncateds, 
+                    infos, 
+                    offpolicy_actions
+                ) = wrapped_env.poll()
+        
+        self.assertLogs("check_nan_wrapper", level="WARNING")
+
+    def test_check_nan_wrapper_exception(self):
+        """Checks, if the Wrapper raises an exception."""
+        env = TestNaNEnv()
+        base_env = convert_to_base_env(env)
+        check_nan_env_config = {
+            "raise_exception": True,
+            "check_inf": True,
+            "warn_once": False,
+        }
+        wrapped_env = CheckNaNWrapper(base_env, check_nan_env_config)
+
+        obs, infos = wrapped_env.try_reset()
+
+        def run(iters):        
+            for i in range(iters):            
+                action = np.random.randint(0, 10)
+                action_to_send = {0: {"agent0": action}}            
+                wrapped_env.send_actions(action_to_send)
+                (
+                    obs, 
+                    rewards, 
+                    terminateds, 
+                    truncateds, 
+                    infos, 
+                    offpolicy_actions
+                ) = wrapped_env.poll()
+
+        self.assertRaises(ValueError, run, iters=100)
+    
+    def test_check_nan_wrapper_with_tune(self):
+        """Regression test.
+        
+        Checks if the Wrapper runs smoothly with RLlib algorithms.
+        """
+        tune.Tuner(
+            "PPO",
+            run_config=air.RunConfig(stop={"num_env_steps_sampled": 200},),
+            param_space={
+                "env": TestNaNEnv,
+                "check_nan_env": True,
+                "check_nan_env_config": {
+                    "raise_exception": False,
+                    "warn_once": False,
+                    "check_inf": True,
+                },
+                "disable_env_checking": True,
+                "num_gpus": 0,
+                "num_workers": 1,
+                "lr": 0.01,
+                "framework": "tf2",
+            },
+        ).fit()
+
+        self.assertLogs("check_nan_env", level="WARNING")
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -682,6 +682,10 @@ class RolloutWorker(ParallelIteratorWorker, FaultAwareApply):
                 env_creator, env_context, validate_env, wrap, self.seed
             )
 
+        # Eventually check the environment for NaNs/Infs.
+        self.check_nan_env = self.config.check_nan_env
+        self.check_nan_env_config = self.config.check_nan_env_config
+
         self.spaces = spaces
         self.default_policy_class = default_policy_class
         self.policy_dict, self.is_policy_to_train = self.config.get_multi_agent_setup(
@@ -829,6 +833,8 @@ class RolloutWorker(ParallelIteratorWorker, FaultAwareApply):
             self.sampler = SyncSampler(
                 worker=self,
                 env=self.async_env,
+                check_nan_env=self.check_nan_env,
+                check_nan_env_config=self.check_nan_env_config,
                 clip_rewards=clip_rewards,
                 rollout_fragment_length=rollout_fragment_length_for_sampler,
                 count_steps_by=self.config.count_steps_by,


### PR DESCRIPTION
Motivated by a larger error in my project and inspired by the `VecCheckNan` class in _stable-baselines_ I wrote an environment wrapper for the `BaseEnv` in RLlib that can check numerics of an environment during runtime. 

In a related issue (#31430) I suggested this feature request following the discussion with @sven1977   in issue #30471. 

The wrapper can be activated by a further configuration parameter in the `AlgorithmConfig` and wraps a `BaseEnv` in such a way that it wraps the three main methods `poll()`, `send_actions()` and `try_reset()` (all other attributes are adopted from the wrapped environment). 

The wrapper's main functionality is to check during 
- **`poll()`:** the observations and rewards for each environment and agent,
- **`try_reset()`:** the observations for each environment and agent,
- **`send_actions()`:** the actions for each environment and agent.

In case Nan/Infs are found a message is printed showing the faulty values as well as their previous counterpart that might have caused them (e.g. for a faulty observation the last action). 

There are three configuraion parameters to modify the wrapper's behavior: 

- **`raise_exception`:** Raise an exception when an NaN/Inf is encountered. Default `False`.
- **`check_inf`:** Check also for Inf values. Default `True`.
- **`warn_once`:** Warn only at the first occurrence of an Nan/Inf. Default `False`.

>**NOTE:** So far it only the previous counterpart for the same agent in a `MultiAgentEnv` is provided, i.e. `agent0` action for a faulty `agent0` observation. If there might be the case where the action of another agent might cause a faulty value for an agent, we have to add a further behavior for it. 

**TESTS:** I wrote some tests for the wrapper to check its behavior. All are passing together with some other environment tests. 

## Related issue number

#31430 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
