### PR TITLE
[CI] Increase target time for `test_result_throughput_cluster`

### DIFF
--- a/release/ray_release/alerts/tune_tests.py
+++ b/release/ray_release/alerts/tune_tests.py
@@ -44,7 +44,7 @@ def handle_result(
         target_time = 900 if not was_smoke_test else 400
     elif test_name == "result_throughput_cluster":
         target_terminated = 1000
-        target_time = 135
+        target_time = 130
     elif test_name == "result_throughput_single_node":
         target_terminated = 96
         target_time = 120

--- a/release/ray_release/alerts/tune_tests.py
+++ b/release/ray_release/alerts/tune_tests.py
@@ -44,7 +44,7 @@ def handle_result(
         target_time = 900 if not was_smoke_test else 400
     elif test_name == "result_throughput_cluster":
         target_terminated = 1000
-        target_time = 130
+        target_time = 160
     elif test_name == "result_throughput_single_node":
         target_terminated = 96
         target_time = 120

--- a/release/tune_tests/scalability_tests/workloads/test_result_throughput_cluster.py
+++ b/release/tune_tests/scalability_tests/workloads/test_result_throughput_cluster.py
@@ -8,7 +8,7 @@ Cluster: cluster_16x64.yaml
 
 Test owner: krfricke
 
-Acceptance criteria: Should run faster than 135 seconds.
+Acceptance criteria: Should run faster than 130 seconds.
 
 Theoretical minimum time: 100 seconds
 """

--- a/release/tune_tests/scalability_tests/workloads/test_result_throughput_cluster.py
+++ b/release/tune_tests/scalability_tests/workloads/test_result_throughput_cluster.py
@@ -8,7 +8,7 @@ Cluster: cluster_16x64.yaml
 
 Test owner: krfricke
 
-Acceptance criteria: Should run faster than 130 seconds.
+Acceptance criteria: Should run faster than 160 seconds.
 
 Theoretical minimum time: 100 seconds
 """

--- a/release/tune_tests/scalability_tests/workloads/test_result_throughput_cluster.py
+++ b/release/tune_tests/scalability_tests/workloads/test_result_throughput_cluster.py
@@ -31,11 +31,11 @@ def main():
     results_per_second = 0.5
     trial_length_s = 100
 
-    max_runtime = 160
+    max_runtime = 130
 
     if _is_ray_cluster():
         # Add constant overhead for SSH connection
-        max_runtime = 130
+        max_runtime = 160
 
     timed_tune_run(
         name="result throughput cluster",

--- a/release/tune_tests/scalability_tests/workloads/test_result_throughput_cluster.py
+++ b/release/tune_tests/scalability_tests/workloads/test_result_throughput_cluster.py
@@ -31,7 +31,7 @@ def main():
     results_per_second = 0.5
     trial_length_s = 100
 
-    max_runtime = 130
+    max_runtime = 160
 
     if _is_ray_cluster():
         # Add constant overhead for SSH connection


### PR DESCRIPTION
https://github.com/ray-project/ray/issues/31337 has become flaky again due to a low timeout. This PR follows https://github.com/ray-project/ray/pull/31338 and increases the timeout.