### PR TITLE
[Datasets] Refactor map-like functions into planner package

### DIFF
--- a/python/ray/data/_internal/planner/filter.py
+++ b/python/ray/data/_internal/planner/filter.py
@@ -1,0 +1,23 @@
+from typing import Callable, Iterator
+
+from ray.data.block import Block, BlockAccessor, RowUDF
+from ray.data.context import DatasetContext
+
+
+def generate_filter_fn() -> Callable[[Iterator[Block]], Iterator[Block]]:
+    """Generate function to apply the UDF to each record of blocks,
+    and filter out records that do not satisfy the given predicate.
+    """
+    context = DatasetContext.get_current()
+
+    def fn(blocks: Iterator[Block], row_fn: RowUDF) -> Iterator[Block]:
+        DatasetContext._set_current(context)
+        for block in blocks:
+            block = BlockAccessor.for_block(block)
+            builder = block.builder()
+            for row in block.iter_rows():
+                if row_fn(row):
+                    builder.add(row)
+            return [builder.build()]
+
+    return fn

--- a/python/ray/data/_internal/planner/flat_map.py
+++ b/python/ray/data/_internal/planner/flat_map.py
@@ -1,0 +1,28 @@
+from typing import Callable, Iterator
+
+from ray.data._internal.output_buffer import BlockOutputBuffer
+from ray.data.block import Block, BlockAccessor, RowUDF
+from ray.data.context import DatasetContext
+
+
+def generate_flat_map_fn() -> Callable[[Iterator[Block]], Iterator[Block]]:
+    """Generate function to apply the UDF to each record of blocks,
+    and then flatten results.
+    """
+    context = DatasetContext.get_current()
+
+    def fn(blocks: Iterator[Block], row_fn: RowUDF) -> Iterator[Block]:
+        DatasetContext._set_current(context)
+        for block in blocks:
+            output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
+            block = BlockAccessor.for_block(block)
+            for row in block.iter_rows():
+                for r2 in row_fn(row):
+                    output_buffer.add(r2)
+                    if output_buffer.has_next():
+                        yield output_buffer.next()
+            output_buffer.finalize()
+            if output_buffer.has_next():
+                yield output_buffer.next()
+
+    return fn

--- a/python/ray/data/_internal/planner/map_batches.py
+++ b/python/ray/data/_internal/planner/map_batches.py
@@ -1,0 +1,104 @@
+import sys
+from typing import Callable, Iterator, Optional
+
+from ray.data._internal.block_batching import batch_blocks
+from ray.data._internal.output_buffer import BlockOutputBuffer
+from ray.data.block import BatchUDF, Block, DataBatch
+from ray.data.context import DEFAULT_BATCH_SIZE, DatasetContext
+
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+
+def generate_map_batches_fn(
+    batch_size: Optional[int] = DEFAULT_BATCH_SIZE,
+    batch_format: Literal["default", "pandas", "pyarrow", "numpy"] = "default",
+    prefetch_batches: int = 0,
+    zero_copy_batch: bool = False,
+) -> Callable[[Iterator[Block]], Iterator[Block]]:
+    """Generate function to apply the batch UDF to blocks."""
+    import numpy as np
+    import pandas as pd
+    import pyarrow as pa
+
+    context = DatasetContext.get_current()
+
+    def fn(
+        blocks: Iterator[Block], batch_fn: BatchUDF, *fn_args, **fn_kwargs
+    ) -> Iterator[Block]:
+        DatasetContext._set_current(context)
+        output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
+
+        def validate_batch(batch: Block) -> None:
+            if not isinstance(
+                batch, (list, pa.Table, np.ndarray, dict, pd.core.frame.DataFrame)
+            ):
+                raise ValueError(
+                    "The `fn` you passed to `map_batches` returned a value of type "
+                    f"{type(batch)}. This isn't allowed -- `map_batches` expects "
+                    "`fn` to return a `pandas.DataFrame`, `pyarrow.Table`, "
+                    "`numpy.ndarray`, `list`, or `dict[str, numpy.ndarray]`."
+                )
+
+            if isinstance(batch, dict):
+                for key, value in batch.items():
+                    if not isinstance(value, np.ndarray):
+                        raise ValueError(
+                            "The `fn` you passed to `map_batches` returned a "
+                            f"`dict`. `map_batches` expects all `dict` values "
+                            f"to be of type `numpy.ndarray`, but the value "
+                            f"corresponding to key {key!r} is of type "
+                            f"{type(value)}. To fix this issue, convert "
+                            f"the {type(value)} to a `numpy.ndarray`."
+                        )
+
+        def process_next_batch(batch: DataBatch) -> Iterator[Block]:
+            # Apply UDF.
+            try:
+                batch = batch_fn(batch, *fn_args, **fn_kwargs)
+            except ValueError as e:
+                read_only_msgs = [
+                    "assignment destination is read-only",
+                    "buffer source array is read-only",
+                ]
+                err_msg = str(e)
+                if any(msg in err_msg for msg in read_only_msgs):
+                    raise ValueError(
+                        f"Batch mapper function {fn.__name__} tried to mutate a "
+                        "zero-copy read-only batch. To be able to mutate the "
+                        "batch, pass zero_copy_batch=False to map_batches(); "
+                        "this will create a writable copy of the batch before "
+                        "giving it to fn. To elide this copy, modify your mapper "
+                        "function so it doesn't try to mutate its input."
+                    ) from e
+                else:
+                    raise e from None
+
+            validate_batch(batch)
+            # Add output batch to output buffer.
+            output_buffer.add_batch(batch)
+            if output_buffer.has_next():
+                yield output_buffer.next()
+
+        # Ensure that zero-copy batch views are copied so mutating UDFs don't error.
+        formatted_batch_iter = batch_blocks(
+            blocks=blocks,
+            stats=None,
+            batch_size=batch_size,
+            batch_format=batch_format,
+            ensure_copy=not zero_copy_batch and batch_size is not None,
+            prefetch_batches=prefetch_batches,
+        )
+
+        for batch in formatted_batch_iter:
+            yield from process_next_batch(batch)
+
+        # Yield remainder block from output buffer.
+        output_buffer.finalize()
+        if output_buffer.has_next():
+            yield output_buffer.next()
+
+    return fn

