### PR TITLE
[RLlib] Introduce ModuleSpecs to construct TrainerRunner from Policies

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -35,6 +35,9 @@ from ray.air.checkpoint import Checkpoint
 import ray.cloudpickle as pickle
 
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
+from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
+from ray.rllib.core.rl_module.marl_module import MultiAgentRLModuleSpec, MultiAgentRLModule
+
 from ray.rllib.connectors.agent.obs_preproc import ObsPreprocessorConnector
 from ray.rllib.algorithms.registry import ALGORITHMS as ALL_ALGORITHMS
 from ray.rllib.env.env_context import EnvContext
@@ -674,25 +677,27 @@ class Algorithm(Trainable):
             # Need to add back method_type in case Algorithm is restored from checkpoint
             method_config["type"] = method_type
 
-        if self.config._enable_rl_module_api:
-            local_worker = self.workers.local_worker()
-            marl_config = {"modules": {}}
-
-            for pid, policy in local_worker.policy_map.items():
-                marl_config["modules"][pid] = {
-                    "module_class": policy.config["rl_module_class"],
-                    "observation_space": policy.observation_space,
-                    "action_space": policy.action_space,
-                    "model_config": policy.config["model"],
-                }
-
-            from ray.rllib.core.rl_module.marl_module import MultiAgentRLModule
-
-            marl = MultiAgentRLModule.from_multi_agent_config(marl_config)
-
         self.trainer_runner = None
         if self.config._enable_rl_trainer_api:
-            trainer_runner_config = self.config.get_trainer_runner_config()
+            # TODO (Kourosh): This is an interim solution where policies and modules co-exist. 
+            # In this world we have both policy_map and MARLModule that need to be 
+            # consistent with one another. To make a consistent parity between the two we 
+            # need to loop throught the policy modules and create a simple MARLModule 
+            # from the RLModule within each policy.
+            local_worker = self.workers.local_worker()
+            module_specs = {}
+
+            for pid, policy in local_worker.policy_map.items():
+                module_specs[pid] = SingleAgentRLModuleSpec(
+                    module_class=policy.config["rl_module_class"],
+                    observation_space=policy.observation_space,
+                    action_space=policy.action_space,
+                    model_config=policy.config["model"],
+                )
+
+            module_spec = MultiAgentRLModuleSpec(module_class=MultiAgentRLModule, module_specs=module_specs)
+
+            trainer_runner_config = self.config.get_trainer_runner_config(module_spec)
             self.trainer_runner = trainer_runner_config.build()
 
         # Run `on_algorithm_init` callback after initialization is done.

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -36,7 +36,10 @@ import ray.cloudpickle as pickle
 
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
-from ray.rllib.core.rl_module.marl_module import MultiAgentRLModuleSpec, MultiAgentRLModule
+from ray.rllib.core.rl_module.marl_module import (
+    MultiAgentRLModuleSpec,
+    MultiAgentRLModule,
+)
 
 from ray.rllib.connectors.agent.obs_preproc import ObsPreprocessorConnector
 from ray.rllib.algorithms.registry import ALGORITHMS as ALL_ALGORITHMS
@@ -679,11 +682,11 @@ class Algorithm(Trainable):
 
         self.trainer_runner = None
         if self.config._enable_rl_trainer_api:
-            # TODO (Kourosh): This is an interim solution where policies and modules co-exist. 
-            # In this world we have both policy_map and MARLModule that need to be 
-            # consistent with one another. To make a consistent parity between the two we 
-            # need to loop throught the policy modules and create a simple MARLModule 
-            # from the RLModule within each policy.
+            # TODO (Kourosh): This is an interim solution where policies and modules
+            # co-exist. In this world we have both policy_map and MARLModule that need
+            # to be consistent with one another. To make a consistent parity between
+            # the two we need to loop throught the policy modules and create a simple
+            # MARLModule from the RLModule within each policy.
             local_worker = self.workers.local_worker()
             module_specs = {}
 
@@ -695,7 +698,9 @@ class Algorithm(Trainable):
                     model_config=policy.config["model"],
                 )
 
-            module_spec = MultiAgentRLModuleSpec(module_class=MultiAgentRLModule, module_specs=module_specs)
+            module_spec = MultiAgentRLModuleSpec(
+                module_class=MultiAgentRLModule, module_specs=module_specs
+            )
 
             trainer_runner_config = self.config.get_trainer_runner_config(module_spec)
             self.trainer_runner = trainer_runner_config.build()

--- a/rllib/core/rl_module/marl_module.py
+++ b/rllib/core/rl_module/marl_module.py
@@ -1,19 +1,37 @@
 import copy
+from dataclasses import dataclass
 import pprint
-from typing import Iterator, Mapping, Any, Union, Dict
+from typing import Iterator, Mapping, Any, Union, Dict, Optional, Type
 
 from ray.util.annotations import PublicAPI
-from ray.rllib.utils.annotations import override
+from ray.rllib.utils.annotations import override, ExperimentalAPI
 from ray.rllib.utils.nested_dict import NestedDict
 
 from ray.rllib.models.specs.specs_dict import SpecDict
 from ray.rllib.policy.sample_batch import MultiAgentBatch
-from ray.rllib.core.rl_module import RLModule
+from ray.rllib.core.rl_module.rl_module import RLModule, SingleAgentRLModuleSpec
 
 # TODO (Kourosh): change this to module_id later to enforce consistency
 from ray.rllib.utils.policy import validate_policy_id
 
 ModuleID = str
+
+
+@ExperimentalAPI
+@dataclass
+class MultiAgentRLModuleSpec:
+    """A utility spec class to make it constructing RLModules (in multi-agent case) easier.
+
+    Args:
+        module_class: ...
+        module_specs: ...
+    """
+
+    module_class: Optional[Type["MultiAgentRLModule"]] = None
+    module_specs: Optional[Dict[ModuleID, SingleAgentRLModuleSpec]] = None
+
+    def build(self) -> "MultiAgentRLModule":
+        return self.module_class.from_multi_agent_config({"modules": self.module_specs})
 
 
 def _get_module_configs(config: Dict[str, Any]):
@@ -26,8 +44,9 @@ def _get_module_configs(config: Dict[str, Any]):
     module_specs = config.pop("modules", {})
     for common_spec in config:
         for module_spec in module_specs.values():
-            if common_spec not in module_spec:
-                module_spec[common_spec] = config[common_spec]
+            if getattr(module_spec, common_spec) is None:
+                setattr(module_spec, common_spec, config[common_spec])
+
     return module_specs
 
 
