### PR TITLE
[Datasets] Fix sort nightly test to skip `stats()` if exception is raised

### DIFF
--- a/release/nightly_tests/dataset/sort.py
+++ b/release/nightly_tests/dataset/sort.py
@@ -119,6 +119,7 @@ if __name__ == "__main__":
         else:
             ds = ds.sort(key="c_0")
         ds.fully_executed()
+        print(ds.stats())
     except Exception as e:
         exc = e
         pass
@@ -142,8 +143,6 @@ if __name__ == "__main__":
         print("Failed to retrieve memory summary")
         print(traceback.format_exc())
     print("")
-
-    print(ds.stats())
 
     if "TEST_OUTPUT_JSON" in os.environ:
         out_file = open(os.environ["TEST_OUTPUT_JSON"], "w")

--- a/release/nightly_tests/dataset/sort.py
+++ b/release/nightly_tests/dataset/sort.py
@@ -113,13 +113,14 @@ if __name__ == "__main__":
         num_columns=1,
     )
     exc = None
+    ds_stats = None
     try:
         if args.shuffle:
             ds = ds.random_shuffle()
         else:
             ds = ds.sort(key="c_0")
         ds.fully_executed()
-        print(ds.stats())
+        ds_stats = ds.stats()
     except Exception as e:
         exc = e
         pass
@@ -143,6 +144,9 @@ if __name__ == "__main__":
         print("Failed to retrieve memory summary")
         print(traceback.format_exc())
     print("")
+
+    if ds_stats is not None:
+        print(ds_stats)
 
     if "TEST_OUTPUT_JSON" in os.environ:
         out_file = open(os.environ["TEST_OUTPUT_JSON"], "w")


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As title, if `ds.fully_executed()` has exception, we should not catch exception and call `ds.stats()`, because at that time, `ds.stats()` would have undefined behavior. Change to skip calling of `ds.stats()` by putting all dataset operation in one code block.

This is to help debug the real issue of https://github.com/ray-project/ray/issues/32203 .

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
