### PR TITLE
[Ray release test infra] Change exponential_backoff_retry to use error instead of info on failure

### DIFF
--- a/release/ray_release/util.py
+++ b/release/ray_release/util.py
@@ -121,7 +121,7 @@ def exponential_backoff_retry(
             retry_cnt += 1
             if retry_cnt > max_retries:
                 raise
-            logger.info(
+            logger.exception(
                 f"Retry function call failed due to {e} "
                 f"in {retry_delay_s} seconds..."
             )


### PR DESCRIPTION
It appears the root cause of flaky failures described in https://github.com/ray-project/ray/issues/31981 is suppressed because we're not logging exceptions in `exponential_backoff_retry`.
```
...
[INFO 2023-01-23 16:55:10,474] sdk_runner.py: 135  ... command still running ...(3540 seconds) ...
[INFO 2023-01-23 16:55:39,934] sdk_runner.py: 135  ... command still running ...(3570 seconds) ...
[0m--- :floppy_disk: Fetching results[0m
[INFO 2023-01-23 16:56:10,439] job_manager.py: 45  Executing pip install -q awscli && aws s3 cp /tmp/release_test_out.json s3://ray-release-automation-results/tmp/iumtsyohrf --acl bucket-owner-full-control with {} via ray job submit
[ERROR 2023-01-23 16:56:11,036] glue.py: 324  Could not fetch results for test command
[ERROR 2023-01-23 16:56:11,037] glue.py: 325  Could not fetch results from session: Error downloading file /tmp/release_test_out.json to /tmp/tmpx3c1t6pi
Traceback (most recent call last):
  File "/tmp/release-QnZJuLnWXj/release/ray_release/command_runner/sdk_runner.py", line 184, in _fetch_json
    self.file_manager.download(path, tmpfile)
  File "/tmp/release-QnZJuLnWXj/release/ray_release/file_manager/job_file_manager.py", line 63, in download
    raise FileDownloadError(f"Error downloading file {source} to {target}")
    ray_release.exception.FileDownloadError: Error downloading file /tmp/release_test_out.json to /tmp/tmpx3c1t6pi
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/tmp/release-QnZJuLnWXj/release/ray_release/glue.py", line 322, in run_release_test
    command_results = command_runner.fetch_results()
  File "/tmp/release-QnZJuLnWXj/release/ray_release/command_runner/sdk_runner.py", line 195, in fetch_results
    return self._fetch_json(self.result_output_json)
  File "/tmp/release-QnZJuLnWXj/release/ray_release/command_runner/sdk_runner.py", line 192, in _fetch_json
    raise ResultsError(f"Could not fetch results from session: {e}") from e
    ray_release.exception.ResultsError: Could not fetch results from session: Error downloading file /tmp/release_test_out.json to /tmp/tmpx3c1t6pi
...
```

## Testing
```python
#!/usr/bin/env python3

import logging
logger = logging.getLogger()
logger.setLevel(logging.INFO)

try:
    raise ValueError()
except ValueError as e:
    logger.info(f"INFO message message message {e}")
    logger.exception(f"EXCEPTION message message message {e}")
```

```
$ ./t
EXCEPTION message message message
Traceback (most recent call last):
  File "./t", line 8, in <module>
    raise ValueError()
ValueError
```