### PR TITLE
[observability][autoscaler] Ensure pending nodes is reset to 0 after scaling

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -1365,7 +1365,6 @@ class StandardAutoscaler:
     def launch_new_node(self, count: int, node_type: str) -> None:
         logger.info("StandardAutoscaler: Queue {} new nodes for launch".format(count))
         self.pending_launches.inc(node_type, count)
-        self.prom_metrics.pending_nodes.set(self.pending_launches.value)
         config = copy.deepcopy(self.config)
         if self.foreground_node_launch:
             assert self.foreground_node_launcher is not None

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -417,8 +417,9 @@ class Monitor:
                             ).set(pending)
 
                     self.prom_metrics.pending_nodes.set(
-                        len(autoscaler_summary.pending_nodes) +
-                        len(autoscaler_summary.pending_launches))
+                        len(autoscaler_summary.pending_nodes)
+                        + len(autoscaler_summary.pending_launches)
+                    )
 
                     for msg in self.event_summarizer.summary():
                         # Need to prefix each line of the message for the lines to

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -416,6 +416,10 @@ class Monitor:
                                 SessionName=self.prom_metrics.session_name,
                             ).set(pending)
 
+                    self.prom_metrics.pending_nodes.set(
+                        len(autoscaler_summary.pending_nodes) +
+                        len(autoscaler_summary.pending_launches))
+
                     for msg in self.event_summarizer.summary():
                         # Need to prefix each line of the message for the lines to
                         # get pushed to the driver logs.

--- a/python/ray/autoscaler/_private/node_launcher.py
+++ b/python/ray/autoscaler/_private/node_launcher.py
@@ -65,7 +65,6 @@ class BaseNodeLauncher:
         self.log("Got {} nodes to launch.".format(count))
         self._launch_node(config, count, node_type)
         self.pending.dec(node_type, count)
-        self.prom_metrics.pending_nodes.set(self.pending.value)
 
     def _launch_node(self, config: Dict[str, Any], count: int, node_type: str):
         if self.node_types:

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -2256,7 +2256,6 @@ class AutoscalingTest(unittest.TestCase):
         waiters = rtc1._cond._waiters
         self.waitFor(lambda: len(waiters) == 2)
         assert autoscaler.pending_launches.value == 10
-        mock_metrics.pending_nodes.set.assert_called_with(10)
         assert (
             len(
                 self.provider.non_terminated_nodes(
@@ -2281,11 +2280,9 @@ class AutoscalingTest(unittest.TestCase):
         )
         self.waitForNodes(10, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
         assert autoscaler.pending_launches.value == 0
-        mock_metrics.pending_nodes.set.assert_called_with(0)
         autoscaler.update()
         self.waitForNodes(10, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
         assert autoscaler.pending_launches.value == 0
-        mock_metrics.pending_nodes.set.assert_called_with(0)
         assert mock_metrics.drain_node_exceptions.inc.call_count == 0
 
     def testUpdateThrottling(self):

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -91,7 +91,7 @@ def test_metrics(shutdown_only):
                 return True
 
         zero_reported_condition = get_metric_check_condition(
-            {"autoscaler_cluster_resources": 0, "autoscaler_pending_resources": 0},
+            {"autoscaler_cluster_resources": 0, "autoscaler_pending_resources": 0, "autoscaler_pending_nodes": 0,},
             export_addr=autoscaler_export_addr,
         )
         wait_for_condition(zero_reported_condition)
@@ -100,7 +100,7 @@ def test_metrics(shutdown_only):
         ray.get([actor.ping.remote() for actor in actors])
 
         two_cpu_no_pending_condition = get_metric_check_condition(
-            {"autoscaler_cluster_resources": 2, "autoscaler_pending_resources": 0},
+            {"autoscaler_cluster_resources": 2, "autoscaler_pending_resources": 0, "autoscaler_pending_nodes": 0,},
             export_addr=autoscaler_export_addr,
         )
         wait_for_condition(two_cpu_no_pending_condition)

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -91,7 +91,11 @@ def test_metrics(shutdown_only):
                 return True
 
         zero_reported_condition = get_metric_check_condition(
-            {"autoscaler_cluster_resources": 0, "autoscaler_pending_resources": 0, "autoscaler_pending_nodes": 0,},
+            {
+                "autoscaler_cluster_resources": 0,
+                "autoscaler_pending_resources": 0,
+                "autoscaler_pending_nodes": 0,
+            },
             export_addr=autoscaler_export_addr,
         )
         wait_for_condition(zero_reported_condition)
@@ -100,7 +104,11 @@ def test_metrics(shutdown_only):
         ray.get([actor.ping.remote() for actor in actors])
 
         two_cpu_no_pending_condition = get_metric_check_condition(
-            {"autoscaler_cluster_resources": 2, "autoscaler_pending_resources": 0, "autoscaler_pending_nodes": 0,},
+            {
+                "autoscaler_cluster_resources": 2,
+                "autoscaler_pending_resources": 0,
+                "autoscaler_pending_nodes": 0,
+            },
             export_addr=autoscaler_export_addr,
         )
         wait_for_condition(two_cpu_no_pending_condition)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The previous way pending_nodes was calculated was prone to race conditions, instead, let's just always publish it in the main thread with other metrics.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #31982

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
