### PR TITLE
[Datasets] Make ray.data.from_* APIs lazy.

### DIFF
--- a/doc/source/data/dataset-ml-preprocessing.rst
+++ b/doc/source/data/dataset-ml-preprocessing.rst
@@ -89,8 +89,7 @@ Other preprocessing operations require global operations, such as groupbys and g
         for x in range(10)])
 
     # Group by the A column and calculate the per-group mean for B and C columns.
-    agg_ds: ray.data.Dataset = ds.groupby("A").mean(["B", "C"])
-    agg_ds.fully_executed()
+    agg_ds: ray.data.Dataset = ds.groupby("A").mean(["B", "C"]).fully_executed()
     # -> Sort Sample: 100%|███████████████████████████████████████| 10/10 [00:01<00:00,  9.04it/s]
     # -> GroupBy Map: 100%|███████████████████████████████████████| 10/10 [00:00<00:00, 23.66it/s]
     # -> GroupBy Reduce: 100%|████████████████████████████████████| 10/10 [00:00<00:00, 937.21it/s]

--- a/doc/source/ray-air/examples/torch_image_example.ipynb
+++ b/doc/source/ray-air/examples/torch_image_example.ipynb
@@ -195,8 +195,8 @@
                 "    return {\"image\": images, \"label\": labels}\n",
                 "\n",
                 "\n",
-                "train_dataset = train_dataset.map_batches(convert_batch_to_numpy)\n",
-                "test_dataset = test_dataset.map_batches(convert_batch_to_numpy)"
+                "train_dataset = train_dataset.map_batches(convert_batch_to_numpy).fully_executed()\n",
+                "test_dataset = test_dataset.map_batches(convert_batch_to_numpy).fully_executed()"
             ]
         },
         {

--- a/doc/source/ray-air/examples/torch_incremental_learning.ipynb
+++ b/doc/source/ray-air/examples/torch_incremental_learning.ipynb
@@ -294,7 +294,7 @@
     "\n",
     "        return {\"image\": images, \"label\": labels}\n",
     "\n",
-    "    mnist_dataset = mnist_dataset.map_batches(convert_batch_to_numpy)\n",
+    "    mnist_dataset = mnist_dataset.map_batches(convert_batch_to_numpy).fully_executed()\n",
     "    return mnist_dataset"
    ]
   },

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -470,7 +470,7 @@ class Dataset(Generic[T]):
             >>> ds
             MapBatches(map_fn)
             +- MapBatches(map_fn)
-                +- Dataset(num_blocks=1, num_rows=3, schema={name: object, age: int64, age_in_dog_years: int64})
+                +- Dataset(num_blocks=1, num_rows=3, schema={name: object, age: int64})
 
             :ref:`Actors <actor-guide>` can improve the performance of some workloads.
             For example, you can use :ref:`actors <actor-guide>` to load a model once

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -270,15 +270,15 @@ class Dataset(Generic[T]):
             >>> import ray
             >>> # Transform python objects.
             >>> ds = ray.data.range(1000)
-            >>> ds.map(lambda x: x * 2).fully_executed()
+            >>> ds.map(lambda x: x * 2)
             Map
             +- Dataset(num_blocks=..., num_rows=1000, schema=<class 'int'>)
             >>> # Transform Arrow records.
             >>> ds = ray.data.from_items(
             ...     [{"value": i} for i in range(1000)])
-            >>> ds.map(lambda record: {"v2": record["value"] * 2}).fully_executed()
+            >>> ds.map(lambda record: {"v2": record["value"] * 2})
             Map
-            +- Dataset(num_blocks=..., num_rows=1000, schema={v2: int64})
+            +- Dataset(num_blocks=..., num_rows=1000, schema={value: int64})
             >>> # Define a callable class that persists state across
             >>> # function invocations for efficiency.
             >>> init_model = ... # doctest: +SKIP
@@ -454,10 +454,10 @@ class Dataset(Generic[T]):
             >>> def map_fn(batch: pd.DataFrame) -> pd.DataFrame:
             ...     batch["age_in_dog_years"] = 7 * batch["age"]
             ...     return batch
-            >>> ds = ds.map_batches(map_fn).fully_executed()
+            >>> ds = ds.map_batches(map_fn)
             >>> ds
             MapBatches(map_fn)
-            +- Dataset(num_blocks=1, num_rows=3, schema={name: object, age: int64, age_in_dog_years: int64})
+            +- Dataset(num_blocks=1, num_rows=3, schema={name: object, age: int64})
 
             Your ``fn`` can return a different type than the input type. To learn more
             about supported output types, read
