### PR TITLE
Modify the 'MemoryTracingCallbacks' to improve comparability of metrics and reduce noise in memory allocations

### DIFF
--- a/rllib/algorithms/callbacks.py
+++ b/rllib/algorithms/callbacks.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import tracemalloc
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
@@ -427,12 +428,14 @@ class MemoryTrackingCallbacks(DefaultCallbacks):
         env_index: Optional[int] = None,
         **kwargs,
     ) -> None:
+        gc.collect()
         snapshot = tracemalloc.take_snapshot()
         top_stats = snapshot.statistics("lineno")
 
         for stat in top_stats[:10]:
             count = stat.count
-            size = stat.size
+            # Convert total size from Bytes to KiB.
+            size = stat.size / 1024
 
             trace = str(stat.traceback)
 

--- a/rllib/algorithms/callbacks.py
+++ b/rllib/algorithms/callbacks.py
@@ -1,5 +1,6 @@
 import gc
 import os
+import platform
 import tracemalloc
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 
@@ -444,10 +445,12 @@ class MemoryTrackingCallbacks(DefaultCallbacks):
 
         process = psutil.Process(os.getpid())
         worker_rss = process.memory_info().rss
-        worker_data = process.memory_info().data
         worker_vms = process.memory_info().vms
+        if platform.system() == "Linux":
+            # This is only available on Linux
+            worker_data = process.memory_info().data
+            episode.custom_metrics["tracemalloc/worker/data"] = worker_data
         episode.custom_metrics["tracemalloc/worker/rss"] = worker_rss
-        episode.custom_metrics["tracemalloc/worker/data"] = worker_data
         episode.custom_metrics["tracemalloc/worker/vms"] = worker_vms
 
 


### PR DESCRIPTION
## Why are these changes needed?

The `MemoryTracingcallbacks`  are very helpful to investigate memory leaks. This PR does mainly two things to improve the usage of the callbacls:
 1. It unifies the unit of measurement for memory block size to be __KiB__ (before it was KiB for the `psutil` data and Bytes for the `tracemalloc` data). 
 2. It reduces noise in memory allocations before a snapshot is created by calling the garbage collector with `gc.collect()` (unreachable memory blocks). 

## Related issue number

None

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
