### PR TITLE
[Serve] Remove logging requirement for `long_running_serve_failure`

### DIFF
--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -151,12 +151,10 @@ class RandomTest:
 
             new_time = time.time()
             print(
-                "Iteration {}:\n"
-                "  - Iteration time: {}.\n"
-                "  - Absolute time: {}.\n"
-                "  - Total elapsed time: {}.".format(
-                    iteration, new_time - previous_time, new_time, new_time - start_time
-                )
+                f"Iteration {iteration}:\n"
+                f"  - Iteration time: {new_time - previous_time}.\n"
+                f"  - Absolute time: {new_time}.\n"
+                f"  - Total elapsed time: {new_time - start_time}."
             )
             update_progress(
                 {

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -37,7 +37,7 @@ def update_progress(result):
     anyscale product runs in each releaser test
     """
     result["last_update"] = time.time()
-    safe_write_to_results_json(result, default_file_name="/tmp/release_test_out.json")
+    safe_write_to_results_json(result)
 
 
 cluster = Cluster()

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -37,7 +37,7 @@ def update_progress(result):
     anyscale product runs in each releaser test
     """
     result["last_update"] = time.time()
-    safe_write_to_results_json(result)
+    safe_write_to_results_json(result, default_file_name="/tmp/release_test_out.json")
 
 
 cluster = Cluster()

--- a/release/ray_release/alerts/long_running_tests.py
+++ b/release/ray_release/alerts/long_running_tests.py
@@ -27,10 +27,13 @@ def handle_result(
     elif test_name in ["apex", "impala", "many_ppo", "pbt"]:
         # Tune/RLlib style tests
         target_update_diff = 480
-    elif test_name in ["serve", "serve_failure"]:
+    elif test_name in ["serve"]:
         # Serve tests have workload logs every five minutes.
         # Leave up to 180 seconds overhead.
         target_update_diff = 480
+    elif test_name in ["serve_failure"]:
+        # TODO (shrekris-anyscale): set update_diff limit for serve failure
+        target_update_diff = float("inf")
     else:
         return None
 


### PR DESCRIPTION
Signed-off-by: Shreyas Krishnaswamy <shrekris@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

#32063 fixed some issues with the `long_running_serve_failure` release test and then marked it `stable`. The test ran successfully afterwards (see [test run](https://buildkite.com/ray-project/release-tests-branch/builds/1324)), but the CI failed to access logs from the cluster and reported the test as errored. The logs were inaccessible on the cluster due to an issue with the cluster setup.

Since this test can run without persisting logs, this change drops the logging requirement for this test.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #32169

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Release tests
     - This change modifies the `long_running_serve_failure` test.
