### PR TITLE
[RLlib] Derive SAC model from AlgorithmConfig["model"] instead of MODEL_DEFAULTS

### DIFF
--- a/rllib/algorithms/sac/rnnsac_torch_policy.py
+++ b/rllib/algorithms/sac/rnnsac_torch_policy.py
@@ -1,13 +1,14 @@
 import gymnasium as gym
 import numpy as np
 from typing import List, Optional, Tuple, Type, Union
+import copy
 
 import ray
 from ray.rllib.algorithms.dqn.dqn_tf_policy import PRIO_WEIGHTS
 from ray.rllib.algorithms.sac import SACTorchPolicy
 from ray.rllib.algorithms.sac.rnnsac_torch_model import RNNSACTorchModel
 from ray.rllib.algorithms.sac.sac_torch_policy import _get_dist_class
-from ray.rllib.models import ModelCatalog, MODEL_DEFAULTS
+from ray.rllib.models import ModelCatalog
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.models.torch.torch_action_dist import TorchDistributionWrapper
 from ray.rllib.policy.policy import Policy
@@ -47,9 +48,9 @@ def build_rnnsac_model(
     # Force-ignore any additionally provided hidden layer sizes.
     # Everything should be configured using SAC's `q_model_config` and
     # `policy_model_config` config settings.
-    policy_model_config = MODEL_DEFAULTS.copy()
+    policy_model_config = copy.deepcopy(config["model"])
     policy_model_config.update(config["policy_model_config"])
-    q_model_config = MODEL_DEFAULTS.copy()
+    q_model_config = copy.deepcopy(config["model"])
     q_model_config.update(config["q_model_config"])
 
     default_model_cls = RNNSACTorchModel

--- a/rllib/algorithms/sac/sac_tf_policy.py
+++ b/rllib/algorithms/sac/sac_tf_policy.py
@@ -18,7 +18,7 @@ from ray.rllib.algorithms.dqn.dqn_tf_policy import (
 from ray.rllib.algorithms.sac.sac_tf_model import SACTFModel
 from ray.rllib.algorithms.sac.sac_torch_model import SACTorchModel
 from ray.rllib.evaluation.episode import Episode
-from ray.rllib.models import ModelCatalog, MODEL_DEFAULTS
+from ray.rllib.models import ModelCatalog
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.models.tf.tf_action_dist import (
     Beta,
@@ -71,9 +71,9 @@ def build_sac_model(
     # Force-ignore any additionally provided hidden layer sizes.
     # Everything should be configured using SAC's `q_model_config` and
     # `policy_model_config` config settings.
-    policy_model_config = copy.deepcopy(MODEL_DEFAULTS)
+    policy_model_config = copy.deepcopy(config["model"])
     policy_model_config.update(config["policy_model_config"])
-    q_model_config = copy.deepcopy(MODEL_DEFAULTS)
+    q_model_config = copy.deepcopy(config["model"])
     q_model_config.update(config["q_model_config"])
 
     default_model_cls = SACTorchModel if config["framework"] == "torch" else SACTFModel


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

AlgorithmConfig.model is a deepcopy of MODEL_DEFAULTS.
When creating SAC models, we don't use AlgorithmConfig.model (which might be configured by users) but configure directly based on MODEL_DEFAULTS.

## Related issue number

https://github.com/ray-project/ray/issues/31783
