### PR TITLE
[2.3.0][tune] Sync less often and only wait at end of experiment (#32155)

### DIFF
--- a/doc/source/tune/api_docs/env.rst
+++ b/doc/source/tune/api_docs/env.rst
@@ -49,6 +49,14 @@ These are the environment variables Ray Tune currently considers:
 * **TUNE_MAX_PENDING_TRIALS_PG**: Maximum number of pending trials when placement groups are used. Defaults
   to ``auto``, which will be updated to ``max(16, cluster_cpus * 1.1)`` for random/grid search and ``1``
   for any other search algorithms.
+* **TUNE_NODE_SYNCING_MIN_ITER_THRESHOLD**: When syncing trial data between nodes, only sync if this many
+  iterations were recorded for the trial or the minimum time threshold was met. This will prevent unnecessary
+  double syncing for trials that finish quickly or report only once. Defaults to ``2``. Disabled
+  when using external storage (e.g., cloud storage).
+* **TUNE_NODE_SYNCING_MIN_TIME_S_THRESHOLD**: When syncing trial data between nodes, only sync if this much
+  time has been spent training or the minimum iteration threshold was met. This will prevent unnecessary
+  double syncing for trials that finish quickly or report only once. Defaults to ``10`` (seconds).
+  Disabled when using external storage (e.g., cloud storage).
 * **TUNE_PLACEMENT_GROUP_PREFIX**: Prefix for placement groups created by Ray Tune. This prefix is used
   e.g. to identify placement groups that should be cleaned up on start/stop of the tuning run. This is
   initialized to a unique name at the start of the first run.
@@ -82,7 +90,6 @@ These are the environment variables Ray Tune currently considers:
 * **TUNE_WARN_EXCESSIVE_EXPERIMENT_CHECKPOINT_SYNC_THRESHOLD_S**: Threshold for throwing a warning if the experiment state is synced
   multiple times in that many seconds. Defaults to 30 (seconds).
 * **TUNE_STATE_REFRESH_PERIOD**: Frequency of updating the resource tracking from Ray. Defaults to 10 (seconds).
-* **TUNE_SYNC_DISABLE_BOOTSTRAP**: Disable bootstrapping the autoscaler config for Docker syncing.
 * **TUNE_RESTORE_RETRY_NUM**: The number of retries that are done before a particular trial's restore is determined
   unsuccessful. After that, the trial is not restored to its previous checkpoint but rather from scratch.
   Default is ``0``. While this retry counter is taking effect, per trial failure number will not be incremented, which

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -9,6 +9,7 @@ from typing import (
     TYPE_CHECKING,
     Union,
     Optional,
+    Set,
     Tuple,
 )
 
@@ -29,6 +30,7 @@ from ray.air._internal.remote_storage import (
 from ray.exceptions import RayActorError
 from ray.tune import TuneError
 from ray.tune.callback import Callback
+from ray.tune.result import TRAINING_ITERATION, TIME_TOTAL_S
 from ray.tune.utils.file_transfer import sync_dir_between_nodes
 from ray.util.annotations import PublicAPI, DeveloperAPI
 from ray.widgets import Template
@@ -43,6 +45,12 @@ DEFAULT_SYNC_PERIOD = 300
 
 # Default sync timeout after which syncing processes are aborted
 DEFAULT_SYNC_TIMEOUT = 1800
+
+# Trigger first node-to-node sync only after this many iterations arrived
+_DEFAULT_NODE_SYNCING_MIN_ITER_THRESHOLD = 2
+# ... or until at least this much time (in seconds) passed
+_DEFAULT_NODE_SYNCING_MIN_TIME_S_THRESHOLD = 10.0
+
 
 _EXCLUDE_FROM_SYNC = [
     "./checkpoint_-00001",
@@ -210,7 +218,7 @@ class _BackgroundProcess:
         self._start_time = time.time()
 
     def wait(self, timeout: Optional[float] = None) -> Any:
-        """Waits for the backgrond process to finish running. Waits until the
+        """Waits for the background process to finish running. Waits until the
         background process has run for at least `timeout` seconds, counting from
         the time when the process was started."""
         if not self._process:
@@ -623,10 +631,39 @@ class SyncerCallback(Callback):
 
     def __init__(self, enabled: bool = True, sync_period: float = DEFAULT_SYNC_PERIOD):
         self._enabled = enabled
+
+        # Map from trial id to syncer process
         self._sync_processes: Dict[str, _BackgroundProcess] = {}
+
+        # Last time we synced a trial
         self._sync_times: Dict[str, float] = {}
+
+        # How often we should sync (in seconds)
         self._sync_period = sync_period
-        self._trial_ips = {}
+
+        # Map of trial id to IP
+        self._trial_ips: Dict[str, str] = {}
+
+        # Set of sync processes that are flagged to remove
+        self._trial_sync_processes_to_remove: Set[str] = set()
+
+        # Recorded training iterations + training times
+        self._trial_iter_training_times: Dict[str, Tuple[int, float]] = {}
+
+        # Only sync if this many items OR this much time has passed
+        # for each individual trial.
+        self._min_iter_threshold = int(
+            os.environ.get(
+                "TUNE_NODE_SYNCING_MIN_ITER_THRESHOLD",
+                _DEFAULT_NODE_SYNCING_MIN_ITER_THRESHOLD,
+            )
+        )
+        self._min_time_s_threshold = float(
+            os.environ.get(
+                "TUNE_NODE_SYNCING_MIN_TIME_S_THRESHOLD",
+                _DEFAULT_NODE_SYNCING_MIN_TIME_S_THRESHOLD,
+            )
+        )
 
     def _get_trial_sync_process(self, trial: "Trial"):
         return self._sync_processes.setdefault(
@@ -634,12 +671,47 @@ class SyncerCallback(Callback):
             _BackgroundProcess(partial(sync_dir_between_nodes, max_size_bytes=None)),
         )
 
-    def _remove_trial_sync_process(self, trial: "Trial"):
-        self._sync_processes.pop(trial.trial_id, None)
+    def _remove_trial_sync_process(self, trial: "Trial", force: bool = False):
+        """Remove trial sync process.
+
+        If ``force=True``, we remove it immediately. If ``force=False``, we flag
+        it for removal and only remove it when it resolved. This is so we can await
+        the sync process at the end of the experiment.
+        """
+        if force:
+            self._sync_processes.pop(trial.trial_id, None)
+        else:
+            self._trial_sync_processes_to_remove.add(trial.trial_id)
+
+    def _cleanup_trial_sync_processes(self):
+        for trial_id in list(self._trial_sync_processes_to_remove):
+            sync_process = self._sync_processes.get(trial_id, None)
+            if not sync_process or not sync_process.is_running:
+                self._trial_sync_processes_to_remove.remove(trial_id)
+                self._sync_processes.pop(trial_id, None)
 
     def _should_sync(self, trial: "Trial"):
+        iteration, time_trained = self._trial_iter_training_times.setdefault(
+            trial.trial_id, (0, 0.0)
+        )
+
+        # If neither the min iter nor the min time threshold were met, we don't sync.
+        # This is to avoid eager syncing when we have many short running trials -
+        # in that case we only want to sync once at the end of training. For longer
+        # running trials the threshold is usually small enough to not make a difference
+        # in practice.
+        if (
+            iteration < self._min_iter_threshold
+            and time_trained < self._min_time_s_threshold
+        ):
+            return False
+
         last_sync_time = self._sync_times.setdefault(trial.trial_id, float("-inf"))
-        return time.time() - last_sync_time >= self._sync_period
+
+        if time.time() - last_sync_time < self._sync_period:
+            return False
+
+        return True
 
     def _mark_as_synced(self, trial: "Trial"):
         self._sync_times[trial.trial_id] = time.time()
@@ -723,20 +795,27 @@ class SyncerCallback(Callback):
         result: Dict,
         **info,
     ):
+        # If the results are not found, default to triggering syncing
+        trial_iter = result.get(TRAINING_ITERATION, self._min_iter_threshold)
+        trial_time_s = result.get(TIME_TOTAL_S, self._min_time_s_threshold)
+
+        self._trial_iter_training_times[trial.trial_id] = (trial_iter, trial_time_s)
         self._sync_trial_dir(trial, force=False, wait=False)
 
     def on_trial_complete(
         self, iteration: int, trials: List["Trial"], trial: "Trial", **info
     ):
-        self._sync_trial_dir(trial, force=True, wait=True)
-        self._remove_trial_sync_process(trial)
+        self._sync_trial_dir(trial, force=True, wait=False)
+        self._remove_trial_sync_process(trial, force=False)
         self._trial_ips.pop(trial.trial_id, None)
+        self._cleanup_trial_sync_processes()
 
     def on_trial_error(
         self, iteration: int, trials: List["Trial"], trial: "Trial", **info
     ):
-        self._remove_trial_sync_process(trial)
+        self._remove_trial_sync_process(trial, force=True)
         self._trial_ips.pop(trial.trial_id, None)
+        self._cleanup_trial_sync_processes()
 
     def on_checkpoint(
         self,
@@ -758,6 +837,8 @@ class SyncerCallback(Callback):
             )
 
     def wait_for_all(self):
+        self._cleanup_trial_sync_processes()
+
         failed_syncs = {}
         for trial, sync_process in self._sync_processes.items():
             try:

--- a/python/ray/tune/tests/test_syncer_callback.py
+++ b/python/ray/tune/tests/test_syncer_callback.py
@@ -12,6 +12,7 @@ from ray.air._internal.checkpoint_manager import CheckpointStorage, _TrackedChec
 from ray.exceptions import RayActorError
 from ray.tune import TuneError
 from ray.tune.logger import NoopLogger
+from ray.tune.result import TRAINING_ITERATION, TIME_TOTAL_S
 from ray.tune.syncer import (
     DEFAULT_SYNC_PERIOD,
     SyncConfig,
@@ -96,6 +97,9 @@ class TestSyncerCallback(SyncerCallback):
         super(TestSyncerCallback, self).__init__(
             enabled=enabled, sync_period=sync_period
         )
+        self._min_iter_threshold = 0
+        self._min_time_s_threshold = 0
+
         self.local_logdir_override = local_logdir_override
         self.remote_logdir_override = remote_logdir_override
 
@@ -189,10 +193,14 @@ def test_syncer_callback_op_on_no_cloud_checkpointing():
         if isinstance(cb, SyncerCallback):
             syncer_callback = cb
 
+    assert syncer_callback
+
+    syncer_callback._min_iter_threshold = 0
+    syncer_callback._min_time_s_threshold = 0
+
     trial1 = MockTrial(trial_id="a", logdir=None)
     trial1.uses_cloud_checkpointing = False
 
-    assert syncer_callback
     assert syncer_callback._enabled
     assert syncer_callback._sync_trial_dir(trial1)
 
@@ -368,6 +376,53 @@ def test_syncer_callback_force_on_complete(ray_start_2_cpus, temp_data_dirs):
         assert_file(True, tmp_target, "level0_new.txt")
 
 
+@pytest.mark.parametrize("threshold", [TRAINING_ITERATION, TIME_TOTAL_S])
+def test_syncer_callback_min_thresholds(ray_start_2_cpus, temp_data_dirs, threshold):
+    """Check that the min_iter/min_time_s thresholds are respected."""
+    tmp_source, tmp_target = temp_data_dirs
+
+    # Keep the other metric at 0
+    other = TRAINING_ITERATION if threshold == TIME_TOTAL_S else TIME_TOTAL_S
+
+    syncer_callback = TestSyncerCallback(local_logdir_override=tmp_target)
+
+    syncer_callback._min_iter_threshold = 8
+    syncer_callback._min_time_s_threshold = 8
+
+    trial1 = MockTrial(trial_id="a", logdir=tmp_source)
+
+    syncer_callback._trial_ips[trial1.trial_id] = "invalid"
+    syncer_callback.on_trial_start(iteration=0, trials=[], trial=trial1)
+
+    for i in range(7):
+        syncer_callback.on_trial_result(
+            iteration=i, trials=[], trial=trial1, result={threshold: i, other: 0}
+        )
+        syncer_callback.wait_for_all()
+        assert_file(False, tmp_target, "level0.txt")
+
+    syncer_callback.on_trial_result(
+        iteration=8, trials=[], trial=trial1, result={threshold: 8, other: 0}
+    )
+    syncer_callback.wait_for_all()
+
+    assert_file(True, tmp_target, "level0.txt")
+    assert_file(True, tmp_target, "level0_exclude.txt")
+    assert_file(True, tmp_target, "subdir/level1.txt")
+    assert_file(True, tmp_target, "subdir/level1_exclude.txt")
+    assert_file(True, tmp_target, "subdir/nested/level2.txt")
+    assert_file(True, tmp_target, "subdir_nested_level2_exclude.txt")
+    assert_file(True, tmp_target, "subdir_exclude/something/somewhere.txt")
+
+    # Also trigger delayed syncer process removal
+    syncer_callback._remove_trial_sync_process(trial=trial1)
+    assert trial1.trial_id in syncer_callback._trial_sync_processes_to_remove
+
+    # Syncing finished so syncer should be removed now
+    syncer_callback._cleanup_trial_sync_processes()
+    assert trial1.trial_id not in syncer_callback._trial_sync_processes_to_remove
+
+
 def test_syncer_callback_wait_for_all_error(ray_start_2_cpus, temp_data_dirs):
     """Check that syncer errors are caught correctly in wait_for_all()"""
     tmp_source, tmp_target = temp_data_dirs
@@ -492,6 +547,7 @@ def test_sync_directory_exclude(ray_start_2_cpus, temp_data_dirs):
         local_logdir_override=tmp_target,
     )
     syncer_callback.on_trial_complete(iteration=1, trials=[], trial=trial1)
+    syncer_callback.wait_for_all()
 
     # Regular files are synced
     assert_file(True, tmp_target, "level0.txt")


### PR DESCRIPTION
Cherry-pick of https://github.com/ray-project/ray/pull/32155

We currently run into syncing bottleneck when running many short running trials in a multi node cluster, see #32121.

After some investigation, there are three major bottlenecks:

1. All of the 100 trials trigger 2 sync processes each. This is because we trigger a sync for both the result (`SyncerCallback.on_trial_result`) and for the trial completion (`SyncerCallback.on_trial_complete`).
2. We wait synchronously for the sync processes to finish on trial completion
3. The packing and unpacking interferes with the actual training processes on the local node, drastically increasing trial runtime for those trials colocated with the driver script

This PR mitigates 1) and 2) to unblock the coming release. For 3), we may have to re-architecture the current packing logic that uses multiple pack actors and unpack tasks that can impact training performance.

For 1), we introduce a **minimum training time + iteration threshold** for the syncing process. Per default, we only trigger the first sync after at least 2 results were received _or_ 10 training seconds passed. The logic here is that this will only affect experiments where we have short running trials that report one result. In that case, we only need the `on_trial_complete` trigger at the end of training. Other experiments are unaffected and there's not much lost if we don't sync results from the first iteration that took less than 10 seconds to run.

For 2), we cache sync process removal on trial completion. This means we do not wait until the sync process finished, but we keep the process around so we can await syncing at the end of the experiment. Periodically we clean up sync processes that were flagged for removal.

Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
