### PR TITLE
[Datasets] [Docs] Update docs to reflect lazy-by-default execution model.

### DIFF
--- a/doc/source/data/dataset-internals.rst
+++ b/doc/source/data/dataset-internals.rst
@@ -66,19 +66,17 @@ Execution
 
 This section covers Dataset execution modes and performance considerations.
 
-Lazy Execution Mode
-~~~~~~~~~~~~~~~~~~~
+Lazy Execution
+~~~~~~~~~~~~~~
 
-By default, most Datasets operations are eager, which provides a simpler iterative
-development experience. Datasets also has a lazy execution mode that can offer
-improved performance due to stage fusion optimizations.
-
-Lazy execution mode can be enabled by calling
-:meth:`ds = ds.lazy() <ray.data.Dataset.lazy()>`, which
-returns a Dataset whose all subsequent operations will be lazy. These operations
-won't be executed until the dataset is consumed or
-:meth:`ds.fully_executed() <ray.data.Dataset.fully_executed>` is called to manually
-trigger execution.
+By default, most Datasets operations are lazy, with execution triggered via "sink"
+APIs, such as consuming (:meth:`ds.iter_batches() <ray.data.Dataset.iter_batches>`),
+writing (:meth:`ds.write_parquet() <ray.data.Dataset.write_parquet>`), certain
+transformations (:meth:`ds.union() <ray.data.Dataset.union>` or
+:meth:`ds.zip() <ray.data.Dataset.zip>`), or manually triggering via
+:meth:`ds.fully_executed() <ray.data.Dataset.fully_executed>`. Lazy execution offers opportunities
+for improved performance and memory stability due to stage fusion optimizations and
+aggressive garbage collection of intermediate results.
 
 Stage Fusion Optimization
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -103,10 +101,6 @@ You can tell if stage fusion is enabled by checking the :ref:`Dataset stats <dat
     * Remote wall time: T min, T max, T mean, T total
     * Remote cpu time: T min, T max, T mean, T total
     * Output num rows: N min, N max, N mean, N total
-
-To avoid unnecessary data movement in the distributed setting,
-:class:`DatasetPipelines <ray.data.dataset_pipelines.DatasetPipeline>` will always use
-lazy execution under the hood.
 
 Memory Management
 =================

--- a/doc/source/data/dataset-internals.rst
+++ b/doc/source/data/dataset-internals.rst
@@ -64,7 +64,7 @@ This should be considered for advanced use cases to improve performance predicta
 Execution
 =========
 
-This section covers Dataset execution modes and performance considerations.
+This section covers the Datasets execution model and performance considerations.
 
 Lazy Execution
 ~~~~~~~~~~~~~~

--- a/doc/source/data/dataset-internals.rst
+++ b/doc/source/data/dataset-internals.rst
@@ -69,14 +69,21 @@ This section covers Dataset execution modes and performance considerations.
 Lazy Execution
 ~~~~~~~~~~~~~~
 
-By default, most Datasets operations are lazy, with execution triggered via "sink"
+Lazy execution offers opportunities for improved performance and memory stability due
+to stage fusion optimizations and aggressive garbage collection of intermediate results.
+
+Dataset creation and transformation APIs are lazy, with execution only triggered via "sink"
 APIs, such as consuming (:meth:`ds.iter_batches() <ray.data.Dataset.iter_batches>`),
-writing (:meth:`ds.write_parquet() <ray.data.Dataset.write_parquet>`), certain
-transformations (:meth:`ds.union() <ray.data.Dataset.union>` or
-:meth:`ds.zip() <ray.data.Dataset.zip>`), or manually triggering via
-:meth:`ds.fully_executed() <ray.data.Dataset.fully_executed>`. Lazy execution offers opportunities
-for improved performance and memory stability due to stage fusion optimizations and
-aggressive garbage collection of intermediate results.
+writing (:meth:`ds.write_parquet() <ray.data.Dataset.write_parquet>`), or manually triggering via
+:meth:`ds.fully_executed() <ray.data.Dataset.fully_executed>`. There are a few
+exceptions to this rule, where transformations such as :meth:`ds.union()
+<ray.data.Dataset.union>` and
+:meth:`ds.limit() <ray.data.Dataset.limit>` trigger execution; we plan to make these
+operations lazy in the future.
+
+Check the API docs for Datasets methods to see if they
+trigger execution. Those that do trigger execution will have a ``Note`` indicating as
+much.
 
 Stage Fusion Optimization
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/data/examples/nyc_taxi_basic_processing.ipynb
+++ b/doc/source/data/examples/nyc_taxi_basic_processing.ipynb
@@ -67,7 +67,7 @@
    "source": [
     "### Reading and Inspecting the Data\n",
     "\n",
-    "Next, we read a few of the files from the dataset. This read is semi-lazy, where reading of the first file is eagerly executed, but reading of all other files is delayed until the underlying data is needed by downstream operations (e.g. consuming the data with {meth}`ds.take() <ray.data.Dataset.take>`, or transforming the data with {meth}`ds.map_batches() <ray.data.Dataset.map_batches>`).\n",
+    "Next, we read a few of the files from the dataset. This read is lazy, where reading and all future transformations are delayed until a downstream operation triggers execution (e.g. consuming the data with {meth}`ds.take() <ray.data.Dataset.take>`)\n",
     "\n",
     "We could process the entire Dataset in a streaming fashion using {ref}`pipelining <dataset_pipeline_concept>` or all of it in parallel using a multi-node Ray cluster, but we'll save that for our large-scale examples. :)"
    ]
@@ -331,7 +331,7 @@
     "For the NYC taxi dataset, instead of reading individual per-month Parquet files, we can read the entire 2009 directory.\n",
     "\n",
     "```{warning}\n",
