### PR TITLE
[core][state][dashboard] Use main threads's task id or actor creation task id for parent's task id in state API

### DIFF
--- a/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
@@ -64,7 +64,8 @@ ObjectID LocalModeTaskSubmitter::Submit(InvocationSpec &invocation,
                             required_resources,
                             required_placement_resources,
                             "",
-                            /*depth=*/0);
+                            /*depth=*/0,
+                            local_mode_ray_tuntime_.GetCurrentTaskId());
   if (invocation.task_type == TaskType::NORMAL_TASK) {
   } else if (invocation.task_type == TaskType::ACTOR_CREATION_TASK) {
     invocation.actor_id = local_mode_ray_tuntime_.GetNextActorID();

--- a/python/ray/experimental/state/common.py
+++ b/python/ray/experimental/state/common.py
@@ -545,7 +545,8 @@ class TaskState(StateSchema):
     #: The runtime environment information for the task.
     runtime_env_info: str = state_column(detail=True, filterable=False)
     #: The parent task id. If the parent is a normal task, it will be the task's id.
-    #: If the parent runs in an actor, it will be the actor's creation task id.
+    #: If the parent runs in a concurrent actor (async actor or threaded actor),
+    #: it will be the actor's creation task id.
     parent_task_id: str = state_column(filterable=True)
     #: The placement group id that's associated with this task.
     placement_group_id: str = state_column(detail=True, filterable=True)

--- a/python/ray/experimental/state/common.py
+++ b/python/ray/experimental/state/common.py
@@ -544,7 +544,8 @@ class TaskState(StateSchema):
     required_resources: dict = state_column(detail=True, filterable=False)
     #: The runtime environment information for the task.
     runtime_env_info: str = state_column(detail=True, filterable=False)
-    #: The parent task id.
+    #: The parent task id. If the parent is a normal task, it will be the task's id.
+    #: If the parent runs in an actor, it will be the actor's creation task id.
     parent_task_id: str = state_column(filterable=True)
     #: The placement group id that's associated with this task.
     placement_group_id: str = state_column(detail=True, filterable=True)

--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -1,12 +1,14 @@
 from collections import defaultdict
 from typing import Dict
 import pytest
+import threading
 import time
 
 import ray
 from ray.experimental.state.common import ListApiOptions, StateResource
 from ray._private.test_utils import (
     raw_metrics,
+    run_string_as_driver,
     run_string_as_driver_nonblocking,
     wait_for_condition,
 )
@@ -122,6 +124,210 @@ def test_fault_tolerance_parent_failed(shutdown_only):
         timeout=10,
         retry_interval_ms=500,
     )
