### PR TITLE
[RLlib] Fix 100 policy test by bringing # of env back to 5.

### DIFF
--- a/rllib/tuned_examples/appo/multi-agent-cartpole-w-100-policies-appo.py
+++ b/rllib/tuned_examples/appo/multi-agent-cartpole-w-100-policies-appo.py
@@ -12,7 +12,7 @@ num_policies = 20
 # Number of those policies that should be trained. These are a subset of `num_policies`.
 num_trainable = 10
 
-num_envs_per_worker = 2
+num_envs_per_worker = 5
 
 # Define the config as an APPOConfig object.
 config = (


### PR DESCRIPTION
Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

Trains much faster with 5 envs.

## Related issue number


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
