### PR TITLE
[RLlib] Fix worker state restoration.

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -1269,7 +1269,11 @@ class Algorithm(Trainable):
             # to bring these workers up to date.
             workers.foreach_worker(
                 func=lambda w: w.set_state(ray.get(state)),
+                remote_worker_ids=restored,
                 local_worker=False,
+                timeout_seconds=self.config.worker_restore_timeout_s,
+                # Bring back actor after successful state syncing.
+                mark_healthy=True,
             )
 
     @OverrideToImplementCustomLogic

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -348,6 +348,8 @@ class AlgorithmConfig:
         self.model = copy.deepcopy(MODEL_DEFAULTS)
         self.optimizer = {}
         self.max_requests_in_flight_per_sampler_worker = 2
+        self.worker_health_probe_timeout_s = 60
+        self.worker_restore_timeout_s = 1800
 
         # `self.callbacks()`
         self.callbacks_class = DefaultCallbacks
@@ -1396,6 +1398,8 @@ class AlgorithmConfig:
         model: Optional[dict] = NotProvided,
         optimizer: Optional[dict] = NotProvided,
         max_requests_in_flight_per_sampler_worker: Optional[int] = NotProvided,
+        worker_health_probe_timeout_s: int = NotProvided,
+        worker_restore_timeout_s: int = NotProvided,
     ) -> "AlgorithmConfig":
         """Sets the training related configuration.
 
@@ -1419,6 +1423,11 @@ class AlgorithmConfig:
                 dashboard. If you're seeing that the object store is filling up,
                 turn down the number of remote requests in flight, or enable compression
                 in your experiment of timesteps.
+            worker_health_probe_timeout_s: Max amount of time we should spend waiting
+                for health probe calls to finish. Health pings are very cheap, so the
+                default is 1 minute.
+            worker_restore_timeout_s: Max amount of time we should wait to restore
+                states on recovered worker actors. Default is 30 mins.
 
         Returns:
             This updated AlgorithmConfig object.
@@ -1459,6 +1468,10 @@ class AlgorithmConfig:
             self.max_requests_in_flight_per_sampler_worker = (
                 max_requests_in_flight_per_sampler_worker
             )
+        if worker_health_probe_timeout_s is not NotProvided:
+            self.worker_health_probe_timeout_s = worker_health_probe_timeout_s
+        if worker_restore_timeout_s is not NotProvided:
+            self.worker_restore_timeout_s = worker_restore_timeout_s
 
         return self
 

--- a/rllib/algorithms/apex_dqn/apex_dqn.py
+++ b/rllib/algorithms/apex_dqn/apex_dqn.py
@@ -410,7 +410,10 @@ class ApexDQN(DQN):
 
         # Training step done. Try to bring replay actors back to life if necessary.
         # Replay actors can start fresh, so we do not need to restore any state.
-        self._replay_actor_manager.probe_unhealthy_actors()
+        self._replay_actor_manager.probe_unhealthy_actors(
+            timeout_seconds=self.config.worker_health_probe_timeout_s,
+            mark_healthy=True,
+        )
 
         return copy.deepcopy(self.learner_thread.learner_info)
 

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -584,7 +584,10 @@ class Impala(Algorithm):
         # Aggregation workers are stateless, so we do not need to restore any
         # state here.
         if self._aggregator_actor_manager:
-            self._aggregator_actor_manager.probe_unhealthy_actors()
+            self._aggregator_actor_manager.probe_unhealthy_actors(
+                timeout_seconds=self.config.worker_health_probe_timeout_s,
+                mark_healthy=True,
+            )
 
         return train_results
 

--- a/rllib/algorithms/tests/test_worker_failures.py
+++ b/rllib/algorithms/tests/test_worker_failures.py
@@ -89,11 +89,12 @@ class FaultInjectEnv(gym.Env):
             self.counter = None
 
         if (
-            config.get("init_delay", 0) > 0.0 and
-            (
-                not config.get("init_delay_indices", []) or
-                self.config.worker_index in config.get("init_delay_indices", [])
-            ) and
+            config.get("init_delay", 0) > 0.0
+            and (
+                not config.get("init_delay_indices", [])
+                or self.config.worker_index in config.get("init_delay_indices", [])
+            )
+            and
             # constructor delay can only happen for recreated actors.
             self._get_count() > 0
         ):
@@ -147,12 +148,9 @@ class FaultInjectEnv(gym.Env):
         self._increment_count()
         self._maybe_raise_error()
 
-        if (
-            self.config.get("step_delay", 0) > 0.0 and
-            (
-                not self.config.get("init_delay_indices", []) or
-                self.config.worker_index in self.config.get("step_delay_indices", [])
-            )
+        if self.config.get("step_delay", 0) > 0.0 and (
+            not self.config.get("init_delay_indices", [])
+            or self.config.worker_index in self.config.get("step_delay_indices", [])
         ):
             # Simulate a step delay.
             time.sleep(self.config.get("step_delay"))
@@ -176,11 +174,11 @@ class ForwardHealthCheckToEnvWorker(RolloutWorker):
         return super().ping()
 
 
-def wait_for_restore(num_restarting_allowd=0):
+def wait_for_restore(num_restarting_allowed=0):
     """Wait for Ray actor fault tolerence to restore all failed workers.
 
     Args:
