### PR TITLE
[docs]Update top-navigation.js

### DIFF
--- a/doc/source/_static/js/top-navigation.js
+++ b/doc/source/_static/js/top-navigation.js
@@ -100,7 +100,7 @@ learnMenu.setAttribute("class", "menu")
 learnMenu.innerHTML = "<a href='#'>Resources" + downCaret + "</a>"
 learnList = document.createElement("ul")
 learnList.innerHTML += "<li><a href='https://discuss.ray.io/'><span class='primary'>Discussion Forum</span><span class='secondary'>Get your Ray questions answered</span></a></li>"
-learnList.innerHTML += "<li><a href='https://www.anyscale.com/events?type=anyscale-academy'><span class='primary'>Training</span><span class='secondary'>Hands-on learning</span></a></li>"
+learnList.innerHTML += "<li><a href='https://github.com/ray-project/ray-educational-materials'><span class='primary'>Training</span><span class='secondary'>Hands-on learning</span></a></li>"
 learnList.innerHTML += "<li><a href='https://www.anyscale.com/blog'><span class='primary'>Blog</span><span class='secondary'>Updates, best practices, user-stories</span></a></li>"
 learnList.innerHTML += "<li><a href='https://www.anyscale.com/events'><span class='primary'>Events</span><span class='secondary'>Webinars, meetups, office hours</span></a></li>"
 learnList.innerHTML += "<li><a href='https://www.anyscale.com/user-stories'><span class='primary'>Success Stories</span><span class='secondary'>Real-world workload examples</span></a></li>"


### PR DESCRIPTION
Fix link for Resources>Training to point to the training modules on GH instead of the events page.

Signed-off-by: angelinalg <122562471+angelinalg@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, the dropdown menu "Resources" in the Ray documentation contains a link called "Training." This link points to the [same site](https://www.anyscale.com/events) as "Events." However, we want this to direct to the repository of [technical training content](https://github.com/ray-project/ray-educational-materials).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
