### PR TITLE
[Serve] Change default app name to a non-empty string

### DIFF
--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -19,6 +19,7 @@ from ray.serve._private.constants import (
     CLIENT_POLLING_INTERVAL_S,
     MAX_CACHED_HANDLES,
     SERVE_NAMESPACE,
+    SERVE_DEFAULT_APP_NAME,
 )
 from ray.serve.controller import ServeController
 from ray.serve.exceptions import RayServeException
@@ -385,7 +386,7 @@ class ServeControllerClient:
         return ray.get(self._controller.get_app_config.remote())
 
     @_ensure_connected
-    def get_serve_status(self, name: str = "") -> StatusOverview:
+    def get_serve_status(self, name: str = SERVE_DEFAULT_APP_NAME) -> StatusOverview:
         proto = StatusOverviewProto.FromString(
             ray.get(self._controller.get_serve_status.remote(name))
         )

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -93,7 +93,7 @@ class DeploymentStatusInfo:
 @dataclass(eq=True)
 class StatusOverview:
     app_status: ApplicationStatusInfo
-    name: str = ""
+    name: str = "default"
     deployment_statuses: List[DeploymentStatusInfo] = field(default_factory=list)
 
     def debug_string(self):

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -67,6 +67,9 @@ RECONFIGURE_METHOD = "reconfigure"
 
 SERVE_ROOT_URL_ENV_KEY = "RAY_SERVE_ROOT_URL"
 
+#: Default Serve application name
+SERVE_DEFAULT_APP_NAME = "default"
+
 #: Number of historically deleted deployments to store in the checkpoint.
 MAX_NUM_DELETED_DEPLOYMENTS = 1000
 

--- a/python/ray/serve/_private/deployment_graph_build.py
+++ b/python/ray/serve/_private/deployment_graph_build.py
@@ -32,7 +32,7 @@ from ray.dag.utils import _DAGNodeNameGenerator
 from ray.experimental.gradio_utils import type_to_string
 
 
