### PR TITLE
[Do not merge] Compare 2.2.0 release benchmarks against 2.3 master branch

### DIFF
--- a/release/release_logs/2.2.0/benchmarks/many_actors.json
+++ b/release/release_logs/2.2.0/benchmarks/many_actors.json
@@ -1,15 +1,32 @@
 {
-    "_peak_memory": 3.18,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n291\t1.44GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2023\t0.85GiB\tpython distributed/test_many_actors.py\n415\t0.35GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n47\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n717\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n44\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-notebook --NotebookApp.token=aph0_Ckc\n2160\t0.06GiB\tray::MemoryMonitorActor.run\n342\t0.05GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.240.63:9031 --host=0.0.0.0\n615\t0.05GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/log_m\n542\t0.02GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=",
-    "actors_per_second": 600.3905147006428,
+    "_dashboard_memory_usage_mb": 427.753472,
+    "_dashboard_test_success": true,
+    "_peak_memory": 6.35,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n291\t4.5GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3424\t0.86GiB\tpython distributed/test_many_actors.py\n464\t0.31GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n47\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n3646\t0.08GiB\tray::DashboardTester.run\n765\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n44\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-notebook --NotebookApp.token=aph0_CkY\n3561\t0.06GiB\tray::MemoryMonitorActor.run\n391\t0.05GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.252.180:9031 --host=0.0.0.\n663\t0.05GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/log_m",
+    "actors_per_second": 764.2541981782514,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 600.3905147006428
+            "perf_metric_value": 764.2541981782514
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 17.429
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 345.315
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4157.664
         }
     ],
     "success": "1",
-    "time": 16.655826091766357
+    "time": 13.084651708602905
 }

--- a/release/release_logs/2.2.0/benchmarks/many_nodes.json
+++ b/release/release_logs/2.2.0/benchmarks/many_nodes.json
@@ -1,15 +1,38 @@
 {
-    "_peak_memory": 1.15,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n291\t0.2GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3002\t0.18GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n415\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n47\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n3204\t0.07GiB\tray::StateAPIGeneratorActor.start\n3139\t0.06GiB\tray::MemoryMonitorActor.run\n798\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n44\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-notebook --NotebookApp.token=agh0_Ckg\n342\t0.05GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.151.143:9031 --host=0.0.0.\n615\t0.05GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/log_m",
+    "_dashboard_memory_usage_mb": 233.955328,
+    "_dashboard_test_success": true,
+    "_peak_memory": 4.43,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n291\t3.28GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n464\t0.21GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n3080\t0.19GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n47\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n765\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n3302\t0.07GiB\tray::DashboardTester.run\n3381\t0.07GiB\tray::StateAPIGeneratorActor.start\n3215\t0.06GiB\tray::MemoryMonitorActor.run\n44\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-notebook --NotebookApp.token=agh0_Ckg\n391\t0.05GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.139.139:9031 --host=0.0.0.",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10.05839692054449
+            "perf_metric_value": 9.578374462181227
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 250.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.208
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 26.241
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 124.386
         }
     ],
     "success": "1",
-    "tasks_per_second": 10.05839692054449,
-    "time": 399.4194211959839
+    "tasks_per_second": 9.578374462181227,
+    "time": 404.4018485546112,
+    "used_cpus": 250.0
 }

--- a/release/release_logs/2.2.0/benchmarks/many_pgs.json
+++ b/release/release_logs/2.2.0/benchmarks/many_pgs.json
@@ -1,15 +1,32 @@
 {
-    "_peak_memory": 1.58,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n291\t0.58GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3057\t0.31GiB\tpython distributed/test_many_pgs.py\n415\t0.13GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n47\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n542\t0.08GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=\n716\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n3192\t0.06GiB\tray::MemoryMonitorActor.run\n44\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-notebook --NotebookApp.token=aph0_Ckc\n342\t0.05GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.238.30:9031 --host=0.0.0.0\n615\t0.05GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/log_m",
+    "_dashboard_memory_usage_mb": 186.888192,
+    "_dashboard_test_success": true,
+    "_peak_memory": 4.38,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n291\t3.33GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2512\t0.23GiB\tpython distributed/test_many_pgs.py\n464\t0.14GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n47\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n765\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n590\t0.08GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=\n2647\t0.06GiB\tray::MemoryMonitorActor.run\n44\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-notebook --NotebookApp.token=aph0_Ckc\n2732\t0.06GiB\tray::DashboardTester.run\n391\t0.05GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.153.35:9031 --host=0.0.0.0",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 16.829968864206098
+            "perf_metric_value": 18.321118079596065
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.133
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 11.277
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 136.774
         }
     ],
