### PR TITLE
[Datasets] Fix to pass TaskContext in generate_random_shuffle_fn()

### DIFF
--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -165,8 +165,13 @@ class TaskContext:
     task_idx: int
 
 
-# Block transform function applied by task and actor pools.
-TransformFn = Callable[[Iterable[Block], TaskContext], Iterable[Block]]
+# Block transform function applied by task and actor pools in MapOperator.
+MapTransformFn = Callable[[Iterable[Block], TaskContext], Iterable[Block]]
+
+# Block transform function applied in AllToAllOperator.
+AllToAllTransformFn = Callable[
+    [List[RefBundle], TaskContext], Tuple[List[RefBundle], StatsDict]
+]
 
 
 class PhysicalOperator(Operator):

--- a/python/ray/data/_internal/execution/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/execution/operators/all_to_all_operator.py
@@ -1,7 +1,8 @@
-from typing import List, Callable, Optional, Tuple
+from typing import List, Optional
 
 from ray.data._internal.stats import StatsDict
 from ray.data._internal.execution.interfaces import (
+    AllToAllTransformFn,
     RefBundle,
     PhysicalOperator,
     TaskContext,
@@ -16,7 +17,7 @@ class AllToAllOperator(PhysicalOperator):
 
     def __init__(
         self,
-        bulk_fn: Callable[[List[RefBundle]], Tuple[List[RefBundle], StatsDict]],
+        bulk_fn: AllToAllTransformFn,
         input_op: PhysicalOperator,
         num_outputs: Optional[int] = None,
         name: str = "AllToAll",

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -16,7 +16,7 @@ from ray.data._internal.execution.interfaces import (
     ExecutionResources,
     PhysicalOperator,
     TaskContext,
-    TransformFn,
+    MapTransformFn,
 )
 from ray.data._internal.memory_tracing import trace_allocation
 from ray.data._internal.stats import StatsDict
@@ -34,7 +34,7 @@ class MapOperator(PhysicalOperator, ABC):
 
     def __init__(
         self,
-        transform_fn: TransformFn,
+        transform_fn: MapTransformFn,
         input_op: PhysicalOperator,
         name: str,
         min_rows_per_bundle: Optional[int],
@@ -64,7 +64,7 @@ class MapOperator(PhysicalOperator, ABC):
     @classmethod
     def create(
         cls,
-        transform_fn: TransformFn,
+        transform_fn: MapTransformFn,
         input_op: PhysicalOperator,
         name: str = "Map",
         # TODO(ekl): slim down ComputeStrategy to only specify the compute
@@ -327,7 +327,7 @@ class _ObjectStoreMetrics:
 
 
 def _map_task(
-    fn: TransformFn,
+    fn: MapTransformFn,
     ctx: TaskContext,
     *blocks: Block,
 ) -> Iterator[Union[Block, List[BlockMetadata]]]:

--- a/python/ray/data/_internal/planner/filter.py
+++ b/python/ray/data/_internal/planner/filter.py
@@ -1,11 +1,13 @@
-from typing import Iterator
+from typing import Callable, Iterator
 
-from ray.data._internal.execution.interfaces import TaskContext, TransformFn
+from ray.data._internal.execution.interfaces import TaskContext
 from ray.data.block import Block, BlockAccessor, RowUDF
 from ray.data.context import DatasetContext
 
 
-def generate_filter_fn() -> TransformFn:
+def generate_filter_fn() -> Callable[
+    [Iterator[Block], TaskContext, RowUDF], Iterator[Block]
+]:
     """Generate function to apply the UDF to each record of blocks,
     and filter out records that do not satisfy the given predicate.
     """

--- a/python/ray/data/_internal/planner/flat_map.py
+++ b/python/ray/data/_internal/planner/flat_map.py
@@ -1,12 +1,14 @@
-from typing import Iterator
+from typing import Callable, Iterator
 
-from ray.data._internal.execution.interfaces import TaskContext, TransformFn
+from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.output_buffer import BlockOutputBuffer
 from ray.data.block import Block, BlockAccessor, RowUDF
 from ray.data.context import DatasetContext
 
 
-def generate_flat_map_fn() -> TransformFn:
+def generate_flat_map_fn() -> Callable[
+    [Iterator[Block], TaskContext, RowUDF], Iterator[Block]
+]:
     """Generate function to apply the UDF to each record of blocks,
     and then flatten results.
     """

--- a/python/ray/data/_internal/planner/map_batches.py
+++ b/python/ray/data/_internal/planner/map_batches.py
@@ -1,8 +1,8 @@
 import sys
-from typing import Iterator, Optional
+from typing import Callable, Iterator, Optional
 
 from ray.data._internal.block_batching import batch_blocks
-from ray.data._internal.execution.interfaces import TaskContext, TransformFn
+from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.output_buffer import BlockOutputBuffer
 from ray.data.block import BatchUDF, Block, DataBatch
 from ray.data.context import DEFAULT_BATCH_SIZE, DatasetContext
@@ -19,7 +19,7 @@ def generate_map_batches_fn(
     batch_format: Literal["default", "pandas", "pyarrow", "numpy"] = "default",
     prefetch_batches: int = 0,
     zero_copy_batch: bool = False,
-) -> TransformFn:
+) -> Callable[[Iterator[Block], TaskContext, BatchUDF], Iterator[Block]]:
     """Generate function to apply the batch UDF to blocks."""
     import numpy as np
     import pandas as pd

--- a/python/ray/data/_internal/planner/map_rows.py
+++ b/python/ray/data/_internal/planner/map_rows.py
@@ -1,12 +1,14 @@
-from typing import Iterator
+from typing import Callable, Iterator
 
-from ray.data._internal.execution.interfaces import TaskContext, TransformFn
+from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.output_buffer import BlockOutputBuffer
 from ray.data.block import Block, BlockAccessor, RowUDF
 from ray.data.context import DatasetContext
 
 
-def generate_map_rows_fn() -> TransformFn:
+def generate_map_rows_fn() -> Callable[
+    [Iterator[Block], TaskContext, RowUDF], Iterator[Block]
+]:
     """Generate function to apply the UDF to each record of blocks."""
 
     context = DatasetContext.get_current()

--- a/python/ray/data/_internal/planner/random_shuffle.py
+++ b/python/ray/data/_internal/planner/random_shuffle.py
@@ -1,6 +1,10 @@
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
-from ray.data._internal.execution.interfaces import RefBundle
+from ray.data._internal.execution.interfaces import (
+    AllToAllTransformFn,
+    RefBundle,
+    TaskContext,
+)
 from ray.data._internal.planner.exchange.push_based_shuffle_task_scheduler import (
     PushBasedShuffleTaskScheduler,
 )
@@ -16,10 +20,13 @@ def generate_random_shuffle_fn(
     seed: Optional[int],
     num_outputs: Optional[int] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
-) -> Callable[[List[RefBundle]], Tuple[List[RefBundle], StatsDict]]:
+) -> AllToAllTransformFn:
     """Generate function to randomly shuffle each records of blocks."""
 
-    def fn(refs: List[RefBundle]) -> Tuple[List[RefBundle], StatsDict]:
+    def fn(
+        refs: List[RefBundle],
+        ctx: TaskContext,
+    ) -> Tuple[List[RefBundle], StatsDict]:
         num_input_blocks = sum(len(r.blocks) for r in refs)
         shuffle_spec = ShuffleTaskSpec(random_shuffle=True, random_seed=seed)
 

--- a/python/ray/data/_internal/planner/randomize_blocks.py
+++ b/python/ray/data/_internal/planner/randomize_blocks.py
@@ -1,12 +1,16 @@
-from typing import Callable, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
-from ray.data._internal.execution.interfaces import RefBundle, TaskContext
+from ray.data._internal.execution.interfaces import (
+    AllToAllTransformFn,
+    RefBundle,
+    TaskContext,
+)
 from ray.data._internal.stats import StatsDict
 
 
 def generate_randomize_blocks_fn(
     seed: Optional[int],
-) -> Callable[[List[RefBundle], TaskContext], Tuple[List[RefBundle], StatsDict]]:
+) -> AllToAllTransformFn:
     """Generate function to randomize order of blocks."""
 
     def fn(


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to fix master with resolving the conflict between https://github.com/ray-project/ray/pull/32080 and https://github.com/ray-project/ray/pull/32081, i.e.

* Pass TaskContext in `random_shuffle.py:generate_random_shuffle_fn()`
* Add `AllToAllTransformFn` and rename `TransformFn` to `MapTransformFn`
* Update the function return type in `generate_map_xxx_fn()`.

The failed tests on master are:

```
FAILED python/ray/data/tests/test_execution_optimizer.py::test_random_shuffle_e2e[True-True] - TypeError: fn() takes 1 positional argu...
FAILED python/ray/data/tests/test_execution_optimizer.py::test_random_shuffle_e2e[True-False] - TypeError: fn() takes 1 positional arg...
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
