### PR TITLE
[data] [streaming] Fixes to autoscaling actor pool streaming op

### DIFF
--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -293,6 +293,13 @@ class PhysicalOperator(Operator):
         """
         return len(self.get_work_refs())
 
+    def internal_queue_size(self) -> int:
+        """If the operator has an internal input queue, return its size.
+
+        This is used to report tasks pending submission to actor pools.
+        """
+        return 0
+
     def notify_work_completed(self, work_ref: ray.ObjectRef) -> None:
         """Executor calls this when the given work is completed and local.
 

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -68,6 +68,9 @@ class ActorPoolMapOperator(MapOperator):
         # Whether no more submittable bundles will be added.
         self._inputs_done = False
 
+    def internal_queue_size(self) -> int:
+        return len(self._bundle_queue)
+
     def start(self, options: ExecutionOptions):
         super().start(options)
 

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -197,10 +197,11 @@ class ActorPoolMapOperator(MapOperator):
         return len(self._tasks)
 
     def progress_str(self) -> str:
-        return (
-            f"{self._actor_pool.num_running_actors()} actors "
-            f"({self._actor_pool.num_pending_actors()} pending)"
-        )
+        base = f"{self._actor_pool.num_running_actors()} actors"
+        pending = self._actor_pool.num_pending_actors()
+        if pending:
+            base += f" ({pending} pending)"
+        return base
 
     def base_resource_usage(self) -> ExecutionResources:
         min_workers = self._autoscaling_policy.min_workers

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -60,7 +60,7 @@ class ActorPoolMapOperator(MapOperator):
             ObjectRef[ObjectRefGenerator], Tuple[_TaskState, ray.actor.ActorHandle]
         ] = {}
         # A pool of running actors on which we can execute mapper tasks.
-        self._actor_pool = _ActorPool()
+        self._actor_pool = _ActorPool(autoscaling_policy._config.max_tasks_in_flight)
         # A queue of bundles awaiting dispatch to actors.
         self._bundle_queue = collections.deque()
         # Cached actor class.
@@ -198,7 +198,7 @@ class ActorPoolMapOperator(MapOperator):
 
     def progress_str(self) -> str:
         return (
-            f"{self._actor_pool.num_running_actors()} "
+            f"{self._actor_pool.num_running_actors()} actors "
             f"({self._actor_pool.num_pending_actors()} pending)"
         )
 

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import posixpath
 
@@ -270,6 +271,14 @@ def assert_base_partitioned_ds():
         ), f"{actual_sorted_values} != {sorted_values}"
 
     yield _assert_base_partitioned_ds
+
+
+@pytest.fixture
+def restore_dataset_context(request):
+    """Restore any DatasetContext changes after the test runs"""
+    original = copy.deepcopy(ray.data.context.DatasetContext.get_current())
+    yield
+    ray.data.context.DatasetContext._set_current(original)
 
 
 @pytest.fixture(params=[True, False])

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -128,10 +128,10 @@ def test_map_operator_bulk(ray_start_regular_shared, use_actors):
         if use_actors and work_refs:
             # After actor is ready (first work ref resolved), actor will remain ready
             # while there is work to do.
-            assert op.progress_str() == "1 actors (0 pending)"
+            assert op.progress_str() == "1 actors"
     if use_actors:
         # After all work is done, actor will have been killed to free up resources..
-        assert op.progress_str() == "0 actors (0 pending)"
+        assert op.progress_str() == "0 actors"
     else:
         assert op.progress_str() == ""
 

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -2,18 +2,13 @@ import pytest
 import time
 from unittest.mock import MagicMock
 
-from typing import List, Any
-
 import ray
-from ray.data.context import DatasetContext
 from ray.data._internal.execution.interfaces import (
     ExecutionOptions,
     ExecutionResources,
-    RefBundle,
     PhysicalOperator,
 )
 from ray.data._internal.execution.streaming_executor import (
-    StreamingExecutor,
     _debug_dump_topology,
     _validate_topology,
 )
@@ -24,13 +19,10 @@ from ray.data._internal.execution.streaming_executor_state import (
     select_operator_to_run,
     _execution_allowed,
 )
-from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
-from ray._private.test_utils import wait_for_condition
-from ray.data.tests.conftest import *  # noqa
 
 
 @ray.remote
@@ -46,15 +38,7 @@ def make_transform(block_fn):
     return map_fn
 
 
