### PR TITLE
[tune] Only keep cached actors if search has not ended

### DIFF
--- a/python/ray/tune/execution/trial_runner.py
+++ b/python/ray/tune/execution/trial_runner.py
@@ -967,7 +967,7 @@ class TrialRunner:
         self._reconcile_live_trials()
 
         with warn_if_slow("on_step_end"):
-            self.trial_executor.on_step_end()
+            self.trial_executor.on_step_end(search_ended=self._search_alg.is_finished())
         with warn_if_slow("callbacks.on_step_end"):
             self._callbacks.on_step_end(iteration=self._iteration, trials=self._trials)
 

--- a/python/ray/tune/tests/test_trial_runner_3.py
+++ b/python/ray/tune/tests/test_trial_runner_3.py
@@ -75,7 +75,7 @@ class TrialRunnerTest3(unittest.TestCase):
             cnt = self.pre_step if hasattr(self, "pre_step") else 0
             self.pre_step = cnt + 1
 
-        def on_step_end(self):
+        def on_step_end(self, search_ended: bool = False):
             cnt = self.pre_step if hasattr(self, "post_step") else 0
             self.post_step = 1 + cnt
 

--- a/release/cluster_tests/workloads/tune_scale_up_down.py
+++ b/release/cluster_tests/workloads/tune_scale_up_down.py
@@ -1,3 +1,27 @@
+"""Test cluster up/down scaling behavior.
+
+This test should run on a cluster with autoscaling enabled. It assumes 1-3 nodes
+with 4 CPUs each.
+
+We start a Ray Tune run with 3 trials. Each trial uses 4 CPUs, so fills up a node
+completely. This means we will trigger autoscaling after starting up.
+
+The trial on the head node will run for 30 minutes. This is to make sure that
+we have enough time that the nodes for the other two trials come up, complete
+training, and come down before the first trial finishes.
+
+The other two trials will run once their nodes are up, and take 3 minutes each
+to finish. The three minutes have been chosen to make sure that both trials
+run in parallel for some time, i.e. to avoid that both additional trials run on
+only one node.
+
+We keep track of the number of nodes we observe at any point during the run.
+
+Test owner: krfricke
+
+Acceptance criteria: Should have scaled to 3 nodes at some point during the run.
+Should have scaled down to 1 node at the end.
+"""
 from collections import Counter
 import time
 


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We currently keep one actor cached if no other trials have been staged to prevent us removing actors when we may need them in one of the next iterations. However, when the search algorithm won't produce new trials anymore, we keep this actor needlessly. This can keep resources occupied needlessly and prevent downscaling, as caught in #31883.

This PR passes another flag to the trial executor cleanup method indicating if new trials are to be expected. If not, we can cleanup unneeded actors even if no further trials are staged.

This behavior is tested in the `cluster_tune_scale_up_down` release test. We won't add a unit test for this as this would effectively mimic the release test. Instead, we can add proper actor reuse testing once we made more progress with the execution refactor.

## Related issue number

Closes #31883

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
