### PR TITLE
[RLlib] Reinstantiate Ape-X release test

### DIFF
--- a/release/long_running_tests/workloads/apex.py
+++ b/release/long_running_tests/workloads/apex.py
@@ -39,7 +39,7 @@ run_experiments(
     {
         "apex": {
             "run": "APEX",
-            "env": "Pong-v0",
+            "env": "ALE/Pong-v5",
             "config": {
                 "num_workers": 3,
                 "num_gpus": 0,

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1484,7 +1484,7 @@ py_test(
 
 
 py_test(
-    name = "test_pg_tf_pong_v0",
+    name = "test_pg_tf_pong_v5",
     main = "train.py", srcs = ["train.py"],
     tags = ["team:rllib", "quick_train"],
     args = [


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

ApeX release test has been failing due to us using Pong-v0 there.
<img width="796" alt="Screenshot 2023-01-18 at 10 48 03" src="https://user-images.githubusercontent.com/9356806/213268075-9f87a0d7-ee27-47c4-a53f-0349202aabdf.png">

Since this is a long running test and we don't care about learning, i've not looked into the environment dynamics but simply replaced it like we did in a Pong-v0 CI test some time ago.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
