### PR TITLE
[Serve] Mark `long_running_serve_failure` test as `stable`

### DIFF
--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -25,6 +25,8 @@ NUM_NODES = 4
 
 # RandomTest setup constants
 CPUS_PER_NODE = 10
+NUM_ITERATIONS = 350
+ACTIONS_PER_ITERATION = 20
 
 RAY_UNIT_TEST = "RAY_UNIT_TEST" in os.environ
 
@@ -138,11 +140,10 @@ class RandomTest:
                 time.sleep(0.01)
 
     def run(self):
-        iteration = 0
         start_time = time.time()
         previous_time = start_time
-        while True:
-            for _ in range(20):
+        for iteration in range(NUM_ITERATIONS):
+            for _ in range(ACTIONS_PER_ITERATION):
                 actions, weights = zip(*self.weighted_actions)
                 action_chosen = random.choices(actions, weights=weights)[0]
                 print(f"Executing {action_chosen}")

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -167,7 +167,6 @@ class RandomTest:
                 }
             )
             previous_time = new_time
-            iteration += 1
 
             if RAY_UNIT_TEST:
                 break

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2062,7 +2062,7 @@
   group: Long running tests
   working_dir: long_running_tests
 
-  stable: false
+  stable: true
 
   legacy:
     test_name: serve_failure


### PR DESCRIPTION
Signed-off-by: Shreyas Krishnaswamy <shrekris@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `long_running_serve_failure` release test is marked as unstable due to recent failures. Recently, #31945 and #32011 have resolved the root causes of these failures. After those changes, [the test ran successfully for 15+ hours](https://github.com/ray-project/ray/issues/31741#issuecomment-1409176353) without failure. This change limits the test's iterations, so it doesn't run forever, and it marks the test as stable.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #31741

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Release tests
     - This change modifies the `long_running_serve_failure` test.
