### PR TITLE
[Core][run_function_on_all_workers]  deflake run_function_on_all_workers and reenable test

### DIFF
--- a/python/ray/_private/import_thread.py
+++ b/python/ray/_private/import_thread.py
@@ -52,6 +52,8 @@ class ImportThread:
     def start(self):
         """Start the import thread."""
         with self._thread_spawn_lock:
+            if self.t is not None:
+                return
             self.t = threading.Thread(target=self._run, name="ray_import_thread")
             # Making the thread a daemon causes it to exit
             # when the main thread exits.

--- a/python/ray/_private/import_thread.py
+++ b/python/ray/_private/import_thread.py
@@ -7,6 +7,7 @@ import grpc
 
 import ray
 import ray._private.profiling as profiling
+from ray import JobID
 from ray import cloudpickle as pickle
 from ray._private import ray_constants
 
@@ -84,10 +85,14 @@ class ImportThread:
             self.subscriber.close()
 
     def _do_importing(self):
+        job_id = self.worker.current_job_id
+        if job_id == JobID.nil():
+            return
+
         while True:
             with self._lock:
                 export_key = ray._private.function_manager.make_export_key(
-                    self.num_imported + 1, self.worker.current_job_id
+                    self.num_imported + 1, job_id
                 )
                 key = self.gcs_client.internal_kv_get(
                     export_key, ray_constants.KV_NAMESPACE_FUNCTION_TABLE

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2195,13 +2195,13 @@ def disconnect(exiting_interpreter=False):
 
 
 def start_import_thread():
-    """Start the import thread if running in worker mode."""
-    assert global_worker, "worker is not initialized"
-    if (
-        global_worker.import_thread
-        and ray._raylet.Config.start_python_importer_thread()
-    ):
-        global_worker.import_thread.start()
+    """Start the import thread if the worker is connected."""
+    worker = global_worker
+    worker.check_connected()
+
+    assert _mode() is WORKER_MODE, "can only start import_thread in WORKER_MODE"
+    if worker.import_thread and ray._raylet.Config.start_python_importer_thread():
+        worker.import_thread.start()
 
 
 @contextmanager

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2097,7 +2097,7 @@ def connect(
             " and will be removed in the future."
         )
 
-    # Setup import thread, but defer the start up of 
+    # Setup import thread, but defer the start up of
     # import thread until job_config is initialized.
     # (python/ray/_raylet.pyx maybe_initialize_job_config)
     if mode not in (RESTORE_WORKER_MODE, SPILL_WORKER_MODE):

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2194,10 +2194,14 @@ def disconnect(exiting_interpreter=False):
         ray_actor._ActorClassMethodMetadata.reset_cache()
 
 
-def start_import_thread(worker=global_worker):
-    worker.function_actor_manager = FunctionActorManager(worker)
-    if worker.import_thread and ray._raylet.Config.start_python_importer_thread():
-        worker.import_thread.start()
+def start_import_thread():
+    """Start the import thread if running in worker mode."""
+    assert global_worker, "worker is not initialized"
+    if (
+        global_worker.import_thread
+        and ray._raylet.Config.start_python_importer_thread()
+    ):
+        global_worker.import_thread.start()
 
 
 @contextmanager

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2199,7 +2199,10 @@ def start_import_thread():
     worker = global_worker
     worker.check_connected()
 
-    assert _mode() is WORKER_MODE, "can only start import_thread in WORKER_MODE"
+    assert _mode() not in (
+        RESTORE_WORKER_MODE,
+        SPILL_WORKER_MODE,
+    ), "import thread can not be used in IO workers."
     if worker.import_thread and ray._raylet.Config.start_python_importer_thread():
         worker.import_thread.start()
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -166,6 +166,7 @@ current_task_id = None
 current_task_id_lock = threading.Lock()
 
 job_config_initialized = False
+job_config_initialization_lock = threading.Lock()
 
 
 class ObjectRefGenerator:
@@ -1389,38 +1390,40 @@ cdef void unhandled_exception_handler(const CRayObject& error) nogil:
 
 
 def maybe_initialize_job_config():
-    global job_config_initialized
-    if job_config_initialized:
-        return
-    # Add code search path to sys.path, set load_code_from_local.
-    core_worker = ray._private.worker.global_worker.core_worker
-    code_search_path = core_worker.get_job_config().code_search_path
-    load_code_from_local = False
-    if code_search_path:
-        load_code_from_local = True
-        for p in code_search_path:
-            if os.path.isfile(p):
-                p = os.path.dirname(p)
-            sys.path.insert(0, p)
-    ray._private.worker.global_worker.set_load_code_from_local(load_code_from_local)
+    with job_config_initialization_lock:
+        global job_config_initialized
+        if job_config_initialized:
+            return
+        # Add code search path to sys.path, set load_code_from_local.
+        core_worker = ray._private.worker.global_worker.core_worker
+        code_search_path = core_worker.get_job_config().code_search_path
+        load_code_from_local = False
+        if code_search_path:
+            load_code_from_local = True
+            for p in code_search_path:
+                if os.path.isfile(p):
+                    p = os.path.dirname(p)
+                sys.path.insert(0, p)
+        ray._private.worker.global_worker.set_load_code_from_local(load_code_from_local)
 
-    # Add driver's system path to sys.path
-    py_driver_sys_path = core_worker.get_job_config().py_driver_sys_path
-    if py_driver_sys_path:
-        for p in py_driver_sys_path:
-            sys.path.insert(0, p)
-    job_config_initialized = True
+        # Add driver's system path to sys.path
+        py_driver_sys_path = core_worker.get_job_config().py_driver_sys_path
+        if py_driver_sys_path:
+            for p in py_driver_sys_path:
+                sys.path.insert(0, p)
 
-    # Record the task name via :task_name: magic token in the log file.
-    # This is used for the prefix in driver logs `(task_name pid=123) ...`
-    job_id_magic_token = "{}{}\n".format(
-        ray_constants.LOG_PREFIX_JOB_ID, core_worker.get_current_job_id().hex())
-    # Print on both .out and .err
-    print(job_id_magic_token, end="")
-    print(job_id_magic_token, file=sys.stderr, end="")
+        # Record the task name via :task_name: magic token in the log file.
+        # This is used for the prefix in driver logs `(task_name pid=123) ...`
+        job_id_magic_token = "{}{}\n".format(
+            ray_constants.LOG_PREFIX_JOB_ID, core_worker.get_current_job_id().hex())
+        # Print on both .out and .err
+        print(job_id_magic_token, end="")
+        print(job_id_magic_token, file=sys.stderr, end="")
 
-    # Only start import thread after job_config is initialized
-    ray._private.worker.start_import_thread()
+        # Only start import thread after job_config is initialized
+        ray._private.worker.start_import_thread()
+
+        job_config_initialized = True
 
 
 # This function introduces ~2-7us of overhead per call (i.e., it can be called

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1419,6 +1419,9 @@ def maybe_initialize_job_config():
     print(job_id_magic_token, end="")
     print(job_id_magic_token, file=sys.stderr, end="")
 
+    # Only start import thread after job_config is initialized
+    ray._private.worker.start_import_thread()
+
 
 # This function introduces ~2-7us of overhead per call (i.e., it can be called
 # up to hundreds of thousands of times per second).

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -193,6 +193,7 @@ def test_caching_functions_to_run(shutdown_only):
     ray._private.worker.global_worker.run_function_on_all_workers(f)
 
 
+@pytest.mark.skipif(client_test_enabled(), reason="internal api")
 def test_running_function_on_all_workers(ray_start_regular):
     def f(worker_info):
         sys.path.append("fake_directory")

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -193,7 +193,6 @@ def test_caching_functions_to_run(shutdown_only):
     ray._private.worker.global_worker.run_function_on_all_workers(f)
 
 
-@pytest.mark.skip(reason="Flaky tests")
 def test_running_function_on_all_workers(ray_start_regular):
     def f(worker_info):
         sys.path.append("fake_directory")

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -142,7 +142,6 @@ ray.get(a.pid.remote())
     assert "Traceback" not in log
 
 
-@pytest.mark.skipif(True, reason="run_function_on_all_workers doesn't work")
 def test_run_on_all_workers(call_ray_start, tmp_path):
     # This test is to ensure run_function_on_all_workers are executed
     # on all workers.

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -142,6 +142,7 @@ ray.get(a.pid.remote())
     assert "Traceback" not in log
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on windows")
 def test_run_on_all_workers(call_ray_start, tmp_path):
     # This test is to ensure run_function_on_all_workers are executed
     # on all workers.

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -246,7 +246,7 @@ def test_worker_kv_calls(monkeypatch, shutdown_only):
     ???? # unknown
     """
     # !!!If you want to increase this number, please let ray-core knows this!!!
-    assert freqs["internal_kv_get"] == 5
+    assert freqs["internal_kv_get"] == 4
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

run_function_on_all_workers importing requires job_id to run properly. after https://github.com/ray-project/ray/pull/30883 the worker might not have job_id when startup, which lead to run_function_on_all_workers failed to be executed on start up. to fix it, we defer the import_thread start up until job_config is initialized.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
