### PR TITLE
[core] Improving failure message when ray processes fail to start on new node

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -294,12 +294,12 @@ class Node:
                     self.gcs_address,
                     self._plasma_store_socket_name,
                 )
-            except TimeoutError:
+            except TimeoutError as te:
                 raise Exception(
-                    "The current node has not been updated within 30 "
-                    "seconds, this could happen because of some of "
-                    "the Ray processes failed to startup."
-                )
+                    "The current node timed out during startup. This "
+                    "could happen because some of the Ray processes "
+                    "failed to startup."
+                ) from te
             node_info = ray._private.services.get_node_to_connect_for_driver(
                 self.gcs_address,
                 self._raylet_ip_address,

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -433,7 +433,11 @@ def wait_for_node(
             return
         else:
             time.sleep(0.1)
-    raise TimeoutError("Timed out while waiting for node to startup.")
+    raise TimeoutError(
+        f"Timed out after {timeout} seconds while waiting for node to startup. "
+        f"Did not find socket name {node_plasma_store_socket_name} in the list "
+        "of object store socket names."
+    )
 
 
 def get_node_to_connect_for_driver(gcs_address, node_ip_address):


### PR DESCRIPTION
We have a release test named `long_running_node_failures` which intermittently fails because a node failed to start up. I couldn't debug it despite having all of the Ray logs. I created this PR to add a bit more information (the node socket that should have started up) in the hopes that this enables us to identify the issue next time it happens.

Failure in `long_running_node_failures`: https://github.com/ray-project/ray/issues/32180