### PR TITLE
[autoscaler] Add env RAY_ENABLE_CLUSTER_STATUS_LOG to disable periodic cluster status log.

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -20,6 +20,7 @@ from ray.autoscaler._private.constants import (
     AUTOSCALER_MAX_CONCURRENT_LAUNCHES,
     AUTOSCALER_MAX_LAUNCH_BATCH,
     AUTOSCALER_MAX_NUM_FAILURES,
+    AUTOSCALER_STATUS_LOG,
     AUTOSCALER_UPDATE_INTERVAL_S,
     DISABLE_LAUNCH_CONFIG_CHECK_KEY,
     DISABLE_NODE_UPDATERS_KEY,
@@ -414,7 +415,8 @@ class StandardAutoscaler:
         )
 
         # Update status strings
-        logger.info(self.info_string())
+        if AUTOSCALER_STATUS_LOG:
+            logger.info(self.info_string())
         legacy_log_info_string(self, self.non_terminated_nodes.worker_ids)
 
         if not self.provider.is_readonly():

--- a/python/ray/autoscaler/_private/constants.py
+++ b/python/ray/autoscaler/_private/constants.py
@@ -20,6 +20,9 @@ def env_integer(key, default):
     return default
 
 
+# Whether autoscaler cluster status logging is enabled. Set to 0 disable.
+AUTOSCALER_STATUS_LOG = env_integer("RAY_ENABLE_CLUSTER_STATUS_LOG", 1)
+
 # The name of the environment variable for plugging in a utilization scorer.
 AUTOSCALER_UTILIZATION_SCORER_KEY = "RAY_AUTOSCALER_UTILIZATION_SCORER"
 

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -3859,7 +3859,6 @@ def test_prom_null_metric_inc_fix():
     NullMetric().inc(5)
 
 
-
 if __name__ == "__main__":
 
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import sys
 import json
 import os
@@ -3801,6 +3802,40 @@ class AutoscalingTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             request_resources(bundles=[{"foo": 1}, {"bar": "baz"}])
 
+    def test_autoscaler_status_log(self):
+        self._test_autoscaler_status_log(status_log_enabled_env=1)
+        self._test_autoscaler_status_log(status_log_enabled_env=0)
+
+    def _test_autoscaler_status_log(self, status_log_enabled_env: int):
+        mock_logger = Mock(spec=logging.Logger(""))
+        with patch.multiple(
+            "ray.autoscaler._private.autoscaler",
+            logger=mock_logger,
+            AUTOSCALER_STATUS_LOG=status_log_enabled_env,
+        ):
+            config = copy.deepcopy(SMALL_CLUSTER)
+            config_path = self.write_config(config)
+            runner = MockProcessRunner()
+            mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
+            autoscaler = MockAutoscaler(
+                config_path,
+                LoadMetrics(),
+                MockNodeInfoStub(),
+                max_failures=0,
+                process_runner=runner,
+                update_interval_s=0,
+                prom_metrics=mock_metrics,
+            )
+            autoscaler.update()
+            status_log_found = False
+            for call in mock_logger.info.call_args_list:
+                args, _ = call
+                arg = args[0]
+                if " Autoscaler status: " in arg:
+                    status_log_found = True
+                    break
+            assert status_log_found is bool(status_log_enabled_env)
+
 
 def test_import():
     """This test ensures that all the autoscaler imports work as expected to
@@ -3821,6 +3856,7 @@ def test_prom_null_metric_inc_fix():
     """
     NullMetric().inc()
     NullMetric().inc(5)
+
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -3817,6 +3817,7 @@ class AutoscalingTest(unittest.TestCase):
             config_path = self.write_config(config)
             runner = MockProcessRunner()
             mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
+            self.provider = MockProvider()
             autoscaler = MockAutoscaler(
                 config_path,
                 LoadMetrics(),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR adds an env flag to disable periodic autoscaler cluster status logging. 

Users may wish to disable these logs because:
- The log entry is rather long and communicates cluster status rather than events in the cluster.
- The log is multi-line, which does not interact well with some users' logging setups.
- You can get the same info by running `ray status`.

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/ray-project/ray/issues/26670

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
