### PR TITLE
Upgrade mypy for linters

### DIFF
--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -135,7 +135,6 @@ SHELLCHECK_FLAGS=(
 MYPY_FLAGS=(
     '--follow-imports=skip'
     '--ignore-missing-imports'
-    '--install-types'
 )
 
 MYPY_FILES=(

--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -135,6 +135,7 @@ SHELLCHECK_FLAGS=(
 MYPY_FLAGS=(
     '--follow-imports=skip'
     '--ignore-missing-imports'
+    '--install-types'
 )
 
 MYPY_FILES=(

--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -138,7 +138,7 @@ MYPY_FLAGS=(
 )
 
 MYPY_FILES=(
-    # Relative to python
+    # Relative to ray/python
     'ray/autoscaler/node_provider.py'
     'ray/autoscaler/sdk/__init__.py'
     'ray/autoscaler/sdk/sdk.py'

--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 FLAKE8_VERSION_REQUIRED="3.9.1"
 BLACK_VERSION_REQUIRED="22.10.0"
 SHELLCHECK_VERSION_REQUIRED="0.7.1"
-MYPY_VERSION_REQUIRED="0.782"
+MYPY_VERSION_REQUIRED="0.982"
 ISORT_VERSION_REQUIRED="5.10.1"
 
 check_python_command_exist() {
@@ -138,13 +138,13 @@ MYPY_FLAGS=(
 )
 
 MYPY_FILES=(
-    # Relative to python/ray
-    'autoscaler/node_provider.py'
-    'autoscaler/sdk/__init__.py'
-    'autoscaler/sdk/sdk.py'
-    'autoscaler/_private/commands.py'
-    'autoscaler/_private/autoscaler.py'
-    '_private/gcs_utils.py'
+    # Relative to python
+    'ray/autoscaler/node_provider.py'
+    'ray/autoscaler/sdk/__init__.py'
+    'ray/autoscaler/sdk/sdk.py'
+    'ray/autoscaler/_private/commands.py'
+    'ray/autoscaler/_private/autoscaler.py'
+    'ray/_private/gcs_utils.py'
 )
 
 
@@ -186,7 +186,7 @@ shellcheck_scripts() {
 # Runs mypy on each argument in sequence. This is different than running mypy
 # once on the list of arguments.
 mypy_on_each() {
-    pushd python/ray
+    pushd python
     for file in "$@"; do
        echo "Running mypy on $file"
        mypy ${MYPY_FLAGS[@]+"${MYPY_FLAGS[@]}"} "$file"

--- a/python/requirements_linters.txt
+++ b/python/requirements_linters.txt
@@ -2,6 +2,6 @@ flake8==3.9.1
 flake8-comprehensions
 flake8-quotes==2.0.0
 flake8-bugbear==21.9.2
-mypy==0.782
+mypy==0.982
 black==22.10.0
 isort==5.10.1

--- a/python/requirements_linters.txt
+++ b/python/requirements_linters.txt
@@ -3,5 +3,6 @@ flake8-comprehensions
 flake8-quotes==2.0.0
 flake8-bugbear==21.9.2
 mypy==0.982
+types-PyYAML==6.0.12.2
 black==22.10.0
 isort==5.10.1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `requirements_linters.txt` are using a very old version of mypy which is pinning typed-ast. This is causing problems when building the Ray documentation on M1 (it is trying to compile typed-ast from source, which fails).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
