### PR TITLE
[CoreWorker][deprecate run_function_on_all_workers 2/n] announcing deprecation of run_function_on_all_workers

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -688,11 +688,11 @@ class Worker:
         )
 
     @Deprecated(
-        message="This function is deprecated and will be removed by Ray 2.4, "
-        "please use Runtime Environment "
+        message="This function is deprecated and will be removed by Ray 2.4. "
+        "Please use Runtime Environments "
         f"https://docs.ray.io/en/{get_ray_doc_version()}/ray-core"
         "/handling-dependencies.html "
-        "to manage worker's dependencies.",
+        "to manage dependencies in workers.",
         warning=True,
     )
     def run_function_on_all_workers(self, function: callable):

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -687,7 +687,14 @@ class Worker:
             debugger_breakpoint,
         )
 
-    @Deprecated
+    @Deprecated(
+        message="This function is deprecated and will be removed by Ray 2.4, "
+        "please use Runtime Environment "
+        f"https://docs.ray.io/en/{get_ray_doc_version()}/ray-core"
+        "/handling-dependencies.html "
+        "to manage worker's dependencies.",
+        warning=True,
+    )
     def run_function_on_all_workers(self, function: callable):
         """This function has been deprecated given the following issues:
             - no guarantee that the function run before the remote function run.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Warn user that run_function_on_all_workers will be deleted by Ray 2.4. Ray core no longer uses this function after https://github.com/ray-project/ray/pull/31383

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
