### PR TITLE
[Release] Do not store metrics in DB

### DIFF
--- a/release/ray_release/reporter/db.py
+++ b/release/ray_release/reporter/db.py
@@ -48,8 +48,6 @@ class DBReporter(Reporter):
                 Record={"Data": json.dumps(result_json)},
             )
         except Exception:
-            logger.exception(
-                "Failed to persist result to the databricks delta lake"
-            )
+            logger.exception("Failed to persist result to the databricks delta lake")
         else:
             logger.info("Result has been persisted to the databricks delta lake")

--- a/release/ray_release/reporter/db.py
+++ b/release/ray_release/reporter/db.py
@@ -16,6 +16,9 @@ class DBReporter(Reporter):
     def report_result(self, test: Test, result: Result):
         logger.info("Persisting result to the databricks delta lake...")
 
+        # Prometheus metrics are saved as buildkite artifacts
+        # and can be obtained using buildkite API.
+
         result_json = {
             "_table": "release_test_result",
             "report_timestamp_ms": int(time.time() * 1000),
@@ -34,7 +37,6 @@ class DBReporter(Reporter):
             "stable": result.stable,
             "return_code": result.return_code,
             "smoke_test": result.smoke_test,
-            "prometheus_metrics": result.prometheus_metrics or {},
             "extra_tags": result.extra_tags or {},
         }
 
@@ -46,20 +48,8 @@ class DBReporter(Reporter):
                 Record={"Data": json.dumps(result_json)},
             )
         except Exception:
-            try:
-                # This may happen if metrics are too big.
-                # TODO persist big metrics in an alternative fashion
-                logger.warning(
-                    "Couldn't persist with prometheus_metrics, trying without them"
-                )
-                result_json.pop("prometheus_metrics", None)
-                self.firehose.put_record(
-                    DeliveryStreamName="ray-ci-results",
-                    Record={"Data": json.dumps(result_json)},
-                )
-            except Exception:
-                logger.exception(
-                    "Failed to persist result to the databricks delta lake"
-                )
+            logger.exception(
+                "Failed to persist result to the databricks delta lake"
+            )
         else:
             logger.info("Result has been persisted to the databricks delta lake")


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We stop storing metric jsons in the release test database as they are now uploaded as separate buildkite artifacts and can be obtained using buildkite's API (metric collection is unaffected).

https://buildkite.com/docs/apis/rest-api/artifacts

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
