### PR TITLE
[CI] Revert version number change for get_wheel tests

### DIFF
--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -43,7 +43,7 @@ import ray._private.ray_constants as ray_constants
 def test_get_wheel_filename():
     """Test the code that generates the filenames of the `latest` wheels."""
     # NOTE: These should not be changed for releases.
-    ray_version = "2.3.0rc0"
+    ray_version = "3.0.0.dev0"
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             if sys_platform == "win32" and py_version == (3, 6):
@@ -58,7 +58,7 @@ def test_get_wheel_filename():
 def test_get_master_wheel_url():
     """Test the code that generates the filenames of `master` commit wheels."""
     # NOTE: These should not be changed for releases.
-    ray_version = "2.3.0rc0"
+    ray_version = "3.0.0.dev0"
     # This should be a commit for which wheels have already been built for
     # all platforms and python versions at
     # `s3://ray-wheels/master/<test_commit>/`.


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There are unit tests for the master wheel file format, which contain the string `3.0.0.dev0`.  This string was inadvertently replaced with `2.3.0rc0` on the release branch, causing the test to fail.  This PR changes it back to `3.0.0.dev0` for these tests.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/32182
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
