### PR TITLE
[core] Fix a memory leak due to lineage counting

### DIFF
--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -780,6 +780,7 @@ def test_generators(one_worker_100MiB):
 
 def test_lineage_leak(shutdown_only):
     ray.init()
+
     @ray.remote
     def process(data):
         return b"\0" * 100_000_000
@@ -792,9 +793,11 @@ def test_lineage_leak(shutdown_only):
 
     def check_usage():
         from ray._private.internal_api import memory_summary
+
         return "Plasma memory usage 0 MiB" in memory_summary(stats_only=True)
 
     wait_for_condition(check_usage)
+
 
 if __name__ == "__main__":
     import sys

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -478,8 +478,6 @@ int64_t ReferenceCounter::ReleaseLineageReferences(ReferenceTable::iterator ref)
     RAY_LOG(DEBUG) << "Releasing lineage internal for argument " << argument_id;
     arg_it->second.lineage_ref_count--;
     if (arg_it->second.ShouldDelete(lineage_pinning_enabled_)) {
-      // We only decremented the lineage ref count, so the argument value
-      // should already be released.
       RAY_CHECK(arg_it->second.on_ref_removed == nullptr);
       lineage_bytes_evicted += ReleaseLineageReferences(arg_it);
       DeleteReferenceInternal(arg_it);

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -483,6 +483,7 @@ int64_t ReferenceCounter::ReleaseLineageReferences(ReferenceTable::iterator ref)
       RAY_CHECK(arg_it->second.on_ref_removed == nullptr);
       lineage_bytes_evicted += ReleaseLineageReferences(arg_it);
       EraseReference(arg_it);
+      ReleasePlasmaObject(arg_it);
     }
   }
   return lineage_bytes_evicted;

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -480,7 +480,7 @@ int64_t ReferenceCounter::ReleaseLineageReferences(ReferenceTable::iterator ref)
     if (arg_it->second.ShouldDelete(lineage_pinning_enabled_)) {
       RAY_CHECK(arg_it->second.on_ref_removed == nullptr);
       lineage_bytes_evicted += ReleaseLineageReferences(arg_it);
-      DeleteReferenceInternal(arg_it);
+      DeleteReferenceInternal(arg_it, nullptr);
     }
   }
   return lineage_bytes_evicted;

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -482,8 +482,7 @@ int64_t ReferenceCounter::ReleaseLineageReferences(ReferenceTable::iterator ref)
       // should already be released.
       RAY_CHECK(arg_it->second.on_ref_removed == nullptr);
       lineage_bytes_evicted += ReleaseLineageReferences(arg_it);
-      EraseReference(arg_it);
-      ReleasePlasmaObject(arg_it);
+      DeleteReferenceInternal(arg_it);
     }
   }
   return lineage_bytes_evicted;

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -480,7 +480,8 @@ int64_t ReferenceCounter::ReleaseLineageReferences(ReferenceTable::iterator ref)
     if (arg_it->second.ShouldDelete(lineage_pinning_enabled_)) {
       RAY_CHECK(arg_it->second.on_ref_removed == nullptr);
       lineage_bytes_evicted += ReleaseLineageReferences(arg_it);
-      DeleteReferenceInternal(arg_it, nullptr);
+      ReleasePlasmaObject(arg_it);
+      EraseReference(arg_it);
     }
   }
   return lineage_bytes_evicted;


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Assume two objects A and B and B depends on A. If A got delete first, it's won't be released because we need to preserve it for B.

The bug here is that even B is released, A won't be released and thus memory leak.

This PR fixed this issue by force delete the object when the ref goes to 0.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
