### PR TITLE
[ActorInit] Fix Bug in Actor creation

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -263,7 +263,7 @@ class RayActorError(RayError):
             but it is there as a safety check.
     """
 
-    def __init__(self, cause: Union[RayTaskError, ActorDiedErrorContext, str] = None):
+    def __init__(self, cause: Union[RayTaskError, ActorDiedErrorContext] = None):
         # -- If the actor has failed in the middle of __init__, this is set. --
         self._actor_init_failed = False
         # -- The base actor error message. --
@@ -271,8 +271,6 @@ class RayActorError(RayError):
 
         if not cause:
             self.error_msg = self.base_error_msg
-        elif isinstance(cause, str):
-            self.error_msg = cause
         elif isinstance(cause, RayTaskError):
             self._actor_init_failed = True
             self.error_msg = (

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -263,7 +263,7 @@ class RayActorError(RayError):
             but it is there as a safety check.
     """
 
-    def __init__(self, cause: Union[RayTaskError, ActorDiedErrorContext] = None):
+    def __init__(self, cause: Union[RayTaskError, ActorDiedErrorContext, str] = None):
         # -- If the actor has failed in the middle of __init__, this is set. --
         self._actor_init_failed = False
         # -- The base actor error message. --
@@ -271,6 +271,8 @@ class RayActorError(RayError):
 
         if not cause:
             self.error_msg = self.base_error_msg
+        elif isinstance(cause, str):
+            self.error_msg = cause
         elif isinstance(cause, RayTaskError):
             self._actor_init_failed = True
             self.error_msg = (


### PR DESCRIPTION
## Why are these changes needed?
* https://github.com/ray-project/ray/pull/28149 calls `RayActorError` with a str as cause, but this is not an accepted type. This leads to hitting the assertion error in the `else` case: `assert isinstance(cause, ActorDiedErrorContext)` on L283.



## Related issue number
* Noticed this by adding debug statements to the assertion on L283 to figure out why I was hitting it: 

```
(TemporaryActor pid=1225210)   File "/home/ubuntu/anaconda3/envs/my_package/lib/python3.7/site-packages/ray/exceptions.py", line 283, in __init__
(TemporaryActor pid=1225210)     assert isinstance(cause, ActorDiedErrorContext), "Not actor creation: " + str(type(cause)) + "\n: " + str(cause)
(TemporaryActor pid=1225210) AssertionError: Not actor creation: <class 'str'>
(TemporaryActor pid=1225210) : Failed to create the actor ActorID(064094ca4d85ae3e8fc943340e000000). The failure reason is that you set the async flag, but the actor has no any coroutine function.
```


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