--- a/python/ray/data/_internal/planner/map_rows.py
+++ b/python/ray/data/_internal/planner/map_rows.py
@@ -1,0 +1,25 @@
+from typing import Callable, Iterator
+
+from ray.data._internal.output_buffer import BlockOutputBuffer
+from ray.data.block import Block, BlockAccessor, RowUDF
+from ray.data.context import DatasetContext
+
+
+def generate_map_rows_fn() -> Callable[[Iterator[Block]], Iterator[Block]]:
+    """Generate function to apply the UDF to each record of blocks."""
+    context = DatasetContext.get_current()
+
+    def fn(blocks: Iterator[Block], row_fn: RowUDF) -> Iterator[Block]:
+        DatasetContext._set_current(context)
+        for block in blocks:
+            output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
+            block = BlockAccessor.for_block(block)
+            for row in block.iter_rows():
+                output_buffer.add(row_fn(row))
+                if output_buffer.has_next():
+                    yield output_buffer.next()
+            output_buffer.finalize()
+            if output_buffer.has_next():
+                yield output_buffer.next()
+
+    return fn

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -56,7 +56,6 @@ def test_map_rows_operator(ray_start_cluster_enabled, enable_optimizer):
     read_op = Read(ParquetDatasource())
     op = MapRows(
         read_op,
-        lambda it: (x for x in it),
         lambda x: x,
     )
     physical_op = planner.plan(op)
@@ -78,7 +77,6 @@ def test_filter_operator(ray_start_cluster_enabled, enable_optimizer):
     read_op = Read(ParquetDatasource())
     op = Filter(
         read_op,
-        lambda it: (x for x in it),
         lambda x: x,
     )
     physical_op = planner.plan(op)
@@ -100,7 +98,6 @@ def test_flat_map(ray_start_cluster_enabled, enable_optimizer):
     read_op = Read(ParquetDatasource())
     op = FlatMap(
         read_op,
-        lambda it: ([x, x] for x in it),
         lambda x: x,
     )
     physical_op = planner.plan(op)


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is followup of https://github.com/ray-project/ray/pull/31977#discussion_r1089483388, to remove `block_fn` from logical operator, and make planner to generate functions for `map_batches/map/flat_map/filter`. The change includes

* Remove `block_fn` from `AbstactMap`, and all subclasses.
* Refactor the `transform` functions defined in `Dataset.map_batches/map/flat_map/filter` into `Planner.generate_xxx_fn` (e.g. `generate_map_batches_fn`)

Decide to doing refactoring from `Dataset` here, because we update those code paths very frequently (e.g. `Dataset.map_batches()`), so don't want to maintain two diverged code paths. Also different from `plan.py` and `stage_impl.py`, we won't delete `dataset.py`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
