### PR TITLE
[Core] Make multiprocessing pool raise TypeError when provided a non-iterable in imap or imap_unordered

### DIFF
--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -6,7 +6,6 @@ import tempfile
 import time
 import random
 from collections import defaultdict
-import warnings
 import queue
 import math
 
@@ -509,26 +508,17 @@ def test_imap(pool_4_processes, use_iter):
         result_iter.next()
 
 
-@pytest.mark.filterwarnings(
-    "default:Passing a non-iterable argument:ray.util.annotations.RayDeprecationWarning"
-)
-def test_warn_on_non_iterable_imap_or_imap_unordered(pool):
+def test_imap_fail_on_non_iterable(pool):
     def fn(_):
         pass
 
     non_iterable = 3
 
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.raises(TypeError, match="object is not iterable"):
         pool.imap(fn, non_iterable)
-        assert any(
-            "Passing a non-iterable argument" in str(warning.message) for warning in w
-        )
 
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.raises(TypeError, match="object is not iterable"):
         pool.imap_unordered(fn, non_iterable)
-        assert any(
-            "Passing a non-iterable argument" in str(warning.message) for warning in w
-        )
 
 
 @pytest.mark.parametrize("use_iter", [True, False])

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -7,14 +7,12 @@ import os
 import queue
 import sys
 import threading
-import warnings
 import time
 from multiprocessing import TimeoutError
 from typing import Any, Callable, Dict, Hashable, Iterable, List, Optional, Tuple
 
 import ray
 from ray.util import log_once
-from ray.util.annotations import RayDeprecationWarning
 
 try:
     from joblib._parallel_backends import SafeFunction
@@ -390,21 +388,7 @@ class IMapIterator:
         # submitted chunks. Ordering mirrors that in the in the ResultThread.
         self._submitted_chunks = []
         self._ready_objects = collections.deque()
-        try:
-            self._iterator = iter(iterable)
-        except TypeError:
-            warnings.warn(
-                "Passing a non-iterable argument to the "
-                "ray.util.multiprocessing.Pool imap and imap_unordered "
-                "methods is deprecated as of Ray 2.3 and "
-                " will be removed in a future release. See "
-                "https://github.com/ray-project/ray/issues/24237 for more "
-                "information.",
-                category=RayDeprecationWarning,
-                stacklevel=3,
-            )
-            iterable = [iterable]
-            self._iterator = iter(iterable)
+        self._iterator = iter(iterable)
         if isinstance(iterable, collections.abc.Iterator):
             # Got iterator (which has no len() function).
             # Make default chunksize 1 instead of using _calculate_chunksize().


### PR DESCRIPTION
### TL;DR
This PR modifies `ray.util.multiprocessing.Pool` so that `pool.imap` and `pool.imap_unordered` throw `TypeError` when given non-iterable inputs.

### More details
We want the API of `ray.util.multiprocessing.Pool` to closely resemble that of `multiprocessing.Pool`. One Ray user pointed out in https://github.com/ray-project/ray/issues/24237 that our `imap` and `imap_unordered` implementations differ slightly from `multiprocessing.Pool` in what arguments they accept. See the following usage:
```python3
#!/usr/bin/env python3

def main():
    import multiprocessing as mp
    with mp.Pool() as pool:
        assert_throws_on_noniterable(pool.imap)
        assert_throws_on_noniterable(pool.imap_unordered)

    import ray.util.multiprocessing as raymp
    with raymp.Pool() as pool:
        assert_throws_on_noniterable(pool.imap)
        assert_throws_on_noniterable(pool.imap_unordered)

def assert_throws_on_noniterable(method):
    iterable_input = [1, 2, 3]
    noniterable_input = 3

    assert len([_ for _ in method(f, iterable_input)]) == len(iterable_input)

    try:
        [_ for _ in method(f, noniterable_input)]
        assert False, f"expected TypeError for {method}"
    except TypeError:
        pass

def f(_):
    pass

if __name__ == '__main__':
    main()
```

With this PR, this code produces no exception. Without this PR, this fails:
```
Traceback (most recent call last):
  File "/data/ray/./cade.py", line 30, in <module>
    main()
  File "/data/ray/./cade.py", line 11, in main
    assert_throws_on_noniterable(pool.imap)
  File "/data/ray/./cade.py", line 22, in assert_throws_on_noniterable
    assert False, f"expected TypeError for {method}"
AssertionError: expected TypeError for <bound method Pool.imap of <ray.util.multiprocessing.pool.Pool object at 0x7f109b9ff640>>
```

Closes https://github.com/ray-project/ray/issues/24237