### PR TITLE
[Dataset] Use job-based file manager for SDK runner in `read_parquet_benchmark_single_node` test

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4303,7 +4303,6 @@
     script: python read_parquet_benchmark.py
 
     type: sdk_command
-    file_manager: sdk
 
 - name: read_images_benchmark_single_node
   group: data-tests


### PR DESCRIPTION
Signed-off-by: Scott Lee <sjl@anyscale.com>



## Why are these changes needed?

The release test `read_parquet_benchmark_single_node` has been failing for the past several master builds (examples [1](https://buildkite.com/ray-project/release-tests-branch/builds/1299#0185c60f-3f0c-4047-84c2-3e12c436ed29), [2](https://buildkite.com/ray-project/release-tests-branch/builds/1294#0185bc04-743b-48fd-9f28-72d410c187ee)), due to the same issue discussed/addressed in https://github.com/ray-project/ray/pull/31493 (the actual error message is: `botocore.exceptions.DataNotFoundError: Unable to load data for: ec2/2016-11-15/endpoint-rule-set-1`). This PR updates one remaining test to match this convention.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
