### PR TITLE
update ray start doc for --temp-dir  option

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -466,7 +466,6 @@ def debug(address):
 )
 @click.option(
     "--temp-dir",
-    hidden=True,
     default=None,
     help="manually specify the root temporary dir of the Ray process",
 )

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -467,7 +467,8 @@ def debug(address):
 @click.option(
     "--temp-dir",
     default=None,
-    help="manually specify the root temporary dir of the Ray process",
+    help="manually specify the root temporary dir of the Ray process, only works"
+    "when --head is specified",
 )
 @click.option(
     "--storage",


### PR DESCRIPTION
Signed-off-by: Yiqing Wang <yiqing.wang@instabase.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The [logging doc](https://docs.ray.io/en/latest/ray-observability/ray-logging.html#logging-directory-structure) mentions that users can customize the log directory in ray start CLI but there is no such option shown in the [ray start doc](https://docs.ray.io/en/latest/cluster/cli.html?highlight=start#ray-start). This PR unhides the --temp-dir option in the doc to avoid confusion.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
