### PR TITLE
Check numerics and print TensorFlow tensors during runtime if needed

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -404,6 +404,7 @@ class AlgorithmConfig:
         self.fake_sampler = False
         self.seed = None
         self.worker_cls = None
+        self.tf_debug = True
 
         # `self.rl_module()`
         self.rl_module_class = None
@@ -2124,6 +2125,7 @@ class AlgorithmConfig:
         fake_sampler: Optional[bool] = NotProvided,
         seed: Optional[int] = NotProvided,
         worker_cls: Optional[Type[RolloutWorker]] = NotProvided,
+        tf_debug: Optional[bool] = NotProvided,
     ) -> "AlgorithmConfig":
         """Sets the config's debugging settings.
 
@@ -2163,6 +2165,8 @@ class AlgorithmConfig:
             self.seed = seed
         if worker_cls is not NotProvided:
             self.worker_cls = worker_cls
+        if tf_debug is not NotProvided:
+            self.tf_debug = tf_debug
 
         return self
 


### PR DESCRIPTION
This is a follow-up on the discussion of debugging and checking numerics in issue #31430 (specifically my [latest comment](https://github.com/ray-project/ray/issues/31430#issuecomment-1372385293) therein), my PR #31431 to that issue, and the initial discussion with @sven1977 in issue #30471. 

_In this PR I propose a genaral debugging wrapper-function and its application to debug __if needed__ TensorFlow tensors on the run to traceback complex errors with `NaN/Infs`._

## Why are these changes needed?

As mentioned in issue #31430, RLlib offers complex algorithms in form of simple application to users. Most users only apply these algorithms and do usually not have more knowledge about the library than is needed for the application of it. 
Some errors that can occur and lately do occur (see [this issue](https://discuss.ray.io/t/action-masking-error/8347) on the discussion board) are hard to traceback: 

1. Because of non-informative error messages (in lower-level libraries like `tensorflow`),
2. complex workflows inside RLlib (needed),
3. and TensorFlow being executed in a static graph.

Some errors are rare and have not been seen before so giving advice is also not possible (me and @mvindiola1 could not simply got to it). It takes sometimes long times to debug it (these are direct costs for businesses and might lower the value of using a library) and even if a user knows what the error was it is still unclear from where it evolved, e.g. NaNs/Infs could come from inputs (environment - for this I proposed in PR #31431 a `BaseEnv` wrapper that could be plugged in, if needed for debugging), the model, the loss, etc. 

### Debugging TensorFlow
Debugging TensorFlow tensors (especially in graph mode) is not easy becuase of many reasons: 

1. A library might use them in its source code - that would need then many adjustments at places that are even unknown to a user,
2. using debugging code as default in source code could severly harm readability,
3. debugging could also hurt performance whn executing the graph as nodes are added to it.

### How this PR wants to help debugging TensorFlow
This PR proposes an approach that simply wraps a tensor in the source code (a given example is `ppo_tf_policy.py`) in such a way that

- it gets checked for numerics and printed, if the user sets `tf_debug`  in the `AlgorithmConfig` to `True`
- if '`tf_debug=False`, erases the nodes from the execution graph by using Grappler's `debug_stripper` optimization option, i.e. keeps the same performance as currently (I tested it for all frameworks)

### How it helps
Like this developers writing an algorithm could decide which tensors might be important to be checked and/or printed and simply wrap them. Users can than turn on `tf_debug` to traceback errors and understand better. Maybe it helps even developers themselves.

### Other options
We could think of other options: 
- [ ] if needed, printing of tensors could be handled independently of checking numerics,
- [ ] other errors could be thrown (right now `tf.errors.InvalidArgumentError`)
- [ ] a `tf_debug_options` dict could be given to users with things like `print=True/False`, `summarize=None|1,2,3|-1` (printing level for tensors), etc.
- [ ] we could create a flexible end-to-end debugging by using for example certain debugging names for certain code areas, like `["grads", "loss", "postprocessing", "model", ...]` which can be provided in the `tf_debug_options` as a list (maybe it makes sense to make the names identical to the file names - as error tracebacks show them)
 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
