### PR TITLE
[RLlib] Auto-detect old gym/gymnasium APIs and wrap accordingly. Configurable.

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2264,7 +2264,7 @@ class Algorithm(Trainable):
                 return env_id, functools.partial(
                     _gym_env_creator,
                     env_descriptor=env_specifier,
-                    auto_wrap_old_gym_envs=config.auto_wrap_old_gym_envs,
+                    auto_wrap_old_gym_envs=config.get("auto_wrap_old_gym_envs", True),
                 )
             # All other env classes: Call c'tor directly.
             else:

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2259,7 +2259,7 @@ class Algorithm(Trainable):
                         return isinstance(self, MultiAgentEnv)
 
                 return env_id, lambda cfg: _wrapper.remote(cfg)
-            # Gymnasium.Env-subclass: Also go through our RLlib gym-creator.
+            # gym.Env-subclass: Also go through our RLlib gym-creator.
             elif issubclass(env_specifier, gym.Env):
                 return env_id, functools.partial(
                     _gym_env_creator,

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2259,6 +2259,14 @@ class Algorithm(Trainable):
                         return isinstance(self, MultiAgentEnv)
 
                 return env_id, lambda cfg: _wrapper.remote(cfg)
+            # Gymnasium.Env-subclass: Also go through our RLlib gym-creator.
+            elif issubclass(env_specifier, gym.Env):
+                return env_id, functools.partial(
+                    _gym_env_creator,
+                    env_descriptor=env_specifier,
+                    auto_wrap_old_gym_envs=config.auto_wrap_old_gym_envs,
+                )
+            # All other env classes: Call c'tor directly.
             else:
                 return env_id, lambda cfg: env_specifier(cfg)
 

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -282,6 +282,7 @@ class AlgorithmConfig:
         # Whether this env is an atari env (for atari-specific preprocessing).
         # If not specified, we will try to auto-detect this.
         self.is_atari = None
+        self.auto_wrap_old_gym_envs = True
 
         # `self.rollouts()`
         self.num_rollout_workers = 0
@@ -1074,6 +1075,7 @@ class AlgorithmConfig:
         clip_actions: Optional[bool] = NotProvided,
         disable_env_checking: Optional[bool] = NotProvided,
         is_atari: Optional[bool] = NotProvided,
+        auto_wrap_old_gym_envs: Optional[bool] = NotProvided,
     ) -> "AlgorithmConfig":
         """Sets the config's RL-environment settings.
 
@@ -1117,6 +1119,12 @@ class AlgorithmConfig:
             is_atari: This config can be used to explicitly specify whether the env is
                 an Atari env or not. If not specified, RLlib will try to auto-detect
                 this during config validation.
+            auto_wrap_old_gym_envs: Whether to auto-wrap old gym environments (using
+                the pre 0.24 gym APIs, e.g. reset() returning single obs and no info
+                dict). If True, RLlib will automatically wrap the given gym env class
+                with the gym-provided compatibility wrapper. If False, RLlib will
+                produce a descriptive error on which steps to perform to upgrade to
+                gymnasium (or to switch this flag to True).
 
         Returns:
             This updated AlgorithmConfig object.
@@ -1147,6 +1155,8 @@ class AlgorithmConfig:
             self.disable_env_checking = disable_env_checking
         if is_atari is not NotProvided:
             self.is_atari = is_atari
+        if auto_wrap_old_gym_envs is not NotProvided:
+            self.auto_wrap_old_gym_envs = auto_wrap_old_gym_envs
 
         return self
 

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -1122,9 +1122,10 @@ class AlgorithmConfig:
             auto_wrap_old_gym_envs: Whether to auto-wrap old gym environments (using
                 the pre 0.24 gym APIs, e.g. reset() returning single obs and no info
                 dict). If True, RLlib will automatically wrap the given gym env class
-                with the gym-provided compatibility wrapper. If False, RLlib will
-                produce a descriptive error on which steps to perform to upgrade to
-                gymnasium (or to switch this flag to True).
+                with the gym-provided compatibility wrapper
+                (gym.wrappers.EnvCompatibility). If False, RLlib will produce a
+                descriptive error on which steps to perform to upgrade to gymnasium
+                (or to switch this flag to True).
 
         Returns:
             This updated AlgorithmConfig object.

--- a/rllib/env/utils.py
+++ b/rllib/env/utils.py
@@ -130,7 +130,7 @@ def _gym_env_creator(
     try:
         # If class provided, call constructor directly.
         if isinstance(env_descriptor, type):
-            env = env_descriptor(**env_context)
+            env = env_descriptor(env_context)
         # Special case: Atari not supported by gymnasium yet -> Need to use their
         # GymV26 compatibility wrapper class.
         # TODO(sven): Remove this if-block once gymnasium fully supports Atari envs.

--- a/rllib/env/utils.py
+++ b/rllib/env/utils.py
@@ -1,8 +1,23 @@
+import logging
+
 import gymnasium as gym
 
 from ray.rllib.env.env_context import EnvContext
-from ray.rllib.utils.error import ERR_MSG_INVALID_ENV_DESCRIPTOR, EnvError
+from ray.rllib.env.multi_agent_env import MultiAgentEnv
+from ray.rllib.env.wrappers.multi_agent_env_compatibility import (
+    MultiAgentEnvCompatibility
+)
+from ray.rllib.utils.error import (
+    ERR_MSG_INVALID_ENV_DESCRIPTOR,
+    ERR_MSG_OLD_GYM_API,
+    EnvError,
+)
+from ray.rllib.utils.gym import check_old_gym_env
+from ray.util import log_once
 from ray.util.annotations import PublicAPI
+
+
+logger = logging.getLogger(__name__)
 
 
 @PublicAPI
@@ -59,7 +74,11 @@ def try_import_open_spiel(error: bool = False):
         return None
 
 
-def _gym_env_creator(env_context: EnvContext, env_descriptor: str) -> gym.Env:
+def _gym_env_creator(
+    env_context: EnvContext,
+    env_descriptor: str,
+    auto_wrap_old_gym_envs: bool = True,
+) -> gym.Env:
     """Tries to create a gym env given an EnvContext object and descriptor.
 
     Note: This function tries to construct the env from a string descriptor