@@ -65,9 +84,8 @@ class MultiAgentRLModule(RLModule):
         """Creates a MultiAgentRLModule from a multi-agent config.
 
         The input config should contain "modules" key that is a mapping from module_id
-        to the module spec for each RLModule. The module spec should be a dict with the
-        following keys: `module_class`, `observation_space`, `action_space`,
-        `model_config`. If there are multiple modules that do share the same
+        to the module spec for each RLModule which is a SingleAgentRLModuleSpec object.
+        If there are multiple modules that do share the same
         `observation_space`, `action_space`, or `model_config`, you can specify these
         keys at the top level of the config, and the module spec will inherit the
         values from the top level config.
@@ -78,16 +96,16 @@ class MultiAgentRLModule(RLModule):
 
             config = {
                 "modules": {
-                    "module_1": {
-                        "module_class": "RLModule1",
-                        "observation_space": gym.spaces.Box(...),
-                        "action_space": gym.spaces.Discrete(...),
-                        "model_config": {hidden_dim: 256}
-                    },
-                    "module_2": {
-                        "module_class": "RLModule2",
-                        "observation_space": gym.spaces.Box(...),
-                    }
+                    "module_1": SingleAgentRLModuleSpec(
+                        module_class="RLModule1",
+                        observation_space=gym.spaces.Box(...),
+                        action_space=gym.spaces.Discrete(...),
+                        model_config={hidden_dim: 256}
+                    )
+                    "module_2": SingleAgentRLModuleSpec(
+                        module_class="RLModule2",
+                        observation_space=gym.spaces.Box(...),
+                    )
                 },
                 "action_space": gym.spaces.Box(...),
                 "model_config": {hidden_dim: 32}
@@ -97,17 +115,17 @@ class MultiAgentRLModule(RLModule):
 
             config = {
                 "modules": {
-                    "module_1": {
-                        "module_class": "RLModule1",
-                        "observation_space": gym.spaces.Box(...),
-                        "action_space": gym.spaces.Discrete(...),
-                        "model_config": {hidden_dim: 256}
-                    },
-                    "module_2": {
-                        "module_class": "RLModule2",
-                        "observation_space": gym.spaces.Box(...),
-                        "action_space": gym.spaces.Box(...), # Inherited
-                        "model_config": {hidden_dim: 32} # Inherited
+                    "module_1": SingleAgentRLModuleSpec(
+                        module_class="RLModule1",
+                        observation_space=gym.spaces.Box(...),
+                        action_space=gym.spaces.Discrete(...),
+                        model_config={hidden_dim: 256}
+                    )
+                    "module_2": SingleAgentRLModuleSpec(
+                        module_class="RLModule2",
+                        observation_space=gym.spaces.Box(...),
+                        action_space=gym.spaces.Box(...), # Inherited
+                        model_config={hidden_dim: 32} # Inherited
                     }
                 },
             }
@@ -126,8 +144,9 @@ class MultiAgentRLModule(RLModule):
         multiagent_module = cls()
 
         for module_id, module_spec in module_configs.items():
-            module_cls: RLModule = module_spec.pop("module_class")
-            module = module_cls.from_model_config(**module_spec)
+            # module_cls: RLModule = module_spec.pop("module_class")
+            # module = module_cls.from_model_config(**module_spec)
+            module = module_spec.build()
             multiagent_module.add_module(module_id, module)
 
         return multiagent_module
@@ -136,9 +155,7 @@ class MultiAgentRLModule(RLModule):
     def __check_module_configs(cls, module_configs: Dict[ModuleID, Any]):
         """Checks the module configs for validity.
 
-        The module_configs be a mapping from module_ids to a dict that contains the
-        following required keys: `module_class`, `observation_space`, `action_space`,
-        `model_config`.
+        The module_configs be a mapping from module_ids to SingleAgentRLModuleSpec objects.
 
         Args:
             module_configs: The module configs to check.
@@ -146,19 +163,12 @@ class MultiAgentRLModule(RLModule):
         Raises:
             ValueError: If the module configs are invalid.
         """
-        REQUIRED_KEYS = {
-            "module_class",
-            "observation_space",
-            "action_space",
-            "model_config",
-        }
         for module_id, module_spec in module_configs.items():
-            for module_key in REQUIRED_KEYS:
-                if module_key not in module_spec:
-                    raise ValueError(
-                        f"Module config for module_id {module_id} is missing "
-                        f"required key {module_key}."
-                    )
+            if not isinstance(module_spec, SingleAgentRLModuleSpec):
+                raise ValueError(
+                    f"Module config for module_id {module_id} is missing "
+                    f"required key {module_key}."
+                )
 
     def keys(self) -> Iterator[ModuleID]:
         """Returns an iteratable of module ids."""

--- a/rllib/core/rl_module/marl_module.py
+++ b/rllib/core/rl_module/marl_module.py
@@ -155,7 +155,8 @@ class MultiAgentRLModule(RLModule):
     def __check_module_configs(cls, module_configs: Dict[ModuleID, Any]):
         """Checks the module configs for validity.
 
-        The module_configs be a mapping from module_ids to SingleAgentRLModuleSpec objects.
+        The module_configs be a mapping from module_ids to SingleAgentRLModuleSpec
+        objects.
 
         Args:
             module_configs: The module configs to check.
@@ -166,8 +167,7 @@ class MultiAgentRLModule(RLModule):
         for module_id, module_spec in module_configs.items():
             if not isinstance(module_spec, SingleAgentRLModuleSpec):
                 raise ValueError(
-                    f"Module config for module_id {module_id} is missing "
-                    f"required key {module_key}."
+                    f"Module {module_id} is not a SingleAgentRLModuleSpec object."
                 )
 
     def keys(self) -> Iterator[ModuleID]:

--- a/rllib/core/rl_module/rl_module.py
+++ b/rllib/core/rl_module/rl_module.py
@@ -48,6 +48,23 @@ class SingleAgentRLModuleSpec:
             model_config=self.model_config,
         )
 
+@ExperimentalAPI
+@dataclass
+class RLModuleConfig:
+    """Configuration for the PPO module.
+    # TODO (Kourosh): Whether we need this or not really depends on how the catalog
+    # design end up being.
+    Attributes:
+        observation_space: The observation space of the environment.
+        action_space: The action space of the environment.
+        max_seq_len: Max seq len for training an RNN model.
+        (TODO (Kourosh) having max_seq_len here seems a bit unnatural, can we rethink
+        this design?)
+    """
+
+    observation_space: gym.Space = None
+    action_space: gym.Space = None
+    max_seq_len: int = None
 
 @ExperimentalAPI
 class RLModule(abc.ABC):

--- a/rllib/core/rl_module/rl_module.py
+++ b/rllib/core/rl_module/rl_module.py
@@ -48,6 +48,7 @@ class SingleAgentRLModuleSpec:
             model_config=self.model_config,
         )
 
+
 @ExperimentalAPI
 @dataclass
 class RLModuleConfig:
