### PR TITLE
[Autoscaler] Prefix (autoscaler) instead of (scheduler) for autoscaler events. Issue #24807

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1777,7 +1777,7 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
             return colorama.Fore.CYAN
 
     if data.get("pid") == "autoscaler":
-        pid = "scheduler +{}".format(time_string())
+        pid = "autoscaler +{}".format(time_string())
         lines = filter_autoscaler_events(data.get("lines", []))
     else:
         pid = data.get("pid")

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -177,6 +177,30 @@ ray.get([f.remote() for _ in range(15)])
     assert "Tip:" not in err_str
 
 
+def test_autoscaler_prefix():
+    script = """
+import ray
+import time
+
+ray.init(num_cpus=1)
+
+@ray.remote(num_cpus=1)
+class A:
+    pass
+
+a = A.remote()
+b = A.remote()
+time.sleep(25)
+    """
+
+    proc = run_string_as_driver_nonblocking(script)
+    out_str = proc.stdout.read().decode("ascii")
+    err_str = proc.stderr.read().decode("ascii")
+
+    print(out_str, err_str)
+    assert "(autoscaler" in out_str
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_fail_importing_actor(ray_start_regular, error_pubsub):
     script = f"""


### PR DESCRIPTION

## Why are these changes needed?

Autoscaler event logs are prefixed with `(scheduler)` which is misleading. This PR changes the prefix to be `(autoscaler)`

Tested [building ray locally](https://docs.ray.io/en/master/ray-contribute/development.html#building-ray-python-only) and running an application (see attached logs). Added unit tests.

## Related issue number

Closes [24807](https://github.com/ray-project/ray/issues/24807)

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

![auto-scaler-fix](https://user-images.githubusercontent.com/543829/210920882-a1d76b7a-5ab4-43e2-a19e-80824ca3f3c3.jpg)