-def build(ray_dag_root_node: DAGNode, name: str = None) -> List[Deployment]:
+def build(ray_dag_root_node: DAGNode, name: str) -> List[Deployment]:
     """Do all the DAG transformation, extraction and generation needed to
     produce a runnable and deployable serve pipeline application from a valid
     DAG authored with Ray DAG API.

--- a/python/ray/serve/_private/deployment_graph_build.py
+++ b/python/ray/serve/_private/deployment_graph_build.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 
 from ray.serve.deployment import Deployment, schema_to_deployment
 from ray.serve.deployment_graph import RayServeDAGHandle
+from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve._private.deployment_method_node import DeploymentMethodNode
 from ray.serve._private.deployment_node import DeploymentNode
 from ray.serve._private.deployment_function_node import DeploymentFunctionNode
@@ -32,7 +33,7 @@ from ray.dag.utils import _DAGNodeNameGenerator
 from ray.experimental.gradio_utils import type_to_string
 
 
-def build(ray_dag_root_node: DAGNode, name: str) -> List[Deployment]:
+def build(ray_dag_root_node: DAGNode, name: str = SERVE_DEFAULT_APP_NAME) -> List[Deployment]:
     """Do all the DAG transformation, extraction and generation needed to
     produce a runnable and deployable serve pipeline application from a valid
     DAG authored with Ray DAG API.

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -19,6 +19,7 @@ from ray.serve.config import AutoscalingConfig, DeploymentConfig, HTTPOptions
 from ray.serve._private.constants import (
     DEFAULT_HTTP_HOST,
     DEFAULT_HTTP_PORT,
+    SERVE_DEFAULT_APP_NAME,
     MIGRATION_MESSAGE,
 )
 from ray.serve.context import (
@@ -457,7 +458,7 @@ def run(
     _blocking: bool = True,
     host: str = DEFAULT_HTTP_HOST,
     port: int = DEFAULT_HTTP_PORT,
-    name: str = "",
+    name: str = SERVE_DEFAULT_APP_NAME,
     route_prefix: str = "/",
 ) -> Optional[RayServeHandle]:
     """Run a Serve application and return a ServeHandle to the ingress.

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -496,9 +496,6 @@ def run(
 
     if isinstance(target, Application):
         deployments = list(target.deployments.values())
-        if name:
-            for deployment in deployments:
-                deployment._name = f"{name}_{deployment._name}"
         ingress = target.ingress
     # Each DAG should always provide a valid Driver ClassNode
     elif isinstance(target, ClassNode):
@@ -565,7 +562,7 @@ def run(
 
 
 @PublicAPI(stability="alpha")
-def build(target: Union[ClassNode, FunctionNode]) -> Application:
+def build(target: Union[ClassNode, FunctionNode], name: str) -> Application:
     """Builds a Serve application into a static application.
 
     Takes in a ClassNode or FunctionNode and converts it to a
@@ -596,7 +593,7 @@ def build(target: Union[ClassNode, FunctionNode]) -> Application:
 
     # TODO(edoakes): this should accept host and port, but we don't
     # currently support them in the REST API.
-    return Application(pipeline_build(target))
+    return Application(pipeline_build(target, name))
 
 
 @PublicAPI(stability="alpha")

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -758,7 +758,7 @@ def run_graph(
 
         # Import and build the graph
         graph = import_attr(import_path)
-        app = build(graph)
+        app = build(graph, name)
 
         # Override options for each deployment
         for options in deployment_override_options:

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -30,6 +30,7 @@ from ray.serve._private.constants import (
     SERVE_LOGGER_NAME,
     CONTROLLER_MAX_CONCURRENCY,
     SERVE_ROOT_URL_ENV_KEY,
+    SERVE_DEFAULT_APP_NAME,
     SERVE_NAMESPACE,
     RAY_INTERNAL_SERVE_CONTROLLER_PIN_ON_NODE,
 )
@@ -585,7 +586,7 @@ class ServeController:
             )
         return deployment_route_list.SerializeToString()
 
-    def get_serve_status(self, name: str = "") -> bytes:
+    def get_serve_status(self, name: str = SERVE_DEFAULT_APP_NAME) -> bytes:
         """Return application status
         Args:
             name: application name. If application name doesn't exist, app_status
@@ -609,7 +610,7 @@ class ServeController:
             statuses.append(self.get_serve_status(name))
         return statuses
 
-    def get_app_config(self, name: str = "") -> Dict:
+    def get_app_config(self, name: str = SERVE_DEFAULT_APP_NAME) -> Dict:
         checkpoint = self.kv_store.get(CONFIG_CHECKPOINT_KEY)
         if checkpoint is None:
             return ServeApplicationSchema.get_empty_schema_dict()
@@ -733,7 +734,7 @@ def run_graph(
     graph_env: Dict,
     deployment_override_options: List[Dict],
     deployment_versions: Dict,
-    name: str = "",
+    name: str = SERVE_DEFAULT_APP_NAME,
     route_prefix: str = "/",
 ):
     """

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -243,7 +243,7 @@ class DeploymentSchema(
 @PublicAPI(stability="beta")
 class ServeApplicationSchema(BaseModel, extra=Extra.forbid):
     name: str = Field(
-        default="",
+        default="default",
         description=(
             "Application name, the name should be unique within the serve instance"
         ),
@@ -412,7 +412,7 @@ class ServeApplicationSchema(BaseModel, extra=Extra.forbid):
 
 @PublicAPI(stability="beta")
 class ServeStatusSchema(BaseModel, extra=Extra.forbid):
-    name: str = Field(description="Application name", default="")
+    name: str = Field(description="Application name", default="default")
     app_status: ApplicationStatusInfo = Field(
         ...,
         description=(

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 import ray
 from ray import serve
 from ray._private.test_utils import SignalActor, wait_for_condition
+from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve.application import Application
 from ray.serve.drivers import DAGDriver
 
@@ -439,8 +440,8 @@ def test_run_delete_old_deployments(serve_instance):
     ingress_handle = serve.run(g.bind())
     assert ray.get(ingress_handle.remote()) == "got g"
 
-    assert "g" in serve.list_deployments()
-    assert "f" not in serve.list_deployments()
+    assert f"{SERVE_DEFAULT_APP_NAME}_g" in serve.list_deployments()
+    assert f"{SERVE_DEFAULT_APP_NAME}_f" not in serve.list_deployments()
 
 
 class TestSetOptions:
@@ -573,7 +574,7 @@ def test_deployment_name_with_app_name():
 
     serve.run(g.bind())
     deployment_info = ray.get(controller._all_running_replicas.remote())
-    assert "g" in deployment_info
+    assert f"{SERVE_DEFAULT_APP_NAME}_g" in deployment_info
 
     @serve.deployment
     def f():


### PR DESCRIPTION
Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

REST api cannot reach default app if the default app name is "".
Changed the default app name to "default", open to other suggestions as well.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
