### PR TITLE
[RLlib] Introduce IMPALA off_policyness test with GPU

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1023,7 +1023,7 @@ py_test(
 # Impala
 py_test(
     name = "test_impala",
-    tags = ["team:rllib", "algorithms_dir", "multi_gpu"],
+    tags = ["team:rllib", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/impala/tests/test_impala.py"]
 )
@@ -1032,6 +1032,12 @@ py_test(
     tags = ["team:rllib", "algorithms_dir"],
     size = "small",
     srcs = ["algorithms/impala/tests/test_vtrace.py"]
+)
+py_test(
+    name = "test_impala_off_policyness",
+    tags = ["team:rllib", "algorithms_dir", "multi_gpu"],
+    size = "large",
+    srcs = ["algorithms/impala/tests/test_impala_off_policyness.py"]
 )
 
 # MARWIL

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1035,7 +1035,7 @@ py_test(
 )
 py_test(
     name = "test_impala_off_policyness",
-    tags = ["team:rllib", "algorithms_dir", "multi_gpu"],
+    tags = ["team:rllib", "algorithms_dir", "multi_gpu", "exclusive"],
     size = "large",
     srcs = ["algorithms/impala/tests/test_impala_off_policyness.py"]
 )
@@ -2566,7 +2566,7 @@ py_test(
 py_test(
      name = "tests/test_supported_spaces_ppo_no_preproceesor_gpu",
      main = "tests/test_supported_spaces.py",
-     tags = ["team:rllib", "tests_dir", "multi_gpu"],
+     tags = ["team:rllib", "tests_dir", "multi_gpu", "exclusive"],
      size = "medium",
      srcs = ["tests/test_supported_spaces.py"],
      args = ["TestSupportedSpacesPPONoPreprocessorGPU"]

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1023,7 +1023,7 @@ py_test(
 # Impala
 py_test(
     name = "test_impala",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rllib", "algorithms_dir", "multi_gpu"],
     size = "large",
     srcs = ["algorithms/impala/tests/test_impala.py"]
 )

--- a/rllib/algorithms/impala/tests/test_impala.py
+++ b/rllib/algorithms/impala/tests/test_impala.py
@@ -8,7 +8,6 @@ from ray.rllib.utils.metrics.learner_info import LEARNER_INFO, LEARNER_STATS_KEY
 from ray.rllib.utils.test_utils import (
     check,
     check_compute_single_action,
-    check_off_policyness,
     check_train_results,
     framework_iterator,
 )
@@ -113,31 +112,6 @@ class TestIMPALA(unittest.TestCase):
                 assert lr3 <= lr2, (lr2, lr3)
                 assert lr3 < lr1, (lr1, lr3)
             finally:
-                algo.stop()
-
-    def test_impala_off_policyness(self):
-        """Test whether Impala can be built with both frameworks."""
-        config = (
-            impala.ImpalaConfig()
-            .environment("CartPole-v1")
-            .resources(num_gpus=1)
-            .rollouts(num_rollout_workers=2)
-        )
-        num_iterations = 4
-
-        for _ in framework_iterator(config, with_eager_tracing=True):
-            for num_aggregation_workers in [0, 1]:
-                config.num_aggregation_workers = num_aggregation_workers
-                print("aggregation-workers={}".format(config.num_aggregation_workers))
-                algo = config.build()
-                for i in range(num_iterations):
-                    results = algo.train()
-                    off_policy_ness = check_off_policyness(results, upper_limit=2.0)
-                    print(f"off-policy'ness={off_policy_ness}")
-
-                check_compute_single_action(
-                    algo,
-                )
                 algo.stop()
 
 

--- a/rllib/algorithms/impala/tests/test_impala_off_policyness.py
+++ b/rllib/algorithms/impala/tests/test_impala_off_policyness.py
@@ -1,0 +1,53 @@
+import unittest
+
+import ray
+import ray.rllib.algorithms.impala as impala
+from ray.rllib.utils.framework import try_import_tf
+from ray.rllib.utils.test_utils import (
+    check_compute_single_action,
+    check_off_policyness,
+    framework_iterator,
+)
+
+tf1, tf, tfv = try_import_tf()
+
+
+class TestIMPALAOffPolicyNess(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        ray.init(num_gpus=1)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        ray.shutdown()
+
+    def test_impala_off_policyness(self):
+        config = (
+            impala.ImpalaConfig()
+            .environment("CartPole-v1")
+            .resources(num_gpus=1)
+            .rollouts(num_rollout_workers=2)
+        )
+        num_iterations = 4
+
+        for _ in framework_iterator(config, with_eager_tracing=True):
+            for num_aggregation_workers in [0, 1]:
+                config.num_aggregation_workers = num_aggregation_workers
+                print("aggregation-workers={}".format(config.num_aggregation_workers))
+                algo = config.build()
+                for i in range(num_iterations):
+                    results = algo.train()
+                    off_policy_ness = check_off_policyness(results, upper_limit=2.0)
+                    print(f"off-policy'ness={off_policy_ness}")
+
+                check_compute_single_action(
+                    algo,
+                )
+                algo.stop()
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/algorithms/impala/tests/test_impala_off_policyness.py
+++ b/rllib/algorithms/impala/tests/test_impala_off_policyness.py
@@ -26,9 +26,9 @@ class TestIMPALAOffPolicyNess(unittest.TestCase):
             impala.ImpalaConfig()
             .environment("CartPole-v1")
             .resources(num_gpus=1)
-            .rollouts(num_rollout_workers=2)
+            .rollouts(num_rollout_workers=4)
         )
-        num_iterations = 4
+        num_iterations = 3
 
         for _ in framework_iterator(config, with_eager_tracing=True):
             for num_aggregation_workers in [0, 1]:

--- a/rllib/execution/buffers/mixin_replay_buffer.py
+++ b/rllib/execution/buffers/mixin_replay_buffer.py
@@ -71,7 +71,7 @@ class MixInMultiAgentReplayBuffer:
         """
         self.capacity = capacity
         self.replay_ratio = replay_ratio
-        self.replay_proportion = 1
+        self.replay_proportion = None
         if self.replay_ratio != 1.0:
             self.replay_proportion = self.replay_ratio / (1.0 - self.replay_ratio)
 

--- a/rllib/execution/buffers/mixin_replay_buffer.py
+++ b/rllib/execution/buffers/mixin_replay_buffer.py
@@ -71,7 +71,7 @@ class MixInMultiAgentReplayBuffer:
         """
         self.capacity = capacity
         self.replay_ratio = replay_ratio
-        self.replay_proportion = None
+        self.replay_proportion = 1
         if self.replay_ratio != 1.0:
             self.replay_proportion = self.replay_ratio / (1.0 - self.replay_ratio)
 


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

IMPALA runs with a GPU learner "by original design". A compilation test without GPU is fine but something like off_policyness depends on learning/sampling speed and we should test it for our standard impala settings (gpu=1, num_rollout_workers=2) - with a GPU and without competing over resources. Only then will we be able to get meaningful measurements of it's off-policyness.
This PR also tries to deflake IMPALA tests.