### PR TITLE
Enable Log Rotation on Serve

### DIFF
--- a/doc/source/ray-observability/ray-logging.rst
+++ b/doc/source/ray-observability/ray-logging.rst
@@ -173,8 +173,11 @@ Here's a Ray log directory structure. Note that ``.out`` is logs from stdout/std
 - ``runtime_env_setup-ray_client_server_[port].log``: Logs from installing :ref:`runtime environments <runtime-environments>` for a job when connecting via :ref:`Ray Client <ray-client-ref>`.
 - ``worker-[worker_id]-[job_id]-[pid].[out|err]``: Python/Java part of Ray drivers and workers. All of stdout and stderr from tasks/actors are streamed here. Note that job_id is an id of the driver.- 
 
+.. _ray-log-rotation:
+
 Log rotation
 ------------
+
 Ray supports log rotation of log files. Note that not all components are currently supporting log rotation. (Raylet and Python/Java worker logs are not rotating).
 
 By default, logs are rotating when it reaches to 512MB (maxBytes), and there could be up to 5 backup files (backupCount). Indexes are appended to all backup files (e.g., `raylet.out.1`)

--- a/doc/source/serve/production-guide/monitoring.md
+++ b/doc/source/serve/production-guide/monitoring.md
@@ -99,6 +99,8 @@ This causes the HTTP proxy and deployment replica to print log statements to the
 
 A copy of these logs are stored at `/tmp/ray/session_latest/logs/serve/`. You can parse these stored logs with a logging stack such as ELK or [Loki](serve-logging-loki) to search them by deployment or replica. 
 
+Serve supports [Log Rotation](ray-log-rotation) of these logs through setting the environment variables `RAY_ROTATION_MAX_BYTES` and `RAY_ROTATION_BACKUP_COUNT`.
+
 To silence the replica-level logs or otherwise configure logging, configure the `"ray.serve"` logger **inside the deployment constructor**:
 
 ```python

--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -22,6 +22,8 @@ def configure_component_logger(
     log_level: int = logging.INFO,
     log_to_stream: bool = True,
     log_to_file: bool = True,
+    max_bytes: Optional[int] = None,
+    backup_count: Optional[int] = None
 ):
     """Returns a logger to be used by a Serve component.
 
@@ -51,8 +53,10 @@ def configure_component_logger(
             ray._private.worker._global_node.get_logs_dir_path(), "serve"
         )
         os.makedirs(logs_dir, exist_ok=True)
-        max_bytes = ray._private.worker._global_node.max_bytes
-        backup_count = ray._private.worker._global_node.backup_count
+        if max_bytes is None:
+            max_bytes = ray._private.worker._global_node.max_bytes
+        if backup_count is None:
+            backup_count = ray._private.worker._global_node.backup_count
         if component_type is not None:
             component_name = f"{component_type}_{component_name}"
         log_file_name = LOG_FILE_FMT.format(

--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -23,7 +23,7 @@ def configure_component_logger(
     log_to_stream: bool = True,
     log_to_file: bool = True,
     max_bytes: Optional[int] = None,
-    backup_count: Optional[int] = None
+    backup_count: Optional[int] = None,
 ):
     """Returns a logger to be used by a Serve component.
 

--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -51,12 +51,18 @@ def configure_component_logger(
             ray._private.worker._global_node.get_logs_dir_path(), "serve"
         )
         os.makedirs(logs_dir, exist_ok=True)
+        max_bytes = ray._private.worker._global_node.max_bytes
+        backup_count = ray._private.worker._global_node.backup_count
         if component_type is not None:
             component_name = f"{component_type}_{component_name}"
         log_file_name = LOG_FILE_FMT.format(
             component_name=component_name, component_id=component_id
         )
-        file_handler = logging.FileHandler(os.path.join(logs_dir, log_file_name))
+        file_handler = logging.handlers.RotatingFileHandler(
+            os.path.join(logs_dir, log_file_name),
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+        )
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR adds log rotation for Ray Serve, letting it inherit rotation parameters (max_bytes, backup_count) from Ray Core, bringing a more consistent logging experience to Ray (as opposed to having the serve/ folder grow forever while the other logs rotate.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #31842 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