+
+
+def test_parent_task_id_threaded_task(shutdown_only):
+    ray.init(_system_config=_SYSTEM_CONFIG)
+
+    # Task starts a thread
+    @ray.remote
+    def main_task():
+        def thd_task():
+            @ray.remote
+            def thd_task():
+                pass
+
+            ray.get(thd_task.remote())
+
+        thd = threading.Thread(target=thd_task)
+        thd.start()
+        thd.join()
+
+    ray.get(main_task.remote())
+
+    def verify():
+        tasks = list_tasks()
+        assert len(tasks) == 2
+        expect_parent_task_id = None
+        actual_parent_task_id = None
+        for task in tasks:
+            if task["name"] == "main_task":
+                expect_parent_task_id = task["task_id"]
+            elif task["name"] == "thd_task":
+                actual_parent_task_id = task["parent_task_id"]
+        assert actual_parent_task_id is not None
+        assert expect_parent_task_id == actual_parent_task_id
+
+        return True
+
+    wait_for_condition(verify)
+
+
+def test_parent_task_id_actor(shutdown_only):
+    ray.init(_system_config=_SYSTEM_CONFIG)
+
+    def run_task_in_thread():
+        def thd_task():
+            @ray.remote
+            def thd_task():
+                pass
+
+            ray.get(thd_task.remote())
+
+        thd = threading.Thread(target=thd_task)
+        thd.start()
+        thd.join()
+
+    @ray.remote
+    class Actor:
+        def main_task(self):
+            run_task_in_thread()
+
+    a = Actor.remote()
+    ray.get(a.main_task.remote())
+
+    def verify():
+        tasks = list_tasks()
+        expect_parent_task_id = None
+        actual_parent_task_id = None
+        for task in tasks:
+            if "main_task" in task["name"]:
+                expect_parent_task_id = task["task_id"]
+            elif "thd_task" in task["name"]:
+                actual_parent_task_id = task["parent_task_id"]
+        print(tasks)
+        assert actual_parent_task_id is not None
+        assert expect_parent_task_id == actual_parent_task_id
+
+        return True
+
+    wait_for_condition(verify)
+
+
+@pytest.mark.parametrize("actor_concurrency", [3, 10])
+def test_parent_task_id_multi_thread_actors(shutdown_only, actor_concurrency):
+    ray.init(_system_config=_SYSTEM_CONFIG)
+
+    def run_task_in_thread(name, i):
+        def thd_task():
+            @ray.remote
+            def thd_task():
+                pass
+
+            ray.get(thd_task.options(name=f"{name}_{i}").remote())
+
+        thd = threading.Thread(target=thd_task)
+        thd.start()
+        thd.join()
+
+    @ray.remote
+    class AsyncActor:
+        async def main_task(self, i):
+            run_task_in_thread("async_thd_task", i)
+
+    @ray.remote
+    class ThreadedActor:
+        def main_task(self, i):
+            run_task_in_thread("threaded_thd_task", i)
+
+    def verify(actor_method_name, actor_class_name):
+        tasks = list_tasks()
+        print(tasks)
+        expect_parent_task_id = None
+        actual_parent_task_id = None
+        for task in tasks:
+            if f"{actor_class_name}.__init__" in task["name"]:
+                expect_parent_task_id = task["task_id"]
+
+        assert expect_parent_task_id is not None
+        for task in tasks:
+            if f"{actor_method_name}" in task["name"]:
+                actual_parent_task_id = task["parent_task_id"]
+                assert expect_parent_task_id == actual_parent_task_id, task
+
+        return True
+
+    async_actor = AsyncActor.options(max_concurrency=actor_concurrency).remote()
+    ray.get([async_actor.main_task.remote(i) for i in range(20)])
+    wait_for_condition(
+        verify, actor_class_name="AsyncActor", actor_method_name="async_thd_task"
+    )
+
+    thd_actor = ThreadedActor.options(max_concurrency=actor_concurrency).remote()
+    ray.get([thd_actor.main_task.remote(i) for i in range(20)])
+    wait_for_condition(
+        verify, actor_class_name="ThreadedActor", actor_method_name="threaded_thd_task"
+    )
+
+
+def test_parent_task_id_tune_e2e(shutdown_only):
+    ray.init(_system_config=_SYSTEM_CONFIG)
+    job_id = ray.get_runtime_context().get_job_id()
+    script = """
+import numpy as np
+import ray
+from ray import tune
+import time
+
+ray.init("auto")
+
+@ray.remote
+def train_step_1():
+    time.sleep(0.5)
+    return 1
+
+def train_function(config):
+    for i in range(5):
+        loss = config["mean"] * np.random.randn() + ray.get(
+            train_step_1.remote())
+        tune.report(loss=loss, nodes=ray.nodes())
+
+
+def tune_function():
+    analysis = tune.run(
+        train_function,
+        metric="loss",
+        mode="min",
+        config={
+            "mean": tune.grid_search([1, 2, 3, 4, 5]),
+        },
+        resources_per_trial=tune.PlacementGroupFactory([{
+            'CPU': 1.0
+        }] + [{
+            'CPU': 1.0
+        }] * 3),
+    )
+    return analysis.best_config
+
+
+tune_function()
+    """
+
+    run_string_as_driver(script)
+    client = StateApiClient()
+
+    def list_tasks():
+        return client.list(
+            StateResource.TASKS,
+            # Filter out this driver
+            options=ListApiOptions(
+                exclude_driver=False, filters=[("job_id", "!=", job_id)], limit=1000
+            ),
+            raise_on_missing_output=True,
+        )
+
+    def verify():
+        tasks = list_tasks()
+
+        task_id_map = {task["task_id"]: task for task in tasks}
+        for task in tasks:
+            if task["type"] == "DRIVER_TASK":
+                continue
+            assert task_id_map.get(task["parent_task_id"], None) is not None, task
+
+        return True
+
+    wait_for_condition(verify)
 
 
 def test_handle_driver_tasks(shutdown_only):

--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -163,8 +163,49 @@ def test_parent_task_id_threaded_task(shutdown_only):
     wait_for_condition(verify)
 
 
-@pytest.mark.parametrize("actor_concurrency", [1, 3, 10])
-def test_parent_task_id_actors(shutdown_only, actor_concurrency):
+def test_parent_task_id_non_concurrent_actor(shutdown_only):
+    ray.init(_system_config=_SYSTEM_CONFIG)
+
+    def run_task_in_thread():
+        def thd_task():
+            @ray.remote
+            def thd_task():
+                pass
+
+            ray.get(thd_task.remote())
+
+        thd = threading.Thread(target=thd_task)
+        thd.start()
+        thd.join()
+
+    @ray.remote
+    class Actor:
+        def main_task(self):
+            run_task_in_thread()
+
+    a = Actor.remote()
+    ray.get(a.main_task.remote())
+
+    def verify():
+        tasks = list_tasks()
+        expect_parent_task_id = None
+        actual_parent_task_id = None
+        for task in tasks:
+            if "main_task" in task["name"]:
+                expect_parent_task_id = task["task_id"]
+            elif "thd_task" in task["name"]:
+                actual_parent_task_id = task["parent_task_id"]
+        print(tasks)
+        assert actual_parent_task_id is not None
+        assert expect_parent_task_id == actual_parent_task_id
+
+        return True
+
+    wait_for_condition(verify)
+
+
+@pytest.mark.parametrize("actor_concurrency", [3, 10])
+def test_parent_task_id_concurrent_actor(shutdown_only, actor_concurrency):
     # Test tasks runs in user started thread from actors have a parent_task_id
     # as the actor's creation task.
     ray.init(_system_config=_SYSTEM_CONFIG)

