### PR TITLE
[dashboard] Make Ray worker traceback/cpu_profile page link available when forwarding dashboard service with proxy

### DIFF
--- a/dashboard/client/src/components/ActorTable.tsx
+++ b/dashboard/client/src/components/ActorTable.tsx
@@ -333,7 +333,7 @@ const ActorTable = ({
                       </Link>
                       <br />
                       <a
-                        href={`/worker/traceback?pid=${pid}&ip=${address?.ipAddress}&native=0`}
+                        href={`worker/traceback?pid=${pid}&ip=${address?.ipAddress}&native=0`}
                         target="_blank"
                         title="Sample the current Python stack trace for this worker."
                         rel="noreferrer"
@@ -342,7 +342,7 @@ const ActorTable = ({
                       </a>
                       <br />
                       <a
-                        href={`/worker/cpu_profile?pid=${pid}&ip=${address?.ipAddress}&duration=5&native=0`}
+                        href={`worker/cpu_profile?pid=${pid}&ip=${address?.ipAddress}&duration=5&native=0`}
                         target="_blank"
                         title="Profile the Python worker for 5 seconds (default) and display a CPU flame graph."
                         rel="noreferrer"


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Make Ray worker traceback/cpu_profile page link available when forwarding dashboard service with proxy.

On databricks, we does not allow user to access web service on cluster driver node.
instead, databricks provide a proxy that forwards service setup on `https://{driver_ip}:{port}` to `https://{driver_ip}/driver-proxy/o/xxx/xxx/{port}`
But, the worker traceback/cpu_profile page does not work after forwarding. So I filed the PR to fix it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
