### PR TITLE
Revert "[Docker] (Kubeflow integration) Add chmod --recursive 777 /home/ray to Ray Dockerfile."

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -77,9 +77,6 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
     else sudo apt-get autoremove -y wget; \
     fi;) \
     && sudo rm -rf /var/lib/apt/lists/* \
-    && sudo apt-get clean \
-    # Ensure all users are able to write to /home/ray because OpenShift uses a random UID when logging into
-    # pods. See #30959 for more context.
-    && chmod --recursive 777 /home/ray
+    && sudo apt-get clean
 
 WORKDIR $HOME


### PR DESCRIPTION
Reverts #31563. See #32025 for more details.