### PR TITLE
[RLlib] Optimize the trainer runner test, add method for shutting down a trainer runner and releasing resources

### DIFF
--- a/rllib/core/rl_trainer/tests/test_trainer_runner.py
+++ b/rllib/core/rl_trainer/tests/test_trainer_runner.py
@@ -74,7 +74,9 @@ class TestTrainerRunner(unittest.TestCase):
     def test_trainer_runner_local(self):
         fws = ["tf", "torch"]
         test_iterator = itertools.product(fws, LOCAL_SCALING_CONFIGS)
-        # run the logic of this test inside of a ray actor
+        # run the logic of this test inside of a ray actor because we want tensorflow
+        # resources to be gracefully released. Tensorflow blocks the gpu resources
+        # otherwise between test cases, causing a gpu oom error.
         remote_helper_fn = ray.remote(self.local_training_helper)
         for fw, scaling_mode in test_iterator:
             print(f"Testing framework: {fw}, scaling mode: {scaling_mode}")

--- a/rllib/core/rl_trainer/tests/test_trainer_runner.py
+++ b/rllib/core/rl_trainer/tests/test_trainer_runner.py
@@ -1,13 +1,11 @@
 import gymnasium as gym
-import unittest
-import ray
-import time
-import numpy as np
 import itertools
+import numpy as np
+import unittest
 
+import ray
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, MultiAgentBatch
 from ray.rllib.utils.test_utils import check, get_cartpole_dataset_reader
