### PR TITLE
[Core] Raise deprecation warning when passing non-iterables to imap and imap_unordered methods of ray.util.multiprocessing.Pool

### DIFF
--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -6,6 +6,7 @@ import tempfile
 import time
 import random
 from collections import defaultdict
+import warnings
 import queue
 import math
 
@@ -506,6 +507,28 @@ def test_imap(pool_4_processes, use_iter):
 
     with pytest.raises(StopIteration):
         result_iter.next()
+
+
+@pytest.mark.filterwarnings(
+    "default:Passing a non-iterable argument:ray.util.annotations.RayDeprecationWarning"
+)
+def test_warn_on_non_iterable_imap_or_imap_unordered(pool):
+    def fn(_):
+        pass
+
+    non_iterable = 3
+
+    with warnings.catch_warnings(record=True) as w:
+        pool.imap(fn, non_iterable)
+        assert any(
+            "Passing a non-iterable argument" in str(warning.message) for warning in w
+        )
+
+    with warnings.catch_warnings(record=True) as w:
+        pool.imap_unordered(fn, non_iterable)
+        assert any(
+            "Passing a non-iterable argument" in str(warning.message) for warning in w
+        )
 
 
 @pytest.mark.parametrize("use_iter", [True, False])

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -7,12 +7,14 @@ import os
 import queue
 import sys
 import threading
+import warnings
 import time
 from multiprocessing import TimeoutError
 from typing import Any, Callable, Dict, Hashable, Iterable, List, Optional, Tuple
 
 import ray
 from ray.util import log_once
+from ray.util.annotations import RayDeprecationWarning
 
 try:
     from joblib._parallel_backends import SafeFunction
@@ -391,7 +393,16 @@ class IMapIterator:
         try:
             self._iterator = iter(iterable)
         except TypeError:
-            # for compatibility with prior releases, encapsulate non-iterable in a list
+            warnings.warn(
+                "Passing a non-iterable argument to the "
+                "ray.util.multiprocessing.Pool imap and imap_unordered "
+                "methods is deprecated as of Ray 2.3 and "
+                " will be removed in a future release. See "
+                "https://github.com/ray-project/ray/issues/24237 for more "
+                "information.",
+                category=RayDeprecationWarning,
+                stacklevel=3,
+            )
             iterable = [iterable]
             self._iterator = iter(iterable)
         if isinstance(iterable, collections.abc.Iterator):


### PR DESCRIPTION
Context: https://github.com/ray-project/ray/issues/24237

We will raise this warning in Ray 2.3. For Ray 2.4, we will merge https://github.com/ray-project/ray/pull/31799 which causes a TypeError to be raised instead.