### PR TITLE
[Datasets] Fix filter logic and reuse output buffer

### DIFF
--- a/python/ray/data/_internal/planner/filter.py
+++ b/python/ray/data/_internal/planner/filter.py
@@ -1,6 +1,7 @@
 from typing import Callable, Iterator
 
 from ray.data._internal.execution.interfaces import TaskContext
+from ray.data._internal.output_buffer import BlockOutputBuffer
 from ray.data.block import Block, BlockAccessor, RowUDF
 from ray.data.context import DatasetContext
 
@@ -18,12 +19,16 @@ def generate_filter_fn() -> Callable[
         blocks: Iterator[Block], ctx: TaskContext, row_fn: RowUDF
     ) -> Iterator[Block]:
         DatasetContext._set_current(context)
+        output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
         for block in blocks:
             block = BlockAccessor.for_block(block)
-            builder = block.builder()
             for row in block.iter_rows():
                 if row_fn(row):
-                    builder.add(row)
-            return [builder.build()]
+                    output_buffer.add(row)
+                    if output_buffer.has_next():
+                        yield output_buffer.next()
+        output_buffer.finalize()
+        if output_buffer.has_next():
+            yield output_buffer.next()
 
     return fn

--- a/python/ray/data/_internal/planner/filter.py
+++ b/python/ray/data/_internal/planner/filter.py
@@ -1,7 +1,6 @@
 from typing import Callable, Iterator
 
 from ray.data._internal.execution.interfaces import TaskContext
-from ray.data._internal.output_buffer import BlockOutputBuffer
 from ray.data.block import Block, BlockAccessor, RowUDF
 from ray.data.context import DatasetContext
 
@@ -19,16 +18,15 @@ def generate_filter_fn() -> Callable[
         blocks: Iterator[Block], ctx: TaskContext, row_fn: RowUDF
     ) -> Iterator[Block]:
         DatasetContext._set_current(context)
-        output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
         for block in blocks:
             block = BlockAccessor.for_block(block)
+            builder = block.builder()
             for row in block.iter_rows():
                 if row_fn(row):
-                    output_buffer.add(row)
-                    if output_buffer.has_next():
-                        yield output_buffer.next()
-        output_buffer.finalize()
-        if output_buffer.has_next():
-            yield output_buffer.next()
+                    builder.add(row)
+            # NOTE: this yields an empty block if all rows are filtered out.
+            # This causes different behavior between filter and other map-like
+            # functions. We should revisit and try to get rid of this logic.
+            yield builder.build()
 
     return fn

--- a/python/ray/data/_internal/planner/flat_map.py
+++ b/python/ray/data/_internal/planner/flat_map.py
@@ -19,16 +19,16 @@ def generate_flat_map_fn() -> Callable[
         blocks: Iterator[Block], ctx: TaskContext, row_fn: RowUDF
     ) -> Iterator[Block]:
         DatasetContext._set_current(context)
+        output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
         for block in blocks:
-            output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
             block = BlockAccessor.for_block(block)
             for row in block.iter_rows():
                 for r2 in row_fn(row):
                     output_buffer.add(r2)
                     if output_buffer.has_next():
                         yield output_buffer.next()
-            output_buffer.finalize()
-            if output_buffer.has_next():
-                yield output_buffer.next()
+        output_buffer.finalize()
+        if output_buffer.has_next():
+            yield output_buffer.next()
 
     return fn

--- a/python/ray/data/_internal/planner/map_rows.py
+++ b/python/ray/data/_internal/planner/map_rows.py
@@ -17,15 +17,15 @@ def generate_map_rows_fn() -> Callable[
         blocks: Iterator[Block], ctx: TaskContext, row_fn: RowUDF
     ) -> Iterator[Block]:
         DatasetContext._set_current(context)
+        output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
         for block in blocks:
-            output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
             block = BlockAccessor.for_block(block)
             for row in block.iter_rows():
                 output_buffer.add(row_fn(row))
                 if output_buffer.has_next():
                     yield output_buffer.next()
-            output_buffer.finalize()
-            if output_buffer.has_next():
-                yield output_buffer.next()
+        output_buffer.finalize()
+        if output_buffer.has_next():
+            yield output_buffer.next()
 
     return fn

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -175,6 +175,31 @@ def test_dataset_pipeline(
     assert len(dsp.take(5)) == 5
 
 
+def test_filter(
+    ray_start_regular_shared, enable_dynamic_block_splitting, target_max_block_size
+):
+    # Test 10 blocks from 1 task, each block is 1024 bytes.
+    num_blocks = 10
+    block_size = 1024
+
+    ds = ray.data.read_datasource(
+        RandomBytesDatasource(),
+        parallelism=1,
+        num_blocks=num_blocks,
+        block_size=block_size,
+    )
+
+    ds = ds.filter(lambda _: True)
+    ds.fully_executed()
+    assert ds.count() == num_blocks
+    assert ds.num_blocks() == num_blocks
+
+    ds = ds.filter(lambda _: False)
+    ds.fully_executed()
+    assert ds.count() == 0
+    assert ds.num_blocks() == num_blocks
+
+
 def test_lazy_block_list(
     shutdown_only, enable_dynamic_block_splitting, target_max_block_size
 ):
@@ -273,31 +298,6 @@ def test_lazy_block_list(
     for block_metadata in metadata:
         assert block_metadata.num_rows == 1
         assert block_metadata.schema is not None
-
-
-def test_filter(
-    ray_start_regular_shared, enable_dynamic_block_splitting, target_max_block_size
-):
-    # Test 10 blocks from 1 task, each block is 1024 bytes.
-    num_blocks = 10
-    block_size = 1024
-
-    ds = ray.data.read_datasource(
-        RandomBytesDatasource(),
-        parallelism=1,
-        num_blocks=num_blocks,
-        block_size=block_size,
-    )
-
-    ds = ds.filter(lambda _: True)
-    ds.fully_executed()
-    assert ds.count() == num_blocks
-    assert ds.num_blocks() == num_blocks
-
-    ds = ds.filter(lambda _: False)
-    ds.fully_executed()
-    assert ds.count() == 0
-    assert ds.num_blocks() == num_blocks
 
 
 def test_read_large_data(ray_start_cluster, enable_dynamic_block_splitting):


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to fix filter logic that it should always `yield`, instead of `return`. Otherwise it will just read first block, and exit. Add a unit test, and verify unit test is failed before this PR.

Also change all map-like functions to reuse same output buffer.

 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
