### PR TITLE
[Ray release infra] Using self-hosted Atari ROMs since torrent is unreliable

### DIFF
--- a/release/dashboard/agent_stress_app_config.yaml
+++ b/release/dashboard/agent_stress_app_config.yaml
@@ -25,7 +25,10 @@ post_build_cmds:
   - pip install ale-py==0.7
   - pip uninstall importlib-metadata -y
   - pip install importlib-metadata==4.13.0
-  - pip install gym[atari] autorom[accept-rom-license]
+  # AutoROM downloads ROMs via torrent when they are built. The torrent is unreliable,
+  # so we built it for py3 and use that instead. This wheel was tested for python 3.7, 3.8,
+  # and 3.9.
+  - pip install gym[atari] https://ray-ci-deps-wheels.s3.us-west-2.amazonaws.com/AutoROM.accept_rom_license-0.5.4-py3-none-any.whl
   - pip3 uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U ray[default]
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -11,9 +11,12 @@ python:
     # requirements_ml_docker.txt and removed here
     - gym>=0.21.0,<0.24.1
     - ale-py==0.7.5
-    - autorom[accept-rom-license]
     - pytest
     - tensorflow
+    # AutoROM downloads ROMs via torrent when they are built. The torrent is unreliable,
+    # so we built it for py3 and use that instead. This wheel was tested for python 3.7, 3.8,
+    # and 3.9.
+    - https://ray-ci-deps-wheels.s3.us-west-2.amazonaws.com/AutoROM.accept_rom_license-0.5.4-py3-none-any.whl
   conda_packages: []
 
 post_build_cmds:

--- a/release/long_running_tests/app_config_np.yaml
+++ b/release/long_running_tests/app_config_np.yaml
@@ -9,11 +9,14 @@ python:
   pip_packages:
     - "gym[atari]>=0.21.0,<0.24.0"
     - ale-py==0.7.5
-    - autorom[accept-rom-license]
     - pygame
     - pytest
     - tensorflow
     - torch
+    # AutoROM downloads ROMs via torrent when they are built. The torrent is unreliable,
+    # so we built it for py3 and use that instead. This wheel was tested for python 3.7, 3.8,
+    # and 3.9.
+    - https://ray-ci-deps-wheels.s3.us-west-2.amazonaws.com/AutoROM.accept_rom_license-0.5.4-py3-none-any.whl
   conda_packages: []
 
 post_build_cmds:


### PR DESCRIPTION
In https://github.com/ray-project/ray/pull/31933 we fix an Atari ROM dependency that by default uses a torrent to download ROMs. The tests in this PR also break occasionally due to the same reason.

I moved the ROM dependency to S3 to increase reliability. I actually think we can remove the ROM dependency from these app configs since I don't see any RL test using them. But I think that is too much risk for this PR, since it will likely end up as a cherry pick to 2.3.