### PR TITLE
[AIR] Rename `save_checkpoints` to `upload_checkpoints`

### DIFF
--- a/python/ray/air/integrations/wandb.py
+++ b/python/ray/air/integrations/wandb.py
@@ -454,7 +454,7 @@ class WandbLoggerCallback(LoggerCallback):
             the ``results`` dict should be logged. This makes sense if
             parameters will change during training, e.g. with
             PopulationBasedTraining. Defaults to False.
-        save_checkpoints: If ``True``, model checkpoints will be saved to
+        upload_checkpoints: If ``True``, model checkpoints will be uploaded to
             Wandb as artifacts. Defaults to ``False``.
         **kwargs: The keyword arguments will be pased to ``wandb.init()``.
 
@@ -509,16 +509,24 @@ class WandbLoggerCallback(LoggerCallback):
         api_key: Optional[str] = None,
         excludes: Optional[List[str]] = None,
         log_config: bool = False,
+        upload_checkpoints: bool = False,
         save_checkpoints: bool = False,
         **kwargs,
     ):
+        if save_checkpoints:
+            warnings.warn(
+                "`save_checkpoints` is deprecated. Use `upload_checkpoints` instead.",
+                DeprecationWarning,
+            )
+            upload_checkpoints = save_checkpoints
+
         self.project = project
         self.group = group
         self.api_key_path = api_key_file
         self.api_key = api_key
         self.excludes = excludes or []
         self.log_config = log_config
-        self.save_checkpoints = save_checkpoints
+        self.upload_checkpoints = upload_checkpoints
         self.kwargs = kwargs
 
         self._remote_logger_class = None
@@ -633,7 +641,7 @@ class WandbLoggerCallback(LoggerCallback):
         self._trial_queues[trial].put((_QueueItem.RESULT, result))
 
     def log_trial_save(self, trial: "Trial"):
-        if self.save_checkpoints and trial.checkpoint:
+        if self.upload_checkpoints and trial.checkpoint:
             self._trial_queues[trial].put(
                 (_QueueItem.CHECKPOINT, trial.checkpoint.dir_or_data)
             )


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The name `save_checkpoints` suggests that `WandbLoggerCallback` saves checkpoints, but it doesn't; it only logs existing checkpoints to Weights and Biases. To prevent confusion, this PR renames `save_checkpoints` as `upload_checkpoints`.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #31218

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
