### PR TITLE
Add version check for `typing_extensions` import in DatasetIterator

### DIFF
--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -1,6 +1,6 @@
 import abc
+import sys
 from typing import TYPE_CHECKING, Dict, List, Optional, Union, Iterator
-from typing_extensions import Literal
 
 from ray.data.block import DataBatch
 from ray.util.annotations import PublicAPI
@@ -9,6 +9,12 @@ if TYPE_CHECKING:
     import tensorflow as tf
     import torch
     from ray.data._internal.torch_iterable_dataset import TorchTensorBatchType
+
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 @PublicAPI(stability="beta")


### PR DESCRIPTION
Signed-off-by: Scott Lee <sjl@anyscale.com>

## Why are these changes needed?

https://github.com/ray-project/ray/pull/31470 imports `from typing_extensions import Literal` for all Python versions, but this breaks ([example buildkite](https://buildkite.com/ray-project/oss-ci-build-branch/builds/1824#0185a7a4-6d17-4eab-bfa7-04c4b5c6e599)) for Python >= 3.8 since `Literal` is part of the `typing` library in this case. We add a Python version check and import from the corresponding library.

## Related issue number
https://github.com/ray-project/ray/pull/31470/

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
