### PR TITLE
[Client] Fix __getattr__ behavior for ClientActorHandles

### DIFF
--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -855,7 +855,8 @@ def test_ignore_reinit(call_ray_start_shared, shutdown_only):
 
 def test_client_actor_missing_field(call_ray_start_shared):
     """
-    Test remote calls with large (multiple chunk) arguments
+    Tests that trying to access methods that don't exist for an actor
+    raises the correct exception.
     """
 
     class SomeSuperClass:

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pytest
 
+import ray.cloudpickle as cloudpickle
 import ray.util.client.server.server as ray_client_server
 from ray._private.client_mode_hook import (
     client_mode_should_convert,
@@ -826,7 +827,7 @@ def test_large_remote_call(call_ray_start_shared):
 
         # 1024x1024x16 f64's =~ 128 MiB. Chunking size is 64 MiB, so guarantees
         # that transferring argument requires multiple chunks.
-        assert OBJECT_TRANSFER_CHUNK_SIZE < 2**20 * 128
+        assert OBJECT_TRANSFER_CHUNK_SIZE < 2 ** 20 * 128
         large_obj = np.random.random((1024, 1024, 16))
         assert ray.get(f.remote(large_obj)) == (1024, 1024, 16)
         assert ray.get(f2.remote(123, large_obj)) == (1024, 1024, 16)
@@ -850,6 +851,54 @@ def test_ignore_reinit(call_ray_start_shared, shutdown_only):
     ctx1 = ray.init(SHARED_CLIENT_SERVER_ADDRESS)
     ctx2 = ray.init(SHARED_CLIENT_SERVER_ADDRESS, ignore_reinit_error=True)
     assert ctx1 == ctx2
+
+
+def test_client_actor_missing_field(call_ray_start_shared):
+    """
+    Test remote calls with large (multiple chunk) arguments
+    """
+
+    class SomeSuperClass:
+        def parent_func(self):
+            return 24
+
+    with ray_start_client_server_for_address(call_ray_start_shared) as ray:
+
+        @ray.remote
+        class SomeClass(SomeSuperClass):
+            def child_func(self):
+                return 42
+
+        handle = SomeClass.remote()
+        assert ray.get(handle.parent_func.remote()) == 24
+        assert ray.get(handle.child_func.remote()) == 42
+        with pytest.raises(AttributeError):
+            # We should raise attribute error when accessing a non-existent func
+            SomeClass.nonexistent_func
+
+
+def test_serialize_client_actor_handle(call_ray_start_shared):
+    """
+    Test that client actor handles can be serialized. This is needed since
+    some objects like datasets keep a handle to actors.
+
+    See https://github.com/ray-project/ray/issues/31581 for more context
+    """
+
+    with ray_start_client_server_for_address(call_ray_start_shared) as ray:
+
+        @ray.remote
+        class SomeClass:
+            def __init__(self, value):
+                self.value = value
+
+            def get_value(self):
+                return self.value
+
+        handle = SomeClass.remote(1234)
+        serialized = cloudpickle.dumps(handle)
+        deserialized = cloudpickle.loads(serialized)
+        assert ray.get(deserialized.get_value.remote()) == 1234
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -827,7 +827,7 @@ def test_large_remote_call(call_ray_start_shared):
 
         # 1024x1024x16 f64's =~ 128 MiB. Chunking size is 64 MiB, so guarantees
         # that transferring argument requires multiple chunks.
-        assert OBJECT_TRANSFER_CHUNK_SIZE < 2 ** 20 * 128
+        assert OBJECT_TRANSFER_CHUNK_SIZE < 2**20 * 128
         large_obj = np.random.random((1024, 1024, 16))
         assert ray.get(f.remote(large_obj)) == (1024, 1024, 16)
         assert ray.get(f2.remote(123, large_obj)) == (1024, 1024, 16)

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -482,14 +482,14 @@ class ClientActorHandle(ClientStub):
 
         if self._method_num_returns is None:
             self._init_class_info()
-        if key in self._method_signatures:
-            return ClientRemoteMethod(
-                self,
-                key,
-                self._method_num_returns.get(key),
-                self._method_signatures.get(key),
-            )
-        raise AttributeError(f"ClientActorRef has no attribute '{key}'")
+        if key not in self._method_signatures:
+            raise AttributeError(f"ClientActorRef has no attribute '{key}'")
+        return ClientRemoteMethod(
+            self,
+            key,
+            self._method_num_returns.get(key),
+            self._method_signatures.get(key),
+        )
 
     def __repr__(self):
         return "ClientActorHandle(%s)" % (self.actor_ref.id.hex())

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 # The maximum field value for int32 id's -- which is also the maximum
 # number of simultaneous in-flight requests.
-INT32_MAX = (2**31) - 1
+INT32_MAX = (2 ** 31) - 1
 
 # gRPC status codes that the client shouldn't attempt to recover from
 # Resource exhausted: Server is low on resources, or has hit the max number
@@ -80,10 +80,10 @@ GRPC_OPTIONS = [
 CLIENT_SERVER_MAX_THREADS = float(os.getenv("RAY_CLIENT_SERVER_MAX_THREADS", 100))
 
 # Large objects are chunked into 64 MiB messages
-OBJECT_TRANSFER_CHUNK_SIZE = 64 * 2**20
+OBJECT_TRANSFER_CHUNK_SIZE = 64 * 2 ** 20
 
 # Warn the user if the object being transferred is larger than 2 GiB
-OBJECT_TRANSFER_WARNING_SIZE = 2 * 2**30
+OBJECT_TRANSFER_WARNING_SIZE = 2 * 2 ** 30
 
 
 class ClientObjectRef(raylet.ObjectRef):
@@ -475,12 +475,14 @@ class ClientActorHandle(ClientStub):
     def __getattr__(self, key):
         if self._method_num_returns is None:
             self._init_class_info()
-        return ClientRemoteMethod(
-            self,
-            key,
-            self._method_num_returns.get(key),
-            self._method_signatures.get(key),
-        )
+        if key in self._method_signatures:
+            return ClientRemoteMethod(
+                self,
+                key,
+                self._method_num_returns.get(key),
+                self._method_signatures.get(key),
+            )
+        raise AttributeError(f"ClientActorRef has no attribute '{key}'")
 
     def __repr__(self):
         return "ClientActorHandle(%s)" % (self.actor_ref.id.hex())

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 # The maximum field value for int32 id's -- which is also the maximum
 # number of simultaneous in-flight requests.
-INT32_MAX = (2 ** 31) - 1
+INT32_MAX = (2**31) - 1
 
 # gRPC status codes that the client shouldn't attempt to recover from
 # Resource exhausted: Server is low on resources, or has hit the max number
@@ -80,10 +80,10 @@ GRPC_OPTIONS = [
 CLIENT_SERVER_MAX_THREADS = float(os.getenv("RAY_CLIENT_SERVER_MAX_THREADS", 100))
 
 # Large objects are chunked into 64 MiB messages
-OBJECT_TRANSFER_CHUNK_SIZE = 64 * 2 ** 20
+OBJECT_TRANSFER_CHUNK_SIZE = 64 * 2**20
 
 # Warn the user if the object being transferred is larger than 2 GiB
-OBJECT_TRANSFER_WARNING_SIZE = 2 * 2 ** 30
+OBJECT_TRANSFER_WARNING_SIZE = 2 * 2**30
 
 
 class ClientObjectRef(raylet.ObjectRef):

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -473,6 +473,13 @@ class ClientActorHandle(ClientStub):
         return self.actor_ref
 
     def __getattr__(self, key):
+        if key == "_method_num_returns":
+            # We need to explicitly handle this value since it is used below,
+            # otherwise we may end up infinitely recursing when deserializing.
+            # This can happen after unpickling an object but before
+            # _method_num_returns is correctly populated.
+            raise AttributeError(f"ClientActorRef has no attribute '{key}'")
+
         if self._method_num_returns is None:
             self._init_class_info()
         if key in self._method_signatures:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Closes #31581

This is currently breaking serialization for client actor handles, which in turn breaks serialization for ray datasets. It also causes confusing error messages when accessing nonexistent fields on actor handles.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
