### PR TITLE
Revert "Revert "[serve] Add initial health check before marking a rep…

### DIFF
--- a/java/serve/src/main/java/io/ray/serve/replica/RayServeWrappedReplica.java
+++ b/java/serve/src/main/java/io/ray/serve/replica/RayServeWrappedReplica.java
@@ -185,6 +185,17 @@ public class RayServeWrappedReplica implements RayServeReplica {
   }
 
   /**
+   * Tell the caller this replica is successfully initialized.
+   *
+   * @return
+   */
+  public boolean isInitialized(Object userConfig) {
+    DeploymentVersion version = self.reconfigure(userConfig);
+    self.checkHealth();
+    return version;
+  }
+
+  /**
    * Wait until there is no request in processing. It is used for stopping replica gracefully.
    *
    * @return true if it is ready for shutdown.

--- a/java/serve/src/main/java/io/ray/serve/replica/RayServeWrappedReplica.java
+++ b/java/serve/src/main/java/io/ray/serve/replica/RayServeWrappedReplica.java
@@ -189,10 +189,10 @@ public class RayServeWrappedReplica implements RayServeReplica {
    *
    * @return
    */
-  public boolean isInitialized(Object userConfig) {
-    DeploymentVersion version = self.reconfigure(userConfig);
-    self.checkHealth();
-    return version;
+  public Object isInitialized(Object userConfig) {
+    Object deploymentVersion = reconfigure(userConfig);
+    checkHealth();
+    return deploymentVersion;
   }
 
   /**

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -375,10 +375,10 @@ class ActorReplicaWrapper:
         if self._is_cross_language:
             self._actor_handle = JavaActorHandleProxy(self._actor_handle)
             self._allocated_obj_ref = self._actor_handle.is_allocated.remote()
-            self._ready_obj_ref = self._actor_handle.reconfigure.remote(user_config)
+            self._ready_obj_ref = self._actor_handle.is_initialized.remote(user_config)
         else:
             self._allocated_obj_ref = self._actor_handle.is_allocated.remote()
-            self._ready_obj_ref = self._actor_handle.reconfigure.remote(
+            self._ready_obj_ref = self._actor_handle.is_initialized.remote(
                 user_config,
                 # Ensure that `is_allocated` will execute before `reconfigure`,
                 # because `reconfigure` runs user code that could block the replica
@@ -431,22 +431,23 @@ class ActorReplicaWrapper:
         Check if current replica has started by making ray API calls on
         relevant actor / object ref.
 
+        Replica initialization calls __init__(), reconfigure(), and check_health().
+
         Returns:
             state (ReplicaStartupStatus):
                 PENDING_ALLOCATION:
                     - replica is waiting for a worker to start
                 PENDING_INITIALIZATION
-                    - replica reconfigure() haven't returned.
+                    - replica initialization hasn't finished.
                 FAILED:
-                    - replica __init__() failed.
+                    - replica initialization failed.
                 SUCCEEDED:
-                    - replica __init__() and reconfigure() succeeded.
+                    - replica initialization succeeded.
             version:
                 None:
-                    - replica reconfigure() haven't returned OR
-                    - replica __init__() failed.
+                    - for PENDING_ALLOCATION, PENDING_INITIALIZATION, or FAILED states
                 version:
-                    - replica __init__() and reconfigure() succeeded.
+                    - for SUCCEEDED state
         """
 
         # Check whether the replica has been allocated.
@@ -1406,9 +1407,10 @@ class DeploymentState:
                     name=self._name,
                     status=DeploymentStatus.UNHEALTHY,
                     message=(
-                        "The Deployment constructor failed "
-                        f"{failed_to_start_count} times in a row. See "
-                        "logs for details."
+                        f"The Deployment failed to start {failed_to_start_count} "
+                        "times in a row. This may be due to a problem with the "
+                        "deployment constructor or the initial health check failing. "
+                        "See logs for details."
                     ),
                 )
                 return False

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -221,14 +221,13 @@ def create_replica_wrapper(name: str):
             # allows delaying reconfiguration until after this call has returned.
             await self._initialize_replica()
 
-            if user_config is not None:
-                await self.reconfigure(user_config)
+            metadata = await self.reconfigure(user_config)
 
             # A new replica should not be considered healthy until it passes an
             # initial health check. If an initial health check fails, consider
             # it an initialization failure.
             await self.check_health()
-            return self.get_metadata()
+            return metadata
 
         async def reconfigure(
             self, user_config: Optional[Any] = None

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -214,13 +214,25 @@ def create_replica_wrapper(name: str):
             """
             return ray.get_runtime_context().node_id
 
-        async def reconfigure(
+        async def is_initialized(
             self, user_config: Optional[Any] = None, _after: Optional[Any] = None
-        ) -> Tuple[DeploymentConfig, DeploymentVersion]:
+        ):
             # Unused `_after` argument is for scheduling: passing an ObjectRef
             # allows delaying reconfiguration until after this call has returned.
-            if self.replica is None:
-                await self._initialize_replica()
+            await self._initialize_replica()
+
+            if user_config is not None:
+                await self.reconfigure(user_config)
+
+            # A new replica should not be considered healthy until it passes an
+            # initial health check. If an initial health check fails, consider
+            # it an initialization failure.
+            await self.check_health()
+            return self.get_metadata()
+
+        async def reconfigure(
+            self, user_config: Optional[Any] = None
+        ) -> Tuple[DeploymentConfig, DeploymentVersion]:
             if user_config is not None:
                 await self.replica.reconfigure(user_config)
 


### PR DESCRIPTION
…lica as RUNNING (#31189)" (#31548)"

This reverts commit 15676dda075690f2cb9f83511a18bcde0404f31f.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/ray/pull/31189 broke the Java codepath. This PR fixes that and also adds the initial health check to Java behavior.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
