### PR TITLE
[ci/release] Improve error message when kicking off tests from a commit

### DIFF
--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -16,7 +16,7 @@ from ray_release.config import (
     DEFAULT_WHEEL_WAIT_TIMEOUT,
     parse_python_version,
 )
-from ray_release.exception import ReleaseTestCLIError
+from ray_release.exception import ReleaseTestCLIError, ReleaseTestConfigError
 from ray_release.logger import logger
 from ray_release.wheels import (
     find_and_wait_for_ray_wheels_url,
@@ -44,12 +44,12 @@ def main(test_collection_file: Optional[str] = None):
     env = {}
     if repo:
         # If the Ray test repo is set, we clone that repo to fetch
-        # the test configuration file. Otherwise we might be missing newly
+        # the test configuration file. Otherwise, we might be missing newly
         # added test.
-        repo = settings["ray_test_repo"]
         tmpdir = tempfile.mktemp()
 
         clone_cmd = f"git clone --depth 1 --branch {branch} {repo} {tmpdir}"
+        logger.info(f"Cloning test repository: {clone_cmd}")
         try:
             subprocess.check_output(clone_cmd, shell=True)
         except Exception as e:
@@ -65,10 +65,6 @@ def main(test_collection_file: Optional[str] = None):
         test_collection_file = test_collection_file or os.path.join(
             os.path.dirname(__file__), "..", "..", "release_tests.yaml"
         )
-    test_collection = read_and_validate_release_test_collection(test_collection_file)
-
-    if tmpdir:
-        shutil.rmtree(tmpdir, ignore_errors=True)
 
     frequency = settings["frequency"]
     prefer_smoke_tests = settings["prefer_smoke_tests"]
@@ -87,6 +83,21 @@ def main(test_collection_file: Optional[str] = None):
         f"  priority =                {settings['priority']}\n"
         f"  no_concurrency_limit =    {settings['no_concurrency_limit']}\n"
     )
+
+    try:
+        test_collection = read_and_validate_release_test_collection(
+            test_collection_file
+        )
+    except ReleaseTestConfigError as e:
+        raise ReleaseTestConfigError(
+            "Cannot load test yaml file.\nHINT: If you're kicking off tests for a "
+            "specific commit on Buildkite, after clicking 'New build', leave the "
+            "commit at HEAD, and only specify the commit in the dialog that asks "
+            "for the Ray wheels."
+        ) from e
+
+    if tmpdir:
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
     filtered_tests = filter_tests(
         test_collection,

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -91,9 +91,9 @@ def main(test_collection_file: Optional[str] = None):
     except ReleaseTestConfigError as e:
         raise ReleaseTestConfigError(
             "Cannot load test yaml file.\nHINT: If you're kicking off tests for a "
-            "specific commit on Buildkite, after clicking 'New build', leave the "
-            "commit at HEAD, and only specify the commit in the dialog that asks "
-            "for the Ray wheels."
+            "specific commit on Buildkite to test Ray wheels, after clicking "
+            "'New build', leave the commit at HEAD, and only specify the commit "
+            "in the dialog that asks for the Ray wheels."
         ) from e
 
     if tmpdir:


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If kicking off release tests from Buildkite, it's easy to make the mistake to insert a commit in both the Buildkite dialog and our own dialog. In the first case, it will checkout the repository from the specific commit, so if a test is not contained in that commit, it can't be run for that commit.

This PR will provide a better error message in that case.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
