### PR TITLE
[Datasets] Rename data team nightly tests and fix several tests ownership

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4404,7 +4404,7 @@
 ###############
 
 - name: inference
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: inference
@@ -4426,7 +4426,7 @@
     file_manager: sdk
 
 - name: shuffle_data_loader
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: shuffle_data_loader
@@ -4445,7 +4445,7 @@
     file_manager: sdk
 
 - name: parquet_metadata_resolution
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: parquet_metadata_resolution
@@ -4467,7 +4467,7 @@
     file_manager: sdk
 
 - name: dataset_random_access
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests/dataset
   stable: false
 
@@ -4487,7 +4487,7 @@
     file_manager: sdk
 
 - name: pipelined_data_ingest_benchmark
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests/dataset
 
   frequency: nightly
@@ -4506,7 +4506,7 @@
     file_manager: sdk
 
 - name: aggregate_benchmark
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests/dataset
 
   frequency: nightly
@@ -4523,7 +4523,7 @@
     file_manager: sdk
 
 - name: read_images_benchmark_single_node
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests/dataset
 
   frequency: nightly
@@ -4540,7 +4540,7 @@
     file_manager: sdk
 
 - name: read_tfrecords_benchmark_single_node
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests/dataset
 
   frequency: nightly
@@ -4558,7 +4558,7 @@
     file_manager: sdk
 
 - name: map_batches_benchmark_single_node
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests/dataset
 
   frequency: nightly
@@ -4576,7 +4576,7 @@
     file_manager: sdk
 
 - name: pipelined_training_50_gb
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: pipelined_training_50_gb
@@ -4598,7 +4598,7 @@
     file_manager: sdk
 
 - name: pipelined_ingestion_1500_gb
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: pipelined_ingestion_1500_gb
@@ -4622,7 +4622,7 @@
     file_manager: sdk
 
 - name: datasets_preprocess_ingest
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: datasets_preprocess_ingest
@@ -4646,7 +4646,7 @@
     file_manager: sdk
 
 - name: datasets_ingest_400G
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: datasets_ingest_400G
@@ -4665,7 +4665,7 @@
     file_manager: sdk
 
 - name: dataset_shuffle_random_shuffle_1tb
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests
   legacy:
     test_name: dataset_shuffle_random_shuffle_1tb
@@ -4686,7 +4686,7 @@
     file_manager: sdk
 
 - name: dataset_shuffle_sort_1tb
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests
   legacy:
     test_name: dataset_shuffle_sort_1tb
@@ -4707,7 +4707,7 @@
     file_manager: sdk
 
 - name: dataset_shuffle_push_based_random_shuffle_1tb
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests
   legacy:
     test_name: dataset_shuffle_push_based_random_shuffle_1tb
@@ -4728,7 +4728,7 @@
     file_manager: sdk
 
 - name: dataset_shuffle_push_based_sort_1tb
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests
   legacy:
     test_name: dataset_shuffle_push_based_sort_1tb
@@ -4749,7 +4749,7 @@
     file_manager: sdk
 
 - name: dataset_shuffle_push_based_random_shuffle_100tb
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests
   legacy:
     test_name: dataset_shuffle_push_based_random_shuffle_100tb
@@ -4820,14 +4820,14 @@
     file_manager: sdk
 
 - name: chaos_dask_on_ray_large_scale_test_no_spilling
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_dask_on_ray_large_scale_test_no_spilling
     test_suite: chaos_test
 
   frequency: nightly
-  team: core
+  team: data
   cluster:
     cluster_env: chaos_test/dask_on_ray_app_config_reconstruction.yaml
     cluster_compute: dask_on_ray/chaos_dask_on_ray_stress_compute.yaml
@@ -4844,14 +4844,14 @@
     file_manager: sdk
 
 - name: chaos_dask_on_ray_large_scale_test_spilling
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_dask_on_ray_large_scale_test_spilling
     test_suite: chaos_test
 
   frequency: nightly
-  team: core
+  team: data
   cluster:
     cluster_env: chaos_test/dask_on_ray_app_config_reconstruction.yaml
     cluster_compute: dask_on_ray/dask_on_ray_stress_compute.yaml
@@ -4868,14 +4868,14 @@
     file_manager: sdk
 
 - name: chaos_pipelined_ingestion_1500_gb_15_windows
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_pipelined_ingestion_1500_gb_15_windows
     test_suite: chaos_test
 
   frequency: nightly
-  team: core
+  team: data
   cluster:
     cluster_env: dataset/pipelined_ingestion_app.yaml
     cluster_compute: dataset/pipelined_ingestion_compute.yaml
@@ -4892,7 +4892,7 @@
     file_manager: sdk
 
 - name: chaos_dataset_shuffle_push_based_sort_1tb
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_dataset_shuffle_push_based_sort_1tb
@@ -4901,7 +4901,7 @@
   stable: false
 
   frequency: nightly
-  team: core
+  team: data
   cluster:
     cluster_env: shuffle/shuffle_app_config.yaml
     cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
@@ -4916,14 +4916,14 @@
     file_manager: sdk
 
 - name: chaos_dataset_shuffle_sort_1tb
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_dataset_shuffle_sort_1tb
     test_suite: chaos_test
 
   frequency: nightly
-  team: core
+  team: data
   cluster:
     cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml
     cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
@@ -4938,7 +4938,7 @@
     file_manager: sdk
 
 - name: chaos_dataset_shuffle_random_shuffle_1tb
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_dataset_shuffle_random_shuffle_1tb
@@ -4947,7 +4947,7 @@
   stable: false
 
   frequency: nightly
