### PR TITLE
[AIR] Allow users to exclude config values with `WandbLoggerCallback`

### DIFF
--- a/python/ray/air/tests/test_integration_wandb.py
+++ b/python/ray/air/tests/test_integration_wandb.py
@@ -64,14 +64,28 @@ class _MockWandbConfig:
     kwargs: Dict
 
 
+class _FakeConfig:
+    def update(self, config, *args, **kwargs):
+        for key, value in config.items():
+            setattr(self, key, value)
+
+    def __iter__(self):
+        return iter(self.__dict__)
+
+
 class _MockWandbAPI:
     def __init__(self):
         self.logs = Queue()
+        self.config = _FakeConfig()
 
     def init(self, *args, **kwargs):
         mock = Mock()
         mock.args = args
         mock.kwargs = kwargs
+
+        if "config" in kwargs:
+            self.config.update(kwargs["config"])
+
         return mock
 
     def log(self, data):
@@ -84,10 +98,6 @@ class _MockWandbAPI:
 
     def finish(self):
         pass
-
-    @property
-    def config(self):
-        return Mock()
 
 
 class _MockWandbLoggingActor(_WandbLoggingActor):
@@ -109,7 +119,7 @@ class WandbTestExperimentLogger(WandbLoggerCallback):
             logdir=trial.logdir,
             queue=self._trial_queues[trial],
             exclude=exclude_results,
-            to_config=self._config_results,
+            to_config=self.AUTO_CONFIG_KEYS,
             **wandb_init_kwargs,
         )
         self._trial_logging_actors[trial] = local_actor
@@ -299,6 +309,43 @@ class TestWandbLogger:
         assert "metric4" in logged
         assert "const" not in logged
         assert "config" not in logged
+
+    def test_wandb_logger_auto_config_keys(self, trial):
+        logger = WandbTestExperimentLogger(project="test_project", api_key="1234")
+        logger.on_trial_start(iteration=0, trials=[], trial=trial)
+        config = logger.trial_processes[trial]._wandb.config
+
+        result = {key: 0 for key in WandbLoggerCallback.AUTO_CONFIG_KEYS}
+        logger.on_trial_result(0, [], trial, result)
+
+        logger.on_trial_complete(0, [], trial)
+        # The results in `AUTO_CONFIG_KEYS` should be saved as training configuration
+        # instead of output metrics.
+        assert set(WandbLoggerCallback.AUTO_CONFIG_KEYS) < set(config)
+
+    def test_wandb_logger_exclude_config(self):
+        trial = Trial(
+            config={"param1": 0, "param2": 0},
+            trial_id=0,
+            trial_name="trial_0",
+            experiment_dir_name="trainable",
+            placement_group_factory=PlacementGroupFactory([{"CPU": 1}]),
+            logdir=tempfile.gettempdir(),
+        )
+        logger = WandbTestExperimentLogger(
+            project="test_project",
+            api_key="1234",
+            excludes=(["param2"] + WandbLoggerCallback.AUTO_CONFIG_KEYS),
+        )
+        logger.on_trial_start(iteration=0, trials=[], trial=trial)
+        config = logger.trial_processes[trial]._wandb.config
+
+        # We need to test that `excludes` also applies to `AUTO_CONFIG_KEYS`.
+        result = {key: 0 for key in WandbLoggerCallback.AUTO_CONFIG_KEYS}
+        logger.on_trial_result(0, [], trial, result)
+
+        logger.on_trial_complete(0, [], trial)
+        assert set(config) == {"param1"}
 
     def test_set_serializability_result(self, trial):
         """Tests that objects that contain sets can be serialized by wandb."""


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Our W&B integration species training configuration values that might not be relevant to the user (e.g., `node_ip`). This PR updates the `exclude` parameter to allow users to exclude these config values.

_Note_: you still can't exclude `trial_log_path` since it's hardcoded. See https://github.com/ray-project/ray/pull/28454.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #31223 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