@@ -65,6 +66,7 @@ class RLModuleConfig:
     observation_space: gym.Space = None
     action_space: gym.Space = None
     max_seq_len: int = None
+
 
 @ExperimentalAPI
 class RLModule(abc.ABC):

--- a/rllib/core/rl_module/rl_module.py
+++ b/rllib/core/rl_module/rl_module.py
@@ -1,7 +1,7 @@
 import abc
 from dataclasses import dataclass
 import gymnasium as gym
-from typing import Mapping, Any, TYPE_CHECKING, Union
+from typing import Mapping, Any, TYPE_CHECKING, Union, Optional, Type, Dict
 
 if TYPE_CHECKING:
     from ray.rllib.core.rl_module.marl_module import MultiAgentRLModule
@@ -26,23 +26,27 @@ ModuleID = str
 
 @ExperimentalAPI
 @dataclass
-class RLModuleConfig:
-    """Configuration for the PPO module.
+class SingleAgentRLModuleSpec:
+    """A utility spec class to make it constructing RLModules (in single-agent case) easier.
 
-    # TODO (Kourosh): Whether we need this or not really depends on how the catalog
-    # design end up being.
-
-    Attributes:
-        observation_space: The observation space of the environment.
-        action_space: The action space of the environment.
-        max_seq_len: Max seq len for training an RNN model.
-        (TODO (Kourosh) having max_seq_len here seems a bit unnatural, can we rethink
-        this design?)
+    Args:
+        module_class: ...
+        observation_space: ...
+        action_space: ...
+        model_config: ...
     """
 
-    observation_space: gym.Space = None
-    action_space: gym.Space = None
-    max_seq_len: int = None
+    module_class: Optional[Type["RLModule"]] = None
+    observation_space: Optional["gym.Space"] = None
+    action_space: Optional["gym.Space"] = None
+    model_config: Optional[Dict[str, Any]] = None
+
+    def build(self) -> "RLModule":
+        return self.module_class.from_model_config(
+            observation_space=self.observation_space,
+            action_space=self.action_space,
+            model_config=self.model_config,
+        )
 
 
 @ExperimentalAPI

--- a/rllib/core/rl_module/tests/test_marl_module.py
+++ b/rllib/core/rl_module/tests/test_marl_module.py
@@ -1,10 +1,12 @@
 import unittest
 
 
+from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
 from ray.rllib.core.rl_module.marl_module import MultiAgentRLModule, _get_module_configs
 from ray.rllib.core.testing.torch.bc_module import DiscreteBCTorchModule
 from ray.rllib.env.multi_agent_env import make_multi_agent
 from ray.rllib.utils.test_utils import check
+
 
 DEFAULT_POLICY_ID = "default_policy"
 
@@ -39,14 +41,14 @@ class TestMARLModule(unittest.TestCase):
 
         multi_agent_dict = {
             "modules": {
-                "module1": {
-                    "module_class": DiscreteBCTorchModule,
-                    "model_config": {"hidden_dim": 64},
-                },
-                "module2": {
-                    "module_class": DiscreteBCTorchModule,
-                    "model_config": {"hidden_dim": 32},
-                },
+                "module1": SingleAgentRLModuleSpec(
+                    module_class=DiscreteBCTorchModule,
+                    model_config={"hidden_dim": 64},
+                ),
+                "module2": SingleAgentRLModuleSpec(
+                    module_class=DiscreteBCTorchModule,
+                    model_config={"hidden_dim": 32},
+                ),
             },
             "observation_space": env.observation_space,  # this is common
             "action_space": env.action_space,  # this is common
@@ -160,57 +162,73 @@ class TestMARLModule(unittest.TestCase):
 
         config = {
             "modules": {
-                "1": {"module_class": "foo", "model_config": "bar"},
-                "2": {"module_class": "foo2", "model_config": "bar2"},
+                "1": SingleAgentRLModuleSpec(
+                    **{"module_class": "foo", "model_config": "bar"}
+                ),
+                "2": SingleAgentRLModuleSpec(
+                    **{"module_class": "foo2", "model_config": "bar2"}
+                ),
             },
             "observation_space": "obs_space",
             "action_space": "action_space",
         }
 
         expected_config = {
-            "1": {
-                "module_class": "foo",
-                "model_config": "bar",
-                "observation_space": "obs_space",
-                "action_space": "action_space",
-            },
-            "2": {
-                "module_class": "foo2",
-                "model_config": "bar2",
-                "observation_space": "obs_space",
-                "action_space": "action_space",
-            },
+            "1": SingleAgentRLModuleSpec(
+                **{
+                    "module_class": "foo",
+                    "model_config": "bar",
+                    "observation_space": "obs_space",
+                    "action_space": "action_space",
+                }
+            ),
+            "2": SingleAgentRLModuleSpec(
+                **{
+                    "module_class": "foo2",
+                    "model_config": "bar2",
+                    "observation_space": "obs_space",
+                    "action_space": "action_space",
+                }
+            ),
         }
 
         self.assertDictEqual(_get_module_configs(config), expected_config)
 
         config = {
             "modules": {
-                "1": {
-                    "module_class": "foo",
-                    "model_config": "bar",
-                    "observation_space": "obs_space1",  # won't get overwritten
-                    "action_space": "action_space1",  # won't get overwritten
-                },
-                "2": {"module_class": "foo2", "model_config": "bar2"},
+                "1": SingleAgentRLModuleSpec(
+                    **{
+                        "module_class": "foo",
+                        "model_config": "bar",
+                        "observation_space": "obs_space1",  # won't get overwritten
+                        "action_space": "action_space1",  # won't get overwritten
+                    }
+                ),
+                "2": SingleAgentRLModuleSpec(
+                    **{"module_class": "foo2", "model_config": "bar2"}
+                ),
             },
             "observation_space": "obs_space",
             "action_space": "action_space",
         }
 
         expected_config = {
-            "1": {
-                "module_class": "foo",
-                "model_config": "bar",
-                "observation_space": "obs_space1",
-                "action_space": "action_space1",
-            },
-            "2": {
-                "module_class": "foo2",
-                "model_config": "bar2",
-                "observation_space": "obs_space",
-                "action_space": "action_space",
-            },
+            "1": SingleAgentRLModuleSpec(
+                **{
+                    "module_class": "foo",
+                    "model_config": "bar",
+                    "observation_space": "obs_space1",
+                    "action_space": "action_space1",
+                }
+            ),
+            "2": SingleAgentRLModuleSpec(
+                **{
+                    "module_class": "foo2",
+                    "model_config": "bar2",
+                    "observation_space": "obs_space",
+                    "action_space": "action_space",
+                }
+            ),
         }
 
         self.assertDictEqual(_get_module_configs(config), expected_config)

--- a/rllib/core/rl_trainer/rl_trainer.py
+++ b/rllib/core/rl_trainer/rl_trainer.py
@@ -435,8 +435,7 @@ class RLTrainer:
         self,
         *,
         module_id: ModuleID,
-        module_cls: Type[RLModule],
-        module_kwargs: Mapping[str, Any],
+        module_spec: SingleAgentRLModuleSpec,
         set_optimizer_fn: Optional[Callable[[RLModule], ParamOptimizerPairs]] = None,
         optimizer_cls: Optional[Type[Optimizer]] = None,
     ) -> None:
@@ -455,7 +454,7 @@ class RLTrainer:
                 should be provided.
         """
         self.__check_if_build_called()
