### PR TITLE
[RLlib] fix the reference in docs of Fault tolerance

### DIFF
--- a/doc/source/rllib/rllib-fault-tolerance.rst
+++ b/doc/source/rllib/rllib-fault-tolerance.rst
@@ -69,7 +69,7 @@ When using Ray Tune with RLlib, you can enable
 :ref:`periodic checkpointing <rllib-saving-and-loading-algos-and-policies-docs>`,
 which saves the state of the experiment to a user-specified persistent storage location.
 If a trial fails, Ray Tune will automatically restart it from the latest
-:ref:`checkpointed <tune-two-types-of-ckpt>` state.
+:ref:`checkpointed <tune-fault-tol>` state.
 
 
 Other Miscellaneous Considerations 


### PR DESCRIPTION
Signed-off-by: Kourosh Hakhamaneshi <kourosh@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fixes the book check error

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
