### PR TITLE
[Core] add client side health-check to detect network failures.

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1352,6 +1352,17 @@ def init_grpc_channel(
     asynchronous: bool = False,
 ):
     grpc_module = aiogrpc if asynchronous else grpc
+
+    options = options or []
+    options_dict = dict(options)
+    options_dict["grpc.keepalive_time_ms"] = options_dict.get(
+        "grpc.keepalive_time_ms", ray._config.grpc_client_keepalive_time_ms()
+    )
+    options_dict["grpc.keepalive_timeout_ms"] = options_dict.get(
+        "grpc.keepalive_timeout_ms", ray._config.grpc_client_keepalive_timeout_ms()
+    )
+    options = options_dict.items()
+
     if os.environ.get("RAY_USE_TLS", "0").lower() in ("1", "true"):
         server_cert_chain, private_key, ca_cert = load_certs_from_env()
         credentials = grpc.ssl_channel_credentials(

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -84,3 +84,11 @@ cdef extern from "ray/common/ray_config.h" nogil:
         int64_t health_check_failure_threshold() const
 
         uint64_t memory_monitor_refresh_ms() const
+
+        int64_t grpc_keepalive_time_ms() const
+
+        int64_t grpc_keepalive_timeout_ms() const
+
+        int64_t grpc_client_keepalive_time_ms() const
+
+        int64_t grpc_client_keepalive_timeout_ms() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -144,3 +144,19 @@ cdef class Config:
     @staticmethod
     def memory_monitor_refresh_ms():
         return (RayConfig.instance().memory_monitor_refresh_ms())
+
+    @staticmethod
+    def grpc_keepalive_time_ms():
+        return RayConfig.instance().grpc_keepalive_time_ms()
+
+    @staticmethod
+    def grpc_keepalive_timeout_ms():
+        return RayConfig.instance().grpc_keepalive_timeout_ms()
+
+    @staticmethod
+    def grpc_client_keepalive_time_ms():
+        return RayConfig.instance().grpc_client_keepalive_time_ms()
+
+    @staticmethod
+    def grpc_client_keepalive_timeout_ms():
+        return RayConfig.instance().grpc_client_keepalive_timeout_ms()

--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -150,7 +150,7 @@ inline absl::flat_hash_map<K, V> MapFromProtobuf(
   return absl::flat_hash_map<K, V>(pb_map.begin(), pb_map.end());
 }
 
-grpc::ChannelArguments CreateDefaultChannelArguments() {
+inline grpc::ChannelArguments CreateDefaultChannelArguments() {
   grpc::ChannelArguments arguments;
   if (::RayConfig::instance().grpc_client_keepalive_time_ms() > 0) {
     arguments.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS,

--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -22,6 +22,7 @@
 #include <sstream>
 
 #include "absl/container/flat_hash_map.h"
+#include "ray/common/ray_config.h"
 #include "ray/common/status.h"
 
 namespace ray {
@@ -153,9 +154,9 @@ grpc::ChannelArguments CreateDefaultChannelArguments() {
   grpc::ChannelArguments arguments;
   if (::RayConfig::instance().grpc_client_keepalive_time_ms() > 0) {
     arguments.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS,
-                      ::RayConfig::instance().grpc_client_keepalive_time_ms());
+                     ::RayConfig::instance().grpc_client_keepalive_time_ms());
     arguments.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
-                      ::RayConfig::instance().grpc_client_keepalive_timeout_ms());
+                     ::RayConfig::instance().grpc_client_keepalive_timeout_ms());
     arguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
   }
   return arguments;

--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -149,4 +149,16 @@ inline absl::flat_hash_map<K, V> MapFromProtobuf(
   return absl::flat_hash_map<K, V>(pb_map.begin(), pb_map.end());
 }
 
+grpc::ChannelArguments CreateDefaultChannelArguments() {
+  grpc::ChannelArguments arguments;
+  if (::RayConfig::instance().grpc_client_keepalive_time_ms() > 0) {
+    arguments.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS,
+                      ::RayConfig::instance().grpc_client_keepalive_time_ms());
+    arguments.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
+                      ::RayConfig::instance().grpc_client_keepalive_timeout_ms());
+    arguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+  }
+  return arguments;
+}
+
 }  // namespace ray

--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -157,7 +157,6 @@ inline grpc::ChannelArguments CreateDefaultChannelArguments() {
                      ::RayConfig::instance().grpc_client_keepalive_time_ms());
     arguments.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
                      ::RayConfig::instance().grpc_client_keepalive_timeout_ms());
-    arguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
   }
   return arguments;
 }

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -673,7 +673,7 @@ RAY_CONFIG(int64_t, grpc_keepalive_timeout_ms, 20000)
 /// and this configuration break that assumption. We should apply to every other component
 /// after we change this failure assumption from code.
 /// grpc keepalive timeout for client.
-RAY_CONFIG(int64_t, grpc_client_keepalive_time_ms, 60000)
+RAY_CONFIG(int64_t, grpc_client_keepalive_time_ms, 160000)
 
 /// grpc keepalive timeout for client.
 RAY_CONFIG(int64_t, grpc_client_keepalive_timeout_ms, 120000)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -661,16 +661,22 @@ RAY_CONFIG(bool, isolate_workers_across_task_types, true)
 /// ServerCall instance number of each RPC service handler
 RAY_CONFIG(int64_t, gcs_max_active_rpcs_per_handler, 100)
 
-/// grpc keepalive sent interval
+/// grpc keepalive sent interval for server.
 /// This is only configured in GCS server now.
