### PR TITLE
[core] Deflakey gcs server rpc test

### DIFF
--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -63,6 +63,7 @@ class GcsServerTest : public ::testing::Test {
     gcs_server_->Stop();
     thread_io_service_->join();
     gcs_server_.reset();
+    ray::gcs::RedisCallbackManager::instance().Clear();
   }
 
   bool AddJob(const rpc::AddJobRequest &request) {

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -213,8 +213,8 @@ std::shared_ptr<RedisCallbackManager::CallbackItem> RedisCallbackManager::GetCal
 }
 
 void RedisCallbackManager::Clear() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    callback_items_.clear();
+  std::lock_guard<std::mutex> lock(mutex_);
+  callback_items_.clear();
 }
 
 void RedisCallbackManager::RemoveCallback(int64_t callback_index) {

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -212,6 +212,11 @@ std::shared_ptr<RedisCallbackManager::CallbackItem> RedisCallbackManager::GetCal
   return it->second;
 }
 
+void RedisCallbackManager::Clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    callback_items_.clear();
+}
+
 void RedisCallbackManager::RemoveCallback(int64_t callback_index) {
   std::lock_guard<std::mutex> lock(mutex_);
   callback_items_.erase(callback_index);

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -145,6 +145,9 @@ class RedisCallbackManager {
   /// Get a callback.
   std::shared_ptr<CallbackItem> GetCallback(int64_t callback_index) const;
 
+  /// Clear all callbacks.
+  void Clear();
+
  private:
   RedisCallbackManager() : num_callbacks_(0){};
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The test failed because in the current ray redis client there is a global variable using io context. and the io context is freed during destruction and when destruct the global variable it'll cause issues.

The current redis client is aweful and ugly. Since we'll move to redis plus plus, and this client doesn't cause other issues, I'll just fix the test case.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
