### PR TITLE
[core] allow infinite oom retry

### DIFF
--- a/doc/source/ray-core/scheduling/ray-oom-prevention.rst
+++ b/doc/source/ray-core/scheduling/ray-oom-prevention.rst
@@ -50,7 +50,7 @@ The memory monitor is controlled by the following environment variables:
   .. note::
 
       Keep the value of ``RAY_task_oom_retries`` low, below 25, to avoid extremely long delays as it is using exponential backoff.
-      The delay is capped at 10 minutes.
+      The delay is capped at 1 minute.
   
 
 Using the Memory Monitor

--- a/doc/source/ray-core/scheduling/ray-oom-prevention.rst
+++ b/doc/source/ray-core/scheduling/ray-oom-prevention.rst
@@ -37,6 +37,7 @@ The memory monitor is controlled by the following environment variables:
   only when the process is killed by the memory monitor, and the retry counter of the
   task or actor (:ref:`max_retries <task-fault-tolerance>` or :ref:`max_restarts <actor-fault-tolerance>`) is used when it fails 
   in other ways. If the process is killed by the operating system OOM killer it will use the task retry and not ``task_oom_retries``.
+  It will retry indefinitely if this value is set to -1.
 
   When the task is retried due to OOM it applies a delay before re-executing the task. The delay is calculated as
 
@@ -49,6 +50,7 @@ The memory monitor is controlled by the following environment variables:
   .. note::
 
       Keep the value of ``RAY_task_oom_retries`` low, below 25, to avoid extremely long delays as it is using exponential backoff.
+      The delay is capped at 10 minutes.
   
 
 Using the Memory Monitor

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -96,8 +96,7 @@ RAY_CONFIG(uint64_t, task_failure_entry_ttl_ms, 15 * 60 * 1000)
 /// memory_monitor_refresh_ms. If the task or actor is not retriable then this value is
 /// ignored. This retry counter is only used when the process is killed due to memory, and
 /// the retry counter of the task or actor is only used when it fails in other ways
