### PR TITLE
[Datasets] Fix dynamic block splitting for new backend.

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -482,9 +482,17 @@ class _OrderedOutputQueue(_OutputQueue):
         )
 
     def get_next(self) -> RefBundle:
-        i = self._next_output_index
-        self._next_output_index += 1
-        return self._tasks_by_output_order.pop(i).output
+        # Get the output RefBundle for the current task.
+        out_bundle = self._tasks_by_output_order[self._next_output_index].output
+        # Pop out the next single-block bundle.
+        next_bundle = RefBundle(
+            [out_bundle.blocks.pop(0)], owns_blocks=out_bundle.owns_blocks
+        )
+        if not out_bundle.blocks:
+            # If this task's RefBundle is exhausted, move to the next one.
+            del self._tasks_by_output_order[self._next_output_index]
+            self._next_output_index += 1
+        return next_bundle
 
 
 class _UnorderedOutputQueue(_OutputQueue):
@@ -500,7 +508,16 @@ class _UnorderedOutputQueue(_OutputQueue):
         return len(self._completed_tasks) > 0
 
     def get_next(self) -> RefBundle:
-        return self._completed_tasks.pop(0).output
+        # Get the output RefBundle for the oldest completed task.
+        out_bundle = self._completed_tasks[0].output
+        # Pop out the next single-block bundle.
+        next_bundle = RefBundle(
+            [out_bundle.blocks.pop(0)], owns_blocks=out_bundle.owns_blocks
+        )
+        if not out_bundle.blocks:
+            # If this task's RefBundle is exhausted, move to the next one.
+            del self._completed_tasks[0]
+        return next_bundle
 
 
 def _canonicalize_ray_remote_args(ray_remote_args: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
This PR fixes dynamic block splitting for the next execution backend; previously, we were sending the `N` blocks output by a task as a single input `RefBundle` to downstream operator tasks, effectively disabling dynamic block splitting. This PR ensures that we only send single-block `RefBundle`s to downstream operator tasks.

Progress bar tweaks can be done as a follow-up.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #32119 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
