### PR TITLE
Fix whitespace in help message for ray cli

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -406,7 +406,7 @@ def debug(address):
     required=False,
     default="localhost",
     help="the host to bind the dashboard server to, either localhost "
-    "(127.0.0.1) or 0.0.0.0 (available from all interfaces). By default, this"
+    "(127.0.0.1) or 0.0.0.0 (available from all interfaces). By default, this "
     "is localhost.",
 )
 @click.option(
@@ -467,8 +467,8 @@ def debug(address):
 @click.option(
     "--temp-dir",
     default=None,
-    help="manually specify the root temporary dir of the Ray process, only works"
-    "when --head is specified",
+    help="manually specify the root temporary dir of the Ray process, only "
+    "works when --head is specified",
 )
 @click.option(
     "--storage",
@@ -515,7 +515,7 @@ def debug(address):
     "--ray-debugger-external",
     is_flag=True,
     default=False,
-    help="Make the Ray debugger available externally to the node. This is only"
+    help="Make the Ray debugger available externally to the node. This is only "
     "safe to activate if the node is behind a firewall.",
 )
 @click.option(


### PR DESCRIPTION
Without this patch, several of the help text are missing whitespace. For
example, `--dashboard-host` appears as follows:
```
  --dashboard-host TEXT           the host to bind the dashboard server to,
                                  either localhost (127.0.0.1) or 0.0.0.0
                                  (available from all interfaces). By default,
                                  thisis localhost.
```
This patch adds the correct trailing whitespace so there are spaces.


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(

Justification for no tests: this only changes static strings.