### PR TITLE
 [core][oom] Use retriable lifo policy for dask 3x nightly test

### DIFF
--- a/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
@@ -1,4 +1,7 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+# We use retriable_lifo as the workload can crash due to
+# 
+env_vars: {"RAY_worker_killing_policy": "retriable_lifo"}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
@@ -1,6 +1,8 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
-# We use retriable_lifo as the workload can crash due to
-# 
+# We use retriable_lifo as the workload can crash due to multiple tasks from different
+# callers running on the same node, we also observed raylet memory leak that would
+# trigger the group-by-policy to fail the workload.
+# https://github.com/ray-project/ray/issues/32195
 env_vars: {"RAY_worker_killing_policy": "retriable_lifo"}
 debian_packages: []
 


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

3x nightly dask test is failing, due to enabling of group-by-owner oom killer policy

This switches the test to use the previous policy

## Related issue number

https://github.com/ray-project/ray/issues/32195

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
