### PR TITLE
Revert "[RLlib] Support multi-gpu CQL for torch (tf already supported…

### DIFF
--- a/rllib/algorithms/cql/cql.py
+++ b/rllib/algorithms/cql/cql.py
@@ -137,6 +137,8 @@ class CQLConfig(SACConfig):
         # CQL-torch performs the optimizer steps inside the loss function.
         # Using the multi-GPU optimizer will therefore not work (see multi-GPU
         # check above) and we must use the simple optimizer for now.
+        if self.simple_optimizer is not True and self.framework_str == "torch":
+            self.simple_optimizer = True
 
         if self.framework_str in ["tf", "tf2"] and tfp is None:
             logger.warning(

--- a/rllib/algorithms/cql/cql_torch_policy.py
+++ b/rllib/algorithms/cql/cql_torch_policy.py
@@ -203,7 +203,7 @@ def cql_loss(
         torch.FloatTensor(actions.shape[0] * num_actions, actions.shape[-1]).uniform_(
             action_low, action_high
         ),
-        actions.device,
+        policy.device,
     )
     curr_actions, curr_logp = policy_actions_repeat(
         model, action_dist_class, model_out_t, num_actions
@@ -323,7 +323,7 @@ def cql_stats(policy: Policy, train_batch: SampleBatch) -> Dict[str, TensorType]
 
     # Add CQL loss stats to the dict.
     stats_dict["cql_loss"] = torch.mean(
-        torch.stack(tree.flatten(policy.get_tower_stats("cql_loss")))
+        torch.stack(*policy.get_tower_stats("cql_loss"))
     )
 
     if policy.config["lagrangian"]:


### PR DESCRIPTION
…). (#31466)"

This reverts commit f05c5f96b7c715a6220043845183d124f64a7b45.

## Why are these changes needed?

I've tested with and w/o revert on a GPU instance.
The commit in question causes the following error:

<img width="1418" alt="Screenshot 2023-01-17 at 19 05 34" src="https://user-images.githubusercontent.com/9356806/213072758-2f35c6ef-1609-4db5-8fe6-1945d30aaf9f.png">

## Related issue number

Fixes https://github.com/ray-project/ray/issues/31720
