### PR TITLE
[Fail on pytest warnings 1/n] Marking strings with invalid escape sequences as raw strings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+# Configure pytest to fail any test that raises an unexpected warning.
+# This will enable us to catch usages of deprecated features in downstream libraries,
+# before they are hard-deprecated.
+# Furthermore, they will catch any test issues which may hide bugs.
+# The format is `action:message_regex:category:module:line`.
+filterwarnings =
+    # Fail builds on any unexpected warnings.
+    # See https://docs.google.com/document/d/1TVMfmhO0vD1MdkVrqRS9t4om2shMTY9nqdqqOopNv0M for more details.
+    error
+    ignore:.*:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,11 +1,10 @@
 [pytest]
-# Configure pytest to fail any test that raises an unexpected warning.
-# This will enable us to catch usages of deprecated features in downstream libraries,
-# before they are hard-deprecated.
-# Furthermore, they will catch any test issues which may hide bugs.
-# The format is `action:message_regex:category:module:line`.
+
 filterwarnings =
-    # Fail builds on any unexpected warnings.
-    # See https://docs.google.com/document/d/1TVMfmhO0vD1MdkVrqRS9t4om2shMTY9nqdqqOopNv0M for more details.
+    # This means: treat every warning as error, except for warnings that match .* (aka all warnings), ignore those.
+    # This triggers the SyntaxError described in https://github.com/ray-project/ray/pull/31523 but keeps the status quo
+    # warning behavior until https://github.com/ray-project/ray/pull/31219 .
     error
+
+    # The format is `action:message_regex:category:module:line`.
     ignore:.*:

--- a/python/ray/_private/runtime_env/context.py
+++ b/python/ray/_private/runtime_env/context.py
@@ -66,7 +66,7 @@ class RuntimeEnvContext:
         else:
             executable = "exec "
 
-        passthrough_args = [s.replace(" ", "\ ") for s in passthrough_args]
+        passthrough_args = [s.replace(" ", r"\ ") for s in passthrough_args]
         exec_command = " ".join([f"{executable}"] + passthrough_args)
         command_str = " ".join(self.command_prefix + [exec_command])
         # TODO(SongGuyang): We add this env to command for macOS because it doesn't

--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -335,7 +335,7 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
 
     @classmethod
     def construct_from_string(cls, string: str):
-        """
+        r"""
         Construct this type from a string.
 
         This is useful mainly for data types that accept parameters.

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -394,7 +394,7 @@ class GroupedDataset(Generic[T]):
     def sum(
         self, on: Union[KeyFn, List[KeyFn]] = None, ignore_nulls: bool = True
     ) -> Dataset[U]:
-        """Compute grouped sum aggregation.
+        r"""Compute grouped sum aggregation.
 
         This is a blocking operation.
 

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -325,6 +325,9 @@ def has_client_deprecation_warn(warning: Warning, expected_replacement: str) -> 
 @pytest.mark.skipif(
     sys.platform == "win32", reason="pip not supported in Windows runtime envs."
 )
