### PR TITLE
Fix overview page to work with the new DASHBOARD_UID env var

### DIFF
--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -241,7 +241,7 @@ export const Metrics = ({ newIA = false }: MetricsProps) => {
             })}
           >
             <Button
-              href={grafanaHost}
+              href={`${grafanaHost}/d/${grafanaDefaultDashboardUid}`}
               target="_blank"
               rel="noopener noreferrer"
               endIcon={<RiExternalLinkLine />}

--- a/dashboard/client/src/pages/overview/cards/ClusterUtilizationCard.tsx
+++ b/dashboard/client/src/pages/overview/cards/ClusterUtilizationCard.tsx
@@ -40,10 +40,13 @@ export const ClusterUtilizationCard = ({
 }: ClusterUtilizationCardProps) => {
   const classes = useStyles();
 
-  const { grafanaHost, prometheusHealth, sessionName } =
-    useContext(GlobalContext);
-  const path =
-    "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=41";
+  const {
+    grafanaHost,
+    prometheusHealth,
+    sessionName,
+    grafanaDefaultDashboardUid = "rayDefaultDashboard",
+  } = useContext(GlobalContext);
+  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=1&theme=light&panelId=41`;
   const timeRangeParams = "&from=now-30m&to=now";
 
   return (

--- a/dashboard/client/src/pages/overview/cards/NodeCountCard.tsx
+++ b/dashboard/client/src/pages/overview/cards/NodeCountCard.tsx
@@ -38,10 +38,13 @@ type NodeCountCardProps = {
 export const NodeCountCard = ({ className }: NodeCountCardProps) => {
   const classes = useStyles();
 
-  const { grafanaHost, prometheusHealth, sessionName } =
-    useContext(GlobalContext);
-  const path =
-    "/d-solo/rayDefaultDashboard/default-dashboard?orgId=1&theme=light&panelId=24";
+  const {
+    grafanaHost,
+    prometheusHealth,
+    sessionName,
+    grafanaDefaultDashboardUid = "rayDefaultDashboard",
+  } = useContext(GlobalContext);
+  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=1&theme=light&panelId=24`;
   const timeRangeParams = "&from=now-30m&to=now";
 
   return (


### PR DESCRIPTION
In #32255 , i added a new env var to customize grafana dashboard uid. I forgot to use this var in the overview page.
I also made the "View in Grafana" button take the user directly to the dashboard instead of the homepage of Grafana.

Signed-off-by: Alan Guo <aguo@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