-def ref_bundles_to_list(bundles: List[RefBundle]) -> List[List[Any]]:
-    output = []
-    for bundle in bundles:
-        for block, _ in bundle.blocks:
-            output.append(ray.get(block))
-    return output
-
-
-def test_build_streaming_topology(ray_start_10_cpus_shared):
+def test_build_streaming_topology():
     inputs = make_ref_bundles([[x] for x in range(20)])
     o1 = InputDataBuffer(inputs)
     o2 = MapOperator.create(make_transform(lambda block: [b * -1 for b in block]), o1)
@@ -68,7 +52,7 @@ def test_build_streaming_topology(ray_start_10_cpus_shared):
     assert list(topo) == [o1, o2, o3]
 
 
-def test_disallow_non_unique_operators(ray_start_10_cpus_shared):
+def test_disallow_non_unique_operators():
     inputs = make_ref_bundles([[x] for x in range(20)])
     # An operator [o1] cannot used in the same DAG twice.
     o1 = InputDataBuffer(inputs)
@@ -79,7 +63,7 @@ def test_disallow_non_unique_operators(ray_start_10_cpus_shared):
         build_streaming_topology(o4, ExecutionOptions())
 
 
-def test_process_completed_tasks(ray_start_10_cpus_shared):
+def test_process_completed_tasks():
     inputs = make_ref_bundles([[x] for x in range(20)])
     o1 = InputDataBuffer(inputs)
     o2 = MapOperator.create(make_transform(lambda block: [b * -1 for b in block]), o1)
@@ -111,7 +95,7 @@ def test_process_completed_tasks(ray_start_10_cpus_shared):
     o2.inputs_done.assert_called_once()
 
 
-def test_select_operator_to_run(ray_start_10_cpus_shared):
+def test_select_operator_to_run():
     opt = ExecutionOptions()
     inputs = make_ref_bundles([[x] for x in range(20)])
     o1 = InputDataBuffer(inputs)
@@ -170,7 +154,7 @@ def test_select_operator_to_run(ray_start_10_cpus_shared):
     )
 
 
-def test_dispatch_next_task(ray_start_10_cpus_shared):
+def test_dispatch_next_task():
     inputs = make_ref_bundles([[x] for x in range(20)])
     o1 = InputDataBuffer(inputs)
     o1_state = OpState(o1, [])
@@ -190,7 +174,7 @@ def test_dispatch_next_task(ray_start_10_cpus_shared):
     assert o2.add_input.called_once_with("dummy2")
 
 
-def test_debug_dump_topology(ray_start_10_cpus_shared):
+def test_debug_dump_topology():
     opt = ExecutionOptions()
     inputs = make_ref_bundles([[x] for x in range(20)])
     o1 = InputDataBuffer(inputs)
@@ -201,7 +185,7 @@ def test_debug_dump_topology(ray_start_10_cpus_shared):
     _debug_dump_topology(topo)
 
 
-def test_validate_topology(ray_start_10_cpus_shared):
+def test_validate_topology():
     opt = ExecutionOptions()
     inputs = make_ref_bundles([[x] for x in range(20)])
     o1 = InputDataBuffer(inputs)
@@ -223,7 +207,7 @@ def test_validate_topology(ray_start_10_cpus_shared):
         _validate_topology(topo, ExecutionResources(cpu=10))
 
 
-def test_execution_allowed(ray_start_10_cpus_shared):
+def test_execution_allowed():
     op = InputDataBuffer([])
 
     # CPU.
@@ -268,7 +252,7 @@ def test_execution_allowed(ray_start_10_cpus_shared):
     )
 
 
-def test_select_ops_ensure_at_least_one_live_operator(ray_start_10_cpus_shared):
+def test_select_ops_ensure_at_least_one_live_operator():
     opt = ExecutionOptions()
     inputs = make_ref_bundles([[x] for x in range(20)])
     o1 = InputDataBuffer(inputs)
@@ -304,163 +288,7 @@ def test_select_ops_ensure_at_least_one_live_operator(ray_start_10_cpus_shared):
     )
 
 
