### PR TITLE
[AIR] Add `Result.uri` property

### DIFF
--- a/python/ray/air/result.py
+++ b/python/ray/air/result.py
@@ -53,6 +53,15 @@ class Result:
             return None
         return self.metrics.get("config", None)
 
+    @property
+    def uri(self) -> Optional[str]:
+        """Return checkpoint URI, if available.
+
+        Same as ``self.checkpoint.uri``."""
+        if not self.checkpoint:
+            return None
+        return self.checkpoint.uri
+
     def __repr__(self):
         from ray.tune.result import AUTO_RESULT_KEYS
 


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a fast path for users to obtain the checkpoint URI directly from the `Result` object.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
