### PR TITLE
[Datasets] Reduce the cluster size for parquet_metadata_resolution test

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4227,14 +4227,13 @@
   frequency: nightly
   team: data
   cluster:
-    cluster_env: pipelined_training_app.yaml
-    cluster_compute: pipelined_training_compute.yaml
+    cluster_env: app_config.yaml
+    cluster_compute: single_node_benchmark_compute.yaml
 
   run:
-    timeout: 1200
+    # Expect the test to finish around 40 seconds.
+    timeout: 80
     script: python parquet_metadata_resolution.py --num-files 915
-    wait_for_nodes:
-      num_nodes: 15
 
 
 - name: dataset_random_access


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
When debugging the nightly test for parquet_metadata_resolution, I found the nightly test is actually pretty lightweight, and can finish around 40 seconds in a single node cluster. Reduce the cluster size here from 16 to 1 node. I remember this test was also flaky from time to time, when the cluster does not have enough node to come up.

```
(base) release/nightly_tests/dataset$ TEST_OUTPUT_JSON=/tmp/release_test_out.json METRICS_OUTPUT_JSON=/tmp/metrics_test_out.json python parquet_metadata_resolution.py --num-files 915
Metadata Fetch Progress:   0%|          | 0/100 [00:00<?, ?it/s]
Metadata Fetch Progress:   1%|          | 1/100 [00:04<07:08,  4.33s/it]
Metadata Fetch Progress:   3%|▎         | 3/100 [00:04<01:52,  1.16s/it]
Metadata Fetch Progress:   5%|▌         | 5/100 [00:04<00:56,  1.68it/s]
Metadata Fetch Progress:   7%|▋         | 7/100 [00:04<00:35,  2.58it/s]
Metadata Fetch Progress:   9%|▉         | 9/100 [00:05<00:37,  2.41it/s]
Metadata Fetch Progress:  11%|█         | 11/100 [00:05<00:25,  3.46it/s]
Metadata Fetch Progress:  15%|█▌        | 15/100 [00:06<00:17,  4.76it/s]
Metadata Fetch Progress:  17%|█▋        | 17/100 [00:07<00:20,  4.06it/s]
Metadata Fetch Progress:  20%|██        | 20/100 [00:07<00:14,  5.67it/s]
Metadata Fetch Progress:  22%|██▏       | 22/100 [00:13<01:14,  1.05it/s]
Metadata Fetch Progress:  24%|██▍       | 24/100 [00:13<00:56,  1.35it/s]
Metadata Fetch Progress:  25%|██▌       | 25/100 [00:14<00:48,  1.55it/s]
Metadata Fetch Progress:  27%|██▋       | 27/100 [00:14<00:33,  2.16it/s]
Metadata Fetch Progress:  30%|███       | 30/100 [00:14<00:20,  3.42it/s]
Metadata Fetch Progress:  32%|███▏      | 32/100 [00:14<00:16,  4.20it/s]
Metadata Fetch Progress:  35%|███▌      | 35/100 [00:14<00:10,  6.09it/s]
Metadata Fetch Progress:  37%|███▋      | 37/100 [00:20<00:53,  1.18it/s]
Metadata Fetch Progress:  39%|███▉      | 39/100 [00:20<00:39,  1.55it/s]
Metadata Fetch Progress:  41%|████      | 41/100 [00:20<00:30,  1.93it/s]
Metadata Fetch Progress:  42%|████▏     | 42/100 [00:20<00:26,  2.20it/s]
Metadata Fetch Progress:  45%|████▌     | 45/100 [00:21<00:16,  3.38it/s]
Metadata Fetch Progress:  48%|████▊     | 48/100 [00:21<00:10,  4.97it/s]
Metadata Fetch Progress:  50%|█████     | 50/100 [00:21<00:09,  5.42it/s]
Metadata Fetch Progress:  53%|█████▎    | 53/100 [00:21<00:06,  7.62it/s]
Metadata Fetch Progress:  55%|█████▌    | 55/100 [00:21<00:06,  7.02it/s]
Metadata Fetch Progress:  57%|█████▋    | 57/100 [00:22<00:05,  8.13it/s]
Metadata Fetch Progress:  60%|██████    | 60/100 [00:22<00:04,  9.02it/s]
Metadata Fetch Progress:  62%|██████▏   | 62/100 [00:22<00:05,  7.52it/s]
Metadata Fetch Progress:  64%|██████▍   | 64/100 [00:28<00:33,  1.08it/s]
Metadata Fetch Progress:  65%|██████▌   | 65/100 [00:29<00:29,  1.18it/s]
Metadata Fetch Progress:  68%|██████▊   | 68/100 [00:29<00:16,  1.94it/s]
Metadata Fetch Progress:  77%|███████▋  | 77/100 [00:29<00:04,  4.95it/s]
Metadata Fetch Progress:  80%|████████  | 80/100 [00:30<00:04,  4.84it/s]
Metadata Fetch Progress:  82%|████████▏ | 82/100 [00:30<00:03,  4.82it/s]
Metadata Fetch Progress:  86%|████████▌ | 86/100 [00:30<00:02,  6.50it/s]
Metadata Fetch Progress:  88%|████████▊ | 88/100 [00:31<00:02,  5.47it/s]
Metadata Fetch Progress:  90%|█████████ | 90/100 [00:31<00:01,  5.62it/s]
Metadata Fetch Progress:  91%|█████████ | 91/100 [00:32<00:01,  4.68it/s]
Metadata Fetch Progress:  93%|█████████▎| 93/100 [00:32<00:01,  5.73it/s]
Metadata Fetch Progress:  94%|█████████▍| 94/100 [00:32<00:01,  5.70it/s]
Metadata Fetch Progress:  96%|█████████▌| 96/100 [00:32<00:00,  7.24it/s]
Metadata Fetch Progress:  98%|█████████▊| 98/100 [00:33<00:00,  5.71it/s]
Metadata Fetch Progress:  99%|█████████▉| 99/100 [00:34<00:00,  3.66it/s]
Metadata Fetch Progress: 100%|██████████| 100/100 [00:34<00:00,  2.93it/s]
Parquet Files Sample:   0%|          | 0/9 [00:00<?, ?it/s]
Parquet Files Sample:  11%|█         | 1/9 [00:01<00:13,  1.67s/it]
Parquet Files Sample: 100%|██████████| 9/9 [00:01<00:00,  4.88it/s]
success! total time 40.17799425125122
```


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
