### PR TITLE
[runtime_env] Print correct default  for expiration_s environment variable

### DIFF
--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -630,7 +630,9 @@ async def download_and_unpack_package(
                         "environment variable "
                         f"{RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_ENV_VAR} "
                         " to a value larger than the upload time in seconds "
-                        "(the default is 30). If this fails, try re-running "
+                        "(the default is "
+                        f"{RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_DEFAULT}). "
+                        "If this fails, try re-running "
                         "after making any change to a file in the file package."
                     )
                 code = code or b""

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -600,9 +600,6 @@ async def download_and_unpack_package(
         NotImplementedError: If the protocol of the URI is not supported.
 
     """
-    if os.environ.get(RAY_RUNTIME_ENV_FAIL_DOWNLOAD_FOR_TESTING_ENV_VAR):
-        raise IOError("Failed to download package. (Simulated failure for testing)")
-
     pkg_file = Path(_get_local_path(base_directory, pkg_uri))
     async with _AsyncFileLock(str(pkg_file) + ".lock"):
         if logger is None:
@@ -621,6 +618,8 @@ async def download_and_unpack_package(
                 code = await gcs_aio_client.internal_kv_get(
                     pkg_uri.encode(), namespace=None, timeout=None
                 )
+                if os.environ.get(RAY_RUNTIME_ENV_FAIL_DOWNLOAD_FOR_TESTING_ENV_VAR):
+                    code = None
                 if code is None:
                     raise IOError(
                         f"Failed to download runtime_env file package {pkg_uri} "

--- a/python/ray/tests/test_runtime_env_failure.py
+++ b/python/ray/tests/test_runtime_env_failure.py
@@ -2,6 +2,7 @@ import os
 from unittest import mock
 
 import pytest
+from ray._private.ray_constants import RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_DEFAULT
 from ray._private.runtime_env.packaging import (
     RAY_RUNTIME_ENV_FAIL_DOWNLOAD_FOR_TESTING_ENV_VAR,
     RAY_RUNTIME_ENV_FAIL_UPLOAD_FOR_TESTING_ENV_VAR,
@@ -89,6 +90,9 @@ class TestRuntimeEnvFailure:
             with pytest.raises(ConnectionAbortedError) as e:
                 init_ray()
             assert "Failed to download" in str(e.value)
+            assert (
+                f"the default is {RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_DEFAULT}"
+            ) in str(e.value)
         else:
             init_ray()
             # TODO(architkulkarni): After #25972 is resolved, we should raise an
@@ -102,6 +106,9 @@ class TestRuntimeEnvFailure:
             with pytest.raises(RuntimeEnvSetupError) as e:
                 ray.get(f.remote())
             assert "Failed to download" in str(e.value)
+            assert (
+                f"the default is {RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_DEFAULT}"
+            ) in str(e.value)
 
     def test_eager_install_fail(
         self, tmpdir, monkeypatch, start_cluster, client_connection_timeout_1s


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The default value of the runtime_env working_dir temporary reference expiration environment variable was changed in https://github.com/ray-project/ray/pull/29070 but the default value printed to the terminal was hard-coded and out of date. This PR updates the value printed in the message.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
