### PR TITLE
[docs] add message with url

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -60,6 +60,7 @@ develop:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+	@echo "View the documentation by opening a browser and going to $(BUILDDIR)/html/index.html."
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml


### PR DESCRIPTION

## Why are these changes needed?
After 'make develop` builds the documentation, we want to print the URL of where to preview the docs in a browser.
 
<!-- Please give a short summary of the change and the problem this solves. -->
Added message with the URL to preview the docs.

## Related issue number
N/A

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
