### PR TITLE
[RLlib] Exclude gpu tag from Examples test suite in RLlib

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -177,7 +177,7 @@
     - RLLIB_TESTING=1 ./ci/env/install-dependencies.sh
     - ./ci/env/env_info.sh
     - ./ci/run/run_bazel_test_with_sharding.sh --config=ci $(./ci/run/bazel_export_options) --build_tests_only
-      --test_tag_filters=examples,-multi_gpu --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 rllib/...
+      --test_tag_filters=examples,-multi_gpu,-gpu --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 rllib/...
 
 - label: ":brain: RLlib: tests/ dir"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_DIRECTLY_AFFECTED"]

--- a/rllib/core/rl_trainer/torch/torch_rl_trainer.py
+++ b/rllib/core/rl_trainer/torch/torch_rl_trainer.py
@@ -78,6 +78,7 @@ class TorchRLTrainer(RLTrainer):
         self._world_size = scaling_config.num_workers or 1
         self._use_gpu = scaling_config.use_gpu
 
+        foo = 1
         # These attributes are set in the `build` method.
         self._device = None
 

--- a/rllib/core/rl_trainer/torch/torch_rl_trainer.py
+++ b/rllib/core/rl_trainer/torch/torch_rl_trainer.py
@@ -47,7 +47,6 @@ logger = logging.getLogger(__name__)
 
 
 class TorchRLTrainer(RLTrainer):
-    """RLTrainer implementation for PyTorch."""
 
     framework: str = "torch"
 
@@ -78,7 +77,6 @@ class TorchRLTrainer(RLTrainer):
         self._world_size = scaling_config.num_workers or 1
         self._use_gpu = scaling_config.use_gpu
 
-        foo = 1
         # These attributes are set in the `build` method.
         self._device = None
 

--- a/rllib/core/rl_trainer/torch/torch_rl_trainer.py
+++ b/rllib/core/rl_trainer/torch/torch_rl_trainer.py
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 
 
 class TorchRLTrainer(RLTrainer):
+    """RLTrainer implementation for PyTorch."""
 
     framework: str = "torch"
 


### PR DESCRIPTION
RLlib's tests that are tagged examples but not tagged gpu or multi-gpu, should run on no-gpu instances, so we should exclude the gpu tag (similar to how multi-gpu is already excluded)

Signed-off-by: Kourosh Hakhamaneshi <kourosh@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