-        module = module_cls.from_model_config(**module_kwargs)
+        module = module_spec.build()
 
         # construct a default set_optimizer_fn if not provided
         if set_optimizer_fn is None:

--- a/rllib/core/rl_trainer/tests/test_rl_trainer.py
+++ b/rllib/core/rl_trainer/tests/test_rl_trainer.py
@@ -127,13 +127,12 @@ class TestRLTrainer(unittest.TestCase):
 
         trainer.add_module(
             module_id="test",
-            module_cls=DiscreteBCTFModule,
-            module_kwargs={
-                "observation_space": env.observation_space,
-                "action_space": env.action_space,
-                # the hidden size is different than the default module
-                "model_config": {"hidden_dim": 16},
-            },
+            module_spec=SingleAgentRLModuleSpec(
+                module_class=DiscreteBCTFModule,
+                observation_space=env.observation_space,
+                action_space=env.action_space,
+                model_config={"hidden_dim": 16},
+            ),
             set_optimizer_fn=set_optimizer_fn,
         )
 

--- a/rllib/core/rl_trainer/tests/test_rl_trainer.py
+++ b/rllib/core/rl_trainer/tests/test_rl_trainer.py
@@ -5,11 +5,13 @@ import numpy as np
 
 import ray
 
+from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
 from ray.rllib.core.rl_trainer.rl_trainer import RLTrainer
 from ray.rllib.core.testing.tf.bc_module import DiscreteBCTFModule
 from ray.rllib.core.testing.tf.bc_rl_trainer import BCTfRLTrainer
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
 from ray.rllib.utils.test_utils import check, get_cartpole_dataset_reader
+from ray.rllib.core.testing.utils import add_module_to_runner_or_trainer
 
 
 def get_trainer(distributed=False) -> RLTrainer:
@@ -21,12 +23,12 @@ def get_trainer(distributed=False) -> RLTrainer:
     # and internally it will serialize and deserialize the module for distributed
     # construction.
     trainer = BCTfRLTrainer(
-        module_class=DiscreteBCTFModule,
-        module_kwargs={
-            "observation_space": env.observation_space,
-            "action_space": env.action_space,
-            "model_config": {"hidden_dim": 32},
-        },
+        module_spec=SingleAgentRLModuleSpec(
+            module_class=DiscreteBCTFModule,
+            observation_space=env.observation_space,
+            action_space=env.action_space,
+            model_config={"hidden_dim": 32},
+        ),
         optimizer_config={"lr": 1e-3},
         distributed=distributed,
     )

--- a/rllib/core/rl_trainer/tests/test_rl_trainer.py
+++ b/rllib/core/rl_trainer/tests/test_rl_trainer.py
@@ -11,7 +11,6 @@ from ray.rllib.core.testing.tf.bc_module import DiscreteBCTFModule
 from ray.rllib.core.testing.tf.bc_rl_trainer import BCTfRLTrainer
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
 from ray.rllib.utils.test_utils import check, get_cartpole_dataset_reader
-from ray.rllib.core.testing.utils import add_module_to_runner_or_trainer
 
 
 def get_trainer(distributed=False) -> RLTrainer:

--- a/rllib/core/rl_trainer/tests/test_trainer_runner_config.py
+++ b/rllib/core/rl_trainer/tests/test_trainer_runner_config.py
@@ -2,10 +2,13 @@ import gym
 import unittest
 
 import ray
+
+from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
+from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
 from ray.rllib.core.rl_trainer.trainer_runner_config import TrainerRunnerConfig
 from ray.rllib.core.testing.tf.bc_module import DiscreteBCTFModule
 from ray.rllib.core.testing.tf.bc_rl_trainer import BCTfRLTrainer
-from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
+from ray.rllib.core.testing.utils import get_module_spec
 
 
 class TestAlgorithmConfig(unittest.TestCase):
@@ -24,12 +27,7 @@ class TestAlgorithmConfig(unittest.TestCase):
 
         config = (
             TrainerRunnerConfig()
-            .module(
-                module_class=DiscreteBCTFModule,
-                observation_space=env.observation_space,
-                action_space=env.action_space,
-                model_config={"hidden_dim": 32},
-            )
+            .module(get_module_spec("tf", env))
             .trainer(
                 trainer_class=BCTfRLTrainer,
             )
@@ -50,7 +48,9 @@ class TestAlgorithmConfig(unittest.TestCase):
         )
         config.freeze()
         runner_config = config.get_trainer_runner_config(
-            env.observation_space, env.action_space
+            SingleAgentRLModuleSpec(
+                observation_space=env.observation_space, action_space=env.action_space
+            )
         )
         runner_config.build()
 

--- a/rllib/core/rl_trainer/tests/test_trainer_runner_local.py
+++ b/rllib/core/rl_trainer/tests/test_trainer_runner_local.py
@@ -9,7 +9,11 @@ from ray.rllib.core.testing.tf.bc_module import DiscreteBCTFModule
 from ray.rllib.core.testing.tf.bc_rl_trainer import BCTfRLTrainer
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, MultiAgentBatch
 from ray.rllib.utils.test_utils import check, get_cartpole_dataset_reader
-from ray.rllib.core.testing.utils import add_module_to_runner_or_trainer
+from ray.rllib.core.testing.utils import (
+    add_module_to_runner_or_trainer,
+    get_trainer_runner,
+    get_rl_trainer,
+)
 
 
 tf1, tf, tfv = try_import_tf()
@@ -31,47 +35,35 @@ class TestTrainerRunnerLocal(unittest.TestCase):
 
     def test_trainer_runner_no_gpus(self):
         env = gym.make("CartPole-v1")
-        trainer_class = BCTfRLTrainer
-        trainer_cfg = dict(
-            module_class=DiscreteBCTFModule,
-            module_kwargs={
-                "observation_space": env.observation_space,
-                "action_space": env.action_space,
-                "model_config": {"hidden_dim": 32},
-            },
-            optimizer_config={"lr": 1e-3},
-        )
-        runner = TrainerRunner(
-            trainer_class, trainer_cfg, compute_config=dict(num_gpus=0)
-        )
+        for fw in ["tf", "torch"]:
+            runner = get_trainer_runner(fw, env, compute_config=dict(num_gpus=0))
+            local_trainer = get_rl_trainer(fw, env)
+            local_trainer.build()
 
