### PR TITLE
[docs] Fix Deprecated annotation indentation

### DIFF
--- a/python/ray/util/annotations.py
+++ b/python/ray/util/annotations.py
@@ -124,7 +124,7 @@ def Deprecated(*args, **kwargs):
         return Deprecated()(args[0])
 
     doc_message = (
-        "\n    DEPRECATED: This API is deprecated and may be removed "
+        "DEPRECATED: This API is deprecated and may be removed "
         "in future Ray releases."
     )
     warning_message = (
@@ -179,10 +179,14 @@ def _append_doc(obj, *, message: str, directive: Optional[str] = None) -> str:
 
     indent = _get_indent(obj.__doc__)
     obj.__doc__ += "\n\n"
+
     if directive is not None:
-        obj.__doc__ += f"{' ' * indent}.. {directive}::\n"
+        obj.__doc__ += f"{' ' * indent}.. {directive}::\n\n"
+
+        message = message.replace("\n", "\n" + " " * (indent + 4))
         obj.__doc__ += f"{' ' * (indent + 4)}{message}"
     else:
+        message = message.replace("\n", "\n" + " " * (indent + 4))
         obj.__doc__ += f"{' ' * indent}{message}"
     obj.__doc__ += f"\n{' ' * indent}"
 

--- a/python/ray/util/annotations.py
+++ b/python/ray/util/annotations.py
@@ -124,7 +124,7 @@ def Deprecated(*args, **kwargs):
         return Deprecated()(args[0])
 
     doc_message = (
-        "DEPRECATED: This API is deprecated and may be removed "
+        "**DEPRECATED**: This API is deprecated and may be removed "
         "in future Ray releases."
     )
     warning_message = (


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Our Documentation build job [currently](https://buildkite.com/ray-project/oss-ci-build-branch/builds/1768#018593d3-ebf5-4a90-a317-192a5bc4d5c1) returns errors like this:

```
/ray/python/ray/air/checkpoint.py:docstring of ray.air.checkpoint.Checkpoint.from_object_ref:9: WARNING: Content block expected for the "warning" directive; none found.
```

The reason for this is the `Deprecated` annotation that adds a `warning` block to the `__doc__` property to be rendered in our documentation.

The code is faulty: A misplaced newline character in the `DEPRECATED` message block removes the proper indentation:

```
        Returns:
            If called by a driver, this returns the job ID. If called in
            a task, return the job ID of the associated driver.

        .. warning::
            
    DEPRECATED: This API is deprecated and may be removed in future Ray releases.
Use get_job_id() instead
```

Additionally, newline characters in the deprecation message are also not indented correctly:

```
        Returns:
            If called by a driver, this returns the job ID. If called in
            a task, return the job ID of the associated driver.

        .. warning::

            DEPRECATED: This API is deprecated and may be removed in future Ray releases.
Use get_job_id() instead
```

This PR fixes both problems:

```
        Returns:
            If called by a driver, this returns the job ID. If called in
            a task, return the job ID of the associated driver.

        .. warning::

            DEPRECATED: This API is deprecated and may be removed in future Ray releases.
            Use get_job_id() instead
        
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
