### PR TITLE
[RLLib] Deflake our APPO test in the same fashion as the IMPALA test

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -898,6 +898,13 @@ py_test(
     srcs = ["algorithms/appo/tests/test_appo.py"]
 )
 
+py_test(
+    name = "test_appo_off_policyness",
+    tags = ["team:rllib", "algorithms_dir", "multi_gpu", "exclusive"],
+    size = "large",
+    srcs = ["algorithms/appo/tests/test_appo_off_policyness.py"]
+)
+
 # ARS
 py_test(
     name = "test_ars",

--- a/rllib/algorithms/appo/tests/test_appo.py
+++ b/rllib/algorithms/appo/tests/test_appo.py
@@ -6,7 +6,6 @@ from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
 from ray.rllib.utils.metrics.learner_info import LEARNER_INFO, LEARNER_STATS_KEY
 from ray.rllib.utils.test_utils import (
     check_compute_single_action,
-    check_off_policyness,
     check_train_results,
     framework_iterator,
 )
@@ -34,8 +33,6 @@ class TestAPPO(unittest.TestCase):
                 results = algo.train()
                 print(results)
                 check_train_results(results)
-                off_policy_ness = check_off_policyness(results, upper_limit=2.0)
-                print(f"off-policy'ness={off_policy_ness}")
 
             check_compute_single_action(algo)
             algo.stop()
@@ -47,10 +44,7 @@ class TestAPPO(unittest.TestCase):
                 results = algo.train()
                 print(results)
                 check_train_results(results)
-                # Roughly: Reaches up to 0.4 for 2 rollout workers and up to 0.2 for
-                # 1 rollout worker.
-                off_policy_ness = check_off_policyness(results, upper_limit=2.0)
-                print(f"off-policy'ness={off_policy_ness}")
+
             check_compute_single_action(algo)
             algo.stop()
 

--- a/rllib/algorithms/appo/tests/test_appo_off_policyness.py
+++ b/rllib/algorithms/appo/tests/test_appo_off_policyness.py
@@ -1,0 +1,55 @@
+import unittest
+
+import ray
+import ray.rllib.algorithms.appo as appo
+from ray.rllib.utils.framework import try_import_tf
+from ray.rllib.utils.test_utils import (
+    check_compute_single_action,
+    check_off_policyness,
+    framework_iterator,
+)
+
+tf1, tf, tfv = try_import_tf()
+
+
+class TestAPPOOffPolicyNess(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        ray.init(num_gpus=1)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        ray.shutdown()
+
+    def test_appo_off_policyness(self):
+        config = (
+            appo.APPOConfig()
+            .environment("CartPole-v1")
+            .resources(num_gpus=1)
+            .rollouts(num_rollout_workers=4)
+        )
+        num_iterations = 3
+
+        for _ in framework_iterator(config, with_eager_tracing=True):
+            for num_aggregation_workers in [0, 1]:
+                config.num_aggregation_workers = num_aggregation_workers
+                print("aggregation-workers={}".format(config.num_aggregation_workers))
+                algo = config.build()
+                for i in range(num_iterations):
+                    results = algo.train()
+                    # Roughly: Reaches up to 0.4 for 2 rollout workers and up to 0.2 for
+                    # 1 rollout worker.
+                    off_policy_ness = check_off_policyness(results, upper_limit=2.0)
+                    print(f"off-policy'ness={off_policy_ness}")
+
+                check_compute_single_action(
+                    algo,
+                )
+                algo.stop()
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

<img width="745" alt="Screen Shot 2023-01-12 at 2 58 53 PM" src="https://user-images.githubusercontent.com/9356806/212199314-a10a023a-9a85-477e-8b53-a5e40ba1950f.png">
<img width="670" alt="Screen Shot 2023-01-12 at 2 51 56 PM" src="https://user-images.githubusercontent.com/9356806/212199448-67ed385f-c330-4900-9682-eb1964aed761.png">

Our APPO tests are almost as flakey as the impala ones.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
