### PR TITLE
[Doc] add job overview diagram to the job overview page

### DIFF
--- a/doc/source/cluster/running-applications/job-submission/index.md
+++ b/doc/source/cluster/running-applications/job-submission/index.md
@@ -3,6 +3,7 @@
 # Ray Jobs Overview
 
 Once you have deployed a Ray cluster (on [VMs](vm-cluster-quick-start) or [Kubernetes](kuberay-quickstart)), you are ready to run a Ray application!
+![A diagram that shows three ways of running a job on a Ray cluster.](../../images/ray-job-diagram.svg "Three ways of running a job on a Ray cluster.")
 
 ## Ray Jobs API
 


### PR DESCRIPTION
Signed-off-by: Huaiwei Sun <scottsun94@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This diagram is currently only placed on the key concepts page. However, when I search for ray jobs, I usually only end up on the job overview page and couldn't find this diagram. This diagram will be very helpful to people who need an overview of ray jobs which this page is intended for.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
