### PR TITLE
[2.3.0][core][state] Task Backend - reduce lock contention on debug stats/metric recording on counters.  (#32355)

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_task_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.h
@@ -20,6 +20,7 @@
 #include "absl/synchronization/mutex.h"
 #include "ray/gcs/gcs_client/usage_stats_client.h"
 #include "ray/rpc/gcs_server/gcs_rpc_server.h"
+#include "ray/util/counter_map.h"
 #include "src/ray/protobuf/gcs.pb.h"
 
 namespace ray {
@@ -27,6 +28,25 @@ namespace gcs {
 
 /// Type alias for a single task attempt, i.e. <task id and attempt number>.
 using TaskAttempt = std::pair<TaskID, int32_t>;
+
+enum GcsTaskManagerCounter {
+  kTotalNumTaskEventsReported,
+  kTotalNumStatusTaskEventsDropped,
+  kTotalNumProfileTaskEventsDropped,
+  kNumTaskEventsBytesStored,
+  kNumTaskEventsStored,
+  kTotalNumActorCreationTask,
+  kTotalNumActorTask,
+  kTotalNumNormalTask,
+  kTotalNumDriverTask,
+};
+
+const absl::flat_hash_map<rpc::TaskType, GcsTaskManagerCounter> kTaskTypeToCounterType = {
+    {rpc::TaskType::NORMAL_TASK, kTotalNumNormalTask},
+    {rpc::TaskType::ACTOR_CREATION_TASK, kTotalNumActorCreationTask},
+    {rpc::TaskType::ACTOR_TASK, kTotalNumActorTask},
+    {rpc::TaskType::DRIVER_TASK, kTotalNumDriverTask},
+};
 
 /// GcsTaskManger is responsible for capturing task states change reported by
 /// TaskEventBuffer from other components.
@@ -42,8 +62,9 @@ class GcsTaskManager : public rpc::TaskInfoHandler {
  public:
   /// Create a GcsTaskManager.
   GcsTaskManager()
-      : task_event_storage_(std::make_unique<GcsTaskManagerStorage>(
-            RayConfig::instance().task_events_max_num_task_in_gcs())),
+      : stats_counter_(),
+        task_event_storage_(std::make_unique<GcsTaskManagerStorage>(
+            RayConfig::instance().task_events_max_num_task_in_gcs(), stats_counter_)),
         io_service_thread_(std::make_unique<std::thread>([this] {
           SetThreadName("task_events");
           // Keep io_service_ alive.
@@ -59,8 +80,7 @@ class GcsTaskManager : public rpc::TaskInfoHandler {
   /// \param send_reply_callback Callback to invoke when sending reply.
   void HandleAddTaskEventData(rpc::AddTaskEventDataRequest request,
                               rpc::AddTaskEventDataReply *reply,
-                              rpc::SendReplyCallback send_reply_callback)
-      LOCKS_EXCLUDED(mutex_) override;
+                              rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle GetTaskEvent request.
   ///
@@ -69,14 +89,13 @@ class GcsTaskManager : public rpc::TaskInfoHandler {
   /// \param send_reply_callback Callback to invoke when sending reply.
   void HandleGetTaskEvents(rpc::GetTaskEventsRequest request,
                            rpc::GetTaskEventsReply *reply,
-                           rpc::SendReplyCallback send_reply_callback)
-      LOCKS_EXCLUDED(mutex_) override;
+                           rpc::SendReplyCallback send_reply_callback) override;
 
   /// Stops the event loop and the thread of the task event handler.
   ///
   /// After this is called, no more requests will be handled.
   /// This function returns when the io thread is joined.
-  void Stop() LOCKS_EXCLUDED(mutex_);
+  void Stop();
 
   /// Handler to be called when a job finishes. This marks all non-terminated tasks
   /// of the job as failed.
@@ -93,7 +112,7 @@ class GcsTaskManager : public rpc::TaskInfoHandler {
   /// Return string of debug state.
   ///
   /// \return Debug string
-  std::string DebugString() LOCKS_EXCLUDED(mutex_);
+  std::string DebugString();
 
   /// Record metrics.
   void RecordMetrics() LOCKS_EXCLUDED(mutex_);
@@ -120,8 +139,9 @@ class GcsTaskManager : public rpc::TaskInfoHandler {
     ///
     /// \param max_num_task_events Max number of task events stored before replacing older
     /// ones.
-    GcsTaskManagerStorage(size_t max_num_task_events)
-        : max_num_task_events_(max_num_task_events) {}
+    GcsTaskManagerStorage(size_t max_num_task_events,
+                          CounterMapThreadSafe<GcsTaskManagerCounter> &stats_counter)
+        : max_num_task_events_(max_num_task_events), stats_counter_(stats_counter) {}
 
     /// Add a new task event or replace an existing task event in the storage.
     ///
@@ -247,20 +267,11 @@ class GcsTaskManager : public rpc::TaskInfoHandler {
     /// could be found or there's data loss.
     absl::optional<TaskAttempt> GetLatestTaskAttempt(const TaskID &task_id) const;
 
-    /// Get the number of task events stored.
-    size_t GetTaskEventsCount() const { return task_events_.size(); }
-
-    /// Get the total number of bytes of task events stored.
-    uint64_t GetTaskEventsBytes() const { return num_bytes_task_events_; }
-
     /// Max number of task events allowed in the storage.
     const size_t max_num_task_events_ = 0;
 
     /// A iterator into task_events_ that determines which element to be overwritten.
     size_t next_idx_to_overwrite_ = 0;
-
-    /// Total number of tasks by types, including ones have been evicted/finished.
-    absl::flat_hash_map<rpc::TaskType, size_t> num_tasks_by_type_;
 
     /// TODO(rickyx): Refactor this into LRI(least recently inserted) buffer:
     /// https://github.com/ray-project/ray/issues/31158
@@ -283,9 +294,8 @@ class GcsTaskManager : public rpc::TaskInfoHandler {
     absl::flat_hash_map<TaskID, absl::flat_hash_set<TaskID>>
         parent_to_children_task_index_;
 
-    /// Counter for tracking the size of task event. This assumes tasks events are never
-    /// removed actively.
-    uint64_t num_bytes_task_events_ = 0;
+    /// Reference to the counter map owned by the GcsTaskManager.
+    CounterMapThreadSafe<GcsTaskManagerCounter> &stats_counter_;
 
     friend class GcsTaskManager;
     FRIEND_TEST(GcsTaskManagerTest, TestHandleAddTaskEventBasic);
@@ -295,20 +305,35 @@ class GcsTaskManager : public rpc::TaskInfoHandler {
   };
 
  private:
-  /// Mutex guarding all fields that will be accessed by main_io as well.
+  /// Test only
+  size_t GetTotalNumStatusTaskEventsDropped() {
+    return stats_counter_.Get(kTotalNumStatusTaskEventsDropped);
+  }
+
+  /// Test only
+  size_t GetTotalNumProfileTaskEventsDropped() {
+    return stats_counter_.Get(kTotalNumProfileTaskEventsDropped);
+  }
+
+  /// Test only
+  size_t GetTotalNumTaskEventsReported() {
+    return stats_counter_.Get(kTotalNumTaskEventsReported);
+  }
+
+  /// Test only
+  size_t GetNumTaskEventsStored() { return stats_counter_.Get(kNumTaskEventsStored); }
+
+  // Mutex guarding the usage stats client
   absl::Mutex mutex_;
 
-  /// Total number of task events reported.
-  uint32_t total_num_task_events_reported_ GUARDED_BY(mutex_) = 0;
+  UsageStatsClient *usage_stats_client_ GUARDED_BY(mutex_) = nullptr;
 
-  /// Total number of status task events dropped on the worker.
-  uint32_t total_num_status_task_events_dropped_ GUARDED_BY(mutex_) = 0;
+  /// Counter map for GcsTaskManager stats.
+  CounterMapThreadSafe<GcsTaskManagerCounter> stats_counter_;
 
-  /// Total number of profile task events dropped on the worker.
-  uint32_t total_num_profile_task_events_dropped_ GUARDED_BY(mutex_) = 0;
-
-  // Pointer to the underlying task events storage.
-  std::unique_ptr<GcsTaskManagerStorage> task_event_storage_ GUARDED_BY(mutex_);
+  // Pointer to the underlying task events storage. This is only accessed from
+  // the io_service_thread_. Access to it is *not* thread safe.
+  std::unique_ptr<GcsTaskManagerStorage> task_event_storage_;
 
   /// Its own separate IO service separated from the main service.
   instrumented_io_context io_service_;
@@ -318,8 +343,6 @@ class GcsTaskManager : public rpc::TaskInfoHandler {
 
   /// Timer for delay functions.
   boost::asio::deadline_timer timer_;
-
-  UsageStatsClient *usage_stats_client_ GUARDED_BY(mutex_) = nullptr;
 
   FRIEND_TEST(GcsTaskManagerTest, TestHandleAddTaskEventBasic);
   FRIEND_TEST(GcsTaskManagerTest, TestMergeTaskEventsSameTaskAttempt);

--- a/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
@@ -83,12 +83,17 @@ class GcsTaskManagerTest : public ::testing::Test {
     std::promise<bool> promise;
 
     request.mutable_data()->CopyFrom(events_data);
-    task_manager->HandleAddTaskEventData(
-        request,
-        &reply,
-        [&promise](Status, std::function<void()>, std::function<void()>) {
-          promise.set_value(true);
-        });
+    // Dispatch so that it runs in GcsTaskManager's io service.
+    task_manager->GetIoContext().dispatch(
+        [this, &promise, &request, &reply]() {
+          task_manager->HandleAddTaskEventData(
+              request,
+              &reply,
+              [&promise](Status, std::function<void()>, std::function<void()>) {
+                promise.set_value(true);
+              });
+        },
+        "SyncAddTaskEventData");
 
     promise.get_future().get();
 
@@ -120,13 +125,16 @@ class GcsTaskManagerTest : public ::testing::Test {
     }
 
     request.set_exclude_driver(exclude_driver);
-
-    task_manager->HandleGetTaskEvents(
-        request,
-        &reply,
-        [&promise](Status, std::function<void()>, std::function<void()>) {
-          promise.set_value(true);
-        });
+    task_manager->GetIoContext().dispatch(
+        [this, &promise, &request, &reply]() {
+          task_manager->HandleGetTaskEvents(
+              request,
+              &reply,
+              [&promise](Status, std::function<void()>, std::function<void()>) {
+                promise.set_value(true);
+              });
+        },
+        "SyncGetTaskEvents");
 
     promise.get_future().get();
 
@@ -248,12 +256,11 @@ TEST_F(GcsTaskManagerTest, TestHandleAddTaskEventBasic) {
 
   // Assert on actual data.
   {
-    absl::MutexLock lock(&task_manager->mutex_);
     EXPECT_EQ(task_manager->task_event_storage_->task_events_.size(), num_task_events);
-    EXPECT_EQ(task_manager->total_num_task_events_reported_, num_task_events);
-    EXPECT_EQ(task_manager->total_num_profile_task_events_dropped_,
+    EXPECT_EQ(task_manager->GetTotalNumTaskEventsReported(), num_task_events);
+    EXPECT_EQ(task_manager->GetTotalNumProfileTaskEventsDropped(),
               num_profile_events_dropped);
-    EXPECT_EQ(task_manager->total_num_status_task_events_dropped_,
+    EXPECT_EQ(task_manager->GetTotalNumStatusTaskEventsDropped(),
               num_status_events_dropped);
   }
 }
@@ -274,7 +281,6 @@ TEST_F(GcsTaskManagerTest, TestMergeTaskEventsSameTaskAttempt) {
 
   // Assert on actual data
   {
-    absl::MutexLock lock(&task_manager->mutex_);
     EXPECT_EQ(task_manager->task_event_storage_->task_events_.size(), 1);
     // Assert on events
     auto task_events = task_manager->task_event_storage_->task_events_[0];
@@ -643,10 +649,8 @@ TEST_F(GcsTaskManagerMemoryLimitedTest, TestIndexNoLeak) {
   }
 
   {
-    absl::MutexLock lock(&task_manager->mutex_);
-    EXPECT_EQ(
-        task_manager->task_event_storage_->num_tasks_by_type_[rpc::TaskType::NORMAL_TASK],
-        task_ids.size());
+    EXPECT_EQ(task_manager->task_event_storage_->stats_counter_.Get(kTotalNumNormalTask),
+              task_ids.size());
   }
 
   // Evict all of them with tasks with single attempt, no parent, same job.
@@ -668,11 +672,9 @@ TEST_F(GcsTaskManagerMemoryLimitedTest, TestIndexNoLeak) {
   }
   // Assert on the indexes and the storage
   {
-    absl::MutexLock lock(&task_manager->mutex_);
     EXPECT_EQ(task_manager->task_event_storage_->task_events_.size(), num_limit);
-    EXPECT_EQ(
-        task_manager->task_event_storage_->num_tasks_by_type_[rpc::TaskType::NORMAL_TASK],
-        task_ids.size() + num_limit);
+    EXPECT_EQ(task_manager->task_event_storage_->stats_counter_.Get(kTotalNumNormalTask),
+              task_ids.size() + num_limit);
     // No task has parent.
     EXPECT_EQ(task_manager->task_event_storage_->parent_to_children_task_index_.size(),
               0);
@@ -729,9 +731,8 @@ TEST_F(GcsTaskManagerMemoryLimitedTest, TestLimitTaskEvents) {
 
   // Assert on actual data.
   {
-    absl::MutexLock lock(&task_manager->mutex_);
-    EXPECT_EQ(task_manager->task_event_storage_->task_events_.size(), num_limit);
-    EXPECT_EQ(task_manager->total_num_task_events_reported_, num_batch1 + num_batch2);
+    EXPECT_EQ(task_manager->GetNumTaskEventsStored(), num_limit);
+    EXPECT_EQ(task_manager->GetTotalNumTaskEventsReported(), num_batch1 + num_batch2);
 
     std::sort(expected_events.begin(), expected_events.end(), SortByTaskAttempt);
     auto actual_events = task_manager->task_event_storage_->task_events_;
@@ -743,9 +744,9 @@ TEST_F(GcsTaskManagerMemoryLimitedTest, TestLimitTaskEvents) {
     }
 
     // Assert on drop counts.
-    EXPECT_EQ(task_manager->total_num_status_task_events_dropped_,
+    EXPECT_EQ(task_manager->GetTotalNumStatusTaskEventsDropped(),
               num_status_events_to_drop + num_status_events_dropped_on_worker);
-    EXPECT_EQ(task_manager->total_num_profile_task_events_dropped_,
+    EXPECT_EQ(task_manager->GetTotalNumProfileTaskEventsDropped(),
               num_profile_events_to_drop + num_profile_events_dropped_on_worker);
   }
 }


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

When GcsTaskManager is busy processing task events, it is not supposed to slow down the GCS. However, we previously have mutexes protecting some of the counter states. So the main io service/thread will get blocked when trying to acquire locks to print debug states + record metrics + add telemetry data.
```
Global stats: 196276 total (5 active)
Queueing time: mean = 5.255 ms, max = 4.545 s, min = -0.000 s, total = 1031.389 s Execution time:  mean = 295.864 us, total = 58.071 s Event stats:
....
        GCSServer.deadline_timer.debug_state_dump - 85 total (1 active), CPU time: mean = 521.750 ms, total = 44.349 s
        GCSServer.deadline_timer.debug_state_event_stats_print - 15 total (1 active, 1 running), CPU time: mean = 404.255 ms, total = 6.064 s
....
```

This PR
- introduced a thread-safe wrapper on CounterMap, such that modifying and reading various debug counters will have minimal lock contentions. Also merged the count by task type for telemetry into the counter map. This way, we will not need to acquire locks at various places. 
- With access to counters thread-safe now, we could also remove the mutex locks on the GcsTaskManagerStorage since it's now thread-safe (only accessed from its dedicated io thread)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/issues/32202

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
