### PR TITLE
[Datasets] Fix Dataset.count() to not trigger execution

### DIFF
--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -404,7 +404,7 @@ class ExecutionPlan:
             # This applies to newly created dataset. For example, initial dataset from
             # read, and output datasets of Dataset.split().
             self.execute()
-        # Snapshot is now guaranteed to be the output of the final stage or None.
+        # Snapshot is now guaranteed to be the final block or None.
         return self._get_num_rows_from_blocks_metadata(self._snapshot_blocks)
 
     def _get_num_rows_from_blocks_metadata(self, blocks: BlockList) -> Optional[int]:

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -399,6 +399,11 @@ class ExecutionPlan:
         """
         if self._stages_after_snapshot:
             return None
+        elif self._in_blocks is not None and self._snapshot_blocks is None:
+            # If the plan only has input blocks, we execute it, so snapshot has output.
+            # This applies to newly created dataset. For example, initial dataset from
+            # read, and output datasets of Dataset.split().
+            self.execute()
         # Snapshot is now guaranteed to be the output of the final stage or None.
         return self._get_num_rows_from_blocks_metadata(self._snapshot_blocks)
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1487,6 +1487,15 @@ def test_schema_lazy(ray_start_regular_shared):
     assert ds._plan.execute()._num_computed() == 1
 
 
+def test_count_lazy(ray_start_regular_shared):
+    ds = ray.data.range(100, parallelism=10)
+    # We do not kick off the read task by default.
+    assert ds._plan._in_blocks._num_computed() == 0
+    assert ds.count() == 100
+    # Getting number of rows should not trigger execution of any read tasks.
+    assert ds._plan._in_blocks._num_computed() == 0
+
+
 def test_lazy_loading_exponential_rampup(ray_start_regular_shared):
     ds = ray.data.range(100, parallelism=20)
     assert ds._plan.execute()._num_computed() == 0

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1492,7 +1492,8 @@ def test_count_lazy(ray_start_regular_shared):
     # We do not kick off the read task by default.
     assert ds._plan._in_blocks._num_computed() == 0
     assert ds.count() == 100
-    # Getting number of rows should not trigger execution of any read tasks.
+    # Getting number of rows should not trigger execution of any read tasks
+    # for ray.data.range(), as the number of rows is known beforehand.
     assert ds._plan._in_blocks._num_computed() == 0
 
 


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is to fix the issue found in nightly test, that `Dataset.count()` trigger unexpected execution, instead of calculating the number of rows from metadata directly. This PR is to fix the issue, reran the nightly test and it works as expected now.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
