### PR TITLE
[RLlib] Issue 32267: `__common__` key should be allowed in multi-agent infos dict (for infos concerning all/no agents).

### DIFF
--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -662,11 +662,14 @@ class MultiAgentEnvWrapper(BaseEnv):
             assert isinstance(terminateds, dict), "Not a multi-agent terminateds dict!"
             assert isinstance(truncateds, dict), "Not a multi-agent truncateds dict!"
             assert isinstance(infos, dict), "Not a multi-agent info dict!"
-            if isinstance(obs, dict) and set(infos).difference(set(obs)):
-                raise ValueError(
-                    "Key set for infos must be a subset of obs: "
-                    "{} vs {}".format(infos.keys(), obs.keys())
-                )
+            if isinstance(obs, dict):
+                info_diff = set(infos).difference(set(obs))
+                if info_diff and info_diff != {"__common__"}:
+                    raise ValueError(
+                        "Key set for infos must be a subset of obs (plus optionally "
+                        "the '__common__' key for infos concerning all/no agents): "
+                        "{} vs {}".format(infos.keys(), obs.keys())
+                    )
             if "__all__" not in terminateds:
                 raise ValueError(
                     "In multi-agent environments, '__all__': True|False must "


### PR DESCRIPTION
Signed-off-by: sven1977 <svenmika1977@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue 32267: `__common__` key should be allowed in multi-agent infos dict (for infos concerning all/no agents).

Closes #32267 

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
