### PR TITLE
[Datasets] Fix Torch tensor memory leak test.

### DIFF
--- a/python/ray/train/tests/test_torch_utils.py
+++ b/python/ray/train/tests/test_torch_utils.py
@@ -77,19 +77,26 @@ class TestConvertPandasToTorch:
             )
 
     def test_tensor_column_no_memory_leak(self):
+        import gc
+
         # Test that converting a Pandas DataFrame containing an object-dtyped tensor
         # column (e.g. post-casting from extension type) doesn't leak memory. Casting
         # these tensors directly with torch.as_tensor() currently leaks memory; see
         # https://github.com/ray-project/ray/issues/30629#issuecomment-1330954556
-        col = np.empty(1000, dtype=object)
-        col[:] = [np.ones((100, 100)) for _ in range(1000)]
-        df = pd.DataFrame({"a": col})
+        def code():
+            gc.collect()
+            col = np.empty(1000, dtype=object)
+            col[:] = [np.ones((100, 100)) for _ in range(1000)]
+            df = pd.DataFrame({"a": col})
+            convert_pandas_to_torch_tensor(
+                df, columns=[["a"]], column_dtypes=[torch.int]
+            )
+            gc.collect()
+
         suspicious_stats = _test_some_code_for_memory_leaks(
             desc="Testing convert_pandas_to_torch_tensor for memory leaks.",
             init=None,
-            code=lambda: convert_pandas_to_torch_tensor(
-                df, columns=[["a"]], column_dtypes=[torch.int]
-            ),
+            code=code,
             repeats=10,
         )
         assert not suspicious_stats

--- a/python/ray/train/tests/test_torch_utils.py
+++ b/python/ray/train/tests/test_torch_utils.py
@@ -77,21 +77,17 @@ class TestConvertPandasToTorch:
             )
 
     def test_tensor_column_no_memory_leak(self):
-        import gc
-
         # Test that converting a Pandas DataFrame containing an object-dtyped tensor
         # column (e.g. post-casting from extension type) doesn't leak memory. Casting
         # these tensors directly with torch.as_tensor() currently leaks memory; see
         # https://github.com/ray-project/ray/issues/30629#issuecomment-1330954556
         def code():
-            gc.collect()
             col = np.empty(1000, dtype=object)
             col[:] = [np.ones((100, 100)) for _ in range(1000)]
             df = pd.DataFrame({"a": col})
             convert_pandas_to_torch_tensor(
                 df, columns=[["a"]], column_dtypes=[torch.int]
             )
-            gc.collect()
 
         suspicious_stats = _test_some_code_for_memory_leaks(
             desc="Testing convert_pandas_to_torch_tensor for memory leaks.",

--- a/python/ray/util/debug.py
+++ b/python/ray/util/debug.py
@@ -1,10 +1,12 @@
 from collections import defaultdict, namedtuple
-import numpy as np
+import gc
 import os
 import re
 import time
 import tracemalloc
 from typing import Callable, List, Optional
+
+import numpy as np
 
 from ray.util.annotations import DeveloperAPI
 
@@ -137,7 +139,11 @@ def _test_some_code_for_memory_leaks(
         # Run `code` n times, each time taking a memory snapshot.
         for i in range(actual_repeats):
             _i_print(i)
+            # Manually trigger garbage collection before and after code runs in order to
+            # make tracemalloc snapshots as accurate as possible.
+            gc.collect()
             code()
+            gc.collect()
             _take_snapshot(table, suspicious)
         print("\n")
 


### PR DESCRIPTION
Torch tensor memory leak test was suffering from a noisy neighbor issue, and was low signal due to not doing the base tensor allocation in the leak-tested code. This PR fixes this by doing explicit garbage collection before and after each leak-code run, and moving the base tensor allocation into the leak-code.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes flaky test.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
