### PR TITLE
[RLlib] Revert "Revert "[RLlib] Enable connectors. (#30388)" (#31495)"

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -324,7 +324,7 @@ class AlgorithmConfig:
         self.sample_collector = SimpleListCollector
         self.create_env_on_local_worker = False
         self.sample_async = False
-        self.enable_connectors = False
+        self.enable_connectors = True
         self.rollout_fragment_length = 200
         self.batch_mode = "truncate_episodes"
         self.remote_worker_envs = False


### PR DESCRIPTION
This reverts commit ee3abd402925273dae376691404a147323546b52.

After the following two PRs, we should be able to flip the switch with this PR.
https://github.com/ray-project/ray/pull/31707
https://github.com/ray-project/ray/pull/31693/