### PR TITLE
[RLlib] Make one hidden layer config possible for TorchMLP

### DIFF
--- a/rllib/algorithms/ppo/tests/test_ppo_rl_module.py
+++ b/rllib/algorithms/ppo/tests/test_ppo_rl_module.py
@@ -70,7 +70,7 @@ def get_expected_model_config(
     )
     vf_config = MLPConfig(
         input_dim=32,
-        hidden_layer_dims=[32, 1],
+        hidden_layer_dims=[32],
         hidden_layer_activation="ReLU",
     )
 

--- a/rllib/algorithms/ppo/torch/ppo_torch_rl_module.py
+++ b/rllib/algorithms/ppo/torch/ppo_torch_rl_module.py
@@ -76,6 +76,15 @@ class PPOTorchRLModule(TorchRLModule):
         assert self.config.vf_config, "vf_config must be provided."
         assert self.config.encoder_config, "shared encoder config must be " "provided."
 
+        # build policy network head
+        self.config.encoder_config.input_dim = self.config.observation_space.shape[0]
+        self.config.pi_config.input_dim = self.config.encoder_config.output_dim
+        if isinstance(self.config.action_space, gym.spaces.Discrete):
+            self.config.pi_config.output_dim = self.config.action_space.n
+        else:
+            self.config.pi_config.output_dim = self.config.action_space.shape[0] * 2
+        self.config.vf_config.output_dim = 1
+
         # TODO(Artur): Unify to tf and torch setup with Catalog
         self.encoder = self.config.encoder_config.build(framework="torch")
         self.pi = self.config.pi_config.build(framework="torch")
@@ -140,7 +149,6 @@ class PPOTorchRLModule(TorchRLModule):
             input_dim=encoder_config.output_dim,
             hidden_layer_dims=[32, 1],
             hidden_layer_activation="ReLU",
-            output_dim=1,
         )
 
         assert isinstance(
@@ -154,14 +162,6 @@ class PPOTorchRLModule(TorchRLModule):
         assert isinstance(action_space, (gym.spaces.Discrete, gym.spaces.Box)), (
             "This simple PPOModule only supports Discrete and Box action space.",
         )
-
-        # build policy network head
-        encoder_config.input_dim = observation_space.shape[0]
-        pi_config.input_dim = encoder_config.output_dim
-        if isinstance(action_space, gym.spaces.Discrete):
-            pi_config.output_dim = action_space.n
-        else:
-            pi_config.output_dim = action_space.shape[0] * 2
 
         config_ = PPOModuleConfig(
             observation_space=observation_space,

--- a/rllib/algorithms/ppo/torch/ppo_torch_rl_module.py
+++ b/rllib/algorithms/ppo/torch/ppo_torch_rl_module.py
@@ -76,7 +76,6 @@ class PPOTorchRLModule(TorchRLModule):
         assert self.config.vf_config, "vf_config must be provided."
         assert self.config.encoder_config, "shared encoder config must be " "provided."
 
-        # build policy network head
         self.config.encoder_config.input_dim = self.config.observation_space.shape[0]
         self.config.pi_config.input_dim = self.config.encoder_config.output_dim
         if isinstance(self.config.action_space, gym.spaces.Discrete):

--- a/rllib/models/experimental/torch/primitives.py
+++ b/rllib/models/experimental/torch/primitives.py
@@ -74,24 +74,21 @@ class TorchMLP(nn.Module):
         self.input_dim = input_dim
         hidden_layer_dims = hidden_layer_dims
 
-        activation_class = getattr(nn, hidden_layer_activation, lambda: None)()
-        layers = []
-        layers.append(nn.Linear(input_dim, hidden_layer_dims[0]))
-        for i in range(len(hidden_layer_dims) - 1):
-            if hidden_layer_activation != "linear":
-                layers.append(activation_class)
-            layers.append(nn.Linear(hidden_layer_dims[i], hidden_layer_dims[i + 1]))
+        activation = getattr(nn, hidden_layer_activation, lambda: None)()
 
-        if output_dim is not None:
+        layers = []
+        dims = [input_dim] + hidden_layer_dims + [output_dim]
+        layers.append(nn.Linear(dims[0], dims[1]))
+        for i in range(1, len(dims) - 1):
             if hidden_layer_activation != "linear":
-                layers.append(activation_class)
-            layers.append(nn.Linear(hidden_layer_dims[-1], output_dim))
-            self.output_dim = output_dim
-        else:
-            self.output_dim = hidden_layer_dims[-1]
+                layers.append(activation)
+            layers.append(nn.Linear(dims[i], dims[i + 1]))
+
+        self.output_dim = dims[-1]
 
         if output_activation != "linear":
-            layers.append(get_activation_fn(output_activation, framework="torch"))
+            activation = getattr(nn, output_activation, lambda: None)()
+            layers.append(activation)
 
         self.mlp = nn.Sequential(*layers)
 

--- a/rllib/models/experimental/torch/primitives.py
+++ b/rllib/models/experimental/torch/primitives.py
@@ -10,7 +10,6 @@ from ray.rllib.models.temp_spec_classes import TensorDict
 from ray.rllib.utils.framework import try_import_torch
 from ray.rllib.utils.typing import TensorType
 from ray.rllib.models.experimental.base import ModelConfig
-from ray.rllib.models.utils import get_activation_fn
 from ray.rllib.models.specs.checker import (
     check_input_specs,
     check_output_specs,


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

TorchMLP does not support MLPs with only one hidden layer.
This should be supported.

This solution is also part of https://github.com/ray-project/ray/pull/32069, which will take a little longer to merge so I'm providing this fix since the raised issue is P0.

## Related issue number

Closes https://github.com/ray-project/ray/issues/32309