-    "pgs_per_second": 16.829968864206098,
+    "pgs_per_second": 18.321118079596065,
     "success": "1",
-    "time": 59.417816400527954
+    "time": 54.58182168006897
 }

--- a/release/release_logs/2.2.0/benchmarks/many_tasks.json
+++ b/release/release_logs/2.2.0/benchmarks/many_tasks.json
@@ -1,15 +1,38 @@
 {
-    "_peak_memory": 2.95,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n291\t1.11GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2033\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n415\t0.45GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n47\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n2240\t0.07GiB\tray::StateAPIGeneratorActor.start\n717\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n2169\t0.06GiB\tray::MemoryMonitorActor.run\n44\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-notebook --NotebookApp.token=aph0_Ckg\n342\t0.05GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.171.196:9031 --host=0.0.0.\n615\t0.05GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/log_m",
+    "_dashboard_memory_usage_mb": 446.6688,
+    "_dashboard_test_success": true,
+    "_peak_memory": 6.4,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n291\t4.35GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2440\t0.73GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n464\t0.5GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n2659\t0.1GiB\tray::DashboardTester.run\n47\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n765\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n2724\t0.07GiB\tray::StateAPIGeneratorActor.start\n2575\t0.06GiB\tray::MemoryMonitorActor.run\n44\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-notebook --NotebookApp.token=aph0_Ckc\n391\t0.05GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.181.115:9031 --host=0.0.0.",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27.08832351001015
+            "perf_metric_value": 26.7708503965987
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1726.75
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.396
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 245.56
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 767.356
         }
     ],
     "success": "1",
-    "tasks_per_second": 27.08832351001015,
-    "time": 669.162750005722
+    "tasks_per_second": 26.7708503965987,
+    "time": 673.5406179428101,
+    "used_cpus": 1726.75
 }