-/// NOTE: It is not ideal for other components because
+RAY_CONFIG(int64_t, grpc_keepalive_time_ms, 10000)
+
+/// grpc keepalive timeout.
+RAY_CONFIG(int64_t, grpc_keepalive_timeout_ms, 20000)
+
+/// NOTE: we set a loose client keep alive because
 /// they have a failure model that considers network failures as component failures
 /// and this configuration break that assumption. We should apply to every other component
 /// after we change this failure assumption from code.
-RAY_CONFIG(int64_t, grpc_keepalive_time_ms, 10000)
+/// grpc keepalive timeout for client.
+RAY_CONFIG(int64_t, grpc_client_keepalive_time_ms, 60000)
 
-/// grpc keepalive timeout
-RAY_CONFIG(int64_t, grpc_keepalive_timeout_ms, 20000)
+/// grpc keepalive timeout for client.
+RAY_CONFIG(int64_t, grpc_client_keepalive_timeout_ms, 120000)
 
 /// Whether to use log reporter in event framework
 RAY_CONFIG(bool, event_log_reporter_enabled, false)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -673,7 +673,7 @@ RAY_CONFIG(int64_t, grpc_keepalive_timeout_ms, 20000)
 /// and this configuration break that assumption. We should apply to every other component
 /// after we change this failure assumption from code.
 /// grpc keepalive timeout for client.
-RAY_CONFIG(int64_t, grpc_client_keepalive_time_ms, 160000)
+RAY_CONFIG(int64_t, grpc_client_keepalive_time_ms, 300000)
 
 /// grpc keepalive timeout for client.
 RAY_CONFIG(int64_t, grpc_client_keepalive_timeout_ms, 120000)

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -185,7 +185,7 @@ class GcsRpcClient {
         gcs_port_(port),
         io_context_(&client_call_manager.GetMainService()),
         timer_(std::make_unique<boost::asio::deadline_timer>(*io_context_)) {
-    grpc::ChannelArguments = CreateDefaultChannelArguments();
+    grpc::ChannelArguments arguments = CreateDefaultChannelArguments();
     arguments.SetInt(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS,
                      ::RayConfig::instance().gcs_grpc_max_reconnect_backoff_ms());
     arguments.SetInt(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS,

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -20,6 +20,7 @@
 #include <thread>
 
 #include "absl/container/btree_map.h"
+#include "ray/common/grpc_util.h"
 #include "ray/common/network_util.h"
 #include "ray/rpc/grpc_client.h"
 #include "src/ray/protobuf/gcs_service.grpc.pb.h"
@@ -184,7 +185,7 @@ class GcsRpcClient {
         gcs_port_(port),
         io_context_(&client_call_manager.GetMainService()),
         timer_(std::make_unique<boost::asio::deadline_timer>(*io_context_)) {
-    grpc::ChannelArguments arguments;
+    grpc::ChannelArguments = CreateDefaultChannelArguments();
     arguments.SetInt(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS,
                      ::RayConfig::instance().gcs_grpc_max_reconnect_backoff_ms());
     arguments.SetInt(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS,

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -126,9 +126,9 @@ class GrpcClient {
   grpc::ChannelArguments CreateDefaultChannelArguments() {
     grpc::ChannelArguments arguments;
     arguments.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS,
-                     RayConfig::instance().grpc_client_keepalive_time_ms());
+                     ::RayConfig::instance().grpc_client_keepalive_time_ms());
     arguments.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
-                     RayConfig::instance().grpc_client_keepalive_timeout_ms());
+                     ::RayConfig::instance().grpc_client_keepalive_timeout_ms());
     arguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
     return arguments;
   }

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -123,18 +123,6 @@ class GrpcClient {
     stub_ = GrpcService::NewStub(channel_);
   }
 
-  grpc::ChannelArguments CreateDefaultChannelArguments() {
-    grpc::ChannelArguments arguments;
-    if (::RayConfig::instance().grpc_client_keepalive_time_ms() > 0) {
-      arguments.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS,
-                       ::RayConfig::instance().grpc_client_keepalive_time_ms());
-      arguments.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
-                       ::RayConfig::instance().grpc_client_keepalive_timeout_ms());
-      arguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
-    }
-    return arguments;
-  }
-
   /// Create a new `ClientCall` and send request.
   ///
   /// \tparam Request Type of the request message.

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -125,11 +125,13 @@ class GrpcClient {
 
   grpc::ChannelArguments CreateDefaultChannelArguments() {
     grpc::ChannelArguments arguments;
-    arguments.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS,
-                     ::RayConfig::instance().grpc_client_keepalive_time_ms());
-    arguments.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
-                     ::RayConfig::instance().grpc_client_keepalive_timeout_ms());
-    arguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+    if (::RayConfig::instance().grpc_client_keepalive_time_ms() > 0) {
+      arguments.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS,
+                       ::RayConfig::instance().grpc_client_keepalive_time_ms());
+      arguments.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
+                       ::RayConfig::instance().grpc_client_keepalive_timeout_ms());
+      arguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+    }
     return arguments;
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Occasionally Ray users have seen `ray.get` hanging, when the node executing the task `ray.get` is waiting for is preempted and disconnected from the cluster.

As we debug one instance of such hanging, we figured this is caused by that the underlining grpc channel failed to detect this network failure. 

To solve this problem, we need add some sort of health check at OS level (TCP keep alive), rpc level (grpc), or application (Ray) level. It seems not easy to configure TCP Keepalive in grpc, and the Ray level involves changing a lot of code, this PR made the change at grpc level.

Also note in Ray we assume network failure as component failure, we set up a more loose timeout to reduce the false positive.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
