### PR TITLE
[ci/release] Use job-based file manager for SDK runner per default

### DIFF
--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -64,7 +64,7 @@ file_manager_str_to_file_manager = {
 }
 
 command_runner_to_file_manager = {
-    SDKRunner: SessionControllerFileManager,
+    SDKRunner: JobFileManager,  # Use job file manager per default
     ClientRunner: RemoteTaskFileManager,
     JobRunner: JobFileManager,
 }

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3481,7 +3481,6 @@
     timeout: 7200
     script: python stress_tests/test_placement_group.py
     type: sdk_command
-    file_manager: sdk
 
 - name: shuffle_1tb_5000_partitions
   group: core-multi-test
@@ -4319,7 +4318,6 @@
     script: python read_tfrecords_benchmark.py
 
     type: sdk_command
-    file_manager: sdk
 
 - name: map_batches_benchmark_single_node
   group: core-dataset-tests
@@ -4337,7 +4335,6 @@
     script: python map_batches_benchmark.py
 
     type: sdk_command
-    file_manager: sdk
 
 - name: iter_batches_benchmark_single_node
   group: core-dataset-tests
@@ -4355,7 +4352,6 @@
     script: python iter_batches_benchmark.py
 
     type: sdk_command
-    file_manager: sdk
 
 - name: pipelined_training_50_gb
   group: core-dataset-tests


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Release tests are currently failing with an error on file upload (`botocore.exceptions.DataNotFoundError: Unable to load data for: ec2/2016-11-15/endpoint-rule-set-1`). This is likely because some tests are using an `anyscale push`-based API to upload files. By switching to the job-based filemanager for all tests the upload issue should be mitigated.

Please note that execution will still happen with SDK commands for those tests that haven't specified to use jobs for execution, so actual test execution should be unaffected.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