-def test_pipelined_execution(ray_start_10_cpus_shared):
-    executor = StreamingExecutor(ExecutionOptions())
-    inputs = make_ref_bundles([[x] for x in range(20)])
-    o1 = InputDataBuffer(inputs)
-    o2 = MapOperator.create(make_transform(lambda block: [b * -1 for b in block]), o1)
-    o3 = MapOperator.create(make_transform(lambda block: [b * 2 for b in block]), o2)
-
-    def reverse_sort(inputs: List[RefBundle]):
-        reversed_list = inputs[::-1]
-        return reversed_list, {}
-
-    o4 = AllToAllOperator(reverse_sort, o3)
-    it = executor.execute(o4)
-    output = ref_bundles_to_list(it)
-    expected = [[x * -2] for x in range(20)][::-1]
-    assert output == expected, (output, expected)
-
-
-def test_e2e_option_propagation(ray_start_10_cpus_shared):
-    DatasetContext.get_current().new_execution_backend = True
-    DatasetContext.get_current().use_streaming_executor = True
-
-    def run():
-        ray.data.range(5, parallelism=5).map(
-            lambda x: x, compute=ray.data.ActorPoolStrategy(2, 2)
-        ).take_all()
-
-    DatasetContext.get_current().execution_options.resource_limits = (
-        ExecutionResources()
-    )
-    run()
-
-    try:
-        DatasetContext.get_current().execution_options.resource_limits.cpu = 1
-        with pytest.raises(ValueError):
-            run()
-    finally:
-        DatasetContext.get_current().execution_options.resource_limits.cpu = None
-
-
-def test_configure_spread_e2e(ray_start_10_cpus_shared):
-    from ray import remote_function
-
-    tasks = []
-
-    def _test_hook(fn, args, strategy):
-        if "map_task" in str(fn):
-            tasks.append(strategy)
-
-    remote_function._task_launch_hook = _test_hook
-    DatasetContext.get_current().use_streaming_executor = True
-    DatasetContext.get_current().execution_options.preserve_order = True
-
-    # Simple 2-stage pipeline.
-    ray.data.range(2, parallelism=2).map(lambda x: x, num_cpus=2).take_all()
-
-    # Read tasks get SPREAD by default, subsequent ones use default policy.
-    tasks = sorted(tasks)
-    assert tasks == ["DEFAULT", "DEFAULT", "SPREAD", "SPREAD"]
-
-
-def test_scheduling_progress_when_output_blocked():
-    # Processing stages should fully finish even if output is completely stalled.
-
-    @ray.remote
-    class Counter:
-        def __init__(self):
-            self.i = 0
-
-        def inc(self):
-            self.i += 1
-
-        def get(self):
-            return self.i
-
-    counter = Counter.remote()
-
-    def func(x):
-        ray.get(counter.inc.remote())
-        return x
-
-    DatasetContext.get_current().use_streaming_executor = True
-    DatasetContext.get_current().execution_options.preserve_order = True
-
-    # Only take the first item from the iterator.
-    it = iter(
-        ray.data.range(100, parallelism=100)
-        .map_batches(func, batch_size=None)
-        .iter_batches(batch_size=None)
-    )
-    next(it)
-    # The pipeline should fully execute even when the output iterator is blocked.
-    wait_for_condition(lambda: ray.get(counter.get.remote()) == 100)
-    # Check we can take the rest.
-    assert list(it) == [[x] for x in range(1, 100)]
-
-
-def test_backpressure_from_output():
-    # Here we set the memory limit low enough so the output getting blocked will
-    # actually stall execution.
-
-    @ray.remote
-    class Counter:
-        def __init__(self):
-            self.i = 0
-
-        def inc(self):
-            self.i += 1
-
-        def get(self):
-            return self.i
-
-    counter = Counter.remote()
-
-    def func(x):
-        ray.get(counter.inc.remote())
-        return x
-
-    ctx = DatasetContext.get_current()
-    try:
-        ctx.use_streaming_executor = True
-        ctx.execution_options.resource_limits.object_store_memory = 10000
-
-        # Only take the first item from the iterator.
-        it = iter(
-            ray.data.range(100000, parallelism=100)
-            .map_batches(func, batch_size=None)
-            .iter_batches(batch_size=None)
-        )
-        next(it)
-        num_finished = ray.get(counter.get.remote())
-        assert num_finished < 5, num_finished
-
-        # Check we can get the rest.
-        for rest in it:
-            pass
-        assert ray.get(counter.get.remote()) == 100
-    finally:
-        ctx.execution_options.resource_limits.object_store_memory = None
-
-
-def test_e2e_liveness_with_output_backpressure_edge_case():
-    # At least one operator is ensured to be running, if the output becomes idle.
-    ctx = DatasetContext.get_current()
-    ctx.use_streaming_executor = True
-    ctx.execution_options.preserve_order = True
-    try:
-        ctx.execution_options.resource_limits.object_store_memory = 1
-        ds = ray.data.range(10000, parallelism=100).map(lambda x: x, num_cpus=2)
-        # This will hang forever if the liveness logic is wrong, since the output
-        # backpressure will prevent any operators from running at all.
-        assert ds.take_all() == list(range(10000))
-    finally:
-        ctx.execution_options.resource_limits.object_store_memory = None
-
-
-def test_configure_output_locality(ray_start_10_cpus_shared):
+def test_configure_output_locality():
     inputs = make_ref_bundles([[x] for x in range(20)])
     o1 = InputDataBuffer(inputs)
     o2 = MapOperator.create(make_transform(lambda block: [b * -1 for b in block]), o1)
