### PR TITLE
[Datasets] [Autoscaling Actor Pool - 2/2] Add autoscaling support to `MapOperator` actor pool.

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -107,19 +107,21 @@ class MapOperator(PhysicalOperator, ABC):
         elif isinstance(compute_strategy, ActorPoolStrategy):
             from ray.data._internal.execution.operators.actor_pool_map_operator import (
                 ActorPoolMapOperator,
+                AutoscalingConfig,
+                AutoscalingPolicy,
             )
 
-            pool_size = compute_strategy.max_size
-            if pool_size == float("inf"):
-                # Use min_size if max_size is unbounded (default).
-                pool_size = compute_strategy.min_size
+            autoscaling_config = AutoscalingConfig.from_compute_strategy(
+                compute_strategy
+            )
+            autoscaling_policy = AutoscalingPolicy(autoscaling_config)
             return ActorPoolMapOperator(
                 transform_fn,
                 input_op,
+                autoscaling_policy=autoscaling_policy,
                 name=name,
                 min_rows_per_bundle=min_rows_per_bundle,
                 ray_remote_args=ray_remote_args,
-                pool_size=pool_size,
             )
         else:
             raise ValueError(f"Unsupported execution strategy {compute_strategy}")


### PR DESCRIPTION
This PR adds support for autoscaling to the actor pool implementation of `MapOperator` (this PR is stacked on top of https://github.com/ray-project/ray/pull/31986).

The same autoscaling policy as the legacy `ActorPoolStrategy` is maintained, as well as providing more aggressive and sensible downscaling via:
* If there are more idle actors than running/pending actors, scale down.
* Once we're done submitting tasks, cancel pending actors and kill idle actors.

In addition to autoscaling, `max_tasks_in_flight` capping is also implemented.

## Related issue number

Closes #31723 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
