### PR TITLE
[nightly] Increase the number of actors started for the test

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3890,7 +3890,7 @@
     timeout: 7200
     # 2cpus per node x 1000 nodes / 0.2 cpus per actor = 10k
     # 2cpus per node x 2000 nodes / 0.2 cpus per actor = 20k
-    script: python distributed/many_nodes_tests/actor_test.py --no-wait --cpus-per-actor=0.2 --total-actors 1000 2000
+    script: python distributed/many_nodes_tests/actor_test.py --no-wait --cpus-per-actor=0.2 --total-actors 10000 20000
     type: job
     wait_for_nodes:
       num_nodes: 500


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In the previously PR, the number failed to be updated. This PR updated it.

```
  many_nodes_actor_tests_10000 = {'actor_launch_time': 14.038594387999979, 'actor_ready_time': 44.27844531799997, 'total_time': 58.317039705999946, 'num_actors': 10000, 'success': '1', 'throughput': 17
1.47646812002273}
  many_nodes_actor_tests_20000 = {'actor_launch_time': 17.670945039000117, 'actor_ready_time': 230.851894916, 'total_time': 248.5228399550001, 'num_actors': 20000, 'success': '1', 'throughput': 80.4755
0077739892}
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
