### PR TITLE
Remove method about py-spy permissions from every py-spy error.

### DIFF
--- a/dashboard/modules/reporter/profile_manager.py
+++ b/dashboard/modules/reporter/profile_manager.py
@@ -25,7 +25,7 @@ def _format_failed_pyspy_command(cmd, stdout, stderr) -> str:
     # If some sort of permission error returned, show a message about how
     # to set up permissions correctly.
     extra_message = (
-        PYSPY_PERMISSIONS_ERROR_MESSAGE if "permission" in stderr_str else ""
+        PYSPY_PERMISSIONS_ERROR_MESSAGE if "permission" in stderr_str.lower() else ""
     )
 
     return f"""Failed to execute `{cmd}`.

--- a/dashboard/modules/reporter/profile_manager.py
+++ b/dashboard/modules/reporter/profile_manager.py
@@ -11,19 +11,11 @@ logger = logging.getLogger(__name__)
 def _format_failed_pyspy_command(cmd, stdout, stderr) -> str:
     return f"""Failed to execute `{cmd}`.
 
-Note that this command requires `py-spy` to be installed with root permissions. You
-can install `py-spy` and give it root permissions as follows:
-  $ pip install py-spy
-  $ sudo chown root:root `which py-spy`
-  $ sudo chmod u+s `which py-spy`
-
-Alternatively, you can start Ray with passwordless sudo / root permissions.
+=== stderr ===
+{stderr.decode("utf-8")}
 
 === stdout ===
 {stdout.decode("utf-8")}
-
-=== stderr ===
-{stderr.decode("utf-8")}
 """
 
 

--- a/dashboard/modules/reporter/profile_manager.py
+++ b/dashboard/modules/reporter/profile_manager.py
@@ -7,10 +7,29 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+PYSPY_PERMISSIONS_ERROR_MESSAGE = """
+Note that this command requires `py-spy` to be installed with root permissions. You
+can install `py-spy` and give it root permissions as follows:
+  $ pip install py-spy
+  $ sudo chown root:root `which py-spy`
+  $ sudo chmod u+s `which py-spy`
+
+Alternatively, you can start Ray with passwordless sudo / root permissions.
+
+"""
+
 
 def _format_failed_pyspy_command(cmd, stdout, stderr) -> str:
-    return f"""Failed to execute `{cmd}`.
+    stderr_str = stderr.decode("utf-8")
 
+    # If some sort of permission error returned, show a message about how
+    # to set up permissions correctly.
+    extra_message = (
+        PYSPY_PERMISSIONS_ERROR_MESSAGE if "permission" in stderr_str else ""
+    )
+
+    return f"""Failed to execute `{cmd}`.
+{extra_message}
 === stderr ===
 {stderr.decode("utf-8")}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This error message confused people into thinking the error was related to permissioning when it was really a much simpler error like "No stack counts found".

When it is a permissioning error, this shouldn't be necessary since py-py already returns a message like `Permission Denied: Try running again with elevated permissions by going 'sudo env "PATH=$PATH" !!'` in stderr.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
fixes #31109
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
