### PR TITLE
[runtime env] Clarify error message about where to install `smart_open` for remote URI

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -572,7 +572,8 @@ Currently, three types of remote URIs are supported for hosting ``working_dir`` 
 
     - ``runtime_env = {"working_dir": "gs://example_bucket/example_file.zip"}``
 
-
+Note that the packages ``smart_open``, ``boto3`` and ``google-cloud-storage`` are not installed by default, and it is not sufficient to specify them in the ``pip`` section of your ``runtime_env``.
+They must already be installed on all nodes of the cluster when Ray starts.
 
 Hosting a Dependency on a Remote Git Provider: Step-by-Step Guide
 -----------------------------------------------------------------

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -573,7 +573,7 @@ Currently, three types of remote URIs are supported for hosting ``working_dir`` 
     - ``runtime_env = {"working_dir": "gs://example_bucket/example_file.zip"}``
 
 Note that the packages ``smart_open``, ``boto3`` and ``google-cloud-storage`` are not installed by default, and it is not sufficient to specify them in the ``pip`` section of your ``runtime_env``.
-They must already be installed on all nodes of the cluster when Ray starts.
+The relevant packages must already be installed on all nodes of the cluster when Ray starts.
 
 Hosting a Dependency on a Remote Git Provider: Step-by-Step Guide
 -----------------------------------------------------------------

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -572,7 +572,7 @@ Currently, three types of remote URIs are supported for hosting ``working_dir`` 
 
     - ``runtime_env = {"working_dir": "gs://example_bucket/example_file.zip"}``
 
-Note that the packages ``smart_open``, ``boto3`` and ``google-cloud-storage`` are not installed by default, and it is not sufficient to specify them in the ``pip`` section of your ``runtime_env``.
+Note that the ``smart_open``, ``boto3``, and ``google-cloud-storage`` packages are not installed by default, and it is not sufficient to specify them in the ``pip`` section of your ``runtime_env``.
 The relevant packages must already be installed on all nodes of the cluster when Ray starts.
 
 Hosting a Dependency on a Remote Git Provider: Step-by-Step Guide

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -649,6 +649,11 @@ async def download_and_unpack_package(
             elif protocol in Protocol.remote_protocols():
                 # Download package from remote URI
                 tp = None
+                install_warning = (
+                    "Note that these must be preinstalled "
+                    "on all nodes in the Ray cluster; it is not "
+                    "sufficient to install them in the runtime_env."
+                )
 
                 if protocol == Protocol.S3:
                     try:
@@ -658,7 +663,7 @@ async def download_and_unpack_package(
                         raise ImportError(
                             "You must `pip install smart_open` and "
                             "`pip install boto3` to fetch URIs in s3 "
-                            "bucket."
+                            "bucket. " + install_warning
                         )
                     tp = {"client": boto3.client("s3")}
                 elif protocol == Protocol.GS:
@@ -670,6 +675,7 @@ async def download_and_unpack_package(
                             "You must `pip install smart_open` and "
                             "`pip install google-cloud-storage` "
                             "to fetch URIs in Google Cloud Storage bucket."
+                            + install_warning
                         )
                 elif protocol == Protocol.FILE:
                     pkg_uri = pkg_uri[len("file://") :]
@@ -683,7 +689,7 @@ async def download_and_unpack_package(
                     except ImportError:
                         raise ImportError(
                             "You must `pip install smart_open` "
-                            f"to fetch {protocol.value.upper()} URIs."
+                            f"to fetch {protocol.value.upper()} URIs." + install_warning
                         )
 
                 with open_file(pkg_uri, "rb", transport_params=tp) as package_zip:

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -689,7 +689,8 @@ async def download_and_unpack_package(
                     except ImportError:
                         raise ImportError(
                             "You must `pip install smart_open` "
-                            f"to fetch {protocol.value.upper()} URIs. " + install_warning
+                            f"to fetch {protocol.value.upper()} URIs. "
+                            + install_warning
                         )
 
                 with open_file(pkg_uri, "rb", transport_params=tp) as package_zip:

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -689,7 +689,7 @@ async def download_and_unpack_package(
                     except ImportError:
                         raise ImportError(
                             "You must `pip install smart_open` "
-                            f"to fetch {protocol.value.upper()} URIs." + install_warning
+                            f"to fetch {protocol.value.upper()} URIs. " + install_warning
                         )
 
                 with open_file(pkg_uri, "rb", transport_params=tp) as package_zip:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
At least two users reported encountering 
```
ImportError(
                            "You must `pip install smart_open` and "
                            "`pip install boto3` to fetch URIs in s3 "
                            "bucket. "
```
and trying to fix it by specifying them in the `pip` field of `runtime_env`, which won't work because the runtime_env setup code doesn't run inside the runtime_env.  This PR clarifies the error message to say that they must be preinstalled on the cluster, and adds a note to the docs.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