@@ -466,11 +466,11 @@ class Dataset(Generic[T]):
             >>> from typing import List
             >>> def map_fn(batch: pd.DataFrame) -> List[int]:
             ...     return list(batch["age_in_dog_years"])
-            >>> ds = ds.map_batches(map_fn).fully_executed()
+            >>> ds = ds.map_batches(map_fn)
             >>> ds
             MapBatches(map_fn)
             +- MapBatches(map_fn)
-                +- Dataset(num_blocks=1, num_rows=3, schema=<class 'int'>)
+                +- Dataset(num_blocks=1, num_rows=3, schema={name: object, age: int64, age_in_dog_years: int64})
 
             :ref:`Actors <actor-guide>` can improve the performance of some workloads.
             For example, you can use :ref:`actors <actor-guide>` to load a model once
@@ -779,10 +779,10 @@ class Dataset(Generic[T]):
             >>> ds = ray.data.from_items([{"col1": i, "col2": i+1, "col3": i+2}
             ...      for i in range(10)])
             >>> # Select only "col1" and "col2" columns.
-            >>> ds = ds.select_columns(cols=["col1", "col2"]).fully_executed()
+            >>> ds = ds.select_columns(cols=["col1", "col2"])
             >>> ds
             MapBatches(<lambda>)
-            +- Dataset(num_blocks=10, num_rows=10, schema={col1: int64, col2: int64})
+            +- Dataset(num_blocks=10, num_rows=10, schema={col1: int64, col2: int64, col3: int64})
 
 
         Time complexity: O(dataset size / parallelism)
@@ -1590,15 +1590,15 @@ class Dataset(Generic[T]):
         Examples:
             >>> import ray
             >>> # Group by a key function and aggregate.
-            >>> ray.data.range(100).groupby(lambda x: x % 3).count().fully_executed()
+            >>> ray.data.range(100).groupby(lambda x: x % 3).count()
             Aggregate
-            +- Dataset(num_blocks=..., num_rows=3, schema=<class 'tuple'>)
+            +- Dataset(num_blocks=..., num_rows=3, schema=<class 'int'>)
             >>> # Group by an Arrow table column and aggregate.
             >>> ray.data.from_items([
             ...     {"A": x % 3, "B": x} for x in range(100)]).groupby(
-            ...     "A").count().fully_executed()
+            ...     "A").count()
             Aggregate
-            +- Dataset(num_blocks=..., num_rows=3, schema={A: int64, count(): int64})
+            +- Dataset(num_blocks=100, num_rows=100, schema={A: int64, B: int64})
 
         Time complexity: O(dataset size * log(dataset size / parallelism))
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -277,7 +277,8 @@ class Dataset(Generic[T]):
             >>> ds = ray.data.from_items(
             ...     [{"value": i} for i in range(1000)])
             >>> ds.map(lambda record: {"v2": record["value"] * 2})
-            Dataset(num_blocks=..., num_rows=1000, schema={v2: int64})
+            Map
+            +- Dataset(num_blocks=..., num_rows=1000, schema={v2: int64})
             >>> # Define a callable class that persists state across
             >>> # function invocations for efficiency.
             >>> init_model = ... # doctest: +SKIP
@@ -455,7 +456,8 @@ class Dataset(Generic[T]):
             ...     return batch
             >>> ds = ds.map_batches(map_fn)
             >>> ds
-            Dataset(num_blocks=1, num_rows=3, schema={name: object, age: int64, age_in_dog_years: int64})
+            MapBatches(map_fn)
+            +- Dataset(num_blocks=1, num_rows=3, schema={name: object, age: int64, age_in_dog_years: int64})
 
             Your ``fn`` can return a different type than the input type. To learn more
             about supported output types, read
@@ -466,7 +468,9 @@ class Dataset(Generic[T]):
             ...     return list(batch["age_in_dog_years"])
             >>> ds = ds.map_batches(map_fn)
             >>> ds
-            Dataset(num_blocks=1, num_rows=3, schema=<class 'int'>)
+            MapBatches(map_fn)
+            +- MapBatches(map_fn)
+              +- Dataset(num_blocks=1, num_rows=3, schema=<class 'int'>)
 
             :ref:`Actors <actor-guide>` can improve the performance of some workloads.
             For example, you can use :ref:`actors <actor-guide>` to load a model once
