### PR TITLE
[core] Increase the threshold for pubsub integration test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1693,7 +1693,7 @@ cc_test(
 
 cc_test(
     name = "pubsub_integration_test",
-    timeout = "short",
+    timeout = "small",
     srcs = ["src/ray/pubsub/test/integration_test.cc"],
     copts = COPTS,
     tags = ["team:core"],

--- a/src/ray/pubsub/test/integration_test.cc
+++ b/src/ray/pubsub/test/integration_test.cc
@@ -295,7 +295,7 @@ TEST_F(IntegrationTest, SubscribersToOneIDAndAllIDs) {
   // logic below.
   int wait_count = 0;
   while (!(subscriber_1->CheckNoLeaks() && subscriber_2->CheckNoLeaks())) {
-    ASSERT_LT(wait_count, 15) << "Subscribers still have inflight operations after 15s";
+    ASSERT_LT(wait_count, 60) << "Subscribers still have inflight operations after 60s";
     ++wait_count;
     absl::SleepFor(absl::Seconds(1));
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The test failed asan because some data is not cleaned when it exits. Increase the threshold to mitigate it. Tested locally and for 500 runs, only 3 failed.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
