### PR TITLE
[Core] Expose Internal KV MultiGet operation

### DIFF
--- a/src/mock/ray/gcs/gcs_server/gcs_kv_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_kv_manager.h
@@ -26,6 +26,12 @@ class MockInternalKVInterface : public ray::gcs::InternalKVInterface {
                std::function<void(std::optional<std::string>)> callback),
               (override));
   MOCK_METHOD(void,
+              MultiGet,
+              (const std::string &ns,
+               const std::vector<std::string> &keys,
+               std::function<void(std::unordered_map<std::string, std::string>)> callback),
+              (override));
+  MOCK_METHOD(void,
               Put,
               (const std::string &ns,
                const std::string &key,

--- a/src/mock/ray/gcs/gcs_server/gcs_kv_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_kv_manager.h
@@ -25,12 +25,13 @@ class MockInternalKVInterface : public ray::gcs::InternalKVInterface {
                const std::string &key,
                std::function<void(std::optional<std::string>)> callback),
               (override));
-  MOCK_METHOD(void,
-              MultiGet,
-              (const std::string &ns,
-               const std::vector<std::string> &keys,
-               std::function<void(std::unordered_map<std::string, std::string>)> callback),
-              (override));
+  MOCK_METHOD(
+      void,
+      MultiGet,
+      (const std::string &ns,
+       const std::vector<std::string> &keys,
+       std::function<void(std::unordered_map<std::string, std::string>)> callback),
+      (override));
   MOCK_METHOD(void,
               Put,
               (const std::string &ns,

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.h
@@ -39,6 +39,16 @@ class InternalKVInterface {
                    const std::string &key,
                    std::function<void(std::optional<std::string>)> callback) = 0;
 
+  /// Get the values associated with `keys`.
+  ///
+  /// \param ns The namespace of the key.
+  /// \param keys The keys to fetch.
+  /// \param callback Returns the values for those keys that exist.
+  virtual void MultiGet(
+      const std::string &ns,
+      const std::vector<std::string> &keys,
+      std::function<void(std::unordered_map<std::string, std::string>)> callback) = 0;
+
   /// Associate a key with the specified value.
   ///
   /// \param ns The namespace of the key.

--- a/src/ray/gcs/gcs_server/store_client_kv.cc
+++ b/src/ray/gcs/gcs_server/store_client_kv.cc
@@ -67,6 +67,28 @@ void StoreClientInternalKV::Get(
       }));
 }
 
+void StoreClientInternalKV::MultiGet(
+    const std::string &ns,
+    const std::vector<std::string> &keys,
+    std::function<void(std::unordered_map<std::string, std::string>)> callback) {
+  if (!callback) {
+    callback = [](auto) {};
+  }
+  std::vector<std::string> prefixed_keys;
+  prefixed_keys.reserve(keys.size());
+  for (const auto &key : keys) {
+    prefixed_keys.emplace_back(MakeKey(ns, key));
+  }
+  RAY_CHECK_OK(delegate_->AsyncMultiGet(
+      table_name_, prefixed_keys, [callback = std::move(callback)](auto result) {
+        std::unordered_map<std::string, std::string> ret;
+        for (const auto &item : result) {
+          ret.emplace(ExtractKey(item.first), item.second);
+        }
+        callback(ret);
+      }));
+}
+
 void StoreClientInternalKV::Put(const std::string &ns,
                                 const std::string &key,
                                 const std::string &value,

--- a/src/ray/gcs/gcs_server/store_client_kv.cc
+++ b/src/ray/gcs/gcs_server/store_client_kv.cc
@@ -85,7 +85,7 @@ void StoreClientInternalKV::MultiGet(
         for (const auto &item : result) {
           ret.emplace(ExtractKey(item.first), item.second);
         }
-        callback(ret);
+        callback(std::move(ret));
       }));
 }
 

--- a/src/ray/gcs/gcs_server/store_client_kv.h
+++ b/src/ray/gcs/gcs_server/store_client_kv.h
@@ -33,6 +33,11 @@ class StoreClientInternalKV : public InternalKVInterface {
            const std::string &key,
            std::function<void(std::optional<std::string>)> callback) override;
 
+  void MultiGet(const std::string &ns,
+                const std::vector<std::string> &keys,
+                std::function<void(std::unordered_map<std::string, std::string>)>
+                    callback) override;
+
   void Put(const std::string &ns,
            const std::string &key,
            const std::string &value,

--- a/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
@@ -73,6 +73,12 @@ TEST_P(GcsKVManagerTest, TestInternalKV) {
   });
   kv_instance->Get("N2", "A_1", [](auto b) { ASSERT_FALSE(b.has_value()); });
   kv_instance->Get("N1", "A_1", [](auto b) { ASSERT_TRUE(b.has_value()); });
+  kv_instance->MultiGet("N1", {"A_1", "A_2", "A_3"}, [](auto b) {
+    ASSERT_EQ(3, b.size());
+    ASSERT_EQ("B", b["A_1"]);
+    ASSERT_EQ("C", b["A_2"]);
+    ASSERT_EQ("C", b["A_3"]);
+  });
   {
     // Delete by prefix are two steps in redis mode, so we need sync here.
     std::promise<void> p;
@@ -101,6 +107,8 @@ TEST_P(GcsKVManagerTest, TestInternalKV) {
     });
     p.get_future().get();
   }
+  kv_instance->MultiGet(
+      "N1", {"A_1", "A_2", "A_3"}, [](auto b) { ASSERT_EQ(0, b.size()); });
 }
 
 INSTANTIATE_TEST_SUITE_P(GcsKVManagerTestFixture,

--- a/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
@@ -79,6 +79,10 @@ TEST_P(GcsKVManagerTest, TestInternalKV) {
     ASSERT_EQ("C", b["A_2"]);
     ASSERT_EQ("C", b["A_3"]);
   });
+  // MultiGet with empty keys.
+  kv_instance->MultiGet("N1", {}, [](auto b) { ASSERT_EQ(0, b.size()); });
+  // MultiGet with non-existent keys.
+  kv_instance->MultiGet("N1", {"A_4", "A_5"}, [](auto b) { ASSERT_EQ(0, b.size()); });
   {
     // Delete by prefix are two steps in redis mode, so we need sync here.
     std::promise<void> p;
@@ -107,6 +111,7 @@ TEST_P(GcsKVManagerTest, TestInternalKV) {
     });
     p.get_future().get();
   }
+  // Check the keys are deleted.
   kv_instance->MultiGet(
       "N1", {"A_1", "A_2", "A_3"}, [](auto b) { ASSERT_EQ(0, b.size()); });
 }

--- a/src/ray/gcs/store_client/store_client.h
+++ b/src/ray/gcs/store_client/store_client.h
@@ -71,7 +71,8 @@ class StoreClient {
   /// Get all data from the given table asynchronously.
   ///
   /// \param table_name The name of the table to be read.
-  /// \param callback returns the key value pairs in a map.
+  /// \param keys The keys to look up from the table.
+  /// \param callback returns the key value pairs in a map for those keys that exist.
   /// \return Status
   virtual Status AsyncMultiGet(const std::string &table_name,
                                const std::vector<std::string> &keys,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR exposes the MultiGet operation to the InternalKVInterface.  The MultiGet operation is already supported in the two backends (InMemory and Redis), so this PR is just plumbing.

This change is needed to support getting multiple keys from the Internal KV in a single RPC.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