-from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.core.rl_trainer.scaling_config import TrainerScalingConfig
 from ray.rllib.core.testing.utils import (
     get_trainer_runner,
@@ -16,94 +14,82 @@ from ray.rllib.core.testing.utils import (
 )
 
 
+REMOTE_SCALING_CONFIGS = {
+    "remote-cpu": TrainerScalingConfig(num_workers=1),
+    "remote-gpu": TrainerScalingConfig(num_workers=1, num_gpus_per_worker=0.5),
+    "multi-gpu-ddp": TrainerScalingConfig(num_workers=2, num_gpus_per_worker=1),
+    "multi-cpu-ddp": TrainerScalingConfig(num_workers=2, num_cpus_per_worker=2),
+    # "multi-gpu-ddp-pipeline": TrainerScalingConfig(
+    #     num_workers=2, num_gpus_per_worker=2
+    # ),
+}
+
+
+LOCAL_SCALING_CONFIGS = {
+    "local-cpu": TrainerScalingConfig(num_workers=0, num_gpus_per_worker=0),
+    "local-gpu": TrainerScalingConfig(num_workers=0, num_gpus_per_worker=0.5),
+}
+
+
 class TestTrainerRunner(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
+    def setUp(self) -> None:
         ray.init()
 
-        # Settings to test
-        cls.scaling_configs = {
-            "local-cpu": TrainerScalingConfig(num_workers=0, num_gpus_per_worker=0),
-            "local-gpu": TrainerScalingConfig(num_workers=0, num_gpus_per_worker=0.5),
-            "remote-cpu": TrainerScalingConfig(num_workers=1),
-            "remote-gpu": TrainerScalingConfig(num_workers=1, num_gpus_per_worker=0.5),
-            "multi-gpu-ddp": TrainerScalingConfig(num_workers=2, num_gpus_per_worker=1),
-            "multi-cpu-ddp": TrainerScalingConfig(num_workers=2, num_cpus_per_worker=2),
-            # "multi-gpu-ddp-pipeline": TrainerScalingConfig(
-            #     num_workers=2, num_gpus_per_worker=2
-            # ),
-        }
-
-    @classmethod
-    def tearDownClass(cls) -> None:
+    def tearDown(self) -> None:
         ray.shutdown()
 
-    def test_trainer_runner_local(self):
-
-        tf1, tf, tfv = try_import_tf()
-        tf1.executing_eagerly()
-
-        # TODO (Avnish): tf does not clear out the GPU memory footprint, therefore
-        # doing it first before torch will result in OOM. Find a way to clear out the
-        # GPU memory footprint of tf.
-        fws = ["torch"]
-        scaling_modes = ["local-cpu", "local-gpu"]
-        test_iterator = itertools.product(fws, scaling_modes)
-
+    @staticmethod
+    def local_training_helper(fw, scaling_mode) -> None:
         env = gym.make("CartPole-v1")
+        scaling_config = LOCAL_SCALING_CONFIGS[scaling_mode]
+        runner = get_trainer_runner(fw, env, scaling_config)
+        local_trainer = get_rl_trainer(fw, env)
+        local_trainer.build()
+
+        # make the state of the trainer and the local runner identical
+        local_trainer.set_state(runner.get_state()[0])
+
+        reader = get_cartpole_dataset_reader(batch_size=500)
+        batch = reader.next()
+        batch = batch.as_multi_agent()
+        check(local_trainer.update(batch), runner.update(batch)[0])
+
+        new_module_id = "test_module"
+
+        add_module_to_runner_or_trainer(fw, env, new_module_id, runner)
+        add_module_to_runner_or_trainer(fw, env, new_module_id, local_trainer)
+
+        # make the state of the trainer and the local runner identical
+        local_trainer.set_state(runner.get_state()[0])
+
+        # do another update
+        batch = reader.next()
+        ma_batch = MultiAgentBatch(
+            {new_module_id: batch, DEFAULT_POLICY_ID: batch}, env_steps=batch.count
+        )
+        check(local_trainer.update(ma_batch), runner.update(ma_batch)[0])
+
+        check(local_trainer.get_state(), runner.get_state()[0])
+
+    def test_trainer_runner_local(self):
+        fws = ["tf", "torch"]
+        test_iterator = itertools.product(fws, LOCAL_SCALING_CONFIGS)
+        # run the logic of this test inside of a ray actor
+        remote_helper_fn = ray.remote(self.local_training_helper)
         for fw, scaling_mode in test_iterator:
             print(f"Testing framework: {fw}, scaling mode: {scaling_mode}")
-            ray.init(ignore_reinit_error=True)
-            scaling_config = self.scaling_configs[scaling_mode]
-            runner = get_trainer_runner(fw, env, scaling_config)
-            local_trainer = get_rl_trainer(fw, env)
-            local_trainer.build()
-
-            # make the state of the trainer and the local runner identical
-            local_trainer.set_state(runner.get_state()[0])
-
-            reader = get_cartpole_dataset_reader(batch_size=500)
-            batch = reader.next()
-            batch = batch.as_multi_agent()
-            check(local_trainer.update(batch), runner.update(batch)[0])
-
-            new_module_id = "test_module"
-
-            add_module_to_runner_or_trainer(fw, env, new_module_id, runner)
-            add_module_to_runner_or_trainer(fw, env, new_module_id, local_trainer)
-
-            # make the state of the trainer and the local runner identical
-            local_trainer.set_state(runner.get_state()[0])
-
-            # do another update
-            batch = reader.next()
-            ma_batch = MultiAgentBatch(
-                {new_module_id: batch, DEFAULT_POLICY_ID: batch}, env_steps=batch.count
-            )
-            check(local_trainer.update(ma_batch), runner.update(ma_batch)[0])
-
-            check(local_trainer.get_state(), runner.get_state()[0])
-
-            # make sure the runner resources are freed up so that we don't autoscale
-            del runner
-            del local_trainer
-            ray.shutdown()
-            time.sleep(10)
+            ray.get(remote_helper_fn.remote(fw, scaling_mode))
 
     def test_update_multigpu(self):
-
-        # TODO (Avnish): The tf + remote-gpu test is flakey. Removing for now until
-        # investigated.
-        fws = ["torch"]
-        scaling_modes = self.scaling_configs.keys()
+        fws = ["tf", "torch"]
+        scaling_modes = REMOTE_SCALING_CONFIGS.keys()
         test_iterator = itertools.product(fws, scaling_modes)
 
         for fw, scaling_mode in test_iterator:
             print(f"Testing framework: {fw}, scaling mode: {scaling_mode}.")
-            ray.init(ignore_reinit_error=True)
             env = gym.make("CartPole-v1")
 
-            scaling_config = self.scaling_configs[scaling_mode]
+            scaling_config = REMOTE_SCALING_CONFIGS[scaling_mode]
             runner = get_trainer_runner(fw, env, scaling_config)
             reader = get_cartpole_dataset_reader(batch_size=1024)
 
@@ -129,23 +115,18 @@ class TestTrainerRunner(unittest.TestCase):
             self.assertLess(min_loss, 0.57)
 
             # make sure the runner resources are freed up so that we don't autoscale
+            runner.shutdown()
             del runner
-            ray.shutdown()
-            time.sleep(10)
 
     def test_add_remove_module(self):
-
-        # TODO (Avnish): The tf + remote-gpu test is flakey. Removing for now until
-        # investigated.
-        fws = ["torch"]
-        scaling_modes = self.scaling_configs.keys()
+        fws = ["tf", "torch"]
+        scaling_modes = REMOTE_SCALING_CONFIGS.keys()
         test_iterator = itertools.product(fws, scaling_modes)
 
         for fw, scaling_mode in test_iterator:
             print(f"Testing framework: {fw}, scaling mode: {scaling_mode}.")
-            ray.init(ignore_reinit_error=True)
             env = gym.make("CartPole-v1")
-            scaling_config = self.scaling_configs[scaling_mode]
+            scaling_config = REMOTE_SCALING_CONFIGS[scaling_mode]
             runner = get_trainer_runner(fw, env, scaling_config)
             reader = get_cartpole_dataset_reader(batch_size=500)
             batch = reader.next()
@@ -204,9 +185,8 @@ class TestTrainerRunner(unittest.TestCase):
                 )
 
             # make sure the runner resources are freed up so that we don't autoscale
+            runner.shutdown()
             del runner
-            ray.shutdown()
-            time.sleep(10)
 
 
 if __name__ == "__main__":

--- a/rllib/core/rl_trainer/trainer_runner.py
+++ b/rllib/core/rl_trainer/trainer_runner.py
@@ -89,6 +89,7 @@ class TrainerRunner:
                 train_cls=rl_trainer_class,
                 train_cls_kwargs=rl_trainer_spec.get_params_dict(),
             )
