### PR TITLE
[tune][docs] quick doc search pass

### DIFF
--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -89,7 +89,9 @@ parts:
         title: Ray Tune
         sections:
           - file: tune/getting-started
+            title: "Getting Started"
           - file: tune/key-concepts
+            title: "Key Concepts"
           - file: tune/tutorials/overview
             sections:
               - file: tune/tutorials/tune-run

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -49,16 +49,16 @@ You can install the nightly Ray wheels via the following links. These daily rele
   # pip install -U LINK_TO_WHEEL.whl
 
 
-=============================================== ================================================  ====================  =======================
-       Linux (x86_64)                                   Linux (arm64/aarch64)                      MacOS                 Windows (beta)
-=============================================== ================================================  ====================  =======================
-`Linux Python 3.10 (x86_64)`_                    `Linux Python 3.10 (aarch64)`_                   `MacOS Python 3.10`_  `Windows Python 3.10`_
-`Linux Python 3.9 (x86_64)`_                     `Linux Python 3.9 (aarch64)`_                   `MacOS Python 3.9`_   `Windows Python 3.9`_
-`Linux Python 3.8 (x86_64)`_                     `Linux Python 3.8 (aarch64)`_                   `MacOS Python 3.8`_   `Windows Python 3.8`_
-`Linux Python 3.7 (x86_64)`_                     `Linux Python 3.7 (aarch64)`_                   `MacOS Python 3.7`_   `Windows Python 3.7`_
-`Linux Python 3.6 (x86_64)`_                     `Linux Python 3.6 (aarch64)`_                   `MacOS Python 3.6`_
-`Linux Python 3.11 (x86_64) (EXPERIMENTAL)`_     `Linux Python 3.11 (aarch64) (EXPERIMENTAL)`_
-=============================================== ================================================  ====================  =======================
+=============================================== ================================================  =====================  =======================
+Linux (x86_64)                                  Linux (arm64/aarch64)                             MacOS                  Windows (beta)
+=============================================== ================================================  =====================  =======================
+`Linux Python 3.10 (x86_64)`_                   `Linux Python 3.10 (aarch64)`_                    `MacOS Python 3.10`_   `Windows Python 3.10`_
+`Linux Python 3.9 (x86_64)`_                    `Linux Python 3.9 (aarch64)`_                     `MacOS Python 3.9`_    `Windows Python 3.9`_
+`Linux Python 3.8 (x86_64)`_                    `Linux Python 3.8 (aarch64)`_                     `MacOS Python 3.8`_    `Windows Python 3.8`_
+`Linux Python 3.7 (x86_64)`_                    `Linux Python 3.7 (aarch64)`_                     `MacOS Python 3.7`_    `Windows Python 3.7`_
+`Linux Python 3.6 (x86_64)`_                    `Linux Python 3.6 (aarch64)`_                     `MacOS Python 3.6`_
+`Linux Python 3.11 (x86_64) (EXPERIMENTAL)`_    `Linux Python 3.11 (aarch64) (EXPERIMENTAL)`_
+=============================================== ================================================  =====================  =======================
 
 .. note::
 

--- a/doc/source/tune/api_docs/env.rst
+++ b/doc/source/tune/api_docs/env.rst
@@ -1,8 +1,9 @@
 
 .. _tune-env-vars:
 
-Environment variables
----------------------
+Environment variables used by Ray Tune
+--------------------------------------
+
 Some of Ray Tune's behavior can be configured using environment variables.
 These are the environment variables Ray Tune currently considers:
 

--- a/doc/source/tune/api_docs/execution.rst
+++ b/doc/source/tune/api_docs/execution.rst
@@ -1,5 +1,5 @@
-Execution (Tuner, tune.Experiment)
-=====================================
+Tune Execution (Tuner, tune.Experiment)
+=======================================
 
 .. _tune-run-ref:
 

--- a/doc/source/tune/api_docs/integration.rst
+++ b/doc/source/tune/api_docs/integration.rst
@@ -1,7 +1,7 @@
 .. _tune-integration:
 
-External library integrations (tune.integration)
-================================================
+External library integrations for Ray Tune (tune.integration)
+=============================================================
 
 .. contents::
     :local:

--- a/doc/source/tune/api_docs/logging.rst
+++ b/doc/source/tune/api_docs/logging.rst
@@ -1,7 +1,7 @@
 .. _loggers-docstring:
 
-Loggers (tune.logger)
-=====================
+Tune Loggers (tune.logger)
+==========================
 
 Tune automatically uses loggers for TensorBoard, CSV, and JSON formats.
 By default, Tune only logs the returned result dictionaries from the training function.

--- a/doc/source/tune/api_docs/reporters.rst
+++ b/doc/source/tune/api_docs/reporters.rst
@@ -1,8 +1,8 @@
 .. _tune-reporter-doc:
 
 
-Console Output (Reporters)
-==========================
+Tune Console Output (Reporters)
+===============================
 
 By default, Tune reports experiment progress periodically to the command-line as follows.
 

--- a/doc/source/tune/api_docs/schedulers.rst
+++ b/doc/source/tune/api_docs/schedulers.rst
@@ -1,7 +1,7 @@
 .. _tune-schedulers:
 
-Trial Schedulers (tune.schedulers)
-==================================
+Tune Trial Schedulers (tune.schedulers)
+=======================================
 
 In Tune, some hyperparameter optimization algorithms are written as "scheduling algorithms".
 These Trial Schedulers can early terminate bad trials, pause trials, clone trials,

--- a/doc/source/tune/api_docs/search_space.rst
+++ b/doc/source/tune/api_docs/search_space.rst
@@ -1,7 +1,7 @@
 .. _tune-search-space:
 
-Search Space API
-================
+Tune Search Space API
+=====================
 
 .. _tune-sample-docs:
 

--- a/doc/source/tune/api_docs/sklearn.rst
+++ b/doc/source/tune/api_docs/sklearn.rst
@@ -1,7 +1,7 @@
 .. _tune-sklearn-docs:
 
-Scikit-Learn API  (tune.sklearn)
-================================
+Tune Scikit-Learn API  (tune.sklearn)
+=====================================
 
 .. _tunegridsearchcv-docs:
 

--- a/doc/source/tune/api_docs/stoppers.rst
+++ b/doc/source/tune/api_docs/stoppers.rst
@@ -1,7 +1,7 @@
 .. _tune-stoppers:
 
 Tune Stopping mechanisms (tune.stopper)
-======================================
+=======================================
 
 In addition to Trial Schedulers like :ref:`ASHA <tune-scheduler-hyperband>`, where a number of
 trials are stopped if they perform subpar, Ray Tune also supports custom stopping mechanisms to stop trials early. They can also stop the entire experiment after a condition is met.

--- a/doc/source/tune/api_docs/stoppers.rst
+++ b/doc/source/tune/api_docs/stoppers.rst
@@ -1,7 +1,7 @@
 .. _tune-stoppers:
 
-Stopping mechanisms (tune.stopper)
-==================================
+Tune Stopping mechanisms (tune.stopper)
+======================================
 
 In addition to Trial Schedulers like :ref:`ASHA <tune-scheduler-hyperband>`, where a number of
 trials are stopped if they perform subpar, Ray Tune also supports custom stopping mechanisms to stop trials early. They can also stop the entire experiment after a condition is met.

--- a/doc/source/tune/api_docs/suggestion.rst
+++ b/doc/source/tune/api_docs/suggestion.rst
@@ -1,7 +1,7 @@
 .. _tune-search-alg:
 
-Search Algorithms (tune.search)
-===============================
+Tune Search Algorithms (tune.search)
+====================================
 
 Tune's Search Algorithms are wrappers around open-source optimization libraries for efficient hyperparameter selection.
 Each library has a specific way of defining the search space - please refer to their documentation for more details.
@@ -17,8 +17,8 @@ You can utilize these search algorithms as follows:
     results = tuner.fit()
 
 
-Saving and Restoring
---------------------
+Saving and Restoring Tune Runs
+------------------------------
 
 .. TODO: what to do about this section? It doesn't really belong here and is not worth its own guide.
 .. TODO: at least check that this pseudo-code runs.

--- a/doc/source/tune/api_docs/syncing.rst
+++ b/doc/source/tune/api_docs/syncing.rst
@@ -1,5 +1,5 @@
-Syncing (tune.SyncConfig, tune.Syncer)
-======================================
+Syncing in Tune (tune.SyncConfig, tune.Syncer)
+==============================================
 
 .. _tune-syncconfig:
 

