### PR TITLE
[Job API] Handle multiple drivers with same job submission id in GCS GetAllJobInfo endpoint

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1337,7 +1337,7 @@ def init(
             runtime_env = _load_class(os.environ[ray_constants.RAY_RUNTIME_ENV_HOOK])(
                 job_config.runtime_env
             )
-            job_config.set_runtime_env(runtime_env) # overwrite.  change to "merge"?
+            job_config.set_runtime_env(runtime_env)
 
     # RAY_JOB_CONFIG_JSON_ENV_VAR is only set at ray job manager level and has
     # higher priority in case user also provided runtime_env for ray.init()

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1337,7 +1337,7 @@ def init(
             runtime_env = _load_class(os.environ[ray_constants.RAY_RUNTIME_ENV_HOOK])(
                 job_config.runtime_env
             )
-            job_config.set_runtime_env(runtime_env)
+            job_config.set_runtime_env(runtime_env) # overwrite.  change to "merge"?
 
     # RAY_JOB_CONFIG_JSON_ENV_VAR is only set at ray job manager level and has
     # higher priority in case user also provided runtime_env for ray.init()

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -169,6 +169,11 @@ void GcsJobManager::HandleGetAllJobInfo(rpc::GetAllJobInfoRequest request,
     // Maps job data keys to the index of the job in the table.
     std::unordered_map<std::string, int> job_data_key_to_index;
 
+    // print full data
+    for (auto &data : result) {
+      RAY_LOG(ERROR) << "job_table_data = " << data.second.DebugString();
+    }
+
     // Load the job table data into the reply.
     int i = 0;
     for (auto &data : result) {
@@ -183,9 +188,28 @@ void GcsJobManager::HandleGetAllJobInfo(rpc::GetAllJobInfoRequest request,
         std::string job_submission_id = iter->second;
         std::string job_data_key = JobDataKey(job_submission_id);
         job_api_data_keys.push_back(job_data_key);
+        // if key is already in the map, it means there are duplicate jobs
+        // print debug info
+        RAY_LOG(ERROR) << "Found duplicate job with job_submission_id = "
+                       << job_submission_id;
         job_data_key_to_index[job_data_key] = i;
       }
       i++;
+    }
+
+    // debug
+    if (!(job_api_data_keys.size() == job_data_key_to_index.size())) {
+      RAY_LOG(ERROR) << "job_api_data_keys.size() != job_data_key_to_index.size()";
+      RAY_LOG(ERROR) << "job_api_data_keys.size() = " << job_api_data_keys.size();
+      RAY_LOG(ERROR) << "job_data_key_to_index.size() = " << job_data_key_to_index.size();
+      // Print the entire job_api_data_keys
+      for (auto &data : job_api_data_keys) {
+        RAY_LOG(ERROR) << "job_api_data_keys = " << data;
+      }
+      // Print the entire job_data_key_to_index
+      for (auto &data : job_data_key_to_index) {
+        RAY_LOG(ERROR) << "job_data_key_to_index = " << data.first << " " << data.second;
+      }
     }
 
     RAY_CHECK(job_api_data_keys.size() == job_data_key_to_index.size());

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -169,12 +169,6 @@ void GcsJobManager::HandleGetAllJobInfo(rpc::GetAllJobInfoRequest request,
     // Maps job data keys to the index of the job in the table.
     std::unordered_map<std::string, int> job_data_key_to_index;
 
-    // print full data
-    RAY_LOG(ERROR) << "result.size() = " << result.size();
-    for (auto &data : result) {
-      RAY_LOG(ERROR) << "job_table_data = " << data.second.DebugString();
-    }
-
     // Load the job table data into the reply.
     int i = 0;
     for (auto &data : result) {
@@ -189,32 +183,9 @@ void GcsJobManager::HandleGetAllJobInfo(rpc::GetAllJobInfoRequest request,
         std::string job_submission_id = iter->second;
         std::string job_data_key = JobDataKey(job_submission_id);
         job_api_data_keys.push_back(job_data_key);
-        // if key is already in the map, it means there are duplicate jobs
-        // print debug info
-        if(job_data_key_to_index.find(job_data_key) != job_data_key_to_index.end()) {
-          RAY_LOG(ERROR) << "job_data_key_to_index[job_data_key] != i";
-          RAY_LOG(ERROR) << "job_data_key_to_index[job_data_key] = " << job_data_key_to_index[job_data_key];
-          RAY_LOG(ERROR) << "i = " << i;
-          RAY_LOG(ERROR) << "job_data_key = " << job_data_key;
-        }
         job_data_key_to_index[job_data_key] = i;
       }
       i++;
-    }
-
-    // debug
-    if (!(job_api_data_keys.size() == job_data_key_to_index.size())) {
-      RAY_LOG(ERROR) << "job_api_data_keys.size() != job_data_key_to_index.size()";
-      RAY_LOG(ERROR) << "job_api_data_keys.size() = " << job_api_data_keys.size();
-      RAY_LOG(ERROR) << "job_data_key_to_index.size() = " << job_data_key_to_index.size();
-      // Print the entire job_api_data_keys
-      for (auto &data : job_api_data_keys) {
-        RAY_LOG(ERROR) << "job_api_data_keys = " << data;
-      }
-      // Print the entire job_data_key_to_index
-      for (auto &data : job_data_key_to_index) {
-        RAY_LOG(ERROR) << "job_data_key_to_index = " << data.first << " " << data.second;
-      }
     }
 
     RAY_CHECK(job_api_data_keys.size() == job_data_key_to_index.size());

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -170,6 +170,7 @@ void GcsJobManager::HandleGetAllJobInfo(rpc::GetAllJobInfoRequest request,
     std::unordered_map<std::string, int> job_data_key_to_index;
 
     // print full data
+    RAY_LOG(ERROR) << "result.size() = " << result.size();
     for (auto &data : result) {
       RAY_LOG(ERROR) << "job_table_data = " << data.second.DebugString();
     }

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -191,8 +191,12 @@ void GcsJobManager::HandleGetAllJobInfo(rpc::GetAllJobInfoRequest request,
         job_api_data_keys.push_back(job_data_key);
         // if key is already in the map, it means there are duplicate jobs
         // print debug info
-        RAY_LOG(ERROR) << "Found duplicate job with job_submission_id = "
-                       << job_submission_id;
+        if(job_data_key_to_index.find(job_data_key) != job_data_key_to_index.end()) {
+          RAY_LOG(ERROR) << "job_data_key_to_index[job_data_key] != i";
+          RAY_LOG(ERROR) << "job_data_key_to_index[job_data_key] = " << job_data_key_to_index[job_data_key];
+          RAY_LOG(ERROR) << "i = " << i;
+          RAY_LOG(ERROR) << "job_data_key = " << job_data_key;
+        }
         job_data_key_to_index[job_data_key] = i;
       }
       i++;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The changes to the `GetAllJobInfo` endpoint in https://github.com/ray-project/ray/pull/31046 did not handle the possibility that multiple job table jobs (drivers) could have the same submission_id. This can actually happen, for example if there are multiple `ray.init()` calls in a Ray Job API `entrypoint` command.  The GCS would crash in this case due to failing a `RAY_CHECK` that the number of jobs equaled the number of `submission_id`s seen.

This PR updates the endpoint to handle the above possibility, and adds a unit test which fails without this PR.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/32213
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
