### PR TITLE
[Release] Download compressed metrics from cluster

### DIFF
--- a/release/BUILD
+++ b/release/BUILD
@@ -354,6 +354,14 @@ py_test(
 )
 
 py_test(
+    name = "test_utils",
+    tags = ["team:ci", "release_unit"],
+    size = "small",
+    srcs = ["ray_release/tests/test_utils.py"]
+)
+
+
+py_test(
     name = "test_wheels",
     tags = ["team:ci", "release_unit"],
     size = "small",

--- a/release/ray_release/command_runner/_prometheus_metrics.py
+++ b/release/ray_release/command_runner/_prometheus_metrics.py
@@ -24,7 +24,7 @@ def write_json(data, path: Union[str, Path], **json_dump_kwargs) -> Path:
     pathlib_path = Path(path)
     if pathlib_path.suffix == ".gz":
         with gzip.open(pathlib_path, "w") as f:
-            f.write(json.dumps(data).encode("utf-8"), **json_dump_kwargs)
+            f.write(json.dumps(data, **json_dump_kwargs).encode("utf-8"))
     else:
         with open(pathlib_path, "w") as f:
             json.dump(data, f, **json_dump_kwargs)

--- a/release/ray_release/command_runner/client_runner.py
+++ b/release/ray_release/command_runner/client_runner.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shlex
 import subprocess
@@ -24,6 +23,7 @@ from ray_release.file_manager.file_manager import FileManager
 from ray_release.logger import logger
 from ray_release.command_runner.command_runner import CommandRunner
 from ray_release.wheels import install_matching_ray_locally
+from ray_release.util import read_json
 
 
 def install_cluster_env_packages(cluster_env: Dict[Any, Any]):
@@ -118,8 +118,7 @@ class ClientRunner(CommandRunner):
 
     def _fetch_json(self, path: str) -> Dict[str, Any]:
         try:
-            with open(path, "rt") as fp:
-                return json.load(fp)
+            return read_json(path)
         except Exception as e:
             raise ResultsError(
                 f"Could not load local results from client command: {e}"

--- a/release/ray_release/command_runner/command_runner.py
+++ b/release/ray_release/command_runner/command_runner.py
@@ -17,7 +17,7 @@ class CommandRunner(abc.ABC):
         self.working_dir = working_dir
 
         self.result_output_json = "/tmp/release_test_out.json"
-        self.metrics_output_json = "/tmp/metrics_test_out.json"
+        self.metrics_output_json = "/tmp/metrics_test_out.json.gz"  # will be compressed
 
     @property
     def command_env(self):

--- a/release/ray_release/command_runner/job_runner.py
+++ b/release/ray_release/command_runner/job_runner.py
@@ -1,6 +1,6 @@
-import json
 import os
 import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from ray_release.cluster_manager.cluster_manager import ClusterManager
@@ -17,7 +17,7 @@ from ray_release.exception import (
 from ray_release.file_manager.file_manager import FileManager
 from ray_release.job_manager import JobManager
 from ray_release.logger import logger
-from ray_release.util import format_link, get_anyscale_sdk
+from ray_release.util import format_link, get_anyscale_sdk, read_json
 from ray_release.wheels import install_matching_ray_locally
 
 if TYPE_CHECKING:
@@ -130,13 +130,13 @@ class JobRunner(CommandRunner):
             raise LogsError(f"Could not get last logs: {e}") from e
 
     def _fetch_json(self, path: str) -> Dict[str, Any]:
+        pathlib_path = Path(path)
         try:
-            tmpfile = tempfile.mkstemp(suffix=".json")[1]
+            tmpfile = tempfile.mkstemp(suffix=pathlib_path.suffix)[1]
             logger.info(tmpfile)
             self.file_manager.download(path, tmpfile)
 
-            with open(tmpfile, "rt") as f:
-                data = json.load(f)
+            data = read_json(tmpfile)
 
             os.unlink(tmpfile)
             return data

--- a/release/ray_release/command_runner/sdk_runner.py
+++ b/release/ray_release/command_runner/sdk_runner.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 import time
@@ -22,6 +21,7 @@ from ray_release.util import (
     format_link,
     get_anyscale_sdk,
     ANYSCALE_HOST,
+    read_json,
 )
 
 if TYPE_CHECKING:
@@ -183,8 +183,7 @@ class SDKRunner(CommandRunner):
             tmpfile = tempfile.mktemp()
             self.file_manager.download(path, tmpfile)
 
-            with open(tmpfile, "rt") as f:
-                data = json.load(f)
+            data = read_json(tmpfile)
 
             os.unlink(tmpfile)
             return data

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -1,4 +1,3 @@
-import json
 import os
 import re
 from typing import Dict, List, Optional, Tuple, Any
@@ -8,7 +7,7 @@ import yaml
 from ray_release.anyscale_util import find_cloud_by_name
 from ray_release.exception import ReleaseTestCLIError, ReleaseTestConfigError
 from ray_release.logger import logger
-from ray_release.util import DeferredEnvVar, deep_update
+from ray_release.util import DeferredEnvVar, deep_update, read_json
 
 
 class Test(dict):
@@ -53,8 +52,7 @@ def read_and_validate_release_test_collection(config_file: str) -> List[Test]:
 
 def load_schema_file(path: Optional[str] = None) -> Dict:
     path = path or RELEASE_TEST_SCHEMA_FILE
-    with open(path, "rt") as fp:
-        return json.load(fp)
+    return read_json(path)
 
 
 def validate_release_test_collection(test_collection: List[Test]):

--- a/release/ray_release/reporter/artifacts.py
+++ b/release/ray_release/reporter/artifacts.py
@@ -1,10 +1,10 @@
-import json
 import os
 
 from ray_release.config import Test
 from ray_release.logger import logger
 from ray_release.reporter.reporter import Reporter
 from ray_release.result import Result
+from ray_release.util import write_json
 
 # Write to this directory. run_release_tests.sh will copy the content
 # overt to DEFAULT_ARTIFACTS_DIR_HOST
@@ -23,12 +23,10 @@ class ArtifactsReporter(Reporter):
             os.makedirs(self.artifacts_dir, 0o755)
 
         test_config_file = os.path.join(self.artifacts_dir, ARTIFACT_TEST_CONFIG_FILE)
-        with open(test_config_file, "wt") as fp:
-            json.dump(test, fp, sort_keys=True, indent=4)
+        write_json(test, test_config_file, sort_keys=True, indent=4)
 
         result_file = os.path.join(self.artifacts_dir, ARTIFACT_RESULT_FILE)
-        with open(result_file, "wt") as fp:
-            json.dump(result.__dict__, fp, sort_keys=True, indent=4)
+        write_json(result.__dict__, result_file, sort_keys=True, indent=4)
 
         logger.info(
             f"Wrote test config and result to artifacts directory: {self.artifacts_dir}"

--- a/release/ray_release/reporter/db.py
+++ b/release/ray_release/reporter/db.py
@@ -38,7 +38,7 @@ class DBReporter(Reporter):
             "extra_tags": result.extra_tags or {},
         }
 
-        print(f"Result json: {json.dumps(result_json)}")
+        logger.debug(f"Result json: {json.dumps(result_json)}")
 
         try:
             self.firehose.put_record(

--- a/release/ray_release/reporter/db.py
+++ b/release/ray_release/reporter/db.py
@@ -38,7 +38,7 @@ class DBReporter(Reporter):
             "extra_tags": result.extra_tags or {},
         }
 
-        logger.debug(f"Result json: {json.dumps(result_json)}")
+        print(f"Result json: {json.dumps(result_json)}")
 
         try:
             self.firehose.put_record(

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -23,6 +23,7 @@ from ray_release.wheels import (
     find_ray_wheels_url,
     get_buildkite_repo_branch,
 )
+from ray_release.util import write_json
 
 PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
 
@@ -171,13 +172,11 @@ def main(test_collection_file: Optional[str] = None):
 
         os.makedirs(PIPELINE_ARTIFACT_PATH, exist_ok=True, mode=0o755)
 
-        with open(os.path.join(PIPELINE_ARTIFACT_PATH, "pipeline.json"), "wt") as fp:
-            json.dump(steps, fp)
+        write_json(steps, os.path.join(PIPELINE_ARTIFACT_PATH, "pipeline.json"))
 
         settings["frequency"] = settings["frequency"].value
         settings["priority"] = settings["priority"].value
-        with open(os.path.join(PIPELINE_ARTIFACT_PATH, "settings.json"), "wt") as fp:
-            json.dump(settings, fp)
+        write_json(settings, os.path.join(PIPELINE_ARTIFACT_PATH, "settings.json"))
 
     steps_str = json.dumps(steps)
     print(steps_str)

--- a/release/ray_release/tests/test_utils.py
+++ b/release/ray_release/tests/test_utils.py
@@ -7,6 +7,7 @@ import pytest
 
 from ray_release.util import read_json, write_json
 
+
 @pytest.mark.parametrize("file_format", (".json", ".gz", ".gz_bad_extension"))
 def test_read_json(tmpdir, file_format):
     file = Path(tmpdir) / f"file{file_format}"
@@ -21,6 +22,7 @@ def test_read_json(tmpdir, file_format):
 
     loaded_data = read_json(file)
     assert data == loaded_data
+
 
 @pytest.mark.parametrize("file_format", (".json", ".gz"))
 def test_write_json(tmpdir, file_format):

--- a/release/ray_release/tests/test_utils.py
+++ b/release/ray_release/tests/test_utils.py
@@ -1,0 +1,42 @@
+import gzip
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from ray_release.util import read_json, write_json
+
+@pytest.mark.parametrize("file_format", (".json", ".gz", ".gz_bad_extension"))
+def test_read_json(tmpdir, file_format):
+    file = Path(tmpdir) / f"file{file_format}"
+    data = {"test": "data"}
+
+    if file_format == ".json":
+        with open(file, "wt") as f:
+            json.dump(data, f)
+    else:
+        with gzip.open(file, "w") as f:
+            f.write(json.dumps(data).encode("utf-8"))
+
+    loaded_data = read_json(file)
+    assert data == loaded_data
+
+@pytest.mark.parametrize("file_format", (".json", ".gz"))
+def test_write_json(tmpdir, file_format):
+    file = Path(tmpdir) / f"file{file_format}"
+    data = {"test": "data"}
+    path = write_json(data, file)
+
+    if file_format == ".json":
+        with open(path, "rt") as f:
+            loaded_data = json.load(f)
+    else:
+        with gzip.open(path, "r") as f:
+            loaded_data = json.loads(f.read().decode("utf-8"))
+
+    assert data == loaded_data
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/util.py
+++ b/release/ray_release/util.py
@@ -165,7 +165,7 @@ def write_json(
     pathlib_path = Path(path)
     if pathlib_path.suffix == ".gz":
         with gzip.open(pathlib_path, "w") as f:
-            f.write(json.dumps(data).encode("utf-8"), **json_dump_kwargs)
+            f.write(json.dumps(data, **json_dump_kwargs).encode("utf-8"))
     else:
         with open(pathlib_path, "wt") as f:
             json.dump(data, f, **json_dump_kwargs)


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Compress metric json files before downloading them from the cluster to save bandwidth and time.

For consistency, all json writing/reading code has been abstracted using `write_json` and `read_json` functions.

This is first of iterative improvements aimed at making metrics collection more robust, performant and able to handle long running tests.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
