### PR TITLE
[Tune] Add `use_threads=False` in pyarrow syncing

### DIFF
--- a/python/ray/air/_internal/remote_storage.py
+++ b/python/ray/air/_internal/remote_storage.py
@@ -35,9 +35,15 @@ except (ImportError, ModuleNotFoundError):
 
 from ray import logger
 
-# Fixes an issue where pyarrow.fs.copy_files deadlocks if there are
-# more files in a directory then there are CPUs available.
-_PYARROW_COPY_FILES_DEFAULT_KWARGS = {"use_threads": False}
+if pyarrow and packaging.version.parse(pyarrow.__version__) < packaging.version.parse(
+    "11.0.0"
+):
+    # Fixes an issue with pyarrow<11.0.0 where pyarrow.fs.copy_files
+    # deadlocks if there are more files in a directory than
+    # there are CPUs available.
+    _PYARROW_COPY_FILES_DEFAULT_KWARGS = {"use_threads": False}
+else:
+    _PYARROW_COPY_FILES_DEFAULT_KWARGS = {}
 
 
 def _pyarrow_fs_copy_files(*args, **kwargs):

--- a/python/ray/tune/tests/test_syncer.py
+++ b/python/ray/tune/tests/test_syncer.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+from pathlib import Path
 from typing import List, Optional
 from unittest.mock import patch
 
@@ -675,21 +676,41 @@ def test_final_experiment_checkpoint_sync(tmpdir):
     )
 
 
-def test_sync_folder_with_many_files(tmpdir):
-    root = "bucket_2/dir"
+def test_sync_folder_with_many_files_s3(tmpdir):
+    # Create 256 files to upload
+    for i in range(256):
+        (tmpdir / str(i)).write_text("", encoding="utf-8")
+
+    root = "bucket_test_syncer/dir"
     with simulate_storage("s3", root) as s3_uri:
-        for i in range(256):
-            with open(os.path.join(tmpdir, str(i)), "w"):
-                pass
-        print(s3_uri)
+        # Upload to S3
+
         s3 = boto3.client(
             "s3", region_name="us-west-2", endpoint_url="http://localhost:5002"
         )
         s3.create_bucket(
-            Bucket="bucket_2",
+            Bucket="bucket_test_syncer",
             CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
         )
         upload_to_uri(tmpdir, s3_uri)
+
+        with tempfile.TemporaryDirectory() as download_dir:
+            download_from_uri(s3_uri, download_dir)
+
+            assert (Path(download_dir) / "255").exists()
+
+
+def test_sync_folder_with_many_files_fs(tmpdir):
+    # Create 256 files to upload
+    for i in range(256):
+        (tmpdir / str(i)).write_text("", encoding="utf-8")
+
+    # Upload to file URI
+    with tempfile.TemporaryDirectory() as upload_dir:
+        target_uri = "file://" + upload_dir
+        upload_to_uri(tmpdir, target_uri)
+
+        assert (tmpdir / "255").exists()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes a pyarrow issue where the syncing deadlocks when there are more files in a directory than available CPU cores.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
