### PR TITLE
[tune] Improve docstring for `tune.grid_search()`

### DIFF
--- a/python/ray/tune/search/variant_generator.py
+++ b/python/ray/tune/search/variant_generator.py
@@ -59,11 +59,38 @@ def generate_variants(
 
 
 @PublicAPI(stability="beta")
-def grid_search(values: Iterable) -> Dict[str, List]:
-    """Convenience method for specifying grid search over a value.
+def grid_search(values: Iterable) -> Dict[str, Iterable]:
+    """Specify a grid of values to search over.
 
-    Arguments:
-        values: An iterable whose parameters will be gridded.
+    Values specified in a grid search are guaranteed to be sampled.
+
+    If multiple grid search variables are defined, they are combined with the
+    combinatorial product. This means every possible combination of values will
+    be sampled.
+
+    Example:
+
+        >>> from ray import tune
+        >>> param_space={
+        ...   "x": tune.grid_search([10, 20]),
+        ...   "y": tune.grid_search["a", "b", "c"])
+        ... }
+
+        This will create a grid of 6 samples:
+        ``{"x": 10, "y": "a"}, {"x": 10, "y": "b"}, `` etc.
+
+    When specifying ``num_samples`` in the
+    :class:`TuneConfig <ray.tune.tune_config.TuneConfig>` in addition to
+    grid search parameters, the number of samples will be drawn for each grid
+    parameter.
+
+    For instance, in the example above, if ``num_samples=4``,
+    a total of 24 trials will be started -
+    4 trials for each of the 6 grid search combinations.
+
+    Args:
+        values: An iterable whose parameters will be used for creating a trial grid.
+
     """
     return {"grid_search": values}
 

--- a/python/ray/tune/search/variant_generator.py
+++ b/python/ray/tune/search/variant_generator.py
@@ -73,16 +73,15 @@ def grid_search(values: Iterable) -> Dict[str, Iterable]:
         >>> from ray import tune
         >>> param_space={
         ...   "x": tune.grid_search([10, 20]),
-        ...   "y": tune.grid_search["a", "b", "c"])
+        ...   "y": tune.grid_search(["a", "b", "c"])
         ... }
 
         This will create a grid of 6 samples:
         ``{"x": 10, "y": "a"}, {"x": 10, "y": "b"}, `` etc.
 
     When specifying ``num_samples`` in the
-    :class:`TuneConfig <ray.tune.tune_config.TuneConfig>` in addition to
-    grid search parameters, the number of samples will be drawn for each grid
-    parameter.
+    :class:`TuneConfig <ray.tune.tune_config.TuneConfig>`, this will specify
+    the number of random samples _per grid search combination_.
 
     For instance, in the example above, if ``num_samples=4``,
     a total of 24 trials will be started -

--- a/python/ray/tune/search/variant_generator.py
+++ b/python/ray/tune/search/variant_generator.py
@@ -77,7 +77,7 @@ def grid_search(values: Iterable) -> Dict[str, Iterable]:
         ... }
 
     This will create a grid of 6 samples:
-    ``{"x": 10, "y": "a"}, {"x": 10, "y": "b"}, `` etc.
+    ``{"x": 10, "y": "a"}``, ``{"x": 10, "y": "b"}``, etc.
 
     When specifying ``num_samples`` in the
     :class:`TuneConfig <ray.tune.tune_config.TuneConfig>`, this will specify

--- a/python/ray/tune/search/variant_generator.py
+++ b/python/ray/tune/search/variant_generator.py
@@ -76,12 +76,12 @@ def grid_search(values: Iterable) -> Dict[str, Iterable]:
         ...   "y": tune.grid_search(["a", "b", "c"])
         ... }
 
-        This will create a grid of 6 samples:
-        ``{"x": 10, "y": "a"}, {"x": 10, "y": "b"}, `` etc.
+    This will create a grid of 6 samples:
+    ``{"x": 10, "y": "a"}, {"x": 10, "y": "b"}, `` etc.
 
     When specifying ``num_samples`` in the
     :class:`TuneConfig <ray.tune.tune_config.TuneConfig>`, this will specify
-    the number of random samples _per grid search combination_.
+    the number of random samples per grid search combination.
 
     For instance, in the example above, if ``num_samples=4``,
     a total of 24 trials will be started -


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current docstring for `tune.grid_search` is lacking information and explanation. This PR adds proper documentation and an example.

## Related issue number

Closes #29733

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
