### PR TITLE
[air/benchmarks] Fix typo in tensorflow_benchmark.py script preventing proper error surfacing

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/tensorflow_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tensorflow_benchmark.py
@@ -310,7 +310,7 @@ def run(
                     config=config,
                 )
             except Exception as e:
-                if i > +2:
+                if i >= 2:
                     raise RuntimeError("Vanilla TF run failed 3 times") from e
                 print("Vanilla TF run failed:", e)
                 continue
@@ -338,6 +338,7 @@ def run(
         times_ray.append(time_ray)
         times_local_ray.append(time_local_ray)
         losses_ray.append(loss_ray)
+
         times_vanilla.append(time_vanilla)
         times_local_vanilla.append(time_local_vanilla)
         losses_vanilla.append(loss_vanilla)


### PR DESCRIPTION

Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There is a small typo in the tensorflow_benchmark.py script that does not properly catch when a vanilla TF run failed three times. Because of this, we would previously record a training time of `0.0` for vanilla TF, which skews the calculated average and suggests that vanilla TF outperformed Ray Train. Instead, we should have raised an error message to surface the problem.

## Related issue number

Closes #31882

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
