### PR TITLE
[RLlib] Support empty leafs with NestedDict

### DIFF
--- a/rllib/models/specs/specs_dict.py
+++ b/rllib/models/specs/specs_dict.py
@@ -107,7 +107,7 @@ class SpecDict(NestedDict[Spec], Spec):
             ValueError: If the data doesn't match the spec.
         """
         data = NestedDict(data)
-        data_keys_set = set(data.shallow_keys())
+        data_keys_set = set(data.keys())
         missing_keys = self._keys_set.difference(data_keys_set)
         if missing_keys:
             raise ValueError(

--- a/rllib/models/specs/specs_dict.py
+++ b/rllib/models/specs/specs_dict.py
@@ -107,7 +107,7 @@ class SpecDict(NestedDict[Spec], Spec):
             ValueError: If the data doesn't match the spec.
         """
         data = NestedDict(data)
-        data_keys_set = set(data.keys())
+        data_keys_set = set(data.shallow_keys())
         missing_keys = self._keys_set.difference(data_keys_set)
         if missing_keys:
             raise ValueError(

--- a/rllib/utils/nested_dict.py
+++ b/rllib/utils/nested_dict.py
@@ -59,7 +59,7 @@ class StrKey(str):
 
 @ExperimentalAPI
 class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
-    """A dict with special properties to support indexing with a sequence of strings.
+    """A dict with special properties to support partial indexing.
 
     The main properties of NestedDict are::
         * The nested dict gives access to nested elements as a sequence of
@@ -73,8 +73,6 @@ class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
         empty leafs.
         * Iterating over a nested dict yields the leaves of the tree, including empty
         leafs.
-    More information on these properties can be found in the docstrings of the
-    respective methods.
 
     Args:
         x: a representation of a nested dict: it can be an iterable of `SeqStrType`
@@ -139,6 +137,7 @@ class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
             raise ValueError(f"Input must be a Mapping or Iterable, got {type(x)}.")
 
     def __contains__(self, k: SeqStrType) -> bool:
+        """Returns true if the key is in the nested dict."""
         k = _flatten_index(k)
 
         data_ptr = self._data  # type: Dict[str, Any]
@@ -156,12 +155,13 @@ class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
         self, k: SeqStrType, default: Optional[T] = None
     ) -> Union[T, "NestedDict[T]"]:
         """Returns `self[k]`, with partial indexing allowed.
+
         If `k` is not in the `NestedDict`, returns default. If default is `None`,
         and `k` is not in the `NestedDict`, a `KeyError` is raised.
 
         Args:
-            k: the key to get. This can be a string or a sequence of strings.
-            default: the default value to return if `k` is not in the `NestedDict`. If
+            k: The key to get. This can be a string or a sequence of strings.
+            default: The default value to return if `k` is not in the `NestedDict`. If
                 default is `None`, and `k` is not in the `NestedDict`, a `KeyError` is
                 raised.
 
@@ -192,8 +192,11 @@ class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
         return output
 
     def __setitem__(self, k: SeqStrType, v: Union[T, _NestedMappingType]) -> None:
-        """This is a zero-copy operation. The pointer to value if preserved in the
-        internal data structure."""
+        """Sets item at `k` to `v`.
+
+        This is a zero-copy operation. The pointer to value if preserved in the
+        internal data structure.
+        """
         if not k:
             raise IndexError(
                 f"Key for {self.__class__.__name__} cannot be empty. Got {k}."
@@ -236,6 +239,7 @@ class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
                 yield tuple(k)
 
     def __delitem__(self, k: SeqStrType) -> None:
+        """Deletes item at `k`."""
         ks, ns = [], []
         data_ptr = self._data
         for k in _flatten_index(k):
@@ -287,6 +291,7 @@ class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
         ignore_missing: bool = False,
     ) -> "NestedDict[T]":
         """Returns a NestedDict with only entries present in `other`.
+
         The values in the `other` NestedDict are ignored. Only the keys are used.
 
         Args:

--- a/rllib/utils/nested_dict.py
+++ b/rllib/utils/nested_dict.py
@@ -62,20 +62,20 @@ class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
     """A dict with special properties to support partial indexing.
 
     The main properties of NestedDict are::
-        * The nested dict gives access to nested elements as a sequence of
+        * The NestedDict gives access to nested elements as a sequence of
         strings.
-        * These nested dicts can also be used to filter a superset into a subset of
+        * These NestedDicts can also be used to filter a superset into a subset of
         nested elements with the filter function.
         * This can be instantiated with any mapping of strings, or an iterable of
         key value tuples where the values can themselves be recursively the values
-        that a nested dict can take.
-        * The length of a nested dict is the number of leaves in the tree, excluding
+        that a NestedDict can take.
+        * The length of a NestedDict is the number of leaves in the tree, excluding
         empty leafs.
-        * Iterating over a nested dict yields the leaves of the tree, including empty
+        * Iterating over a NestedDict yields the leaves of the tree, including empty
         leafs.
 
     Args:
-        x: a representation of a nested dict: it can be an iterable of `SeqStrType`
+        x: a representation of a NestedDict: it can be an iterable of `SeqStrType`
         to values. e.g. `[(("a", "b") , 1), ("b", 2)]` or a mapping of flattened
         keys to values. e.g. `{("a", "b"): 1, ("b",): 2}` or any nested mapping,
         e.g. `{"a": {"b": 1}, "b": {}}`.
@@ -137,7 +137,7 @@ class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
             raise ValueError(f"Input must be a Mapping or Iterable, got {type(x)}.")
 
     def __contains__(self, k: SeqStrType) -> bool:
-        """Returns true if the key is in the nested dict."""
+        """Returns true if the key is in the NestedDict."""
         k = _flatten_index(k)
 
         data_ptr = self._data  # type: Dict[str, Any]

--- a/rllib/utils/nested_dict.py
+++ b/rllib/utils/nested_dict.py
@@ -210,7 +210,11 @@ class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
         while stack:
             k, v = stack.pop(0)
             if isinstance(v, NestedDict):
-                stack = [(k + (StrKey(k2),), v) for k2, v in v._data.items()] + stack
+                items = v._data.items()
+                if len(items) == 0:
+                    yield tuple(k)
+                else:
+                    stack = [(k + (StrKey(k2),), v) for k2, v in items] + stack
             else:
                 yield tuple(k)
 
@@ -297,7 +301,7 @@ class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
 
     def copy(self) -> "NestedDict[T]":
         """Returns a shallow copy of the NestedDict."""
-        return NestedDict(self)
+        return NestedDict(self.items())
 
     def __copy__(self) -> "NestedDict[T]":
         return self.copy()

--- a/rllib/utils/nested_dict.py
+++ b/rllib/utils/nested_dict.py
@@ -72,7 +72,7 @@ class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
         x: a representation of a nested dict: it can be an iterable of `SeqStrType`
         to values. e.g. `[(("a", "b") , 1), ("b", 2)]` or a mapping of flattened
         keys to values. e.g. `{("a", "b"): 1, ("b",): 2}` or any nested mapping,
-        e.g. `{"a": {"b": 1}, "b": 2}`.
+        e.g. `{"a": {"b": 1}, "b": {}}`.
 
     Example:
         Basic usage:
@@ -186,8 +186,6 @@ class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
     def __setitem__(self, k: SeqStrType, v: Union[T, _NestedMappingType]) -> None:
         """This is a zero-copy operation. The pointer to value if preserved in the
         internal data structure."""
-        if isinstance(v, Mapping) and len(v) == 0:
-            return
         if not k:
             raise IndexError(
                 f"Key for {self.__class__.__name__} cannot be empty. Got {k}."
@@ -299,7 +297,7 @@ class NestedDict(Generic[T], MutableMapping[str, Union[T, "NestedDict"]]):
 
     def copy(self) -> "NestedDict[T]":
         """Returns a shallow copy of the NestedDict."""
-        return NestedDict(self.items())
+        return NestedDict(self)
 
     def __copy__(self) -> "NestedDict[T]":
         return self.copy()

--- a/rllib/utils/tests/test_nested_dict.py
+++ b/rllib/utils/tests/test_nested_dict.py
@@ -24,7 +24,8 @@ class TestNestedDict(unittest.TestCase):
             "d": {"g": {"h": {"i": 500}}},
             # An empty dict that has no leafs and thus should be ignored when
             # counting or iterating
-            "j": {},
+            "j": {"k": {}},
+            "l": {},
         }
 
         desired_keys = [
@@ -50,7 +51,8 @@ class TestNestedDict(unittest.TestCase):
 
         # this call will use __len__ and __iter__
         foo_dict["d"] = {"g": NestedDict([("h", NestedDict({"i": 500}))])}
-        foo_dict["j"] = {}
+        foo_dict["j"] = {"k": {}}
+        foo_dict["l"] = {}
 
         # test asdict
         check(foo_dict.asdict(), desired_dict)
@@ -99,7 +101,7 @@ class TestNestedDict(unittest.TestCase):
         )
 
         # test shallow_keys()
-        self.assertEqual(list(foo_dict.shallow_keys()), ["aa", "b", "c", "d", "j"])
+        self.assertEqual(list(foo_dict.shallow_keys()), ["aa", "b", "c", "d", "j", "l"])
 
         # test copy()
         foo_dict_copy = foo_dict.copy()

--- a/rllib/utils/tests/test_nested_dict.py
+++ b/rllib/utils/tests/test_nested_dict.py
@@ -34,9 +34,12 @@ class TestNestedDict(unittest.TestCase):
             ("b", "d"),
             ("c", "e", "f"),
             ("d", "g", "h", "i"),
+            ("j", "k"),
+            ("l",),
         ]
 
-        desired_values = [100, 200, 300, 400, 500]
+        # We have 5 leafs that are not empty and two empty leafs
+        desired_values = [100, 200, 300, 400, 500, NestedDict({}), NestedDict({})]
 
         foo_dict["aa"] = 100
         foo_dict["b", "c"] = 200
@@ -44,10 +47,11 @@ class TestNestedDict(unittest.TestCase):
         foo_dict["c", "e"] = {"f": 400}
 
         # test __len__
-        self.assertEqual(len(foo_dict), len(desired_keys) - 1)
+        # We have not yet included d, j and l in foo_dict
+        self.assertEqual(len(foo_dict), len(desired_keys) - 3)
 
         # test __iter__
-        self.assertEqual(list(iter(foo_dict)), desired_keys[:-1])
+        self.assertEqual(list(iter(foo_dict)), desired_keys[:-3])
 
         # this call will use __len__ and __iter__
         foo_dict["d"] = {"g": NestedDict([("h", NestedDict({"i": 500}))])}
@@ -58,7 +62,9 @@ class TestNestedDict(unittest.TestCase):
         check(foo_dict.asdict(), desired_dict)
 
         # test __len__ again
-        self.assertEqual(len(foo_dict), len(desired_keys))
+        # We have included d, j and l in foo_dict, but j and l don't contribute to
+        # the length
+        self.assertEqual(len(foo_dict), len(desired_keys) - 2)
 
         # test __iter__ again
         self.assertEqual(list(iter(foo_dict)), desired_keys)

--- a/rllib/utils/tests/test_nested_dict.py
+++ b/rllib/utils/tests/test_nested_dict.py
@@ -39,7 +39,7 @@ class TestNestedDict(unittest.TestCase):
         ]
 
         # We have 5 leafs that are not empty and two empty leafs
-        desired_values = [100, 200, 300, 400, 500, NestedDict({}), NestedDict({})]
+        desired_values = [100, 200, 300, 400, 500, NestedDict(), NestedDict()]
 
         foo_dict["aa"] = 100
         foo_dict["b", "c"] = 200
@@ -63,7 +63,8 @@ class TestNestedDict(unittest.TestCase):
 
         # test __len__ again
         # We have included d, j and l in foo_dict, but j and l don't contribute to
-        # the length
+        # the length because they are empty sub-roots of the tree structure with no
+        # leafs.
         self.assertEqual(len(foo_dict), len(desired_keys) - 2)
 
         # test __iter__ again
@@ -169,6 +170,9 @@ class TestNestedDict(unittest.TestCase):
         # test init with nested empty element
         foo_dict = NestedDict({"a": {"b": {}, "c": 2}})
         self.assertEqual(foo_dict.asdict(), {"a": {"b": {}, "c": 2}})
+
+        # test init with empty dict
+        self.assertEqual(NestedDict().asdict(), {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

In order to support checking arbitrary dicts (for example when recurrent state is simply an empty dict), we need to be able to instantiate NestedDicts with such "empty" branches where the leafs are empty dicts. Meanwhile, they should not contribute to the length or be included when iterating over a NestedDict. This PR makes the requirements above happen.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