-        local_trainer = trainer_class(**trainer_cfg)
-        local_trainer.build()
+            # make the state of the trainer and the local runner identical
+            local_trainer.set_state(runner.get_state()[0])
 
-        # make the state of the trainer and the local runner identical
-        local_trainer.set_state(runner.get_state()[0])
+            reader = get_cartpole_dataset_reader(batch_size=500)
+            batch = reader.next()
+            batch = batch.as_multi_agent()
+            check(local_trainer.update(batch), runner.update(batch)[0])
 
-        reader = get_cartpole_dataset_reader(batch_size=500)
-        batch = reader.next()
-        batch = batch.as_multi_agent()
-        check(local_trainer.update(batch), runner.update(batch)[0])
+            new_module_id = "test_module"
 
-        new_module_id = "test_module"
+            add_module_to_runner_or_trainer(fw, env, new_module_id, runner)
+            add_module_to_runner_or_trainer(fw, env, new_module_id, local_trainer)
 
-        add_module_to_runner_or_trainer("tf", env, new_module_id, runner)
-        add_module_to_runner_or_trainer("tf", env, new_module_id, local_trainer)
+            # make the state of the trainer and the local runner identical
+            local_trainer.set_state(runner.get_state()[0])
 
-        # make the state of the trainer and the local runner identical
-        local_trainer.set_state(runner.get_state()[0])
+            # do another update
+            batch = reader.next()
+            ma_batch = MultiAgentBatch(
+                {new_module_id: batch, DEFAULT_POLICY_ID: batch}, env_steps=batch.count
+            )
+            check(local_trainer.update(ma_batch), runner.update(ma_batch)[0])
 
-        # do another update
-        batch = reader.next()
-        ma_batch = MultiAgentBatch(
-            {new_module_id: batch, DEFAULT_POLICY_ID: batch}, env_steps=batch.count
-        )
-        check(local_trainer.update(ma_batch), runner.update(ma_batch)[0])
-
-        check(local_trainer.get_state(), runner.get_state()[0])
+            check(local_trainer.get_state(), runner.get_state()[0])
 
 
 if __name__ == "__main__":

--- a/rllib/core/rl_trainer/tests/test_trainer_runner_local.py
+++ b/rllib/core/rl_trainer/tests/test_trainer_runner_local.py
@@ -1,14 +1,11 @@
 import gymnasium as gym
 import unittest
 
-from ray.rllib.utils.framework import try_import_tf
 import ray
 
-from ray.rllib.core.rl_trainer.trainer_runner import TrainerRunner
-from ray.rllib.core.testing.tf.bc_module import DiscreteBCTFModule
-from ray.rllib.core.testing.tf.bc_rl_trainer import BCTfRLTrainer
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, MultiAgentBatch
 from ray.rllib.utils.test_utils import check, get_cartpole_dataset_reader
+from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.core.testing.utils import (
     add_module_to_runner_or_trainer,
     get_trainer_runner,

--- a/rllib/core/rl_trainer/tf/tf_rl_trainer.py
+++ b/rllib/core/rl_trainer/tf/tf_rl_trainer.py
@@ -205,8 +205,7 @@ class TfRLTrainer(RLTrainer):
         self,
         *,
         module_id: ModuleID,
-        module_cls: Type[RLModule],
-        module_kwargs: Mapping[str, Any],
+        module_spec: SingleAgentRLModuleSpec,
         set_optimizer_fn: Optional[Callable[[RLModule], ParamOptimizerPairs]] = None,
         optimizer_cls: Optional[Type[Optimizer]] = None,
     ) -> None:
@@ -214,16 +213,14 @@ class TfRLTrainer(RLTrainer):
             with self.strategy.scope():
                 super().add_module(
                     module_id=module_id,
-                    module_cls=module_cls,
-                    module_kwargs=module_kwargs,
+                    module_spec=module_spec,
                     set_optimizer_fn=set_optimizer_fn,
                     optimizer_cls=optimizer_cls,
                 )
         else:
             super().add_module(
                 module_id=module_id,
-                module_cls=module_cls,
-                module_kwargs=module_kwargs,
+                module_spec=module_spec,
                 set_optimizer_fn=set_optimizer_fn,
                 optimizer_cls=optimizer_cls,
             )

