### PR TITLE
[Datasets] Add support for dynamic block splitting to actor pool.

### DIFF
--- a/python/ray/data/_internal/execution/operators/task_pool_submitter.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_submitter.py
@@ -1,8 +1,11 @@
 from typing import Dict, Any, Iterator, Callable, Union, List
 
 import ray
-from ray.data.block import Block, BlockAccessor, BlockMetadata, BlockExecStats
-from ray.data._internal.execution.operators.map_task_submitter import MapTaskSubmitter
+from ray.data.block import Block
+from ray.data._internal.execution.operators.map_task_submitter import (
+    MapTaskSubmitter,
+    _map_task,
+)
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.types import ObjectRef
 from ray._raylet import ObjectRefGenerator
@@ -48,30 +51,3 @@ class TaskPoolSubmitter(MapTaskSubmitter):
                 # a different error, or cancellation failed. In all cases, we
                 # swallow the exception.
                 pass
-
-
-def _map_task(
-    fn: Callable[[Iterator[Block]], Iterator[Block]],
-    *blocks: Block,
-) -> Iterator[Union[Block, List[BlockMetadata]]]:
-    """Remote function for a single operator task.
-
-    Args:
-        fn: The callable that takes Iterator[Block] as input and returns
-            Iterator[Block] as output.
-        blocks: The concrete block values from the task ref bundle.
-
-    Returns:
-        A generator of blocks, followed by the list of BlockMetadata for the blocks
-        as the last generator return.
-    """
-    output_metadata = []
-    stats = BlockExecStats.builder()
-    for b_out in fn(iter(blocks)):
-        # TODO(Clark): Add input file propagation from input blocks.
-        m_out = BlockAccessor.for_block(b_out).get_metadata([], None)
-        m_out.exec_stats = stats.build()
-        output_metadata.append(m_out)
-        yield b_out
-        stats = BlockExecStats.builder()
-    yield output_metadata

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -166,11 +166,7 @@ def test_map_operator_min_rows_per_bundle(ray_start_regular_shared, use_actors):
         op.notify_work_completed(work)
 
     # Check we return transformed bundles in order.
-    if use_actors:
-        # TODO(Clark): Remove this once dynamic block splitting is supported for actors.
-        assert _take_outputs(op) == [list(range(5)), list(range(5, 10))]
-    else:
-        assert _take_outputs(op) == [[i] for i in range(10)]
+    assert _take_outputs(op) == [[i] for i in range(10)]
     assert op.completed()
 
 


### PR DESCRIPTION
This PR adds support for dynamic block splitting to the actor pool in the new execution backend.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
