### PR TITLE
[docs] Improve visibility of API annotations

### DIFF
--- a/python/ray/util/annotations.py
+++ b/python/ray/util/annotations.py
@@ -80,7 +80,8 @@ def DeveloperAPI(*args, **kwargs):
 
     def wrap(obj):
         _append_doc(
-            obj, message="**DeveloperAPI:** This API may change across minor Ray releases."
+            obj,
+            message="**DeveloperAPI:** This API may change across minor Ray releases.",
         )
         _mark_annotated(obj)
         return obj

--- a/python/ray/util/annotations.py
+++ b/python/ray/util/annotations.py
@@ -49,7 +49,7 @@ def PublicAPI(*args, **kwargs):
     def wrap(obj):
         if stability in ["alpha", "beta"]:
             message = (
-                f"PublicAPI ({stability}): This API is in {stability} "
+                f"**PublicAPI ({stability}):** This API is in {stability} "
                 "and may change before becoming stable."
             )
         else:
@@ -80,7 +80,7 @@ def DeveloperAPI(*args, **kwargs):
 
     def wrap(obj):
         _append_doc(
-            obj, message="DeveloperAPI: This API may change across minor Ray releases."
+            obj, message="**DeveloperAPI:** This API may change across minor Ray releases."
         )
         _mark_annotated(obj)
         return obj


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

You can easily miss the API annotations. As a result, you might unintentionally use an API that's intended for developers. This PR improves the visibility of the API annotations by bolding the first word. 

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #30396 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
