### PR TITLE
[Serve] Multi app deploy improvements (route check & deployment clean up)

### DIFF
--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -350,7 +350,9 @@ class ServeControllerClient:
                     return
                 time.sleep(CLIENT_POLLING_INTERVAL_S)
             else:
-                raise TimeoutError(f"Applications {names} wasn't deleted after 60s.")
+                raise TimeoutError(
+                    f"Some of these applications weren't deleted after 60s: {names}"
+                )
 
     @_ensure_connected
     def delete_all_apps(self, blocking: bool = True):

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -350,7 +350,17 @@ class ServeControllerClient:
                     return
                 time.sleep(CLIENT_POLLING_INTERVAL_S)
             else:
-                raise TimeoutError(f"Deployment {names} wasn't deleted after 60s.")
+                raise TimeoutError(f"Applications {names} wasn't deleted after 60s.")
+
+    @_ensure_connected
+    def delete_all_apps(self, blocking: bool = True):
+        """Delete all applications"""
+        all_apps = []
+        for status_bytes in ray.get(self._controller.list_serve_statuses.remote()):
+            proto = StatusOverviewProto.FromString(status_bytes)
+            status = StatusOverview.from_proto(proto)
+            all_apps.append(status.name)
+        self.delete_apps(all_apps, blocking)
 
     @_ensure_connected
     def delete_deployments(self, names: Iterable[str], blocking: bool = True) -> None:

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -434,8 +434,12 @@ class ServeController:
         group of deployments.
         """
 
+        application_deploy_success = self.application_state_manager.deploy_application(
+            name, deployment_args_list
+        )
+        if application_deploy_success is False:
+            return [False] * len(deployment_args_list)
         deployments_success = [self.deploy(**args) for args in deployment_args_list]
-        self.application_state_manager.deploy_application(name, deployment_args_list)
         return deployments_success
 
     def deploy_apps(
@@ -664,6 +668,12 @@ class ServeController:
     def get_serve_statuses(self, names: List[str]) -> List[bytes]:
         statuses = []
         for name in names:
+            statuses.append(self.get_serve_status(name))
+        return statuses
+
+    def list_serve_statuses(self) -> List[bytes]:
+        statuses = []
+        for name in self.application_state_manager.list_app_status():
             statuses.append(self.get_serve_status(name))
         return statuses
 

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -432,15 +432,22 @@ class ServeController:
         controller's deploy() function. Calls deploy on all the argument
         dictionaries in the list. Effectively executes an atomic deploy on a
         group of deployments.
+        If same app name deployed, old application will be overwrriten.
+
+        Args:
+            name: Application name.
+            deployment_args_list: List of deployment infomation, each item in the list
+                contains all the information for the single deployment.
+
+        Returns: list of deployment status to indicate whether each deployment is
+            deployed successfully or not.
         """
 
-        application_deploy_success = self.application_state_manager.deploy_application(
+        deployments_to_delete = self.application_state_manager.deploy_application(
             name, deployment_args_list
         )
-        if application_deploy_success is False:
-            return [False] * len(deployment_args_list)
-        deployments_success = [self.deploy(**args) for args in deployment_args_list]
-        return deployments_success
+        self.delete_deployments(deployments_to_delete)
+        return [self.deploy(**args) for args in deployment_args_list]
 
     def deploy_apps(
         self,
@@ -673,7 +680,7 @@ class ServeController:
 
     def list_serve_statuses(self) -> List[bytes]:
         statuses = []
-        for name in self.application_state_manager.list_app_status():
+        for name in self.application_state_manager.list_app_statuses():
             statuses.append(self.get_serve_status(name))
         return statuses
 

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -78,6 +78,8 @@ def _shared_serve_instance():
 @pytest.fixture
 def serve_instance(_shared_serve_instance):
     yield _shared_serve_instance
+    # Clear all applications to avoid naming & route_prefix collisions.
+    _shared_serve_instance.delete_all_apps()
     # Clear all state between tests to avoid naming collisions.
     _shared_serve_instance.delete_deployments(serve.list_deployments().keys())
     # Clear the ServeHandle cache between tests to avoid them piling up.

--- a/python/ray/serve/tests/test_application.py
+++ b/python/ray/serve/tests/test_application.py
@@ -66,7 +66,12 @@ class TestServeRun:
         the client to wait until the deployments finish deploying.
         """
 
-        serve.run(Application(deployments), _blocking=blocking)
+        for i in range(len(deployments)):
+            serve.run(
+                Application([deployments[i]]),
+                name=f"app{i}",
+                _blocking=blocking,
+            )
 
         def check_all_deployed():
             try:
@@ -113,7 +118,7 @@ class TestServeRun:
         deployments deploy correctly.
         """
 
-        @serve.deployment
+        @serve.deployment(route_prefix=None)
         class MutualHandles:
             async def __init__(self, handle_name):
                 self.handle = serve.get_deployment(handle_name).get_handle()
@@ -236,13 +241,13 @@ class TestServeRun:
         self.deploy_and_check_responses(deployments, responses)
 
     def test_import_path_deployment_decorated(self, serve_instance):
-        func = serve.deployment(
-            name="decorated_func",
-        )("ray.serve.tests.test_application.decorated_func")
+        func = serve.deployment(name="decorated_func", route_prefix="/decorated_func")(
+            "ray.serve.tests.test_application.decorated_func"
+        )
 
-        clss = serve.deployment(
-            name="decorated_clss",
-        )("ray.serve.tests.test_application.DecoratedClass")
+        clss = serve.deployment(name="decorated_clss", route_prefix="/decorated_clss")(
+            "ray.serve.tests.test_application.DecoratedClass"
+        )
 
         deployments = [func, clss]
         responses = ["got decorated func", "got decorated class"]


### PR DESCRIPTION
Signed-off-by: Sihan Wang <sihanwang41@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As tested, there are two issues in current Multi app API.

- There is no route prefix check. With this change, a new application (different app name) can't be deployed with the route prefix used by other existing applications.
- When an application is redeployed, old deployments (not used in the new app) will be deleted, and keep tracking the status until it is fully deleted by the deployment state manager.

## Related issue number

https://github.com/ray-project/ray/issues/32369
https://github.com/ray-project/ray/issues/32370

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
