### PR TITLE
[RLlib] Error out if action_dict is empty in MultiAgentEnv. 

### DIFF
--- a/python/ray/train/examples/pytorch/tune_cifar_torch_pbt_example.py
+++ b/python/ray/train/examples/pytorch/tune_cifar_torch_pbt_example.py
@@ -70,6 +70,10 @@ def train_func(config):
 
     model = resnet18()
 
+    # Note that `prepare_model` needs to be called before setting optimizer.
+    if not session.get_checkpoint():  # fresh start
+        model = train.torch.prepare_model(model)
+
     # Create optimizer.
     optimizer_config = {
         "lr": config.get("lr"),
@@ -84,6 +88,7 @@ def train_func(config):
         # Load in model
         model_state = checkpoint_dict["model"]
         model.load_state_dict(model_state)
+        model = train.torch.prepare_model(model)
 
         # Load in optimizer
         optimizer_state = checkpoint_dict["optimizer_state_dict"]
@@ -96,8 +101,6 @@ def train_func(config):
         # The current epoch increments the loaded epoch by 1
         checkpoint_epoch = checkpoint_dict["epoch"]
         starting_epoch = checkpoint_epoch + 1
-
-    model = train.torch.prepare_model(model)
 
     # Load in training and validation data.
     transform_train = transforms.Compose(

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -536,6 +536,12 @@ def make_multi_agent(
         @override(MultiAgentEnv)
         def step(self, action_dict):
             obs, rew, terminated, truncated, info = {}, {}, {}, {}, {}
+
+            # the environment is expecting actions for all sub-envs
+            if set(action_dict) != self._agent_ids:
+                missings = self._agent_ids - set(action_dict)
+                raise ValueError(f"Missing actions for agent ids: {missings}")
+
             for i, action in action_dict.items():
                 obs[i], rew[i], terminated[i], truncated[i], info[i] = self.envs[
                     i

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -537,10 +537,11 @@ def make_multi_agent(
         def step(self, action_dict):
             obs, rew, terminated, truncated, info = {}, {}, {}, {}, {}
 
-            # the environment is expecting actions for all sub-envs
-            if set(action_dict) != self._agent_ids:
-                missings = self._agent_ids - set(action_dict)
-                raise ValueError(f"Missing actions for agent ids: {missings}")
+            # the environment is expecting action for at least one agent
+            if len(action_dict) == 0:
+                raise ValueError(
+                    "The environment is expecting action for at least one agent."
+                )
 
             for i, action in action_dict.items():
                 obs[i], rew[i], terminated[i], truncated[i], info[i] = self.envs[


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The multiAgentEnv class should error out if the action_dict is empty.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