--- a/doc/source/tune/api_docs/trainable.rst
+++ b/doc/source/tune/api_docs/trainable.rst
@@ -4,8 +4,8 @@
     API does not really have a signature to just describe.
 .. TODO: Reusing actors and advanced resources allocation seem ill-placed.
 
-Training (tune.Trainable, session.report)
-==========================================
+Training in Tune (tune.Trainable, session.report)
+=================================================
 
 Training can be done with either a **Function API** (:ref:`session.report <tune-function-docstring>`) or **Class API** (:ref:`tune.Trainable <tune-trainable-docstring>`).
 
@@ -18,8 +18,8 @@ For the sake of example, let's maximize this objective function:
 
 .. _tune-function-api:
 
-Function API
-------------
+Tune's Function API
+-------------------
 
 The Function API allows you to define a custom training function that Tune will run in parallel Ray actor processes,
 one for each Tune trial.
@@ -80,8 +80,8 @@ references to framework-specific checkpoints such as `TensorflowCheckpoint`.
 
 .. _tune-class-api:
 
-Trainable Class API
--------------------
+Tune's Trainable Class API
+--------------------------
 
 .. caution:: Do not use ``session.report`` within a ``Trainable`` class.
 
@@ -180,8 +180,8 @@ Use ``validate_save_restore`` to catch ``save_checkpoint``/``load_checkpoint`` e
 
 
 
-Advanced: Reusing Actors
-~~~~~~~~~~~~~~~~~~~~~~~~
+Advanced: Reusing Actors in Tune
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. note:: This feature is only for the Trainable Class API.
 
@@ -217,8 +217,8 @@ It is up to the user to correctly update the hyperparameters of your trainable.
             return True
 
 
-Comparing the Function API and Class API
-----------------------------------------
+Comparing Tune's Function API and Class API
+-------------------------------------------
 
 Here are a few key concepts and what they look like for the Function and Class API's.
 

--- a/doc/source/tune/examples/exercises.rst
+++ b/doc/source/tune/examples/exercises.rst
@@ -1,5 +1,5 @@
-Exercises
----------
+Tune Exercises
+--------------
 
 Learn how to use Tune in your browser with the following Colab-based exercises.
 

--- a/doc/source/tune/examples/experiment-tracking.rst
+++ b/doc/source/tune/examples/experiment-tracking.rst
@@ -1,5 +1,5 @@
-Experiment Tracking Examples
-----------------------------
+Tune Experiment Tracking Examples
+---------------------------------
 
 Ray Tune integrates with some popular Experiment tracking and management tools,
 such as CometML, or Weights & Biases. If you're interested in learning how

--- a/doc/source/tune/examples/hpo-frameworks.rst
+++ b/doc/source/tune/examples/hpo-frameworks.rst
@@ -1,5 +1,5 @@
-Hyperparameter Optimization Framework Examples
-----------------------------------------------
+Tune Hyperparameter Optimization Framework Examples
+---------------------------------------------------
 
 Tune integrates with a wide variety of hyperparameter optimization frameworks
 and their respective search algorithms. Here you can find detailed examples

--- a/doc/source/tune/examples/index.rst
+++ b/doc/source/tune/examples/index.rst
@@ -1,8 +1,8 @@
 .. _tune-examples-ref:
 
-========
-Examples
-========
+=================
+Ray Tune Examples
+=================
 
 .. tip:: Check out :ref:`the Tune User Guides <tune-guides>` To learn more about Tune's features in depth.
 

--- a/doc/source/tune/examples/ml-frameworks.rst
+++ b/doc/source/tune/examples/ml-frameworks.rst
@@ -1,5 +1,5 @@
-ML Framework Examples
----------------------
+Examples using Ray Tune with ML Frameworks
+------------------------------------------
 
 Ray Tune integrates with many popular machine learning frameworks.
 Here you find a few practical examples showing you how to tune your models.

--- a/doc/source/tune/examples/pbt_guide.ipynb
+++ b/doc/source/tune/examples/pbt_guide.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "(pbt-guide-ref)=\n",
     "\n",
-    "# A Guide to Population Based Training\n",
+    "# A Guide to Population Based Training with Tune\n",
     "\n",
     "Tune includes a distributed implementation of [Population Based Training (PBT)](https://www.deepmind.com/blog/population-based-training-of-neural-networks) as\n",
     "a [scheduler](tune-scheduler-pbt).\n",

