### PR TITLE
[core][state] Ignore tasks w/o status updates (driver generated tasks) by default from GCS

### DIFF
--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -373,9 +373,6 @@ class StateAPIManager:
             task_info = task_attempt.get("task_info", {})
             state_updates = task_attempt.get("state_updates", None)
 
-            if state_updates is None:
-                return {}
-
             # Convert those settable fields
             mappings = [
                 (
@@ -426,7 +423,6 @@ class StateAPIManager:
             )
             for message in reply.events_by_task
         ]
-        result = [e for e in result if len(e) > 0]
 
         num_after_truncation = len(result)
         num_total = num_after_truncation + reply.num_status_task_events_dropped

--- a/python/ray/experimental/state/state_manager.py
+++ b/python/ray/experimental/state/state_manager.py
@@ -236,7 +236,7 @@ class StateDataSourceClient:
     ) -> Optional[GetTaskEventsReply]:
         if not limit:
             limit = RAY_MAX_LIMIT_FROM_DATA_SOURCE
-        request = GetTaskEventsRequest(limit=limit, task_state_only=True)
+        request = GetTaskEventsRequest(limit=limit, exclude_driver_task=True)
         reply = await self._gcs_task_info_stub.GetTaskEvents(request, timeout=timeout)
         return reply
 

--- a/python/ray/experimental/state/state_manager.py
+++ b/python/ray/experimental/state/state_manager.py
@@ -236,7 +236,7 @@ class StateDataSourceClient:
     ) -> Optional[GetTaskEventsReply]:
         if not limit:
             limit = RAY_MAX_LIMIT_FROM_DATA_SOURCE
-        request = GetTaskEventsRequest(limit=limit)
+        request = GetTaskEventsRequest(limit=limit, task_state_only=True)
         reply = await self._gcs_task_info_stub.GetTaskEvents(request, timeout=timeout)
         return reply
 

--- a/src/ray/gcs/gcs_server/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.cc
@@ -179,7 +179,7 @@ void GcsTaskManager::HandleGetTaskEvents(rpc::GetTaskEventsRequest request,
   int32_t num_profile_event_limit = 0;
   int32_t num_status_event_limit = 0;
   for (auto &task_event : task_events) {
-    if (request.task_state_only() && !task_event.has_state_updates()) {
+    if (request.exclude_driver_task() && !task_event.has_state_updates()) {
       // Driver related profile events will generate TaskEvent w/o any task state updates.
       continue;
     }

--- a/src/ray/gcs/gcs_server/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.cc
@@ -179,7 +179,7 @@ void GcsTaskManager::HandleGetTaskEvents(rpc::GetTaskEventsRequest request,
   int32_t num_profile_event_limit = 0;
   int32_t num_status_event_limit = 0;
   for (auto &task_event : task_events) {
-    if (!request.include_driver() && !task_event.has_state_updates()) {
+    if (request.task_state_only() && !task_event.has_state_updates()) {
       // Driver related profile events will generate TaskEvent w/o any task state updates.
       continue;
     }

--- a/src/ray/gcs/gcs_server/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.cc
@@ -179,6 +179,11 @@ void GcsTaskManager::HandleGetTaskEvents(rpc::GetTaskEventsRequest request,
   int32_t num_profile_event_limit = 0;
   int32_t num_status_event_limit = 0;
   for (auto &task_event : task_events) {
+    if (!request.include_driver() && !task_event.has_state_updates()) {
+      // Driver related profile events will generate TaskEvent w/o any task state updates.
+      continue;
+    }
+
     if (limit < 0 || count++ < limit) {
       auto events = reply->add_events_by_task();
       events->Swap(&task_event);

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -624,8 +624,8 @@ message GetTaskEventsRequest {
   // If set, the exact `limit` TaskEvents returned do not have any ordering or selection
   // guarantee.
   optional int64 limit = 3;
-  // True if only task events with non-empty task state changes should be returned.
-  bool task_state_only = 4;
+  // True if task events from driver (only profiling events) should be excluded.
+  bool exclude_driver_task = 4;
 }
 
 message GetTaskEventsReply {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -624,9 +624,8 @@ message GetTaskEventsRequest {
   // If set, the exact `limit` TaskEvents returned do not have any ordering or selection
   // guarantee.
   optional int64 limit = 3;
-  // Include driver associated task events. Driver will generate profiling evnets, but
-  // have no task status changes.
-  bool include_driver = 4;
+  // True if only task events with non-empty task state changes should be returned.
+  bool task_state_only = 4;
 }
 
 message GetTaskEventsReply {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -624,6 +624,9 @@ message GetTaskEventsRequest {
   // If set, the exact `limit` TaskEvents returned do not have any ordering or selection
   // guarantee.
   optional int64 limit = 3;
+  // Include driver associated task events. Driver will generate profiling evnets, but
+  // have no task status changes.
+  bool include_driver = 4;
 }
 
 message GetTaskEventsReply {


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
With profiling events (`submit_task`) collected on the driver, we will have entries of `TaskEvent` from the driver being reported to GCS. These events don't have any task spec info associated with them (only profile events with task id and job id).  When querying events in state API, the driver task event will get accounted for sometimes when truncation happens. This PR does a source-side filtering of driver events with `exclude_driver_task` to True to filter out driver tasks. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/31438


<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
