### PR TITLE
[RLlib] Support multi-gpu CQL for torch (tf already supported).

### DIFF
--- a/rllib/algorithms/cql/cql.py
+++ b/rllib/algorithms/cql/cql.py
@@ -137,8 +137,8 @@ class CQLConfig(SACConfig):
         # CQL-torch performs the optimizer steps inside the loss function.
         # Using the multi-GPU optimizer will therefore not work (see multi-GPU
         # check above) and we must use the simple optimizer for now.
-        if self.simple_optimizer is not True and self.framework_str == "torch":
-            self.simple_optimizer = True
+        # if self.simple_optimizer is not True and self.framework_str == "torch":
+        #    self.simple_optimizer = True
 
         if self.framework_str in ["tf", "tf2"] and tfp is None:
             logger.warning(

--- a/rllib/algorithms/cql/cql.py
+++ b/rllib/algorithms/cql/cql.py
@@ -137,8 +137,6 @@ class CQLConfig(SACConfig):
         # CQL-torch performs the optimizer steps inside the loss function.
         # Using the multi-GPU optimizer will therefore not work (see multi-GPU
         # check above) and we must use the simple optimizer for now.
-        # if self.simple_optimizer is not True and self.framework_str == "torch":
-        #    self.simple_optimizer = True
 
         if self.framework_str in ["tf", "tf2"] and tfp is None:
             logger.warning(

--- a/rllib/algorithms/cql/cql_torch_policy.py
+++ b/rllib/algorithms/cql/cql_torch_policy.py
@@ -203,7 +203,7 @@ def cql_loss(
         torch.FloatTensor(actions.shape[0] * num_actions, actions.shape[-1]).uniform_(
             action_low, action_high
         ),
-        policy.device,
+        actions.device,
     )
     curr_actions, curr_logp = policy_actions_repeat(
         model, action_dist_class, model_out_t, num_actions
@@ -323,7 +323,7 @@ def cql_stats(policy: Policy, train_batch: SampleBatch) -> Dict[str, TensorType]
 
     # Add CQL loss stats to the dict.
     stats_dict["cql_loss"] = torch.mean(
-        torch.stack(*policy.get_tower_stats("cql_loss"))
+        torch.stack(tree.flatten(policy.get_tower_stats("cql_loss")))
     )
 
     if policy.config["lagrangian"]:


### PR DESCRIPTION
## Why are these changes needed?
These changes are necessary to enable the `multi_gpu_train_one_step()` for the CQL algorithm. Previous CQL implementations force the algorithm to use the simple optimizer. In this PR, we remove this constraint, and resolve the loss device problem in [#31427](https://github.com/ray-project/ray/issues/31427) to enable multi-gpu CQL training.

## Related issue number
[#31427](https://github.com/ray-project/ray/issues/31427) and [#31323](https://github.com/ray-project/ray/issues/31323).

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