-    "This could be a lot of data (downsampled with 0.01 ratio leads to ~50.2 MB on disk, ~147 MB in memory), so be careful triggering full reads on a limited-memory machine! This is one place where Datasets' semi-lazy reading comes in handy: Datasets will only read one file eagerly, which allows us to inspect a subset of the data without having to read the entire dataset.\n",
+    "This could be a lot of data (downsampled with 0.01 ratio leads to ~50.2 MB on disk, ~147 MB in memory), so be careful triggering full reads on a limited-memory machine! This is one place where Datasets' lazy reading comes in handy: Datasets will not execute any read tasks eagerly and will execute the minimum number of file reads to satisfy downstream operations, which allows us to inspect a subset of the data without having to read the entire dataset.\n",
     "```"
    ]
   },

--- a/doc/source/data/faq.rst
+++ b/doc/source/data/faq.rst
@@ -134,11 +134,6 @@ TensorFlow datasets
   `separate concepts <https://www.tensorflow.org/api_docs/python/tf/distribute/DistributedDataset>`__
   for distributed data loading and prevents code from being seamlessly scaled to larger
   clusters.
-* **Lazy execution:** Datasets executed operations eagerly by default, while TensorFlow
-  datasets are lazy by default. The formter provides easier iterative development and
-  debuggability, and when needing the optimizations that become available with lazy execution,
-  Ray Datasets has a lazy execution mode that you can turn on when productionizing your
-  integration.
 * **Generic distributed data processing:** Datasets is more general: it can handle
   generic distributed operations, including global per-epoch shuffling,
   which would otherwise have to be implemented by stitching together two separate

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -275,7 +275,12 @@ def _insert_doc_at_pattern(
         i = tail.find(pattern)
         skip_matches_left = skip_matches
         while i != -1:
-            offset = i + len(pattern) if insert_after else i
+            if insert_after:
+                # Set offset to the first character after the pattern.
+                offset = i + len(pattern)
+            else:
+                # Set offset to the first character in the matched line.
+                offset = tail[:i].rfind("\n") + 1
             head = tail[:offset]
             tail = tail[offset:]
             skip_matches_left -= 1
@@ -300,7 +305,7 @@ def _insert_doc_at_pattern(
     # Handle directive.
     message = message.strip("\n")
     if directive is not None:
-        base = f"{indent}.. {directive}\n"
+        base = f"{indent}.. {directive}::\n"
         message = message.replace("\n", "\n" + indent + " " * 4)
         message = base + indent + " " * 4 + message
     else:

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -296,7 +296,7 @@ def _insert_doc_at_pattern(
         lines = before_lines
     # Should always have at least one non-empty line in the docstring.
     assert len(lines) > 0
-    indent = " " * (len(lines[1]) - len(lines[1].lstrip()))
+    indent = " " * (len(lines[0]) - len(lines[0].lstrip()))
     # Handle directive.
     message = message.strip("\n")
     if directive is not None:

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -286,6 +286,9 @@ def _insert_doc_at_pattern(
             skip_matches_left -= 1
             if skip_matches_left <= 0:
                 break
+            elif not insert_after:
+                # Move past the found pattern, since we're skipping it.
+                tail = tail[i - offset + len(pattern) :]
             i = tail.find(pattern)
         else:
             raise ValueError(
@@ -293,12 +296,11 @@ def _insert_doc_at_pattern(
                 f"{doc}"
             )
     # Get indentation of the to-be-inserted text.
-    before_lines = list(filter(bool, reversed(head.splitlines())))
     after_lines = list(filter(bool, tail.splitlines()))
-    if insert_after and len(after_lines) > 0:
+    if len(after_lines) > 0:
         lines = after_lines
     else:
-        lines = before_lines
+        lines = list(filter(bool, reversed(head.splitlines())))
     # Should always have at least one non-empty line in the docstring.
     assert len(lines) > 0
     indent = " " * (len(lines[0]) - len(lines[0].lstrip()))

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -342,7 +342,7 @@ def _consumption_api(
     will trigger Datasets execution.
     """
     base = (
-        " will trigger execution of the lazy transformations performed on"
+        " will trigger execution of the lazy transformations performed on "
         "this dataset, and will block until execution completes."
     )
     if delegate:

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -244,3 +244,132 @@ def _is_local_scheme(paths: Union[str, List[str]]) -> bool:
 
 def _is_tensor_schema(column_names: List[str]):
     return column_names == [TENSOR_COLUMN_NAME]
+
+
+def _insert_doc_at_pattern(
+    obj,
+    *,
+    message: str,
+    pattern: str,
+    insert_after: bool = True,
+    directive: Optional[str] = None,
+    skip_matches: int = 0,
+) -> str:
+    if "\n" in message:
+        raise ValueError(
+            "message shouldn't contain any newlines, since this function will insert "
+            f"its own linebreaks when text wrapping: {message}"
+        )
+
+    doc = obj.__doc__.strip()
+    if not doc:
+        doc = ""
+
+    if pattern == "" and insert_after:
+        # Empty pattern + insert_after means that we want to append the message to the
+        # end of the docstring.
+        head = doc
+        tail = ""
+    else:
+        tail = doc
+        i = tail.find(pattern)
+        skip_matches_left = skip_matches
+        while i != -1:
+            offset = i + len(pattern) if insert_after else i
+            head = tail[:offset]
+            tail = tail[offset:]
+            skip_matches_left -= 1
+            if skip_matches_left <= 0:
+                break
+            i = tail.find(pattern)
+        else:
+            raise ValueError(
+                f"Pattern {pattern} not found after {skip_matches} skips in docstring "
+                f"{doc}"
+            )
+    # Get indentation of the to-be-inserted text.
+    before_lines = list(filter(bool, reversed(head.splitlines())))
+    after_lines = list(filter(bool, tail.splitlines()))
+    if insert_after and len(after_lines) > 0:
+        lines = after_lines
+    else:
+        lines = before_lines
+    # Should always have at least one non-empty line in the docstring.
+    assert len(lines) > 0
+    indent = " " * (len(lines[1]) - len(lines[1].lstrip()))
+    # Handle directive.
+    message = message.strip("\n")
+    if directive is not None:
+        base = f"{indent}.. {directive}\n"
+        message = message.replace("\n", "\n" + indent + " " * 4)
+        message = base + indent + " " * 4 + message
+    else:
+        message = indent + message.replace("\n", "\n" + indent)
+    # Add two blank lines before/after message, if necessary.
+    if insert_after ^ (pattern == "\n\n"):
+        # Only two blank lines before message if:
+        # 1. Inserting message after pattern and pattern is not two blank lines.
+        # 2. Inserting message before pattern and pattern is two blank lines.
+        message = "\n\n" + message
+    if (not insert_after) ^ (pattern == "\n\n"):
+        # Only two blank lines after message if:
+        # 1. Inserting message before pattern and pattern is not two blank lines.
+        # 2. Inserting message after pattern and pattern is two blank lines.
+        message = message + "\n\n"
+
+    # Insert message before/after pattern.
+    parts = [head, message, tail]
+    # Build new docstring.
+    obj.__doc__ = "".join(parts)
+
+
+def _consumption_api(
+    if_more_than_read: bool = False,
+    datasource_metadata: Optional[str] = None,
+    extra_condition: Optional[str] = None,
+    delegate: Optional[str] = None,
+    pattern="Examples:",
+    insert_after=False,
+):
+    """Annotate the function with an indication that it's a consumption API, and that it
+    will trigger Datasets execution.
+    """
+    base = (
+        " will trigger execution of the lazy transformations performed on"
+        "this dataset, and will block until execution completes."
+    )
+    if delegate:
+        message = delegate + base
+    elif not if_more_than_read:
+        message = "This operation" + base
+    else:
+        condition = "If this dataset consists of more than a read, "
+        if datasource_metadata is not None:
+            condition += (
+                f"or if the {datasource_metadata} can't be determined from the "
+                "metadata provided by the datasource, "
+            )
+        if extra_condition is not None:
+            condition += extra_condition + ", "
+        message = condition + "then this operation" + base
+
+    def wrap(obj):
+        _insert_doc_at_pattern(
+            obj,
+            message=message,
+            pattern=pattern,
+            insert_after=insert_after,
+            directive="note",
+        )
+        return obj
+
+    return wrap
+
+
+def ConsumptionAPI(*args, **kwargs):
+    """Annotate the function with an indication that it's a consumption API, and that it
+    will trigger Datasets execution.
+    """
+    if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+        return _consumption_api()(args[0])
+    return _consumption_api(*args, **kwargs)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2102,7 +2102,7 @@ class Dataset(Generic[T]):
             self._lazy,
         )
 
-    @ConsumptionAPI
+    @ConsumptionAPI(pattern="Time complexity:")
     def take(self, limit: int = 20) -> List[T]:
         """Return up to ``limit`` records from the dataset.
 
@@ -2125,7 +2125,7 @@ class Dataset(Generic[T]):
                 break
         return output
 
-    @ConsumptionAPI
+    @ConsumptionAPI(pattern="Time complexity:")
     def take_all(self, limit: Optional[int] = None) -> List[T]:
         """Return all of the records in the dataset.
 
@@ -2152,7 +2152,7 @@ class Dataset(Generic[T]):
                 )
         return output
 
-    @ConsumptionAPI
+    @ConsumptionAPI(pattern="Time complexity:")
     def show(self, limit: int = 20) -> None:
         """Print up to the given number of records from the dataset.
 
@@ -2164,7 +2164,11 @@ class Dataset(Generic[T]):
         for row in self.take(limit):
             print(row)
 
-    @ConsumptionAPI(if_more_than_read=True, datasource_metadata="row count")
+    @ConsumptionAPI(
+        if_more_than_read=True,
+        datasource_metadata="row count",
+        pattern="Time complexity:",
+    )
     def count(self) -> int:
         """Count the number of records in the dataset.
 
@@ -2194,6 +2198,7 @@ class Dataset(Generic[T]):
         if_more_than_read=True,
         datasource_metadata="schema",
         extra_condition="or if ``fetch_if_missing=True`` (the default)",
+        pattern="Time complexity:",
     )
     def schema(
         self, fetch_if_missing: bool = True
@@ -2230,7 +2235,7 @@ class Dataset(Generic[T]):
         """
         return self._plan.initial_num_blocks()
 
-    @ConsumptionAPI(if_more_than_read=True)
+    @ConsumptionAPI(if_more_than_read=True, pattern="Time complexity:")
     def size_bytes(self) -> int:
         """Return the in-memory size of the dataset.
 
@@ -2245,7 +2250,7 @@ class Dataset(Generic[T]):
             return None
         return sum(m.size_bytes for m in metadata)
 
-    @ConsumptionAPI(if_more_than_read=True)
+    @ConsumptionAPI(if_more_than_read=True, pattern="Time complexity:")
     def input_files(self) -> List[str]:
         """Return the list of input files for the dataset.
 
@@ -3019,7 +3024,7 @@ class Dataset(Generic[T]):
         ):
             yield convert_ndarray_batch_to_tf_tensor_batch(batch, dtypes=dtypes)
 
-    @ConsumptionAPI
+    @ConsumptionAPI(pattern="Time complexity:")
     def to_torch(
         self,
         *,

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -138,8 +138,6 @@ class GroupedDataset(Generic[T]):
     def aggregate(self, *aggs: AggregateFn) -> Dataset[U]:
         """Implements an accumulator-based aggregation.
 
-        This is a blocking operation.
-
         Examples:
 
             .. testcode::
@@ -263,8 +261,6 @@ class GroupedDataset(Generic[T]):
 
         In general, prefer to use aggregate() instead of map_groups().
 
-        This is a blocking operation.
-
         Examples:
             >>> # Return a single record per group (list of multiple records in,
             >>> # list of a single record out).
@@ -374,8 +370,6 @@ class GroupedDataset(Generic[T]):
     def count(self) -> Dataset[U]:
         """Compute count aggregation.
 
-        This is a blocking operation.
-
         Examples:
             >>> import ray
             >>> ray.data.range(100).groupby(lambda x: x % 3).count() # doctest: +SKIP
@@ -395,8 +389,6 @@ class GroupedDataset(Generic[T]):
         self, on: Union[KeyFn, List[KeyFn]] = None, ignore_nulls: bool = True
     ) -> Dataset[U]:
         r"""Compute grouped sum aggregation.
-
-        This is a blocking operation.
 
         Examples:
             >>> import ray
@@ -457,8 +449,6 @@ class GroupedDataset(Generic[T]):
     ) -> Dataset[U]:
         """Compute grouped min aggregation.
 
-        This is a blocking operation.
-
         Examples:
             >>> import ray
             >>> ray.data.range(100).groupby(lambda x: x % 3).min() # doctest: +SKIP
@@ -518,8 +508,6 @@ class GroupedDataset(Generic[T]):
     ) -> Dataset[U]:
         """Compute grouped max aggregation.
 
-        This is a blocking operation.
-
         Examples:
             >>> import ray
             >>> ray.data.range(100).groupby(lambda x: x % 3).max() # doctest: +SKIP
@@ -578,8 +566,6 @@ class GroupedDataset(Generic[T]):
         self, on: Union[KeyFn, List[KeyFn]] = None, ignore_nulls: bool = True
     ) -> Dataset[U]:
         """Compute grouped mean aggregation.
-
-        This is a blocking operation.
 
         Examples:
             >>> import ray
@@ -643,8 +629,6 @@ class GroupedDataset(Generic[T]):
         ignore_nulls: bool = True,
     ) -> Dataset[U]:
         """Compute grouped standard deviation aggregation.
-
-        This is a blocking operation.
 
         Examples:
             >>> import ray

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -77,13 +77,6 @@ logger = logging.getLogger(__name__)
 def from_items(items: List[Any], *, parallelism: int = -1) -> Dataset[Any]:
     """Create a dataset from a list of local Python objects.
 
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
-
     Examples:
         >>> import ray
         >>> ds = ray.data.from_items([1, 2, 3, 4, 5]) # doctest: +SKIP
@@ -1152,13 +1145,6 @@ def read_binary_files(
 def from_dask(df: "dask.DataFrame") -> Dataset[ArrowRow]:
     """Create a dataset from a Dask DataFrame.
 
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
-
     Args:
         df: A Dask DataFrame.
 
@@ -1193,13 +1179,6 @@ def from_dask(df: "dask.DataFrame") -> Dataset[ArrowRow]:
 def from_mars(df: "mars.DataFrame") -> Dataset[ArrowRow]:
     """Create a dataset from a MARS dataframe.
 
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
-
     Args:
         df: A MARS dataframe, which must be executed by MARS-on-Ray.
 
@@ -1214,13 +1193,6 @@ def from_mars(df: "mars.DataFrame") -> Dataset[ArrowRow]:
 @PublicAPI
 def from_modin(df: "modin.DataFrame") -> Dataset[ArrowRow]:
     """Create a dataset from a Modin dataframe.
-
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Args:
         df: A Modin dataframe, which must be using the Ray backend.
@@ -1239,13 +1211,6 @@ def from_pandas(
     dfs: Union["pandas.DataFrame", List["pandas.DataFrame"]]
 ) -> Dataset[ArrowRow]:
     """Create a dataset from a list of Pandas dataframes.
-
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Args:
         dfs: A Pandas dataframe or a list of Pandas dataframes.
@@ -1266,13 +1231,6 @@ def from_pandas_refs(
 ) -> Dataset[ArrowRow]:
     """Create a dataset from a list of Ray object references to Pandas
     dataframes.
-
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Args:
         dfs: A Ray object references to pandas dataframe, or a list of
@@ -1329,13 +1287,6 @@ def from_pandas_refs(
 def from_numpy(ndarrays: Union[np.ndarray, List[np.ndarray]]) -> Dataset[ArrowRow]:
     """Create a dataset from a list of NumPy ndarrays.
 
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
-
     Args:
         ndarrays: A NumPy ndarray or a list of NumPy ndarrays.
 
@@ -1353,13 +1304,6 @@ def from_numpy_refs(
     ndarrays: Union[ObjectRef[np.ndarray], List[ObjectRef[np.ndarray]]],
 ) -> Dataset[ArrowRow]:
     """Create a dataset from a list of NumPy ndarray futures.
-
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Args:
         ndarrays: A Ray object reference to a NumPy ndarray or a list of Ray object
@@ -1404,13 +1348,6 @@ def from_arrow(
 ) -> Dataset[ArrowRow]:
     """Create a dataset from a list of Arrow tables.
 
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
-
     Args:
         tables: An Arrow table, or a list of Arrow tables,
                 or its streaming format in bytes.
@@ -1433,13 +1370,6 @@ def from_arrow_refs(
     ]
 ) -> Dataset[ArrowRow]:
     """Create a dataset from a set of Arrow tables.
-
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Args:
         tables: A Ray object reference to Arrow table, or list of Ray object
@@ -1470,13 +1400,6 @@ def from_spark(
 ) -> Dataset[ArrowRow]:
     """Create a dataset from a Spark dataframe.
 
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
-
     Args:
         spark: A SparkSession, which must be created by RayDP (Spark-on-Ray).
         df: A Spark dataframe, which must be created by RayDP (Spark-on-Ray).
@@ -1501,13 +1424,6 @@ def from_huggingface(
     This function is not parallelized, and is intended to be used
     with Hugging Face Datasets that are loaded into memory (as opposed
     to memory-mapped).
-
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Args:
         dataset: A Hugging Face ``Dataset``, or ``DatasetDict``.
@@ -1549,13 +1465,6 @@ def from_tf(
     .. note::
         This function isn't paralellized. It loads the entire dataset into the head
         node's memory before moving the data to the distributed object store.
-
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Examples:
         >>> import ray
@@ -1609,13 +1518,6 @@ def from_torch(
     .. note::
         This function isn't paralellized. It loads the entire dataset into the head
         node's memory before moving the data to the distributed object store.
-
-    .. note::
-        This dataset will be an eagerly computed dataset, where all subsequent
-        transformations will execute eagerly rather than lazily. If you want these
-        transformations to be lazy in order to benefit from better performance and
-        memory stability, convert it to a lazy dataset via
-        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Examples:
         >>> import ray

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -77,6 +77,13 @@ logger = logging.getLogger(__name__)
 def from_items(items: List[Any], *, parallelism: int = -1) -> Dataset[Any]:
     """Create a dataset from a list of local Python objects.
 
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
+
     Examples:
         >>> import ray
         >>> ds = ray.data.from_items([1, 2, 3, 4, 5]) # doctest: +SKIP
@@ -1145,6 +1152,13 @@ def read_binary_files(
 def from_dask(df: "dask.DataFrame") -> Dataset[ArrowRow]:
     """Create a dataset from a Dask DataFrame.
 
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
+
     Args:
         df: A Dask DataFrame.
 
@@ -1179,6 +1193,13 @@ def from_dask(df: "dask.DataFrame") -> Dataset[ArrowRow]:
 def from_mars(df: "mars.DataFrame") -> Dataset[ArrowRow]:
     """Create a dataset from a MARS dataframe.
 
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
+
     Args:
         df: A MARS dataframe, which must be executed by MARS-on-Ray.
 
@@ -1193,6 +1214,13 @@ def from_mars(df: "mars.DataFrame") -> Dataset[ArrowRow]:
 @PublicAPI
 def from_modin(df: "modin.DataFrame") -> Dataset[ArrowRow]:
     """Create a dataset from a Modin dataframe.
+
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Args:
         df: A Modin dataframe, which must be using the Ray backend.
@@ -1211,6 +1239,13 @@ def from_pandas(
     dfs: Union["pandas.DataFrame", List["pandas.DataFrame"]]
 ) -> Dataset[ArrowRow]:
     """Create a dataset from a list of Pandas dataframes.
+
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Args:
         dfs: A Pandas dataframe or a list of Pandas dataframes.
@@ -1231,6 +1266,13 @@ def from_pandas_refs(
 ) -> Dataset[ArrowRow]:
     """Create a dataset from a list of Ray object references to Pandas
     dataframes.
+
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Args:
         dfs: A Ray object references to pandas dataframe, or a list of
@@ -1287,6 +1329,13 @@ def from_pandas_refs(
 def from_numpy(ndarrays: Union[np.ndarray, List[np.ndarray]]) -> Dataset[ArrowRow]:
     """Create a dataset from a list of NumPy ndarrays.
 
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
+
     Args:
         ndarrays: A NumPy ndarray or a list of NumPy ndarrays.
 
@@ -1304,6 +1353,13 @@ def from_numpy_refs(
     ndarrays: Union[ObjectRef[np.ndarray], List[ObjectRef[np.ndarray]]],
 ) -> Dataset[ArrowRow]:
     """Create a dataset from a list of NumPy ndarray futures.
+
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Args:
         ndarrays: A Ray object reference to a NumPy ndarray or a list of Ray object
@@ -1348,6 +1404,13 @@ def from_arrow(
 ) -> Dataset[ArrowRow]:
     """Create a dataset from a list of Arrow tables.
 
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
+
     Args:
         tables: An Arrow table, or a list of Arrow tables,
                 or its streaming format in bytes.
@@ -1370,6 +1433,13 @@ def from_arrow_refs(
     ]
 ) -> Dataset[ArrowRow]:
     """Create a dataset from a set of Arrow tables.
+
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Args:
         tables: A Ray object reference to Arrow table, or list of Ray object
@@ -1400,6 +1470,13 @@ def from_spark(
 ) -> Dataset[ArrowRow]:
     """Create a dataset from a Spark dataframe.
 
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
+
     Args:
         spark: A SparkSession, which must be created by RayDP (Spark-on-Ray).
         df: A Spark dataframe, which must be created by RayDP (Spark-on-Ray).
@@ -1424,6 +1501,13 @@ def from_huggingface(
     This function is not parallelized, and is intended to be used
     with Hugging Face Datasets that are loaded into memory (as opposed
     to memory-mapped).
+
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Args:
         dataset: A Hugging Face ``Dataset``, or ``DatasetDict``.
@@ -1465,6 +1549,13 @@ def from_tf(
     .. note::
         This function isn't paralellized. It loads the entire dataset into the head
         node's memory before moving the data to the distributed object store.
+
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Examples:
         >>> import ray
@@ -1518,6 +1609,13 @@ def from_torch(
     .. note::
         This function isn't paralellized. It loads the entire dataset into the head
         node's memory before moving the data to the distributed object store.
+
+    .. note::
+        This dataset will be an eagerly computed dataset, where all subsequent
+        transformations will execute eagerly rather than lazily. If you want these
+        transformations to be lazy in order to benefit from better performance and
+        memory stability, convert it to a lazy dataset via
+        :meth:`ds = ds.lazy() <ray.data.Dataset.lazy>` first.
 
     Examples:
         >>> import ray


### PR DESCRIPTION
This PR updates the docs for a portion of the feature guides, the FAQ, the examples, and the docstrings for the `Dataset`, `GroupedDataset`, and read APIs, to reflect the new lazy-by-default execution semantics.

## Coverage

- [x] "Custom Datasources" feature guide
- [x] "Pipelining Compute" feature guide
- [x] "Scheduling Execution, and Memory Management" feature guide
- [x] "Performance Tips and Tuning" feature guide
- [x] Examples
- [x] FAQ
- [x] `Dataset` API docstrings
- [x] `GroupedDataset` API docstrings
- [x] All read API docstrings

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
