### PR TITLE
Revert "[Datasets] Update usages of `np.array` constructor for ragged…

### DIFF
--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -45,8 +45,8 @@ from pandas.core.indexers import check_array_indexer, validate_indices
 from pandas.io.formats.format import ExtensionArrayFormatter
 
 from ray.air.util.tensor_extensions.utils import (
-    _create_possibly_ragged_ndarray,
     _is_ndarray_variable_shaped_tensor,
+    _create_strict_ragged_ndarray,
 )
 from ray.util.annotations import PublicAPI
 
@@ -1422,6 +1422,28 @@ TensorArrayElement._add_logical_ops()
 TensorArray._add_arithmetic_ops()
 TensorArray._add_comparison_ops()
 TensorArray._add_logical_ops()
+
+
+def _create_possibly_ragged_ndarray(
+    values: Union[np.ndarray, ABCSeries, Sequence[np.ndarray]]
+) -> np.ndarray:
+    """
+    Create a possibly ragged ndarray.
+
+    Using the np.array() constructor will fail to construct a ragged ndarray that has a
+    uniform first dimension (e.g. uniform channel dimension in imagery). This function
+    catches this failure and tries a create-and-fill method to construct the ragged
+    ndarray.
+    """
+    try:
+        return np.array(values, copy=False)
+    except ValueError as e:
+        if "could not broadcast input array from shape" in str(e):
+            # Fall back to strictly creating a ragged ndarray.
+            return _create_strict_ragged_ndarray(values)
+        else:
+            # Re-raise original error if the failure wasn't a broadcast error.
+            raise e from None
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -1,8 +1,6 @@
-from typing import Any, Sequence, Union
-import warnings
+from typing import Any
 
 import numpy as np
-from pandas.core.dtypes.generic import ABCSeries
 
 
 def _is_ndarray_variable_shaped_tensor(arr: np.ndarray) -> bool:
@@ -44,42 +42,3 @@ def _create_strict_ragged_ndarray(values: Any) -> np.ndarray:
     # Try to fill the 1D array of pointers with the (ragged) tensors.
     arr[:] = list(values)
     return arr
-
-
-def _create_possibly_ragged_ndarray(
-    values: Union[np.ndarray, ABCSeries, Sequence[Any]]
-) -> np.ndarray:
-    """
-    Create a possibly ragged ndarray.
-
-    Using the np.array() constructor will fail to construct a ragged ndarray that has a
-    uniform first dimension (e.g. uniform channel dimension in imagery). This function
-    catches this failure and tries a create-and-fill method to construct the ragged
-    ndarray.
-    """
-    try:
-        with warnings.catch_warnings():
-            # For NumPy < 1.24, constructing a ragged ndarray directly via
-            # `np.array(...)` without the `dtype=object` parameter will raise a
-            # VisibleDeprecationWarning which we suppress.
-            # More details: https://stackoverflow.com/q/63097829
-            warnings.simplefilter("ignore", category=np.VisibleDeprecationWarning)
-            return np.array(values, copy=False)
-    except ValueError as e:
-        # Constructing a ragged ndarray directly via `np.array(...)`
-        # without the `dtype=object` parameter will raise a ValueError.
-        # For NumPy < 1.24, the message is of the form:
-        # "could not broadcast input array from shape..."
-        # For NumPy >= 1.24, the message is of the form:
-        # "The requested array has an inhomogeneous shape..."
-        # More details: https://github.com/numpy/numpy/pull/22004
-        error_str = str(e)
-        if (
-            "could not broadcast input array from shape" in error_str
-            or "The requested array has an inhomogeneous shape" in error_str
-        ):
-            # Fall back to strictly creating a ragged ndarray.
-            return _create_strict_ragged_ndarray(values)
-        else:
-            # Re-raise original error if the failure wasn't a broadcast error.
-            raise e from None

--- a/python/ray/data/_internal/simple_block.py
+++ b/python/ray/data/_internal/simple_block.py
@@ -5,8 +5,6 @@ from typing import Union, Callable, Iterator, List, Tuple, Any, Optional, TYPE_C
 
 import numpy as np
 
-from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
-
 if TYPE_CHECKING:
     import pandas
     import pyarrow
@@ -105,7 +103,7 @@ class SimpleBlockAccessor(BlockAccessor):
             if not isinstance(columns, list):
                 columns = [columns]
             return BlockAccessor.for_block(self.select(columns)).to_numpy()
-        return _create_possibly_ragged_ndarray(self._items)
+        return np.array(self._items)
 
     def to_arrow(self) -> "pyarrow.Table":
         import pyarrow

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -25,7 +25,6 @@ import warnings
 import numpy as np
 
 import ray
-from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
 import ray.cloudpickle as pickle
 from ray._private.usage import usage_lib
 from ray.air.constants import TENSOR_COLUMN_NAME
@@ -1067,9 +1066,7 @@ class Dataset(Generic[T]):
             if isinstance(batch, pd.DataFrame):
                 return batch.sample(frac=fraction)
             if isinstance(batch, np.ndarray):
-                return _create_possibly_ragged_ndarray(
-                    [row for row in batch if random.random() <= fraction]
-                )
+                return np.array([row for row in batch if random.random() <= fraction])
             raise ValueError(f"Unsupported batch type: {type(batch)}")
 
         return self.map_batches(process_batch)

--- a/python/ray/data/preprocessors/torch.py
+++ b/python/ray/data/preprocessors/torch.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Callable, Dict, List, Union
 
 import numpy as np
-from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
 
 from ray.data.preprocessor import Preprocessor
 from ray.util.annotations import PublicAPI
@@ -86,9 +85,7 @@ class TorchVisionPreprocessor(Preprocessor):
         def transform(batch: np.ndarray) -> np.ndarray:
             if self._batched:
                 return self._fn(batch).numpy()
-            return _create_possibly_ragged_ndarray(
-                [self._fn(array).numpy() for array in batch],
-            )
+            return np.array([self._fn(array).numpy() for array in batch])
 
         if isinstance(np_data, dict):
             outputs = {}

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypeVar, Uni
 import numpy as np
 
 import ray
-from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
 from ray.data._internal.arrow_block import ArrowRow
 from ray.data._internal.block_list import BlockList
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
@@ -1609,7 +1608,7 @@ def _resolve_parquet_args(
                 # NOTE(Clark): We use NumPy to consolidate these potentially
                 # non-contiguous buffers, and to do buffer bookkeeping in
                 # general.
-                np_col = _create_possibly_ragged_ndarray(
+                np_col = np.array(
                     [
                         np.ndarray(shape, buffer=buf.as_buffer(), dtype=dtype)
                         for buf in block.column(tensor_col_name)


### PR DESCRIPTION
… ndarrays to specify `dtype=object` (#31544)"

This reverts commit f07a1b7e9762708701fa83f1d0664191daa10b3c.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<img width="285" alt="Screen Shot 2023-01-12 at 9 38 38 PM" src="https://user-images.githubusercontent.com/18510752/212245398-de1a0547-3439-4599-9d1b-ef3c711e2e15.png">


test basic and some other tests (tune & operator test) became failing / flaky after this PR. Try reverting it. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
