### PR TITLE
[tune] Do not default to reuse_actors=True when mixins are used

### DIFF
--- a/python/ray/air/integrations/wandb.py
+++ b/python/ray/air/integrations/wandb.py
@@ -30,7 +30,6 @@ try:
     from wandb.sdk.lib.disabled import RunDisabled
     from wandb.sdk.data_types.base_types.wb_value import WBValue
 except ImportError:
-    logger.error("pip install 'wandb' to use WandbLoggerCallback/WandbTrainableMixin.")
     wandb = json_dumps_safer = Run = RunDisabled = WBValue = None
 
 
@@ -544,6 +543,11 @@ class WandbLoggerCallback(LoggerCallback):
         save_checkpoints: bool = False,
         **kwargs,
     ):
+        if not wandb:
+            raise RuntimeError(
+                "Wandb was not found - please install with `pip install wandb`"
+            )
+
         if save_checkpoints:
             warnings.warn(
                 "`save_checkpoints` is deprecated. Use `upload_checkpoints` instead.",

--- a/python/ray/tune/integration/mlflow.py
+++ b/python/ray/tune/integration/mlflow.py
@@ -169,6 +169,8 @@ def mlflow_mixin(func: Callable):
     )
 )
 class MLflowTrainableMixin:
+    _is_mixin = True
+
     def __init__(self, config: Dict, *args, **kwargs):
         self.mlflow_util = _MLflowLoggerUtil()
 

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -148,6 +148,7 @@ def wandb_mixin(func: Callable):
 )
 class WandbTrainableMixin:
     _wandb = wandb
+    _is_mixin = True
 
     def __init__(self, config: Dict, *args, **kwargs):
         if not isinstance(self, Trainable):

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -107,8 +107,9 @@ def _check_mixin(run_identifier: Union[Experiment, str, Type, Callable]) -> bool
     from ray.tune.integration.mlflow import MLflowTrainableMixin
 
     try:
-        return hasattr(trainable_cls, "__mixins__") or issubclass(
-            trainable_cls, (MLflowTrainableMixin, WandbTrainableMixin)
+        return hasattr(trainable_cls, "__mixins__") or (
+            isinstance(trainable_cls, type)
+            and issubclass(trainable_cls, (MLflowTrainableMixin, WandbTrainableMixin))
         )
     except Exception:
         # Default to True e.g. on TypeError (if it's not function or class)

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -103,17 +103,9 @@ def _check_mixin(run_identifier: Union[Experiment, str, Type, Callable]) -> bool
         # Default to True
         return True
 
-    from ray.tune.integration.wandb import WandbTrainableMixin
-    from ray.tune.integration.mlflow import MLflowTrainableMixin
-
-    try:
-        return hasattr(trainable_cls, "__mixins__") or (
-            isinstance(trainable_cls, type)
-            and issubclass(trainable_cls, (MLflowTrainableMixin, WandbTrainableMixin))
-        )
-    except Exception:
-        # Default to True e.g. on TypeError (if it's not function or class)
-        return True
+    return hasattr(trainable_cls, "__mixins__") or getattr(
+        trainable_cls, "_is_mixin", False
+    )
 
 
 def _check_gpus_in_resources(


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Mixins don't work well with reuse_actors because the init is only called on construction. In the case of mlflow, this means that reused actors will try to overwrite state from the trials that previously ran on them. This is incorrect behavior and errors on the mlflow server side.

Thus, we should default to not reuse actors for mixins.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
