### PR TITLE
[Tune] Clarify which `RunConfig` is used when there are multiple places to specify it

### DIFF
--- a/python/ray/train/tests/test_tune.py
+++ b/python/ray/train/tests/test_tune.py
@@ -300,6 +300,16 @@ def test_run_config_in_trainer_and_tuner(
     )
 
 
+def test_run_config_in_param_space():
+    trainer = DataParallelTrainer(
+        lambda config: None,
+        backend_config=TestConfig(),
+        scaling_config=ScalingConfig(num_workers=1),
+    )
+    with pytest.raises(ValueError):
+        Tuner(trainer, param_space={"run_config": RunConfig(name="ignored")})
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/tests/test_tune.py
+++ b/python/ray/train/tests/test_tune.py
@@ -290,9 +290,7 @@ def test_run_config_in_trainer_and_tuner(
         run_config=RunConfig(name="ignored", local_dir="ignored"),
     )
     with caplog.at_level(logging.INFO, logger="ray.tune.impl.tuner_internal"):
-        tuner = Tuner(
-            trainer, run_config=RunConfig(name="used", local_dir=str(tmp_path))
-        )
+        Tuner(trainer, run_config=RunConfig(name="used", local_dir=str(tmp_path)))
     assert list((tmp_path / "used").glob(_TUNER_PKL))
     assert (
         "`RunConfig` was passed to both the `Tuner` and the `DataParallelTrainer`"

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -92,6 +92,12 @@ class TunerInternal:
                     "`{trainable.__class__.__name__}`. The run config passed to "
                     "the `Tuner` is the one that will be used."
                 )
+            if "run_config" in param_space:
+                raise ValueError(
+                    "`RunConfig` cannot be tuned as part of the `param_space`! "
+                    "Move the run config to be a parameter of the `Tuner`: "
+                    "Tuner(..., run_config=RunConfig(...))"
+                )
 
         self._tune_config = tune_config or TuneConfig()
         self._run_config = run_config or RunConfig()

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -81,10 +81,17 @@ class TunerInternal:
     ):
         from ray.train.trainer import BaseTrainer
 
-        # If no run config was passed to Tuner directly, use the one from the Trainer,
-        # if available
-        if not run_config and isinstance(trainable, BaseTrainer):
-            run_config = trainable.run_config
+        if isinstance(trainable, BaseTrainer):
+            # If no run config was passed to the Tuner directly,
+            # use the one from the Trainer, if available
+            if not run_config:
+                run_config = trainable.run_config
+            if run_config and trainable.run_config != RunConfig():
+                logger.info(
+                    "A `RunConfig` was passed to both the `Tuner` and the "
+                    "`{trainable.__class__.__name__}`. The run config passed to "
+                    "the `Tuner` is the one that will be used."
+                )
 
         self._tune_config = tune_config or TuneConfig()
         self._run_config = run_config or RunConfig()

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -89,10 +89,10 @@ class TunerInternal:
             if run_config and trainable.run_config != RunConfig():
                 logger.info(
                     "A `RunConfig` was passed to both the `Tuner` and the "
-                    "`{trainable.__class__.__name__}`. The run config passed to "
+                    f"`{trainable.__class__.__name__}`. The run config passed to "
                     "the `Tuner` is the one that will be used."
                 )
-            if "run_config" in param_space:
+            if param_space and "run_config" in param_space:
                 raise ValueError(
                     "`RunConfig` cannot be tuned as part of the `param_space`! "
                     "Move the run config to be a parameter of the `Tuner`: "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR clarifies where `RunConfig` can be specified. Also, when multiple configs are specified in different locations (in the Tuner and Trainer), this PR also logs information about which `RunConfig` is actually used.

### Context

- Scenario 1: `RunConfig` gets passed into both the Tuner and Trainer. The Tuner run config gets used, but this is not obvious/logged to the user.
- Scenario 2: User tries to pass `RunConfig` in through the `param_space`. This silently fails (aka it doesn't get used), and it shouldn't be allowed, since the `RunConfig` cannot be tuned.
- Scenario 3: Allowing a RunConfig in the Trainer when wrapping it with a Tuner makes it confusing whether or not this can be updated on restore, since it can be passed in again through the overwritten Trainable.

This PR logs something to the user for scenario 1, and disallows scenario 2.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
