### PR TITLE
[CI] De-flake `tune_scalability_network_overhead [smoketest]`

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1631,7 +1631,7 @@
       cluster_compute: tpl_20x2.yaml
 
     run:
-      timeout: 400
+      timeout: 500
       prepare_timeout: 600
       wait_for_nodes:
         num_nodes: 20


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

**tl;dr**: Timeout is too short. This PR increases the timeout.

`tune_scalability_network_overhead [smoketest]` failed twice recently.

In each case, the test "was successful":

```
The result network overhead test took 386.87 seconds, which is below the budget of 1000.00 seconds. Test successful.
--
  |  
  | PASSED: RESULT NETWORK OVERHEAD ::: 386.87 <= 1000.00 ---
```

But CI failed:

```
Traceback (most recent call last):
--
  | File "/tmp/release-h7VxvWLfwr/release/ray_release/glue.py", line 302, in run_release_test
  | command, env=command_env, timeout=command_timeout
  | File "/tmp/release-h7VxvWLfwr/release/ray_release/command_runner/sdk_runner.py", line 130, in run_command
  | f"Cluster command timed out after {timeout} seconds."
  | ray_release.exception.CommandTimeout: Cluster command timed out after 400 seconds.
  |  
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
