### PR TITLE
[Ray 2.3 release] Marking RLLib release tests as unstable if xfail

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2824,6 +2824,9 @@
     test_name: learning_tests
     test_suite: rllib_tests
 
+  # Marking unstable since it's currently expected to fail.
+  stable: false
+
   frequency: nightly
   team: rllib
   env: staging
@@ -2894,6 +2897,9 @@
   team: rllib
   env: staging
 
+  # Marking unstable since it's currently expected to fail.
+  stable: false
+
   cluster:
     cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
@@ -2911,6 +2917,9 @@
   legacy:
     test_name: learning_tests
     test_suite: rllib_tests
+
+  # Marking unstable since it's currently expected to fail.
+  stable: false
 
   frequency: nightly
   team: rllib
@@ -3002,6 +3011,9 @@
   legacy:
     test_name: learning_tests
     test_suite: rllib_tests
+
+  # Marking unstable since it's currently expected to fail.
+  stable: false
 
   frequency: nightly
   team: rllib
@@ -3118,6 +3130,9 @@
     test_name: learning_tests
     test_suite: rllib_tests
 
+  # Marking unstable since it's currently expected to fail.
+  stable: false
+
   frequency: nightly
   team: rllib
   env: staging
@@ -3140,6 +3155,9 @@
   legacy:
     test_name: learning_tests
     test_suite: rllib_tests
+
+  # Marking unstable since it's currently expected to fail.
+  stable: false
 
   frequency: nightly
   team: rllib
@@ -3186,6 +3204,9 @@
   legacy:
     test_name: learning_tests
     test_suite: rllib_tests
+
+  # Marking unstable since it's currently expected to fail.
+  stable: false
 
   frequency: nightly
   team: rllib

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2757,6 +2757,9 @@
     test_name: learning_tests
     test_suite: rllib_tests
 
+  # Marking as unstable since it's currently expected to fail.
+  stable: false
+
   frequency: nightly
   team: rllib
   env: staging
@@ -2824,7 +2827,7 @@
     test_name: learning_tests
     test_suite: rllib_tests
 
-  # Marking unstable since it's currently expected to fail.
+  # Marking as unstable since it's currently expected to fail.
   stable: false
 
   frequency: nightly
@@ -2897,7 +2900,7 @@
   team: rllib
   env: staging
 
-  # Marking unstable since it's currently expected to fail.
+  # Marking as unstable since it's currently expected to fail.
   stable: false
 
   cluster:
@@ -2918,7 +2921,7 @@
     test_name: learning_tests
     test_suite: rllib_tests
 
-  # Marking unstable since it's currently expected to fail.
+  # Marking as unstable since it's currently expected to fail.
   stable: false
 
   frequency: nightly
@@ -3012,7 +3015,7 @@
     test_name: learning_tests
     test_suite: rllib_tests
 
-  # Marking unstable since it's currently expected to fail.
+  # Marking as unstable since it's currently expected to fail.
   stable: false
 
   frequency: nightly
@@ -3130,7 +3133,7 @@
     test_name: learning_tests
     test_suite: rllib_tests
 
-  # Marking unstable since it's currently expected to fail.
+  # Marking as unstable since it's currently expected to fail.
   stable: false
 
   frequency: nightly
@@ -3156,7 +3159,7 @@
     test_name: learning_tests
     test_suite: rllib_tests
 
-  # Marking unstable since it's currently expected to fail.
+  # Marking as unstable since it's currently expected to fail.
   stable: false
 
   frequency: nightly
@@ -3205,7 +3208,7 @@
     test_name: learning_tests
     test_suite: rllib_tests
 
-  # Marking unstable since it's currently expected to fail.
+  # Marking as unstable since it's currently expected to fail.
   stable: false
 
   frequency: nightly
@@ -3298,6 +3301,9 @@
   legacy:
     test_name: learning_tests
     test_suite: rllib_tests
+
+  # Marking as unstable since it's currently expected to fail.
+  stable: false
 
   frequency: nightly
   team: rllib


### PR DESCRIPTION
There are a few RLLib release tests that currently are expected to fail. This PR marks them as unstable to simplify the overhead of the release manager.