### PR TITLE
[Datasets] Add logical operator for repartition()

### DIFF
--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -62,3 +62,20 @@ class RandomShuffle(AbstractAllToAll):
             ray_remote_args=ray_remote_args,
         )
         self._seed = seed
+
+
+class Repartition(AbstractAllToAll):
+    """Logical operator for repartition."""
+
+    def __init__(
+        self,
+        input_op: LogicalOperator,
+        num_outputs: int,
+        shuffle: bool,
+    ):
+        super().__init__(
+            "Repartition",
+            input_op,
+            num_outputs=num_outputs,
+        )
+        self._shuffle = shuffle

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -4,9 +4,11 @@ from ray.data._internal.logical.operators.all_to_all_operator import (
     AbstractAllToAll,
     RandomShuffle,
     RandomizeBlocks,
+    Repartition,
 )
 from ray.data._internal.planner.random_shuffle import generate_random_shuffle_fn
 from ray.data._internal.planner.randomize_blocks import generate_randomize_blocks_fn
+from ray.data._internal.planner.repartition import generate_repartition_fn
 
 
 def _plan_all_to_all_op(
@@ -22,6 +24,8 @@ def _plan_all_to_all_op(
         fn = generate_randomize_blocks_fn(op._seed)
     elif isinstance(op, RandomShuffle):
         fn = generate_random_shuffle_fn(op._seed, op._num_outputs)
+    elif isinstance(op, Repartition):
+        fn = generate_repartition_fn(op._num_outputs, op._shuffle)
     else:
         raise ValueError(f"Found unknown logical operator during planning: {op}")
 

--- a/python/ray/data/_internal/planner/repartition.py
+++ b/python/ray/data/_internal/planner/repartition.py
@@ -1,6 +1,10 @@
-from typing import Callable, List, Tuple
+from typing import List, Tuple
 
-from ray.data._internal.execution.interfaces import RefBundle, TaskContext
+from ray.data._internal.execution.interfaces import (
+    AllToAllTransformFn,
+    RefBundle,
+    TaskContext,
+)
 from ray.data._internal.planner.exchange.push_based_shuffle_task_scheduler import (
     PushBasedShuffleTaskScheduler,
 )
@@ -15,7 +19,7 @@ from ray.data.context import DatasetContext
 def generate_repartition_fn(
     num_outputs: int,
     shuffle: bool,
-) -> Callable[[List[RefBundle], TaskContext], Tuple[List[RefBundle], StatsDict]]:
+) -> AllToAllTransformFn:
     """Generate function to randomly shuffle each records of blocks."""
     # TODO: support non-shuffle repartition as _internal/fast_repartition.py.
     assert shuffle, "Execution optimizer does not support non-shuffle repartition yet."

--- a/python/ray/data/_internal/planner/repartition.py
+++ b/python/ray/data/_internal/planner/repartition.py
@@ -1,0 +1,36 @@
+from typing import Callable, List, Tuple
+
+from ray.data._internal.execution.interfaces import RefBundle, TaskContext
+from ray.data._internal.planner.exchange.push_based_shuffle_task_scheduler import (
+    PushBasedShuffleTaskScheduler,
+)
+from ray.data._internal.planner.exchange.shuffle_task_spec import ShuffleTaskSpec
+from ray.data._internal.planner.exchange.pull_based_shuffle_task_scheduler import (
+    PullBasedShuffleTaskScheduler,
+)
+from ray.data._internal.stats import StatsDict
+from ray.data.context import DatasetContext
+
+
+def generate_repartition_fn(
+    num_outputs: int,
+    shuffle: bool,
+) -> Callable[[List[RefBundle], TaskContext], Tuple[List[RefBundle], StatsDict]]:
+    """Generate function to randomly shuffle each records of blocks."""
+    # TODO: support non-shuffle repartition as _internal/fast_repartition.py.
+    assert shuffle, "Execution optimizer does not support non-shuffle repartition yet."
+
+    def fn(
+        refs: List[RefBundle],
+        ctx: TaskContext,
+    ) -> Tuple[List[RefBundle], StatsDict]:
+        shuffle_spec = ShuffleTaskSpec(random_shuffle=False)
+
+        if DatasetContext.get_current().use_push_based_shuffle:
+            scheduler = PushBasedShuffleTaskScheduler(shuffle_spec)
+        else:
+            scheduler = PullBasedShuffleTaskScheduler(shuffle_spec)
+
+        return scheduler.execute(refs, num_outputs)
+
+    return fn


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR adds logical operator for `repartition()`. Only implement shuffle repartition (`repartition.py:generate_repartition_fn()`).

Non-shuffle repartition is left as TODO, as the corresponding code in [fast_repartition.py](https://github.com/ray-project/ray/blob/master/python/ray/data/_internal/fast_repartition.py) involves `BlockList`, `ExecutionPlan` and `Dataset.split()`, so it needs a deeper refactoring and code change.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