@@ -480,98 +308,6 @@ def test_configure_output_locality(ray_start_10_cpus_shared):
         o3._ray_remote_args["scheduling_strategy"],
         NodeAffinitySchedulingStrategy,
     )
-
-
-def test_e2e_autoscaling_up(ray_start_10_cpus_shared):
-    DatasetContext.get_current().new_execution_backend = True
-    DatasetContext.get_current().use_streaming_executor = True
-
-    @ray.remote(max_concurrency=10)
-    class Barrier:
-        def __init__(self, n, delay=0):
-            self.n = n
-            self.delay = delay
-            self.max_waiters = 0
-            self.cur_waiters = 0
-
-        def wait(self):
-            self.cur_waiters += 1
-            if self.cur_waiters > self.max_waiters:
-                self.max_waiters = self.cur_waiters
-            self.n -= 1
-            print("wait", self.n)
-            while self.n > 0:
-                time.sleep(0.1)
-            time.sleep(self.delay)
-            print("wait done")
-            self.cur_waiters -= 1
-
-        def get_max_waiters(self):
-            return self.max_waiters
-
-    b1 = Barrier.remote(6)
-
-    def barrier1(x):
-        ray.get(b1.wait.remote(), timeout=10)
-        return x
-
-    # Tests that we autoscale up to necessary size.
-    # 6 tasks + 1 tasks in flight per actor => need at least 6 actors to run.
-    ray.data.range(6, parallelism=6).map_batches(
-        barrier1,
-        compute=ray.data.ActorPoolStrategy(1, 6, max_tasks_in_flight_per_actor=1),
-        batch_size=None,
-    ).take_all()
-    assert ray.get(b1.get_max_waiters.remote()) == 6
-
-    b2 = Barrier.remote(3, delay=2)
-
-    def barrier2(x):
-        ray.get(b2.wait.remote(), timeout=10)
-        return x
-
-    # Tests that we don't over-scale up.
-    # 6 tasks + 2 tasks in flight per actor => only scale up to 3 actors
-    ray.data.range(6, parallelism=6).map_batches(
-        barrier2,
-        compute=ray.data.ActorPoolStrategy(1, 3, max_tasks_in_flight_per_actor=2),
-        batch_size=None,
-    ).take_all()
-    assert ray.get(b2.get_max_waiters.remote()) == 3
-
-    # Tests that the max pool size is respected.
-    b3 = Barrier.remote(6)
-
-    def barrier3(x):
-        ray.get(b3.wait.remote(), timeout=2)
-        return x
-
-    # This will hang, since the actor pool is too small.
-    with pytest.raises(ray.exceptions.RayTaskError):
-        ray.data.range(6, parallelism=6).map(
-            barrier3, compute=ray.data.ActorPoolStrategy(1, 2)
-        ).take_all()
-
-
-def test_e2e_autoscaling_down(ray_start_10_cpus_shared):
-    DatasetContext.get_current().new_execution_backend = True
-    DatasetContext.get_current().use_streaming_executor = True
-
-    def f(x):
-        time.sleep(1)
-        return x
-
-    # Tests that autoscaling works even when resource constrained via actor killing.
-    # To pass this, we need to autoscale down to free up slots for task execution.
-    try:
-        DatasetContext.get_current().execution_options.resource_limits.cpu = 2
-        ray.data.range(5, parallelism=5).map_batches(
-            f,
-            compute=ray.data.ActorPoolStrategy(1, 2),
-            batch_size=None,
-        ).map_batches(lambda x: x, batch_size=None, num_cpus=2).take_all()
-    finally:
-        DatasetContext.get_current().execution_options.resource_limits.cpu = None
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -144,11 +144,26 @@ def test_select_operator_to_run(ray_start_10_cpus_shared):
 
     # Test backpressure includes num active tasks as well.
     topo[o3].num_active_tasks = MagicMock(return_value=2)
+    o3.internal_queue_size = MagicMock(return_value=0)
+    assert (
+        select_operator_to_run(topo, ExecutionResources(), ExecutionResources(), True)
+        == o2
+    )
+    # Internal queue size is added to num active tasks.
+    topo[o3].num_active_tasks = MagicMock(return_value=0)
+    o3.internal_queue_size = MagicMock(return_value=2)
     assert (
         select_operator_to_run(topo, ExecutionResources(), ExecutionResources(), True)
         == o2
     )
     topo[o2].num_active_tasks = MagicMock(return_value=2)
