### PR TITLE
[core] remove legacy memory monitor from task submission codepath

### DIFF
--- a/python/ray/_private/memory_monitor.py
+++ b/python/ray/_private/memory_monitor.py
@@ -103,6 +103,8 @@ class MemoryMonitor:
 
     The environment variable `RAY_MEMORY_MONITOR_ERROR_THRESHOLD` can be used
     to overwrite the default error_threshold setting.
+
+    Used by test only. For production code use memory_monitor.cc
     """
 
     def __init__(self, error_threshold=0.95, check_interval=1):

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -44,7 +44,6 @@ else:
 import ray
 import ray._private.gcs_utils as gcs_utils
 import ray._private.import_thread as import_thread
-import ray._private.memory_monitor as memory_monitor
 import ray._private.node
 import ray._private.parameter
 import ray._private.profiling as profiling
@@ -426,7 +425,6 @@ class Worker:
         # When the worker is constructed. Record the original value of the
         # CUDA_VISIBLE_DEVICES environment variable.
         self.original_gpu_ids = ray._private.utils.get_cuda_visible_devices()
-        self.memory_monitor = memory_monitor.MemoryMonitor()
         # A dictionary that maps from driver id to SerializationContext
         # TODO: clean up the SerializationContext once the job finished.
         self.serialization_context_map = {}

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -804,11 +804,6 @@ cdef void execute_task(
 
     with core_worker.profile_event(b"task::" + name, extra_data=extra_data):
         try:
-            if (not (<int>task_type == <int>TASK_TYPE_ACTOR_TASK
-                     and function_name == "__ray_terminate__") and
-                    ray._config.memory_monitor_refresh_ms() == 0):
-                worker.memory_monitor.raise_if_low_memory()
-
             with core_worker.profile_event(b"task:deserialize_arguments"):
                 if c_args.empty():
                     args, kwargs = [], {}

--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -1,5 +1,4 @@
 from math import ceil
-import os
 import sys
 import time
 
@@ -468,27 +467,6 @@ def test_put_object_task_usage_slightly_below_limit_does_not_crash():
             ),
             timeout=90,
         )
-
-
-@pytest.mark.skipif(
-    sys.platform != "linux" and sys.platform != "linux2",
-    reason="memory monitor only on linux currently",
-)
-def test_legacy_memory_monitor_disabled_by_oom_killer():
-    os.environ["RAY_MEMORY_MONITOR_ERROR_THRESHOLD"] = "0.5"
-    with ray.init(
-        _system_config={
-            "memory_monitor_refresh_ms": 50,
-            "memory_usage_threshold": 0.9,
-            "min_memory_free_bytes": -1,
-        },
-    ):
-        bytes_to_alloc = get_additional_bytes_to_reach_memory_usage_pct(0.7)
-        leaker = Leaker.options(max_restarts=0, max_task_retries=0).remote()
-        ray.get(leaker.allocate.remote(bytes_to_alloc))
-
-        bytes_to_alloc = get_additional_bytes_to_reach_memory_usage_pct(0.8)
-        ray.get(leaker.allocate.remote(allocate_bytes=bytes_to_alloc, sleep_time_s=10))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

Remove legacy memory monitor from worker submission code path, as that was already disabled by default in Ray 2.2

## Related issue number

30703

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
