### PR TITLE
Update `BulkExecutor` to use new `DatasetStatsSummary` methods

### DIFF
--- a/python/ray/data/_internal/execution/bulk_executor.py
+++ b/python/ray/data/_internal/execution/bulk_executor.py
@@ -70,7 +70,8 @@ class BulkExecutor(Executor):
             if op_stats:
                 self._stats = builder.build_multistage(op_stats)
                 self._stats.extra_metrics = op_metrics
-            stats_summary_string = self._stats.summary_string(include_parent=False)
+            stats_summary = self._stats.to_summary()
+            stats_summary_string = stats_summary.to_string(include_parent=False)
             context = DatasetContext.get_current()
             logger.get_logger(log_to_stdout=context.enable_auto_log_stats).info(
                 stats_summary_string,


### PR DESCRIPTION
Signed-off-by: Scott Lee <sjl@anyscale.com>

## Why are these changes needed?
The new `BulkExecutor` introduced in https://github.com/ray-project/ray/pull/31602 makes use of the `DatasetStats` class, but is calling outdated methods which have since been refactored into the `DatasetStatsSummary` class as of https://github.com/ray-project/ray/pull/30764. As a result, CI tests are breaking.

This PR updates the usage of the `summary_string()` method to use the newly refactored method in the aforementioned  `DatasetStatsSummary` class, which maintains the same functionality.

## Related issue number
Hotfix for https://github.com/ray-project/ray/pull/31602

## Checks
- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
