### PR TITLE
[core][state] State API scale losing data

### DIFF
--- a/release/nightly_tests/stress_tests/state_api_app_config.yaml
+++ b/release/nightly_tests/stress_tests/state_api_app_config.yaml
@@ -1,6 +1,6 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
-env_vars: {"RAY_MAX_LIMIT_FROM_API_SERVER": "1000000000", "RAY_MAX_LIMIT_FROM_DATA_SOURCE":"1000000000"}
+env_vars: {"RAY_MAX_LIMIT_FROM_API_SERVER": "1000000000", "RAY_MAX_LIMIT_FROM_DATA_SOURCE":"1000000000", "RAY_task_events_max_buffer_size":"100000"}
 
 python:
   pip_packages:


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We are dropping data at 10K as default, changing the buffer size larger right now before we figure out a way to store bursty task submissions. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
