### PR TITLE
[core][state] Fix task failed time when job finishes (#32161)

### DIFF
--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -442,11 +442,13 @@ ray.get(parent.remote())
         timeout=10,
         retry_interval_ms=500,
     )
+    time_sleep_s = 2
+    time.sleep(time_sleep_s)
 
     proc.kill()
 
     def verify():
-        tasks = list_tasks()
+        tasks = list_tasks(detail=True)
         assert len(tasks) == 7, (
             "Incorrect number of tasks are reported. "
             "Expected length: 1 parent + 2 finished child +  2 failed child + "
@@ -461,6 +463,12 @@ ray.get(parent.remote())
                 assert (
                     task["state"] == "FAILED"
                 ), f"task {task['func_or_class_name']} has wrong state"
+
+                duration_ms = task["end_time_ms"] - task["start_time_ms"]
+                assert (
+                    duration_ms > time_sleep_s * 1000
+                    and duration_ms < 2 * time_sleep_s * 1000
+                )
 
         return True
 

--- a/src/ray/gcs/gcs_server/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.cc
@@ -479,7 +479,7 @@ void GcsTaskManager::OnJobFinished(const JobID &job_id, int64_t job_finish_time_
         absl::MutexLock lock(&mutex_);
         // If there are any non-terminated tasks from the job, mark them failed since all
         // workers associated with the job will be killed.
-        task_event_storage_->MarkTasksFailed(job_id, job_finish_time_ms * 1000);
+        task_event_storage_->MarkTasksFailed(job_id, job_finish_time_ms * 1000 * 1000);
       });
 }
 

--- a/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
@@ -564,7 +564,7 @@ TEST_F(GcsTaskManagerTest, TestJobFinishesFailAllRunningTasks) {
     auto reply = SyncGetTaskEvents(tasks);
     EXPECT_EQ(reply.events_by_task_size(), 10);
     for (const auto &task_event : reply.events_by_task()) {
-      EXPECT_EQ(task_event.state_updates().failed_ts(), 5000);
+      EXPECT_EQ(task_event.state_updates().failed_ts(), /* 5 ms to ns */ 5 * 1000 * 1000);
     }
   }
 


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We have the wrong unit translation right now when recording tasks' failed status if the owning job finishes. This results in negative duration of such tasks.

<img width="721" alt="image" src="https://user-images.githubusercontent.com/11676094/217132601-1c22bf8b-b165-4365-84f8-bf357e94fe0b.png">



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Pick of #32161 


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
