### PR TITLE
[Cherry pick into 2.3.0] [Flaky release test] Increase timeout of stress_test_many_tasks to ensure perf metrics are available #32286

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3771,7 +3771,7 @@
     cluster_compute: stress_tests/stress_tests_compute.yaml
 
   run:
-    timeout: 7200
+    timeout: 14400
     wait_for_nodes:
       num_nodes: 101
 


### PR DESCRIPTION
Cherry-picking https://github.com/ray-project/ray/pull/32286 into the 2.3.0 branch. This will unblock us from getting performance numbers from stress_test_many_tasks, which currently aren't available because the test is failing due to low timeout.