### PR TITLE
[AIR] Use Train device in `iter_torch_batches`

### DIFF
--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -136,7 +136,8 @@ def convert_ndarray_to_torch_tensor(
     """
     if device is None:
         # If we are in a TorchTrainer worker function, automatically
-        # use the correct device.
+        # use the correct device. This is tested in Train tests.
+
         # Lazy import to avoid circular imports.
         from ray.train.torch.train_loop_utils import get_device
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2811,7 +2811,8 @@ class Dataset(Generic[T]):
             dtypes: The Torch dtype(s) for the created tensor(s); if None, the dtype
                 will be inferred from the tensor data.
             device: The device on which the tensor should be placed; if None, the Torch
-                tensor will be constructed on the CPU.
+                tensor will be constructed on the default device (automatic if running
+                inside a Ray Train worker, CPU otherwise).
             drop_last: Whether to drop the last batch if it's incomplete.
             local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
                 using a local in-memory shuffle buffer, and this value will serve as the

--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -354,6 +354,10 @@ def test_torch_iter_torch_batches_auto_device(ray_start_4_cpus_2_gpus, use_gpu):
             assert str(batch.device) == str(train.torch.get_device())
 
     dataset = ray.data.from_numpy(np.array([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]]).T)
+    # Test that this works outside a Train function
+    for batch in dataset.iter_torch_batches(dtypes=torch.float, device="cpu"):
+        assert str(batch.device) == "cpu"
+
     trainer = TorchTrainer(
         train_fn,
         scaling_config=ScalingConfig(num_workers=2, use_gpu=use_gpu),


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR lets `Dataset.iter_torch_batches` automatically use the correct Torch device by default if running in a `TorchTrainer` worker function (as returned by `train.torch.get_device()`).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