-        num_restarting_allowd: Number of actors that are allowed to be
+        num_restarting_allowed: Number of actors that are allowed to be
             in "RESTARTING" state. This is because some actors may
             hang in __init__().
     """
@@ -193,7 +191,7 @@ def wait_for_restore(num_restarting_allowd=0):
         ]
         finished = True
         for s in states:
-            # Wait till all actors are either "ALIVE" (retored),
+            # Wait till all actors are either "ALIVE" (restored),
             # or "DEAD" (cancelled. these actors are from other
             # finished test cases) or "RESTARTING" (being restored).
             if s not in ["ALIVE", "DEAD", "RESTARTING"]:
@@ -201,7 +199,7 @@ def wait_for_restore(num_restarting_allowd=0):
                 break
 
         restarting = [s for s in states if s == "RESTARTING"]
-        if len(restarting) > num_restarting_allowd:
+        if len(restarting) > num_restarting_allowed:
             finished = False
 
         print("waiting ... ", states)
@@ -718,7 +716,7 @@ class TestWorkerFailures(unittest.TestCase):
             self.assertEqual(a.workers.num_remote_worker_restarts(), 0)
 
             a.train()
-            wait_for_restore(num_restarting_allowd=1)
+            wait_for_restore(num_restarting_allowed=1)
             # Most importantly, training progressed fine.
             a.train()
 

--- a/rllib/algorithms/tests/test_worker_failures.py
+++ b/rllib/algorithms/tests/test_worker_failures.py
@@ -668,12 +668,12 @@ class TestWorkerFailures(unittest.TestCase):
                 rollout_fragment_length=16,
                 ignore_worker_failures=False,  # Not ignore failure.
                 recreate_failed_workers=True,  # And recover
+                worker_health_probe_timeout_s=0.01,
+                worker_restore_timeout_s=5,
             )
             .training(
                 train_batch_size=32,
                 model={"fcnet_hiddens": [4]},
-                worker_health_probe_timeout_s=0.01,
-                worker_restore_timeout_s=5,
             )
             .reporting(
                 # Make sure each iteration doesn't take too long.

--- a/rllib/algorithms/tests/test_worker_failures.py
+++ b/rllib/algorithms/tests/test_worker_failures.py
@@ -88,7 +88,15 @@ class FaultInjectEnv(gym.Env):
         else:
             self.counter = None
 
-        if config.get("init_delay", 0) > 0.0:
+        if (
+            config.get("init_delay", 0) > 0.0 and
+            (
+                not config.get("init_delay_indices", []) or
+                self.config.worker_index in config.get("init_delay_indices", [])
+            ) and
+            # constructor delay can only happen for recreated actors.
+            self._get_count() > 0
+        ):
             # Simulate an initialization delay.
             time.sleep(config.get("init_delay"))
 
@@ -110,14 +118,6 @@ class FaultInjectEnv(gym.Env):
     def _maybe_raise_error(self):
         # Do not raise simulated error if this worker is not bad.
         if self.config.worker_index not in self.config.get("bad_indices", []):
-            return
-
-        # Do not raise simulated error if recreated worker can not fail,
-        # and this is a recreated worker.
-        if (
-            not self.config.get("recreated_worker_can_fail", False)
-            and self.config.recreated_worker
-        ):
             return
 
         if self.counter:
@@ -146,6 +146,17 @@ class FaultInjectEnv(gym.Env):
     def step(self, action):
         self._increment_count()
         self._maybe_raise_error()
+
+        if (
+            self.config.get("step_delay", 0) > 0.0 and
+            (
+                not self.config.get("init_delay_indices", []) or
+                self.config.worker_index in self.config.get("step_delay_indices", [])
+            )
+        ):
+            # Simulate a step delay.
+            time.sleep(self.config.get("step_delay"))
+
         return self.env.step(action)
 
     def action_space_sample(self):
@@ -165,20 +176,36 @@ class ForwardHealthCheckToEnvWorker(RolloutWorker):
         return super().ping()
 
 
-def wait_for_restore():
-    """Wait for Ray actor fault tolerence to restore all failed workers."""
+def wait_for_restore(num_restarting_allowd=0):
+    """Wait for Ray actor fault tolerence to restore all failed workers.
+
+    Args:
+        num_restarting_allowd: Number of actors that are allowed to be
+            in "RESTARTING" state. This is because some actors may
+            hang in __init__().
+    """
     while True:
         states = [
-            # Wait till all actors are either "ALIVE" (retored),
-            # or "DEAD" (cancelled. these actors are from other
-            # finished test cases).
-            a["state"] == "ALIVE" or a["state"] == "DEAD"
+            a["state"]
             for a in list_actors(
                 filters=[("class_name", "=", "ForwardHealthCheckToEnvWorker")]
             )
         ]
+        finished = True
+        for s in states:
+            # Wait till all actors are either "ALIVE" (retored),
+            # or "DEAD" (cancelled. these actors are from other
+            # finished test cases) or "RESTARTING" (being restored).
+            if s not in ["ALIVE", "DEAD", "RESTARTING"]:
+                finished = False
+                break
+
+        restarting = [s for s in states if s == "RESTARTING"]
+        if len(restarting) > num_restarting_allowd:
+            finished = False
+
         print("waiting ... ", states)
-        if all(states):
+        if finished:
             break
         # Otherwise, wait a bit.
         time.sleep(0.5)
@@ -626,6 +653,80 @@ class TestWorkerFailures(unittest.TestCase):
             # Everything still healthy. And all workers are restarted.
             self.assertEqual(a.evaluation_workers.num_healthy_remote_workers(), 2)
             self.assertEqual(a.evaluation_workers.num_remote_worker_restarts(), 2)
+
+    def test_worker_recover_with_hanging_workers(self):
+        # Counter that will survive restarts.
+        COUNTER_NAME = "test_eval_workers_fault_but_recover"
+        counter = Counter.options(name=COUNTER_NAME).remote()
+
+        config = (
+            # Must use off-policy algorithm since we are gonna have hanging workers.
+            ImpalaConfig()
+            .resources(
+                num_gpus=0,
+            )
+            .rollouts(
+                num_rollout_workers=3,
+                rollout_fragment_length=16,
+                ignore_worker_failures=False,  # Not ignore failure.
+                recreate_failed_workers=True,  # And recover
+            )
+            .training(
+                train_batch_size=32,
+                model={"fcnet_hiddens": [4]},
+                worker_health_probe_timeout_s=0.01,
+                worker_restore_timeout_s=5,
+            )
+            .reporting(
+                # Make sure each iteration doesn't take too long.
+                min_time_s_per_iteration=0.5,
+                # Make sure metrics reporting doesn't hang for too long
+                # since we are gonna have a hanging worker.
+                metrics_episode_collection_timeout_s=1,
+            )
+            .environment(
+                env="fault_env",
+                env_config={
+                    "evaluation": True,
+                    "p_terminated": 0.0,
+                    "max_episode_len": 20,
+                    # Worker 1 and 2 will fail in step().
+                    "bad_indices": [1, 2],
+                    # Env throws error between steps 3 and 4.
+                    "failure_start_count": 3,
+                    "failure_stop_count": 4,
+                    "counter": COUNTER_NAME,
+                    # Worker 2 will hang for long time during init after restart.
+                    "init_delay": 3600,
+                    "init_delay_indices": [2],
+                    # Worker 3 will hang in env.step().
+                    "step_delay": 3600,
+                    "step_delay_indices": [3],
+                },
+            )
+            .debugging(worker_cls=ForwardHealthCheckToEnvWorker)
+        )
+
+        for _ in framework_iterator(config, frameworks=("tf2", "torch")):
+            # Reset interaciton counter.
+            ray.wait([counter.reset.remote()])
+
+            a = config.build()
+
+            # Before train loop, workers are fresh and not recreated.
+            self.assertEqual(a.workers.num_healthy_remote_workers(), 3)
+            self.assertEqual(a.workers.num_remote_worker_restarts(), 0)
+
+            a.train()
+            wait_for_restore(num_restarting_allowd=1)
+            # Most importantly, training progressed fine.
+            a.train()
+
+            # 2 healthy remote workers left, although worker 3 is stuck in rollout.
+            self.assertEqual(a.workers.num_healthy_remote_workers(), 2)
+            # Only 1 successful restore, since worker 2 is stuck in indefinite init
+            # and can not be properly restored.
+            self.assertEqual(a.workers.num_remote_worker_restarts(), 1)
 
     def test_eval_workers_fault_but_restore_env(self):
         # Counter that will survive restarts.


### PR DESCRIPTION
Signed-off-by: Jun Gong <jungong@anyscale.com>

## Why are these changes needed?

We should only restore state on recovered workers.
Also introduce timeouts for health probing and state restoration calls so we don't hang forever because of a bad actor.

## Related issue number


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
