### PR TITLE
Allow overriding the UID of the default grafana dashboard exported by ray

### DIFF
--- a/dashboard/client/src/App.tsx
+++ b/dashboard/client/src/App.tsx
@@ -54,6 +54,10 @@ type GlobalContextType = {
    */
   grafanaHost: string | undefined;
   /**
+   * The uid of the default dashboard that powers the Metrics page.
+   */
+  grafanaDefaultDashboardUid: string | undefined;
+  /**
    * Whether prometheus is runing or not
    */
   prometheusHealth: boolean | undefined;
@@ -68,6 +72,7 @@ export const GlobalContext = React.createContext<GlobalContextType>({
   ipLogMap: {},
   namespaceMap: {},
   grafanaHost: undefined,
+  grafanaDefaultDashboardUid: undefined,
   prometheusHealth: undefined,
   sessionName: undefined,
 });
@@ -85,6 +90,7 @@ const App = () => {
     ipLogMap: {},
     namespaceMap: {},
     grafanaHost: undefined,
+    grafanaDefaultDashboardUid: undefined,
     prometheusHealth: undefined,
     sessionName: undefined,
   });
@@ -126,11 +132,16 @@ const App = () => {
   // Detect if grafana is running
   useEffect(() => {
     const doEffect = async () => {
-      const { grafanaHost, sessionName, prometheusHealth } =
-        await getMetricsInfo();
+      const {
+        grafanaHost,
+        sessionName,
+        prometheusHealth,
+        grafanaDefaultDashboardUid,
+      } = await getMetricsInfo();
       setContext((existingContext) => ({
         ...existingContext,
         grafanaHost,
+        grafanaDefaultDashboardUid,
         sessionName,
         prometheusHealth,
       }));

--- a/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
@@ -8,6 +8,7 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
     <GlobalContext.Provider
       value={{
         grafanaHost: "localhost:3000",
+        grafanaDefaultDashboardUid: "rayDefaultDashboard",
         prometheusHealth: true,
         sessionName: "session-name",
         ipLogMap: {},
@@ -26,6 +27,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
     <GlobalContext.Provider
       value={{
         grafanaHost: undefined,
+        grafanaDefaultDashboardUid: undefined,
         prometheusHealth: false,
         sessionName: undefined,
         ipLogMap: {},

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -94,7 +94,7 @@ const TIME_RANGE_TO_FROM_VALUE: Record<TimeRangeOptions, string> = {
 
 type MetricConfig = {
   title: string;
-  path: string;
+  pathParams: string;
 };
 
 type MetricsSectionConfig = {
@@ -109,19 +109,19 @@ const METRICS_CONFIG: MetricsSectionConfig[] = [
     contents: [
       {
         title: "Scheduler Task State",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=26",
+        pathParams: "orgId=1&theme=light&panelId=26",
       },
       {
         title: "Active Tasks by Name",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=35",
+        pathParams: "orgId=1&theme=light&panelId=35",
       },
       {
         title: "Scheduler Actor State",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=33",
+        pathParams: "orgId=1&theme=light&panelId=33",
       },
       {
         title: "Active Actors by Name",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=36",
+        pathParams: "orgId=1&theme=light&panelId=36",
       },
     ],
   },
@@ -130,19 +130,19 @@ const METRICS_CONFIG: MetricsSectionConfig[] = [
     contents: [
       {
         title: "Scheduler CPUs (logical slots)",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=27",
+        pathParams: "orgId=1&theme=light&panelId=27",
       },
       {
         title: "Scheduler GPUs (logical slots)",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=28",
+        pathParams: "orgId=1&theme=light&panelId=28",
       },
       {
         title: "Object Store Memory",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=29",
+        pathParams: "orgId=1&theme=light&panelId=29",
       },
       {
         title: "Placement Groups",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=40",
+        pathParams: "orgId=1&theme=light&panelId=40",
       },
     ],
   },
@@ -151,43 +151,43 @@ const METRICS_CONFIG: MetricsSectionConfig[] = [
     contents: [
       {
         title: "Node Count",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=24",
+        pathParams: "orgId=1&theme=light&panelId=24",
       },
       {
         title: "Node CPU (hardware utilization)",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=2",
+        pathParams: "orgId=1&theme=light&panelId=2",
       },
       {
         title: "Node Memory (heap + object store)",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=4",
+        pathParams: "orgId=1&theme=light&panelId=4",
       },
       {
         title: "Node GPU (hardware utilization)",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=8",
+        pathParams: "orgId=1&theme=light&panelId=8",
       },
       {
         title: "Node GPU Memory (GRAM)",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=18",
+        pathParams: "orgId=1&theme=light&panelId=18",
       },
       {
         title: "Node Disk",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=6",
+        pathParams: "orgId=1&theme=light&panelId=6",
       },
       {
         title: "Node Disk IO Speed",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=32",
+        pathParams: "orgId=1&theme=light&panelId=32",
       },
       {
         title: "Node Network",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=20",
+        pathParams: "orgId=1&theme=light&panelId=20",
       },
       {
         title: "Node CPU by Component",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=37",
+        pathParams: "orgId=1&theme=light&panelId=37",
       },
       {
         title: "Node Memory by Component",
-        path: "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=34",
+        pathParams: "orgId=1&theme=light&panelId=34",
       },
     ],
   },
@@ -199,8 +199,12 @@ type MetricsProps = {
 
 export const Metrics = ({ newIA = false }: MetricsProps) => {
   const classes = useStyles();
-  const { grafanaHost, sessionName, prometheusHealth } =
-    useContext(GlobalContext);
+  const {
+    grafanaHost,
+    sessionName,
+    prometheusHealth,
+    grafanaDefaultDashboardUid = "rayDefaultDashboard",
+  } = useContext(GlobalContext);
 
   const [timeRangeOption, setTimeRangeOption] = useState<TimeRangeOptions>(
     TimeRangeOptions.FIVE_MINS,
@@ -276,22 +280,27 @@ export const Metrics = ({ newIA = false }: MetricsProps) => {
                 keepRendered
               >
                 <div className={classes.grafanaEmbedsContainer}>
-                  {contents.map(({ title, path }) => (
-                    <Paper
-                      key={path}
-                      className={classes.chart}
-                      elevation={1}
-                      variant="outlined"
-                    >
-                      <iframe
-                        key={title}
-                        title={title}
-                        className={classes.grafanaEmbed}
-                        src={`${grafanaHost}${path}&refresh${timeRangeParams}&var-SessionName=${sessionName}`}
-                        frameBorder="0"
-                      />
-                    </Paper>
-                  ))}
+                  {contents.map(({ title, pathParams }) => {
+                    const path =
+                      `/d-solo/${grafanaDefaultDashboardUid}?${pathParams}` +
+                      `&refresh${timeRangeParams}&var-SessionName=${sessionName}`;
+                    return (
+                      <Paper
+                        key={pathParams}
+                        className={classes.chart}
+                        elevation={1}
+                        variant="outlined"
+                      >
+                        <iframe
+                          key={title}
+                          title={title}
+                          className={classes.grafanaEmbed}
+                          src={`${grafanaHost}${path}`}
+                          frameBorder="0"
+                        />
+                      </Paper>
+                    );
+                  })}
                 </div>
               </CollapsibleSection>
             ))}

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -241,7 +241,7 @@ export const Metrics = ({ newIA = false }: MetricsProps) => {
             })}
           >
             <Button
-              href={grafanaHost}
+              href={`${grafanaHost}/d/${grafanaDefaultDashboardUid}`}
               target="_blank"
               rel="noopener noreferrer"
               endIcon={<RiExternalLinkLine />}

--- a/dashboard/client/src/pages/metrics/utils.ts
+++ b/dashboard/client/src/pages/metrics/utils.ts
@@ -9,6 +9,7 @@ type GrafanaHealthcheckRsp = {
   data: {
     grafanaHost: string;
     sessionName: string;
+    grafanaDefaultDashboardUid: string;
   };
 };
 
@@ -29,6 +30,7 @@ type MetricsInfo = {
   grafanaHost?: string;
   sessionName?: string;
   prometheusHealth?: boolean;
+  grafanaDefaultDashboardUid?: string;
 };
 
 export const getMetricsInfo = async () => {
@@ -36,12 +38,15 @@ export const getMetricsInfo = async () => {
     grafanaHost: undefined,
     sessionName: undefined,
     prometheusHealth: undefined,
+    grafanaDefaultDashboardUid: undefined,
   };
   try {
     const resp = await fetchGrafanaHealthcheck();
     if (resp.data.result) {
       info.grafanaHost = resp.data.data.grafanaHost;
       info.sessionName = resp.data.data.sessionName;
+      info.grafanaDefaultDashboardUid =
+        resp.data.data.grafanaDefaultDashboardUid;
     }
   } catch (e) {}
   try {

--- a/dashboard/client/src/pages/overview/cards/ClusterUtilizationCard.tsx
+++ b/dashboard/client/src/pages/overview/cards/ClusterUtilizationCard.tsx
@@ -40,10 +40,13 @@ export const ClusterUtilizationCard = ({
 }: ClusterUtilizationCardProps) => {
   const classes = useStyles();
 
-  const { grafanaHost, prometheusHealth, sessionName } =
-    useContext(GlobalContext);
-  const path =
-    "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=41";
+  const {
+    grafanaHost,
+    prometheusHealth,
+    sessionName,
+    grafanaDefaultDashboardUid = "rayDefaultDashboard",
+  } = useContext(GlobalContext);
+  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=1&theme=light&panelId=41`;
   const timeRangeParams = "&from=now-30m&to=now";
 
   return (

--- a/dashboard/client/src/pages/overview/cards/NodeCountCard.tsx
+++ b/dashboard/client/src/pages/overview/cards/NodeCountCard.tsx
@@ -38,10 +38,13 @@ type NodeCountCardProps = {
 export const NodeCountCard = ({ className }: NodeCountCardProps) => {
   const classes = useStyles();
 
-  const { grafanaHost, prometheusHealth, sessionName } =
-    useContext(GlobalContext);
-  const path =
-    "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=24";
+  const {
+    grafanaHost,
+    prometheusHealth,
+    sessionName,
+    grafanaDefaultDashboardUid = "rayDefaultDashboard",
+  } = useContext(GlobalContext);
+  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=1&theme=light&panelId=24`;
   const timeRangeParams = "&from=now-30m&to=now";
 
   return (

--- a/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -4,8 +4,9 @@ import copy
 import json
 import os
 from dataclasses import dataclass
+from typing import List, Dict, Optional
 
-from typing import List, Dict
+import ray
 
 
 @dataclass
@@ -527,11 +528,16 @@ PANEL_TEMPLATE = {
 }
 
 
-def generate_grafana_dashboard() -> str:
+def generate_grafana_dashboard(override_uid: Optional[str] = None) -> str:
     base_json = json.load(
         open(os.path.join(os.path.dirname(__file__), "grafana_dashboard_base.json"))
     )
     base_json["panels"] = _generate_grafana_panels()
+    tags = base_json.get("tags", []) or []
+    tags.append(f"rayVersion:{ray.__version__}")
+    base_json["tags"] = tags
+    if override_uid:
+        base_json["uid"] = override_uid
     return json.dumps(base_json, indent=4)
 
 

--- a/dashboard/modules/metrics/metrics_head.py
+++ b/dashboard/modules/metrics/metrics_head.py
@@ -45,6 +45,7 @@ DEFAULT_GRAFANA_HOST = "http://localhost:3000"
 GRAFANA_HOST_ENV_VAR = "RAY_GRAFANA_HOST"
 GRAFANA_HOST_DISABLED_VALUE = "DISABLED"
 GRAFANA_IFRAME_HOST_ENV_VAR = "RAY_GRAFANA_IFRAME_HOST"
+GRAFANA_DEFAULT_DASHBOARD_UID = "RAY_GRAFANA_DEFAULT_DASHBOARD_UID"
 GRAFANA_DASHBOARD_OUTPUT_DIR_ENV_VAR = "RAY_METRICS_GRAFANA_DASHBOARD_OUTPUT_DIR"
 GRAFANA_CONFIG_INPUT_PATH = os.path.join(METRICS_INPUT_ROOT, "grafana")
 GRAFANA_HEALTHCHECK_PATH = "api/health"
@@ -111,6 +112,9 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
             GRAFANA_DASHBOARD_OUTPUT_DIR_ENV_VAR,
             os.path.join(grafana_config_output_path, "dashboards"),
         )
+        self._grafana_default_dashboard_uid = os.environ.get(
+            GRAFANA_DEFAULT_DASHBOARD_UID, "rayDefaultDashboard"
+        )
 
         self._session = aiohttp.ClientSession()
         self._ip = dashboard_head.ip
@@ -159,6 +163,7 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
                     message="Grafana running",
                     grafana_host=grafana_iframe_host,
                     session_name=self._session_name,
+                    grafana_default_dashboard_uid=self._grafana_default_dashboard_uid,
                 )
 
         except Exception as e:
@@ -341,7 +346,7 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
             ),
             "w",
         ) as f:
-            f.write(generate_grafana_dashboard())
+            f.write(generate_grafana_dashboard(self._grafana_default_dashboard_uid))
 
     def _create_default_prometheus_configs(self):
         """

--- a/python/ray/tests/test_metrics_head.py
+++ b/python/ray/tests/test_metrics_head.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import json
 import logging
 import os
 import pytest
@@ -47,7 +48,17 @@ def override_dashboard_dir():
         del os.environ["RAY_METRICS_GRAFANA_DASHBOARD_OUTPUT_DIR"]
 
 
-def test_metrics_folder_with_dashboard_override(override_dashboard_dir):
+@pytest.fixture
+def override_dashboard_uid():
+    uid = "test_uid_ses_12345"
+    os.environ["RAY_GRAFANA_DEFAULT_DASHBOARD_UID"] = "test_uid_ses_12345"
+    yield uid
+    del os.environ["RAY_GRAFANA_DEFAULT_DASHBOARD_UID"]
+
+
+def test_metrics_folder_with_dashboard_override(
+    override_dashboard_dir, override_dashboard_uid
+):
     """
     Tests that the default dashboard files get created.
     """
@@ -61,6 +72,9 @@ def test_metrics_folder_with_dashboard_override(override_dashboard_dir):
         ) as f:
             contents = f.read()
             assert override_dashboard_dir in contents
+        with open(f"{override_dashboard_dir}/default_grafana_dashboard.json") as f:
+            contents = json.loads(f.read())
+            assert contents["uid"] == override_dashboard_uid
 
 
 def test_metrics_folder_when_dashboard_disabled():


### PR DESCRIPTION
cherry-pick of #32255 

Signed-off-by: Alan Guo <aguo@anyscale.com>

This lets users with their own grafana setups to have multiple dashboards, one per ray instance. Without this change, each dashboard would have the same uid and replace each other in the grafana DB.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
