### PR TITLE
[RLlib] More workers for Q-Mix's two-step-game regression

### DIFF
--- a/rllib/tuned_examples/qmix/two-step-game-qmix-no-mixer.yaml
+++ b/rllib/tuned_examples/qmix/two-step-game-qmix-no-mixer.yaml
@@ -18,5 +18,5 @@ two-step-game-qmix-without-mixer:
 
         rollout_fragment_length: 4
         train_batch_size: 32
-        num_workers: 0
+        num_workers: 2
         mixer: null

--- a/rllib/tuned_examples/qmix/two-step-game-qmix-no-mixer.yaml
+++ b/rllib/tuned_examples/qmix/two-step-game-qmix-no-mixer.yaml
@@ -2,7 +2,7 @@ two-step-game-qmix-without-mixer:
     env: ray.rllib.examples.env.two_step_game.TwoStepGameWithGroupedAgents
     run: QMIX
     stop:
-        episode_reward_mean: 7.0
+        episode_reward_mean: 6.5
         timesteps_total: 70000
     config:
         # QMIX only supports torch for now.
@@ -18,5 +18,5 @@ two-step-game-qmix-without-mixer:
 
         rollout_fragment_length: 4
         train_batch_size: 32
-        num_workers: 2
+        num_workers: 4
         mixer: null

--- a/rllib/tuned_examples/qmix/two-step-game-qmix-vdn-mixer.yaml
+++ b/rllib/tuned_examples/qmix/two-step-game-qmix-vdn-mixer.yaml
@@ -18,5 +18,5 @@ two-step-game-qmix-with-vdn-mixer:
 
         rollout_fragment_length: 4
         train_batch_size: 32
-        num_workers: 0
+        num_workers: 2
         mixer: vdn

--- a/rllib/tuned_examples/qmix/two-step-game-qmix-vdn-mixer.yaml
+++ b/rllib/tuned_examples/qmix/two-step-game-qmix-vdn-mixer.yaml
@@ -2,7 +2,7 @@ two-step-game-qmix-with-vdn-mixer:
     env: ray.rllib.examples.env.two_step_game.TwoStepGameWithGroupedAgents
     run: QMIX
     stop:
-        episode_reward_mean: 7.0
+        episode_reward_mean: 6.5
         timesteps_total: 70000
     config:
         # QMIX only supports torch for now.
@@ -16,7 +16,7 @@ two-step-game-qmix-with-vdn-mixer:
         exploration_config:
             final_epsilon: 0.0
 
-        rollout_fragment_length: 4
+        rollout_fragment_length: 8
         train_batch_size: 32
-        num_workers: 2
+        num_workers: 4
         mixer: vdn

--- a/rllib/tuned_examples/qmix/two-step-game-qmix.yaml
+++ b/rllib/tuned_examples/qmix/two-step-game-qmix.yaml
@@ -19,5 +19,5 @@ two-step-game-qmix-with-qmix-mixer:
 
         rollout_fragment_length: 4
         train_batch_size: 32
-        num_workers: 0
+        num_workers: 2
         mixer: qmix

--- a/rllib/tuned_examples/qmix/two-step-game-qmix.yaml
+++ b/rllib/tuned_examples/qmix/two-step-game-qmix.yaml
@@ -2,7 +2,7 @@ two-step-game-qmix-with-qmix-mixer:
     env: ray.rllib.examples.env.two_step_game.TwoStepGameWithGroupedAgents
     run: QMIX
     stop:
-        episode_reward_mean: 8.0
+        episode_reward_mean: 7.5
         timesteps_total: 70000
     config:
         # QMIX only supports torch for now.
@@ -13,11 +13,10 @@ two-step-game-qmix-with-qmix-mixer:
               separate_state_space: true
               one_hot_state_encoding: true
 
-        # W/o this setting, won't get to 8.0 reward.
         exploration_config:
             final_epsilon: 0.0
 
         rollout_fragment_length: 4
         train_batch_size: 32
-        num_workers: 2
+        num_workers: 4
         mixer: qmix


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

We need to offset the sampling-speed regression we face with connectors and QMix.
Related PRs: 
https://github.com/ray-project/ray/pull/30936
https://github.com/ray-project/ray/pull/31693

After this, we can have our next shot at enable connectors:
https://github.com/ray-project/ray/pull/31733

I tested the learning tests in question on an m5.2xlarge instance for a few times and it makes me confident that the QMix test will now do better than what we have now (with connectors switched on)
<img width="1553" alt="Screenshot 2023-01-17 at 16 18 27" src="https://user-images.githubusercontent.com/9356806/213043292-15f459fe-4e5e-4671-9288-0b51f482ed03.png">


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