@@ -772,7 +776,8 @@ class Dataset(Generic[T]):
             >>> # Select only "col1" and "col2" columns.
             >>> ds = ds.select_columns(cols=["col1", "col2"])
             >>> ds
-            Dataset(num_blocks=..., num_rows=10, schema={col1: int64, col2: int64})
+            MapBatches(<lambda>)
+            +- Dataset(num_blocks=..., num_rows=10, schema={col1: int64, col2: int64})
 
 
         Time complexity: O(dataset size / parallelism)
@@ -1587,7 +1592,8 @@ class Dataset(Generic[T]):
             >>> ray.data.from_items([
             ...     {"A": x % 3, "B": x} for x in range(100)]).groupby(
             ...     "A").count()
-            Dataset(num_blocks=..., num_rows=3, schema={A: int64, count(): int64})
+            Aggregate
+            +- Dataset(num_blocks=..., num_rows=3, schema={A: int64, count(): int64})
 
         Time complexity: O(dataset size * log(dataset size / parallelism))
 
@@ -1988,7 +1994,8 @@ class Dataset(Generic[T]):
             >>> ds = ray.data.from_items(
             ...     [{"value": i} for i in range(1000)])
             >>> ds.sort("value", descending=True)
-            Dataset(num_blocks=..., num_rows=1000, schema={value: int64})
+            Sort
+            +- Dataset(num_blocks=..., num_rows=1000, schema={value: int64})
             >>> # Sort by a key function.
             >>> ds.sort(lambda record: record["value"]) # doctest: +SKIP
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -270,13 +270,13 @@ class Dataset(Generic[T]):
             >>> import ray
             >>> # Transform python objects.
             >>> ds = ray.data.range(1000)
-            >>> ds.map(lambda x: x * 2)
+            >>> ds.map(lambda x: x * 2).fully_executed()
             Map
             +- Dataset(num_blocks=..., num_rows=1000, schema=<class 'int'>)
             >>> # Transform Arrow records.
             >>> ds = ray.data.from_items(
             ...     [{"value": i} for i in range(1000)])
-            >>> ds.map(lambda record: {"v2": record["value"] * 2})
+            >>> ds.map(lambda record: {"v2": record["value"] * 2}).fully_executed()
             Map
             +- Dataset(num_blocks=..., num_rows=1000, schema={v2: int64})
             >>> # Define a callable class that persists state across
@@ -454,7 +454,7 @@ class Dataset(Generic[T]):
             >>> def map_fn(batch: pd.DataFrame) -> pd.DataFrame:
             ...     batch["age_in_dog_years"] = 7 * batch["age"]
             ...     return batch
-            >>> ds = ds.map_batches(map_fn)
+            >>> ds = ds.map_batches(map_fn).fully_executed()
             >>> ds
             MapBatches(map_fn)
             +- Dataset(num_blocks=1, num_rows=3, schema={name: object, age: int64, age_in_dog_years: int64})
@@ -466,11 +466,11 @@ class Dataset(Generic[T]):
             >>> from typing import List
             >>> def map_fn(batch: pd.DataFrame) -> List[int]:
             ...     return list(batch["age_in_dog_years"])
-            >>> ds = ds.map_batches(map_fn)
+            >>> ds = ds.map_batches(map_fn).fully_executed()
             >>> ds
             MapBatches(map_fn)
             +- MapBatches(map_fn)
-              +- Dataset(num_blocks=1, num_rows=3, schema=<class 'int'>)
+                +- Dataset(num_blocks=1, num_rows=3, schema=<class 'int'>)
 
             :ref:`Actors <actor-guide>` can improve the performance of some workloads.
             For example, you can use :ref:`actors <actor-guide>` to load a model once
@@ -519,7 +519,12 @@ class Dataset(Generic[T]):
                 ``Dict[str, numpy.ndarray]`` for tabular datasets. Default is "default".
             prefetch_batches: The number of batches to fetch ahead of the current batch
                 to process. If set to greater than 0, a separate thread will be used
-                to fetch the specified amount of formatted batches from blocks. This improves performance for non-CPU bound UDFs, allowing batch fetching compute and formatting to be overlapped with the UDF. Defaults to 0 (no prefetching enabled.) Increasing the number of batches to prefetch can result in higher throughput, at the expense of requiring more heap memory to buffer the batches.
+                to fetch the specified amount of formatted batches from blocks. This
+                improves performance for non-CPU bound UDFs, allowing batch fetching
+                compute and formatting to be overlapped with the UDF. Defaults to 0 (no
+                prefetching enabled.) Increasing the number of batches to prefetch can
+                result in higher throughput, at the expense of requiring more heap
+                memory to buffer the batches.
             zero_copy_batch: Whether ``fn`` should be provided zero-copy, read-only
                 batches. If this is ``True`` and no copy is required for the
                 ``batch_format`` conversion, the batch will be a zero-copy, read-only
