### PR TITLE
Prepend task id if it exists to "ray task list --detail"

### DIFF
--- a/python/ray/experimental/state/state_cli.py
+++ b/python/ray/experimental/state/state_cli.py
@@ -27,6 +27,7 @@ from ray.experimental.state.common import (
     StateResource,
     StateSchema,
     SupportedFilterType,
+    TaskState,
     resource_to_schema,
 )
 from ray.experimental.state.exception import RayStateApiException
@@ -173,10 +174,7 @@ def output_with_format(
     if format == AvailableFormat.DEFAULT:
         return get_table_output(state_data, schema)
     if format == AvailableFormat.YAML:
-        augmented_state_data = [
-            {("task_id: " + state["task_id"]): state} for state in state_data
-        ]
-        return yaml.dump(augmented_state_data, indent=4, explicit_start=True)
+        return yaml.dump(state_data, indent=4, explicit_start=True)
     elif format == AvailableFormat.JSON:
         return json.dumps(state_data)
     elif format == AvailableFormat.TABLE:
@@ -285,9 +283,17 @@ def format_get_api_output(
     schema: StateSchema,
     format: AvailableFormat = AvailableFormat.YAML,
 ) -> str:
+
     if not state_data or len(state_data) == 0:
         return f"Resource with id={id} not found in the cluster."
 
+    if schema == TaskState:
+        augmented_task_state_data = [
+            {("task_id: " + state["task_id"]): state} for state in state_data
+        ]
+        return output_with_format(
+            augmented_task_state_data, schema=schema, format=format
+        )
     return output_with_format(state_data, schema=schema, format=format)
 
 
@@ -299,6 +305,13 @@ def format_list_api_output(
 ) -> str:
     if len(state_data) == 0:
         return "No resource in the cluster"
+    if schema == TaskState:
+        augmented_task_state_data = [
+            {("task_id: " + state["task_id"]): state} for state in state_data
+        ]
+        return output_with_format(
+            augmented_task_state_data, schema=schema, format=format
+        )
     return output_with_format(state_data, schema=schema, format=format)
 
 

--- a/python/ray/experimental/state/state_cli.py
+++ b/python/ray/experimental/state/state_cli.py
@@ -173,7 +173,8 @@ def output_with_format(
     if format == AvailableFormat.DEFAULT:
         return get_table_output(state_data, schema)
     if format == AvailableFormat.YAML:
-        return yaml.dump(state_data, indent=4, explicit_start=True)
+        augmented_state_data = [[{"task_id" : state["task_id"] if "task_id" in state else None }, state] for state in state_data]
+        return yaml.dump(augmented_state_data, indent=4, explicit_start=True)
     elif format == AvailableFormat.JSON:
         return json.dumps(state_data)
     elif format == AvailableFormat.TABLE:

--- a/python/ray/experimental/state/state_cli.py
+++ b/python/ray/experimental/state/state_cli.py
@@ -174,12 +174,7 @@ def output_with_format(
         return get_table_output(state_data, schema)
     if format == AvailableFormat.YAML:
         augmented_state_data = [
-            {
-                ("task_id: " + state["task_id"])
-                if "task_id" in state
-                else "No task_id found": state
-            }
-            for state in state_data
+            {("task_id: " + state["task_id"]): state} for state in state_data
         ]
         return yaml.dump(augmented_state_data, indent=4, explicit_start=True)
     elif format == AvailableFormat.JSON:

--- a/python/ray/experimental/state/state_cli.py
+++ b/python/ray/experimental/state/state_cli.py
@@ -287,7 +287,7 @@ def format_get_api_output(
     if not state_data or len(state_data) == 0:
         return f"Resource with id={id} not found in the cluster."
 
-    if schema == TaskState:
+    if schema == TaskState and format == AvailableFormat.YAML:
         augmented_task_state_data = [
             {("task_id: " + state["task_id"]): state} for state in state_data
         ]
@@ -305,7 +305,7 @@ def format_list_api_output(
 ) -> str:
     if len(state_data) == 0:
         return "No resource in the cluster"
-    if schema == TaskState:
+    if schema == TaskState and format == AvailableFormat.YAML:
         augmented_task_state_data = [
             {("task_id: " + state["task_id"]): state} for state in state_data
         ]

--- a/python/ray/experimental/state/state_cli.py
+++ b/python/ray/experimental/state/state_cli.py
@@ -173,7 +173,10 @@ def output_with_format(
     if format == AvailableFormat.DEFAULT:
         return get_table_output(state_data, schema)
     if format == AvailableFormat.YAML:
-        augmented_state_data = [[{"task_id" : state["task_id"] if "task_id" in state else None }, state] for state in state_data]
+        augmented_state_data = [
+            [{"task_id": state["task_id"] if "task_id" in state else None}, state]
+            for state in state_data
+        ]
         return yaml.dump(augmented_state_data, indent=4, explicit_start=True)
     elif format == AvailableFormat.JSON:
         return json.dumps(state_data)

--- a/python/ray/experimental/state/state_cli.py
+++ b/python/ray/experimental/state/state_cli.py
@@ -174,7 +174,11 @@ def output_with_format(
         return get_table_output(state_data, schema)
     if format == AvailableFormat.YAML:
         augmented_state_data = [
-            [{"task_id": state["task_id"] if "task_id" in state else None}, state]
+            {
+                ("task_id: " + state["task_id"])
+                if "task_id" in state
+                else "No task_id found": state
+            }
             for state in state_data
         ]
         return yaml.dump(augmented_state_data, indent=4, explicit_start=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change addresses this issue: https://github.com/ray-project/ray/issues/30805.

It solves a UX issue where the "task_id" field isn't printed FIRST. So this change prepends it, which can be shown in the following screenshot: 

UPDATED screenshot:

<img width="540" alt="Screen Shot 2023-02-21 at 4 08 12 PM" src="https://user-images.githubusercontent.com/43735701/220487130-d69b2f9c-1d4b-459d-81be-8750cbf87936.png">


<img width="485" alt="Screen Shot 2023-02-13 at 5 54 54 PM" src="https://user-images.githubusercontent.com/43735701/218618474-8b973c91-42b9-42a4-a432-4821f9afbffc.png">


## Related issue number

Closes Part 2 of #30805 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
