### PR TITLE
[RLlib] Deflake replay buffer demo by making training shorter

### DIFF
--- a/rllib/examples/documentation/replay_buffer_demo.py
+++ b/rllib/examples/documentation/replay_buffer_demo.py
@@ -144,8 +144,6 @@ config = (
 tune.Tuner(
     "DQN",
     param_space=config.to_dict(),
-    run_config=air.RunConfig(
-        stop={"episode_reward_mean": 40, "training_iteration": 7}
-    ),
+    run_config=air.RunConfig(stop={"episode_reward_mean": 40, "training_iteration": 7}),
 ).fit()
 # __sphinx_doc_replay_buffer_advanced_usage_underlying_buffers__end__

--- a/rllib/examples/documentation/replay_buffer_demo.py
+++ b/rllib/examples/documentation/replay_buffer_demo.py
@@ -127,7 +127,6 @@ assert len(less_sampled_buffer._storage) == 0
 # __sphinx_doc_replay_buffer_advanced_usage_underlying_buffers__begin__
 config = (
     DQNConfig()
-    .rollouts(num_rollout_workers=3)
     .training(
         replay_buffer_config={
             "type": "MultiAgentReplayBuffer",
@@ -146,7 +145,7 @@ tune.Tuner(
     "DQN",
     param_space=config.to_dict(),
     run_config=air.RunConfig(
-        stop={"episode_reward_mean": 50, "training_iteration": 10}
+        stop={"episode_reward_mean": 40, "training_iteration": 7}
     ),
 ).fit()
 # __sphinx_doc_replay_buffer_advanced_usage_underlying_buffers__end__


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

Last attempt at deflaking did not seem to have had the effect we wished for (training did not accelerate as significantly on CI as it did locally).
<img width="397" alt="Screenshot 2023-01-05 at 16 53 47" src="https://user-images.githubusercontent.com/9356806/210823512-36917f91-cf1d-4669-a061-ce0a1a629a91.png">

## Why are these changes needed?

replay_buffer_demo is almost always yellow on CI.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