--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -163,49 +163,10 @@ def test_parent_task_id_threaded_task(shutdown_only):
     wait_for_condition(verify)
 
 
-def test_parent_task_id_actor(shutdown_only):
-    ray.init(_system_config=_SYSTEM_CONFIG)
-
-    def run_task_in_thread():
-        def thd_task():
-            @ray.remote
-            def thd_task():
-                pass
-
-            ray.get(thd_task.remote())
-
-        thd = threading.Thread(target=thd_task)
-        thd.start()
-        thd.join()
-
-    @ray.remote
-    class Actor:
-        def main_task(self):
-            run_task_in_thread()
-
-    a = Actor.remote()
-    ray.get(a.main_task.remote())
-
-    def verify():
-        tasks = list_tasks()
-        expect_parent_task_id = None
-        actual_parent_task_id = None
-        for task in tasks:
-            if "main_task" in task["name"]:
-                expect_parent_task_id = task["task_id"]
-            elif "thd_task" in task["name"]:
-                actual_parent_task_id = task["parent_task_id"]
-        print(tasks)
-        assert actual_parent_task_id is not None
-        assert expect_parent_task_id == actual_parent_task_id
-
-        return True
-
-    wait_for_condition(verify)
-
-
-@pytest.mark.parametrize("actor_concurrency", [3, 10])
-def test_parent_task_id_multi_thread_actors(shutdown_only, actor_concurrency):
+@pytest.mark.parametrize("actor_concurrency", [1, 3, 10])
+def test_parent_task_id_actors(shutdown_only, actor_concurrency):
+    # Test tasks runs in user started thread from actors have a parent_task_id
+    # as the actor's creation task.
     ray.init(_system_config=_SYSTEM_CONFIG)
 
     def run_task_in_thread(name, i):
@@ -261,6 +222,8 @@ def test_parent_task_id_multi_thread_actors(shutdown_only, actor_concurrency):
 
 
 def test_parent_task_id_tune_e2e(shutdown_only):
