### PR TITLE
[AIR] Add `set_preprocessor` method to `Checkpoint`

### DIFF
--- a/doc/source/ray-air/doc_code/mxnet_predictor.py
+++ b/doc/source/ray-air/doc_code/mxnet_predictor.py
@@ -37,12 +37,11 @@ class MXNetPredictor(Predictor):
         cls,
         checkpoint: Checkpoint,
         net: gluon.Block,
-        preprocessor: Optional[Preprocessor] = None,
     ) -> Predictor:
         with checkpoint.as_directory() as directory:
             path = os.path.join(directory, "net.params")
             net.load_parameters(path)
-        return cls(net, preprocessor=preprocessor)
+        return cls(net, preprocessor=checkpoint.get_preprocessor())
     # __mxnetpredictor_from_checkpoint_end__
 
     # __mxnetpredictor_predict_numpy_start__
@@ -86,9 +85,14 @@ def preprocess(batch: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
     return batch
 
 
+# Create the preprocessor and set it in the checkpoint.
+# This preprocessor will be used to transform the data prior to prediction.
 preprocessor = BatchMapper(preprocess, batch_format="numpy")
+checkpoint.set_preprocessor(preprocessor=preprocessor)
+
+
 predictor = BatchPredictor.from_checkpoint(
-    checkpoint, MXNetPredictor, net=net, preprocessor=preprocessor
+    checkpoint, MXNetPredictor, net=net
 )
 predictor.predict(dataset)
 # __mxnetpredictor_predict_end__

--- a/doc/source/ray-air/doc_code/statsmodel_predictor.py
+++ b/doc/source/ray-air/doc_code/statsmodel_predictor.py
@@ -41,12 +41,11 @@ class StatsmodelPredictor(Predictor):
         cls,
         checkpoint: Checkpoint,
         filename: str,
-        preprocessor: Optional[Preprocessor] = None,
     ) -> Predictor:
         with checkpoint.as_directory() as directory:
             path = os.path.join(directory, filename)
             results = OLSResults.load(path)
-        return cls(results, preprocessor)
+        return cls(results, checkpoint.get_preprocessor())
 # __statsmodelpredictor_from_checkpoint_end__
 
 

--- a/doc/source/ray-air/predictors.rst
+++ b/doc/source/ray-air/predictors.rst
@@ -376,11 +376,12 @@ Perform inference
 
         To perform inference with the completed ``MXNetPredictor``:
 
-        1. Create a :class:`~ray.train.batch_predictor.BatchPredictor` from your
+        1. Create a :class:`~ray.data.preprocessor.Preprocessor` and set it in the 
+           :class:`~ray.air.checkpoint.Checkpoint`. 
+           You can also use any of the out-of-the-box preprocessors instead of implementing your own: :ref:`air-preprocessor-ref`.
+        2. Create a :class:`~ray.train.batch_predictor.BatchPredictor` from your
            checkpoint.
-        2. Read sample images into a :class:`~ray.data.Dataset`.
-        3. Create your :class:`~ray.data.preprocessor.Preprocessor` and set it in your 
-           :class:`~ray.air.checkpoint.Checkpoint`. You can also use any of the out of the box preprocessors instead of implementing your own: :ref:`air-preprocessor-ref`.
+        3. Read sample images into a :class:`~ray.data.Dataset`.
         4. Call :class:`~ray.train.batch_predictor.BatchPredictor.predict` to classify
            the images in the dataset.
 

--- a/doc/source/ray-air/predictors.rst
+++ b/doc/source/ray-air/predictors.rst
@@ -379,7 +379,9 @@ Perform inference
         1. Create a :class:`~ray.train.batch_predictor.BatchPredictor` from your
            checkpoint.
         2. Read sample images into a :class:`~ray.data.Dataset`.
-        3. Call :class:`~ray.train.batch_predictor.BatchPredictor.predict` to classify
+        3. Create your :class:`~ray.data.preprocessor.Preprocessor` and set it in your 
+           :class:`~ray.air.checkpoint.Checkpoint`. You can also use any of the out of the box preprocessors instead of implementing your own: :ref:`air-preprocessor-ref`.
+        4. Call :class:`~ray.train.batch_predictor.BatchPredictor.predict` to classify
            the images in the dataset.
 
         .. literalinclude:: doc_code/mxnet_predictor.py

--- a/python/ray/air/checkpoint.py
+++ b/python/ray/air/checkpoint.py
@@ -14,7 +14,10 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Tuple, Type, Un
 
 import ray
 from ray import cloudpickle as pickle
-from ray.air._internal.checkpointing import load_preprocessor_from_dir
+from ray.air._internal.checkpointing import (
+    load_preprocessor_from_dir,
+    save_preprocessor_to_dir,
+)
 from ray.air._internal.filelock import TempFileLock
 from ray.air._internal.remote_storage import (
     download_from_uri,
@@ -219,6 +222,7 @@ class Checkpoint:
         self._data_dict: Optional[Dict[str, Any]] = data_dict
         self._uri: Optional[str] = uri
         self._obj_ref: Optional[ray.ObjectRef] = obj_ref
+        self._override_preprocessor: Optional["Preprocessor"] = None
 
         self._uuid = uuid.uuid4()
 
@@ -405,6 +409,11 @@ class Checkpoint:
             raise RuntimeError(f"Empty data for checkpoint {self}")
 
         checkpoint_data[_METADATA_KEY] = self._metadata
+
+        # If override_preprocessor is specified, then set that in the output dict.
+        if self._override_preprocessor:
+            checkpoint_data[PREPROCESSOR_KEY] = self._override_preprocessor
+            self._override_preprocessor = None
         return checkpoint_data
 
     @classmethod
@@ -584,6 +593,10 @@ class Checkpoint:
                 )
 
         self._save_checkpoint_metadata_in_directory(path)
