### PR TITLE
[tune] External hook as last option for getting W&B API key

### DIFF
--- a/python/ray/air/integrations/wandb.py
+++ b/python/ray/air/integrations/wandb.py
@@ -294,36 +294,35 @@ def _set_api_key(api_key_file: Optional[str] = None, api_key: Optional[str] = No
     The order of fetching the API key is:
       1) From `api_key` or `api_key_file` arguments
       2) From WANDB_API_KEY environment variables
-      3) From external hook WANDB_SETUP_API_KEY_HOOK"""
+      3) User already logged in to W&B (wandb.api.api_key set)
+      4) From external hook WANDB_SETUP_API_KEY_HOOK"""
     if api_key_file:
         if api_key:
             raise ValueError("Both WandB `api_key_file` and `api_key` set.")
         with open(api_key_file, "rt") as fp:
             api_key = fp.readline().strip()
-    # Try to get API key from external hook
-    if (
-        not api_key
-        and not os.environ.get(WANDB_ENV_VAR)
-        and WANDB_SETUP_API_KEY_HOOK in os.environ
-    ):
+
+    if not api_key and not os.environ.get(WANDB_ENV_VAR):
+        # Check if user is already logged into wandb.
         try:
-            api_key = _load_class(os.environ[WANDB_SETUP_API_KEY_HOOK])()
-        except Exception as e:
-            logger.exception(
-                f"Error executing {WANDB_SETUP_API_KEY_HOOK} to setup API key: {e}",
-                exc_info=e,
-            )
-    if api_key:
-        os.environ[WANDB_ENV_VAR] = api_key
-    elif not os.environ.get(WANDB_ENV_VAR):
-        try:
-            # Check if user is already logged into wandb.
             wandb.ensure_configured()
             if wandb.api.api_key:
                 logger.info("Already logged into W&B.")
                 return
         except AttributeError:
             pass
+        # Try to get API key from external hook
+        if WANDB_SETUP_API_KEY_HOOK in os.environ:
+            try:
+                api_key = _load_class(os.environ[WANDB_SETUP_API_KEY_HOOK])()
+            except Exception as e:
+                logger.exception(
+                    f"Error executing {WANDB_SETUP_API_KEY_HOOK} to setup API key: {e}",
+                    exc_info=e,
+                )
+    if api_key:
+        os.environ[WANDB_ENV_VAR] = api_key
+    elif not os.environ.get(WANDB_ENV_VAR):
         raise ValueError(
             "No WandB API key found. Either set the {} environment "
             "variable, pass `api_key` or `api_key_file` to the"

--- a/python/ray/air/tests/test_integration_wandb.py
+++ b/python/ray/air/tests/test_integration_wandb.py
@@ -209,8 +209,9 @@ class TestWandbLogger:
 
         # Fetch API key from argument even if external hook and WANDB_ENV_VAR set
         monkeypatch.setenv(
-            WANDB_SETUP_API_KEY_HOOK,
-            "ray._private.test_utils.wandb_setup_api_key_hook",
+            WANDB_SETUP_API_KEY_HOOK, "ray._private.test_utils.wandb_setup_api_key_hook"
+        )
+        monkeypatch.setenv(
             WANDB_ENV_VAR,
             "abcde",
         )
@@ -222,8 +223,9 @@ class TestWandbLogger:
     def test_wandb_logger_api_key_file(self, monkeypatch):
         # Fetch API key from file even if external hook and WANDB_ENV_VAR set
         monkeypatch.setenv(
-            WANDB_SETUP_API_KEY_HOOK,
-            "ray._private.test_utils.wandb_setup_api_key_hook",
+            WANDB_SETUP_API_KEY_HOOK, "ray._private.test_utils.wandb_setup_api_key_hook"
+        )
+        monkeypatch.setenv(
             WANDB_ENV_VAR,
             "abcde",
         )
@@ -241,8 +243,9 @@ class TestWandbLogger:
     def test_wandb_logger_api_key_env_var(self, monkeypatch):
         # API Key from env var takes precedence over external hook
         monkeypatch.setenv(
-            WANDB_SETUP_API_KEY_HOOK,
-            "ray._private.test_utils.wandb_setup_api_key_hook",
+            WANDB_SETUP_API_KEY_HOOK, "ray._private.test_utils.wandb_setup_api_key_hook"
+        )
+        monkeypatch.setenv(
             WANDB_ENV_VAR,
             "1234",
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fetching the W&B API key from an external hook should be the last option after getting the API key from the arguments, from environment variable, or if user already logged into W&B through `wandb login`. This allow the OSS integration code that already provides the API key to have the same execution behavior even if `WANDB_SETUP_API_KEY_HOOK` is set.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