+    # Test a tune e2e workload should not have any task with parent_task_id that's
+    # not found.
     ray.init(_system_config=_SYSTEM_CONFIG)
     job_id = ray.get_runtime_context().get_job_id()
     script = """

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -160,6 +160,13 @@ TaskID TaskSpecification::ParentTaskId() const {
   return TaskID::FromBinary(message_->parent_task_id());
 }
 
+TaskID TaskSpecification::MainThreadParentTaskId() const {
+  if (message_->main_thread_parent_task_id().empty() /* e.g., empty proto default */) {
+    return TaskID::Nil();
+  }
+  return TaskID::FromBinary(message_->main_thread_parent_task_id());
+}
+
 size_t TaskSpecification::ParentCounter() const { return message_->parent_counter(); }
 
 ray::FunctionDescriptor TaskSpecification::FunctionDescriptor() const {

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -160,11 +160,11 @@ TaskID TaskSpecification::ParentTaskId() const {
   return TaskID::FromBinary(message_->parent_task_id());
 }
 
-TaskID TaskSpecification::MainThreadParentTaskId() const {
-  if (message_->main_thread_parent_task_id().empty() /* e.g., empty proto default */) {
+TaskID TaskSpecification::SubmitterTaskId() const {
+  if (message_->submitter_task_id().empty() /* e.g., empty proto default */) {
     return TaskID::Nil();
   }
-  return TaskID::FromBinary(message_->main_thread_parent_task_id());
+  return TaskID::FromBinary(message_->submitter_task_id());
 }
 
 size_t TaskSpecification::ParentCounter() const { return message_->parent_counter(); }

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -222,6 +222,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   TaskID ParentTaskId() const;
 
+  TaskID MainThreadParentTaskId() const;
+
   size_t ParentCounter() const;
 
   ray::FunctionDescriptor FunctionDescriptor() const;

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -222,7 +222,7 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   TaskID ParentTaskId() const;
 
-  TaskID MainThreadParentTaskId() const;
+  TaskID SubmitterTaskId() const;
 
   size_t ParentCounter() const;
 

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -130,7 +130,7 @@ class TaskSpecBuilder {
       const std::unordered_map<std::string, double> &required_placement_resources,
       const std::string &debugger_breakpoint,
       int64_t depth,
-      const TaskID &main_thread_parent_task_id,
+      const TaskID &submitter_task_id,
       const std::shared_ptr<rpc::RuntimeEnvInfo> runtime_env_info = nullptr,
       const std::string &concurrency_group_name = "") {
     message_->set_type(TaskType::NORMAL_TASK);
@@ -143,7 +143,7 @@ class TaskSpecBuilder {
     }
     message_->set_task_id(task_id.Binary());
     message_->set_parent_task_id(parent_task_id.Binary());
-    message_->set_main_thread_parent_task_id(main_thread_parent_task_id.Binary());
+    message_->set_submitter_task_id(submitter_task_id.Binary());
     message_->set_parent_counter(parent_counter);
     message_->set_caller_id(caller_id.Binary());
     message_->mutable_caller_address()->CopyFrom(caller_address);
@@ -185,13 +185,13 @@ class TaskSpecBuilder {
                                      const TaskID &parent_task_id,
                                      const TaskID &caller_id,
                                      const rpc::Address &caller_address,
-                                     const TaskID &main_thread_parent_task_id) {
+                                     const TaskID &submitter_task_id) {
     message_->set_type(TaskType::DRIVER_TASK);
     message_->set_language(language);
     message_->set_job_id(job_id.Binary());
     message_->set_task_id(task_id.Binary());
     message_->set_parent_task_id(parent_task_id.Binary());
-    message_->set_main_thread_parent_task_id(main_thread_parent_task_id.Binary());
+    message_->set_submitter_task_id(submitter_task_id.Binary());
     message_->set_parent_counter(0);
     message_->set_caller_id(caller_id.Binary());
     message_->mutable_caller_address()->CopyFrom(caller_address);

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -130,6 +130,7 @@ class TaskSpecBuilder {
       const std::unordered_map<std::string, double> &required_placement_resources,
       const std::string &debugger_breakpoint,
       int64_t depth,
+      const TaskID &main_thread_parent_task_id,
       const std::shared_ptr<rpc::RuntimeEnvInfo> runtime_env_info = nullptr,
       const std::string &concurrency_group_name = "") {
     message_->set_type(TaskType::NORMAL_TASK);
@@ -142,6 +143,7 @@ class TaskSpecBuilder {
     }
     message_->set_task_id(task_id.Binary());
     message_->set_parent_task_id(parent_task_id.Binary());
+    message_->set_main_thread_parent_task_id(main_thread_parent_task_id.Binary());
     message_->set_parent_counter(parent_counter);
     message_->set_caller_id(caller_id.Binary());
     message_->mutable_caller_address()->CopyFrom(caller_address);
@@ -182,12 +184,14 @@ class TaskSpecBuilder {
                                      const JobID &job_id,
                                      const TaskID &parent_task_id,
                                      const TaskID &caller_id,
-                                     const rpc::Address &caller_address) {
+                                     const rpc::Address &caller_address,
+                                     const TaskID &main_thread_parent_task_id) {
     message_->set_type(TaskType::DRIVER_TASK);
     message_->set_language(language);
     message_->set_job_id(job_id.Binary());
     message_->set_task_id(task_id.Binary());
     message_->set_parent_task_id(parent_task_id.Binary());
+    message_->set_main_thread_parent_task_id(main_thread_parent_task_id.Binary());
     message_->set_parent_counter(0);
     message_->set_caller_id(caller_id.Binary());
     message_->mutable_caller_address()->CopyFrom(caller_address);

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -161,7 +161,10 @@ WorkerContext::WorkerContext(WorkerType worker_type,
     GetThreadContext().SetCurrentTaskId(TaskID::ForDriverTask(job_id),
                                         /*attempt_number=*/0);
     // Driver runs in the main thread.
-    main_thread_or_actor_creation_task_id_ = TaskID::ForDriverTask(job_id);
+    {
+      absl::WriterMutexLock lock(&mutex_);
+      main_thread_or_actor_creation_task_id_ = TaskID::ForDriverTask(job_id);
+    }
   }
 }
 

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -161,7 +161,7 @@ WorkerContext::WorkerContext(WorkerType worker_type,
     GetThreadContext().SetCurrentTaskId(TaskID::ForDriverTask(job_id),
                                         /*attempt_number=*/0);
     // Driver runs in the main thread.
-    main_thread_current_task_id_ = TaskID::ForDriverTask(job_id);
+    main_thread_or_actor_creation_task_id = TaskID::ForDriverTask(job_id);
   }
 }
 
@@ -268,17 +268,18 @@ void WorkerContext::SetTaskDepth(int64_t depth) { task_depth_ = depth; }
 void WorkerContext::SetCurrentTask(const TaskSpecification &task_spec) {
   GetThreadContext().SetCurrentTask(task_spec);
   absl::WriterMutexLock lock(&mutex_);
-  if (CurrentThreadIsMain()) {
-    main_thread_current_task_id_ = task_spec.TaskId();
-  }
   SetTaskDepth(task_spec.GetDepth());
   RAY_CHECK(current_job_id_ == task_spec.JobId());
   if (task_spec.IsNormalTask()) {
     current_task_is_direct_call_ = true;
+    if (CurrentThreadIsMain()) {
+      main_thread_or_actor_creation_task_id = task_spec.TaskId();
+    }
   } else if (task_spec.IsActorCreationTask()) {
     if (!current_actor_id_.IsNil()) {
       RAY_CHECK(current_actor_id_ == task_spec.ActorCreationId());
     }
+    main_thread_or_actor_creation_task_id = task_spec.TaskId();
     current_actor_id_ = task_spec.ActorCreationId();
     current_actor_is_direct_call_ = true;
     current_actor_max_concurrency_ = task_spec.MaxActorConcurrency();
@@ -319,9 +320,9 @@ bool WorkerContext::CurrentThreadIsMain() const {
   return boost::this_thread::get_id() == main_thread_id_;
 }
 
-const TaskID WorkerContext::GetMainThreadCurrentTaskID() const {
+const TaskID WorkerContext::GetMainThreadOrActorCreationTaskID() const {
   absl::ReaderMutexLock lock(&mutex_);
-  return main_thread_current_task_id_;
+  return main_thread_or_actor_creation_task_id;
 }
 
 bool WorkerContext::ShouldReleaseResourcesOnBlockingCalls() const {

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -161,7 +161,7 @@ WorkerContext::WorkerContext(WorkerType worker_type,
     GetThreadContext().SetCurrentTaskId(TaskID::ForDriverTask(job_id),
                                         /*attempt_number=*/0);
     // Driver runs in the main thread.
-    main_thread_or_actor_creation_task_id = TaskID::ForDriverTask(job_id);
+    main_thread_or_actor_creation_task_id_ = TaskID::ForDriverTask(job_id);
   }
 }
 
@@ -273,13 +273,13 @@ void WorkerContext::SetCurrentTask(const TaskSpecification &task_spec) {
   if (task_spec.IsNormalTask()) {
     current_task_is_direct_call_ = true;
     if (CurrentThreadIsMain()) {
-      main_thread_or_actor_creation_task_id = task_spec.TaskId();
+      main_thread_or_actor_creation_task_id_ = task_spec.TaskId();
     }
   } else if (task_spec.IsActorCreationTask()) {
     if (!current_actor_id_.IsNil()) {
       RAY_CHECK(current_actor_id_ == task_spec.ActorCreationId());
     }
-    main_thread_or_actor_creation_task_id = task_spec.TaskId();
+    main_thread_or_actor_creation_task_id_ = task_spec.TaskId();
     current_actor_id_ = task_spec.ActorCreationId();
     current_actor_is_direct_call_ = true;
     current_actor_max_concurrency_ = task_spec.MaxActorConcurrency();
@@ -322,7 +322,7 @@ bool WorkerContext::CurrentThreadIsMain() const {
 
 const TaskID WorkerContext::GetMainThreadOrActorCreationTaskID() const {
   absl::ReaderMutexLock lock(&mutex_);
-  return main_thread_or_actor_creation_task_id;
+  return main_thread_or_actor_creation_task_id_;
 }
 
 bool WorkerContext::ShouldReleaseResourcesOnBlockingCalls() const {

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -272,17 +272,16 @@ void WorkerContext::SetCurrentTask(const TaskSpecification &task_spec) {
   GetThreadContext().SetCurrentTask(task_spec);
   absl::WriterMutexLock lock(&mutex_);
   SetTaskDepth(task_spec.GetDepth());
+  if (CurrentThreadIsMain()) {
+    main_thread_or_actor_creation_task_id_ = task_spec.TaskId();
+  }
   RAY_CHECK(current_job_id_ == task_spec.JobId());
   if (task_spec.IsNormalTask()) {
     current_task_is_direct_call_ = true;
-    if (CurrentThreadIsMain()) {
-      main_thread_or_actor_creation_task_id_ = task_spec.TaskId();
-    }
   } else if (task_spec.IsActorCreationTask()) {
     if (!current_actor_id_.IsNil()) {
       RAY_CHECK(current_actor_id_ == task_spec.ActorCreationId());
     }
-    main_thread_or_actor_creation_task_id_ = task_spec.TaskId();
     current_actor_id_ = task_spec.ActorCreationId();
     current_actor_is_direct_call_ = true;
     current_actor_max_concurrency_ = task_spec.MaxActorConcurrency();

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -40,6 +40,8 @@ class WorkerContext {
 
   const TaskID &GetCurrentTaskID() const;
 
+  const TaskID GetMainThreadCurrentTaskID() const;
+
   const PlacementGroupID &GetCurrentPlacementGroupId() const LOCKS_EXCLUDED(mutex_);
 
   bool ShouldCaptureChildTasksInPlacementGroup() const LOCKS_EXCLUDED(mutex_);
@@ -130,6 +132,9 @@ class WorkerContext {
   std::shared_ptr<rpc::RuntimeEnvInfo> runtime_env_info_ GUARDED_BY(mutex_);
   /// The id of the (main) thread that constructed this worker context.
   const boost::thread::id main_thread_id_;
+  /// The currently executing main thread's task id. Used merely for observability
+  /// purposes to track task hierarchy.
+  TaskID main_thread_current_task_id_;
   // To protect access to mutable members;
   mutable absl::Mutex mutex_;
 

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -133,7 +133,7 @@ class WorkerContext {
   /// The id of the (main) thread that constructed this worker context.
   const boost::thread::id main_thread_id_;
   /// The currently executing main thread's task id. It's the actor creation task id
-  /// for actor, or the main thread's task id for normal tasks.
+  /// for concurrent actor, or the main thread's task id for other cases.
   /// Used merely for observability purposes to track task hierarchy.
   TaskID main_thread_or_actor_creation_task_id_ GUARDED_BY(mutex_);
   // To protect access to mutable members;

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -135,7 +135,7 @@ class WorkerContext {
   /// The currently executing main thread's task id. It's the actor creation task id
   /// for actor, or the main thread's task id for normal tasks.
   /// Used merely for observability purposes to track task hierarchy.
-  TaskID main_thread_or_actor_creation_task_id;
+  TaskID main_thread_or_actor_creation_task_id_ GUARDED_BY(mutex_);
   // To protect access to mutable members;
   mutable absl::Mutex mutex_;
 

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -40,7 +40,7 @@ class WorkerContext {
 
   const TaskID &GetCurrentTaskID() const;
 
-  const TaskID GetMainThreadCurrentTaskID() const;
+  const TaskID GetMainThreadOrActorCreationTaskID() const;
 
   const PlacementGroupID &GetCurrentPlacementGroupId() const LOCKS_EXCLUDED(mutex_);
 
@@ -132,9 +132,10 @@ class WorkerContext {
   std::shared_ptr<rpc::RuntimeEnvInfo> runtime_env_info_ GUARDED_BY(mutex_);
   /// The id of the (main) thread that constructed this worker context.
   const boost::thread::id main_thread_id_;
-  /// The currently executing main thread's task id. Used merely for observability
-  /// purposes to track task hierarchy.
-  TaskID main_thread_current_task_id_;
+  /// The currently executing main thread's task id. It's the actor creation task id
+  /// for actor, or the main thread's task id for normal tasks.
+  /// Used merely for observability purposes to track task hierarchy.
+  TaskID main_thread_or_actor_creation_task_id;
   // To protect access to mutable members;
   mutable absl::Mutex mutex_;
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1833,7 +1833,7 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitTask(
                       debugger_breakpoint,
                       depth,
                       task_options.serialized_runtime_env_info,
-                      worker_context_.GetMainThreadCurrentTaskID(),
+                      worker_context_.GetMainThreadOrActorCreationTaskID(),
                       /*concurrency_group_name*/ "",
                       /*include_job_config*/ true);
   builder.SetNormalTaskSpec(max_retries,
@@ -1917,7 +1917,7 @@ Status CoreWorker::CreateActor(const RayFunction &function,
                       "" /* debugger_breakpoint */,
                       depth,
                       actor_creation_options.serialized_runtime_env_info,
-                      worker_context_.GetMainThreadCurrentTaskID(),
+                      worker_context_.GetMainThreadOrActorCreationTaskID(),
                       /*concurrency_group_name*/ "",
                       /*include_job_config*/ true);
 
@@ -2142,7 +2142,7 @@ std::optional<std::vector<rpc::ObjectReference>> CoreWorker::SubmitActorTask(
                       "",    /* debugger_breakpoint */
                       depth, /*depth*/
                       "{}",  /* serialized_runtime_env_info */
-                      worker_context_.GetMainThreadCurrentTaskID(),
+                      worker_context_.GetMainThreadOrActorCreationTaskID(),
                       task_options.concurrency_group_name,
                       /*include_job_config*/ false);
   // NOTE: placement_group_capture_child_tasks and runtime_env will

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -363,7 +363,8 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
                               // Driver has no parent task
                               /* parent_task_id */ TaskID::Nil(),
                               GetCallerId(),
-                              rpc_address_);
+                              rpc_address_,
+                              TaskID::Nil());
     // Drivers are never re-executed.
     SetCurrentTaskId(task_id, /*attempt_number=*/0, "driver");
 
@@ -1748,6 +1749,7 @@ void CoreWorker::BuildCommonTaskSpec(
     const std::string &debugger_breakpoint,
     int64_t depth,
     const std::string &serialized_runtime_env_info,
+    const TaskID &main_thread_current_task_id,
     const std::string &concurrency_group_name,
     bool include_job_config) {
   // Build common task spec.
@@ -1780,6 +1782,7 @@ void CoreWorker::BuildCommonTaskSpec(
       required_placement_resources,
       debugger_breakpoint,
       depth,
+      main_thread_current_task_id,
       override_runtime_env_info,
       concurrency_group_name);
   // Set task arguments.
@@ -1830,6 +1833,7 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitTask(
                       debugger_breakpoint,
                       depth,
                       task_options.serialized_runtime_env_info,
+                      worker_context_.GetMainThreadCurrentTaskID(),
                       /*concurrency_group_name*/ "",
                       /*include_job_config*/ true);
   builder.SetNormalTaskSpec(max_retries,
@@ -1913,6 +1917,7 @@ Status CoreWorker::CreateActor(const RayFunction &function,
                       "" /* debugger_breakpoint */,
                       depth,
                       actor_creation_options.serialized_runtime_env_info,
+                      worker_context_.GetMainThreadCurrentTaskID(),
                       /*concurrency_group_name*/ "",
                       /*include_job_config*/ true);
 
@@ -2137,6 +2142,7 @@ std::optional<std::vector<rpc::ObjectReference>> CoreWorker::SubmitActorTask(
                       "",    /* debugger_breakpoint */
                       depth, /*depth*/
                       "{}",  /* serialized_runtime_env_info */
+                      worker_context_.GetMainThreadCurrentTaskID(),
                       task_options.concurrency_group_name,
                       /*include_job_config*/ false);
   // NOTE: placement_group_capture_child_tasks and runtime_env will

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1145,6 +1145,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
       const std::string &debugger_breakpoint,
       int64_t depth,
       const std::string &serialized_runtime_env_info,
+      const TaskID &main_thread_current_task_id,
       const std::string &concurrency_group_name = "",
       bool include_job_config = false);
   void SetCurrentTaskId(const TaskID &task_id,

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -861,6 +861,11 @@ rpc::TaskInfoEntry TaskManager::MakeTaskInfoEntry(
   task_info.set_job_id(task_spec.JobId().Binary());
 
   task_info.set_task_id(task_spec.TaskId().Binary());
+  // NOTE: we set the parent task id of a task to be submitter's task id, where
+  // the submitter depends on the owner coreworker's:
+  // - if the owner coreworker runs a normal task, the submitter's task id is the task id.
+  // - if the owner coreworker runs an actor, the submitter's task id will be the actor's
+  // creation task id.
   task_info.set_parent_task_id(task_spec.SubmitterTaskId().Binary());
   const auto &resources_map = task_spec.GetRequiredResources().GetResourceMap();
   task_info.mutable_required_resources()->insert(resources_map.begin(),

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -861,7 +861,7 @@ rpc::TaskInfoEntry TaskManager::MakeTaskInfoEntry(
   task_info.set_job_id(task_spec.JobId().Binary());
 
   task_info.set_task_id(task_spec.TaskId().Binary());
-  task_info.set_parent_task_id(task_spec.MainThreadParentTaskId().Binary());
+  task_info.set_parent_task_id(task_spec.SubmitterTaskId().Binary());
   const auto &resources_map = task_spec.GetRequiredResources().GetResourceMap();
   task_info.mutable_required_resources()->insert(resources_map.begin(),
                                                  resources_map.end());

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -861,7 +861,7 @@ rpc::TaskInfoEntry TaskManager::MakeTaskInfoEntry(
   task_info.set_job_id(task_spec.JobId().Binary());
 
   task_info.set_task_id(task_spec.TaskId().Binary());
-  task_info.set_parent_task_id(task_spec.ParentTaskId().Binary());
+  task_info.set_parent_task_id(task_spec.MainThreadParentTaskId().Binary());
   const auto &resources_map = task_spec.GetRequiredResources().GetResourceMap();
   task_info.mutable_required_resources()->insert(resources_map.begin(),
                                                  resources_map.end());

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -565,7 +565,8 @@ TEST_F(ZeroNodeTest, TestTaskSpecPerf) {
                               resources,
                               resources,
                               "",
-                              0);
+                              0,
+                              RandomTaskId());
     // Set task arguments.
     for (const auto &arg : args) {
       builder.AddArg(*arg);
@@ -631,6 +632,7 @@ TEST_F(ZeroNodeTest, TestWorkerContext) {
   auto job_id = NextJobId();
 
   WorkerContext context(WorkerType::WORKER, WorkerID::FromRandom(), job_id);
+  // This fails locally somehow. Guess we reuse the thread in testing.
   ASSERT_TRUE(context.GetCurrentTaskID().IsNil());
   ASSERT_EQ(context.GetNextTaskIndex(), 1);
   ASSERT_EQ(context.GetNextTaskIndex(), 2);
@@ -657,6 +659,14 @@ TEST_F(ZeroNodeTest, TestWorkerContext) {
   context.ResetCurrentTask();
   context.SetCurrentTask(task_spec);
   ASSERT_EQ(context.GetCurrentTaskID(), task_spec.TaskId());
+
+  auto main_thread_task_id = task_spec.TaskId();
+  auto thread_func2 = [&context, &main_thread_task_id]() {
+    // Verify the main thread task id matches.
+    ASSERT_EQ(context.GetMainThreadCurrentTaskID(), main_thread_task_id);
+  };
+  std::thread async_thread2(thread_func2);
+  async_thread2.join();
 
   // Verify that put index doesn't confict with the return object range.
   ASSERT_EQ(context.GetNextPutIndex(), num_returns + 1);

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -663,7 +663,7 @@ TEST_F(ZeroNodeTest, TestWorkerContext) {
   auto main_thread_task_id = task_spec.TaskId();
   auto thread_func2 = [&context, &main_thread_task_id]() {
     // Verify the main thread task id matches.
-    ASSERT_EQ(context.GetMainThreadCurrentTaskID(), main_thread_task_id);
+    ASSERT_EQ(context.GetMainThreadOrActorCreationTaskID(), main_thread_task_id);
   };
   std::thread async_thread2(thread_func2);
   async_thread2.join();

--- a/src/ray/core_worker/test/dependency_resolver_test.cc
+++ b/src/ray/core_worker/test/dependency_resolver_test.cc
@@ -47,7 +47,8 @@ TaskSpecification BuildTaskSpec(const std::unordered_map<std::string, double> &r
                             resources,
                             resources,
                             serialized_runtime_env,
-                            depth);
+                            depth,
+                            TaskID::Nil());
   return builder.Build();
 }
 TaskSpecification BuildEmptyTaskSpec() {

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -52,7 +52,8 @@ TaskSpecification BuildTaskSpec(const std::unordered_map<std::string, double> &r
                             resources,
                             resources,
                             serialized_runtime_env,
-                            depth);
+                            depth,
+                            TaskID::Nil());
   return builder.Build();
 }
 // Calls BuildTaskSpec with empty resources map and empty function descriptor

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -61,7 +61,8 @@ struct Mocker {
                               required_resources,
                               required_placement_resources,
                               "",
-                              0);
+                              0,
+                              TaskID::Nil());
     rpc::SchedulingStrategy scheduling_strategy;
     scheduling_strategy.mutable_default_scheduling_strategy();
     builder.SetActorCreationTaskSpec(actor_id,

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -404,7 +404,9 @@ message TaskSpec {
   // TODO(rickyx): Remove this once we figure out a way to handle task ids
   // across multiple threads properly.
   // The task id of the CoreWorker's main thread from which the task is submitted.
-  bytes main_thread_parent_task_id = 33;
+  // This will be the main thread's task id for normal task, or the actor creation
+  // task's task id for actors.
+  bytes submitter_task_id = 33;
 }
 
 message TaskInfoEntry {

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -404,8 +404,8 @@ message TaskSpec {
   // TODO(rickyx): Remove this once we figure out a way to handle task ids
   // across multiple threads properly.
   // The task id of the CoreWorker's main thread from which the task is submitted.
-  // This will be the main thread's task id for normal task, or the actor creation
-  // task's task id for actors.
+  // This will be the actor creation task's task id for concurrent actors. Or
+  // the main thread's task id for other cases.
   bytes submitter_task_id = 33;
 }
 

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -401,6 +401,10 @@ message TaskSpec {
   repeated bytes dynamic_return_ids = 31;
   // Job config for the task. Only set for normal task or actor creation task.
   optional JobConfig job_config = 32;
+  // TODO(rickyx): Remove this once we figure out a way to handle task ids
+  // across multiple threads properly.
+  // The task id of the CoreWorker's main thread from which the task is submitted.
+  bytes main_thread_parent_task_id = 33;
 }
 
 message TaskInfoEntry {

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -168,6 +168,7 @@ RayTask CreateTask(
                                  {},
                                  "",
                                  0,
+                                 TaskID::Nil(),
                                  runtime_env_info);
 
   if (!args.empty()) {


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
###  Problems
Right now, if a new thread (or async actor's event loop executing thread) runs some ray code (e.g. submitting a task, calling runtime context), the thread will have a `WorkerThreadContext` that has a random task id. 

This causes issues in state API since the task tree will have wrong structures, i.e. some tasks might have `parent_task_id` that doesn't match any existing tasks: 

```
@ray.remote
class Actor:
    def actor_method(self):
        ... 
        # if below code runs in a separate thread (e.g. the actor manages its own thread pool) 
        # the task `some_ray_task` will have a parent task id that doesn't match any task. 
        ray.get(some_ray_task.remote())
        ...
```

### Solutions 
This PR adds a `main_thread_or_actor_creation_task_id` so that this will be used as the parent task id info for State API related features so that: 
1. Actors:
    -  Tasks submitted in the anonymous thread **will have the actor's creation task as the parent task.** 
1. For normal tasks
    - Task submitted in the anonymous thread will have the main thread's task as the parent task. 


### Not fixed in this PR
This PR doesn't address the actual runtime context of tasks in anonymous threads: calling `ray.get_runtime_context()` is still not defined for async actors or threaded actors that start new threads. 




<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
