### PR TITLE
[Release] Store metrics separately in buildkite artifacts

### DIFF
--- a/release/ray_release/reporter/artifacts.py
+++ b/release/ray_release/reporter/artifacts.py
@@ -43,4 +43,4 @@ class ArtifactsReporter(Reporter):
             with gzip.open(metrics_file, "wt", encoding="UTF-8") as fp:
                 json.dump(metrics_dict, fp, sort_keys=True, indent=4)
 
-            logger.info(f"Wrote metrics to artifacts directory: {self.artifacts_dir}")
+            logger.info(f"Wrote prometheus metrics to artifacts directory: {self.artifacts_dir}")

--- a/release/ray_release/reporter/artifacts.py
+++ b/release/ray_release/reporter/artifacts.py
@@ -40,9 +40,7 @@ class ArtifactsReporter(Reporter):
 
         if metrics_dict:
             metrics_file = os.path.join(self.artifacts_dir, METRICS_RESULT_FILE)
-            with gzip.open(metrics_file, "w") as f:
-                f.write(
-                    json.dumps(metrics_dict, sort_keys=True, indent=4).encode("utf-8")
-                )
+            with gzip.open(metrics_file, "wt", encoding="UTF-8") as fp:
+                json.dump(metrics_dict, fp, sort_keys=True, indent=4)
 
             logger.info(f"Wrote metrics to artifacts directory: {self.artifacts_dir}")

--- a/release/ray_release/reporter/artifacts.py
+++ b/release/ray_release/reporter/artifacts.py
@@ -1,3 +1,4 @@
+import gzip
 import json
 import os
 
@@ -12,6 +13,7 @@ DEFAULT_ARTIFACTS_DIR = "/tmp/artifacts"
 
 ARTIFACT_TEST_CONFIG_FILE = "test_config.json"
 ARTIFACT_RESULT_FILE = "result.json"
+METRICS_RESULT_FILE = "metrics.json.gz"
 
 
 class ArtifactsReporter(Reporter):
@@ -27,9 +29,20 @@ class ArtifactsReporter(Reporter):
             json.dump(test, fp, sort_keys=True, indent=4)
 
         result_file = os.path.join(self.artifacts_dir, ARTIFACT_RESULT_FILE)
+        result_dict = result.__dict__
+        metrics_dict = result_dict.pop("prometheus_metrics")
         with open(result_file, "wt") as fp:
-            json.dump(result.__dict__, fp, sort_keys=True, indent=4)
+            json.dump(result_dict, fp, sort_keys=True, indent=4)
 
         logger.info(
             f"Wrote test config and result to artifacts directory: {self.artifacts_dir}"
         )
+
+        if metrics_dict:
+            metrics_file = os.path.join(self.artifacts_dir, METRICS_RESULT_FILE)
+            with gzip.open(metrics_file, "w") as f:
+                f.write(
+                    json.dumps(metrics_dict, sort_keys=True, indent=4).encode("utf-8")
+                )
+
+            logger.info(f"Wrote metrics to artifacts directory: {self.artifacts_dir}")

--- a/release/ray_release/reporter/artifacts.py
+++ b/release/ray_release/reporter/artifacts.py
@@ -43,4 +43,6 @@ class ArtifactsReporter(Reporter):
             with gzip.open(metrics_file, "wt", encoding="UTF-8") as fp:
                 json.dump(metrics_dict, fp, sort_keys=True, indent=4)
 
-            logger.info(f"Wrote prometheus metrics to artifacts directory: {self.artifacts_dir}")
+            logger.info(
+                f"Wrote prometheus metrics to artifacts directory: {self.artifacts_dir}"
+            )


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Stores prometheus metrics as a separate file in buildkite artifacts.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