--- a/doc/source/tune/examples/tune-xgboost.ipynb
+++ b/doc/source/tune/examples/tune-xgboost.ipynb
@@ -5,7 +5,7 @@
    "id": "edce67b9",
    "metadata": {},
    "source": [
-    "# Tuning XGBoost parameters\n",
+    "# Tuning XGBoost hyperparameters with Ray Tune\n",
     "\n",
     "(tune-xgboost-ref)=\n",
     "\n",
@@ -82,9 +82,6 @@
    "execution_count": 1,
    "id": "77b3c71c",
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "vscode": {
      "languageId": "python"
     }
@@ -137,11 +134,7 @@
   {
    "cell_type": "markdown",
    "id": "ec2a13f8",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "As you can see, the code is quite simple. First, the dataset is loaded and split\n",
     "into a `test` and `train` set. The XGBoost model is trained with `xgb.train()`.\n",
@@ -272,9 +265,6 @@
    "execution_count": 2,
    "id": "35073e88",
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "vscode": {
      "languageId": "python"
     }
@@ -306,11 +296,7 @@
   {
    "cell_type": "markdown",
    "id": "69cf0c13",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The rest stays the same. Please note that we do not adjust the `num_boost_rounds` here.\n",
     "The result should also show a high accuracy of over 90%.\n",
@@ -342,9 +328,6 @@
    "execution_count": 3,
    "id": "ff856a82",
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "vscode": {
      "languageId": "python"
     }
@@ -354,7 +337,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-07-22 15:52:52,004\tINFO services.py:1483 -- View the Ray dashboard at \u001b[1m\u001b[32mhttp://127.0.0.1:8268\u001b[39m\u001b[22m\n",
+      "2022-07-22 15:52:52,004\tINFO services.py:1483 -- View the Ray dashboard at \u001B[1m\u001B[32mhttp://127.0.0.1:8268\u001B[39m\u001B[22m\n",
       "2022-07-22 15:52:55,858\tWARNING function_trainable.py:619 -- Function checkpointing is disabled. This may result in unexpected behavior when using checkpointing features or certain schedulers. To enable, set the train function arguments to be `func(config, checkpoint_dir=None)`.\n"
      ]
     },
@@ -639,11 +622,7 @@
   {
    "cell_type": "markdown",
    "id": "4999e858",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "As you can see, the changes in the actual training function are minimal. Instead of\n",
     "returning the accuracy value, we report it back to Tune using `session.report()`.\n",
@@ -743,9 +722,6 @@
    "execution_count": 9,
    "id": "d08b5b0a",
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "vscode": {
      "languageId": "python"
     }
@@ -1172,11 +1148,7 @@
   {
    "cell_type": "markdown",
    "id": "20732fe4",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The output of our run could look like this:\n",
     "\n",
@@ -1227,9 +1199,6 @@
    "execution_count": 8,
    "id": "7d1b20a3",
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "vscode": {
      "languageId": "python"
     }
@@ -1267,8 +1236,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[2m\u001b[1m\u001b[36m(scheduler +24m15s)\u001b[0m Tip: use `ray status` to view detailed cluster status. To disable these messages, set RAY_SCHEDULER_EVENTS=0.\n",
-      "\u001b[2m\u001b[1m\u001b[33m(scheduler +24m15s)\u001b[0m Error: No available node types can fulfill resource request {'CPU': 1.0, 'GPU': 0.1}. Add suitable node types to this cluster to resolve this issue.\n"
+      "\u001B[2m\u001B[1m\u001B[36m(scheduler +24m15s)\u001B[0m Tip: use `ray status` to view detailed cluster status. To disable these messages, set RAY_SCHEDULER_EVENTS=0.\n",
+      "\u001B[2m\u001B[1m\u001B[33m(scheduler +24m15s)\u001B[0m Error: No available node types can fulfill resource request {'CPU': 1.0, 'GPU': 0.1}. Add suitable node types to this cluster to resolve this issue.\n"
      ]
     },
     {
@@ -1283,21 +1252,21 @@
      "evalue": "",
      "output_type": "error",
      "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-      "\u001b[0;32m/var/folders/b2/0_91bd757rz02lrmr920v0gw0000gn/T/ipykernel_48774/3983013579.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     19\u001b[0m     \u001b[0mparam_space\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mconfig\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     20\u001b[0m )\n\u001b[0;32m---> 21\u001b[0;31m \u001b[0mresults\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtuner\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/coding/ray/python/ray/tune/tuner.py\u001b[0m in \u001b[0;36mfit\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    190\u001b[0m         \"\"\"\n\u001b[1;32m    191\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 192\u001b[0;31m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_is_ray_client\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    193\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    194\u001b[0m                 \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_local_tuner\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/coding/ray/python/ray/tune/impl/tuner_internal.py\u001b[0m in \u001b[0;36mfit\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    159\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mtrainable\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    160\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 161\u001b[0;31m     \u001b[0;32mdef\u001b[0m \u001b[0mfit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mResultGrid\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    162\u001b[0m         \u001b[0mtrainable\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_convert_trainable\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_trainable\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    163\u001b[0m         \u001b[0;32massert\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_experiment_checkpoint_dir\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/coding/ray/python/ray/tune/impl/tuner_internal.py\u001b[0m in \u001b[0;36m_fit_internal\u001b[0;34m(self, trainable, param_space)\u001b[0m\n\u001b[1;32m    256\u001b[0m                 \u001b[0mscheduler\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_tune_config\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mscheduler\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    257\u001b[0m                 \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_run_config\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 258\u001b[0;31m                 \u001b[0mlog_to_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_run_config\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlog_to_file\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    259\u001b[0m             ),\n\u001b[1;32m    260\u001b[0m             \u001b[0;34m**\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_tuner_kwargs\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/coding/ray/python/ray/tune/tune.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(run_or_experiment, name, metric, mode, stop, time_budget_s, config, resources_per_trial, num_samples, local_dir, search_alg, scheduler, keep_checkpoints_num, checkpoint_score_attr, checkpoint_freq, checkpoint_at_end, verbose, progress_reporter, log_to_file, trial_name_creator, trial_dirname_creator, sync_config, export_formats, max_failures, fail_fast, restore, server_port, resume, reuse_actors, trial_executor, raise_on_failed_trial, callbacks, max_concurrent_trials, _experiment_checkpoint_dir, _remote)\u001b[0m\n\u001b[1;32m    699\u001b[0m     )\n\u001b[1;32m    700\u001b[0m     \u001b[0;32mwhile\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mrunner\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mis_finished\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mstate\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"signal\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 701\u001b[0;31m         \u001b[0mrunner\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstep\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    702\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mhas_verbosity\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mVerbosity\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mV1_EXPERIMENT\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    703\u001b[0m             \u001b[0m_report_progress\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrunner\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mprogress_reporter\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/coding/ray/python/ray/tune/execution/trial_runner.py\u001b[0m in \u001b[0;36mstep\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    811\u001b[0m             \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdebug\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"Got new trial to run: {next_trial}\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    812\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 813\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_wait_and_handle_event\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnext_trial\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    814\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    815\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_stop_experiment_if_needed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/coding/ray/python/ray/tune/execution/trial_runner.py\u001b[0m in \u001b[0;36m_wait_and_handle_event\u001b[0;34m(self, next_trial)\u001b[0m\n\u001b[1;32m    755\u001b[0m             \u001b[0;31m# Single wait of entire tune loop.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    756\u001b[0m             event = self.trial_executor.get_next_executor_event(\n\u001b[0;32m--> 757\u001b[0;31m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_live_trials\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnext_trial\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    758\u001b[0m             )\n\u001b[1;32m    759\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mevent\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtype\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0m_ExecutorEventType\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPG_READY\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/coding/ray/python/ray/tune/execution/ray_trial_executor.py\u001b[0m in \u001b[0;36mget_next_executor_event\u001b[0;34m(self, live_trials, next_trial_exists)\u001b[0m\n\u001b[1;32m    944\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    945\u001b[0m             ready_futures, _ = ray.wait(\n\u001b[0;32m--> 946\u001b[0;31m                 \u001b[0mfutures_to_wait\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnum_returns\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtimeout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_next_event_wait\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    947\u001b[0m             )\n\u001b[1;32m    948\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/coding/ray/python/ray/_private/client_mode_hook.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    103\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m\"init\"\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0mis_client_mode_enabled_by_default\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    104\u001b[0m                 \u001b[0;32mreturn\u001b[0m \u001b[0mgetattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mray\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 105\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    106\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    107\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mwrapper\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/coding/ray/python/ray/_private/worker.py\u001b[0m in \u001b[0;36mwait\u001b[0;34m(object_refs, num_returns, timeout, fetch_local)\u001b[0m\n\u001b[1;32m   2386\u001b[0m             \u001b[0mtimeout_milliseconds\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2387\u001b[0m             \u001b[0mworker\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcurrent_task_id\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2388\u001b[0;31m             \u001b[0mfetch_local\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2389\u001b[0m         )\n\u001b[1;32m   2390\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mready_ids\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mremaining_ids\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32mpython/ray/_raylet.pyx\u001b[0m in \u001b[0;36mray._raylet.CoreWorker.wait\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;32mpython/ray/_raylet.pyx\u001b[0m in \u001b[0;36mray._raylet.check_status\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mKeyboardInterrupt\u001B[0m                         Traceback (most recent call last)",
+      "\u001B[0;32m/var/folders/b2/0_91bd757rz02lrmr920v0gw0000gn/T/ipykernel_48774/3983013579.py\u001B[0m in \u001B[0;36m<module>\u001B[0;34m\u001B[0m\n\u001B[1;32m     19\u001B[0m     \u001B[0mparam_space\u001B[0m\u001B[0;34m=\u001B[0m\u001B[0mconfig\u001B[0m\u001B[0;34m,\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m     20\u001B[0m )\n\u001B[0;32m---> 21\u001B[0;31m \u001B[0mresults\u001B[0m \u001B[0;34m=\u001B[0m \u001B[0mtuner\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mfit\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m",
+      "\u001B[0;32m~/coding/ray/python/ray/tune/tuner.py\u001B[0m in \u001B[0;36mfit\u001B[0;34m(self)\u001B[0m\n\u001B[1;32m    190\u001B[0m         \"\"\"\n\u001B[1;32m    191\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m--> 192\u001B[0;31m         \u001B[0;32mif\u001B[0m \u001B[0;32mnot\u001B[0m \u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m_is_ray_client\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m    193\u001B[0m             \u001B[0;32mtry\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m    194\u001B[0m                 \u001B[0;32mreturn\u001B[0m \u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m_local_tuner\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mfit\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;32m~/coding/ray/python/ray/tune/impl/tuner_internal.py\u001B[0m in \u001B[0;36mfit\u001B[0;34m(self)\u001B[0m\n\u001B[1;32m    159\u001B[0m         \u001B[0;32mreturn\u001B[0m \u001B[0mtrainable\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m    160\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m--> 161\u001B[0;31m     \u001B[0;32mdef\u001B[0m \u001B[0mfit\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mself\u001B[0m\u001B[0;34m)\u001B[0m \u001B[0;34m->\u001B[0m \u001B[0mResultGrid\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m    162\u001B[0m         \u001B[0mtrainable\u001B[0m \u001B[0;34m=\u001B[0m \u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m_convert_trainable\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m_trainable\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m    163\u001B[0m         \u001B[0;32massert\u001B[0m \u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m_experiment_checkpoint_dir\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;32m~/coding/ray/python/ray/tune/impl/tuner_internal.py\u001B[0m in \u001B[0;36m_fit_internal\u001B[0;34m(self, trainable, param_space)\u001B[0m\n\u001B[1;32m    256\u001B[0m                 \u001B[0mscheduler\u001B[0m\u001B[0;34m=\u001B[0m\u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m_tune_config\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mscheduler\u001B[0m\u001B[0;34m,\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m    257\u001B[0m                 \u001B[0mname\u001B[0m\u001B[0;34m=\u001B[0m\u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m_run_config\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mname\u001B[0m\u001B[0;34m,\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m--> 258\u001B[0;31m                 \u001B[0mlog_to_file\u001B[0m\u001B[0;34m=\u001B[0m\u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m_run_config\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mlog_to_file\u001B[0m\u001B[0;34m,\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m    259\u001B[0m             ),\n\u001B[1;32m    260\u001B[0m             \u001B[0;34m**\u001B[0m\u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m_tuner_kwargs\u001B[0m\u001B[0;34m,\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;32m~/coding/ray/python/ray/tune/tune.py\u001B[0m in \u001B[0;36mrun\u001B[0;34m(run_or_experiment, name, metric, mode, stop, time_budget_s, config, resources_per_trial, num_samples, local_dir, search_alg, scheduler, keep_checkpoints_num, checkpoint_score_attr, checkpoint_freq, checkpoint_at_end, verbose, progress_reporter, log_to_file, trial_name_creator, trial_dirname_creator, sync_config, export_formats, max_failures, fail_fast, restore, server_port, resume, reuse_actors, trial_executor, raise_on_failed_trial, callbacks, max_concurrent_trials, _experiment_checkpoint_dir, _remote)\u001B[0m\n\u001B[1;32m    699\u001B[0m     )\n\u001B[1;32m    700\u001B[0m     \u001B[0;32mwhile\u001B[0m \u001B[0;32mnot\u001B[0m \u001B[0mrunner\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mis_finished\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m)\u001B[0m \u001B[0;32mand\u001B[0m \u001B[0;32mnot\u001B[0m \u001B[0mstate\u001B[0m\u001B[0;34m[\u001B[0m\u001B[0;34m\"signal\"\u001B[0m\u001B[0;34m]\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m--> 701\u001B[0;31m         \u001B[0mrunner\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mstep\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m    702\u001B[0m         \u001B[0;32mif\u001B[0m \u001B[0mhas_verbosity\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mVerbosity\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mV1_EXPERIMENT\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m    703\u001B[0m             \u001B[0m_report_progress\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mrunner\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mprogress_reporter\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;32m~/coding/ray/python/ray/tune/execution/trial_runner.py\u001B[0m in \u001B[0;36mstep\u001B[0;34m(self)\u001B[0m\n\u001B[1;32m    811\u001B[0m             \u001B[0mlogger\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mdebug\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34mf\"Got new trial to run: {next_trial}\"\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m    812\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m--> 813\u001B[0;31m         \u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m_wait_and_handle_event\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mnext_trial\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m    814\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m    815\u001B[0m         \u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m_stop_experiment_if_needed\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;32m~/coding/ray/python/ray/tune/execution/trial_runner.py\u001B[0m in \u001B[0;36m_wait_and_handle_event\u001B[0;34m(self, next_trial)\u001B[0m\n\u001B[1;32m    755\u001B[0m             \u001B[0;31m# Single wait of entire tune loop.\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m    756\u001B[0m             event = self.trial_executor.get_next_executor_event(\n\u001B[0;32m--> 757\u001B[0;31m                 \u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m_live_trials\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mnext_trial\u001B[0m \u001B[0;32mis\u001B[0m \u001B[0;32mnot\u001B[0m \u001B[0;32mNone\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m    758\u001B[0m             )\n\u001B[1;32m    759\u001B[0m             \u001B[0;32mif\u001B[0m \u001B[0mevent\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mtype\u001B[0m \u001B[0;34m==\u001B[0m \u001B[0m_ExecutorEventType\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mPG_READY\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;32m~/coding/ray/python/ray/tune/execution/ray_trial_executor.py\u001B[0m in \u001B[0;36mget_next_executor_event\u001B[0;34m(self, live_trials, next_trial_exists)\u001B[0m\n\u001B[1;32m    944\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m    945\u001B[0m             ready_futures, _ = ray.wait(\n\u001B[0;32m--> 946\u001B[0;31m                 \u001B[0mfutures_to_wait\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mnum_returns\u001B[0m\u001B[0;34m=\u001B[0m\u001B[0;36m1\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mtimeout\u001B[0m\u001B[0;34m=\u001B[0m\u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m_get_next_event_wait\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m    947\u001B[0m             )\n\u001B[1;32m    948\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;32m~/coding/ray/python/ray/_private/client_mode_hook.py\u001B[0m in \u001B[0;36mwrapper\u001B[0;34m(*args, **kwargs)\u001B[0m\n\u001B[1;32m    103\u001B[0m             \u001B[0;32mif\u001B[0m \u001B[0mfunc\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m__name__\u001B[0m \u001B[0;34m!=\u001B[0m \u001B[0;34m\"init\"\u001B[0m \u001B[0;32mor\u001B[0m \u001B[0mis_client_mode_enabled_by_default\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m    104\u001B[0m                 \u001B[0;32mreturn\u001B[0m \u001B[0mgetattr\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mray\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mfunc\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m__name__\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m*\u001B[0m\u001B[0margs\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0;34m**\u001B[0m\u001B[0mkwargs\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m--> 105\u001B[0;31m         \u001B[0;32mreturn\u001B[0m \u001B[0mfunc\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m*\u001B[0m\u001B[0margs\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0;34m**\u001B[0m\u001B[0mkwargs\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m    106\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m    107\u001B[0m     \u001B[0;32mreturn\u001B[0m \u001B[0mwrapper\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;32m~/coding/ray/python/ray/_private/worker.py\u001B[0m in \u001B[0;36mwait\u001B[0;34m(object_refs, num_returns, timeout, fetch_local)\u001B[0m\n\u001B[1;32m   2386\u001B[0m             \u001B[0mtimeout_milliseconds\u001B[0m\u001B[0;34m,\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m   2387\u001B[0m             \u001B[0mworker\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mcurrent_task_id\u001B[0m\u001B[0;34m,\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m-> 2388\u001B[0;31m             \u001B[0mfetch_local\u001B[0m\u001B[0;34m,\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m   2389\u001B[0m         )\n\u001B[1;32m   2390\u001B[0m         \u001B[0;32mreturn\u001B[0m \u001B[0mready_ids\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mremaining_ids\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;32mpython/ray/_raylet.pyx\u001B[0m in \u001B[0;36mray._raylet.CoreWorker.wait\u001B[0;34m()\u001B[0m\n",
+      "\u001B[0;32mpython/ray/_raylet.pyx\u001B[0m in \u001B[0;36mray._raylet.check_status\u001B[0;34m()\u001B[0m\n",
+      "\u001B[0;31mKeyboardInterrupt\u001B[0m: "
      ]
     }
    ],
@@ -1328,11 +1297,7 @@
   {
    "cell_type": "markdown",
    "id": "ee131861",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Each task thus works with 10% of the available GPU memory. You also have to tell\n",
     "XGBoost to use the `gpu_hist` tree method, so it knows it should use the GPU.\n",

--- a/doc/source/tune/getting-started.rst
+++ b/doc/source/tune/getting-started.rst
@@ -57,8 +57,8 @@ If you know how to do this, skip ahead to the next section.
 
 .. _tutorial-tune-setup:
 
-Setting up Tune for a Training Run
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Setting up a ``Tuner`` for a Training Run with Tune
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Below, we define a function that trains the Pytorch model for multiple epochs.
 This function will be executed on a separate :ref:`Ray Actor (process) <actor-guide>` underneath the hood,

--- a/doc/source/tune/getting-started.rst
+++ b/doc/source/tune/getting-started.rst
@@ -2,11 +2,12 @@
 
 .. TODO: make this an executable notebook later on.
 
-Getting Started
-===============
+Getting Started with Ray Tune
+=============================
 
 This tutorial will walk you through the process of setting up a Tune experiment.
-We'll start with a PyTorch model and show you how to leverage Ray Tune to optimize the hyperparameters of this model.
+To get started, we take a PyTorch model and show you how to leverage Ray Tune to
+optimize the hyperparameters of this model.
 Specifically, we'll leverage early stopping and Bayesian Optimization via HyperOpt to do so.
 
 .. tip:: If you have suggestions on how to improve this tutorial,
@@ -24,8 +25,8 @@ Setting Up a Pytorch Model to Tune
 To start off, let's first import some dependencies.
 We import some PyTorch and TorchVision modules to help us create a model and train it.
 Also, we'll import Ray Tune to help us optimize the model.
-As you can see we use a so-called scheduler, in this case the ``ASHAScheduler`` that we will use for tuning the model
-later in this tutorial.
+As you can see we use a so-called scheduler, in this case the ``ASHAScheduler``
+that we will use for tuning the model later in this tutorial.
 
 .. literalinclude:: /../../python/ray/tune/tests/tutorial.py
    :language: python
@@ -56,8 +57,8 @@ If you know how to do this, skip ahead to the next section.
 
 .. _tutorial-tune-setup:
 
-Setting up Tune
-~~~~~~~~~~~~~~~
+Setting up Tune for a Training Run
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Below, we define a function that trains the Pytorch model for multiple epochs.
 This function will be executed on a separate :ref:`Ray Actor (process) <actor-guide>` underneath the hood,
@@ -92,8 +93,8 @@ You can use this to plot the performance of this trial.
     To limit the number of concurrent trials, use the :ref:`ConcurrencyLimiter <limiter>`.
 
 
-Early Stopping with ASHA
-~~~~~~~~~~~~~~~~~~~~~~~~
+Early Stopping with Adaptive Successive Halving (ASHAScheduler)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Let's integrate early stopping into our optimization process. Let's use :ref:`ASHA <tune-scheduler-hyperband>`, a scalable algorithm for `principled early stopping`_.
 
@@ -129,8 +130,8 @@ You can also use :ref:`TensorBoard <tensorboard>` for visualizing results.
     $ tensorboard --logdir {logdir}
 
 
-Search Algorithms in Tune
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Using Search Algorithms in Tune
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In addition to :ref:`TrialSchedulers <tune-schedulers>`, you can further optimize your hyperparameters
 by using an intelligent search technique like Bayesian Optimization.
@@ -146,8 +147,8 @@ Note that each library has a specific way of defining the search space.
 
 .. note:: Tune allows you to use some search algorithms in combination with different trial schedulers. See :ref:`this page for more details <tune-schedulers>`.
 
-Evaluate your model
-~~~~~~~~~~~~~~~~~~~
+Evaluating Your Model after Tuning
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can evaluate best trained model using the :ref:`ExperimentAnalysis object <tune-analysis-docs>` to retrieve the best model:
 

--- a/doc/source/tune/index.rst
+++ b/doc/source/tune/index.rst
@@ -214,8 +214,8 @@ Feel free to submit a pull-request adding (or requesting a removal!) of a listed
 
 
 
-Learn More
-----------
+Learn More About Ray Tune
+-------------------------
 
 Below you can find blog posts and talks about Ray Tune:
 

--- a/doc/source/tune/key-concepts.rst
+++ b/doc/source/tune/key-concepts.rst
@@ -1,8 +1,8 @@
 .. _tune-60-seconds:
 
-============
-Key Concepts
-============
+========================
+Key Concepts of Ray Tune
+========================
 
 .. TODO: should we introduce checkpoints as well?
 .. TODO: should we at least mention "Stopper" classes here?
@@ -24,8 +24,8 @@ The following figure shows an overview of these components, which we cover in de
 
 .. _tune_60_seconds_trainables:
 
-Trainables
-----------
+Ray Tune Trainables
+-------------------
 
 In short, a :ref:`Trainable <trainable-docs>` is an object that you can pass into a Tune run.
 Ray Tune has two ways of defining a `trainable`, namely the :ref:`Function API <tune-function-api>`
@@ -72,8 +72,8 @@ Next, let's have a closer look at what the ``config`` dictionary is that you pas
 
 .. _tune-key-concepts-search-spaces:
 
-Search Spaces
--------------
+Tune Search Spaces
+------------------
 
 To optimize your *hyperparameters*, you have to define a *search space*.
 A search space defines valid values for your hyperparameters and can specify
@@ -93,8 +93,8 @@ Here's an example covering all search space functions. Again,
 
 .. _tune_60_seconds_trials:
 
-Trials
-------
+Tune Trials
+-----------
 
 You use :ref:`Tuner.fit <tune-run-ref>` to execute and manage hyperparameter tuning and generate your `trials`.
 At a minimum, your ``Tuner`` call takes in a trainable as first argument, and a ``param_space`` dictionary
@@ -161,8 +161,8 @@ check out the :ref:`Tuner API reference <tune-run-ref>`.
 
 .. _search-alg-ref:
 
-Search Algorithms
------------------
+Tune Search Algorithms
+----------------------
 
 To optimize the hyperparameters of your training process, you use
 a :ref:`Search Algorithm <tune-search-alg>` which suggests hyperparameter configurations.
@@ -270,8 +270,8 @@ This way of stopping trials with explicit rules is useful, but in many cases we 
 
 .. _schedulers-ref:
 
-Schedulers
-----------
+Tune Schedulers
+---------------
 
 To make your training process more efficient, you can use a :ref:`Trial Scheduler <tune-schedulers>`.
 For instance, in our ``trainable`` example minimizing a function in a training loop, we used ``session.report()``.
@@ -348,8 +348,8 @@ Learn more about trial schedulers in :ref:`the scheduler API documentation <sche
 
 .. _tune-concepts-analysis:
 
-Analyses
---------
+Tune Run Analyses
+-----------------
 
 ``Tuner.fit()`` returns an :ref:`ResultGrid <tune-analysis-docs>` object which has methods you can use for
 analyzing your training.

--- a/doc/source/tune/tutorials/tune-checkpoints.rst
+++ b/doc/source/tune/tutorials/tune-checkpoints.rst
@@ -1,5 +1,5 @@
-A Guide To Using Checkpoints
-============================
+A Guide To Using Tune Checkpoints
+=================================
 
 .. _tune-two-types-of-ckpt:
 
@@ -61,8 +61,9 @@ Generally we consider three cases:
 
 The default option here is 3, which will be automatically used if nothing else is configured.
 
-Using a shared directory
-~~~~~~~~~~~~~~~~~~~~~~~~
+Using a shared directory for checkpoints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 If all Ray nodes have access to a shared filesystem, e.g. via NFS, they can all write to this directory.
 In this case, we don't need any synchronization at all, as it is implicitly done by the operating system.
 
@@ -90,8 +91,9 @@ shared directory) for further processing.
 
 .. _tune-cloud-checkpointing:
 
-Using cloud storage
-~~~~~~~~~~~~~~~~~~~
+Using cloud storage for Tune checkpoints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 If all nodes have access to cloud storage, e.g. S3 or GS, the remote trials can automatically synchronize their
 checkpoints. For the filesystem, we end up with a similar situation as in the first case,
 only that the consolidated directory including all logs and checkpoints lives on cloud storage.
@@ -147,8 +149,9 @@ The consolidated data will live be available in the cloud bucket. This means tha
 e.g. the best checkpoint further, you will first have to fetch it from the cloud storage.
 
 
-Default syncing (no shared/cloud storage)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Default syncing Tune checkpoints (no shared/cloud storage)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 If you're using neither a shared filesystem nor cloud storage, Ray Tune will resort to the
 default syncing mechanisms, which utilizes ``rsync`` (via SSH) to synchronize checkpoints across
 nodes.
@@ -213,13 +216,13 @@ but it will also lead to more synchronization overhead (as SSH is usually slow).
 As in the first case, the driver (on the head node) will have access to all checkpoints locally
 for further processing.
 
-Checkpointing examples
-----------------------
+Tune checkpointing examples
+---------------------------
 
 Let's cover how to configure your checkpoints storage location, checkpointing frequency, and how to resume from a previous run.
 
-A simple (cloud) checkpointing example
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A simple (cloud) checkpointing example with Tune
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Cloud storage-backed Tune checkpointing is the recommended best practice for both performance and reliability reasons.
 It also enables checkpointing if using Ray on Kubernetes, which does not work out of the box with rsync-based sync,
@@ -312,8 +315,8 @@ Please see the documentation of
 
 .. _rsync-checkpointing:
 
-A simple local/rsync checkpointing example
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A simple local/rsync checkpointing example with Tune
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Local or rsync checkpointing can be a good option if:
 
@@ -353,8 +356,8 @@ Let's take a look at an example:
 
 .. _tune-distributed-checkpointing:
 
-Distributed Checkpointing
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Distributed Checkpointing with Ray Tune
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 On a multinode cluster, Tune automatically creates a copy of all trial checkpoints on the head node.
 This requires the Ray cluster to be started with the :ref:`cluster launcher <cluster-index>` and also

--- a/doc/source/tune/tutorials/tune-distributed.rst
+++ b/doc/source/tune/tutorials/tune-distributed.rst
@@ -1,7 +1,7 @@
 .. _tune-distributed-ref:
 
-Tune Distributed Experiments
-============================
+Running  Distributed Experiments with Ray Tune
+==============================================
 
 Tune is commonly used for large-scale distributed hyperparameter optimization. This page will overview how to setup and launch a distributed experiment along with :ref:`commonly used commands <tune-distributed-common>` for Tune when running distributed experiments.
 
@@ -19,8 +19,8 @@ To run a distributed experiment with Tune, you need to:
 
 .. tune-distributed-cloud:
 
-Example: Tune on AWS VMs
-------------------------
+Example: Distributed Tune on AWS VMs
+------------------------------------
 
 Follow the instructions below to launch nodes on AWS (using the Deep Learning AMI). See the :ref:`cluster setup documentation <cluster-index>`. Save the below cluster configuration (``tune-default.yaml``):
 
@@ -55,10 +55,11 @@ Analyze your results on TensorBoard by starting TensorBoard on the remote head m
 Note that you can customize the directory of results by specifying: ``air.RunConfig(local_dir=..)``, taken in by ``Tuner``. You can then point TensorBoard to that directory to visualize results. You can also use `awless <https://github.com/wallix/awless>`_ for easy cluster management on AWS.
 
 
-Running a distributed experiment
---------------------------------
+Running a distributed Tune experiment
+-------------------------------------
 
-Running a distributed (multi-node) experiment requires Ray to be started already. You can do this on local machines or on the cloud.
+Running a distributed (multi-node) experiment requires Ray to be started already.
+You can do this on local machines or on the cloud.
 
 Across your machines, Tune will automatically detect the number of GPUs and CPUs without you needing to manage ``CUDA_VISIBLE_DEVICES``.
 
@@ -96,8 +97,8 @@ If you used a cluster configuration (starting a cluster with ``ray up`` or ``ray
     2. If the Ray cluster is already started, you should not need to run anything on the worker nodes.
 
 
-Syncing
--------
+Syncing Checkpoints in a distributed Tune run
+---------------------------------------------
 
 In a distributed experiment, you should try to use :ref:`cloud checkpointing <tune-cloud-checkpointing>` to
 reduce synchronization overhead. For this, you just have to specify an ``upload_dir`` in the
@@ -121,11 +122,10 @@ For more details or customization, see our
 :ref:`guide on checkpointing <tune-checkpoint-syncing>`.
 
 
-
 .. _tune-distributed-spot:
 
-Pre-emptible Instances (Cloud)
-------------------------------
+Tune runs on pre-emptible instances
+-----------------------------------
 
 Running on spot instances (or pre-emptible instances) can reduce the cost of your experiment. You can enable spot instances in AWS via the following configuration modification:
 

--- a/doc/source/tune/tutorials/tune-distributed.rst
+++ b/doc/source/tune/tutorials/tune-distributed.rst
@@ -1,6 +1,6 @@
 .. _tune-distributed-ref:
 
-Running  Distributed Experiments with Ray Tune
+Running Distributed Experiments with Ray Tune
 ==============================================
 
 Tune is commonly used for large-scale distributed hyperparameter optimization. This page will overview how to setup and launch a distributed experiment along with :ref:`commonly used commands <tune-distributed-common>` for Tune when running distributed experiments.
@@ -55,7 +55,7 @@ Analyze your results on TensorBoard by starting TensorBoard on the remote head m
 Note that you can customize the directory of results by specifying: ``air.RunConfig(local_dir=..)``, taken in by ``Tuner``. You can then point TensorBoard to that directory to visualize results. You can also use `awless <https://github.com/wallix/awless>`_ for easy cluster management on AWS.
 
 
-Running a distributed Tune experiment
+Running a Distributed Tune Experiment
 -------------------------------------
 
 Running a distributed (multi-node) experiment requires Ray to be started already.
@@ -97,7 +97,7 @@ If you used a cluster configuration (starting a cluster with ``ray up`` or ``ray
     2. If the Ray cluster is already started, you should not need to run anything on the worker nodes.
 
 
-Syncing Checkpoints in a distributed Tune run
+Syncing Checkpoints in a Distributed Tune Run
 ---------------------------------------------
 
 In a distributed experiment, you should try to use :ref:`cloud checkpointing <tune-cloud-checkpointing>` to
@@ -124,10 +124,11 @@ For more details or customization, see our
 
 .. _tune-distributed-spot:
 
-Tune runs on pre-emptible instances
+Tune Runs on preemptible instances
 -----------------------------------
 
-Running on spot instances (or pre-emptible instances) can reduce the cost of your experiment. You can enable spot instances in AWS via the following configuration modification:
+Running on spot instances (or preemptible instances) can reduce the cost of your experiment.
+You can enable spot instances in AWS via the following configuration modification:
 
 .. code-block:: yaml
 
@@ -169,8 +170,8 @@ Spot instances may be removed suddenly while trials are still running. Often tim
     :end-before: __trainable_run_end__
 
 
-Example for using spot instances (AWS)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Example for Using Tune with Spot instances (AWS)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Here is an example for running Tune on spot instances. This assumes your AWS credentials have already been setup (``aws configure``):
 
@@ -211,8 +212,8 @@ You can also specify ``sync_config=tune.SyncConfig(upload_dir=...)``, as part of
 
 .. _tune-fault-tol:
 
-Fault Tolerance
----------------
+Fault Tolerance of Tune Runs
+----------------------------
 
 Tune will automatically restart trials in case of trial failures/error (if ``max_failures != 0``), both in the single node and distributed setting.
 
@@ -229,8 +230,8 @@ Tune automatically persists the progress of your entire experiment (a ``Tuner.fi
 
 .. _tune-distributed-common:
 
-Common Commands
----------------
+Common Tune Commands
+--------------------
 
 Below are some commonly used commands for submitting experiments. Please see the :ref:`Clusters page <cluster-index>` to see find more comprehensive documentation of commands.
 
@@ -275,7 +276,8 @@ Below are some commonly used commands for submitting experiments. Please see the
 Troubleshooting
 ---------------
 
-Sometimes, your program may freeze. Run this to restart the Ray cluster without running any of the installation commands.
+Sometimes, your program may freeze.
+Run this to restart the Ray cluster without running any of the installation commands.
 
 .. code-block:: bash
 

--- a/doc/source/tune/tutorials/tune-lifecycle.rst
+++ b/doc/source/tune/tutorials/tune-lifecycle.rst
@@ -46,8 +46,8 @@ When the Trainable terminates (or is stopped), the actor is also terminated.
 
 .. _trainable-execution:
 
-The execution of a trainable
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The execution of a trainable in Tune
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tune uses :ref:`Ray actors <actor-guide>` to parallelize the evaluation of multiple hyperparameter configurations.
 Each actor is a Python process that executes an instance of the user-provided Trainable.
@@ -79,8 +79,8 @@ See :doc:`tune-resources` for more information.
 
 .. _trial-lifecycle:
 
-Lifecycle of a Trial
---------------------
+Lifecycle of a Tune Trial
+-------------------------
 
 A trial's life cycle consists of 6 stages:
 
@@ -128,6 +128,7 @@ This is an illustration of the high-level training flow and how some of the comp
 
 TrialRunner
 ~~~~~~~~~~~
+
 [`source code <https://github.com/ray-project/ray/blob/master/python/ray/tune/execution/trial_runner.py>`__]
 This is the main driver of the training loop. This component
 uses the TrialScheduler to prioritize and execute trials,
@@ -148,6 +149,7 @@ See the docstring at :ref:`trialrunner-docstring`.
 
 Trial objects
 ~~~~~~~~~~~~~
+
 [`source code <https://github.com/ray-project/ray/blob/master/python/ray/tune/experiment/trial.py>`__]
 This is an internal data structure that contains metadata about each training run. Each Trial
 object is mapped one-to-one with a Trainable object but are not themselves

--- a/doc/source/tune/tutorials/tune-metrics.rst
+++ b/doc/source/tune/tutorials/tune-metrics.rst
@@ -3,8 +3,8 @@ A Guide To Callbacks & Metrics in Tune
 
 .. _tune-callbacks:
 
-How to work with Callbacks?
----------------------------
+How to work with Callbacks in Ray Tune?
+---------------------------------------
 
 Ray Tune supports callbacks that are called during various times of the training process.
 Callbacks can be passed as a parameter to ``air.RunConfig``, taken in by ``Tuner``, and the sub-method you provide will be invoked automatically.
@@ -61,8 +61,8 @@ You can log arbitrary values and metrics in both Function and Class training API
     Note that ``session.report()`` is not meant to transfer large amounts of data, like models or datasets.
     Doing so can incur large overheads and slow down your Tune run significantly.
 
-Which metrics get automatically filled in?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Which Tune metrics get automatically filled in?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tune has the concept of auto-filled metrics.
 During training, Tune will automatically log the below metrics in addition to any user-provided values.

--- a/doc/source/tune/tutorials/tune-output.rst
+++ b/doc/source/tune/tutorials/tune-output.rst
@@ -38,8 +38,8 @@ To learn more about Trials, see its detailed API documentation: :ref:`trial-docs
 
 .. _tensorboard:
 
-How to log to TensorBoard?
---------------------------
+How to log your Tune runs to TensorBoard?
+-----------------------------------------
 
 Tune automatically outputs TensorBoard files during ``Tuner.fit()``.
 To visualize learning in tensorboard, install tensorboardX:
@@ -82,8 +82,8 @@ If using TensorFlow ``2.x``, Tune also automatically generates TensorBoard HPara
 
 .. _tune-console-output:
 
-How to control console output?
-------------------------------
+How to control console output with Tune?
+----------------------------------------
 
 User-provided fields will be outputted automatically on a best-effort basis.
 You can use a :ref:`Reporter <tune-reporter-doc>` object to customize the console output.
@@ -108,8 +108,8 @@ You can use a :ref:`Reporter <tune-reporter-doc>` object to customize the consol
 
 .. _tune-log_to_file:
 
-How to redirect stdout and stderr to files?
--------------------------------------------
+How to redirect stdout and stderr to files in a Tune run?
+---------------------------------------------------------
 
 The stdout and stderr streams are usually printed to the console.
 For remote actors, Ray collects these logs and prints them to the head process.
@@ -154,8 +154,8 @@ for Ray's base logger and log the output to the specified stderr output file.
 
 .. _trainable-logging:
 
-How to Configure Trainable Logging?
------------------------------------
+How to configure logging of Tune Trainables?
+--------------------------------------------
 
 By default, Tune only logs the *training result dictionaries* from your Trainable.
 However, you may want to visualize the model weights, model graph,
@@ -225,8 +225,8 @@ In the distributed case, these logs will be sync'ed back to the driver under you
 This will allow you to visualize and analyze logs of all distributed training workers on a single machine.
 
 
-How to Build Custom Loggers?
-----------------------------
+How to Build Custom Tune Loggers?
+---------------------------------
 
 You can create a custom logger by inheriting the LoggerCallback interface (:ref:`logger-interface`):
 

--- a/doc/source/tune/tutorials/tune-resources.rst
+++ b/doc/source/tune/tutorials/tune-resources.rst
@@ -1,7 +1,7 @@
 .. _tune-parallelism:
 
-A Guide To Parallelism and Resources
-------------------------------------
+A Guide To Parallelism and Resources for Ray Tune
+-------------------------------------------------
 
 Parallelism is determined by per trial resources (defaulting to 1 CPU, 0 GPU per trial)
 and the resources available to Tune (``ray.cluster_resources()``).
@@ -83,8 +83,8 @@ Failure to set resources correctly may result in a deadlock, "hanging" the clust
     You will have to make sure your trainable has enough resources to run (e.g. by setting ``n_jobs`` for a
     scikit-learn model accordingly).
 
-How to leverage GPUs?
-~~~~~~~~~~~~~~~~~~~~~
+How to leverage GPUs in Tune?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To leverage GPUs, you must set ``gpu`` in ``tune.with_resources(trainable, resources_per_trial)``.
 This will automatically set ``CUDA_VISIBLE_DEVICES`` for each trial.
@@ -144,8 +144,8 @@ How to run distributed training with Tune?
 To tune distributed training jobs, you should use :ref:`Ray AI Runtime (Ray AIR) <air>` to use Ray Tune and Ray Train in conjunction with
 each other. Ray Tune will run multiple trials in parallel, with each trial running distributed training with Ray Train.
 
-How to limit concurrency?
-~~~~~~~~~~~~~~~~~~~~~~~~~
+How to limit concurrency in Tune?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If using a :ref:`search algorithm <tune-search-alg>`, you may want to limit the number of trials that are being evaluated.
 For example, you may want to serialize the evaluation of trials to do sequential optimization.

--- a/doc/source/tune/tutorials/tune-run.rst
+++ b/doc/source/tune/tutorials/tune-run.rst
@@ -1,10 +1,10 @@
-Running Basic Experiments
-=========================
+Running Basic Tune Experiments
+==============================
 
 The most common way to use Tune is also the simplest: as a parallel experiment runner. If you can define experiment trials in a Python function, you can use Tune to run hundreds to thousands of independent trial instances in a cluster. Tune manages trial execution, status reporting, and fault tolerance.
 
-Running ``N`` Independent Trials in Parallel
---------------------------------------------
+Running Independent Tune Trials in Parallel
+-------------------------------------------
 
 As a general example, let's consider executing ``N`` independent model training trials using Tune as a simple grid sweep. Each trial can execute different code depending on a passed-in config dictionary.
 
@@ -69,8 +69,8 @@ The final result objects contain finished trial metadata:
     Result(metrics={'score': 'model_1', 'other_data': Ellipsis, 'done': True, 'trial_id': '8d627_00001', 'experiment_tag': '1_model_id=model_1'}, error=None, log_dir=PosixPath('/home/ubuntu/ray_results/train_model_2022-09-21_10-19-26/train_model_8d627_00001_1_model_id=model_1_2022-09-21_10-19-31'))
     Result(metrics={'score': 'model_2', 'other_data': Ellipsis, 'done': True, 'trial_id': '8d627_00002', 'experiment_tag': '2_model_id=model_2'}, error=None, log_dir=PosixPath('/home/ubuntu/ray_results/train_model_2022-09-21_10-19-26/train_model_8d627_00002_2_model_id=model_2_2022-09-21_10-19-31'))
 
-Comparison to ``ray.remote``
-----------------------------
+How does Tune compare  to using Ray Core (``ray.remote``)?
+----------------------------------------------------------
 
 You might be wondering how Tune differs from simply using :ref:`ray-remote-functions` for parallel trial execution. Indeed, the above example could be re-written similarly as:
 

--- a/doc/source/tune/tutorials/tune-scalability.rst
+++ b/doc/source/tune/tutorials/tune-scalability.rst
@@ -1,7 +1,7 @@
 :orphan:
 
-Scalability and Overhead Benchmarks
-===================================
+Scalability and Overhead Benchmarks for Ray Tune
+================================================
 
 We conducted a series of micro-benchmarks where we evaluated the scalability of Ray Tune and analyzed the
 performance overhead we observed. The results from these benchmarks are reflected in the documentation,
@@ -85,6 +85,7 @@ Below we discuss some insights on results where we observed much overhead.
 
 Result throughput
 -----------------
+
 Result throughput describes the number of results Ray Tune can process in a given timeframe (e.g.
 "results per second").
 The higher the throughput, the more concurrent results can be processed without major delays.
@@ -105,8 +106,9 @@ intervals by a factor of 5-10x.
 
 Below we present more detailed results on the result throughput performance.
 
-Many concurrent trials
-""""""""""""""""""""""
+Benchmarking many concurrent Tune trials
+""""""""""""""""""""""""""""""""""""""""
+
 In this setup, loggers (CSV, JSON, and TensorBoardX) and trial synchronization are disabled, except when
 explicitly noted.
 
@@ -141,8 +143,9 @@ should be considered.
 +-------------+--------------------------+---------+---------------+------------------+---------+
 
 
-Many results on a single node
-"""""""""""""""""""""""""""""
+Benchmarking many Tune results on a single node
+"""""""""""""""""""""""""""""""""""""""""""""""
+
 In this setup, loggers (CSV, JSON, and TensorBoardX) are disabled, except when
 explicitly noted.
 
@@ -172,8 +175,9 @@ seems acceptable in terms of overhead, though you should probably still target f
 +-------------+--------------------------+---------+---------------+------------------+---------+
 
 
-Network overhead
-----------------
+Network overhead in Ray Tune
+----------------------------
+
 Running Ray Tune on a distributed setup leads to network communication overhead. This is mostly due to
 trial synchronization, where results and checkpoints are periodically synchronized and sent via the network.
 Per default this happens via SSH, where connnection initialization can take between 1 and 2 seconds each time.

--- a/doc/source/tune/tutorials/tune-search-spaces.rst
+++ b/doc/source/tune/tutorials/tune-search-spaces.rst
@@ -136,8 +136,8 @@ for a total of 90 trials, each with randomly sampled values of ``alpha`` and ``b
 
 .. _tune_custom-search:
 
-How to use Custom and Conditional Search Spaces?
-------------------------------------------------
+How to use Custom and Conditional Search Spaces in Tune?
+--------------------------------------------------------
 
 You'll often run into awkward search spaces (i.e., when one hyperparameter depends on another).
 Use ``tune.sample_from(func)`` to provide a **custom** callable function for generating a search space.

--- a/doc/source/tune/tutorials/tune-stopping.rst
+++ b/doc/source/tune/tutorials/tune-stopping.rst
@@ -48,8 +48,8 @@ of your original tuning run:
     Result logdir: /Users/ray/ray_results/my_trainable_2021-01-29_10-16-44
     Number of trials: 1/1 (1 RUNNING)
 
-What's happening under the hood?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+What's happening under the hood in a Tune run?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :ref:`Here <tune-two-types-of-ckpt>`, we describe the two types of Tune checkpoints:
 experiment-level and trial-level checkpoints.
@@ -74,8 +74,8 @@ This argument takes, a dictionary, a function, or a :class:`Stopper <ray.tune.st
 If a dictionary is passed in, the keys may be any field in the return result of ``session.report`` in the
 Function API or ``step()`` (including the results from ``step`` and auto-filled metrics).
 
-Stopping with a dictionary
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Stopping Tune runs with a dictionary
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In the example below, each trial will be stopped either when it completes ``10`` iterations or when it
 reaches a mean accuracy of ``0.98``.
@@ -89,8 +89,8 @@ These metrics are assumed to be **increasing**.
         run_config=air.RunConfig(stop={"training_iteration": 10, "mean_accuracy": 0.98})
     ).fit()
 
-Stopping with a function
-~~~~~~~~~~~~~~~~~~~~~~~~
+Stopping Tune runs with a function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For more flexibility, you can pass in a function instead.
 If a function is passed in, it must take ``(trial_id, result)`` as arguments and return a boolean
@@ -103,8 +103,8 @@ If a function is passed in, it must take ``(trial_id, result)`` as arguments and
 
     tune.Tuner(my_trainable, run_config=air.RunConfig(stop=stopper)).fit()
 
-Stopping with a class
-~~~~~~~~~~~~~~~~~~~~~
+Stopping Tune runs with a class
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Finally, you can implement the :class:`Stopper <ray.tune.stopper.Stopper>` abstract class for stopping entire experiments. For example, the following example stops all trials after the criteria is fulfilled by any individual trial, and prevents new ones from starting:
 
@@ -135,8 +135,8 @@ once their current iterations are complete.
 Ray Tune comes with a set of out-of-the-box stopper classes. See the :ref:`Stopper <tune-stoppers>` documentation.
 
 
-Stopping after the first failure
---------------------------------
+Stopping a ``Tuner`` after the first failure
+--------------------------------------------
 
 By default, ``Tuner.fit()`` will continue executing until all trials have terminated or errored.
 To stop the entire Tune run as soon as **any** trial errors:

--- a/doc/source/tune/tutorials/tune_get_data_in_and_out.md
+++ b/doc/source/tune/tutorials/tune_get_data_in_and_out.md
@@ -44,7 +44,7 @@ from ray import tune
 tuner = Tuner(training_function, tune_config=tune.TuneConfig(num_samples=4))
 ```
 
-## Getting data in
+## Getting data into Tune
 
 First order of business is to provide the inputs for the Trainable. We can broadly separate them into two categories - variables and constants.
 
@@ -56,7 +56,7 @@ Constants are the parameters that are the same for every Trial. Those can be the
 Objects from the outer scope of the `training_function` will also be automatically serialized and sent to Trial Actors, which may lead to unintended behavior. Examples include global locks not working (as each Actor operates on a copy) or general errors related to serialization. Best practice is to not refer to any objects from outer scope in the `training_function`.
 ```
 
-### Search space
+### Passing data into a Tune run through search spaces
 
 ```{note}
 TL;DR - use the `param_space` argument to specify small, serializable constants and variables.
@@ -110,7 +110,7 @@ tuner = Tuner(
 )
 ```
 
-### Parameters
+### Using `tune.with_parameters` access data in Tune runs
 
 ```{note}
 TL;DR - use the `tune.with_parameters` util function to specify large constant parameters.
@@ -172,7 +172,7 @@ tuner = Tuner(
 )
 ```
 
-### Loading data in Trainable
+### Loading data in a Tune Trainable
 
 You can also load data directly in Trainable from e.g. cloud storage, shared file storage such as NFS, or from the local disk of the Trainable worker.
 
@@ -193,13 +193,13 @@ results = tuner.fit()
 ```
 
 
-## Getting data out
+## Getting data out of Ray Tune
 
 We can now run our tuning run using the `training_function` Trainable. The next step is to report *metrics* to Tune that can be used to guide the optimization. We will also want to *checkpoint* our trained models so that we can resume the training after an interruption, and to use them for prediction later.
 
 The [`ray.air.session`](air-session-ref) API is used to get data out of the Trainable workers. `session.report` can be called multiple times in the Trainable function. Each call corresponds to one iteration (epoch, step, tree) of training.
 
-### Reporting metrics
+### Reporting metrics with Tune
 
 *Metrics* are values passed through the `metrics` argument in a `session.report` call. Metrics can be used by Tune [Search Algorithms](search-alg-ref) and [Schedulers](schedulers-ref) to direct the search. After the tuning run is complete, you can [analyze the results](/tune/examples/tune_analyze_results), which include the reported metrics.
 
@@ -247,7 +247,7 @@ tuner = Tuner(
 )
 ```
 
-### Logging metrics with callbacks
+### Logging metrics with Tune callbacks
 
 Every metric logged using `session.report` can be accessed during the tuning run through Tune [Callbacks](tune-logging). Ray AIR provides [several built-in integrations](air-builtin-callbacks) with popular frameworks, such as MLFlow, Weights & Biases, CometML and more. You can also use the [Callback API](tune-callbacks-docs) to create your own callbacks.
 
@@ -293,9 +293,9 @@ tuner = Tuner(
 )
 ```
 
-### Checkpoints & other artifacts
+### Getting data out of Tune using checkpoints & other artifacts
 
-Aside from metrics, you may want to save the state of your trained model and any other artifacts to allow resumption from training failure and further inspection and usage. Those cannot be saved as metrics, as they often are far too large and may not be easily serializable. Finally, they should be persisted on disk or cloud storage to allow access after the Tune run is interrupted or terminated.
+Aside from metrics, you may want to save the state of your trained model and any other artifacts to allow resumption from training failure and further inspection and usage. Those cannot be saved as metrics, as they are often far too large and may not be easily serializable. Finally, they should be persisted on disk or cloud storage to allow access after the Tune run is interrupted or terminated.
 
 Ray AIR (which contains Ray Tune) provides a [`Checkpoint`](air-checkpoints-doc) API for that purpose. `Checkpoint` objects can be created from various sources (dictionaries, directories, cloud storage) and used between different AIR components.
 
@@ -520,7 +520,7 @@ results.get_dataframe()
 Checkpoints, metrics, and the log directory for each trial can be accessed through the `ResultGrid` output of a Tune experiment. For more information on how to interact with the returned `ResultGrid`, see {doc}`/tune/examples/tune_analyze_results`.
 
 
-### How do I access results after I am finished?
+### How do I access Tune results after I am finished?
 
 After you have finished running the Python session, you can still access the results and checkpoints. By default, Tune will save the experiment results to the `~/ray_results` local directory. You can configure Tune to persist results in the cloud as well. See {ref}`tune-checkpoint-syncing` for more information on how to configure syncing.
 


### PR DESCRIPTION
We can improve doc search (and likely SEO) by respecting a couple of trivial web things:

- Make titles in docs (h1 to h6) contain proper context and key terms necessary for crawlers to find things.
- Be more descriptive and make sections work standalone
- Surface the topics that we want to surface

For Tune this turned out to be ok, but we have other libs that have more problems with this topic (e.g. Train).
I'm working on a document to explain the context of this better and apply this to other libs.