-  team: core
+  team: data
   cluster:
     # leave oom disabled as test is marked unstable at the moment.
     cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml
@@ -4963,7 +4963,7 @@
     file_manager: sdk
 
 - name: chaos_dataset_shuffle_push_based_random_shuffle_1tb
-  group: core-dataset-tests
+  group: Data tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_dataset_shuffle_push_based_random_shuffle_1tb
@@ -4972,7 +4972,7 @@
   stable: false
 
   frequency: nightly
-  team: core
+  team: data
   cluster:
     # leave oom disabled as test is marked unstable at the moment.
     cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4404,7 +4404,7 @@
 ###############
 
 - name: inference
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: inference
@@ -4426,7 +4426,7 @@
     file_manager: sdk
 
 - name: shuffle_data_loader
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: shuffle_data_loader
@@ -4445,7 +4445,7 @@
     file_manager: sdk
 
 - name: parquet_metadata_resolution
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: parquet_metadata_resolution
@@ -4467,7 +4467,7 @@
     file_manager: sdk
 
 - name: dataset_random_access
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests/dataset
   stable: false
 
@@ -4487,7 +4487,7 @@
     file_manager: sdk
 
 - name: pipelined_data_ingest_benchmark
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests/dataset
 
   frequency: nightly
@@ -4506,7 +4506,7 @@
     file_manager: sdk
 
 - name: aggregate_benchmark
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests/dataset
 
   frequency: nightly
@@ -4523,7 +4523,7 @@
     file_manager: sdk
 
 - name: read_images_benchmark_single_node
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests/dataset
 
   frequency: nightly
@@ -4540,7 +4540,7 @@
     file_manager: sdk
 
 - name: read_tfrecords_benchmark_single_node
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests/dataset
 
   frequency: nightly
@@ -4558,7 +4558,7 @@
     file_manager: sdk
 
 - name: map_batches_benchmark_single_node
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests/dataset
 
   frequency: nightly
@@ -4576,7 +4576,7 @@
     file_manager: sdk
 
 - name: pipelined_training_50_gb
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: pipelined_training_50_gb
@@ -4598,7 +4598,7 @@
     file_manager: sdk
 
 - name: pipelined_ingestion_1500_gb
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: pipelined_ingestion_1500_gb
@@ -4622,7 +4622,7 @@
     file_manager: sdk
 
 - name: datasets_preprocess_ingest
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: datasets_preprocess_ingest
@@ -4646,7 +4646,7 @@
     file_manager: sdk
 
 - name: datasets_ingest_400G
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests/dataset
   legacy:
     test_name: datasets_ingest_400G
@@ -4665,7 +4665,7 @@
     file_manager: sdk
 
 - name: dataset_shuffle_random_shuffle_1tb
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests
   legacy:
     test_name: dataset_shuffle_random_shuffle_1tb
@@ -4686,7 +4686,7 @@
     file_manager: sdk
 
 - name: dataset_shuffle_sort_1tb
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests
   legacy:
     test_name: dataset_shuffle_sort_1tb
@@ -4707,7 +4707,7 @@
     file_manager: sdk
 
 - name: dataset_shuffle_push_based_random_shuffle_1tb
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests
   legacy:
     test_name: dataset_shuffle_push_based_random_shuffle_1tb
@@ -4728,7 +4728,7 @@
     file_manager: sdk
 
 - name: dataset_shuffle_push_based_sort_1tb
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests
   legacy:
     test_name: dataset_shuffle_push_based_sort_1tb
@@ -4749,7 +4749,7 @@
     file_manager: sdk
 
 - name: dataset_shuffle_push_based_random_shuffle_100tb
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests
   legacy:
     test_name: dataset_shuffle_push_based_random_shuffle_100tb
@@ -4820,7 +4820,7 @@
     file_manager: sdk
 
 - name: chaos_dask_on_ray_large_scale_test_no_spilling
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_dask_on_ray_large_scale_test_no_spilling
@@ -4844,7 +4844,7 @@
     file_manager: sdk
 
 - name: chaos_dask_on_ray_large_scale_test_spilling
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_dask_on_ray_large_scale_test_spilling
@@ -4868,7 +4868,7 @@
     file_manager: sdk
 
 - name: chaos_pipelined_ingestion_1500_gb_15_windows
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_pipelined_ingestion_1500_gb_15_windows
@@ -4892,7 +4892,7 @@
     file_manager: sdk
 
 - name: chaos_dataset_shuffle_push_based_sort_1tb
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_dataset_shuffle_push_based_sort_1tb
@@ -4916,7 +4916,7 @@
     file_manager: sdk
 
 - name: chaos_dataset_shuffle_sort_1tb
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_dataset_shuffle_sort_1tb
@@ -4938,7 +4938,7 @@
     file_manager: sdk
 
 - name: chaos_dataset_shuffle_random_shuffle_1tb
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_dataset_shuffle_random_shuffle_1tb
@@ -4963,7 +4963,7 @@
     file_manager: sdk
 
 - name: chaos_dataset_shuffle_push_based_random_shuffle_1tb
-  group: Data tests
+  group: data-tests
   working_dir: nightly_tests
   legacy:
     test_name: chaos_dataset_shuffle_push_based_random_shuffle_1tb


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As title. The current name `core-dataset-tests` is quite confusing. Rename it to `Data tests`, to be consistent with `RLlib tests`, `Train tests`, `Serve tests`, etc.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
