### PR TITLE
[core] Fix gcs healthch manager crash when node is removed by node manager.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -97,6 +97,7 @@ build:tsan --copt -g
 build:tsan --copt -fno-omit-frame-pointer
 build:tsan --copt -Wno-uninitialized
 build:tsan --linkopt -fsanitize=thread
+build:tsan --cxxopt="-D_RAY_TSAN_BUILD"
 # This config is only for running TSAN with LLVM toolchain on Linux.
 build:tsan-clang --config=tsan
 build:tsan-clang --config=llvm

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1844,7 +1844,7 @@ cc_library(
 
 cc_test(
     name = "gcs_health_check_manager_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc",
     ],

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
@@ -84,10 +84,8 @@ void GcsHealthCheckManager::HealthCheckContext::StartHealthCheck() {
       context_.get(),
       &request_,
       &response_,
-      [this,
-       stopped = this->stopped_,
-       context = this->context_,
-       now = absl::Now()](::grpc::Status status) {
+      [this, stopped = this->stopped_, context = this->context_, now = absl::Now()](
+          ::grpc::Status status) {
         // This callback is done in gRPC's thread pool.
         STATS_health_check_rpc_latency_ms.Record(
             absl::ToInt64Milliseconds(absl::Now() - now));
@@ -112,12 +110,14 @@ void GcsHealthCheckManager::HealthCheckContext::StartHealthCheck() {
               }
 
               if (health_check_remaining_ == 0) {
-                manager_->io_service_.post([this, stopped]() {
-                  if(*stopped) {
-                    return;
-                  }
-                  manager_->FailNode(node_id_); },
-                  "");
+                manager_->io_service_.post(
+                    [this, stopped]() {
+                      if (*stopped) {
+                        return;
+                      }
+                      manager_->FailNode(node_id_);
+                    },
+                    "");
               } else {
                 // Do another health check.
                 timer_.expires_from_now(

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
@@ -84,8 +84,11 @@ void GcsHealthCheckManager::HealthCheckContext::StartHealthCheck() {
       context_.get(),
       &request_,
       &response_,
-      [this, stub = stub_, stopped = this->stopped_, context = this->context_, now = absl::Now()](
-          ::grpc::Status status) {
+      [this,
+       stub = stub_,
+       stopped = this->stopped_,
+       context = this->context_,
+       now = absl::Now()](::grpc::Status status) {
         // This callback is done in gRPC's thread pool.
         STATS_health_check_rpc_latency_ms.Record(
             absl::ToInt64Milliseconds(absl::Now() - now));

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
@@ -84,7 +84,7 @@ void GcsHealthCheckManager::HealthCheckContext::StartHealthCheck() {
       context_.get(),
       &request_,
       &response_,
-      [this, stopped = this->stopped_, context = this->context_, now = absl::Now()](
+      [this, stub = stub_, stopped = this->stopped_, context = this->context_, now = absl::Now()](
           ::grpc::Status status) {
         // This callback is done in gRPC's thread pool.
         STATS_health_check_rpc_latency_ms.Record(

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
@@ -62,7 +62,7 @@ void GcsHealthCheckManager::RemoveNode(const NodeID &node_id) {
 void GcsHealthCheckManager::FailNode(const NodeID &node_id) {
   RAY_LOG(WARNING) << "Node " << node_id << " is dead because the health check failed.";
   auto iter = health_check_contexts_.find(node_id);
-  if(iter != health_check_contexts_.end()) {
+  if (iter != health_check_contexts_.end()) {
     on_node_death_callback_(node_id);
     health_check_contexts_.erase(iter);
   }

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
@@ -53,6 +53,7 @@ void GcsHealthCheckManager::RemoveNode(const NodeID &node_id) {
         if (iter == health_check_contexts_.end()) {
           return;
         }
+        iter->second->Stop();
         health_check_contexts_.erase(iter);
       },
       "GcsHealthCheckManager::RemoveNode");
@@ -60,8 +61,11 @@ void GcsHealthCheckManager::RemoveNode(const NodeID &node_id) {
 
 void GcsHealthCheckManager::FailNode(const NodeID &node_id) {
   RAY_LOG(WARNING) << "Node " << node_id << " is dead because the health check failed.";
-  on_node_death_callback_(node_id);
-  health_check_contexts_.erase(node_id);
+  auto iter = health_check_contexts_.find(node_id);
+  if(iter != health_check_contexts_.end()) {
+    on_node_death_callback_(node_id);
+    health_check_contexts_.erase(iter);
+  }
 }
 
 std::vector<NodeID> GcsHealthCheckManager::GetAllNodes() const {
@@ -75,27 +79,23 @@ std::vector<NodeID> GcsHealthCheckManager::GetAllNodes() const {
 void GcsHealthCheckManager::HealthCheckContext::StartHealthCheck() {
   using ::grpc::health::v1::HealthCheckResponse;
 
-  context_ = std::make_shared<grpc::ClientContext>();
+  // Reset the context/request/response for the next request.
+  context_.~ClientContext();
+  new (&context_) grpc::ClientContext();
+  response_.Clear();
 
   auto deadline =
       std::chrono::system_clock::now() + std::chrono::milliseconds(manager_->timeout_ms_);
-  context_->set_deadline(deadline);
+  context_.set_deadline(deadline);
   stub_->async()->Check(
-      context_.get(),
-      &request_,
-      &response_,
-      [this, stopped = this->stopped_, context = this->context_, now = absl::Now()](
-          ::grpc::Status status) {
+      &context_, &request_, &response_, [this, now = absl::Now()](::grpc::Status status) {
         // This callback is done in gRPC's thread pool.
         STATS_health_check_rpc_latency_ms.Record(
             absl::ToInt64Milliseconds(absl::Now() - now));
-        if (*stopped || status.error_code() == ::grpc::StatusCode::CANCELLED) {
-          return;
-        }
         manager_->io_service_.post(
-            [this, stopped, status]() {
-              // Stopped has to be read in the same thread where it's updated.
-              if (*stopped) {
+            [this, status]() {
+              if (stopped_) {
+                delete this;
                 return;
               }
               RAY_LOG(DEBUG) << "Health check status: " << int(response_.status());
@@ -110,38 +110,28 @@ void GcsHealthCheckManager::HealthCheckContext::StartHealthCheck() {
               }
 
               if (health_check_remaining_ == 0) {
-                manager_->io_service_.post(
-                    [this, stopped]() {
-                      if (*stopped) {
-                        return;
-                      }
-                      manager_->FailNode(node_id_);
-                    },
-                    "");
+                manager_->FailNode(node_id_);
+                delete this;
               } else {
                 // Do another health check.
                 timer_.expires_from_now(
                     boost::posix_time::milliseconds(manager_->period_ms_));
-                timer_.async_wait([this, stopped](auto ec) {
-                  // We need to check stopped here as well since cancel
-                  // won't impact the queued tasks.
-                  if (ec != boost::asio::error::operation_aborted && !*stopped) {
-                    StartHealthCheck();
-                  }
-                });
+                timer_.async_wait([this](auto) { StartHealthCheck(); });
               }
             },
             "HealthCheck");
       });
 }
 
+void GcsHealthCheckManager::HealthCheckContext::Stop() { stopped_ = true; }
+
 void GcsHealthCheckManager::AddNode(const NodeID &node_id,
                                     std::shared_ptr<grpc::Channel> channel) {
   io_service_.dispatch(
       [this, channel, node_id]() {
         RAY_CHECK(health_check_contexts_.count(node_id) == 0);
-        auto context = std::make_unique<HealthCheckContext>(this, channel, node_id);
-        health_check_contexts_.emplace(std::make_pair(node_id, std::move(context)));
+        auto context = new HealthCheckContext(this, channel, node_id);
+        health_check_contexts_.emplace(std::make_pair(node_id, context));
       },
       "GcsHealthCheckManager::AddNode");
 }

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.h
@@ -124,7 +124,7 @@ class GcsHealthCheckManager {
     std::shared_ptr<bool> stopped_;
 
     /// gRPC related fields
-    std::shared_ptr<::grpc::health::v1::Health::Stub> stub_;
+    std::unique_ptr<::grpc::health::v1::Health::Stub> stub_;
 
     // The context is used in the gRPC callback which is in another
     // thread, so we need it to be a shared_ptr.

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.h
@@ -98,8 +98,8 @@ class GcsHealthCheckManager {
       stub_ = grpc::health::v1::Health::NewStub(channel);
       timer_.expires_from_now(
           boost::posix_time::milliseconds(manager_->initial_delay_ms_));
-      timer_.async_wait([this](auto ec) {
-        if (ec != boost::asio::error::operation_aborted) {
+      timer_.async_wait([this, stopped = stopped_](auto ec) {
+        if (!*stopped && ec != boost::asio::error::operation_aborted) {
           StartHealthCheck();
         }
       });
@@ -124,7 +124,7 @@ class GcsHealthCheckManager {
     std::shared_ptr<bool> stopped_;
 
     /// gRPC related fields
-    std::unique_ptr<::grpc::health::v1::Health::Stub> stub_;
+    std::shared_ptr<::grpc::health::v1::Health::Stub> stub_;
 
     // The context is used in the gRPC callback which is in another
     // thread, so we need it to be a shared_ptr.

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.h
@@ -98,7 +98,7 @@ class GcsHealthCheckManager {
       stub_ = grpc::health::v1::Health::NewStub(channel);
       timer_.expires_from_now(
           boost::posix_time::milliseconds(manager_->initial_delay_ms_));
-      timer_.async_wait([this, stopped = stopped_](auto ec) {
+      timer_.async_wait([stopped = stopped_, this](auto ec) {
         if (!*stopped && ec != boost::asio::error::operation_aborted) {
           StartHealthCheck();
         }

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.h
@@ -91,27 +91,16 @@ class GcsHealthCheckManager {
                        NodeID node_id)
         : manager_(manager),
           node_id_(node_id),
-          stopped_(std::make_shared<bool>(false)),
           timer_(manager->io_service_),
           health_check_remaining_(manager->failure_threshold_) {
       request_.set_service(node_id.Hex());
       stub_ = grpc::health::v1::Health::NewStub(channel);
       timer_.expires_from_now(
           boost::posix_time::milliseconds(manager_->initial_delay_ms_));
-      timer_.async_wait([stopped = stopped_, this](auto ec) {
-        if (!*stopped && ec != boost::asio::error::operation_aborted) {
-          StartHealthCheck();
-        }
-      });
+      timer_.async_wait([this](auto) { StartHealthCheck(); });
     }
 
-    ~HealthCheckContext() {
-      timer_.cancel();
-      if (context_ != nullptr) {
-        context_->TryCancel();
-      }
-      *stopped_ = true;
-    }
+    void Stop();
 
    private:
     void StartHealthCheck();
@@ -121,14 +110,14 @@ class GcsHealthCheckManager {
     NodeID node_id_;
 
     // Whether the health check has stopped.
-    std::shared_ptr<bool> stopped_;
+    bool stopped_ = false;
 
     /// gRPC related fields
     std::unique_ptr<::grpc::health::v1::Health::Stub> stub_;
 
     // The context is used in the gRPC callback which is in another
     // thread, so we need it to be a shared_ptr.
-    std::shared_ptr<grpc::ClientContext> context_;
+    grpc::ClientContext context_;
     ::grpc::health::v1::HealthCheckRequest request_;
     ::grpc::health::v1::HealthCheckResponse response_;
 
@@ -146,7 +135,7 @@ class GcsHealthCheckManager {
   std::function<void(const NodeID &)> on_node_death_callback_;
 
   /// The context of the health check for each nodes.
-  absl::flat_hash_map<NodeID, std::unique_ptr<HealthCheckContext>> health_check_contexts_;
+  absl::flat_hash_map<NodeID, HealthCheckContext *> health_check_contexts_;
 
   /// The delay for the first health check request.
   const int64_t initial_delay_ms_;

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.h
@@ -115,8 +115,6 @@ class GcsHealthCheckManager {
     /// gRPC related fields
     std::unique_ptr<::grpc::health::v1::Health::Stub> stub_;
 
-    // The context is used in the gRPC callback which is in another
-    // thread, so we need it to be a shared_ptr.
     grpc::ClientContext context_;
     ::grpc::health::v1::HealthCheckRequest request_;
     ::grpc::health::v1::HealthCheckResponse response_;

--- a/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
@@ -263,8 +263,9 @@ TEST_F(GcsHealthCheckManagerTest, StressTest) {
     std::this_thread::sleep_for(10ms);
   }
 
-  for (size_t i = 0; i < 200000000UL; ++i) {
+  for (size_t i = 0; i < 20000UL; ++i) {
     auto iter = alive_nodes.begin() + std::rand() % alive_nodes.size();
+    health_check->RemoveNode(*iter);
     DeleteServer(*iter);
     alive_nodes.erase(iter);
     alive_nodes.emplace_back(AddServer(true));

--- a/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdlib>
 #include <grpcpp/grpcpp.h>
 
 #include <boost/asio.hpp>
@@ -20,6 +19,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/optional.hpp>
 #include <boost/thread.hpp>
+#include <cstdlib>
 #include <unordered_map>
 
 using namespace boost;
@@ -254,18 +254,16 @@ TEST_F(GcsHealthCheckManagerTest, NoRegister) {
 TEST_F(GcsHealthCheckManagerTest, StressTest) {
   boost::asio::io_service::work work(io_service);
   std::srand(std::time(nullptr));
-  auto t = std::make_unique<std::thread>([this]() {
-    io_service.run();
-  });
+  auto t = std::make_unique<std::thread>([this]() { io_service.run(); });
 
   std::vector<NodeID> alive_nodes;
 
-  for(int i = 0; i < 200; ++i) {
+  for (int i = 0; i < 200; ++i) {
     alive_nodes.emplace_back(AddServer(true));
     std::this_thread::sleep_for(10ms);
   }
 
-  for(size_t i = 0; i < 200000000UL; ++i) {
+  for (size_t i = 0; i < 200000000UL; ++i) {
     auto iter = alive_nodes.begin() + std::rand() % alive_nodes.size();
     DeleteServer(*iter);
     alive_nodes.erase(iter);

--- a/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
@@ -246,6 +246,9 @@ TEST_F(GcsHealthCheckManagerTest, NoRegister) {
 }
 
 TEST_F(GcsHealthCheckManagerTest, StressTest) {
+#if defined(__has_feature) && __has_feature(thread_sanitizer)
+  GTEST_SKIP() << "Disabled in tsan because of performance";
+#endif
   boost::asio::io_service::work work(io_service);
   std::srand(std::time(nullptr));
   auto t = std::make_unique<std::thread>([this]() { this->io_service.run(); });

--- a/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
@@ -246,7 +246,7 @@ TEST_F(GcsHealthCheckManagerTest, NoRegister) {
 }
 
 TEST_F(GcsHealthCheckManagerTest, StressTest) {
-#if defined(__has_feature) && __has_feature(thread_sanitizer)
+#ifdef _RAY_TSAN_BUILD
   GTEST_SKIP() << "Disabled in tsan because of performance";
 #endif
   boost::asio::io_service::work work(io_service);

--- a/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
@@ -159,8 +159,6 @@ TEST_F(GcsHealthCheckManagerTest, TestBasic) {
     Run(2);  // One for starting RPC and one for the RPC callback.
   }
 
-  Run();  // For failure callback.
-
   ASSERT_EQ(1, dead_nodes.size());
   ASSERT_TRUE(dead_nodes.count(node_id));
 }
@@ -184,8 +182,6 @@ TEST_F(GcsHealthCheckManagerTest, StoppedAndResume) {
       StartServing(node_id);
     }
   }
-
-  Run();  // For failure callback.
 
   ASSERT_EQ(0, dead_nodes.size());
 }
@@ -211,8 +207,6 @@ TEST_F(GcsHealthCheckManagerTest, Crashed) {
   for (auto i = 0; i < failure_threshold; ++i) {
     Run(2);  // One for starting RPC and one for the RPC callback.
   }
-
-  Run();  // For failure callback.
 
   ASSERT_EQ(1, dead_nodes.size());
   ASSERT_TRUE(dead_nodes.count(node_id));
@@ -246,7 +240,7 @@ TEST_F(GcsHealthCheckManagerTest, NoRegister) {
     Run(2);  // One for starting RPC and one for the RPC callback.
   }
 
-  Run(2);
+  Run(1);
   ASSERT_EQ(1, dead_nodes.size());
   ASSERT_TRUE(dead_nodes.count(node_id));
 }

--- a/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
@@ -264,6 +264,7 @@ TEST_F(GcsHealthCheckManagerTest, StressTest) {
   }
 
   for (size_t i = 0; i < 20000UL; ++i) {
+    RAY_LOG(INFO) << "Progress: " << i << "/20000";
     auto iter = alive_nodes.begin() + std::rand() % alive_nodes.size();
     health_check->RemoveNode(*iter);
     DeleteServer(*iter);

--- a/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
@@ -254,7 +254,7 @@ TEST_F(GcsHealthCheckManagerTest, NoRegister) {
 TEST_F(GcsHealthCheckManagerTest, StressTest) {
   boost::asio::io_service::work work(io_service);
   std::srand(std::time(nullptr));
-  auto t = std::make_unique<std::thread>([this]() { io_service.run(); });
+  auto t = std::make_unique<std::thread>([this]() { this->io_service.run(); });
 
   std::vector<NodeID> alive_nodes;
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The root cause is because the data structure is deleted, but call backs is not canceled and got executed. This PR simplify the life model and make it the way gRPC works. We only delete the structure after gRPC OnDone is called.

In the shortcut, according to the doc https://github.com/grpc/proposal/blob/master/L67-cpp-callback-api.md#unary-rpc-shortcuts , OnDone will call the callback function.

A better model is needed here. The code will be changed once we update the threading model in gRPC.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