--- a/release/release_logs/2.2.0/microbenchmark.json
+++ b/release/release_logs/2.2.0/microbenchmark.json
@@ -1,274 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        5770.038567273023,
-        206.44389261979617
+        6891.810983940368,
+        158.90447500223524
     ],
     "1_1_actor_calls_concurrent": [
-        4668.012480386666,
-        76.96043329916138
+        4600.118710434536,
+        185.68090874199228
     ],
     "1_1_actor_calls_sync": [
-        2181.5451120926223,
-        32.66603381414397
+        2124.9132137079505,
+        95.76505353572665
     ],
     "1_1_async_actor_calls_async": [
-        2746.018365776892,
-        28.674614193223935
+        2938.3869503327624,
+        211.3601552693039
     ],
     "1_1_async_actor_calls_sync": [
-        1479.0342425173185,
-        54.61144402719159
+        1485.131572774145,
+        5.900809744936613
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2087.8113920074993,
-        129.27044131913016
+        2135.7604313398756,
+        87.7178518172901
     ],
     "1_n_actor_calls_async": [
-        11646.429573331836,
-        186.28612826816098
+        10264.35850171556,
+        523.0041873281805
     ],
     "1_n_async_actor_calls_async": [
-        10613.303070856366,
-        80.42114185266792
+        9558.899002308037,
+        50.371006779937524
     ],
     "client__1_1_actor_calls_async": [
-        884.3193857194137,
-        16.65105872726005
+        945.3308717388207,
+        9.80963377810469
     ],
     "client__1_1_actor_calls_concurrent": [
-        869.9137568724132,
-        21.532105224423685
+        950.2416789794908,
+        10.613602385349074
     ],
     "client__1_1_actor_calls_sync": [
-        473.24166933984384,
-        5.283691471724411
+        511.642935750412,
+        6.1916675846126195
     ],
     "client__get_calls": [
-        1076.6787125404312,
-        59.134034063864476
+        1093.4303789307519,
+        55.85058477806556
     ],
     "client__put_calls": [
-        837.6281468983028,
-        16.408932890437775
+        829.8430791435788,
+        18.33042696296652
     ],
     "client__put_gigabytes": [
-        0.04628119129452739,
-        0.000367405387400611
+        0.04578746799093541,
+        0.0005704600065999942
     ],
     "client__tasks_and_get_batch": [
-        0.839103686516063,
-        0.003611138788132031
+        0.853905298196734,
+        0.015280693558557957
     ],
     "client__tasks_and_put_batch": [
-        10354.852611782111,
-        158.46659458867242
+        10616.102176334804,
+        71.01626299968487
     ],
     "multi_client_put_calls_Plasma_Store": [
-        11140.619921989977,
-        297.86684281187377
+        11839.11215023034,
+        337.36863768436444
     ],
     "multi_client_put_gigabytes": [
-        38.43419037441269,
-        3.320904535395364
+        37.12054483662857,
+        2.299083324936217
     ],
     "multi_client_tasks_async": [
-        32133.367075183483,
-        1514.5615857392947
+        24894.461452735395,
+        507.6419588250048
     ],
     "n_n_actor_calls_async": [
-        35151.93038362862,
-        916.3229251520664
+        29179.56691260244,
+        866.0137201858089
     ],
     "n_n_actor_calls_with_arg_async": [
-        2831.4666955768935,
-        25.67262592491785
+        2728.7063897979388,
+        26.44382679940674
     ],
     "n_n_async_actor_calls_async": [
-        28665.946308284096,
-        401.6526904468394
+        24203.919719797126,
+        371.9666452863952
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5877.43374153343
+            "perf_metric_value": 6752.1289146397485
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5893.086020155377
+            "perf_metric_value": 5635.808769325
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11140.619921989977
+            "perf_metric_value": 11839.11215023034
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.206197812517708
+            "perf_metric_value": 18.22158388450479
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11.24301668594478
+            "perf_metric_value": 9.84148376315661
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 38.43419037441269
+            "perf_metric_value": 37.12054483662857
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.380926011280408
+            "perf_metric_value": 14.155223981622498
+        },
+        {
+            "perf_metric_name": "single_client_wait_1k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5.244999881215876
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1294.2667282228672
+            "perf_metric_value": 1200.8853386364904
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10904.790007336374
+            "perf_metric_value": 9992.216255226114
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 32133.367075183483
+            "perf_metric_value": 24894.461452735395
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2181.5451120926223
+            "perf_metric_value": 2124.9132137079505
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5770.038567273023
+            "perf_metric_value": 6891.810983940368
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4668.012480386666
+            "perf_metric_value": 4600.118710434536
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11646.429573331836
+            "perf_metric_value": 10264.35850171556
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 35151.93038362862
+            "perf_metric_value": 29179.56691260244
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2831.4666955768935
+            "perf_metric_value": 2728.7063897979388
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1479.0342425173185
+            "perf_metric_value": 1485.131572774145
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2746.018365776892
+            "perf_metric_value": 2938.3869503327624
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2087.8113920074993
+            "perf_metric_value": 2135.7604313398756
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10613.303070856366
+            "perf_metric_value": 9558.899002308037
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 28665.946308284096
+            "perf_metric_value": 24203.919719797126
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1016.2011272594634
+            "perf_metric_value": 995.3026814101579
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1076.6787125404312
+            "perf_metric_value": 1093.4303789307519
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 837.6281468983028
+            "perf_metric_value": 829.8430791435788
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.04628119129452739
+            "perf_metric_value": 0.04578746799093541
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10354.852611782111
+            "perf_metric_value": 10616.102176334804
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 473.24166933984384
+            "perf_metric_value": 511.642935750412
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 884.3193857194137
+            "perf_metric_value": 945.3308717388207
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 869.9137568724132
+            "perf_metric_value": 950.2416789794908
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.839103686516063
+            "perf_metric_value": 0.853905298196734
         }
     ],
     "placement_group_create/removal": [
-        1016.2011272594634,
-        14.139674889591547
+        995.3026814101579,
+        14.830064924444647
     ],
     "single_client_get_calls_Plasma_Store": [
-        5877.43374153343,
-        120.42853501381207
+        6752.1289146397485,
+        666.7266307295981
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.380926011280408,
-        0.14097107569952724
+        14.155223981622498,
+        0.1429406608187741
     ],
     "single_client_put_calls_Plasma_Store": [
-        5893.086020155377,
-        48.04204837197115
+        5635.808769325,
+        111.9367102987809
     ],
     "single_client_put_gigabytes": [
-        19.206197812517708,
-        5.898953273640887
+        18.22158388450479,
+        5.519289907000518
     ],
     "single_client_tasks_and_get_batch": [
-        11.24301668594478,
-        0.2902417978086234
+        9.84148376315661,
+        0.353913749171297
     ],
     "single_client_tasks_async": [
-        10904.790007336374,
-        223.90617510438346
+        9992.216255226114,
+        157.26582847837795
     ],
     "single_client_tasks_sync": [
-        1294.2667282228672,
-        10.600925877033148
+        1200.8853386364904,
+        18.574650128067024
+    ],
+    "single_client_wait_1k_refs": [
+        5.244999881215876,
+        0.09844856288807985
     ]
 }