@@ -75,6 +94,12 @@ def _gym_env_creator(env_context: EnvContext, env_descriptor: str) -> gym.Env:
         env_descriptor: The env descriptor, e.g. CartPole-v1,
             ALE/MsPacman-v5, VizdoomBasic-v0, or
             CartPoleContinuousBulletEnv-v0.
+        auto_wrap_old_gym_envs: Whether to auto-wrap old gym environments (using
+            the pre 0.24 gym APIs, e.g. reset() returning single obs and no info
+            dict). If True, RLlib will automatically wrap the given gym env class
+            with the gym-provided compatibility wrapper. If False, RLlib will
+            produce a descriptive error on which steps to perform to upgrade to
+            gymnasium (or to switch this flag to True).
 
     Returns:
         The actual gym environment object.
@@ -102,16 +127,42 @@ def _gym_env_creator(env_context: EnvContext, env_descriptor: str) -> gym.Env:
     # Try creating a gym env. If this fails we can output a
     # decent error message.
     try:
+        # If class provided, call constructor directly.
+        if isinstance(env_descriptor, type):
+            env = env_descriptor(**env_context)
         # Special case: Atari not supported by gymnasium yet -> Need to use their
         # GymV26 compatibility wrapper class.
         # TODO(sven): Remove this if-block once gymnasium fully supports Atari envs.
-        if env_descriptor.startswith("ALE/"):
-            return gym.make(
+        elif env_descriptor.startswith("ALE/"):
+            env = gym.make(
                 "GymV26Environment-v0",
                 env_id=env_descriptor,
                 make_kwargs=env_context,
             )
         else:
-            return gym.make(env_descriptor, **env_context)
+            env = gym.make(env_descriptor, **env_context)
+        # If we are dealing with an old gym-env API, use the provided compatibility
+        # wrapper.
+        if auto_wrap_old_gym_envs:
+            try:
+                obs_and_infos = env.reset(seed=None, options={})
+                check_old_gym_env(reset_results=obs_and_infos)
+            except Exception:
+                if log_once("auto_wrap_gym_api"):
+                    logger.warning(
+                        "`config.auto_wrap_old_gym_envs` is activated AND you seem to have "
+                        "provided an old gym-API environment. RLlib will therefore try and "
+                        "auto-fix the following error. However, please consider switching "
+                        "over to the new `gymnasium` APIs:\n" + 
+                        ERR_MSG_OLD_GYM_API
+                    )
+                # Multi-agent case.
+                if isinstance(env, MultiAgentEnv):
+                    env = MultiAgentEnvCompatibility(env)
+                # Single agent (gymnasium.Env) case.
+                else:
+                    env = gym.wrappers.EnvCompatibility(env)
     except gym.error.Error:
         raise EnvError(ERR_MSG_INVALID_ENV_DESCRIPTOR.format(env_descriptor))
+
+    return env

--- a/rllib/utils/gym.py
+++ b/rllib/utils/gym.py
@@ -27,12 +27,14 @@ def check_old_gym_env(
                 and isinstance(env.observation_space.spaces[1], gym.spaces.Dict)
             )
         ):
-            raise ValueError
+            raise ValueError(
+                "The number of values returned from `gym.Env.reset(seed=.., options=..)"
+                "` must be 2! Make sure your `reset()` method returns: [obs] and "
+                "[infos]."
+            )
     # Check `step()` results.
     elif step_results is not None:
-        if len(step_results) == 4:
-            return ValueError
-        elif len(step_results) == 5:
+        if len(step_results) == 5:
             return False
         else:
             raise ValueError(


### PR DESCRIPTION
Signed-off-by: sven1977 <svenmika1977@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Auto-detect old gym/gymnasium APIs and wrap accordingly. Configurable.
* Works for both olf gym Env (single-agent) APIs and MultiAgentEnv subclasses that use the old gym APIs.
* Configurable (but auto-wrapping is on by default).
* Added 4 new test cases.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
