### PR TITLE
[Datasets] Handle `np.array(dtype=object)` constructor for ragged ndarrays

### DIFF
--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -45,8 +45,8 @@ from pandas.core.indexers import check_array_indexer, validate_indices
 from pandas.io.formats.format import ExtensionArrayFormatter
 
 from ray.air.util.tensor_extensions.utils import (
+    _create_possibly_ragged_ndarray,
     _is_ndarray_variable_shaped_tensor,
-    _create_strict_ragged_ndarray,
 )
 from ray.util.annotations import PublicAPI
 
@@ -1422,28 +1422,6 @@ TensorArrayElement._add_logical_ops()
 TensorArray._add_arithmetic_ops()
 TensorArray._add_comparison_ops()
 TensorArray._add_logical_ops()
-
-
-def _create_possibly_ragged_ndarray(
-    values: Union[np.ndarray, ABCSeries, Sequence[np.ndarray]]
-) -> np.ndarray:
-    """
-    Create a possibly ragged ndarray.
-
-    Using the np.array() constructor will fail to construct a ragged ndarray that has a
-    uniform first dimension (e.g. uniform channel dimension in imagery). This function
-    catches this failure and tries a create-and-fill method to construct the ragged
-    ndarray.
-    """
-    try:
-        return np.array(values, copy=False)
-    except ValueError as e:
-        if "could not broadcast input array from shape" in str(e):
-            # Fall back to strictly creating a ragged ndarray.
-            return _create_strict_ragged_ndarray(values)
-        else:
-            # Re-raise original error if the failure wasn't a broadcast error.
-            raise e from None
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -29,7 +29,7 @@ def _is_ndarray_variable_shaped_tensor(arr: np.ndarray) -> bool:
 
 
 def _create_possibly_ragged_ndarray(
-    values: Union[np.ndarray, ABCSeries, Sequence[Any]]
+    values: Union[np.ndarray, "ABCSeries", Sequence[Any]]
 ) -> np.ndarray:
     """
     Create a possibly ragged ndarray.

--- a/python/ray/data/_internal/simple_block.py
+++ b/python/ray/data/_internal/simple_block.py
@@ -5,6 +5,8 @@ from typing import Union, Callable, Iterator, List, Tuple, Any, Optional, TYPE_C
 
 import numpy as np
 
+from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
+
 if TYPE_CHECKING:
     import pandas
     import pyarrow
@@ -103,7 +105,7 @@ class SimpleBlockAccessor(BlockAccessor):
             if not isinstance(columns, list):
                 columns = [columns]
             return BlockAccessor.for_block(self.select(columns)).to_numpy()
-        return np.array(self._items)
+        return _create_possibly_ragged_ndarray(self._items)
 
     def to_arrow(self) -> "pyarrow.Table":
         import pyarrow

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -25,6 +25,7 @@ import warnings
 import numpy as np
 
 import ray
+from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
 import ray.cloudpickle as pickle
 from ray._private.usage import usage_lib
 from ray.air.constants import TENSOR_COLUMN_NAME
@@ -1066,7 +1067,9 @@ class Dataset(Generic[T]):
             if isinstance(batch, pd.DataFrame):
                 return batch.sample(frac=fraction)
             if isinstance(batch, np.ndarray):
-                return np.array([row for row in batch if random.random() <= fraction])
+                return _create_possibly_ragged_ndarray(
+                    [row for row in batch if random.random() <= fraction]
+                )
             raise ValueError(f"Unsupported batch type: {type(batch)}")
 
         return self.map_batches(process_batch)

--- a/python/ray/data/preprocessors/torch.py
+++ b/python/ray/data/preprocessors/torch.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Callable, Dict, List, Union
 
 import numpy as np
+from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
 
 from ray.data.preprocessor import Preprocessor
 from ray.util.annotations import PublicAPI
@@ -85,7 +86,9 @@ class TorchVisionPreprocessor(Preprocessor):
         def transform(batch: np.ndarray) -> np.ndarray:
             if self._batched:
                 return self._fn(batch).numpy()
-            return np.array([self._fn(array).numpy() for array in batch])
+            return _create_possibly_ragged_ndarray(
+                [self._fn(array).numpy() for array in batch],
+            )
 
         if isinstance(np_data, dict):
             outputs = {}

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypeVar, Uni
 import numpy as np
 
 import ray
+from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
 from ray.data._internal.arrow_block import ArrowRow
 from ray.data._internal.block_list import BlockList
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
@@ -1608,7 +1609,7 @@ def _resolve_parquet_args(
                 # NOTE(Clark): We use NumPy to consolidate these potentially
                 # non-contiguous buffers, and to do buffer bookkeeping in
                 # general.
-                np_col = np.array(
+                np_col = _create_possibly_ragged_ndarray(
                     [
                         np.ndarray(shape, buffer=buf.as_buffer(), dtype=dtype)
                         for buf in block.column(tensor_col_name)


### PR DESCRIPTION
Signed-off-by: Scott Lee <sjl@anyscale.com>

## Why are these changes needed?

This is a rework of https://github.com/ray-project/ray/pull/31544, which was reverted because of broken CI tests (bad `pandas` import). We replicate the aforementioned PR, with an additional `TYPE_CHECKING` usage to only import from `pandas`when type-checking.

## Related issue number
Rework of PR https://github.com/ray-project/ray/pull/31544


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