-/// that is not related to running out of memory. Note infinite retry (-1) is not
-/// supported.
+/// that is not related to running out of memory. Retries indefinitely if the value is -1.
 RAY_CONFIG(uint64_t, task_oom_retries, 15)
 
 /// If the raylet fails to get agent info, we will retry after this interval.

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -438,6 +438,10 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
       if (num_oom_retries_left > 0) {
         will_retry = true;
         it->second.num_oom_retries_left--;
+      } else if (num_oom_retries_left == -1) {
+        will_retry = true;
+      } else {
+        RAY_CHECK(num_oom_retries_left == 0);
       }
     } else {
       if (num_retries_left > 0) {

--- a/src/ray/util/exponential_backoff.cc
+++ b/src/ray/util/exponential_backoff.cc
@@ -22,13 +22,7 @@ namespace ray {
 
 uint64_t ExponentialBackoff::GetBackoffMs(uint64_t attempt,
                                           uint64_t base_ms,
-                                          uint64_t max_attempt,
                                           uint64_t max_backoff_ms) {
-  if (attempt > max_attempt) {
-    attempt = max_attempt;
-    RAY_LOG_EVERY_MS(INFO, 60000) << "Backoff attempt exceeded max, attempt= " << attempt
-                                  << " max attempt= " << max_backoff_ms;
-  }
   uint64_t delay = static_cast<uint64_t>(pow(2, attempt));
   // Use max_backoff_ms if there is an overflow.
   if (delay == 0) {

--- a/src/ray/util/exponential_backoff.h
+++ b/src/ray/util/exponential_backoff.h
@@ -37,7 +37,7 @@ class ExponentialBackoff {
 
  private:
   // The default cap on the backoff delay.
-  static constexpr uint64_t kMaxBackoffMs = 10 * 60 * 1000;
+  static constexpr uint64_t kMaxBackoffMs = 1 * 60 * 1000;
 };
 
 }  // namespace ray

--- a/src/ray/util/exponential_backoff.h
+++ b/src/ray/util/exponential_backoff.h
@@ -25,20 +25,17 @@ class ExponentialBackoff {
  public:
   /// Computes the backoff delay using the exponential backoff algorithm,
   /// using the formula
-  /// delay = base * 2 ^ attempt
   ///
-  /// @param max_attempt the maximum acceptable attempt count
+  /// delay = min(base * 2 ^ attempt, max_backoff)
+  ///
+  ///
   /// @param max_backoff_ms the maximum backoff value
   /// @return the delay in ms based on the formula
   static uint64_t GetBackoffMs(uint64_t attempt,
                                uint64_t base_ms,
-                               uint64_t max_attempt = kMaxAttempt,
                                uint64_t max_backoff_ms = kMaxBackoffMs);
 
  private:
-  // The default cap on the attempt number;
-  static constexpr uint64_t kMaxAttempt = 50;
-
   // The default cap on the backoff delay.
   static constexpr uint64_t kMaxBackoffMs = 10 * 60 * 1000;
 };

--- a/src/ray/util/exponential_backoff_test.cc
+++ b/src/ray/util/exponential_backoff_test.cc
@@ -30,39 +30,21 @@ TEST(ExponentialBackoffTest, TestExponentialIncrease) {
   ASSERT_EQ(ExponentialBackoff::GetBackoffMs(11, 0), 0);
 }
 
-TEST(ExponentialBackoffTest, TestExceedMaxAttemptReturnsMaxAttempt) {
-  auto backoff = ExponentialBackoff::GetBackoffMs(
-      /*attempt*/ 11,
-      /*base_ms*/ 1,
-      /*max_attempt*/ 5,
-      /*max_backoff_ms*/ std::numeric_limits<uint64_t>::max());
-  ASSERT_EQ(backoff, static_cast<uint64_t>(pow(2, 5)));
-}
-
 TEST(ExponentialBackoffTest, TestExceedMaxBackoffReturnsMaxBackoff) {
   auto backoff = ExponentialBackoff::GetBackoffMs(
-      /*attempt*/ 10, /*base_ms*/ 1, /*max_attempt*/ 10, /*max_backoff_ms*/ 5);
+      /*attempt*/ 10, /*base_ms*/ 1, /*max_backoff_ms*/ 5);
   ASSERT_EQ(backoff, 5);
 }
 
-TEST(ExponentialBackoffTest, TestOverflowReturnsMaxAttempt) {
-  // 2 ^ 80 will overflow.
-  auto backoff = ExponentialBackoff::GetBackoffMs(
-      /*attempt*/ 80,
-      /*base_ms*/ 1,
-      /*max_attempt*/ 50,
-      /*max_backoff_ms*/ std::numeric_limits<uint64_t>::max());
-  ASSERT_EQ(backoff, static_cast<uint64_t>(pow(2, 50)));
-}
-
 TEST(ExponentialBackoffTest, TestOverflowReturnsMaxBackoff) {
-  // 2 ^ 80 will overflow.
-  auto backoff = ExponentialBackoff::GetBackoffMs(
-      /*attempt*/ 80,
-      /*base_ms*/ 1,
-      /*max_attempt*/ 80,
-      /*max_backoff_ms*/ 1234);
-  ASSERT_EQ(backoff, 1234);
+  // 2 ^ 64+ will overflow.
+  for (int i = 64; i < 10000; i++) {
+    auto backoff = ExponentialBackoff::GetBackoffMs(
+        /*attempt*/ i,
+        /*base_ms*/ 1,
+        /*max_backoff_ms*/ 1234);
+    ASSERT_EQ(backoff, 1234);
+  }
 }
 
 }  // namespace ray


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

[No op change PR] Allow infinite oom retry when value is set to -1.

Some minor simplication to exponential backoff class 

To be used by group-by-owner worker killing policy (draft PR https://github.com/ray-project/ray/pull/31272)

## Related issue number

https://github.com/ray-project/ray/issues/31508

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
