### PR TITLE
[core] Add test case to verify certain behavior when the head node is down.

### DIFF
--- a/python/ray/tests/test_gcs_ha_e2e.py
+++ b/python/ray/tests/test_gcs_ha_e2e.py
@@ -49,6 +49,7 @@ redis = container(
     ),
 )
 
+
 def make_head_node(num_cpus=0, envs=None):
     if envs is None:
         envs = {}
@@ -80,6 +81,7 @@ def make_head_node(num_cpus=0, envs=None):
 
 head_node = make_head_node(num_cpus=0)
 
+
 def make_worker_node():
     return container(
         image="ray_ci:v1",
@@ -102,8 +104,10 @@ def make_worker_node():
         },
     )
 
+
 worker_node = make_worker_node()
 worker_node_2 = make_worker_node()
+
 
 @pytest.fixture
 def docker_cluster(head_node, worker_node):
@@ -250,11 +254,16 @@ print(sum([1 if n["Alive"] else 0 for n in ray.nodes()]))
     # Later, GCS detect the old raylet dead and the alive nodes will be 2
     wait_for_condition(check_alive, timeout=30, n=2)
 
-head_node_1cpu = make_head_node(num_cpus=1, envs={"RAY_gcs_server_request_timeout_seconds": "3"})
+
+head_node_1cpu = make_head_node(
+    num_cpus=1, envs={"RAY_gcs_server_request_timeout_seconds": "3"}
+)
+
 
 @pytest.fixture
 def docker_cluster_1cpu(head_node_1cpu, worker_node):
     yield (head_node_1cpu, worker_node)
+
 
 @pytest.mark.skipif(sys.platform != "linux", reason="Only works on linux.")
 def test_ray_deadnode_actor_call(docker_cluster_1cpu):
@@ -393,7 +402,9 @@ for i in range({num_iters}):
     print(i, time.time(), ray.get(ray.get(c.hello.remote())))
     time.sleep(1)
 """
-    output = worker.exec_run(cmd=f"python -c '{create_cache_script.format(num_iters=1)}'")
+    output = worker.exec_run(
+        cmd=f"python -c '{create_cache_script.format(num_iters=1)}'"
+    )
     assert output.exit_code == 0
 
     def kill_head():
@@ -407,12 +418,13 @@ for i in range({num_iters}):
     t = threading.Thread(target=kill_head)
     t.start()
 
-    output = worker.exec_run(cmd=f"python -c '{create_cache_script.format(num_iters=4)}'")
+    output = worker.exec_run(
+        cmd=f"python -c '{create_cache_script.format(num_iters=4)}'"
+    )
     print(output.output.decode())
     assert output.exit_code == 0
     print(output.output.decode())
     t.join()
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In this PR the following two cases are covered in e2e test:

1. When the headnode died, since actor death info is not published, actor calls are going to hang forever until GCS is back.
2. When the head node died, the object created by the actor can be fetched if it's stored locally.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