--- a/release/release_logs/2.2.0/scalability/object_store.json
+++ b/release/release_logs/2.2.0/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 91.34722920899992,
+    "broadcast_time": 84.76416113200003,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 91.34722920899992
+            "perf_metric_value": 84.76416113200003
         }
     ],
     "success": "1"

--- a/release/release_logs/2.2.0/scalability/single_node.json
+++ b/release/release_logs/2.2.0/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.115523338999992,
-    "get_time": 26.32780160499999,
+    "args_time": 16.555890774999966,
+    "get_time": 25.818155864999994,
     "large_object_size": 107374182400,
-    "large_object_time": 255.3529769390001,
+    "large_object_time": 338.213855138,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.115523338999992
+            "perf_metric_value": 16.555890774999966
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.100632732999998
+            "perf_metric_value": 6.395861592000017
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 26.32780160499999
+            "perf_metric_value": 25.818155864999994
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 186.92522427999995
+            "perf_metric_value": 205.44312294999997
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 255.3529769390001
+            "perf_metric_value": 338.213855138
         }
     ],
-    "queued_time": 186.92522427999995,
-    "returns_time": 6.100632732999998,
+    "queued_time": 205.44312294999997,
+    "returns_time": 6.395861592000017,
     "success": "1"
 }

--- a/release/release_logs/2.2.0/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.2.0/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.9442666888237,
-    "max_iteration_time": 9.263823747634888,
-    "min_iteration_time": 0.8118352890014648,
+    "avg_iteration_time": 2.066628179550171,
+    "max_iteration_time": 13.97415018081665,
+    "min_iteration_time": 0.445157527923584,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.9442666888237
+            "perf_metric_value": 2.066628179550171
         }
     ],
     "success": 1,
-    "total_time": 194.42695713043213
+    "total_time": 206.66313886642456
 }

--- a/release/release_logs/2.2.0/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.2.0/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.958704233169556
+            "perf_metric_value": 9.163766622543335
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 22.138524317741393
+            "perf_metric_value": 23.146324729919435
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 53.894669151306154
+            "perf_metric_value": 51.32741203308105
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.055498600006103516
+            "perf_metric_value": 0.05630922317504883
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2336.072838306427
+            "perf_metric_value": 2730.786130428314
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.9960808970571373
+            "perf_metric_value": 1.7465769326110931
         }
     ],
-    "stage_0_time": 5.958704233169556,
-    "stage_1_avg_iteration_time": 22.138524317741393,
-    "stage_1_max_iteration_time": 22.87304377555847,
-    "stage_1_min_iteration_time": 21.092820644378662,
-    "stage_1_time": 221.38535571098328,
-    "stage_2_avg_iteration_time": 53.894669151306154,
-    "stage_2_max_iteration_time": 56.26228141784668,
-    "stage_2_min_iteration_time": 52.07155895233154,
-    "stage_2_time": 269.47429752349854,
-    "stage_3_creation_time": 0.055498600006103516,
-    "stage_3_time": 2336.072838306427,
-    "stage_4_spread": 1.9960808970571373,
+    "stage_0_time": 9.163766622543335,
+    "stage_1_avg_iteration_time": 23.146324729919435,
+    "stage_1_max_iteration_time": 24.636783361434937,
+    "stage_1_min_iteration_time": 22.392932415008545,
+    "stage_1_time": 231.46333026885986,
+    "stage_2_avg_iteration_time": 51.32741203308105,
+    "stage_2_max_iteration_time": 52.82801818847656,
+    "stage_2_min_iteration_time": 49.090659856796265,
+    "stage_2_time": 256.638076543808,
+    "stage_3_creation_time": 0.05630922317504883,
+    "stage_3_time": 2730.786130428314,
+    "stage_4_spread": 1.7465769326110931,
     "success": 1
 }

--- a/release/release_logs/2.2.0/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.2.0/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.8335708558568591,
-    "avg_pg_remove_time_ms": 0.847586638137635,
+    "avg_pg_create_time_ms": 0.8819333648672524,
+    "avg_pg_remove_time_ms": 0.8447476801805934,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.8335708558568591
+            "perf_metric_value": 0.8819333648672524
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.847586638137635
+            "perf_metric_value": 0.8447476801805934
         }
     ],
     "success": 1


### PR DESCRIPTION
This PR compares latest performance numbers, as of commit 664c8442c32f5ae2fd3361a9db7450fbf07c2511, with the Ray 2.2.0 release. I'll create another PR after branch cut; this is just to catch things earlier.