### PR TITLE
[Flaky release test] Increase timeout of stress_test_many_tasks to ensure perf metrics are available

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3771,7 +3771,7 @@
     cluster_compute: stress_tests/stress_tests_compute.yaml
 
   run:
-    timeout: 7200
+    timeout: 14400
     wait_for_nodes:
       num_nodes: 101
 


### PR DESCRIPTION
[fetch_release_logs](https://github.com/ray-project/ray/blob/master/release/release_logs/fetch_release_logs.py) does not yield any perf metrics for `stress_test_many_tasks` because it hasn't passed for a few consecutive runs. It hasn't passed because it simply times out. I am doubling the timeout as we should catch regressions by tracking metrics, not by the test failing.

I plan on cherry-picking this into 2.3.0 so we can get perf numbers.