--- a/rllib/core/rl_trainer/tf/tf_rl_trainer.py
+++ b/rllib/core/rl_trainer/tf/tf_rl_trainer.py
@@ -14,14 +14,21 @@ from typing import (
 
 from ray.rllib.core.rl_trainer.rl_trainer import (
     RLTrainer,
-    MultiAgentRLModule,
     ParamOptimizerPairs,
     ParamRef,
     Optimizer,
     ParamType,
     ParamDictType,
 )
-from ray.rllib.core.rl_module.rl_module import RLModule, ModuleID
+from ray.rllib.core.rl_module.rl_module import (
+    RLModule,
+    ModuleID,
+    SingleAgentRLModuleSpec,
+)
+from ray.rllib.core.rl_module.marl_module import (
+    MultiAgentRLModule,
+    MultiAgentRLModuleSpec,
+)
 from ray.rllib.policy.sample_batch import MultiAgentBatch
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_tf
@@ -86,8 +93,11 @@ class TfRLTrainer(RLTrainer):
 
     def __init__(
         self,
-        module_class: Union[Type[RLModule], Type[MultiAgentRLModule]],
-        module_kwargs: Mapping[str, Any],
+        *,
+        module_spec: Optional[
+            Union[SingleAgentRLModuleSpec, MultiAgentRLModuleSpec]
+        ] = None,
+        module: Optional[RLModule] = None,
         optimizer_config: Mapping[str, Any],
         distributed: bool = False,
         enable_tf_function: bool = True,
@@ -95,8 +105,8 @@ class TfRLTrainer(RLTrainer):
         algorithm_config: Optional["AlgorithmConfig"] = None,
     ):
         super().__init__(
-            module_class=module_class,
-            module_kwargs=module_kwargs,
+            module_spec=module_spec,
+            module=module,
             optimizer_config=optimizer_config,
             distributed=distributed,
             scaling_config=scaling_config,

--- a/rllib/core/rl_trainer/torch/tests/test_torch_rl_trainer.py
+++ b/rllib/core/rl_trainer/torch/tests/test_torch_rl_trainer.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import ray
 
+from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
 from ray.rllib.core.rl_trainer.rl_trainer import RLTrainer
 from ray.rllib.core.testing.torch.bc_module import DiscreteBCTorchModule
 from ray.rllib.core.testing.torch.bc_rl_trainer import BCTorchRLTrainer
@@ -26,12 +27,12 @@ def _get_trainer(scaling_config=None, distributed: bool = False) -> RLTrainer:
     # and internally it will serialize and deserialize the module for distributed
     # construction.
     trainer = BCTorchRLTrainer(
-        module_class=DiscreteBCTorchModule,
-        module_kwargs={
-            "observation_space": env.observation_space,
-            "action_space": env.action_space,
-            "model_config": {"hidden_dim": 32},
-        },
+        module_spec=SingleAgentRLModuleSpec(
+            module_class=DiscreteBCTorchModule,
+            observation_space=env.observation_space,
+            action_space=env.action_space,
+            model_config={"hidden_dim": 32},
+        ),
         scaling_config=scaling_config,
         optimizer_config={"lr": 1e-3},
         distributed=distributed,

--- a/rllib/core/rl_trainer/torch/tests/test_torch_rl_trainer.py
+++ b/rllib/core/rl_trainer/torch/tests/test_torch_rl_trainer.py
@@ -130,13 +130,12 @@ class TestRLTrainer(unittest.TestCase):
 
         trainer.add_module(
             module_id="test",
-            module_cls=DiscreteBCTorchModule,
-            module_kwargs={
-                "observation_space": env.observation_space,
-                "action_space": env.action_space,
-                # the hidden size is different than the default module
-                "model_config": {"hidden_dim": 16},
-            },
+            module_spec=SingleAgentRLModuleSpec(
+                module_class=DiscreteBCTorchModule,
+                observation_space=env.observation_space,
+                action_space=env.action_space,
+                model_config={"hidden_dim": 16},
+            ),
             set_optimizer_fn=set_optimizer_fn,
         )
 

--- a/rllib/core/rl_trainer/torch/torch_rl_trainer.py
+++ b/rllib/core/rl_trainer/torch/torch_rl_trainer.py
@@ -11,10 +11,17 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from ray.rllib.core.rl_module.rl_module import RLModule, ModuleID
+from ray.rllib.core.rl_module.rl_module import (
+    RLModule,
+    ModuleID,
+    SingleAgentRLModuleSpec,
+)
+from ray.rllib.core.rl_module.marl_module import (
+    MultiAgentRLModule,
+    MultiAgentRLModuleSpec,
+)
 from ray.rllib.core.rl_trainer.rl_trainer import (
     RLTrainer,
-    MultiAgentRLModule,
     ParamOptimizerPairs,
     Optimizer,
     ParamType,
@@ -45,16 +52,19 @@ class TorchRLTrainer(RLTrainer):
 
     def __init__(
         self,
-        module_class: Union[Type[RLModule], Type[MultiAgentRLModule]],
-        module_kwargs: Mapping[str, Any],
+        *,
+        module_spec: Optional[
+            Union[SingleAgentRLModuleSpec, MultiAgentRLModuleSpec]
+        ] = None,
+        module: Optional[RLModule] = None,
         optimizer_config: Mapping[str, Any],
         distributed: bool = False,
         scaling_config: Optional["ScalingConfig"] = None,
         algorithm_config: Optional["AlgorithmConfig"] = None,
     ):
         super().__init__(
-            module_class=module_class,
-            module_kwargs=module_kwargs,
+            module_spec=module_spec,
+            module=module,
             optimizer_config=optimizer_config,
             distributed=distributed,
             scaling_config=scaling_config,

--- a/rllib/core/rl_trainer/torch/torch_rl_trainer.py
+++ b/rllib/core/rl_trainer/torch/torch_rl_trainer.py
@@ -193,15 +193,13 @@ class TorchRLTrainer(RLTrainer):
         self,
         *,
         module_id: ModuleID,
-        module_cls: Type[RLModule],
-        module_kwargs: Mapping[str, Any],
+        module_spec: SingleAgentRLModuleSpec,
         set_optimizer_fn: Optional[Callable[[RLModule], ParamOptimizerPairs]] = None,
         optimizer_cls: Optional[Type[Optimizer]] = None,
     ) -> None:
         super().add_module(
             module_id=module_id,
-            module_cls=module_cls,
-            module_kwargs=module_kwargs,
+            module_spec=module_spec,
             set_optimizer_fn=set_optimizer_fn,
             optimizer_cls=optimizer_cls,
         )

--- a/rllib/core/rl_trainer/trainer_runner.py
+++ b/rllib/core/rl_trainer/trainer_runner.py
@@ -3,7 +3,11 @@ from typing import Any, List, Mapping, Type, Optional, Callable, Dict
 
 import ray
 
-from ray.rllib.core.rl_module.rl_module import RLModule, ModuleID
+from ray.rllib.core.rl_module.rl_module import (
+    RLModule,
+    ModuleID,
+    SingleAgentRLModuleSpec,
+)
 from ray.rllib.core.rl_trainer.rl_trainer import (
     RLTrainer,
     ParamOptimizerPairs,
@@ -165,8 +169,7 @@ class TrainerRunner:
         self,
         *,
         module_id: ModuleID,
-        module_cls: Type[RLModule],
-        module_kwargs: Mapping[str, Any],
+        module_spec: SingleAgentRLModuleSpec,
         set_optimizer_fn: Optional[Callable[[RLModule], ParamOptimizerPairs]] = None,
         optimizer_cls: Optional[Type[Optimizer]] = None,
     ) -> None:
@@ -174,8 +177,7 @@ class TrainerRunner:
 
         Args:
             module_id: The id of the module to add.
-            module_cls: The module class to add.
-            module_kwargs: The config for the module.
+            module_spec:  #TODO (Kourosh) fill in here.
             set_optimizer_fn: A function that takes in the module and returns a list of
                 (param, optimizer) pairs. Each element in the tuple describes a
                 parameter group that share the same optimizer object, if None, the
@@ -189,8 +191,7 @@ class TrainerRunner:
             for worker in self._workers:
                 ref = worker.add_module.remote(
                     module_id=module_id,
-                    module_cls=module_cls,
-                    module_kwargs=module_kwargs,
+                    module_spec=module_spec,
                     set_optimizer_fn=set_optimizer_fn,
                     optimizer_cls=optimizer_cls,
                 )
@@ -199,8 +200,7 @@ class TrainerRunner:
         else:
             self._trainer.add_module(
                 module_id=module_id,
-                module_cls=module_cls,
-                module_kwargs=module_kwargs,
+                module_spec=module_spec,
                 set_optimizer_fn=set_optimizer_fn,
                 optimizer_cls=optimizer_cls,
             )

--- a/rllib/core/rl_trainer/trainer_runner_config.py
+++ b/rllib/core/rl_trainer/trainer_runner_config.py
@@ -6,11 +6,10 @@ from ray.rllib.core.rl_trainer.trainer_runner import TrainerRunner
 
 if TYPE_CHECKING:
     from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
-    from ray.rllib.core.rl_module import RLModule
     from ray.rllib.core.rl_trainer import RLTrainer
-    import gymnasium as gym
 
 ModuleSpec = Union[SingleAgentRLModuleSpec, MultiAgentRLModuleSpec]
+
 
 # TODO (Kourosh): We should make all configs come from a standard base class that
 # defines the general interfaces for validation, from_dict, to_dict etc.
@@ -41,8 +40,8 @@ class TrainerRunnerConfig:
 
         if self.module_spec is None:
             raise ValueError(
-                "Cannot initialize an RLTrainer without the module specs. Please provide "
-                "the specs via .module(module_spec)."
+                "Cannot initialize an RLTrainer without the module specs. "
+                "Please provide the specs via .module(module_spec)."
             )
 
         if self.trainer_class is None:
@@ -68,8 +67,9 @@ class TrainerRunnerConfig:
     def build(self) -> TrainerRunner:
         self.validate()
 
-        # if the module class is a multi agent class it will override the default MultiAgentRLModule class
-        # otherwise, it will be a single agent wrapped with mutliagent
+        # If the module class is a multi agent class it will override the default
+        # MultiAgentRLModule class. otherwise, it will be a single agent wrapped with
+        # mutliagent
         # TODO (Kourosh): What should be scaling_config? it's not clear what
         # should be passed in as trainer_config and what will be inferred
         return self.trainer_runner_class(
@@ -106,14 +106,6 @@ class TrainerRunnerConfig:
             self.module_spec = module_spec
 
         return self
-
-    def multi_agent(
-        self,
-        *,
-        modules: Optional[Dict[str, "SingleAgentRLModuleConfig"]] = NotProvided,
-        marl_module_class: Optional[Type["MultiAgentRLModule"]] = NotProvided,
-    ) -> "TrainerRunnerConfig":
-        pass
 
     def resources(
         self,

--- a/rllib/core/rl_trainer/trainer_runner_config.py
+++ b/rllib/core/rl_trainer/trainer_runner_config.py
@@ -1,4 +1,6 @@
 from typing import Type, Optional, TYPE_CHECKING, Union, Dict
+from ray.rllib.core.rl_module.marl_module import MultiAgentRLModuleSpec
+from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
 from ray.rllib.utils.from_config import NotProvided
 from ray.rllib.core.rl_trainer.trainer_runner import TrainerRunner
 
@@ -8,6 +10,7 @@ if TYPE_CHECKING:
     from ray.rllib.core.rl_trainer import RLTrainer
     import gymnasium as gym
 
+ModuleSpec = Union[SingleAgentRLModuleSpec, MultiAgentRLModuleSpec]
 
 # TODO (Kourosh): We should make all configs come from a standard base class that
 # defines the general interfaces for validation, from_dict, to_dict etc.
@@ -20,11 +23,7 @@ class TrainerRunnerConfig:
         self.trainer_runner_class = cls or TrainerRunner
 
         # `self.module()`
-        self.module_obj = None
-        self.module_class = None
-        self.observation_space = None
-        self.action_space = None
-        self.model_config = None
+        self.module_spec = None
 
         # `self.trainer()`
         self.trainer_class = None
@@ -40,29 +39,11 @@ class TrainerRunnerConfig:
 
     def validate(self) -> None:
 
-        if self.module_class is None and self.module_obj is None:
+        if self.module_spec is None:
             raise ValueError(
-                "Cannot initialize an RLTrainer without an RLModule. Please provide "
-                "the RLModule class with .module(module_class=MyModuleClass) or "
-                "an RLModule instance with .module(module=MyModuleInstance)."
+                "Cannot initialize an RLTrainer without the module specs. Please provide "
+                "the specs via .module(module_spec)."
             )
-
-        if self.module_class is not None:
-            if self.observation_space is None:
-                raise ValueError(
-                    "Must provide observation_space for RLModule when RLModule class "
-                    "is provided. Use .module(observation_space=MySpace)."
-                )
-            if self.action_space is None:
-                raise ValueError(
-                    "Must provide action_space for RLModule when RLModule class "
-                    "is provided. Use .module(action_space=MySpace)."
-                )
-            if self.model_config is None:
-                raise ValueError(
-                    "Must provide model_config for RLModule when RLModule class "
-                    "is provided. Use .module(model_config=MyConfig)."
-                )
 
         if self.trainer_class is None:
             raise ValueError(
@@ -86,17 +67,15 @@ class TrainerRunnerConfig:
 
     def build(self) -> TrainerRunner:
         self.validate()
+
+        # if the module class is a multi agent class it will override the default MultiAgentRLModule class
+        # otherwise, it will be a single agent wrapped with mutliagent
         # TODO (Kourosh): What should be scaling_config? it's not clear what
         # should be passed in as trainer_config and what will be inferred
         return self.trainer_runner_class(
             trainer_class=self.trainer_class,
             trainer_config={
-                "module_class": self.module_class,
-                "module_kwargs": {
-                    "observation_space": self.observation_space,
-                    "action_space": self.action_space,
-                    "model_config": self.model_config,
-                },
+                "module_spec": self.module_spec,
                 # TODO (Kourosh): should this be inferred inside the constructor?
                 "distributed": self.num_gpus > 1,
                 # TODO (Avnish): add this
@@ -120,31 +99,32 @@ class TrainerRunnerConfig:
 
     def module(
         self,
-        *,
-        module_class: Optional[Type["RLModule"]] = NotProvided,
-        observation_space: Optional["gym.Space"] = NotProvided,
-        action_space: Optional["gym.Space"] = NotProvided,
-        model_config: Optional[dict] = NotProvided,
-        module: Optional["RLModule"] = NotProvided,
+        module_spec: Optional[ModuleSpec] = NotProvided,
     ) -> "TrainerRunnerConfig":
 
-        if module is NotProvided and module_class is NotProvided:
-            raise ValueError(
-                "Must provide either module or module_class. Please provide "
-                "the RLModule class with .module(module=MyModule) or "
-                ".module(module_class=MyModuleClass)."
-            )
+        if module_spec is not NotProvided:
+            self.module_spec = module_spec
 
-        if module_class is not NotProvided:
-            self.module_class = module_class
-        if observation_space is not NotProvided:
-            self.observation_space = observation_space
-        if action_space is not NotProvided:
-            self.action_space = action_space
-        if model_config is not NotProvided:
-            self.model_config = model_config
-        if module is not NotProvided:
-            self.module_obj = module
+        return self
+
+    def multi_agent(
+        self,
+        *,
+        modules: Optional[Dict[str, "SingleAgentRLModuleConfig"]] = NotProvided,
+        marl_module_class: Optional[Type["MultiAgentRLModule"]] = NotProvided,
+    ) -> "TrainerRunnerConfig":
+        pass
+
+    def resources(
+        self,
+        num_gpus: Optional[Union[float, int]] = NotProvided,
+        fake_gpus: Optional[bool] = NotProvided,
+    ) -> "TrainerRunnerConfig":
+
+        if num_gpus is not NotProvided:
+            self.num_gpus = num_gpus
+        if fake_gpus is not NotProvided:
+            self.fake_gpus = fake_gpus
 
         return self
 
@@ -162,18 +142,5 @@ class TrainerRunnerConfig:
             self.eager_tracing = eager_tracing
         if optimizer_config is not NotProvided:
             self.optimizer_config = optimizer_config
-
-        return self
-
-    def resources(
-        self,
-        num_gpus: Optional[Union[float, int]] = NotProvided,
-        fake_gpus: Optional[bool] = NotProvided,
-    ) -> "TrainerRunnerConfig":
-
-        if num_gpus is not NotProvided:
-            self.num_gpus = num_gpus
-        if fake_gpus is not NotProvided:
-            self.fake_gpus = fake_gpus
 
         return self

--- a/rllib/core/testing/utils.py
+++ b/rllib/core/testing/utils.py
@@ -1,8 +1,12 @@
 from typing import Type, Union, TYPE_CHECKING
+from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
 
 
 from ray.rllib.utils.annotations import DeveloperAPI
 from ray.rllib.core.rl_trainer.trainer_runner import TrainerRunner
+
+from rllib.core.rl_module.marl_module import MultiAgentRLModuleSpec
+from rllib.core.rl_module.tests.test_marl_module import DEFAULT_POLICY_ID
 
 if TYPE_CHECKING:
     import gymnasium as gym
@@ -45,6 +49,25 @@ def get_module_class(framework: str) -> Type["RLModule"]:
 
 
 @DeveloperAPI
+def get_module_spec(framework: str, env: "gym.Env", is_multi_agent: bool = False):
+
+    spec = SingleAgentRLModuleSpec(
+        module_class=get_module_class(framework),
+        observation_space=env.observation_space,
+        action_space=env.action_space,
+        model_config={"hidden_dim": 32},
+    )
+
+    if is_multi_agent:
+        # TODO (Kourosh): Make this more multi-agent for example with policy ids "1", and "2".
+        return MultiAgentRLModuleSpec(
+            module_class=MultiAgentRLModule, module_specs={DEFAULT_POLICY_ID: spec}
+        )
+    else:
+        return spec
+
+
+@DeveloperAPI
 def get_optimizer_default_class(framework: str) -> Type[Optimizer]:
     if framework == "tf":
         import tensorflow as tf
@@ -59,17 +82,29 @@ def get_optimizer_default_class(framework: str) -> Type[Optimizer]:
 
 
 @DeveloperAPI
+def get_rl_trainer(
+    framework: str,
+    env: "gym.Env",
+    is_multi_agent: bool = False,
+) -> "RLTrainer":
+
+    _cls = get_trainer_class(framework)
+    spec = get_module_spec(framework=framework, env=env, is_multi_agent=is_multi_agent)
+    return _cls(module_spec=spec, optimizer_config={"lr": 0.1})
+
+
+@DeveloperAPI
 def get_trainer_runner(
-    framework: str, env: "gym.Env", compute_config: dict
+    framework: str,
+    env: "gym.Env",
+    compute_config: dict,
+    is_multi_agent: bool = False,
 ) -> TrainerRunner:
     trainer_class = get_trainer_class(framework)
     trainer_cfg = dict(
-        module_class=get_module_class(framework),
-        module_kwargs={
-            "observation_space": env.observation_space,
-            "action_space": env.action_space,
-            "model_config": {"hidden_dim": 32},
-        },
+        module_spec=get_module_spec(
+            framework=framework, env=env, is_multi_agent=is_multi_agent
+        ),
         optimizer_config={"lr": 0.1},
     )
     runner = TrainerRunner(trainer_class, trainer_cfg, compute_config=compute_config)

--- a/rllib/core/testing/utils.py
+++ b/rllib/core/testing/utils.py
@@ -121,11 +121,6 @@ def add_module_to_runner_or_trainer(
 ):
     runner_or_trainer.add_module(
         module_id=module_id,
-        module_cls=get_module_class(framework),
-        module_kwargs={
-            "observation_space": env.observation_space,
-            "action_space": env.action_space,
-            "model_config": {"hidden_dim": 32},
-        },
+        module_spec=get_module_spec(framework, env, is_multi_agent=False),
         optimizer_cls=get_optimizer_default_class(framework),
     )

--- a/rllib/core/testing/utils.py
+++ b/rllib/core/testing/utils.py
@@ -5,7 +5,7 @@ from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
 from ray.rllib.utils.annotations import DeveloperAPI
 from ray.rllib.core.rl_trainer.trainer_runner import TrainerRunner
 
-from rllib.core.rl_module.marl_module import MultiAgentRLModuleSpec
+from rllib.core.rl_module.marl_module import MultiAgentRLModuleSpec, MultiAgentRLModule
 from rllib.core.rl_module.tests.test_marl_module import DEFAULT_POLICY_ID
 
 if TYPE_CHECKING:
@@ -59,7 +59,8 @@ def get_module_spec(framework: str, env: "gym.Env", is_multi_agent: bool = False
     )
 
     if is_multi_agent:
-        # TODO (Kourosh): Make this more multi-agent for example with policy ids "1", and "2".
+        # TODO (Kourosh): Make this more multi-agent for example with policy ids "1",
+        # and "2".
         return MultiAgentRLModuleSpec(
             module_class=MultiAgentRLModule, module_specs={DEFAULT_POLICY_ID: spec}
         )

--- a/rllib/core/testing/utils.py
+++ b/rllib/core/testing/utils.py
@@ -5,8 +5,11 @@ from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
 from ray.rllib.utils.annotations import DeveloperAPI
 from ray.rllib.core.rl_trainer.trainer_runner import TrainerRunner
 
-from rllib.core.rl_module.marl_module import MultiAgentRLModuleSpec, MultiAgentRLModule
-from rllib.core.rl_module.tests.test_marl_module import DEFAULT_POLICY_ID
+from ray.rllib.core.rl_module.marl_module import (
+    MultiAgentRLModuleSpec,
+    MultiAgentRLModule,
+)
+from ray.rllib.core.rl_module.tests.test_marl_module import DEFAULT_POLICY_ID
 
 if TYPE_CHECKING:
     import gymnasium as gym


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Introducing ModuleSpecs allows for elegant and module instantiation of RLModules. We can use these specs to unify single agent and multi-agent marl module instantiation inside RLTrainers. In the interim transition where policies co-exist with RLModules we have to construct MARLModules inside trainers based on individual RLModules inside each policy. Hopefully with this we can add Multi-GPU support to all of our existing policy + RL module code. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
