### PR TITLE
[RLlib] Make torch PPO regression test longer

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3174,7 +3174,7 @@
 
   run:
     timeout: 18000
-    script: python learning_tests/run.py --yaml-sub-dir=ppo --framework=tf
+    script: python learning_tests/run.py --yaml-sub-dir=ppo/tf --framework=tf
 
 
   alert: default
@@ -3197,7 +3197,7 @@
 
   run:
     timeout: 18000
-    script: python learning_tests/run.py --yaml-sub-dir=ppo --framework=torch
+    script: python learning_tests/run.py --yaml-sub-dir=ppo/torch --framework=torch
 
 
   alert: default

--- a/release/rllib_tests/learning_tests/yaml_files/ppo/tf/ppo-breakoutnoframeskip-v5-tf.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/ppo/tf/ppo-breakoutnoframeskip-v5-tf.yaml
@@ -7,7 +7,6 @@ ppo-breakoutnoframeskip-v5:
         timesteps_total: 7000000
     stop:
         time_total_s: 3600
-    num_samples: 10
     config:
         # Make analogous to old v4 + NoFrameskip.
         env_config:

--- a/release/rllib_tests/learning_tests/yaml_files/ppo/tf/ppo-breakoutnoframeskip-v5-tf.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/ppo/tf/ppo-breakoutnoframeskip-v5-tf.yaml
@@ -1,0 +1,36 @@
+ppo-breakoutnoframeskip-v5:
+    env: ALE/Breakout-v5
+    run: PPO
+    # Minimum reward and total ts (in given time_total_s) to pass this test.
+    pass_criteria:
+        episode_reward_mean: 50.0
+        timesteps_total: 7000000
+    stop:
+        time_total_s: 3600
+    num_samples: 10
+    config:
+        # Make analogous to old v4 + NoFrameskip.
+        env_config:
+            frameskip: 1
+            full_action_space: false
+            repeat_action_probability: 0.0
+        lambda: 0.95
+        kl_coeff: 0.5
+        clip_rewards: True
+        clip_param: 0.1
+        vf_clip_param: 10.0
+        entropy_coeff: 0.01
+        train_batch_size: 5000
+        rollout_fragment_length: auto
+        sgd_minibatch_size: 500
+        num_sgd_iter: 10
+        num_workers: 30
+        num_envs_per_worker: 1
+        batch_mode: truncate_episodes
+        observation_filter: NoFilter
+        model:
+            vf_share_layers: true
+        num_gpus: 2
+        min_time_s_per_iteration: 30
+        lr: 0.0001
+        grad_clip: 100

--- a/release/rllib_tests/learning_tests/yaml_files/ppo/torch/ppo-breakoutnoframeskip-v5-torch.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/ppo/torch/ppo-breakoutnoframeskip-v5-torch.yaml
@@ -6,7 +6,9 @@ ppo-breakoutnoframeskip-v5:
         episode_reward_mean: 50.0
         timesteps_total: 7000000
     stop:
-        time_total_s: 3600
+        # This is double the time we use for tf because of 2x throughput there.
+        time_total_s: 7200
+    num_samples: 10
     config:
         # Make analogous to old v4 + NoFrameskip.
         env_config:

--- a/release/rllib_tests/learning_tests/yaml_files/ppo/torch/ppo-breakoutnoframeskip-v5-torch.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/ppo/torch/ppo-breakoutnoframeskip-v5-torch.yaml
@@ -8,7 +8,6 @@ ppo-breakoutnoframeskip-v5:
     stop:
         # This is double the time we use for tf because of 2x throughput there.
         time_total_s: 7200
-    num_samples: 10
     config:
         # Make analogous to old v4 + NoFrameskip.
         env_config:


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Because of a throughput difference between torch and tf (tf being 2x faster), we should give torch more time in this test.
I've run a couple of experiments and observed that torch has the same sample efficiency and that the only difference appears to be throughput. Until @smorad has resolved this mystery, we should make this test longer and simply make it shorter when we are able to resolve this so that this test can properly fail/succeed for the time being.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