+    o2.internal_queue_size = MagicMock(return_value=0)
+    assert (
+        select_operator_to_run(topo, ExecutionResources(), ExecutionResources(), True)
+        == o3
+    )
+    topo[o2].num_active_tasks = MagicMock(return_value=0)
+    o2.internal_queue_size = MagicMock(return_value=2)
     assert (
         select_operator_to_run(topo, ExecutionResources(), ExecutionResources(), True)
         == o3
@@ -321,9 +336,12 @@ def test_e2e_option_propagation(ray_start_10_cpus_shared):
     )
     run()
 
-    DatasetContext.get_current().execution_options.resource_limits.cpu = 1
-    with pytest.raises(ValueError):
-        run()
+    try:
+        DatasetContext.get_current().execution_options.resource_limits.cpu = 1
+        with pytest.raises(ValueError):
+            run()
+    finally:
+        DatasetContext.get_current().execution_options.resource_limits.cpu = None
 
 
 def test_configure_spread_e2e(ray_start_10_cpus_shared):
@@ -462,6 +480,98 @@ def test_configure_output_locality(ray_start_10_cpus_shared):
         o3._ray_remote_args["scheduling_strategy"],
         NodeAffinitySchedulingStrategy,
     )
+
+
+def test_e2e_autoscaling_up(ray_start_10_cpus_shared):
+    DatasetContext.get_current().new_execution_backend = True
+    DatasetContext.get_current().use_streaming_executor = True
+
+    @ray.remote(max_concurrency=10)
+    class Barrier:
+        def __init__(self, n, delay=0):
+            self.n = n
+            self.delay = delay
+            self.max_waiters = 0
+            self.cur_waiters = 0
+
+        def wait(self):
+            self.cur_waiters += 1
+            if self.cur_waiters > self.max_waiters:
+                self.max_waiters = self.cur_waiters
+            self.n -= 1
+            print("wait", self.n)
+            while self.n > 0:
+                time.sleep(0.1)
+            time.sleep(self.delay)
+            print("wait done")
+            self.cur_waiters -= 1
+
+        def get_max_waiters(self):
+            return self.max_waiters
+
+    b1 = Barrier.remote(6)
+
+    def barrier1(x):
+        ray.get(b1.wait.remote(), timeout=10)
+        return x
+
+    # Tests that we autoscale up to necessary size.
+    # 6 tasks + 1 tasks in flight per actor => need at least 6 actors to run.
+    ray.data.range(6, parallelism=6).map_batches(
+        barrier1,
+        compute=ray.data.ActorPoolStrategy(1, 6, max_tasks_in_flight_per_actor=1),
+        batch_size=None,
+    ).take_all()
+    assert ray.get(b1.get_max_waiters.remote()) == 6
+
+    b2 = Barrier.remote(3, delay=2)
+
+    def barrier2(x):
+        ray.get(b2.wait.remote(), timeout=10)
+        return x
+
+    # Tests that we don't over-scale up.
+    # 6 tasks + 2 tasks in flight per actor => only scale up to 3 actors
+    ray.data.range(6, parallelism=6).map_batches(
+        barrier2,
+        compute=ray.data.ActorPoolStrategy(1, 3, max_tasks_in_flight_per_actor=2),
+        batch_size=None,
+    ).take_all()
+    assert ray.get(b2.get_max_waiters.remote()) == 3
+
+    # Tests that the max pool size is respected.
+    b3 = Barrier.remote(6)
+
+    def barrier3(x):
+        ray.get(b3.wait.remote(), timeout=2)
+        return x
+
+    # This will hang, since the actor pool is too small.
+    with pytest.raises(ray.exceptions.RayTaskError):
+        ray.data.range(6, parallelism=6).map(
+            barrier3, compute=ray.data.ActorPoolStrategy(1, 2)
+        ).take_all()
+
+
+def test_e2e_autoscaling_down(ray_start_10_cpus_shared):
+    DatasetContext.get_current().new_execution_backend = True
+    DatasetContext.get_current().use_streaming_executor = True
+
+    def f(x):
+        time.sleep(1)
+        return x
+
+    # Tests that autoscaling works even when resource constrained via actor killing.
+    # To pass this, we need to autoscale down to free up slots for task execution.
+    try:
+        DatasetContext.get_current().execution_options.resource_limits.cpu = 2
+        ray.data.range(5, parallelism=5).map_batches(
+            f,
+            compute=ray.data.ActorPoolStrategy(1, 2),
+            batch_size=None,
+        ).map_batches(lambda x: x, batch_size=None, num_cpus=2).take_all()
+    finally:
+        DatasetContext.get_current().execution_options.resource_limits.cpu = None
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -127,26 +127,26 @@ def test_select_operator_to_run():
     )
 
     # Test backpressure includes num active tasks as well.