+            self._backend_executor = backend_executor
 
             self._workers = [w.actor for w in backend_executor.worker_group.workers]
 
@@ -255,3 +256,8 @@ class TrainerRunner:
             for worker in self._workers:
                 refs.append(worker.set_state.remote(state))
             ray.get(refs)
+
+    def shutdown(self):
+        """Shuts down the TrainerRunner."""
+        if not self._is_local:
+            self._backend_executor.shutdown()

--- a/rllib/core/rl_trainer/trainer_runner.py
+++ b/rllib/core/rl_trainer/trainer_runner.py
@@ -261,3 +261,7 @@ class TrainerRunner:
         """Shuts down the TrainerRunner."""
         if not self._is_local:
             self._backend_executor.shutdown()
+
+    def __del__(self):
+        self.shutdown()
+        super().__del__()


### PR DESCRIPTION
Signed-off-by: avnish <avnish@anyscale.com>

Add a shutdown method to the trainer runner, that way training actors can be gracefully cleaned up. Clean up the trainer runner tests by removing time.sleep statements and separate out distributed and non distributed test cases.

Run local tests from inside of a ray task. This is because tensorflow has a problem with running distributed and non distributed in the same python process. The gpu memory memory ends up being blocked, causing an oom. Running within a ray task allows for the tensorflow resources to be gracefully reaped.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
