### PR TITLE
[Data] Fix Imputer failing with categorical dtype

### DIFF
--- a/python/ray/data/preprocessors/imputer.py
+++ b/python/ray/data/preprocessors/imputer.py
@@ -3,6 +3,7 @@ from numbers import Number
 from collections import Counter
 
 import pandas as pd
+from pandas.api.types import is_categorical_dtype
 
 from ray.data import Dataset
 from ray.data.aggregate import Mean
@@ -126,6 +127,9 @@ class SimpleImputer(Preprocessor):
             }
         elif self.strategy == "constant":
             new_values = {column: self.fill_value for column in self.columns}
+            for column, value in new_values.items():
+                if is_categorical_dtype(df.dtypes[column]):
+                    df[column] = df[column].cat.add_categories(value)
 
         df = df.fillna(new_values)
         return df

--- a/python/ray/data/tests/preprocessors/test_imputer.py
+++ b/python/ray/data/tests/preprocessors/test_imputer.py
@@ -89,11 +89,14 @@ def test_simple_imputer():
 
     # Test "constant" strategy.
     constant_col_a = ["apple", None]
-    constant_df = pd.DataFrame.from_dict({"A": constant_col_a})
+    constant_col_b = constant_col_a.copy()
+    constant_df = pd.DataFrame.from_dict({"A": constant_col_a, "B": constant_col_b})
+    # category dtype requires special handling
+    constant_df["B"] = constant_df["B"].astype("category")
     constant_ds = ray.data.from_pandas(constant_df)
 
     with pytest.raises(ValueError):
-        SimpleImputer(["A"], strategy="constant")
+        SimpleImputer(["A", "B"], strategy="constant")
 
     constant_imputer = SimpleImputer(
         ["A", "B"], strategy="constant", fill_value="missing"
@@ -102,7 +105,11 @@ def test_simple_imputer():
     constant_out_df = constant_transformed.to_pandas()
 
     constant_processed_col_a = ["apple", "missing"]
-    constant_expected_df = pd.DataFrame.from_dict({"A": constant_processed_col_a})
+    constant_processed_col_b = constant_processed_col_a.copy()
+    constant_expected_df = pd.DataFrame.from_dict(
+        {"A": constant_processed_col_a, "B": constant_processed_col_b}
+    )
+    constant_expected_df["B"] = constant_expected_df["B"].astype("category")
 
     assert constant_out_df.equals(constant_expected_df)
 


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`SimpleImputer` with `constant` strategy fails if used on a column with pandas Categorical dtype, as the new value has to be added to the categories first.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
