### PR TITLE
[Core][Worker_Pool] Wait for prestarted-workers for the first job and disable run_on_all_workers flaky tests

### DIFF
--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -147,7 +147,7 @@ def test_multiple_waits_and_gets(shutdown_only):
     ray.get([h.remote([x]), h.remote([x])])
 
 
-@pytest.mark.skipif(True, "Flaky tests")
+@pytest.mark.skip(reasone="Flaky tests")
 def test_caching_functions_to_run(shutdown_only):
     # Test that we export functions to run on all workers before the driver
     # is connected.
@@ -193,7 +193,7 @@ def test_caching_functions_to_run(shutdown_only):
     ray._private.worker.global_worker.run_function_on_all_workers(f)
 
 
-@pytest.mark.skipif(True, "Flaky tests")
+@pytest.mark.skip(reason="Flaky tests")
 def test_running_function_on_all_workers(ray_start_regular):
     def f(worker_info):
         sys.path.append("fake_directory")

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -147,7 +147,7 @@ def test_multiple_waits_and_gets(shutdown_only):
     ray.get([h.remote([x]), h.remote([x])])
 
 
-@pytest.mark.skipif(client_test_enabled(), reason="internal api")
+@pytest.mark.skipif(True, "Flaky tests")
 def test_caching_functions_to_run(shutdown_only):
     # Test that we export functions to run on all workers before the driver
     # is connected.
@@ -193,9 +193,7 @@ def test_caching_functions_to_run(shutdown_only):
     ray._private.worker.global_worker.run_function_on_all_workers(f)
 
 
-@pytest.mark.skipif(
-    client_test_enabled() or sys.platform == "win32", reason="internal api"
-)
+@pytest.mark.skipif(True, "Flaky tests")
 def test_running_function_on_all_workers(ray_start_regular):
     def f(worker_info):
         sys.path.append("fake_directory")

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -147,7 +147,7 @@ def test_multiple_waits_and_gets(shutdown_only):
     ray.get([h.remote([x]), h.remote([x])])
 
 
-@pytest.mark.skip(reasone="Flaky tests")
+@pytest.mark.skip(reason="Flaky tests")
 def test_caching_functions_to_run(shutdown_only):
     # Test that we export functions to run on all workers before the driver
     # is connected.

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -537,7 +537,6 @@ ray.get(task.remote(), timeout=3)
         ) not in e.value.output.decode()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Flaky tests on Windows")
 def test_task_failure_when_driver_local_raylet_dies(ray_start_cluster):
     cluster = ray_start_cluster
     head = cluster.add_node(num_cpus=4, resources={"foo": 1})
@@ -664,18 +663,15 @@ def test_actor_task_fast_fail(ray_start_cluster):
 
 def test_task_crash_after_raylet_dead_throws_node_died_error():
     @ray.remote(max_retries=0)
-    def sleeper(kill):
+    def sleeper():
         import os
 
-        if kill:
-            time.sleep(5)
-            os.kill(os.getpid(), 9)
+        time.sleep(3)
+        os.kill(os.getpid(), 9)
 
     with ray.init():
-        ray.get(sleeper.remote(kill=False))
-        ref = sleeper.remote(kill=True)
+        ref = sleeper.remote()
 
-        time.sleep(2)
         raylet = ray.nodes()[0]
         kill_raylet(raylet)
 

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -664,14 +664,16 @@ def test_actor_task_fast_fail(ray_start_cluster):
 
 def test_task_crash_after_raylet_dead_throws_node_died_error():
     @ray.remote(max_retries=0)
-    def sleeper():
+    def sleeper(kill):
         import os
 
-        time.sleep(5)
-        os.kill(os.getpid(), 9)
+        if kill:
+            time.sleep(5)
+            os.kill(os.getpid(), 9)
 
     with ray.init():
-        ref = sleeper.remote()
+        ray.get(sleeper.remote(kill=False))
+        ref = sleeper.remote(kill=True)
 
         time.sleep(2)
         raylet = ray.nodes()[0]

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -765,7 +765,7 @@ void WorkerPool::OnWorkerStarted(const std::shared_ptr<WorkerInterface> &worker)
   // This is a workaround to finish driver registration after all initial workers are
   // registered to Raylet if and only if Raylet is started by a Python driver and the
   // job config is not set in `ray.init(...)`.
-  if (worker->GetAssignedJobId().IsNil() && worker_type == rpc::WorkerType::WORKER &&
+  if (worker_type == rpc::WorkerType::WORKER &&
       worker->GetLanguage() == Language::PYTHON) {
     if (++first_job_registered_python_worker_count_ ==
         first_job_driver_wait_num_python_workers_) {

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -765,7 +765,8 @@ void WorkerPool::OnWorkerStarted(const std::shared_ptr<WorkerInterface> &worker)
   // This is a workaround to finish driver registration after all initial workers are
   // registered to Raylet if and only if Raylet is started by a Python driver and the
   // job config is not set in `ray.init(...)`.
-  if (first_job_ == worker->GetAssignedJobId() &&
+  if (worker->GetAssignedJobId().IsNil() &&
+      worker_type == rpc::WorkerType::WORKER &&
       worker->GetLanguage() == Language::PYTHON) {
     if (++first_job_registered_python_worker_count_ ==
         first_job_driver_wait_num_python_workers_) {
@@ -803,6 +804,7 @@ Status WorkerPool::RegisterDriver(const std::shared_ptr<WorkerInterface> &driver
     first_job_ = job_id;
     // If the number of Python workers we need to wait is positive.
     if (num_initial_python_workers_for_first_job_ > 0) {
+      delay_callback = true;
       PrestartDefaultCpuWorkers(Language::PYTHON,
                                 num_initial_python_workers_for_first_job_);
     }

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -765,8 +765,7 @@ void WorkerPool::OnWorkerStarted(const std::shared_ptr<WorkerInterface> &worker)
   // This is a workaround to finish driver registration after all initial workers are
   // registered to Raylet if and only if Raylet is started by a Python driver and the
   // job config is not set in `ray.init(...)`.
-  if (worker->GetAssignedJobId().IsNil() &&
-      worker_type == rpc::WorkerType::WORKER &&
+  if (worker->GetAssignedJobId().IsNil() && worker_type == rpc::WorkerType::WORKER &&
       worker->GetLanguage() == Language::PYTHON) {
     if (++first_job_registered_python_worker_count_ ==
         first_job_driver_wait_num_python_workers_) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#30883 we changed the behavior of first driver connect to a raylet: previously the driver connection will wait for the prestarted workers to connect before returns, and after #30883 it no longer does so. This has caused some test flakiness for 
`test_failure_4.py -k test_task_crash_after_raylet_dead_throws_node_died_error` and `test_ray_shutdown.py -k test_driver_dead`

We restore the previous behavior and fixes the test flakiness.

Also #30883 added flakiness for run_functions_on_all_workers. we disable those flaky tests 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
