### PR TITLE
[2.3][Datasets] Fix filter logic and reuse output buffer 

### DIFF
--- a/python/ray/data/_internal/planner/filter.py
+++ b/python/ray/data/_internal/planner/filter.py
@@ -24,6 +24,9 @@ def generate_filter_fn() -> Callable[
             for row in block.iter_rows():
                 if row_fn(row):
                     builder.add(row)
-            return [builder.build()]
+            # NOTE: this yields an empty block if all rows are filtered out.
+            # This causes different behavior between filter and other map-like
+            # functions. We should revisit and try to get rid of this logic.
+            yield builder.build()
 
     return fn

--- a/python/ray/data/_internal/planner/flat_map.py
+++ b/python/ray/data/_internal/planner/flat_map.py
@@ -19,16 +19,16 @@ def generate_flat_map_fn() -> Callable[
         blocks: Iterator[Block], ctx: TaskContext, row_fn: RowUDF
     ) -> Iterator[Block]:
         DatasetContext._set_current(context)
+        output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
         for block in blocks:
-            output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
             block = BlockAccessor.for_block(block)
             for row in block.iter_rows():
                 for r2 in row_fn(row):
                     output_buffer.add(r2)
                     if output_buffer.has_next():
                         yield output_buffer.next()
-            output_buffer.finalize()
-            if output_buffer.has_next():
-                yield output_buffer.next()
+        output_buffer.finalize()
+        if output_buffer.has_next():
+            yield output_buffer.next()
 
     return fn

--- a/python/ray/data/_internal/planner/map_rows.py
+++ b/python/ray/data/_internal/planner/map_rows.py
@@ -17,15 +17,15 @@ def generate_map_rows_fn() -> Callable[
         blocks: Iterator[Block], ctx: TaskContext, row_fn: RowUDF
     ) -> Iterator[Block]:
         DatasetContext._set_current(context)
+        output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
         for block in blocks:
-            output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
             block = BlockAccessor.for_block(block)
             for row in block.iter_rows():
                 output_buffer.add(row_fn(row))
                 if output_buffer.has_next():
                     yield output_buffer.next()
-            output_buffer.finalize()
-            if output_buffer.has_next():
-                yield output_buffer.next()
+        output_buffer.finalize()
+        if output_buffer.has_next():
+            yield output_buffer.next()
 
     return fn

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -175,6 +175,31 @@ def test_dataset_pipeline(
     assert len(dsp.take(5)) == 5
 
 
+def test_filter(
+    ray_start_regular_shared, enable_dynamic_block_splitting, target_max_block_size
+):
+    # Test 10 blocks from 1 task, each block is 1024 bytes.
+    num_blocks = 10
+    block_size = 1024
+
+    ds = ray.data.read_datasource(
+        RandomBytesDatasource(),
+        parallelism=1,
+        num_blocks=num_blocks,
+        block_size=block_size,
+    )
+
+    ds = ds.filter(lambda _: True)
+    ds.fully_executed()
+    assert ds.count() == num_blocks
+    assert ds.num_blocks() == num_blocks
+
+    ds = ds.filter(lambda _: False)
+    ds.fully_executed()
+    assert ds.count() == 0
+    assert ds.num_blocks() == num_blocks
+
+
 def test_lazy_block_list(
     shutdown_only, enable_dynamic_block_splitting, target_max_block_size
 ):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Cherry picking https://github.com/ray-project/ray/pull/32160 into `releases/2.3.0` branch, because this is to fix a new regression introduced in master after 2.2 (affecting correctness of `Dataset.filter()`).
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