@@ -774,10 +779,10 @@ class Dataset(Generic[T]):
             >>> ds = ray.data.from_items([{"col1": i, "col2": i+1, "col3": i+2}
             ...      for i in range(10)])
             >>> # Select only "col1" and "col2" columns.
-            >>> ds = ds.select_columns(cols=["col1", "col2"])
+            >>> ds = ds.select_columns(cols=["col1", "col2"]).fully_executed()
             >>> ds
             MapBatches(<lambda>)
-            +- Dataset(num_blocks=..., num_rows=10, schema={col1: int64, col2: int64})
+            +- Dataset(num_blocks=10, num_rows=10, schema={col1: int64, col2: int64})
 
 
         Time complexity: O(dataset size / parallelism)
@@ -789,7 +794,7 @@ class Dataset(Generic[T]):
                 tasks, or ActorPoolStrategy(min, max) to use an autoscaling actor pool.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
-        """
+        """  # noqa: E501
         return self.map_batches(
             lambda batch: BlockAccessor.for_block(batch).select(columns=cols),
             zero_copy_batch=True,
@@ -1585,13 +1590,13 @@ class Dataset(Generic[T]):
         Examples:
             >>> import ray
             >>> # Group by a key function and aggregate.
-            >>> ray.data.range(100).groupby(lambda x: x % 3).count()
+            >>> ray.data.range(100).groupby(lambda x: x % 3).count().fully_executed()
             Aggregate
-            +- Dataset(num_blocks=..., num_rows=100, schema=<class 'int'>)
+            +- Dataset(num_blocks=..., num_rows=3, schema=<class 'tuple'>)
             >>> # Group by an Arrow table column and aggregate.
             >>> ray.data.from_items([
             ...     {"A": x % 3, "B": x} for x in range(100)]).groupby(
-            ...     "A").count()
+            ...     "A").count().fully_executed()
             Aggregate
             +- Dataset(num_blocks=..., num_rows=3, schema={A: int64, count(): int64})
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -128,7 +128,7 @@ def from_items(items: List[Any], *, parallelism: int = -1) -> Dataset[Any]:
             run_by_consumer=False,
         ),
         0,
-        False,
+        True,
     )
 
 
@@ -1264,7 +1264,7 @@ def from_pandas_refs(
                 run_by_consumer=False,
             ),
             0,
-            False,
+            True,
         )
 
     df_to_block = cached_remote_fn(_df_to_block, num_returns=2)
@@ -1279,7 +1279,7 @@ def from_pandas_refs(
             run_by_consumer=False,
         ),
         0,
-        False,
+        True,
     )
 
 
@@ -1338,7 +1338,7 @@ def from_numpy_refs(
             run_by_consumer=False,
         ),
         0,
-        False,
+        True,
     )
 
 
@@ -1390,7 +1390,7 @@ def from_arrow_refs(
             run_by_consumer=False,
         ),
         0,
-        False,
+        True,
     )
 
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -233,7 +233,7 @@ def test_transform_failure(shutdown_only):
         return x
 
     with pytest.raises(ray.exceptions.RayTaskError):
-        ds.map(mapper)
+        ds.map(mapper).fully_executed()
 
 
 def test_dataset_lineage_serialization(shutdown_only):