-    topo[o3].num_active_tasks = MagicMock(return_value=2)
+    o3.num_active_work_refs = MagicMock(return_value=2)
     o3.internal_queue_size = MagicMock(return_value=0)
     assert (
         select_operator_to_run(topo, ExecutionResources(), ExecutionResources(), True)
         == o2
     )
-    # Internal queue size is added to num active tasks.
-    topo[o3].num_active_tasks = MagicMock(return_value=0)
+    # nternal queue size is added to num active tasks.
+    o3.num_active_work_refs = MagicMock(return_value=0)
     o3.internal_queue_size = MagicMock(return_value=2)
     assert (
         select_operator_to_run(topo, ExecutionResources(), ExecutionResources(), True)
         == o2
     )
-    topo[o2].num_active_tasks = MagicMock(return_value=2)
+    o2.num_active_work_refs = MagicMock(return_value=2)
     o2.internal_queue_size = MagicMock(return_value=0)
     assert (
         select_operator_to_run(topo, ExecutionResources(), ExecutionResources(), True)
         == o3
     )
-    topo[o2].num_active_tasks = MagicMock(return_value=0)
+    o2.num_active_work_refs = MagicMock(return_value=0)
     o2.internal_queue_size = MagicMock(return_value=2)
     assert (
         select_operator_to_run(topo, ExecutionResources(), ExecutionResources(), True)

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -1,0 +1,291 @@
+import pytest
+import time
+
+from typing import List, Any
+
+import ray
+from ray.data.context import DatasetContext
+from ray.data._internal.execution.interfaces import (
+    ExecutionOptions,
+    ExecutionResources,
+    RefBundle,
+)
+from ray.data._internal.execution.streaming_executor import (
+    StreamingExecutor,
+)
+from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
+from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
+from ray.data._internal.execution.util import make_ref_bundles
+from ray._private.test_utils import wait_for_condition
+from ray.data.tests.conftest import *  # noqa
+
+
+def make_transform(block_fn):
+    def map_fn(block_iter):
+        for block in block_iter:
+            yield block_fn(block)
+
+    return map_fn
+
+
+def ref_bundles_to_list(bundles: List[RefBundle]) -> List[List[Any]]:
+    output = []
+    for bundle in bundles:
+        for block, _ in bundle.blocks:
+            output.append(ray.get(block))
+    return output
+
+
+def test_pipelined_execution(ray_start_10_cpus_shared):
+    executor = StreamingExecutor(ExecutionOptions())
+    inputs = make_ref_bundles([[x] for x in range(20)])
+    o1 = InputDataBuffer(inputs)
+    o2 = MapOperator.create(make_transform(lambda block: [b * -1 for b in block]), o1)
+    o3 = MapOperator.create(make_transform(lambda block: [b * 2 for b in block]), o2)
+
+    def reverse_sort(inputs: List[RefBundle]):
+        reversed_list = inputs[::-1]
+        return reversed_list, {}
+
+    o4 = AllToAllOperator(reverse_sort, o3)
+    it = executor.execute(o4)
+    output = ref_bundles_to_list(it)
+    expected = [[x * -2] for x in range(20)][::-1]
+    assert output == expected, (output, expected)
+
+
+def test_e2e_option_propagation(ray_start_10_cpus_shared):
+    DatasetContext.get_current().new_execution_backend = True
+    DatasetContext.get_current().use_streaming_executor = True
+
+    def run():
+        ray.data.range(5, parallelism=5).map(
+            lambda x: x, compute=ray.data.ActorPoolStrategy(2, 2)
+        ).take_all()
+
+    DatasetContext.get_current().execution_options.resource_limits = (
+        ExecutionResources()
+    )
+    run()
+
+    try:
+        DatasetContext.get_current().execution_options.resource_limits.cpu = 1
+        with pytest.raises(ValueError):
+            run()
+    finally:
+        DatasetContext.get_current().execution_options.resource_limits.cpu = None
+
+
+def test_configure_spread_e2e(ray_start_10_cpus_shared):
+    from ray import remote_function
+
+    tasks = []
+
+    def _test_hook(fn, args, strategy):
+        if "map_task" in str(fn):
+            tasks.append(strategy)
+
+    remote_function._task_launch_hook = _test_hook
+    DatasetContext.get_current().use_streaming_executor = True
+    DatasetContext.get_current().execution_options.preserve_order = True
+
+    # Simple 2-stage pipeline.
+    ray.data.range(2, parallelism=2).map(lambda x: x, num_cpus=2).take_all()
+
+    # Read tasks get SPREAD by default, subsequent ones use default policy.
+    tasks = sorted(tasks)
+    assert tasks == ["DEFAULT", "DEFAULT", "SPREAD", "SPREAD"]
+
+
+def test_scheduling_progress_when_output_blocked():
+    # Processing stages should fully finish even if output is completely stalled.
+
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            self.i = 0
+
+        def inc(self):
+            self.i += 1
+
+        def get(self):
+            return self.i
+
+    counter = Counter.remote()
+
+    def func(x):
+        ray.get(counter.inc.remote())
+        return x
+
+    DatasetContext.get_current().use_streaming_executor = True
+    DatasetContext.get_current().execution_options.preserve_order = True
+
+    # Only take the first item from the iterator.
+    it = iter(
+        ray.data.range(100, parallelism=100)
+        .map_batches(func, batch_size=None)
+        .iter_batches(batch_size=None)
+    )
+    next(it)
+    # The pipeline should fully execute even when the output iterator is blocked.
+    wait_for_condition(lambda: ray.get(counter.get.remote()) == 100)
+    # Check we can take the rest.
+    assert list(it) == [[x] for x in range(1, 100)]
+
+
+def test_backpressure_from_output():
+    # Here we set the memory limit low enough so the output getting blocked will
+    # actually stall execution.
+
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            self.i = 0
+
+        def inc(self):
+            self.i += 1
+
+        def get(self):
+            return self.i
+
+    counter = Counter.remote()
+
+    def func(x):
+        ray.get(counter.inc.remote())
+        return x
+
+    ctx = DatasetContext.get_current()
+    try:
+        ctx.use_streaming_executor = True
+        ctx.execution_options.resource_limits.object_store_memory = 10000
+
+        # Only take the first item from the iterator.
+        it = iter(
+            ray.data.range(100000, parallelism=100)
+            .map_batches(func, batch_size=None)
+            .iter_batches(batch_size=None)
+        )
+        next(it)
+        num_finished = ray.get(counter.get.remote())
+        assert num_finished < 5, num_finished
+
+        # Check we can get the rest.
+        for rest in it:
+            pass
+        assert ray.get(counter.get.remote()) == 100
+    finally:
+        ctx.execution_options.resource_limits.object_store_memory = None
+
+
+def test_e2e_liveness_with_output_backpressure_edge_case():
+    # At least one operator is ensured to be running, if the output becomes idle.
+    ctx = DatasetContext.get_current()
+    ctx.use_streaming_executor = True
+    ctx.execution_options.preserve_order = True
+    try:
+        ctx.execution_options.resource_limits.object_store_memory = 1
+        ds = ray.data.range(10000, parallelism=100).map(lambda x: x, num_cpus=2)
+        # This will hang forever if the liveness logic is wrong, since the output
+        # backpressure will prevent any operators from running at all.
+        assert ds.take_all() == list(range(10000))
+    finally:
+        ctx.execution_options.resource_limits.object_store_memory = None
+
+
+def test_e2e_autoscaling_up(ray_start_10_cpus_shared):
+    DatasetContext.get_current().new_execution_backend = True
+    DatasetContext.get_current().use_streaming_executor = True
+
+    @ray.remote(max_concurrency=10)
+    class Barrier:
+        def __init__(self, n, delay=0):
+            self.n = n
+            self.delay = delay
+            self.max_waiters = 0
+            self.cur_waiters = 0
+
+        def wait(self):
+            self.cur_waiters += 1
+            if self.cur_waiters > self.max_waiters:
+                self.max_waiters = self.cur_waiters
+            self.n -= 1
+            print("wait", self.n)
+            while self.n > 0:
+                time.sleep(0.1)
+            time.sleep(self.delay)
+            print("wait done")
+            self.cur_waiters -= 1
+
+        def get_max_waiters(self):
+            return self.max_waiters
+
+    b1 = Barrier.remote(6)
+
+    def barrier1(x):
+        ray.get(b1.wait.remote(), timeout=10)
+        return x
+
+    # Tests that we autoscale up to necessary size.
+    # 6 tasks + 1 tasks in flight per actor => need at least 6 actors to run.
+    ray.data.range(6, parallelism=6).map_batches(
+        barrier1,
+        compute=ray.data.ActorPoolStrategy(1, 6, max_tasks_in_flight_per_actor=1),
+        batch_size=None,
+    ).take_all()
+    assert ray.get(b1.get_max_waiters.remote()) == 6
+
+    b2 = Barrier.remote(3, delay=2)
+
+    def barrier2(x):
+        ray.get(b2.wait.remote(), timeout=10)
+        return x
+
+    # Tests that we don't over-scale up.
+    # 6 tasks + 2 tasks in flight per actor => only scale up to 3 actors
+    ray.data.range(6, parallelism=6).map_batches(
+        barrier2,
+        compute=ray.data.ActorPoolStrategy(1, 3, max_tasks_in_flight_per_actor=2),
+        batch_size=None,
+    ).take_all()
+    assert ray.get(b2.get_max_waiters.remote()) == 3
+
+    # Tests that the max pool size is respected.
+    b3 = Barrier.remote(6)
+
+    def barrier3(x):
+        ray.get(b3.wait.remote(), timeout=2)
+        return x
+
+    # This will hang, since the actor pool is too small.
+    with pytest.raises(ray.exceptions.RayTaskError):
+        ray.data.range(6, parallelism=6).map(
+            barrier3, compute=ray.data.ActorPoolStrategy(1, 2)
+        ).take_all()
+
+
+def test_e2e_autoscaling_down(ray_start_10_cpus_shared):
+    DatasetContext.get_current().new_execution_backend = True
+    DatasetContext.get_current().use_streaming_executor = True
+
+    def f(x):
+        time.sleep(1)
+        return x
+
+    # Tests that autoscaling works even when resource constrained via actor killing.
+    # To pass this, we need to autoscale down to free up slots for task execution.
+    try:
+        DatasetContext.get_current().execution_options.resource_limits.cpu = 2
+        ray.data.range(5, parallelism=5).map_batches(
+            f,
+            compute=ray.data.ActorPoolStrategy(1, 2),
+            batch_size=None,
+        ).map_batches(lambda x: x, batch_size=None, num_cpus=2).take_all()
+    finally:
+        DatasetContext.get_current().execution_options.resource_limits.cpu = None
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -74,7 +74,7 @@ def test_e2e_option_propagation(ray_start_10_cpus_shared, restore_dataset_contex
         run()
 
 
-def test_configure_spread_e2e(ray_start_10_cpus_shared):
+def test_configure_spread_e2e(ray_start_10_cpus_shared, restore_dataset_context):
     from ray import remote_function
 
     tasks = []
@@ -95,7 +95,9 @@ def test_configure_spread_e2e(ray_start_10_cpus_shared):
     assert tasks == ["DEFAULT", "DEFAULT", "SPREAD", "SPREAD"]
 
 
-def test_scheduling_progress_when_output_blocked(ray_start_10_cpus_shared):
+def test_scheduling_progress_when_output_blocked(
+    ray_start_10_cpus_shared, restore_dataset_context
+):
     # Processing stages should fully finish even if output is completely stalled.
 
     @ray.remote

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -98,7 +98,7 @@ def test_configure_spread_e2e(ray_start_10_cpus_shared):
     assert tasks == ["DEFAULT", "DEFAULT", "SPREAD", "SPREAD"]
 
 
-def test_scheduling_progress_when_output_blocked():
+def test_scheduling_progress_when_output_blocked(ray_start_10_cpus_shared):
     # Processing stages should fully finish even if output is completely stalled.
 
     @ray.remote
@@ -134,7 +134,7 @@ def test_scheduling_progress_when_output_blocked():
     assert list(it) == [[x] for x in range(1, 100)]
 
 
-def test_backpressure_from_output():
+def test_backpressure_from_output(ray_start_10_cpus_shared):
     # Here we set the memory limit low enough so the output getting blocked will
     # actually stall execution.
 
@@ -178,7 +178,7 @@ def test_backpressure_from_output():
         ctx.execution_options.resource_limits.object_store_memory = None
 
 
-def test_e2e_liveness_with_output_backpressure_edge_case():
+def test_e2e_liveness_with_output_backpressure_edge_case(ray_start_10_cpus_shared):
     # At least one operator is ensured to be running, if the output becomes idle.
     ctx = DatasetContext.get_current()
     ctx.use_streaming_executor = True


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes:
- Properly wire max tasks per actor to pool
- Account for internal queue size in scheduling algorithm
- Small improvements to progress bar UX

TODO:
- [x] Improve unit tests