### PR TITLE
[core] Reduce the timeout for many nodes actor tests.

### DIFF
--- a/release/benchmarks/distributed/many_nodes_tests/actor_test.py
+++ b/release/benchmarks/distributed/many_nodes_tests/actor_test.py
@@ -118,7 +118,10 @@ def main():
             result["perf_metrics"] = perf
             dashboard_test.update_release_test_result(result)
 
+        print(f"Writing data into file: {os.environ['TEST_OUTPUT_JSON']}")
         json.dump(result, out_file)
+    print(f"Result: {json.dumps(result, indent=2)}")
+    print("Test finished successfully!")
 
 
 if __name__ == "__main__":

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3887,7 +3887,7 @@
     cluster_compute: distributed/many_nodes_tests/compute_config.yaml
 
   run:
-    timeout: 7200
+    timeout: 3600
     # 2cpus per node x 1000 nodes / 0.2 cpus per actor = 10k
     # 2cpus per node x 2000 nodes / 0.2 cpus per actor = 20k
     script: python distributed/many_nodes_tests/actor_test.py --no-wait --cpus-per-actor=0.2 --total-actors 10000 20000


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Reduce the timeout for many nodes actor test given that a test should finish within 1h.
It can save some cost for problematic runs.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
