### PR TITLE
[Datasets] Fix the bug of eagerly clearing up input blocks

### DIFF
--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -452,11 +452,6 @@ class ExecutionPlan:
             # beginning.
             blocks = self._in_blocks
             stats = self._in_stats
-            if not self.has_lazy_input():
-                # If not a lazy datasource, unlink the input blocks from the plan so we
-                # can eagerly reclaim the input block memory after the first stage is
-                # done executing.
-                self._in_blocks = None
         return blocks, stats, stages
 
     def has_lazy_input(self) -> bool:


### PR DESCRIPTION
Co-authored-by: Clark Zinzow <clark@anyscale.com>
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is fixing the issue found in https://github.com/ray-project/ray/pull/31286. Previously we always eagerly clears up non-lazy input blocks (`plan._in_blocks`) when executing the plan. This is not safe as the input blocks might be used by downstream operations later.

An example of exception:

```
import ray
import pandas as pd

input_ds = ray.data.from_pandas(pd.DataFrame({"col1": [1, 2], "col2": [4, 5]}))
input_ds = input_ds.map_batches(lambda x:x)
input_ds = input_ds.lazy()

ds1 = input_ds.map_batches(lambda x:x)
ds1.fully_executed()
ds2 = input_ds.map_batches(lambda x:x)
ds2.fully_executed()
```

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/chengsu/ray/python/ray/data/dataset.py", line 3834, in fully_executed
    self._plan.execute(force_read=True)
  File "/Users/chengsu/ray/python/ray/data/_internal/plan.py", line 321, in execute
    blocks, stage_info = stage(
  File "/Users/chengsu/ray/python/ray/data/_internal/plan.py", line 683, in __call__
    if blocks._owned_by_consumer:
AttributeError: 'NoneType' object has no attribute '_owned_by_consumer'
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
