### PR TITLE
[Datasets] Do not eagerly execute first block for read_xxx API

### DIFF
--- a/doc/source/ray-core/_examples/datasets_train/datasets_train.py
+++ b/doc/source/ray-core/_examples/datasets_train/datasets_train.py
@@ -580,7 +580,7 @@ if __name__ == "__main__":
         read_dataset(data_path)
     )
 
-    num_columns = len(train_dataset.schema(fetch_if_missing=True).names)
+    num_columns = len(train_dataset.schema().names)
     # remove label column.
     num_features = num_columns - 1
 

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -260,10 +260,13 @@ class ExecutionPlan:
         blocks = self._snapshot_blocks
         if not blocks:
             return None
-        # Don't force fetching in case it's a lazy block list, in which case we
-        # don't want to trigger full execution for a schema read. If we want to
-        # trigger execution to get schema, we'll trigger read tasks progressively
-        # until a viable schema is available, below.
+
+        # Only trigger the execution of first block in case it's a lazy block list.
+        # Don't trigger full execution for a schema read.
+        if isinstance(blocks, LazyBlockList):
+            blocks.compute_first_block()
+            blocks.ensure_metadata_for_first_block()
+
         metadata = blocks.get_metadata(fetch_if_missing=False)
         # Some blocks could be empty, in which case we cannot get their schema.
         # TODO(ekl) validate schema is the same across different blocks.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2128,7 +2128,7 @@ class Dataset(Generic[T]):
         )
 
     def schema(
-        self, fetch_if_missing: bool = False
+        self, fetch_if_missing: bool = True
     ) -> Union[type, "pyarrow.lib.Schema"]:
         """Return the schema of the dataset.
 
@@ -2139,8 +2139,8 @@ class Dataset(Generic[T]):
 
         Args:
             fetch_if_missing: If True, synchronously fetch the schema if it's
-                not known. Default is False, where None is returned if the
-                schema is not known.
+                not known. If False, None is returned if the schema is not known.
+                Default is True.
 
         Returns:
             The Python type or Arrow schema of the records, or None if the
@@ -4224,7 +4224,9 @@ class Dataset(Generic[T]):
         return Tab(children, titles=["Metadata", "Schema"])
 
     def __repr__(self) -> str:
-        schema = self.schema()
+        # Do not force execution for schema, as this method is expected to be very
+        # cheap.
+        schema = self.schema(fetch_if_missing=False)
         if schema is None:
             schema_str = "Unknown schema"
         elif isinstance(schema, type):

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -335,8 +335,6 @@ def read_datasource(
     block_list = LazyBlockList(
         read_tasks, ray_remote_args=ray_remote_args, owned_by_consumer=False
     )
-    block_list.compute_first_block()
-    block_list.ensure_metadata_for_first_block()
 
     return Dataset(
         plan=ExecutionPlan(block_list, block_list.stats(), run_by_consumer=False),

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -224,10 +224,7 @@ def assert_base_partitioned_ds():
         if sorted_values is None:
             sorted_values = [[1, "a"], [1, "b"], [1, "c"], [3, "e"], [3, "f"], [3, "g"]]
         # Test metadata ops.
-        if num_computed is not None:
-            assert (
-                ds._plan.execute()._num_computed() == 1
-            ), f"{ds._plan.execute()._num_computed()} != 1"
+        assert ds._plan.execute()._num_computed() == 0
         assert ds.count() == count, f"{ds.count()} != {count}"
         assert ds.size_bytes() > 0, f"{ds.size_bytes()} <= 0"
         assert ds.schema() is not None

--- a/python/ray/data/tests/test_dataset_csv.py
+++ b/python/ray/data/tests/test_dataset_csv.py
@@ -656,7 +656,7 @@ def test_csv_read_with_column_type_specified(shutdown_only, tmp_path):
             convert_options=csv.ConvertOptions(
                 column_types={"one": "int64", "two": "string"}
             ),
-        )
+        ).schema()
 
     # Parsing scientific notation in double should work.
     ds = ray.data.read_csv(
@@ -692,12 +692,12 @@ def test_csv_read_filter_non_csv_file(shutdown_only, tmp_path):
     # Single non-CSV file.
     error_message = "Failed to read CSV file"
     with pytest.raises(ValueError, match=error_message):
-        ray.data.read_csv(path3)
+        ray.data.read_csv(path3).schema()
 
     # Single non-CSV file with filter.
     error_message = "No input files found to read"
     with pytest.raises(ValueError, match=error_message):
-        ray.data.read_csv(path3, partition_filter=FileExtensionFilter("csv"))
+        ray.data.read_csv(path3, partition_filter=FileExtensionFilter("csv")).schema()
 
     # Single CSV file without extension.
     ds = ray.data.read_csv(path2)
@@ -706,12 +706,12 @@ def test_csv_read_filter_non_csv_file(shutdown_only, tmp_path):
     # Single CSV file without extension with filter.
     error_message = "No input files found to read"
     with pytest.raises(ValueError, match=error_message):
-        ray.data.read_csv(path2, partition_filter=FileExtensionFilter("csv"))
+        ray.data.read_csv(path2, partition_filter=FileExtensionFilter("csv")).schema()
 
     # Directory of CSV and non-CSV files.
     error_message = "Failed to read CSV file"
     with pytest.raises(ValueError, match=error_message):
-        ray.data.read_csv(tmp_path)
+        ray.data.read_csv(tmp_path).schema()
 
     # Directory of CSV and non-CSV files with filter.
     ds = ray.data.read_csv(tmp_path, partition_filter=FileExtensionFilter("csv"))

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -128,7 +128,7 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     ds = ray.data.read_parquet([path1, path2], filesystem=fs)
 
     # Test metadata-only parquet ops.
-    assert ds._plan.execute()._num_computed() == 1
+    assert ds._plan.execute()._num_computed() == 0
     assert ds.count() == 6
 
     out_path = os.path.join(tmp_path, "out")

--- a/python/ray/data/tests/test_dataset_parquet.py
+++ b/python/ray/data/tests/test_dataset_parquet.py
@@ -122,10 +122,11 @@ def test_parquet_read_basic(ray_start_regular_shared, fs, data_path):
     ds = ray.data.read_parquet(data_path, filesystem=fs)
 
     # Test metadata-only parquet ops.
-    assert ds._plan.execute()._num_computed() == 1
+    assert ds._plan.execute()._num_computed() == 0
     assert ds.count() == 6
     assert ds.size_bytes() > 0
     assert ds.schema() is not None
+    assert ds._plan.execute()._num_computed() == 1
     input_files = ds.input_files()
     assert len(input_files) == 2, input_files
     assert "test1.parquet" in str(input_files)
@@ -200,7 +201,7 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
     )
 
     # Expect to lazily compute all metadata correctly.
-    assert ds._plan.execute()._num_computed() == 1
+    assert ds._plan.execute()._num_computed() == 0
     assert ds.count() == 6
     assert ds.size_bytes() > 0
     assert ds.schema() is not None
@@ -266,7 +267,8 @@ def test_parquet_read_bulk(ray_start_regular_shared, fs, data_path):
     # Expect directory path expansion to fail with OS error if default format-based path
     # filtering is turned off.
     with pytest.raises(OSError):
-        ray.data.read_parquet_bulk(data_path, filesystem=fs, partition_filter=None)
+        ds = ray.data.read_parquet_bulk(data_path, filesystem=fs, partition_filter=None)
+        ds.schema()
 
     # Expect individual file paths to be processed successfully.
     paths = [path1, path2]
@@ -276,7 +278,7 @@ def test_parquet_read_bulk(ray_start_regular_shared, fs, data_path):
     assert ds._meta_count() is None
 
     # Expect to lazily compute all metadata correctly.
-    assert ds._plan.execute()._num_computed() == 1
+    assert ds._plan.execute()._num_computed() == 0
     assert ds.count() == 6
     assert ds.size_bytes() > 0
     assert ds.schema() is not None
@@ -366,7 +368,7 @@ def test_parquet_read_bulk_meta_provider(ray_start_regular_shared, fs, data_path
     assert ds._meta_count() is None
 
     # Expect to lazily compute all metadata correctly.
-    assert ds._plan.execute()._num_computed() == 1
+    assert ds._plan.execute()._num_computed() == 0
     assert ds.count() == 6
     assert ds.size_bytes() > 0
     assert ds.schema() is not None
@@ -425,7 +427,7 @@ def test_parquet_read_partitioned(ray_start_regular_shared, fs, data_path):
     ds = ray.data.read_parquet(data_path, filesystem=fs)
 
     # Test metadata-only parquet ops.
-    assert ds._plan.execute()._num_computed() == 1
+    assert ds._plan.execute()._num_computed() == 0
     assert ds.count() == 6
     assert ds.size_bytes() > 0
     assert ds.schema() is not None
@@ -511,7 +513,7 @@ def test_parquet_read_partitioned_explicit(ray_start_regular_shared, tmp_path):
     )
 
     # Test metadata-only parquet ops.
-    assert ds._plan.execute()._num_computed() == 1
+    assert ds._plan.execute()._num_computed() == 0
     assert ds.count() == 6
     assert ds.size_bytes() > 0
     assert ds.schema() is not None
@@ -609,7 +611,7 @@ def test_parquet_read_parallel_meta_fetch(ray_start_regular_shared, fs, data_pat
     ds = ray.data.read_parquet(data_path, filesystem=fs, parallelism=parallelism)
 
     # Test metadata-only parquet ops.
-    assert ds._plan.execute()._num_computed() == 1
+    assert ds._plan.execute()._num_computed() == 0
     assert ds.count() == num_dfs * 3
     assert ds.size_bytes() > 0
     assert ds.schema() is not None

--- a/python/ray/data/tests/test_dataset_tfrecords.py
+++ b/python/ray/data/tests/test_dataset_tfrecords.py
@@ -221,7 +221,7 @@ def test_read_invalid_tfrecords(ray_start_regular_shared, tmp_path):
 
     # Expect RuntimeError raised when reading JSON as TFRecord file.
     with pytest.raises(RuntimeError, match="Failed to read TFRecord file"):
-        ray.data.read_tfrecords(file_path)
+        ray.data.read_tfrecords(file_path).schema()
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -165,6 +165,7 @@ def test_lazy_block_list(
         num_blocks=num_blocks,
         block_size=block_size,
     )
+    ds.schema()
 
     # Check internal states of LazyBlockList before execution
     block_list = ds._plan._in_blocks

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -229,9 +229,8 @@ def test_lazy_fanout(shutdown_only, local_path):
         {"one": 4, "two": "b"},
         {"one": 5, "two": "c"},
     ]
-    # Test that data is read twice (+ 1 extra for ramp-up read before converting to a
-    # lazy dataset).
-    assert ray.get(read_counter.get.remote()) == 3
+    # Test that data is read twice.
+    assert ray.get(read_counter.get.remote()) == 2
     # Test that first map is executed twice.
     assert ray.get(map_counter.get.remote()) == 2 * 3 + 3 + 3
 
@@ -608,7 +607,7 @@ def test_optimize_reread_base_data(ray_start_regular_shared, local_path):
     pipe = ds1.repeat(N)
     pipe.take()
     num_reads = ray.get(counter.get.remote())
-    assert num_reads == N + 1, num_reads
+    assert num_reads == N, num_reads
 
     # Re-read off.
     context.optimize_fuse_read_stages = False

--- a/python/ray/data/tests/test_partitioning.py
+++ b/python/ray/data/tests/test_partitioning.py
@@ -116,7 +116,10 @@ class TestReadHivePartitionedFiles:
         with pytest.raises(ValueError):
             # `read_csv` should error because `month` is a field in both the CSV and
             # the path, and the data is different.
-            read_csv(path, partitioning=Partitioning("hive"), block_type=block_type)
+            ds = read_csv(
+                path, partitioning=Partitioning("hive"), block_type=block_type
+            )
+            ds.schema()
 
     @pytest.mark.parametrize("data", [[1, 1, 1], [1, None, 1]])
     def test_read_files_with_legally_conflicting_key(
@@ -226,7 +229,7 @@ class TestReadDirPartitionedFiles:
                     "dir", field_names=["year", "country"], base_dir=tmp_path
                 ),
                 block_type=block_type,
-            )
+            ).schema()
 
     @pytest.mark.parametrize(
         "relative_path", ["1970/data.csv", "1970/us/94704/data.csv"]
@@ -244,7 +247,7 @@ class TestReadDirPartitionedFiles:
                     "dir", field_names=["year", "country"], base_dir=tmp_path
                 ),
                 block_type=block_type,
-            )
+            ).schema()
 
     def test_read_files_with_conflicting_key(
         self, tmp_path, block_type, ray_start_regular_shared
@@ -260,7 +263,7 @@ class TestReadDirPartitionedFiles:
                     "dir", field_names=["month"], base_dir=tmp_path
                 ),
                 block_type=block_type,
-            )
+            ).schema()
 
     @pytest.mark.parametrize("data", [[1, 1, 1], [1, None, 1]])
     def test_read_files_with_legally_conflicting_key(


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is the followup of https://github.com/ray-project/ray/pull/31286#pullrequestreview-1238017386. The change includes:
* `read_api.py:read_datasource()`: Remove the logic to eagerly execute first block for read.
* `Dataset.schema()`: Change default value of `fetch_if_missing` from False to True. So always trigger execution if schame is missing.
* `ExecutionPlan.schema()`: if plan is having lazy block list as output, execute the first block only to get schema, instead of executing all blocks.
* Other files: unit test change to work with new logic.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
