### PR TITLE
Fix the `restore_1_of_n_agents_from_checkpoint` example

### DIFF
--- a/rllib/examples/restore_1_of_n_agents_from_checkpoint.py
+++ b/rllib/examples/restore_1_of_n_agents_from_checkpoint.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
         best_checkpoint.to_directory(), "policies/policy_0"
     )
     restored_policy_0 = Policy.from_checkpoint(policy_0_checkpoint)
-
+    restored_policy_0_weights = restored_policy_0.get_weights()
     print("Starting new tune.Tuner().fit()")
 
     # Start our actual experiment.
@@ -114,11 +114,11 @@ if __name__ == "__main__":
 
     class RestoreWeightsCallback(DefaultCallbacks):
         def on_algorithm_init(self, *, algorithm: "Algorithm", **kwargs) -> None:
-            algorithm.set_weights({"policy_0": restored_policy_0.get_weights()})
+            algorithm.set_weights({"policy_0": restored_policy_0_weights})
 
     # Make sure, the non-1st policies are not updated anymore.
     config.policies_to_train = [pid for pid in policy_ids if pid != "policy_0"]
-    config.callbacks = RestoreWeightsCallback
+    config.callbacks(RestoreWeightsCallback)
 
     results = tune.run(
         "PPO",


### PR DESCRIPTION
## Why are these changes needed?

The `restore_1_of_n_agents_from_checkpoint` was failing due to the `config` not being able to be serialized. The fix is quite easy, it needed to use the policy weights in the `RestoreWeightsCallback` class definition directly instead of using the policy.

## Related issue number

#31599

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
