### PR TITLE
[RLlib] Unify RLlib team tag to `rl`

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -43,7 +43,7 @@
 # separately via the "documentation" tag.
 
 # Additional tags are:
-# - "team:rllib": Indicating that all tests in this file are the responsibility of
+# - "team:rl": Indicating that all tests in this file are the responsibility of
 #   the RLlib Team.
 # - "needs_gpu": Indicating that a test needs to have a GPU in order to run.
 # - "gpu": Indicating that a test may (but doesn't have to) be run in the GPU
@@ -73,7 +73,7 @@ load("//bazel:python.bzl", "py_test_module_list")
 # py_test(
 #    name = "learning_tests_cartpole_a2c",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+#    tags = ["team:rl", "", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/a2c/cartpole-a2c.yaml"],
@@ -83,7 +83,7 @@ load("//bazel:python.bzl", "py_test_module_list")
 py_test(
     name = "learning_tests_cartpole_a2c_microbatch",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/a2c/cartpole-a2c-microbatch.yaml"],
@@ -93,7 +93,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_a2c_fake_gpus",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/a2c/cartpole-a2c-fake-gpus.yaml"],
@@ -105,7 +105,7 @@ py_test(
 # py_test(
 #    name = "learning_tests_cartpole_a3c",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/a3c/cartpole-a3c.yaml"],
@@ -116,7 +116,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_alpha_star",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/alpha_star/multi-agent-cartpole-alpha-star.yaml"],
@@ -126,7 +126,7 @@ py_test(
 # AlphaZero
 py_test(
     name = "learning_tests_cartpole_sparse_rewards_alpha_zero",
-    tags = ["team:rllib", "exclusive", "torch_only", "learning_tests", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "torch_only", "learning_tests", "learning_tests_discrete"],
     main = "tests/run_regression_tests.py",
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
@@ -138,7 +138,7 @@ py_test(
 # py_test(
 #    name = "learning_tests_cartpole_apex",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = [
@@ -151,7 +151,7 @@ py_test(
 # py_test(
 #    name = "learning_cartpole_apex_fake_gpus",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/apex_dqn/cartpole-apex-fake-gpus.yaml"],
@@ -162,7 +162,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_appo_no_vtrace",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "medium", # bazel may complain about it being too long sometimes - medium is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/cartpole-appo.yaml"],
@@ -172,7 +172,7 @@ py_test(
 # py_test(
 #    name = "learning_tests_cartpole_appo_vtrace",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/appo/cartpole-appo-vtrace.yaml"],
@@ -182,7 +182,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_separate_losses_appo",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "tf_only", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "tf_only", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = [
@@ -194,7 +194,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_appo",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/multi-agent-cartpole-appo.yaml"],
@@ -204,7 +204,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_w_100_policies_appo",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/multi-agent-cartpole-w-100-policies-appo.py"],
@@ -214,7 +214,7 @@ py_test(
 # py_test(
 #    name = "learning_tests_frozenlake_appo",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_discrete"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/appo/frozenlake-appo-vtrace.yaml"],
@@ -224,7 +224,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_appo_fake_gpus",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/cartpole-appo-vtrace-fake-gpus.yaml"],
@@ -235,7 +235,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_ars",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ars/cartpole-ars.yaml"],
@@ -246,7 +246,7 @@ py_test(
 py_test(
     name = "learning_tests_pendulum_cql",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     # Include the zipped json data file as well.
@@ -262,7 +262,7 @@ py_test(
 py_test(
    name = "learning_tests_pendulum_crr",
    main = "tests/run_regression_tests.py",
-   tags = ["team:rllib", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+   tags = ["team:rl", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
    size = "large",
    srcs = ["tests/run_regression_tests.py"],
    # Include an offline json data file as well.
@@ -276,7 +276,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_crr",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "torch_only", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "torch_only", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     # Include an offline json data file as well.
@@ -290,7 +290,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_crr_expectation",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "torch_only", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "torch_only", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     # Include an offline json data file as well.
@@ -305,7 +305,7 @@ py_test(
 # py_test(
 #   name = "learning_tests_pendulum_ddpg",
 #   main = "tests/run_regression_tests.py",
-#   tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+#   tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
 #   size = "large",
 #   srcs = ["tests/run_regression_tests.py"],
 #   data = glob(["tuned_examples/ddpg/pendulum-ddpg.yaml"]),
@@ -315,7 +315,7 @@ py_test(
 py_test(
    name = "learning_tests_pendulum_ddpg_fake_gpus",
    main = "tests/run_regression_tests.py",
-   tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous", "fake_gpus"],
+   tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous", "fake_gpus"],
    size = "large",
    srcs = ["tests/run_regression_tests.py"],
    data = ["tuned_examples/ddpg/pendulum-ddpg-fake-gpus.yaml"],
@@ -326,7 +326,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_ddppo",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "torch_only", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "torch_only", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "small",
     srcs = ["tests/run_regression_tests.py"],
     data = glob(["tuned_examples/ddppo/cartpole-ddppo.yaml"]),
@@ -336,7 +336,7 @@ py_test(
 py_test(
     name = "learning_tests_pendulum_ddppo",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+    tags = ["team:rl", "exclusive", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = glob(["tuned_examples/ddppo/pendulum-ddppo.yaml"]),
@@ -347,7 +347,7 @@ py_test(
 # py_test(
 #    name = "learning_tests_cartpole_dqn",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/dqn/cartpole-dqn.yaml"],
@@ -357,7 +357,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_dqn_softq",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/dqn/cartpole-dqn-softq.yaml"],
@@ -370,7 +370,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_dqn_param_noise",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "no_tf_eager_tracing"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "no_tf_eager_tracing"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/dqn/cartpole-dqn-param-noise.yaml"],
@@ -380,7 +380,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_dqn_fake_gpus",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/dqn/cartpole-dqn-fake-gpus.yaml"],
@@ -391,7 +391,7 @@ py_test(
 py_test(
    name = "learning_tests_pendulum_dt",
    main = "tests/run_regression_tests.py",
-   tags = ["team:rllib", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+   tags = ["team:rl", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
    size = "large",
    srcs = ["tests/run_regression_tests.py"],
    # Include an offline json data file as well.
@@ -405,7 +405,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_dt",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "torch_only", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "torch_only", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     # Include an offline json data file as well.
@@ -420,7 +420,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_simpleq",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = [
@@ -432,7 +432,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_simpleq_fake_gpus",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/simple_q/cartpole-simpleq-fake-gpus.yaml"],
@@ -443,7 +443,7 @@ py_test(
 # py_test(
 #    name = "learning_tests_cartpole_es",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/es/cartpole-es.yaml"],
@@ -454,7 +454,7 @@ py_test(
 # py_test(
 #    name = "learning_tests_cartpole_impala",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/impala/cartpole-impala.yaml"],
@@ -464,7 +464,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_impala",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/impala/multi-agent-cartpole-impala.yaml"],
@@ -474,7 +474,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_impala_fake_gpus",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/impala/cartpole-impala-fake-gpus.yaml"],
@@ -485,7 +485,7 @@ py_test(
 py_test(
     name = "learning_tests_two_step_game_maddpg",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "tf_only", "no_tf_eager_tracing", "learning_tests", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "tf_only", "no_tf_eager_tracing", "learning_tests", "learning_tests_discrete"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/maddpg/two-step-game-maddpg.yaml"],
@@ -498,7 +498,7 @@ py_test(
 #py_test(
 #    name = "learning_tests_pendulum_mbmpo",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+#    tags = ["team:rl", "exclusive", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/mbmpo/pendulum-mbmpo.yaml"],
@@ -509,7 +509,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_pg",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "medium", # bazel may complain about it being too long sometimes - medium is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/pg/cartpole-pg.yaml"],
@@ -519,7 +519,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_crashing_pg",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "crashing_cartpole"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "crashing_cartpole"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/pg/cartpole-crashing-pg.yaml"],
@@ -529,7 +529,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_crashing_with_remote_envs_pg",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "crashing_cartpole"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "crashing_cartpole"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/pg/cartpole-crashing-with-remote-envs-pg.yaml"],
@@ -539,7 +539,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_crashing_restart_sub_envs_pg",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "crashing_cartpole"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "crashing_cartpole"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/pg/multi-agent-cartpole-crashing-restart-sub-envs-pg.yaml"],
@@ -549,7 +549,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_crashing_with_remote_envs_pg",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "crashing_cartpole"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "crashing_cartpole"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/pg/multi-agent-cartpole-crashing-with-remote-envs-pg.yaml"],
@@ -559,7 +559,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_pg_fake_gpus",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/pg/cartpole-pg-fake-gpus.yaml"],
@@ -570,7 +570,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_truncated_ppo",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/cartpole-truncated-ppo.py"],
@@ -580,7 +580,7 @@ py_test(
 py_test(
     name = "learning_tests_pendulum_ppo",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/pendulum-ppo.yaml"],
@@ -590,7 +590,7 @@ py_test(
 py_test(
     name = "learning_tests_pendulum_ppo_with_rl_module_torch",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous", "torch_only"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous", "torch_only"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/pendulum-ppo-with-rl-module.yaml"],
@@ -600,7 +600,7 @@ py_test(
 py_test(
     name = "learning_tests_pendulum_ppo_with_rl_module_tf2_eager",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous", "tf2_only", "no_tf_static_graph"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous", "tf2_only", "no_tf_static_graph"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/pendulum-ppo-with-rl-module.yaml"],
@@ -610,7 +610,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_pendulum_ppo",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/multi_agent_pendulum_ppo.py"],
@@ -620,7 +620,7 @@ py_test(
 py_test(
     name = "learning_tests_transformed_actions_pendulum_ppo",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/pendulum-transformed-actions-ppo.yaml"],
@@ -630,7 +630,7 @@ py_test(
 py_test(
     name = "learning_tests_repeat_after_me_ppo",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_discrete"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/repeatafterme-ppo-lstm.yaml"],
@@ -640,7 +640,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_ppo_fake_gpus",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "fake_gpus"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/cartpole-ppo-fake-gpus.yaml"],
@@ -651,7 +651,7 @@ py_test(
 py_test(
     name = "learning_tests_two_step_game_qmix",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_discrete"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/qmix/two-step-game-qmix.yaml"],
@@ -661,7 +661,7 @@ py_test(
 py_test(
     name = "learning_tests_two_step_game_qmix_vdn_mixer",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_discrete"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/qmix/two-step-game-qmix-vdn-mixer.yaml"],
@@ -671,7 +671,7 @@ py_test(
 py_test(
     name = "learning_tests_two_step_game_qmix_no_mixer",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_discrete"],
     size = "medium", # bazel may complain about it being too long sometimes - medium is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/qmix/two-step-game-qmix-no-mixer.yaml"],
@@ -682,7 +682,7 @@ py_test(
 py_test(
     name = "learning_tests_stateless_cartpole_r2d2",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "stateless_cartpole"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "stateless_cartpole"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/r2d2/stateless-cartpole-r2d2.yaml"],
@@ -692,7 +692,7 @@ py_test(
 py_test(
     name = "learning_tests_stateless_cartpole_r2d2_fake_gpus",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "stateless_cartpole", "fake_gpus"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "stateless_cartpole", "fake_gpus"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/r2d2/stateless-cartpole-r2d2-fake-gpus.yaml"],
@@ -703,7 +703,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_sac",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/sac/cartpole-sac.yaml"],
@@ -713,7 +713,7 @@ py_test(
 # py_test(
 #    name = "learning_tests_cartpole_continuous_pybullet_sac",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_continuous"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_continuous"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/sac/cartpole-continuous-pybullet-sac.yaml"],
@@ -723,7 +723,7 @@ py_test(
 # py_test(
 #    name = "learning_tests_pendulum_sac",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/sac/pendulum-sac.yaml"],
@@ -733,7 +733,7 @@ py_test(
 # py_test(
 #    name = "learning_tests_transformed_actions_pendulum_sac",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/sac/pendulum-transformed-actions-sac.yaml"],
@@ -743,7 +743,7 @@ py_test(
 # py_test(
 #    name = "learning_tests_pendulum_sac_fake_gpus",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous", "fake_gpus"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous", "fake_gpus"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/sac/pendulum-sac-fake-gpus.yaml"],
@@ -754,7 +754,7 @@ py_test(
 # py_test(
 #    name = "learning_tests_interest_evolution_10_candidates_recsim_env_slateq",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_discrete"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/slateq/interest-evolution-10-candidates-recsim-env-slateq.yaml"],
@@ -764,7 +764,7 @@ py_test(
 py_test(
     name = "learning_tests_interest_evolution_10_candidates_recsim_env_slateq_fake_gpus",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete", "fake_gpus"],
+    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_discrete", "fake_gpus"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/slateq/interest-evolution-10-candidates-recsim-env-slateq.yaml"],
@@ -775,7 +775,7 @@ py_test(
 # py_test(
 #    name = "learning_tests_pendulum_td3",
 #    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+#    tags = ["team:rl", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
 #    size = "large",
 #    srcs = ["tests/run_regression_tests.py"],
 #    data = ["tuned_examples/ddpg/pendulum-td3.yaml"],
@@ -794,7 +794,7 @@ py_test(
 
 py_test(
     name = "test_algorithm",
-    tags = ["team:rllib", "algorithms_dir", "algorithms_dir_generic"],
+    tags = ["team:rl", "algorithms_dir", "algorithms_dir_generic"],
     size = "large",
     srcs = ["algorithms/tests/test_algorithm.py"],
     data = ["tests/data/cartpole/small.json"],
@@ -802,21 +802,21 @@ py_test(
 
 py_test(
     name = "test_algorithm_config",
-    tags = ["team:rllib", "algorithms_dir", "algorithms_dir_generic"],
+    tags = ["team:rl", "algorithms_dir", "algorithms_dir_generic"],
     size = "small",
     srcs = ["algorithms/tests/test_algorithm_config.py"],
 )
 
 py_test(
     name = "test_algorithm_export_checkpoint",
-    tags = ["team:rllib", "algorithms_dir", "algorithms_dir_generic"],
+    tags = ["team:rl", "algorithms_dir", "algorithms_dir_generic"],
     size = "medium",
     srcs = ["algorithms/tests/test_algorithm_export_checkpoint.py"],
 )
 
 py_test(
     name = "test_callbacks",
-    tags = ["team:rllib", "algorithms_dir", "algorithms_dir_generic"],
+    tags = ["team:rl", "algorithms_dir", "algorithms_dir_generic"],
     size = "large",
     srcs = ["algorithms/tests/test_callbacks.py"]
 )
@@ -824,28 +824,28 @@ py_test(
 py_test(
     name = "test_memory_leaks_generic",
     main = "algorithms/tests/test_memory_leaks.py",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/tests/test_memory_leaks.py"]
 )
 
 py_test(
     name = "test_node_failure",
-    tags = ["team:rllib", "tests_dir", "exclusive"],
+    tags = ["team:rl", "tests_dir", "exclusive"],
     size = "medium",
     srcs = ["tests/test_node_failure.py"],
 )
 
 py_test(
     name = "test_registry",
-    tags = ["team:rllib", "algorithms_dir", "algorithms_dir_generic"],
+    tags = ["team:rl", "algorithms_dir", "algorithms_dir_generic"],
     size = "small",
     srcs = ["algorithms/tests/test_registry.py"],
 )
 
 py_test(
     name = "test_worker_failures",
-    tags = ["team:rllib", "algorithms_dir", "algorithms_dir_generic", "exclusive"],
+    tags = ["team:rl", "algorithms_dir", "algorithms_dir_generic", "exclusive"],
     size = "large",
     srcs = ["algorithms/tests/test_worker_failures.py"]
 )
@@ -855,7 +855,7 @@ py_test(
 # A2C
 py_test(
     name = "test_a2c",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/a2c/tests/test_a2c.py"]
 )
@@ -863,7 +863,7 @@ py_test(
 # A3C
 py_test(
     name = "test_a3c",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/a3c/tests/test_a3c.py"]
 )
@@ -871,7 +871,7 @@ py_test(
 # AlphaStar
 py_test(
     name = "test_alpha_star",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/alpha_star/tests/test_alpha_star.py"]
 )
@@ -879,7 +879,7 @@ py_test(
 # AlphaZero
 py_test(
     name = "test_alpha_zero",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/alpha_zero/tests/test_alpha_zero.py"]
 )
@@ -887,7 +887,7 @@ py_test(
 # APEX-DQN
 py_test(
     name = "test_apex_dqn",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/apex_dqn/tests/test_apex_dqn.py"]
 )
@@ -895,7 +895,7 @@ py_test(
 # APEX-DDPG
 py_test(
     name = "test_apex_ddpg",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/apex_ddpg/tests/test_apex_ddpg.py"]
 )
@@ -903,14 +903,14 @@ py_test(
 # APPO
 py_test(
     name = "test_appo",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/appo/tests/test_appo.py"]
 )
 
 py_test(
     name = "test_appo_off_policyness",
-    tags = ["team:rllib", "algorithms_dir", "multi_gpu", "exclusive"],
+    tags = ["team:rl", "algorithms_dir", "multi_gpu", "exclusive"],
     size = "large",
     srcs = ["algorithms/appo/tests/test_appo_off_policyness.py"]
 )
@@ -918,7 +918,7 @@ py_test(
 # ARS
 py_test(
     name = "test_ars",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/ars/tests/test_ars.py"]
 )
@@ -926,7 +926,7 @@ py_test(
 # Bandits
 py_test(
     name = "test_bandits",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/bandit/tests/test_bandits.py"],
 )
@@ -934,7 +934,7 @@ py_test(
 # BC
 py_test(
     name = "test_bc",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     # Include the json data file.
     data = ["tests/data/cartpole/large.json"],
@@ -944,7 +944,7 @@ py_test(
 # CQL
 py_test(
     name = "test_cql",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     data = ["tests/data/pendulum/small.json"],
     srcs = ["algorithms/cql/tests/test_cql.py"]
@@ -953,7 +953,7 @@ py_test(
 # CRR
 py_test(
     name = "test_crr",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/crr/tests/test_crr.py"],
     data = ["tests/data/pendulum/large.json"],
@@ -962,7 +962,7 @@ py_test(
 # DDPG
 py_test(
     name = "test_ddpg",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/ddpg/tests/test_ddpg.py"]
 )
@@ -970,7 +970,7 @@ py_test(
 # DDPPO
 py_test(
     name = "test_ddppo",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/ddppo/tests/test_ddppo.py"]
 )
@@ -978,7 +978,7 @@ py_test(
 # DQN
 py_test(
     name = "test_dqn",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/dqn/tests/test_dqn.py"]
 )
@@ -986,7 +986,7 @@ py_test(
 # DQN Reproducibility
 py_test(
     name = "test_repro_dqn",
-    tags = ["team:rllib", "algorithms_dir", "gpu"],
+    tags = ["team:rl", "algorithms_dir", "gpu"],
     size = "large",
     srcs = ["algorithms/dqn/tests/test_repro_dqn.py"]
 )
@@ -994,7 +994,7 @@ py_test(
 # Dreamer
 py_test(
     name = "test_dreamer",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/dreamer/tests/test_dreamer.py"]
 )
@@ -1002,28 +1002,28 @@ py_test(
 # DT
 py_test(
     name = "test_segmentation_buffer",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "small",
     srcs = ["algorithms/dt/tests/test_segmentation_buffer.py"]
 )
 
 py_test(
     name = "test_dt_model",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "small",
     srcs = ["algorithms/dt/tests/test_dt_model.py"]
 )
 
 py_test(
     name = "test_dt_policy",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "small",
     srcs = ["algorithms/dt/tests/test_dt_policy.py"]
 )
 
 py_test(
     name = "test_dt",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/dt/tests/test_dt.py"],
     data = ["tests/data/pendulum/large.json"],
@@ -1032,7 +1032,7 @@ py_test(
 # ES
 py_test(
     name = "test_es",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/es/tests/test_es.py"]
 )
@@ -1040,19 +1040,19 @@ py_test(
 # Impala
 py_test(
     name = "test_impala",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/impala/tests/test_impala.py"]
 )
 py_test(
     name = "test_vtrace",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "small",
     srcs = ["algorithms/impala/tests/test_vtrace.py"]
 )
 py_test(
     name = "test_impala_off_policyness",
-    tags = ["team:rllib", "algorithms_dir", "multi_gpu", "exclusive"],
+    tags = ["team:rl", "algorithms_dir", "multi_gpu", "exclusive"],
     size = "large",
     srcs = ["algorithms/impala/tests/test_impala_off_policyness.py"]
 )
@@ -1060,7 +1060,7 @@ py_test(
 # MARWIL
 py_test(
     name = "test_marwil",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     # Include the json data file.
     data = [
@@ -1074,7 +1074,7 @@ py_test(
 # MADDPG
 py_test(
     name = "test_maddpg",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/maddpg/tests/test_maddpg.py"]
 )
@@ -1082,7 +1082,7 @@ py_test(
 # MAML
 py_test(
     name = "test_maml",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/maml/tests/test_maml.py"]
 )
@@ -1090,7 +1090,7 @@ py_test(
 # MBMPO
 py_test(
     name = "test_mbmpo",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/mbmpo/tests/test_mbmpo.py"]
 )
@@ -1098,7 +1098,7 @@ py_test(
 # PG
 py_test(
     name = "test_pg",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/pg/tests/test_pg.py"]
 )
@@ -1106,21 +1106,21 @@ py_test(
 # PPO
 py_test(
     name = "test_ppo",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/ppo/tests/test_ppo.py"]
 )
 
 py_test(
     name = "test_ppo_with_rl_module",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/ppo/tests/test_ppo_with_rl_module.py"]
 )
 
 py_test(
     name = "test_ppo_rl_module",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/ppo/tests/test_ppo_rl_module.py"]
 )
@@ -1128,7 +1128,7 @@ py_test(
 # PPO Reproducibility
 py_test(
     name = "test_repro_ppo",
-    tags = ["team:rllib", "algorithms_dir", "gpu"],
+    tags = ["team:rl", "algorithms_dir", "gpu"],
     size = "large",
     srcs = ["algorithms/ppo/tests/test_repro_ppo.py"]
 )
@@ -1136,7 +1136,7 @@ py_test(
 # QMix
 py_test(
     name = "test_qmix",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/qmix/tests/test_qmix.py"]
 )
@@ -1144,7 +1144,7 @@ py_test(
 # R2D2
 py_test(
     name = "test_r2d2",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/r2d2/tests/test_r2d2.py"]
 )
@@ -1153,7 +1153,7 @@ py_test(
 py_test(
     name = "test_random_agent",
     main = "algorithms/random_agent/random_agent.py",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "small",
     srcs = ["algorithms/random_agent/random_agent.py"]
 )
@@ -1161,7 +1161,7 @@ py_test(
 # RNNSAC
 py_test(
     name = "test_rnnsac",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "small",
     srcs = ["algorithms/sac/tests/test_rnnsac.py"]
 )
@@ -1169,7 +1169,7 @@ py_test(
 # SAC
 py_test(
     name = "test_sac",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "large",
     srcs = ["algorithms/sac/tests/test_sac.py"]
 )
@@ -1177,7 +1177,7 @@ py_test(
 # SimpleQ
 py_test(
     name = "test_simple_q",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/simple_q/tests/test_simple_q.py"]
 )
@@ -1185,7 +1185,7 @@ py_test(
 # SimpleQ Reproducibility
 py_test(
     name = "test_repro_simple_q",
-    tags = ["team:rllib", "algorithms_dir", "gpu"],
+    tags = ["team:rl", "algorithms_dir", "gpu"],
     size = "large",
     srcs = ["algorithms/simple_q/tests/test_repro_simple_q.py"]
 )
@@ -1193,7 +1193,7 @@ py_test(
 # SlateQ
 py_test(
     name = "test_slateq",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/slateq/tests/test_slateq.py"]
 )
@@ -1201,7 +1201,7 @@ py_test(
 # TD3
 py_test(
     name = "test_td3",
-    tags = ["team:rllib", "algorithms_dir"],
+    tags = ["team:rl", "algorithms_dir"],
     size = "medium",
     srcs = ["algorithms/td3/tests/test_td3.py"]
 )
@@ -1215,7 +1215,7 @@ py_test(
 
 py_test(
     name = "test_memory_leak_a3c",
-    tags = ["team:rllib", "memory_leak_tests"],
+    tags = ["team:rl", "memory_leak_tests"],
     main = "utils/tests/run_memory_leak_tests.py",
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
@@ -1225,7 +1225,7 @@ py_test(
 
 py_test(
     name = "test_memory_leak_appo",
-    tags = ["team:rllib", "memory_leak_tests"],
+    tags = ["team:rl", "memory_leak_tests"],
     main = "utils/tests/run_memory_leak_tests.py",
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
@@ -1235,7 +1235,7 @@ py_test(
 
 py_test(
     name = "test_memory_leak_ddpg",
-    tags = ["team:rllib", "memory_leak_tests"],
+    tags = ["team:rl", "memory_leak_tests"],
     main = "utils/tests/run_memory_leak_tests.py",
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
@@ -1245,7 +1245,7 @@ py_test(
 
 py_test(
     name = "test_memory_leak_dqn",
-    tags = ["team:rllib", "memory_leak_tests"],
+    tags = ["team:rl", "memory_leak_tests"],
     main = "utils/tests/run_memory_leak_tests.py",
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
@@ -1255,7 +1255,7 @@ py_test(
 
 py_test(
     name = "test_memory_leak_impala",
-    tags = ["team:rllib", "memory_leak_tests"],
+    tags = ["team:rl", "memory_leak_tests"],
     main = "utils/tests/run_memory_leak_tests.py",
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
@@ -1265,7 +1265,7 @@ py_test(
 
 py_test(
     name = "test_memory_leak_ppo",
-    tags = ["team:rllib", "memory_leak_tests"],
+    tags = ["team:rl", "memory_leak_tests"],
     main = "utils/tests/run_memory_leak_tests.py",
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
@@ -1275,7 +1275,7 @@ py_test(
 
 py_test(
     name = "test_memory_leak_sac",
-    tags = ["team:rllib", "memory_leak_tests"],
+    tags = ["team:rl", "memory_leak_tests"],
     main = "utils/tests/run_memory_leak_tests.py",
     size = "large",
     srcs = ["utils/tests/run_memory_leak_tests.py"],
@@ -1298,7 +1298,7 @@ py_test(
 py_test(
     name = "test_a3c_torch_pong_v5",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "ALE/Pong-v5",
         "--run", "A3C",
@@ -1311,7 +1311,7 @@ py_test(
 py_test(
     name = "test_a3c_tf_pong_ram_v5",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "ALE/Pong-ram-v5",
         "--run", "A3C",
@@ -1326,7 +1326,7 @@ py_test(
 py_test(
     name = "test_ddpg_mountaincar_continuous_v0_num_workers_0",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "MountainCarContinuous-v0",
         "--run", "DDPG",
@@ -1338,7 +1338,7 @@ py_test(
 py_test(
     name = "test_ddpg_mountaincar_continuous_v0_num_workers_1",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "MountainCarContinuous-v0",
         "--run", "DDPG",
@@ -1350,7 +1350,7 @@ py_test(
 py_test(
     name = "test_apex_ddpg_pendulum_v1_complete_episode_batches",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "Pendulum-v1",
         "--run", "APEX_DDPG",
@@ -1366,7 +1366,7 @@ py_test(
     name = "test_dqn_frozenlake_v1",
     main = "train.py", srcs = ["train.py"],
     size = "medium",
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "FrozenLake-v1",
         "--run", "DQN",
@@ -1379,7 +1379,7 @@ py_test(
     name = "test_dqn_cartpole_v1_no_dueling",
     main = "train.py", srcs = ["train.py"],
     size = "medium",
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "CartPole-v1",
         "--run", "DQN",
@@ -1391,7 +1391,7 @@ py_test(
 py_test(
     name = "test_dqn_cartpole_v1",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "CartPole-v1",
         "--run", "DQN",
@@ -1404,7 +1404,7 @@ py_test(
 py_test(
     name = "test_dqn_cartpole_v1_with_offline_input_and_softq",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train", "external_files"],
+    tags = ["team:rl", "quick_train", "external_files"],
     size = "medium",
     # Include the json data file.
     data = ["tests/data/cartpole/small.json"],
@@ -1419,7 +1419,7 @@ py_test(
 py_test(
     name = "test_dqn_pong_v5",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "ALE/Pong-v5",
         "--run", "DQN",
@@ -1433,7 +1433,7 @@ py_test(
 py_test(
     name = "test_impala_buffers_2",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "CartPole-v1",
         "--run", "IMPALA",
@@ -1447,7 +1447,7 @@ py_test(
     name = "test_impala_cartpole_v1_buffers_2_lstm",
     main = "train.py",
     srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "CartPole-v1",
         "--run", "IMPALA",
@@ -1461,7 +1461,7 @@ py_test(
     name = "test_impala_pong_v5_40k_ts_1G_obj_store",
     main = "train.py",
     srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     args = [
         "--env", "ALE/Pong-v5",
@@ -1477,7 +1477,7 @@ py_test(
 py_test(
     name = "test_pg_tf_cartpole_v1_lstm",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "CartPole-v1",
         "--run", "PG",
@@ -1490,7 +1490,7 @@ py_test(
     name = "test_pg_tf_cartpole_v1_multi_envs_per_worker",
     main = "train.py", srcs = ["train.py"],
     size = "medium",
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "CartPole-v1",
         "--run", "PG",
@@ -1503,7 +1503,7 @@ py_test(
 py_test(
     name = "test_pg_tf_pong_v5",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "ALE/Pong-v5",
         "--run", "PG",
@@ -1517,7 +1517,7 @@ py_test(
 py_test(
     name = "test_ppo_tf_cartpole_v1_complete_episode_batches",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "CartPole-v1",
         "--run", "PPO",
@@ -1529,7 +1529,7 @@ py_test(
 py_test(
     name = "test_ppo_tf_cartpole_v1_remote_worker_envs",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "CartPole-v1",
         "--run", "PPO",
@@ -1541,7 +1541,7 @@ py_test(
 py_test(
     name = "test_ppo_tf_cartpole_v1_remote_worker_envs_b",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "CartPole-v1",
         "--run", "PPO",
@@ -1553,7 +1553,7 @@ py_test(
 py_test(
     name = "test_appo_tf_pendulum_v1_no_gpus",
     main = "train.py", srcs = ["train.py"],
-    tags = ["team:rllib", "quick_train"],
+    tags = ["team:rl", "quick_train"],
     args = [
         "--env", "Pendulum-v1",
         "--run", "APPO",
@@ -1572,21 +1572,21 @@ py_test(
 
 py_test(
     name = "connectors/tests/test_connector",
-    tags = ["team:rllib", "connector"],
+    tags = ["team:rl", "connector"],
     size = "small",
     srcs = ["connectors/tests/test_connector.py"]
 )
 
 py_test(
     name = "connectors/tests/test_action",
-    tags = ["team:rllib", "connector"],
+    tags = ["team:rl", "connector"],
     size = "small",
     srcs = ["connectors/tests/test_action.py"]
 )
 
 py_test(
     name = "connectors/tests/test_agent",
-    tags = ["team:rllib", "connector"],
+    tags = ["team:rl", "connector"],
     size = "small",
     srcs = ["connectors/tests/test_agent.py"]
 )
@@ -1600,28 +1600,28 @@ py_test(
 
 py_test(
     name = "env/tests/test_env_with_subprocess",
-    tags = ["team:rllib", "env"],
+    tags = ["team:rl", "env"],
     size = "medium",
     srcs = ["env/tests/test_env_with_subprocess.py"]
 )
 
 py_test(
     name = "env/tests/test_external_env",
-    tags = ["team:rllib", "env"],
+    tags = ["team:rl", "env"],
     size = "large",
     srcs = ["env/tests/test_external_env.py"]
 )
 
 py_test(
     name = "env/tests/test_external_multi_agent_env",
-    tags = ["team:rllib", "env"],
+    tags = ["team:rl", "env"],
     size = "small",
     srcs = ["env/tests/test_external_multi_agent_env.py"]
 )
 
 sh_test(
     name = "env/tests/test_local_inference_cartpole",
-    tags = ["team:rllib", "env"],
+    tags = ["team:rl", "env"],
     size = "medium",
     srcs = ["env/tests/test_policy_client_server_setup.sh"],
     args = ["local", "cartpole", "8800"],
@@ -1630,7 +1630,7 @@ sh_test(
 
 sh_test(
     name = "env/tests/test_local_inference_cartpole_w_2_concurrent_episodes",
-    tags = ["team:rllib", "env"],
+    tags = ["team:rl", "env"],
     size = "medium",
     srcs = ["env/tests/test_policy_client_server_setup.sh"],
     args = ["local", "cartpole-dummy-2-episodes", "8830"],
@@ -1639,7 +1639,7 @@ sh_test(
 
 sh_test(
     name = "env/tests/test_local_inference_unity3d",
-    tags = ["team:rllib", "env"],
+    tags = ["team:rl", "env"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["env/tests/test_policy_client_server_setup.sh"],
     args = ["local", "unity3d", "8850"],
@@ -1648,14 +1648,14 @@ sh_test(
 
 py_test(
     name = "env/tests/test_multi_agent_env",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "medium",
     srcs = ["env/tests/test_multi_agent_env.py"]
 )
 
 sh_test(
     name = "env/tests/test_remote_inference_cartpole",
-    tags = ["team:rllib", "env", "exclusive"],
+    tags = ["team:rl", "env", "exclusive"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["env/tests/test_policy_client_server_setup.sh"],
     args = ["remote", "cartpole", "8810"],
@@ -1664,7 +1664,7 @@ sh_test(
 
 sh_test(
     name = "env/tests/test_remote_inference_cartpole_lstm",
-    tags = ["team:rllib", "env", "exclusive"],
+    tags = ["team:rl", "env", "exclusive"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["env/tests/test_policy_client_server_setup.sh"],
     args = ["remote", "cartpole_lstm", "8820"],
@@ -1673,7 +1673,7 @@ sh_test(
 
 sh_test(
     name = "env/tests/test_remote_inference_cartpole_w_2_concurrent_episodes",
-    tags = ["team:rllib", "env", "exclusive"],
+    tags = ["team:rl", "env", "exclusive"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["env/tests/test_policy_client_server_setup.sh"],
     args = ["remote", "cartpole-dummy-2-episodes", "8840"],
@@ -1682,7 +1682,7 @@ sh_test(
 
 sh_test(
     name = "env/tests/test_remote_inference_unity3d",
-    tags = ["team:rllib", "env", "exclusive"],
+    tags = ["team:rl", "env", "exclusive"],
     size = "small",
     srcs = ["env/tests/test_policy_client_server_setup.sh"],
     args = ["remote", "unity3d", "8860"],
@@ -1691,35 +1691,35 @@ sh_test(
 
 py_test(
     name = "env/tests/test_remote_worker_envs",
-    tags = ["team:rllib", "env"],
+    tags = ["team:rl", "env"],
     size = "medium",
     srcs = ["env/tests/test_remote_worker_envs.py"]
 )
 
 py_test(
     name = "env/wrappers/tests/test_exception_wrapper",
-    tags = ["team:rllib", "env"],
+    tags = ["team:rl", "env"],
     size = "small",
     srcs = ["env/wrappers/tests/test_exception_wrapper.py"]
 )
 
 py_test(
     name = "env/wrappers/tests/test_group_agents_wrapper",
-    tags = ["team:rllib", "env"],
+    tags = ["team:rl", "env"],
     size = "small",
     srcs = ["env/wrappers/tests/test_group_agents_wrapper.py"]
 )
 
 py_test(
     name = "env/wrappers/tests/test_recsim_wrapper",
-    tags = ["team:rllib", "env"],
+    tags = ["team:rl", "env"],
     size = "small",
     srcs = ["env/wrappers/tests/test_recsim_wrapper.py"]
 )
 
 py_test(
     name = "env/wrappers/tests/test_unity3d_env",
-    tags = ["team:rllib", "env"],
+    tags = ["team:rl", "env"],
     size = "small",
     srcs = ["env/wrappers/tests/test_unity3d_env.py"]
 )
@@ -1732,63 +1732,63 @@ py_test(
 # --------------------------------------------------------------------
 py_test(
     name = "evaluation/tests/test_agent_collector",
-    tags = ["team:rllib", "evaluation"],
+    tags = ["team:rl", "evaluation"],
     size = "small",
     srcs = ["evaluation/tests/test_agent_collector.py"]
 )
 
 py_test(
     name = "evaluation/tests/test_envs_that_crash",
-    tags = ["team:rllib", "evaluation"],
+    tags = ["team:rl", "evaluation"],
     size = "medium",
     srcs = ["evaluation/tests/test_envs_that_crash.py"]
 )
 
 py_test(
     name = "evaluation/tests/test_episode",
-    tags = ["team:rllib", "evaluation"],
+    tags = ["team:rl", "evaluation"],
     size = "small",
     srcs = ["evaluation/tests/test_episode.py"]
 )
 
 py_test(
     name = "evaluation/tests/test_env_runner_v2",
-    tags = ["team:rllib", "evaluation"],
+    tags = ["team:rl", "evaluation"],
     size = "small",
     srcs = ["evaluation/tests/test_env_runner_v2.py"]
 )
 
 py_test(
     name = "evaluation/tests/test_episode_v2",
-    tags = ["team:rllib", "evaluation"],
+    tags = ["team:rl", "evaluation"],
     size = "small",
     srcs = ["evaluation/tests/test_episode_v2.py"]
 )
 
 py_test(
     name = "evaluation/tests/test_postprocessing",
-    tags = ["team:rllib", "evaluation"],
+    tags = ["team:rl", "evaluation"],
     size = "small",
     srcs = ["evaluation/tests/test_postprocessing.py"]
 )
 
 py_test(
     name = "evaluation/tests/test_worker_set",
-    tags = ["team:rllib", "evaluation", "exclusive"],
+    tags = ["team:rl", "evaluation", "exclusive"],
     size = "small",
     srcs = ["evaluation/tests/test_worker_set.py"]
 )
 
 py_test(
     name = "evaluation/tests/test_rollout_worker",
-    tags = ["team:rllib", "evaluation", "exclusive"],
+    tags = ["team:rl", "evaluation", "exclusive"],
     size = "large",
     srcs = ["evaluation/tests/test_rollout_worker.py"]
 )
 
 py_test(
     name = "evaluation/tests/test_trajectory_view_api",
-    tags = ["team:rllib", "evaluation"],
+    tags = ["team:rl", "evaluation"],
     size = "large",
     srcs = ["evaluation/tests/test_trajectory_view_api.py"]
 )
@@ -1802,7 +1802,7 @@ py_test(
 
 py_test(
     name = "test_async_requests_manager",
-    tags = ["team:rllib", "execution", "exclusive"],
+    tags = ["team:rl", "execution", "exclusive"],
     size = "medium",
     srcs = ["execution/tests/test_async_requests_manager.py"]
 )
@@ -1816,49 +1816,49 @@ py_test(
 
 py_test(
     name = "test_torch_rl_module",
-    tags = ["team:rllib", "core"],
+    tags = ["team:rl", "core"],
     size = "medium",
     srcs = ["core/rl_module/torch/tests/test_torch_rl_module.py"]
 )
 
 py_test(
     name = "test_tf_rl_module",
-    tags = ["team:rllib", "core"],
+    tags = ["team:rl", "core"],
     size = "medium",
     srcs = ["core/rl_module/tf/tests/test_tf_rl_module.py"]
 )
 
 py_test(
     name = "test_marl_module",
-    tags = ["team:rllib", "core"],
+    tags = ["team:rl", "core"],
     size = "medium",
     srcs = ["core/rl_module/tests/test_marl_module.py"]
 )
 
 py_test(
     name = "test_trainer_runner",
-    tags = ["team:rllib", "multi_gpu", "exclusive"],
+    tags = ["team:rl", "multi_gpu", "exclusive"],
     size = "medium",
     srcs = ["core/rl_trainer/tests/test_trainer_runner.py"]
 )
 
 py_test(
     name = "test_trainer_runner_local",
-    tags = ["team:rllib", "core", "exclusive"],
+    tags = ["team:rl", "core", "exclusive"],
     size = "medium",
     srcs = ["core/rl_trainer/tests/test_trainer_runner_local.py"]
 )
 
 py_test(
     name = "test_trainer_runner_config",
-    tags = ["team:rllib", "core"],
+    tags = ["team:rl", "core"],
     size = "medium",
     srcs = ["core/rl_trainer/tests/test_trainer_runner_config.py"]
 )
 
 py_test(
     name = "test_rl_trainer",
-    tags = ["team:rllib", "core"],
+    tags = ["team:rl", "core"],
     size = "medium",
     srcs = ["core/rl_trainer/tests/test_rl_trainer.py"]
 )
@@ -1866,7 +1866,7 @@ py_test(
 # TODO (Kourosh): to be removed in favor of test_rl_trainer.py
 py_test(
     name = "test_torch_rl_trainer",
-    tags = ["team:rllib", "core"],
+    tags = ["team:rl", "core"],
     size = "medium",
     srcs = ["core/rl_trainer/torch/tests/test_torch_rl_trainer.py"]
 )
@@ -1880,28 +1880,28 @@ py_test(
 
 py_test(
     name = "test_attention_nets",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "large",
     srcs = ["models/tests/test_attention_nets.py"]
 )
 
 py_test(
     name = "test_check_specs",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "small",
     srcs = ["models/specs/tests/test_check_specs.py"]
 )
 
 py_test(
     name = "test_conv2d_default_stacks",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "small",
     srcs = ["models/tests/test_conv2d_default_stacks.py"]
 )
 
 py_test(
     name = "test_convtranspose2d_stack",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "small",
     data = glob(["tests/data/images/obstacle_tower.png"]),
     srcs = ["models/tests/test_convtranspose2d_stack.py"]
@@ -1909,35 +1909,35 @@ py_test(
 
 py_test(
     name = "test_action_distributions",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "medium",
     srcs = ["models/tests/test_action_distributions.py"]
 )
 
 py_test(
     name = "test_distributions",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "small",
     srcs = ["models/tests/test_distributions.py"]
 )
 
 py_test(
     name = "test_lstms",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "large",
     srcs = ["models/tests/test_lstms.py"]
 )
 
 py_test(
     name = "test_models",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "medium",
     srcs = ["models/tests/test_models.py"]
 )
 
 py_test(
     name = "test_preprocessors",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "medium",
     srcs = ["models/tests/test_preprocessors.py"]
 )
@@ -1945,7 +1945,7 @@ py_test(
 # Test Tensor specs
 py_test(
     name = "test_tensor_spec",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "small",
     srcs = ["models/specs/tests/test_tensor_spec.py"]
 )
@@ -1953,7 +1953,7 @@ py_test(
 # test abstract base models
 py_test(
     name = "test_base_model",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "small",
     srcs = ["models/tests/test_base_model.py"]
 )
@@ -1961,7 +1961,7 @@ py_test(
 # test torch base models
 py_test(
     name = "test_torch_model",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "small",
     srcs = ["models/tests/test_torch_model.py"]
 )
@@ -1969,7 +1969,7 @@ py_test(
 # test ModelSpec
 py_test(
     name = "test_spec_dict",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "small",
     srcs = ["models/specs/tests/test_spec_dict.py"]
 )
@@ -1977,7 +1977,7 @@ py_test(
 # test TorchVectorEncoder
 py_test(
     name = "test_torch_vector_encoder",
-    tags = ["team:rllib", "models"],
+    tags = ["team:rl", "models"],
     size = "small",
     srcs = ["models/torch/encoders/tests/test_torch_vector_encoder.py"]
 )
@@ -1992,7 +1992,7 @@ py_test(
 
 py_test(
     name = "test_dataset_reader",
-    tags = ["team:rllib", "offline"],
+    tags = ["team:rl", "offline"],
     size = "small",
     srcs = ["offline/tests/test_dataset_reader.py"],
     data = [
@@ -2003,14 +2003,14 @@ py_test(
 
 py_test(
     name = "test_feature_importance",
-    tags = ["team:rllib", "offline", "torch_only"],
+    tags = ["team:rl", "offline", "torch_only"],
     size = "medium",
     srcs = ["offline/tests/test_feature_importance.py"]
 )
 
 py_test(
     name = "test_json_reader",
-    tags = ["team:rllib", "offline"],
+    tags = ["team:rl", "offline"],
     size = "small",
     srcs = ["offline/tests/test_json_reader.py"],
     data = ["tests/data/pendulum/large.json"],
@@ -2018,7 +2018,7 @@ py_test(
 
 py_test(
     name = "test_ope",
-    tags = ["team:rllib", "offline"],
+    tags = ["team:rl", "offline"],
     size = "medium",
     srcs = ["offline/estimators/tests/test_ope.py"],
     data = ["tests/data/cartpole/small.json"],
@@ -2026,21 +2026,21 @@ py_test(
 
 py_test(
     name = "test_ope_math",
-    tags = ["team:rllib", "offline"],
+    tags = ["team:rl", "offline"],
     size = "small",
     srcs = ["offline/estimators/tests/test_ope_math.py"]
 )
 
 py_test(
     name = "test_dm_learning",
-    tags = ["team:rllib", "offline"],
+    tags = ["team:rl", "offline"],
     size = "large",
     srcs = ["offline/estimators/tests/test_dm_learning.py"],
 )
 
 py_test(
     name = "test_dr_learning",
-    tags = ["team:rllib", "offline"],
+    tags = ["team:rl", "offline"],
     size = "large",
     srcs = ["offline/estimators/tests/test_dr_learning.py"],
 )
@@ -2054,63 +2054,63 @@ py_test(
 
 py_test(
     name = "policy/tests/test_compute_log_likelihoods",
-    tags = ["team:rllib", "policy"],
+    tags = ["team:rl", "policy"],
     size = "medium",
     srcs = ["policy/tests/test_compute_log_likelihoods.py"]
 )
 
 py_test(
     name = "policy/tests/test_export_checkpoint_and_model",
-    tags = ["team:rllib", "policy"],
+    tags = ["team:rl", "policy"],
     size = "large",
     srcs = ["policy/tests/test_export_checkpoint_and_model.py"]
 )
 
 py_test(
     name = "policy/tests/test_multi_agent_batch",
-    tags = ["team:rllib", "policy"],
+    tags = ["team:rl", "policy"],
     size = "small",
     srcs = ["policy/tests/test_multi_agent_batch.py"]
 )
 
 py_test(
     name = "policy/tests/test_policy",
-    tags = ["team:rllib", "policy"],
+    tags = ["team:rl", "policy"],
     size = "medium",
     srcs = ["policy/tests/test_policy.py"]
 )
 
 py_test(
     name = "policy/tests/test_policy_map",
-    tags = ["team:rllib", "policy"],
+    tags = ["team:rl", "policy"],
     size = "medium",
     srcs = ["policy/tests/test_policy_map.py"]
 )
 
 py_test(
     name = "policy/tests/test_policy_state_swapping",
-    tags = ["team:rllib", "policy", "gpu"],
+    tags = ["team:rl", "policy", "gpu"],
     size = "medium",
     srcs = ["policy/tests/test_policy_state_swapping.py"]
 )
 
 py_test(
     name = "policy/tests/test_rnn_sequencing",
-    tags = ["team:rllib", "policy"],
+    tags = ["team:rl", "policy"],
     size = "small",
     srcs = ["policy/tests/test_rnn_sequencing.py"]
 )
 
 py_test(
     name = "policy/tests/test_sample_batch",
-    tags = ["team:rllib", "policy", "multi_gpu"],
+    tags = ["team:rl", "policy", "multi_gpu"],
     size = "small",
     srcs = ["policy/tests/test_sample_batch.py"]
 )
 
 py_test(
     name = "policy/tests/test_view_requirement",
-    tags = ["team:rllib", "policy"],
+    tags = ["team:rl", "policy"],
     size = "small",
     srcs = ["policy/tests/test_view_requirement.py"]
 )
@@ -2126,63 +2126,63 @@ py_test(
 # Checkpoint Utils
 py_test(
     name = "test_checkpoint_utils",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/tests/test_checkpoint_utils.py"]
 )
 
 py_test(
     name = "test_errors",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "medium",
     srcs = ["utils/tests/test_errors.py"]
 )
 
 py_test(
     name = "test_nested_dict",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/tests/test_nested_dict.py"]
 )
 
 py_test(
     name = "test_serialization",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/tests/test_serialization.py"]
 )
 
 py_test(
     name = "test_curiosity",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "large",
     srcs = ["utils/exploration/tests/test_curiosity.py"]
 )
 
 py_test(
     name = "test_explorations",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "large",
     srcs = ["utils/exploration/tests/test_explorations.py"]
 )
 
 py_test(
     name = "test_parameter_noise",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "medium",
     srcs = ["utils/exploration/tests/test_parameter_noise.py"]
 )
 
 py_test(
     name = "test_random_encoder",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "large",
     srcs = ["utils/exploration/tests/test_random_encoder.py"]
 )
 
 py_test(
     name = "utils/tests/test_torch_utils",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/tests/test_torch_utils.py"]
 )
@@ -2190,14 +2190,14 @@ py_test(
 # Schedules
 py_test(
     name = "test_schedules",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/schedules/tests/test_schedules.py"]
 )
 
 py_test(
     name = "test_framework_agnostic_components",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     data = glob(["utils/tests/**"]),
     srcs = ["utils/tests/test_framework_agnostic_components.py"]
@@ -2206,7 +2206,7 @@ py_test(
 # Spaces/Space utils.
 py_test(
     name = "test_space_utils",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/spaces/tests/test_space_utils.py"]
 )
@@ -2214,7 +2214,7 @@ py_test(
 # TaskPool
 py_test(
     name = "test_taskpool",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/tests/test_taskpool.py"]
 )
@@ -2222,77 +2222,77 @@ py_test(
 # ReplayBuffers
 py_test(
     name = "test_multi_agent_mixin_replay_buffer",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/replay_buffers/tests/test_multi_agent_mixin_replay_buffer.py"]
 )
 
 py_test(
     name = "test_multi_agent_prioritized_replay_buffer",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/replay_buffers/tests/test_multi_agent_prioritized_replay_buffer.py"]
 )
 
 py_test(
     name = "test_multi_agent_replay_buffer",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/replay_buffers/tests/test_multi_agent_replay_buffer.py"]
 )
 
 py_test(
     name = "test_prioritized_replay_buffer_replay_buffer_api",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/replay_buffers/tests/test_prioritized_replay_buffer_replay_buffer_api.py"]
 )
 
 py_test(
     name = "test_replay_buffer",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/replay_buffers/tests/test_replay_buffer.py"]
 )
 
 py_test(
     name = "test_fifo_replay_buffer",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/replay_buffers/tests/test_fifo_replay_buffer.py"]
 )
 
 py_test(
     name = "test_reservoir_buffer",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/replay_buffers/tests/test_reservoir_buffer.py"]
 )
 
 py_test(
     name = "test_segment_tree_replay_buffer_api",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/replay_buffers/tests/test_segment_tree_replay_buffer_api.py"]
 )
 
 py_test(
     name = "test_check_env",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/tests/test_check_env.py"]
 )
 
 py_test(
     name = "test_check_multi_agent",
-    tags = ["team:rllib", "utils"],
+    tags = ["team:rl", "utils"],
     size = "small",
     srcs = ["utils/tests/test_check_multi_agent.py"]
 )
 
 py_test(
     name = "test_actor_manager",
-    tags = ["team:rllib", "utils", "exclusive"],
+    tags = ["team:rl", "utils", "exclusive"],
     size = "medium",
     srcs = ["utils/tests/test_actor_manager.py"],
     data = ["utils/tests/random_numbers.pkl"],
@@ -2308,7 +2308,7 @@ py_test(
 
 py_test(
     name = "tests/backward_compat/test_backward_compat",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "medium",
     srcs = ["tests/backward_compat/test_backward_compat.py"],
     data = glob(["tests/backward_compat/checkpoints/**"]),
@@ -2316,21 +2316,21 @@ py_test(
 
 py_test(
     name = "tests/backward_compat/test_gym_env_apis",
-    tags = ["team:rllib", "env"],
+    tags = ["team:rl", "env"],
     size = "medium",
     srcs = ["tests/backward_compat/test_gym_env_apis.py"]
 )
 
 py_test(
     name = "tests/test_algorithm_imports",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "small",
     srcs = ["tests/test_algorithm_imports.py"]
 )
 
 py_test(
     name = "tests/test_catalog",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "medium",
     srcs = ["tests/test_catalog.py"]
 )
@@ -2338,7 +2338,7 @@ py_test(
 py_test(
     name = "tests/test_checkpoint_restore_pg",
     main = "tests/test_algorithm_checkpoint_restore.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     srcs = ["tests/test_algorithm_checkpoint_restore.py"],
     args = ["TestCheckpointRestorePG"]
@@ -2347,7 +2347,7 @@ py_test(
 py_test(
     name = "tests/test_checkpoint_restore_off_policy",
     main = "tests/test_algorithm_checkpoint_restore.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     srcs = ["tests/test_algorithm_checkpoint_restore.py"],
     args = ["TestCheckpointRestoreOffPolicy"]
@@ -2356,7 +2356,7 @@ py_test(
 py_test(
     name = "tests/test_checkpoint_restore_evolution_algos",
     main = "tests/test_algorithm_checkpoint_restore.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "medium",
     srcs = ["tests/test_algorithm_checkpoint_restore.py"],
     args = ["TestCheckpointRestoreEvolutionAlgos"]
@@ -2365,7 +2365,7 @@ py_test(
 py_test(
     name = "policy/tests/test_policy_checkpoint_restore",
     main = "policy/tests/test_policy_checkpoint_restore.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     data = glob([
         "tests/data/checkpoints/APPO_CartPole-v1-connector-enabled/**",
@@ -2375,21 +2375,21 @@ py_test(
 
 py_test(
     name = "tests/test_custom_resource",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/test_custom_resource.py"]
 )
 
 py_test(
     name = "tests/test_dependency_tf",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "small",
     srcs = ["tests/test_dependency_tf.py"]
 )
 
 py_test(
     name = "tests/test_dependency_torch",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "small",
     srcs = ["tests/test_dependency_torch.py"]
 )
@@ -2397,7 +2397,7 @@ py_test(
 py_test(
     name = "tests/test_eager_support_pg",
     main = "tests/test_eager_support.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "small",
     srcs = ["tests/test_eager_support.py"],
     args = ["TestEagerSupportPG"]
@@ -2406,7 +2406,7 @@ py_test(
 py_test(
     name = "tests/test_eager_support_off_policy",
     main = "tests/test_eager_support.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "small",
     srcs = ["tests/test_eager_support.py"],
     args = ["TestEagerSupportOffPolicy"]
@@ -2414,42 +2414,42 @@ py_test(
 
 py_test(
     name = "tests/test_filters",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "small",
     srcs = ["tests/test_filters.py"]
 )
 
 py_test(
     name = "tests/test_gpus",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     srcs = ["tests/test_gpus.py"]
 )
 
 py_test(
     name = "tests/test_io",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     srcs = ["tests/test_io.py"]
 )
 
 py_test(
     name = "tests/test_local",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "small",
     srcs = ["tests/test_local.py"]
 )
 
 py_test(
     name = "tests/test_lstm",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "medium",
     srcs = ["tests/test_lstm.py"]
 )
 
 py_test(
     name = "tests/test_model_imports",
-    tags = ["team:rllib", "tests_dir", "model_imports"],
+    tags = ["team:rl", "tests_dir", "model_imports"],
     size = "medium",
     data = glob(["tests/data/model_weights/**"]),
     srcs = ["tests/test_model_imports.py"]
@@ -2458,7 +2458,7 @@ py_test(
 py_test(
     name = "tests/test_nested_action_spaces",
     main = "tests/test_nested_action_spaces.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "medium",
     srcs = ["tests/test_nested_action_spaces.py"]
 )
@@ -2466,42 +2466,42 @@ py_test(
 py_test(
     name = "tests/test_nested_observation_spaces",
     main = "tests/test_nested_observation_spaces.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "medium",
     srcs = ["tests/test_nested_observation_spaces.py"]
 )
 
 py_test(
     name = "tests/test_nn_framework_import_errors",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "small",
     srcs = ["tests/test_nn_framework_import_errors.py"]
 )
 
 py_test(
     name = "tests/test_pettingzoo_env",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "medium",
     srcs = ["tests/test_pettingzoo_env.py"]
 )
 
 py_test(
     name = "tests/test_placement_groups",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/test_placement_groups.py"]
 )
 
 py_test(
     name = "tests/test_ray_client",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     srcs = ["tests/test_ray_client.py"]
 )
 
 py_test(
     name = "tests/test_reproducibility",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "medium",
     srcs = ["tests/test_reproducibility.py"]
 )
@@ -2510,7 +2510,7 @@ py_test(
 py_test(
     name = "test_rllib_evaluate_1",
     main = "tests/test_rllib_train_and_evaluate.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     data = ["train.py", "evaluate.py"],
     srcs = ["tests/test_rllib_train_and_evaluate.py"],
@@ -2520,7 +2520,7 @@ py_test(
 py_test(
     name = "test_rllib_evaluate_2",
     main = "tests/test_rllib_train_and_evaluate.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     data = ["train.py", "evaluate.py"],
     srcs = ["tests/test_rllib_train_and_evaluate.py"],
@@ -2530,7 +2530,7 @@ py_test(
 py_test(
     name = "test_rllib_evaluate_3",
     main = "tests/test_rllib_train_and_evaluate.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     data = ["train.py", "evaluate.py"],
     srcs = ["tests/test_rllib_train_and_evaluate.py"],
@@ -2540,7 +2540,7 @@ py_test(
 py_test(
     name = "test_rllib_evaluate_4",
     main = "tests/test_rllib_train_and_evaluate.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     data = ["train.py", "evaluate.py"],
     srcs = ["tests/test_rllib_train_and_evaluate.py"],
@@ -2552,7 +2552,7 @@ py_test(
 py_test(
     name = "test_rllib_train_and_evaluate",
     main = "tests/test_rllib_train_and_evaluate.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     data = ["train.py", "evaluate.py"],
     srcs = ["tests/test_rllib_train_and_evaluate.py"],
@@ -2562,7 +2562,7 @@ py_test(
 py_test(
     name = "tests/test_supported_multi_agent_pg",
     main = "tests/test_supported_multi_agent.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     srcs = ["tests/test_supported_multi_agent.py"],
     args = ["TestSupportedMultiAgentPG"]
@@ -2571,7 +2571,7 @@ py_test(
 py_test(
     name = "tests/test_supported_multi_agent_off_policy",
     main = "tests/test_supported_multi_agent.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     srcs = ["tests/test_supported_multi_agent.py"],
     args = ["TestSupportedMultiAgentOffPolicy"]
@@ -2580,7 +2580,7 @@ py_test(
 py_test(
      name = "tests/test_supported_spaces_impala_appo",
      main = "tests/test_supported_spaces.py",
-     tags = ["team:rllib", "tests_dir"],
+     tags = ["team:rl", "tests_dir"],
      size = "large",
      srcs = ["tests/test_supported_spaces.py"],
      args = ["TestSupportedSpacesIMPALAAPPO"]
@@ -2589,7 +2589,7 @@ py_test(
 py_test(
      name = "tests/test_supported_spaces_a3c_ppo",
      main = "tests/test_supported_spaces.py",
-     tags = ["team:rllib", "tests_dir"],
+     tags = ["team:rl", "tests_dir"],
      size = "large",
      srcs = ["tests/test_supported_spaces.py"],
      args = ["TestSupportedSpacesA3CPPO"]
@@ -2598,7 +2598,7 @@ py_test(
 py_test(
      name = "tests/test_supported_spaces_ppo_no_preproceesor_gpu",
      main = "tests/test_supported_spaces.py",
-     tags = ["team:rllib", "tests_dir", "multi_gpu", "exclusive"],
+     tags = ["team:rl", "tests_dir", "multi_gpu", "exclusive"],
      size = "medium",
      srcs = ["tests/test_supported_spaces.py"],
      args = ["TestSupportedSpacesPPONoPreprocessorGPU"]
@@ -2607,7 +2607,7 @@ py_test(
 py_test(
     name = "tests/test_supported_spaces_off_policy",
     main = "tests/test_supported_spaces.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "medium",
     srcs = ["tests/test_supported_spaces.py"],
     args = ["TestSupportedSpacesOffPolicy"]
@@ -2616,7 +2616,7 @@ py_test(
 py_test(
     name = "tests/test_supported_spaces_evolution_algos",
     main = "tests/test_supported_spaces.py",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "large",
     srcs = ["tests/test_supported_spaces.py"],
     args = ["TestSupportedSpacesEvolutionAlgos"]
@@ -2624,7 +2624,7 @@ py_test(
 
 py_test(
     name = "tests/test_timesteps",
-    tags = ["team:rllib", "tests_dir"],
+    tags = ["team:rl", "tests_dir"],
     size = "small",
     srcs = ["tests/test_timesteps.py"]
 )
@@ -2640,7 +2640,7 @@ py_test(
 py_test(
     name = "examples/action_masking_tf",
     main = "examples/action_masking.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/action_masking.py"],
     args = ["--stop-iter=2"]
@@ -2649,7 +2649,7 @@ py_test(
 py_test(
     name = "examples/action_masking_torch",
     main = "examples/action_masking.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/action_masking.py"],
     args = ["--stop-iter=2", "--framework=torch"]
@@ -2658,7 +2658,7 @@ py_test(
 py_test(
     name = "examples/attention_net_tf",
     main = "examples/attention_net.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/attention_net.py"],
     args = ["--as-test", "--stop-reward=70"]
@@ -2667,7 +2667,7 @@ py_test(
 py_test(
     name = "examples/attention_net_torch",
     main = "examples/attention_net.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/attention_net.py"],
     args = ["--as-test", "--stop-reward=70", "--framework torch"]
@@ -2676,7 +2676,7 @@ py_test(
 py_test(
     name = "examples/autoregressive_action_dist_tf",
     main = "examples/autoregressive_action_dist.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/autoregressive_action_dist.py"],
     args = ["--as-test", "--stop-reward=150", "--num-cpus=4"]
@@ -2685,7 +2685,7 @@ py_test(
 py_test(
     name = "examples/autoregressive_action_dist_torch",
     main = "examples/autoregressive_action_dist.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/autoregressive_action_dist.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=150", "--num-cpus=4"]
@@ -2694,7 +2694,7 @@ py_test(
 py_test(
     name = "examples/bare_metal_policy_with_custom_view_reqs",
     main = "examples/bare_metal_policy_with_custom_view_reqs.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/bare_metal_policy_with_custom_view_reqs.py"],
 )
@@ -2702,7 +2702,7 @@ py_test(
 py_test(
     name = "examples/batch_norm_model_ppo_tf",
     main = "examples/batch_norm_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/batch_norm_model.py"],
     args = ["--as-test", "--run=PPO", "--stop-reward=80"]
@@ -2711,7 +2711,7 @@ py_test(
 py_test(
     name = "examples/batch_norm_model_ppo_torch",
     main = "examples/batch_norm_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/batch_norm_model.py"],
     args = ["--as-test", "--framework=torch", "--run=PPO", "--stop-reward=80"]
@@ -2720,7 +2720,7 @@ py_test(
 py_test(
     name = "examples/batch_norm_model_dqn_tf",
     main = "examples/batch_norm_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "large",
     srcs = ["examples/batch_norm_model.py"],
     args = ["--as-test", "--run=DQN", "--stop-reward=70", "--stop-time=400"]
@@ -2729,7 +2729,7 @@ py_test(
 py_test(
     name = "examples/batch_norm_model_dqn_torch",
     main = "examples/batch_norm_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "large",  # DQN learns much slower with BatchNorm.
     srcs = ["examples/batch_norm_model.py"],
     args = ["--as-test", "--framework=torch", "--run=DQN", "--stop-reward=70", "--stop-time=400"]
@@ -2738,7 +2738,7 @@ py_test(
 py_test(
     name = "examples/batch_norm_model_ddpg_tf",
     main = "examples/batch_norm_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/batch_norm_model.py"],
     args = ["--run=DDPG", "--stop-iters=1"]
@@ -2747,7 +2747,7 @@ py_test(
 py_test(
     name = "examples/batch_norm_model_ddpg_torch",
     main = "examples/batch_norm_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/batch_norm_model.py"],
     args = ["--framework=torch", "--run=DDPG", "--stop-iters=1"]
@@ -2756,7 +2756,7 @@ py_test(
 py_test(
     name = "examples/cartpole_lstm_impala_tf",
     main = "examples/cartpole_lstm.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/cartpole_lstm.py"],
     args = ["--as-test", "--run=IMPALA", "--stop-reward=40", "--num-cpus=4"]
@@ -2765,7 +2765,7 @@ py_test(
 py_test(
     name = "examples/cartpole_lstm_impala_torch",
     main = "examples/cartpole_lstm.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/cartpole_lstm.py"],
     args = ["--as-test", "--framework=torch", "--run=IMPALA", "--stop-reward=40", "--num-cpus=4"]
@@ -2774,7 +2774,7 @@ py_test(
 py_test(
     name = "examples/cartpole_lstm_ppo_tf",
     main = "examples/cartpole_lstm.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/cartpole_lstm.py"],
     args = ["--as-test", "--framework=tf", "--run=PPO", "--stop-reward=40", "--num-cpus=4"]
@@ -2783,7 +2783,7 @@ py_test(
 py_test(
     name = "examples/cartpole_lstm_ppo_tf2",
     main = "examples/cartpole_lstm.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/cartpole_lstm.py"],
     args = ["--as-test", "--framework=tf2", "--run=PPO", "--stop-reward=40", "--num-cpus=4"]
@@ -2792,7 +2792,7 @@ py_test(
 py_test(
     name = "examples/cartpole_lstm_ppo_torch",
     main = "examples/cartpole_lstm.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/cartpole_lstm.py"],
     args = ["--as-test", "--framework=torch", "--run=PPO", "--stop-reward=40", "--num-cpus=4"]
@@ -2801,7 +2801,7 @@ py_test(
 py_test(
     name = "examples/cartpole_lstm_ppo_tf_with_prev_a_and_r",
     main = "examples/cartpole_lstm.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/cartpole_lstm.py"],
     args = ["--as-test", "--run=PPO", "--stop-reward=40", "--use-prev-action",  "--use-prev-reward", "--num-cpus=4"]
@@ -2810,7 +2810,7 @@ py_test(
 py_test(
     name = "examples/centralized_critic_tf",
     main = "examples/centralized_critic.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/centralized_critic.py"],
     args = ["--as-test", "--stop-reward=7.2"]
@@ -2819,7 +2819,7 @@ py_test(
 py_test(
     name = "examples/centralized_critic_torch",
     main = "examples/centralized_critic.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/centralized_critic.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=7.2"]
@@ -2828,7 +2828,7 @@ py_test(
 py_test(
     name = "examples/centralized_critic_2_tf",
     main = "examples/centralized_critic_2.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/centralized_critic_2.py"],
     args = ["--as-test", "--stop-reward=6.0"]
@@ -2837,7 +2837,7 @@ py_test(
 py_test(
     name = "examples/centralized_critic_2_torch",
     main = "examples/centralized_critic_2.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/centralized_critic_2.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=6.0"]
@@ -2846,7 +2846,7 @@ py_test(
 py_test(
     name = "examples/checkpoint_by_custom_criteria",
     main = "examples/checkpoint_by_custom_criteria.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/checkpoint_by_custom_criteria.py"],
     args = ["--stop-iters=3 --num-cpus=3"]
@@ -2855,7 +2855,7 @@ py_test(
 py_test(
     name = "examples/complex_struct_space_tf",
     main = "examples/complex_struct_space.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/complex_struct_space.py"],
     args = ["--framework=tf"],
@@ -2864,7 +2864,7 @@ py_test(
 py_test(
     name = "examples/complex_struct_space_tf_eager",
     main = "examples/complex_struct_space.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/complex_struct_space.py"],
     args = ["--framework=tf2"],
@@ -2873,7 +2873,7 @@ py_test(
 py_test(
     name = "examples/complex_struct_space_torch",
     main = "examples/complex_struct_space.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/complex_struct_space.py"],
     args = ["--framework=torch"],
@@ -2882,7 +2882,7 @@ py_test(
 py_test(
     name = "examples/curriculum_learning",
     main = "examples/curriculum_learning.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/curriculum_learning.py"],
     args = ["--as-test", "--stop-reward=800.0"]
@@ -2891,7 +2891,7 @@ py_test(
 py_test(
     name = "examples/custom_env_tf",
     main = "examples/custom_env.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/custom_env.py"],
     args = ["--as-test"]
@@ -2900,7 +2900,7 @@ py_test(
 py_test(
     name = "examples/custom_env_torch",
     main = "examples/custom_env.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/custom_env.py"],
     args = ["--as-test", "--framework=torch"]
@@ -2909,7 +2909,7 @@ py_test(
 py_test(
     name = "examples/custom_eval_tf",
     main = "examples/custom_eval.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/custom_eval.py"],
     args = ["--num-cpus=4", "--as-test"]
@@ -2918,7 +2918,7 @@ py_test(
 py_test(
     name = "examples/custom_eval_torch",
     main = "examples/custom_eval.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/custom_eval.py"],
     args = ["--num-cpus=4", "--as-test", "--framework=torch"]
@@ -2927,7 +2927,7 @@ py_test(
 py_test(
     name = "examples/custom_eval_parallel_to_training_torch",
     main = "examples/custom_eval.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/custom_eval.py"],
     args = ["--num-cpus=4", "--as-test", "--framework=torch", "--evaluation-parallel-to-training"]
@@ -2936,7 +2936,7 @@ py_test(
 py_test(
     name = "examples/custom_experiment",
     main = "examples/custom_experiment.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/custom_experiment.py"],
     args = ["--train-iterations=10"]
@@ -2945,7 +2945,7 @@ py_test(
 py_test(
     name = "examples/custom_fast_model_tf",
     main = "examples/custom_fast_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/custom_fast_model.py"],
     args = ["--stop-iters=1"]
@@ -2954,7 +2954,7 @@ py_test(
 py_test(
     name = "examples/custom_fast_model_torch",
     main = "examples/custom_fast_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/custom_fast_model.py"],
     args = ["--stop-iters=1", "--framework=torch"]
@@ -2963,7 +2963,7 @@ py_test(
 py_test(
     name = "examples/custom_keras_model_a2c",
     main = "examples/custom_keras_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/custom_keras_model.py"],
     args = ["--run=A2C", "--stop=50", "--num-cpus=4"]
@@ -2972,7 +2972,7 @@ py_test(
 py_test(
     name = "examples/custom_keras_model_dqn",
     main = "examples/custom_keras_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/custom_keras_model.py"],
     args = ["--run=DQN", "--stop=50"]
@@ -2981,7 +2981,7 @@ py_test(
 py_test(
     name = "examples/custom_keras_model_ppo",
     main = "examples/custom_keras_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/custom_keras_model.py"],
     args = ["--run=PPO", "--stop=50", "--num-cpus=4"]
@@ -2990,7 +2990,7 @@ py_test(
 py_test(
     name = "examples/custom_metrics_and_callbacks",
     main = "examples/custom_metrics_and_callbacks.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/custom_metrics_and_callbacks.py"],
     args = ["--stop-iters=2"]
@@ -2999,7 +2999,7 @@ py_test(
 py_test(
     name = "examples/custom_model_api_tf",
     main = "examples/custom_model_api.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/custom_model_api.py"],
 )
@@ -3007,7 +3007,7 @@ py_test(
 py_test(
     name = "examples/custom_model_api_torch",
     main = "examples/custom_model_api.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/custom_model_api.py"],
     args = ["--framework=torch"],
@@ -3016,7 +3016,7 @@ py_test(
 py_test(
     name = "examples/custom_model_loss_and_metrics_ppo_tf",
     main = "examples/custom_model_loss_and_metrics.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     # Include the json data file.
     data = ["tests/data/cartpole/small.json"],
@@ -3027,7 +3027,7 @@ py_test(
 py_test(
     name = "examples/custom_model_loss_and_metrics_ppo_torch",
     main = "examples/custom_model_loss_and_metrics.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     # Include the json data file.
     data = ["tests/data/cartpole/small.json"],
@@ -3038,7 +3038,7 @@ py_test(
 py_test(
     name = "examples/custom_model_loss_and_metrics_pg_tf",
     main = "examples/custom_model_loss_and_metrics.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     # Include the json data file.
     data = ["tests/data/cartpole/small.json"],
@@ -3049,7 +3049,7 @@ py_test(
 py_test(
     name = "examples/custom_model_loss_and_metrics_pg_torch",
     main = "examples/custom_model_loss_and_metrics.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     # Include the json data file.
     data = ["tests/data/cartpole/small.json"],
@@ -3060,7 +3060,7 @@ py_test(
 py_test(
     name = "examples/custom_observation_filters",
     main = "examples/custom_observation_filters.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/custom_observation_filters.py"],
     args = ["--stop-iters=3"]
@@ -3069,7 +3069,7 @@ py_test(
 py_test(
     name = "examples/custom_rnn_model_repeat_after_me_tf",
     main = "examples/custom_rnn_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/custom_rnn_model.py"],
     args = ["--as-test", "--run=PPO", "--stop-reward=40", "--env=RepeatAfterMeEnv", "--num-cpus=4"]
@@ -3078,7 +3078,7 @@ py_test(
 py_test(
     name = "examples/custom_rnn_model_repeat_initial_obs_tf",
     main = "examples/custom_rnn_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/custom_rnn_model.py"],
     args = ["--as-test", "--run=PPO", "--stop-reward=10", "--stop-timesteps=300000", "--env=RepeatInitialObsEnv", "--num-cpus=4"]
@@ -3087,7 +3087,7 @@ py_test(
 py_test(
     name = "examples/custom_rnn_model_repeat_after_me_torch",
     main = "examples/custom_rnn_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/custom_rnn_model.py"],
     args = ["--as-test", "--framework=torch", "--run=PPO", "--stop-reward=40", "--env=RepeatAfterMeEnv", "--num-cpus=4"]
@@ -3096,7 +3096,7 @@ py_test(
 py_test(
     name = "examples/custom_rnn_model_repeat_initial_obs_torch",
     main = "examples/custom_rnn_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/custom_rnn_model.py"],
     args = ["--as-test", "--framework=torch", "--run=PPO", "--stop-reward=10", "--stop-timesteps=300000", "--env=RepeatInitialObsEnv", "--num-cpus=4"]
@@ -3104,7 +3104,7 @@ py_test(
 
 py_test(
     name = "examples/custom_tf_policy",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/custom_tf_policy.py"],
     args = ["--stop-iters=2", "--num-cpus=4"]
@@ -3112,7 +3112,7 @@ py_test(
 
 py_test(
     name = "examples/custom_torch_policy",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/custom_torch_policy.py"],
     args = ["--stop-iters=2", "--num-cpus=4"]
@@ -3121,7 +3121,7 @@ py_test(
 py_test(
     name = "examples/custom_train_fn",
     main = "examples/custom_train_fn.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/custom_train_fn.py"],
 )
@@ -3129,7 +3129,7 @@ py_test(
 py_test(
     name = "examples/custom_vector_env_tf",
     main = "examples/custom_vector_env.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/custom_vector_env.py"],
     args = ["--as-test", "--stop-reward=40.0"]
@@ -3138,7 +3138,7 @@ py_test(
 py_test(
     name = "examples/custom_vector_env_torch",
     main = "examples/custom_vector_env.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/custom_vector_env.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=40.0"]
@@ -3147,7 +3147,7 @@ py_test(
 py_test(
     name = "examples/deterministic_training_tf",
     main = "examples/deterministic_training.py",
-    tags = ["team:rllib", "exclusive", "multi_gpu", "examples"],
+    tags = ["team:rl", "exclusive", "multi_gpu", "examples"],
     size = "medium",
     srcs = ["examples/deterministic_training.py"],
     args = ["--as-test", "--stop-iters=1", "--framework=tf", "--num-gpus=1", "--num-gpus-per-worker=1"]
@@ -3156,7 +3156,7 @@ py_test(
 py_test(
     name = "examples/deterministic_training_tf2",
     main = "examples/deterministic_training.py",
-    tags = ["team:rllib", "exclusive", "multi_gpu", "examples"],
+    tags = ["team:rl", "exclusive", "multi_gpu", "examples"],
     size = "medium",
     srcs = ["examples/deterministic_training.py"],
     args = ["--as-test", "--stop-iters=1", "--framework=tf2", "--num-gpus=1", "--num-gpus-per-worker=1"]
@@ -3165,7 +3165,7 @@ py_test(
 py_test(
     name = "examples/deterministic_training_torch",
     main = "examples/deterministic_training.py",
-    tags = ["team:rllib", "exclusive", "multi_gpu", "examples"],
+    tags = ["team:rl", "exclusive", "multi_gpu", "examples"],
     size = "medium",
     srcs = ["examples/deterministic_training.py"],
     args = ["--as-test", "--stop-iters=1", "--framework=torch", "--num-gpus=1", "--num-gpus-per-worker=1"]
@@ -3173,7 +3173,7 @@ py_test(
 
 py_test(
     name = "examples/eager_execution",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/eager_execution.py"],
     args = ["--stop-iters=2"]
@@ -3182,7 +3182,7 @@ py_test(
 py_test(
     name = "examples/export/cartpole_dqn_export",
     main = "examples/export/cartpole_dqn_export.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/export/cartpole_dqn_export.py"],
 )
@@ -3190,7 +3190,7 @@ py_test(
 py_test(
     name = "examples/export/onnx_tf",
     main = "examples/export/onnx_tf.py",
-    tags = ["team:rllib", "exclusive", "examples", "no_main"],
+    tags = ["team:rl", "exclusive", "examples", "no_main"],
     size = "small",
     srcs = ["examples/export/onnx_tf.py"],
     args = ["--framework=tf"],
@@ -3199,7 +3199,7 @@ py_test(
 py_test(
     name = "examples/export/onnx_tf2",
     main = "examples/export/onnx_tf.py",
-    tags = ["team:rllib", "exclusive", "examples", "no_main"],
+    tags = ["team:rl", "exclusive", "examples", "no_main"],
     size = "small",
     srcs = ["examples/export/onnx_tf.py"],
     args = ["--framework=tf2"],
@@ -3208,7 +3208,7 @@ py_test(
 py_test(
     name = "examples/export/onnx_torch",
     main = "examples/export/onnx_torch.py",
-    tags = ["team:rllib", "exclusive", "examples", "no_main"],
+    tags = ["team:rl", "exclusive", "examples", "no_main"],
     size = "small",
     srcs = ["examples/export/onnx_torch.py"],
 )
@@ -3216,7 +3216,7 @@ py_test(
 py_test(
     name = "examples/fractional_gpus",
     main = "examples/fractional_gpus.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/fractional_gpus.py"],
     args = ["--as-test", "--stop-reward=40.0", "--num-gpus=0", "--num-workers=0"]
@@ -3225,7 +3225,7 @@ py_test(
 py_test(
     name = "examples/hierarchical_training_tf",
     main = "examples/hierarchical_training.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/hierarchical_training.py"],
     args = ["--stop-reward=0.0"]
@@ -3234,7 +3234,7 @@ py_test(
 py_test(
     name = "examples/hierarchical_training_torch",
     main = "examples/hierarchical_training.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/hierarchical_training.py"],
     args = ["--framework=torch", "--stop-reward=0.0"]
@@ -3244,7 +3244,7 @@ py_test(
 # py_test(
 #     name = "examples/mobilenet_v2_with_lstm_tf",
 #     main = "examples/mobilenet_v2_with_lstm.py",
-#     tags = ["team:rllib", "examples"],
+#     tags = ["team:rl", "examples"],
 #     size = "small",
 #     srcs = ["examples/mobilenet_v2_with_lstm.py"]
 # )
@@ -3252,7 +3252,7 @@ py_test(
 py_test(
     name = "examples/multi_agent_cartpole_tf",
     main = "examples/multi_agent_cartpole.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/multi_agent_cartpole.py"],
     args = ["--as-test", "--stop-reward=70.0", "--num-cpus=4"]
@@ -3261,7 +3261,7 @@ py_test(
 py_test(
     name = "examples/multi_agent_cartpole_torch",
     main = "examples/multi_agent_cartpole.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/multi_agent_cartpole.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=70.0", "--num-cpus=4"]
@@ -3270,7 +3270,7 @@ py_test(
 py_test(
     name = "examples/multi_agent_cartpole_torch_w_rlm",
     main = "examples/multi_agent_cartpole.py",
-    tags = ["team:rllib", "exclusive", "examples", "rlm"],
+    tags = ["team:rl", "exclusive", "examples", "rlm"],
     size = "small",
     srcs = ["examples/multi_agent_cartpole.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=70.0", "--num-cpus=4"]
@@ -3279,7 +3279,7 @@ py_test(
 py_test(
     name = "examples/multi_agent_custom_policy_tf",
     main = "examples/multi_agent_custom_policy.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/multi_agent_custom_policy.py"],
     args = ["--as-test", "--stop-reward=80"]
@@ -3288,7 +3288,7 @@ py_test(
 py_test(
     name = "examples/multi_agent_custom_policy_torch",
     main = "examples/multi_agent_custom_policy.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/multi_agent_custom_policy.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=80"]
@@ -3297,7 +3297,7 @@ py_test(
 py_test(
     name = "examples/multi_agent_custom_policy_torch_w_rlm",
     main = "examples/multi_agent_custom_policy.py",
-    tags = ["team:rllib", "exclusive", "examples", "rlm"],
+    tags = ["team:rl", "exclusive", "examples", "rlm"],
     size = "small",
     srcs = ["examples/multi_agent_custom_policy.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=80"]
@@ -3306,7 +3306,7 @@ py_test(
 py_test(
     name = "examples/multi_agent_different_spaces_for_agents_tf2",
     main = "examples/multi_agent_different_spaces_for_agents.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/multi_agent_different_spaces_for_agents.py"],
     args = ["--stop-iters=4", "--framework=tf2", "--eager-tracing"]
@@ -3315,7 +3315,7 @@ py_test(
 py_test(
     name = "examples/multi_agent_different_spaces_for_agents_torch",
     main = "examples/multi_agent_different_spaces_for_agents.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/multi_agent_different_spaces_for_agents.py"],
     args = ["--stop-iters=4", "--framework=torch"]
@@ -3324,7 +3324,7 @@ py_test(
 py_test(
     name = "examples/multi_agent_different_spaces_for_agents_torch_w_rlm",
     main = "examples/multi_agent_different_spaces_for_agents.py",
-    tags = ["team:rllib", "exclusive", "examples", "rlm"],
+    tags = ["team:rl", "exclusive", "examples", "rlm"],
     size = "medium",
     srcs = ["examples/multi_agent_different_spaces_for_agents.py"],
     args = ["--stop-iters=4", "--framework=torch"]
@@ -3334,7 +3334,7 @@ py_test(
 py_test(
     name = "examples/multi_agent_two_trainers_tf",
     main = "examples/multi_agent_two_trainers.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/multi_agent_two_trainers.py"],
     args = ["--as-test", "--stop-reward=70"]
@@ -3343,7 +3343,7 @@ py_test(
 py_test(
     name = "examples/multi_agent_two_trainers_torch",
     main = "examples/multi_agent_two_trainers.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/multi_agent_two_trainers.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=70"]
@@ -3352,7 +3352,7 @@ py_test(
 py_test(
     name = "examples/offline_rl_torch",
     main = "examples/offline_rl.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/offline_rl.py"],
     args = ["--as-test", "--stop-reward=-300", "--stop-iters=1"]
@@ -3363,7 +3363,7 @@ py_test(
 # py_test(
 #     name = "examples/multi_agent_two_trainers_mixed_torch_tf",
 #     main = "examples/multi_agent_two_trainers.py",
-#     tags = ["team:rllib", "exclusive", "examples"],
+#     tags = ["team:rl", "exclusive", "examples"],
 #     size = "medium",
 #     srcs = ["examples/multi_agent_two_trainers.py"],
 #     args = ["--as-test", "--mixed-torch-tf", "--stop-reward=70"]
@@ -3372,7 +3372,7 @@ py_test(
 py_test(
     name = "examples/nested_action_spaces_ppo_tf",
     main = "examples/nested_action_spaces.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/nested_action_spaces.py"],
     args = ["--as-test", "--stop-reward=-600", "--run=PPO"]
@@ -3381,7 +3381,7 @@ py_test(
 py_test(
     name = "examples/nested_action_spaces_ppo_torch",
     main = "examples/nested_action_spaces.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/nested_action_spaces.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=-600", "--run=PPO"]
@@ -3390,7 +3390,7 @@ py_test(
 py_test(
     name = "examples/parallel_evaluation_and_training_13_episodes_tf",
     main = "examples/parallel_evaluation_and_training.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/parallel_evaluation_and_training.py"],
     args = ["--as-test", "--stop-reward=50.0", "--num-cpus=6", "--evaluation-duration=13"]
@@ -3399,7 +3399,7 @@ py_test(
 py_test(
     name = "examples/parallel_evaluation_and_training_auto_episodes_tf",
     main = "examples/parallel_evaluation_and_training.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/parallel_evaluation_and_training.py"],
     args = ["--as-test", "--stop-reward=50.0", "--num-cpus=6", "--evaluation-duration=auto"]
@@ -3408,7 +3408,7 @@ py_test(
 py_test(
     name = "examples/parallel_evaluation_and_training_211_ts_tf2",
     main = "examples/parallel_evaluation_and_training.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/parallel_evaluation_and_training.py"],
     args = ["--as-test", "--framework=tf2", "--stop-reward=30.0", "--num-cpus=6", "--evaluation-num-workers=3", "--evaluation-duration=211", "--evaluation-duration-unit=timesteps"]
@@ -3417,7 +3417,7 @@ py_test(
 py_test(
     name = "examples/parallel_evaluation_and_training_auto_ts_torch",
     main = "examples/parallel_evaluation_and_training.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/parallel_evaluation_and_training.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=30.0", "--num-cpus=6", "--evaluation-num-workers=3", "--evaluation-duration=auto", "--evaluation-duration-unit=timesteps"]
@@ -3426,7 +3426,7 @@ py_test(
 py_test(
     name = "examples/parametric_actions_cartpole_pg_tf",
     main = "examples/parametric_actions_cartpole.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/parametric_actions_cartpole.py"],
     args = ["--as-test", "--stop-reward=60.0", "--run=PG"]
@@ -3435,7 +3435,7 @@ py_test(
 py_test(
     name = "examples/parametric_actions_cartpole_dqn_tf",
     main = "examples/parametric_actions_cartpole.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/parametric_actions_cartpole.py"],
     args = ["--as-test", "--stop-reward=60.0", "--run=DQN"]
@@ -3444,7 +3444,7 @@ py_test(
 py_test(
     name = "examples/parametric_actions_cartpole_pg_torch",
     main = "examples/parametric_actions_cartpole.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/parametric_actions_cartpole.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=60.0", "--run=PG"]
@@ -3453,7 +3453,7 @@ py_test(
 py_test(
     name = "examples/parametric_actions_cartpole_dqn_torch",
     main = "examples/parametric_actions_cartpole.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/parametric_actions_cartpole.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=60.0", "--run=DQN"]
@@ -3462,7 +3462,7 @@ py_test(
 py_test(
     name = "examples/parametric_actions_cartpole_embeddings_learnt_by_model",
     main = "examples/parametric_actions_cartpole_embeddings_learnt_by_model.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/parametric_actions_cartpole_embeddings_learnt_by_model.py"],
     args = ["--as-test", "--stop-reward=80.0"]
@@ -3471,7 +3471,7 @@ py_test(
 py_test(
     name = "examples/inference_and_serving/policy_inference_after_training_tf",
     main = "examples/inference_and_serving/policy_inference_after_training.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/inference_and_serving/policy_inference_after_training.py"],
     args = ["--stop-iters=3", "--framework=tf"]
@@ -3480,7 +3480,7 @@ py_test(
 py_test(
     name = "examples/inference_and_serving/policy_inference_after_training_torch",
     main = "examples/inference_and_serving/policy_inference_after_training.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/inference_and_serving/policy_inference_after_training.py"],
     args = ["--stop-iters=3", "--framework=torch"]
@@ -3489,7 +3489,7 @@ py_test(
 py_test(
     name = "examples/inference_and_serving/policy_inference_after_training_with_attention_tf",
     main = "examples/inference_and_serving/policy_inference_after_training_with_attention.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/inference_and_serving/policy_inference_after_training_with_attention.py"],
     args = ["--stop-iters=2", "--framework=tf"]
@@ -3498,7 +3498,7 @@ py_test(
 py_test(
     name = "examples/inference_and_serving/policy_inference_after_training_with_attention_torch",
     main = "examples/inference_and_serving/policy_inference_after_training_with_attention.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/inference_and_serving/policy_inference_after_training_with_attention.py"],
     args = ["--stop-iters=2", "--framework=torch"]
@@ -3507,7 +3507,7 @@ py_test(
 py_test(
     name = "examples/inference_and_serving/policy_inference_after_training_with_dt_torch",
     main = "examples/inference_and_serving/policy_inference_after_training_with_dt.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/inference_and_serving/policy_inference_after_training_with_dt.py"],
     data = ["tests/data/cartpole/large.json"],
@@ -3517,7 +3517,7 @@ py_test(
 py_test(
     name = "examples/inference_and_serving/policy_inference_after_training_with_lstm_tf",
     main = "examples/inference_and_serving/policy_inference_after_training_with_lstm.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/inference_and_serving/policy_inference_after_training_with_lstm.py"],
     args = ["--stop-iters=1", "--framework=tf"]
@@ -3526,7 +3526,7 @@ py_test(
 py_test(
     name = "examples/inference_and_serving/policy_inference_after_training_with_lstm_torch",
     main = "examples/inference_and_serving/policy_inference_after_training_with_lstm.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/inference_and_serving/policy_inference_after_training_with_lstm.py"],
     args = ["--stop-iters=1", "--framework=torch"]
@@ -3535,7 +3535,7 @@ py_test(
 py_test(
     name = "examples/preprocessing_disabled_tf",
     main = "examples/preprocessing_disabled.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/preprocessing_disabled.py"],
     args = ["--stop-iters=2"]
@@ -3544,7 +3544,7 @@ py_test(
 py_test(
     name = "examples/preprocessing_disabled_torch",
     main = "examples/preprocessing_disabled.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/preprocessing_disabled.py"],
     args = ["--framework=torch", "--stop-iters=2"]
@@ -3553,7 +3553,7 @@ py_test(
 py_test(
     name = "examples/recommender_system_with_recsim_and_slateq_tf2",
     main = "examples/recommender_system_with_recsim_and_slateq.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "large",
     srcs = ["examples/recommender_system_with_recsim_and_slateq.py"],
     args = ["--stop-iters=2", "--num-steps-sampled-before-learning_starts=100", "--framework=tf2", "--use-tune", "--random-test-episodes=10", "--env-num-candidates=50", "--env-slate-size=2"],
@@ -3562,7 +3562,7 @@ py_test(
 py_test(
     name = "examples/remote_envs_with_inference_done_on_main_node_tf",
     main = "examples/remote_envs_with_inference_done_on_main_node.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/remote_envs_with_inference_done_on_main_node.py"],
     args = ["--as-test"],
@@ -3571,7 +3571,7 @@ py_test(
 py_test(
     name = "examples/remote_envs_with_inference_done_on_main_node_torch",
     main = "examples/remote_envs_with_inference_done_on_main_node.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/remote_envs_with_inference_done_on_main_node.py"],
     args = ["--as-test", "--framework=torch"],
@@ -3579,7 +3579,7 @@ py_test(
 
 # py_test(
 #    name = "examples/remote_base_env_with_custom_api",
-#    tags = ["team:rllib", "exclusive", "examples"],
+#    tags = ["team:rl", "exclusive", "examples"],
 #    size = "medium",
 #    srcs = ["examples/remote_base_env_with_custom_api.py"],
 #    args = ["--stop-iters=3"]
@@ -3587,14 +3587,14 @@ py_test(
 
 py_test(
     name = "examples/replay_buffer_api",
-    tags = ["team:rllib", "examples"],
+    tags = ["team:rl", "examples"],
     size = "large",
     srcs = ["examples/replay_buffer_api.py"],
 )
 
 py_test(
     name = "examples/restore_1_of_n_agents_from_checkpoint",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/restore_1_of_n_agents_from_checkpoint.py"],
     args = ["--pre-training-iters=1", "--stop-iters=1", "--num-cpus=4"]
@@ -3602,14 +3602,14 @@ py_test(
 
 py_test(
     name = "examples/rnnsac_stateless_cartpole",
-    tags = ["team:rllib", "exclusive", "gpu"],
+    tags = ["team:rl", "exclusive", "gpu"],
     size = "medium",
     srcs = ["examples/rnnsac_stateless_cartpole.py"]
 )
 
 py_test(
     name = "examples/rollout_worker_custom_workflow",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/rollout_worker_custom_workflow.py"],
     args = ["--num-cpus=4"]
@@ -3618,7 +3618,7 @@ py_test(
 py_test(
     name = "examples/rock_paper_scissors_multiagent_tf",
     main = "examples/rock_paper_scissors_multiagent.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/rock_paper_scissors_multiagent.py"],
     args = ["--as-test"],
@@ -3627,7 +3627,7 @@ py_test(
 py_test(
     name = "examples/rock_paper_scissors_multiagent_torch",
     main = "examples/rock_paper_scissors_multiagent.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/rock_paper_scissors_multiagent.py"],
     args = ["--as-test", "--framework=torch"],
@@ -3636,7 +3636,7 @@ py_test(
 py_test(
     name = "examples/self_play_with_open_spiel_connect_4_tf",
     main = "examples/self_play_with_open_spiel.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/self_play_with_open_spiel.py"],
     args = ["--framework=tf", "--env=connect_four", "--win-rate-threshold=0.6", "--stop-iters=2", "--num-episodes-human-play=0"]
@@ -3645,7 +3645,7 @@ py_test(
 py_test(
     name = "examples/self_play_with_open_spiel_connect_4_torch",
     main = "examples/self_play_with_open_spiel.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/self_play_with_open_spiel.py"],
     args = ["--framework=torch", "--env=connect_four", "--win-rate-threshold=0.6", "--stop-iters=2", "--num-episodes-human-play=0"]
@@ -3654,7 +3654,7 @@ py_test(
 py_test(
     name = "examples/self_play_with_open_spiel_connect_4_torch_w_rlm",
     main = "examples/self_play_with_open_spiel.py",
-    tags = ["team:rllib", "exclusive", "examples", "rlm"],
+    tags = ["team:rl", "exclusive", "examples", "rlm"],
     size = "medium",
     srcs = ["examples/self_play_with_open_spiel.py"],
     args = ["--framework=torch", "--env=connect_four", "--win-rate-threshold=0.6", "--stop-iters=2", "--num-episodes-human-play=0"]
@@ -3663,7 +3663,7 @@ py_test(
 py_test(
     name = "examples/self_play_league_based_with_open_spiel_markov_soccer_tf",
     main = "examples/self_play_league_based_with_open_spiel.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/self_play_league_based_with_open_spiel.py"],
     args = ["--framework=tf", "--env=markov_soccer", "--win-rate-threshold=0.6", "--stop-iters=2", "--num-episodes-human-play=0"]
@@ -3672,7 +3672,7 @@ py_test(
 py_test(
     name = "examples/self_play_league_based_with_open_spiel_markov_soccer_torch",
     main = "examples/self_play_league_based_with_open_spiel.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/self_play_league_based_with_open_spiel.py"],
     args = ["--framework=torch", "--env=markov_soccer", "--win-rate-threshold=0.6", "--stop-iters=2", "--num-episodes-human-play=0"]
@@ -3681,7 +3681,7 @@ py_test(
 py_test(
     name = "examples/self_play_league_based_with_open_spiel_markov_soccer_torch_w_rlm",
     main = "examples/self_play_league_based_with_open_spiel.py",
-    tags = ["team:rllib", "exclusive", "examples", "rlm"],
+    tags = ["team:rl", "exclusive", "examples", "rlm"],
     size = "medium",
     srcs = ["examples/self_play_league_based_with_open_spiel.py"],
     args = ["--framework=torch", "--env=markov_soccer", "--win-rate-threshold=0.6", "--stop-iters=2", "--num-episodes-human-play=0"]
@@ -3690,7 +3690,7 @@ py_test(
 py_test(
     name = "examples/trajectory_view_api_tf",
     main = "examples/trajectory_view_api.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/trajectory_view_api.py"],
     args = ["--as-test", "--framework=tf", "--stop-reward=100.0"]
@@ -3699,7 +3699,7 @@ py_test(
 py_test(
     name = "examples/trajectory_view_api_torch",
     main = "examples/trajectory_view_api.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/trajectory_view_api.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=100.0"]
@@ -3708,7 +3708,7 @@ py_test(
 py_test(
     name = "examples/tune/framework",
     main = "examples/tune/framework.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/tune/framework.py"],
     args = ["--smoke-test"]
@@ -3717,7 +3717,7 @@ py_test(
 py_test(
     name = "examples/two_trainer_workflow_tf",
     main = "examples/two_trainer_workflow.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/two_trainer_workflow.py"],
     args = ["--as-test", "--stop-reward=450.0"]
@@ -3726,7 +3726,7 @@ py_test(
 py_test(
     name = "examples/two_trainer_workflow_torch",
     main = "examples/two_trainer_workflow.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/two_trainer_workflow.py"],
     args = ["--as-test", "--torch", "--stop-reward=450.0"]
@@ -3735,7 +3735,7 @@ py_test(
 py_test(
     name = "examples/two_trainer_workflow_mixed_torch_tf",
     main = "examples/two_trainer_workflow.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/two_trainer_workflow.py"],
     args = ["--as-test", "--mixed-torch-tf", "--stop-reward=450.0"]
@@ -3744,7 +3744,7 @@ py_test(
 py_test(
     name = "examples/two_step_game_pg_tf",
     main = "examples/two_step_game.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/two_step_game.py"],
     args = ["--as-test", "--stop-reward=7", "--run=PG"]
@@ -3753,7 +3753,7 @@ py_test(
 py_test(
     name = "examples/two_step_game_pg_torch",
     main = "examples/two_step_game.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/two_step_game.py"],
     args = ["--as-test", "--framework=torch", "--stop-reward=7", "--run=PG"]
@@ -3763,7 +3763,7 @@ py_test(
 py_test(
     name = "examples/bandit/lin_ts_train_wheel_env",
     main = "examples/bandit/lin_ts_train_wheel_env.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/bandit/lin_ts_train_wheel_env.py"],
 )
@@ -3771,7 +3771,7 @@ py_test(
 py_test(
     name = "examples/bandit/tune_lin_ts_train_wheel_env",
     main = "examples/bandit/tune_lin_ts_train_wheel_env.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/bandit/tune_lin_ts_train_wheel_env.py"],
 )
@@ -3779,7 +3779,7 @@ py_test(
 py_test(
     name = "examples/bandit/tune_lin_ucb_train_recommendation",
     main = "examples/bandit/tune_lin_ucb_train_recommendation.py",
-    tags = ["team:rllib","exclusive",  "examples"],
+    tags = ["team:rl","exclusive",  "examples"],
     size = "small",
     srcs = ["examples/bandit/tune_lin_ucb_train_recommendation.py"],
 )
@@ -3787,7 +3787,7 @@ py_test(
 py_test(
     name = "examples/bandit/tune_lin_ucb_train_recsim_env",
     main = "examples/bandit/tune_lin_ucb_train_recsim_env.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/bandit/tune_lin_ucb_train_recsim_env.py"],
 )
@@ -3795,7 +3795,7 @@ py_test(
 py_test(
     name = "examples/connectors/run_connector_policy",
     main = "examples/connectors/run_connector_policy.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/connectors/run_connector_policy.py"],
     data = glob([
@@ -3807,7 +3807,7 @@ py_test(
 py_test(
     name = "examples/connectors/adapt_connector_policy",
     main = "examples/connectors/adapt_connector_policy.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/connectors/adapt_connector_policy.py"],
     data = glob([
@@ -3819,7 +3819,7 @@ py_test(
 py_test(
     name = "examples/connectors/self_play_with_policy_checkpoint",
     main = "examples/connectors/self_play_with_policy_checkpoint.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rl", "exclusive", "examples"],
     size = "small",
     srcs = ["examples/connectors/self_play_with_policy_checkpoint.py"],
     data = glob([
@@ -3842,7 +3842,7 @@ py_test(
 py_test(
     name = "examples/documentation/custom_gym_env",
     main = "examples/documentation/custom_gym_env.py",
-    tags = ["team:rllib", "documentation", "no_main"],
+    tags = ["team:rl", "documentation", "no_main"],
     size = "medium",
     srcs = ["examples/documentation/custom_gym_env.py"],
 )
@@ -3850,7 +3850,7 @@ py_test(
 py_test(
     name = "examples/documentation/saving_and_loading_algos_and_policies",
     main = "examples/documentation/saving_and_loading_algos_and_policies.py",
-    tags = ["team:rllib", "documentation", "no_main"],
+    tags = ["team:rl", "documentation", "no_main"],
     size = "medium",
     srcs = ["examples/documentation/saving_and_loading_algos_and_policies.py"],
 )
@@ -3858,7 +3858,7 @@ py_test(
 py_test(
     name = "examples/documentation/replay_buffer_demo",
     main = "examples/documentation/replay_buffer_demo.py",
-    tags = ["team:rllib", "documentation", "no_main"],
+    tags = ["team:rl", "documentation", "no_main"],
     size = "medium",
     srcs = ["examples/documentation/replay_buffer_demo.py"],
 )
@@ -3866,7 +3866,7 @@ py_test(
 py_test(
     name = "examples/documentation/rllib_on_ray_readme",
     main = "examples/documentation/rllib_on_ray_readme.py",
-    tags = ["team:rllib", "documentation", "no_main"],
+    tags = ["team:rl", "documentation", "no_main"],
     size = "medium",
     srcs = ["examples/documentation/rllib_on_ray_readme.py"],
 )
@@ -3874,7 +3874,7 @@ py_test(
 py_test(
     name = "examples/documentation/rllib_on_rllib_readme",
     main = "examples/documentation/rllib_on_rllib_readme.py",
-    tags = ["team:rllib", "documentation", "no_main"],
+    tags = ["team:rl", "documentation", "no_main"],
     size = "medium",
     srcs = ["examples/documentation/rllib_on_rllib_readme.py"],
 )
@@ -3897,5 +3897,5 @@ py_test_module_list(
   size = "large",
   extra_srcs = [],
   deps = [],
-  tags = ["manual", "team:rllib", "no_main"],
+  tags = ["manual", "team:rl", "no_main"],
 )


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

We currently have two tags:
This one unifies to `rl`.

<img width="953" alt="Screenshot 2023-01-29 at 14 09 25" src="https://user-images.githubusercontent.com/9356806/215359010-14163c6d-d0b7-42b0-a067-e365063efba8.png">