@@ -2791,13 +2791,11 @@ def test_map_batches_block_bundling_auto(
     assert ds.num_blocks() == num_blocks
 
     # Blocks should be bundled up to the batch size.
-    ds1 = ds.map_batches(lambda x: x, batch_size=batch_size)
-    ds1.fully_executed()
+    ds1 = ds.map_batches(lambda x: x, batch_size=batch_size).fully_executed()
     assert ds1.num_blocks() == math.ceil(num_blocks / max(batch_size // block_size, 1))
 
     # Blocks should not be bundled up when batch_size is not specified.
-    ds2 = ds.map_batches(lambda x: x)
-    ds2.fully_executed()
+    ds2 = ds.map_batches(lambda x: x).fully_executed()
     assert ds2.num_blocks() == num_blocks
 
 
@@ -2823,7 +2821,7 @@ def test_map_batches_block_bundling_skewed_manual(
     )
     # Confirm that we have the expected number of initial blocks.
     assert ds.num_blocks() == num_blocks
-    ds = ds.map_batches(lambda x: x, batch_size=batch_size)
+    ds = ds.map_batches(lambda x: x, batch_size=batch_size).fully_executed()
 
     # Blocks should be bundled up to the batch size.
     assert ds.num_blocks() == expected_num_blocks
@@ -2849,7 +2847,7 @@ def test_map_batches_block_bundling_skewed_auto(
     )
     # Confirm that we have the expected number of initial blocks.
     assert ds.num_blocks() == num_blocks
-    ds = ds.map_batches(lambda x: x, batch_size=batch_size)
+    ds = ds.map_batches(lambda x: x, batch_size=batch_size).fully_executed()
     curr = 0
     num_out_blocks = 0
     for block_size in block_sizes:
@@ -4005,38 +4003,38 @@ def test_groupby_agg_bad_on(ray_start_regular_shared):
     df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs, "C": [2 * x for x in xs]})
     # Wrong type.
     with pytest.raises(TypeError):
-        ray.data.from_pandas(df).groupby("A").mean(5)
+        ray.data.from_pandas(df).groupby("A").mean(5).fully_executed()
     with pytest.raises(TypeError):
-        ray.data.from_pandas(df).groupby("A").mean([5])
+        ray.data.from_pandas(df).groupby("A").mean([5]).fully_executed()
     # Empty list.
     with pytest.raises(ValueError):
-        ray.data.from_pandas(df).groupby("A").mean([])
+        ray.data.from_pandas(df).groupby("A").mean([]).fully_executed()
     # Nonexistent column.
     with pytest.raises(ValueError):
-        ray.data.from_pandas(df).groupby("A").mean("D")
+        ray.data.from_pandas(df).groupby("A").mean("D").fully_executed()
     with pytest.raises(ValueError):
-        ray.data.from_pandas(df).groupby("A").mean(["B", "D"])
+        ray.data.from_pandas(df).groupby("A").mean(["B", "D"]).fully_executed()
     # Columns for simple Dataset.
     with pytest.raises(ValueError):
-        ray.data.from_items(xs).groupby(lambda x: x % 3 == 0).mean("A")
+        ray.data.from_items(xs).groupby(lambda x: x % 3 == 0).mean("A").fully_executed()
 
     # Test bad on for global aggregation
     # Wrong type.
     with pytest.raises(TypeError):
-        ray.data.from_pandas(df).mean(5)
+        ray.data.from_pandas(df).mean(5).fully_executed()
     with pytest.raises(TypeError):
-        ray.data.from_pandas(df).mean([5])
+        ray.data.from_pandas(df).mean([5]).fully_executed()
     # Empty list.
     with pytest.raises(ValueError):
-        ray.data.from_pandas(df).mean([])
+        ray.data.from_pandas(df).mean([]).fully_executed()
     # Nonexistent column.
     with pytest.raises(ValueError):
-        ray.data.from_pandas(df).mean("D")
+        ray.data.from_pandas(df).mean("D").fully_executed()
     with pytest.raises(ValueError):
-        ray.data.from_pandas(df).mean(["B", "D"])
+        ray.data.from_pandas(df).mean(["B", "D"]).fully_executed()
     # Columns for simple Dataset.
     with pytest.raises(ValueError):
-        ray.data.from_items(xs).mean("A")
+        ray.data.from_items(xs).mean("A").fully_executed()
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
@@ -4285,7 +4283,7 @@ def test_groupby_map_groups_merging_invalid_result(ray_start_regular_shared):
 
     # The UDF returns None, which is invalid.
     with pytest.raises(TypeError):
-        grouped.map_groups(lambda x: None if x == [1] else x)
+        grouped.map_groups(lambda x: None if x == [1] else x).fully_executed()
 
 
 @pytest.mark.parametrize("num_parts", [1, 2, 30])
@@ -5406,6 +5404,7 @@ def test_polars_lazy_import(shutdown_only):
             ray.data.from_pandas(dfs)
             .map_batches(lambda t: t, batch_format="pyarrow", batch_size=None)
             .sort(key="a")
+            .fully_executed()
         )
         assert any(ray.get([f.remote(True) for _ in range(parallelism)]))
 


### PR DESCRIPTION
This PR makes the `ray.data.from_*()` APIs lazy.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
