### PR TITLE
[RLlib] Issue 31525: Observation Space Dict w/ Box+Discrete elements errors out.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2143,6 +2143,13 @@ py_test(
 )
 
 py_test(
+    name = "utils/tests/test_tf_utils",
+    tags = ["team:rllib", "utils"],
+    size = "small",
+    srcs = ["utils/tests/test_tf_utils.py"]
+)
+
+py_test(
     name = "utils/tests/test_torch_utils",
     tags = ["team:rllib", "utils"],
     size = "small",

--- a/rllib/policy/dynamic_tf_policy_v2.py
+++ b/rllib/policy/dynamic_tf_policy_v2.py
@@ -530,25 +530,32 @@ class DynamicTFPolicyV2(TFPolicy):
                     # Create a +time-axis placeholder if the shift is not an
                     # int (range or list of ints).
                     # Do not flatten actions if action flattening disabled.
-                    if self.config.get("_disable_action_flattening") and view_col in [
-                        SampleBatch.ACTIONS,
-                        SampleBatch.PREV_ACTIONS,
-                    ]:
-                        flatten = False
+                    if view_col in [SampleBatch.ACTIONS, SampleBatch.PREV_ACTIONS]:
+                        if self.config.get("_disable_action_flattening"):
+                            flatten = False
+                            one_hot = False
+                        else:
+                            flatten = True
+                            one_hot = False
                     # Do not flatten observations if no preprocessor API used.
                     elif (
                         view_col in [SampleBatch.OBS, SampleBatch.NEXT_OBS]
                         and self.config["_disable_preprocessor_api"]
                     ):
                         flatten = False
+                        one_hot = False
                     # Flatten everything else.
                     else:
                         flatten = True
+                        one_hot = True
+
                     input_dict[view_col] = get_placeholder(
                         space=view_req.space,
                         name=view_col,
                         time_axis=time_axis,
                         flatten=flatten,
+                        one_hot=one_hot,
+
                     )
         dummy_batch = self._get_dummy_batch_from_view_requirements(batch_size=32)
 

--- a/rllib/utils/tests/test_tf_utils.py
+++ b/rllib/utils/tests/test_tf_utils.py
@@ -1,0 +1,77 @@
+import unittest
+
+import gymnasium as gym
+import numpy as np
+
+import ray
+from ray.rllib.utils.tf_utils import get_placeholder
+
+
+class TestTfUtils(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        ray.init()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        ray.shutdown()
+
+    def test_get_placeholder_w_discrete(self):
+        """Tests whether `get_placeholder` works as expected on Box spaces."""
+        space = gym.spaces.Discrete(2)
+        placeholder = get_placeholder(
+            space=space, time_axis=False, flatten=False, one_hot=False
+        )
+        self.assertTrue(placeholder.shape.as_list() == [None])
+        self.assertTrue(placeholder.dtype.name == "int64")
+
+        space = gym.spaces.Discrete(3)
+        placeholder = get_placeholder(
+            space=space, time_axis=False, flatten=True, one_hot=False
+        )
+        self.assertTrue(placeholder.shape.as_list() == [None])
+        self.assertTrue(placeholder.dtype.name == "int64")
+
+        space = gym.spaces.Discrete(4)
+        placeholder = get_placeholder(
+            space=space, time_axis=False, flatten=False, one_hot=True
+        )
+        self.assertTrue(placeholder.shape.as_list() == [None, 4])
+        self.assertTrue(placeholder.dtype.name == "float32")
+
+    def test_get_placeholder_w_box(self):
+        """Tests whether `get_placeholder` works as expected on Box spaces."""
+        space = gym.spaces.Box(-1.0, 1.0, (2,), dtype=np.float32)
+        placeholder = get_placeholder(
+            space=space, time_axis=False, flatten=False, one_hot=False
+        )
+        self.assertTrue(placeholder.shape.as_list() == [None, 2])
+        self.assertTrue(placeholder.dtype.name == "float32")
+
+        space = gym.spaces.Box(-1.0, 1.0, (2, 3), dtype=np.float32)
+        placeholder = get_placeholder(
+            space=space, time_axis=False, flatten=False, one_hot=False
+        )
+        self.assertTrue(placeholder.shape.as_list() == [None, 2, 3])
+        self.assertTrue(placeholder.dtype.name == "float32")
+
+        space = gym.spaces.Box(-1.0, 1.0, (2, 3), dtype=np.float32)
+        placeholder = get_placeholder(
+            space=space, time_axis=False, flatten=True, one_hot=False
+        )
+        self.assertTrue(placeholder.shape.as_list() == [None, 2, 3])
+        self.assertTrue(placeholder.dtype.name == "float32")
+
+        space = gym.spaces.Box(-1.0, 1.0, (2, 3), dtype=np.float32)
+        placeholder = get_placeholder(
+            space=space, time_axis=False, flatten=True, one_hot=True
+        )
+        self.assertTrue(placeholder.shape.as_list() == [None, 2, 3])
+        self.assertTrue(placeholder.dtype.name == "float32")
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Signed-off-by: sven1977 <svenmika1977@gmail.com>

Issue 31525: Observation Space Dict w/ Box+Discrete elements errors out.

Note that this is only an issue for framework="tf" as it is caused by a wrong placeholder being created from the mixed (box+discrete) dict observation space.

Closes #31525 

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