+@pytest.mark.filterwarnings(
+    "default:Starting a connection through `ray.client` will be deprecated"
+)
 def test_client_deprecation_warn():
     """
     Tests that calling ray.client directly raises a deprecation warning with

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -512,6 +512,7 @@ def test_placement_group_empty_bundle_error(ray_start_regular, connect_to_client
             ray.util.placement_group([])
 
 
+@pytest.mark.filterwarnings("default:placement_group parameter is deprecated")
 def test_placement_group_scheduling_warning(ray_start_regular_shared):
     @ray.remote
     class Foo:
@@ -557,6 +558,9 @@ def test_placement_group_scheduling_warning(ray_start_regular_shared):
     assert not w
 
 
+@pytest.mark.filterwarnings(
+    "default:Setting 'object_store_memory' for actors is deprecated"
+)
 def test_object_store_memory_deprecation_warning(ray_start_regular_shared):
     with warnings.catch_warnings(record=True) as w:
 

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -561,6 +561,9 @@ def test_placement_group_scheduling_warning(ray_start_regular_shared):
 @pytest.mark.filterwarnings(
     "default:Setting 'object_store_memory' for actors is deprecated"
 )
+@pytest.mark.filterwarnings(
+    "default:Setting 'object_store_memory' for bundles is deprecated"
+)
 def test_object_store_memory_deprecation_warning(ray_start_regular_shared):
     with warnings.catch_warnings(record=True) as w:
 

--- a/release/serve_tests/workloads/deployment_graph_wide_ensemble.py
+++ b/release/serve_tests/workloads/deployment_graph_wide_ensemble.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Test that focuses on wide fanout of deployment graph
        -> Node_1
       /          \
@@ -56,7 +56,7 @@ def combine(value_refs):
 def test_wide_fanout_deployment_graph(
     fanout_degree, init_delay_secs=0, compute_delay_secs=0
 ):
-    """
+    r"""
     Test that focuses on wide fanout of deployment graph
         -> Node_1
         /          \

--- a/release/serve_tests/workloads/serve_handle_wide_ensemble.py
+++ b/release/serve_tests/workloads/serve_handle_wide_ensemble.py
@@ -1,4 +1,4 @@
-"""
+r"""
 This test is parity of
 release/serve_tests/workloads/deployment_graph_wide_ensemble.py
 Instead of using graph api, the test is using pure handle to

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -2301,7 +2301,7 @@ class AlgorithmConfig:
         spaces: Optional[Dict[PolicyID, Tuple[Space, Space]]] = None,
         default_policy_class: Optional[Type[Policy]] = None,
     ) -> Tuple[MultiAgentPolicyConfigDict, Callable[[PolicyID, SampleBatchType], bool]]:
-        """Compiles complete multi-agent config (dict) from the information in `self`.
+        r"""Compiles complete multi-agent config (dict) from the information in `self`.
 
         Infers the observation- and action spaces, the policy classes, and the policy's
         configs. The returned `MultiAgentPolicyConfigDict` is fully unified and strictly

--- a/rllib/algorithms/dqn/dqn.py
+++ b/rllib/algorithms/dqn/dqn.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 
 class DQNConfig(SimpleQConfig):
-    """Defines a configuration class from which a DQN Algorithm can be built.
+    r"""Defines a configuration class from which a DQN Algorithm can be built.
 
     Example:
         >>> from ray.rllib.algorithms.dqn.dqn import DQNConfig

--- a/rllib/algorithms/marwil/marwil.py
+++ b/rllib/algorithms/marwil/marwil.py
@@ -178,7 +178,7 @@ class MARWILConfig(AlgorithmConfig):
     ) -> "Algorithm":
         if not self._set_off_policy_estimation_methods:
             deprecation_warning(
-                old="MARWIL used to have off_policy_estimation_methods "
+                old=r"MARWIL used to have off_policy_estimation_methods "
                 "is and wis by default. This has"
                 "changed to off_policy_estimation_methods: \{\}."
                 "If you want to use an off-policy estimator, specify it in"

--- a/rllib/algorithms/mbmpo/mbmpo.py
+++ b/rllib/algorithms/mbmpo/mbmpo.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 
 class MBMPOConfig(AlgorithmConfig):
-    """Defines a configuration class from which an MBMPO Algorithm can be built.
+    r"""Defines a configuration class from which an MBMPO Algorithm can be built.
 
     Example:
         >>> from ray.rllib.algorithms.mbmpo import MBMPOConfig

--- a/rllib/algorithms/r2d2/r2d2.py
+++ b/rllib/algorithms/r2d2/r2d2.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class R2D2Config(DQNConfig):
-    """Defines a configuration class from which a R2D2 Algorithm can be built.
+    r"""Defines a configuration class from which a R2D2 Algorithm can be built.
 
     Example:
         >>> from ray.rllib.algorithms.r2d2.r2d2 import R2D2Config


### PR DESCRIPTION
## Background

Python deprecated invalid unicode escape sequences a while back (Python3.6) and they [will start breaking in newer Pythons](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals):
> Changed in version 3.6: Unrecognized escape sequences produce a [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). In a future Python version they will be a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning) and eventually a [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError).

Docstrings and other strings that need `\ ` et al. [should be raw strings](https://github.com/python/cpython/issues/71551#issuecomment-1093718618).

### Pytest?

For reasons unclear to me, pytest encounters the SyntaxError when it instruments tests with improved assertions when its warnings are interpreted as failures. It's unclear how to ignore them (because they're marked as SyntaxErrors, which aren't warnings and can't be filtered).

So, in this PR we fix the occurrences where we have invalid escape sequences. We have to do it in a separate PR from https://github.com/ray-project/ray/pull/31219 because our CI is using a prebuilt wheel instead of a per-PR wheel.

https://github.com/ray-project/ray/issues/31479 tracks the work to fail on pytest warnings. 

### Example offenders

For example, see lines 406, 407, 412, and 413 here: https://github.com/ray-project/ray/blob/0c8b59d2d90df0cfe0f17d9feb7ef9b3e5fe53f2/python/ray/data/grouped_dataset.py#L406-L413