+
+        if self._override_preprocessor:
+            save_preprocessor_to_dir(self._override_preprocessor, path)
+            self._override_preprocessor = None
 
     def _to_directory_safe(self, path: str, move_instead_of_copy: bool = False) -> None:
         try:
@@ -820,6 +833,11 @@ class Checkpoint:
                 preprocessor = load_preprocessor_from_dir(checkpoint_path)
 
         return preprocessor
+
+    def set_preprocessor(self, preprocessor: "Preprocessor"):
+        """Saves the provided preprocessor to this Checkpoint."""
+
+        self._override_preprocessor = preprocessor
 
     @classmethod
     def _get_checkpoint_type(

--- a/python/ray/air/checkpoint.py
+++ b/python/ray/air/checkpoint.py
@@ -413,7 +413,6 @@ class Checkpoint:
         # If override_preprocessor is specified, then set that in the output dict.
         if self._override_preprocessor:
             checkpoint_data[PREPROCESSOR_KEY] = self._override_preprocessor
-            self._override_preprocessor = None
         return checkpoint_data
 
     @classmethod
@@ -596,7 +595,6 @@ class Checkpoint:
 
         if self._override_preprocessor:
             save_preprocessor_to_dir(self._override_preprocessor, path)
-            self._override_preprocessor = None
 
     def _to_directory_safe(self, path: str, move_instead_of_copy: bool = False) -> None:
         try:

--- a/python/ray/air/tests/test_checkpoints.py
+++ b/python/ray/air/tests/test_checkpoints.py
@@ -728,6 +728,52 @@ class PreprocessorCheckpointTest(unittest.TestCase):
             preprocessor = checkpoint.get_preprocessor()
             assert preprocessor.multiplier == 1
 
+    def testDictCheckpointSetPreprocessor(self):
+        preprocessor = DummyPreprocessor(1)
+        data = {"metric": 5}
+        checkpoint = Checkpoint.from_dict(data)
+        checkpoint.set_preprocessor(preprocessor)
+        preprocessor = checkpoint.get_preprocessor()
+        assert preprocessor.multiplier == 1
+
+    def testDictCheckpointSetPreprocessorAsDir(self):
+        preprocessor = DummyPreprocessor(1)
+        data = {"metric": 5}
+        checkpoint = Checkpoint.from_dict(data)
+        checkpoint.set_preprocessor(preprocessor)
+        checkpoint_path = checkpoint.to_directory()
+        checkpoint = Checkpoint.from_directory(checkpoint_path)
+        preprocessor = checkpoint.get_preprocessor()
+        assert preprocessor.multiplier == 1
+
+    def testDirCheckpointSetPreprocessor(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            preprocessor = DummyPreprocessor(1)
+            data = {"metric": 5}
+            checkpoint_dir = os.path.join(tmpdir, "existing_checkpoint")
+            os.mkdir(checkpoint_dir, 0o755)
+            with open(os.path.join(checkpoint_dir, "test_data.pkl"), "wb") as fp:
+                pickle.dump(data, fp)
+            checkpoint = Checkpoint.from_directory(checkpoint_dir)
+            checkpoint.set_preprocessor(preprocessor)
+            preprocessor = checkpoint.get_preprocessor()
+            assert preprocessor.multiplier == 1
+
+    def testDirCheckpointSetPreprocessorAsDict(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            preprocessor = DummyPreprocessor(1)
+            data = {"metric": 5}
+            checkpoint_dir = os.path.join(tmpdir, "existing_checkpoint")
+            os.mkdir(checkpoint_dir, 0o755)
+            with open(os.path.join(checkpoint_dir, "test_data.pkl"), "wb") as fp:
+                pickle.dump(data, fp)
+            checkpoint = Checkpoint.from_directory(checkpoint_dir)
+            checkpoint.set_preprocessor(preprocessor)
+            checkpoint_dict = checkpoint.to_dict()
+            checkpoint = checkpoint.from_dict(checkpoint_dict)
+            preprocessor = checkpoint.get_preprocessor()
+            assert preprocessor.multiplier == 1
+
     def testAttrPath(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             checkpoint = Checkpoint.from_directory(tmpdir)

--- a/python/ray/air/tests/test_checkpoints.py
+++ b/python/ray/air/tests/test_checkpoints.py
@@ -774,6 +774,14 @@ class PreprocessorCheckpointTest(unittest.TestCase):
             preprocessor = checkpoint.get_preprocessor()
             assert preprocessor.multiplier == 1
 
+    def testObjectRefCheckpointSetPreprocessor(self):
+        ckpt = Checkpoint.from_dict({"x": 1})
+        ckpt = ray.get(ray.put(ckpt))
+        preprocessor = DummyPreprocessor(1)
+        ckpt.set_preprocessor(preprocessor)
+
+        assert ckpt.get_preprocessor() == preprocessor
+
     def testAttrPath(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             checkpoint = Checkpoint.from_directory(tmpdir)


### PR DESCRIPTION
Signed-off-by: amogkam <amogkamsetty@yahoo.com>

Adds a `set_preprocessor` method to the `Checkpoint` class, analogous to the existing `get_checkpoint` method. This is necessary to easily specify preprocessors to Checkpoints when not using any of the existing framework-specific checkpoints.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
