### PR TITLE
[Ray][Java]Support configuring job id for userlogger file name.

### DIFF
--- a/java/test/src/main/java/io/ray/test/UserLoggerTest.java
+++ b/java/test/src/main/java/io/ray/test/UserLoggerTest.java
@@ -15,7 +15,6 @@ import org.testng.annotations.Test;
 
 @Test(groups = {"cluster"})
 public class UserLoggerTest extends BaseTest {
-
   private static final Logger LOG1 = LoggerFactory.getLogger("test_user_logger1");
 
   private static final Logger LOG2 = LoggerFactory.getLogger("test_user_logger2");
@@ -28,13 +27,13 @@ public class UserLoggerTest extends BaseTest {
   public void setupJobConfig() {
     System.setProperty("ray.job.jvm-options.0", "-Dray.logging.loggers.0.name=test_user_logger1");
     System.setProperty(
-        "ray.job.jvm-options.1", "-Dray.logging.loggers.0.file-name=test_user_logger-1-%p");
+        "ray.job.jvm-options.1", "-Dray.logging.loggers.0.file-name=test_user_logger-1-%p-%j");
     System.setProperty(
         "ray.job.jvm-options.2",
         "-Dray.logging.loggers.0.pattern=%d{yyyy-MM-dd-HH:mm:ss,SSS}%p,%c{1},[%t]:%m%n");
     System.setProperty("ray.job.jvm-options.3", "-Dray.logging.loggers.1.name=test_user_logger2");
     System.setProperty(
-        "ray.job.jvm-options.4", "-Dray.logging.loggers.1.file-name=test_user_logger-2-%p");
+        "ray.job.jvm-options.4", "-Dray.logging.loggers.1.file-name=test_user_logger-2-%p-%j");
   }
 
   private static class ActorWithUserLogger {
@@ -56,9 +55,10 @@ public class UserLoggerTest extends BaseTest {
     File userLoggerFile =
         new File(
             CURR_LOG_DIR
-                + "/test_user_logger-%i-%p.log"
+                + "/test_user_logger-%i-%p-%j.log"
                     .replace("%i", indexStr)
-                    .replace("%p", String.valueOf(pid)));
+                    .replace("%p", String.valueOf(pid))
+                    .replace("%j", Ray.getRuntimeContext().getCurrentJobId().toString()));
     Assert.assertTrue(userLoggerFile.exists());
     BufferedReader reader = new BufferedReader(new FileReader(userLoggerFile));
     String context = reader.readLine();


### PR DESCRIPTION
Signed-off-by: lvxiaodong <lvxiaodong.lxd@antgroup.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Before this PR, the user log file name is not associated to job id, which it's not consistent with the worker log file name. This PR make them get consistent.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
