### PR TITLE
[Datasets] Loosen check on global node session path in DatasetLogger initialization

### DIFF
--- a/python/ray/data/_internal/dataset_logger.py
+++ b/python/ray/data/_internal/dataset_logger.py
@@ -1,8 +1,6 @@
 import logging
 import os
 
-# import sys
-
 import ray
 from ray._private.ray_constants import LOGGER_FORMAT, LOGGER_LEVEL
 

--- a/python/ray/data/_internal/dataset_logger.py
+++ b/python/ray/data/_internal/dataset_logger.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+# import sys
+
 import ray
 from ray._private.ray_constants import LOGGER_FORMAT, LOGGER_LEVEL
 
@@ -43,33 +45,48 @@ class DatasetLogger:
         for writing to the Dataset log file. Not intended (nor should it be necessary)
         to call explicitly. Assumes that `ray.init()` has already been called prior
         to calling this method; otherwise raises a `ValueError`."""
-        # With current implementation, we can only get the global node session
-        # directory path after ray.init() is called. A less hacky way could
-        # potentially fix this.
-        global_node = ray._private.worker._global_node
-        if global_node is None:
-            raise ValueError(
-                "DatasetLogger._initialize_logger() must be called after ray.init()."
-            )
+        # In the case where logger has not yet been set up in another file,
+        # initialize basic configs to set log level and format.
+        logging.basicConfig(
+            level=LOGGER_LEVEL.upper(),
+            format=LOGGER_FORMAT,
+        )
 
+        # We initialize a logger using the given base `log_name`, which
+        # logs to stdout. Logging with this logger to stdout is enabled by the
+        # `log_to_stdout` parameter in `self.get_logger()`.
+        stdout_logger = logging.getLogger(self.log_name)
+        stdout_logger.setLevel(LOGGER_LEVEL.upper())
+
+        # The second logger that we initialize is designated as the main logger,
+        # which has the above `stdout_logger` as an ancestor.
+        # This is so that even if the file handler is not initialized below,
+        # the logger will still propagate up to `stdout_logger` for the option
+        # of logging to stdout.
         logger = logging.getLogger(f"{self.log_name}.logfile")
         # We need to set the log level again when explicitly
         # initializing a new logger (otherwise can have undesirable level).
         logger.setLevel(LOGGER_LEVEL.upper())
 
-        # Add log handler which writes to a separate Datasets log file
-        # at `DatasetLogger.DEFAULT_DATASET_LOG_PATH`
-        session_dir = global_node.get_session_dir_path()
-        datasets_log_path = os.path.join(
-            session_dir,
-            DatasetLogger.DEFAULT_DATASET_LOG_PATH,
-        )
-        # Add a FileHandler to write to the specific Ray Datasets log file,
-        # using the standard default logger format used by the root logger
-        file_log_handler = logging.FileHandler(datasets_log_path)
-        file_log_formatter = logging.Formatter(fmt=LOGGER_FORMAT)
-        file_log_handler.setFormatter(file_log_formatter)
-        logger.addHandler(file_log_handler)
+        # If ray.init() is called and the global node session directory path
+        # is valid, we can create the additional handler to write to the
+        # Dataset log file. If this is not the case (e.g. when used in Ray
+        # Client), then we skip initializing the FileHandler.
+        global_node = ray._private.worker._global_node
+        if global_node is not None:
+            # Add a FileHandler to write to the specific Ray Datasets log file
+            # at `DatasetLogger.DEFAULT_DATASET_LOG_PATH`, using the standard
+            # default logger format used by the root logger
+            session_dir = global_node.get_session_dir_path()
+            datasets_log_path = os.path.join(
+                session_dir,
+                DatasetLogger.DEFAULT_DATASET_LOG_PATH,
+            )
+            file_log_formatter = logging.Formatter(fmt=LOGGER_FORMAT)
+            file_log_handler = logging.FileHandler(datasets_log_path)
+            file_log_handler.setLevel(LOGGER_LEVEL.upper())
+            file_log_handler.setFormatter(file_log_formatter)
+            logger.addHandler(file_log_handler)
         return logger
 
     def get_logger(self, log_to_stdout: bool = True) -> logging.Logger:


### PR DESCRIPTION
Signed-off-by: Scott Lee <sjl@anyscale.com>

## Why are these changes needed?

In `DatasetLogger._initialize_logger()`, we previously threw a `ValueError` if the global node's session path (`ray._private.worker._global_node.get_session_dir_path()`) was not valid, as this implied that the log file path is unknown. However, we found that in cases where `ray.init()` is not called and Ray Data is still used (most notably, in Ray Client), this undesirably throws the above error and blocks usage of Ray Data.

This PR removes the `ValueError` and instead initializes the additional `FileHandler` for the Data-specific log file only if the global node's session path is valid. Existing behavior for optionally logging to stdout is not impacted, and the remaining logging functionality remains the same as well.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
