### PR TITLE
[Docker] (Kubeflow integration) Add chmod --recursive 777 /home/ray to Ray Dockerfile.

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update -y \
     && apt-get install -y sudo tzdata \
     && useradd -ms /bin/bash -d /home/ray ray --uid $RAY_UID --gid $RAY_GID \
     && usermod -aG sudo ray \
-    && chmod 777 /home/ray \
     && echo 'ray ALL=NOPASSWD: ALL' >> /etc/sudoers \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
@@ -76,7 +75,9 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
     else sudo apt-get autoremove -y wget; \
     fi;) \
     && sudo rm -rf /var/lib/apt/lists/* \
-    && sudo apt-get clean
-
+    && sudo apt-get clean \
+    # For OpenShift (a Kubernetes distribution), a random non-root UID will be used when we log in to a ray Pod.
+    # However, only UID=1000 (i.e. RAY_UID) has the write access of /home/ray. Hence, open the write access here.
+    && chmod --recursive 777 /home/ray
 
 WORKDIR $HOME

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -76,8 +76,8 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
     fi;) \
     && sudo rm -rf /var/lib/apt/lists/* \
     && sudo apt-get clean \
-    # For OpenShift (a Kubernetes distribution), a random non-root UID will be used when we log in to a ray Pod.
-    # However, only UID=1000 (i.e. RAY_UID) has the write access of /home/ray. Hence, open the write access here.
+    # Ensure all users are able to write to /home/ray because OpenShift uses a random UID when logging into
+    # pods. See #30959 for more context.
     && chmod --recursive 777 /home/ray
 
 WORKDIR $HOME

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update -y \
     && apt-get install -y sudo tzdata \
     && useradd -ms /bin/bash -d /home/ray ray --uid $RAY_UID --gid $RAY_GID \
     && usermod -aG sudo ray \
+    && chmod 777 /home/ray \
     && echo 'ray ALL=NOPASSWD: ALL' >> /etc/sudoers \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean


### PR DESCRIPTION
Signed-off-by: kaihsun <kaihsun@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This issue is a part of the integration between KubeRay and Kubeflow. See https://github.com/ray-project/kuberay/pull/750#issuecomment-1329856912 for some context.

In KinD (a Kubernetes distribution) cluster, when we use the command `kubectl exec ..` to log in to a ray Pod, the UID will be the same as $RAY_UID (i.e. 1000) in [base-deps/Dockerfile](https://github.com/ray-project/ray/blob/b15d8f3f06598dd8b5dc77206c56e0b029006ddd/docker/base-deps/Dockerfile).

https://github.com/ray-project/ray/blob/b15d8f3f06598dd8b5dc77206c56e0b029006ddd/docker/base-deps/Dockerfile#L16-L27

For OpenShift (a Kubernetes distribution), a random non-root UID will be used when we log in to a ray Pod. However, only `UID=1000` has the write access of `/home/ray`. Therefore, the error message of `Permission denied` will be reported. As follows, only `ray` (UID = 1000) has `rwx` (read, write, execute) access to `/home/ray`. Others only have `r-x` (read & execute) access to `/home/ray`.

```bash
> ls -l /home/
drwxr-xr-x 1 ray users 4096 Dec  7 17:18 ray
```



To reproduce it, we can follow instructions in [pod-security.md](https://github.com/ray-project/kuberay/pull/750/files), and add `runAsUser` and `runAsGroup` to the `securityContext` of `ray-head` in [ray-cluster.pod-security.yaml](https://github.com/ray-project/kuberay/pull/750/files#diff-5327e12f3256bf9b0c90257de425d3c1b5e5ea4d634cba6217258b9f4b550b03).

```yaml
 securityContext:
    runAsUser: 1001190000
    runAsGroup: 0
    allowPrivilegeEscalation: false
    capabilities:
      drop: ["ALL"]
    runAsNonRoot: true
    seccompProfile:
      type: RuntimeDefault 
```

After the RayCluster is ready, use `kubectl exec ...` to log in to the head Pod. Next, execute the following commands.
```bash
(base) I have no name!@raycluster-pod-security-head-nlfmj:~$ id
uid=1001190000 gid=0(root) groups=0(root)
(base) I have no name!@raycluster-pod-security-head-nlfmj:~$ pwd
/home/ray
(base) I have no name!@raycluster-pod-security-head-nlfmj:~$ touch 123
touch: cannot touch '123': Permission denied
```

## Related issue number

Closes #30959 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Test

* Step 1: Build Docker images.
```sh
# Download wheels
export RAY_HASH=f1b8bfd219a98da69a612558cbae32441d98ca60
export RAY_VERSION=2.2.0
./release/util/download_wheels.sh # Modify this file, and comment out unused wheels.

# Move wheels to .whl/
mv *.whl .whl

# I do not know what is this, but "build-docker-images.py" asks me to run this command.
pip download --python-version 3.8 ray==2.2.0 --only-binary=:all:

# Build Docker images
python ./ci/build/build-docker-images.py --py-versions py37 --device-types cpu --build-type HUMAN --build-base
```

* Step 2: Update Docker images in [ray-cluster.pod-security.yaml](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/security/ray-cluster.pod-security.yaml) to point to the images built in Step 1. Then, load the images into the Kind cluster and follow the instructions in the section "Why are these changes needed?".

<img width="1033" alt="Screen Shot 2023-01-11 at 1 18 42 AM" src="https://user-images.githubusercontent.com/20109646/211766752-8dfaf229-7401-4bf0-b6ad-f325ee04479e.png">



