### PR TITLE
[2.3.0] Use dataset random_shuffle() for shuffle nightly

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3535,27 +3535,6 @@
     script: python stress_tests/test_placement_group.py
     type: sdk_command
 
-- name: shuffle_1tb_5000_partitions
-  group: core-multi-test
-  working_dir: nightly_tests
-  legacy:
-    test_name: shuffle_1tb_5000_partitions
-    test_suite: nightly_tests
-
-  frequency: nightly-3x
-  team: core
-  env: staging
-  cluster:
-    cluster_env: shuffle/shuffle_app_config.yaml
-    cluster_compute: shuffle/shuffle_compute_large_scale.yaml
-
-  run:
-    timeout: 9000
-    script: python shuffle/shuffle_test.py --num-partitions=5000 --partition-size=200e6
-    wait_for_nodes:
-      num_nodes: 20
-
-
 - name: decision_tree_autoscaling_20_runs
   group: core-multi-test
   working_dir: nightly_tests


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Cherrypick for fixing https://github.com/ray-project/ray/issues/32272 . Master PR #32343

The reason for removal is that this test is running python/ray/experimental/shuffle.py, which has the issue:
- Not reliable as objects may not be owned by driver (if those nodes crashes, the entire job may fail if objects got lost)
- It's not really testing the target code path (i.e. Dataset)
- There is already a `dataset_shuffle_random_shuffle_1tb` exist for Dataset random shuffle. We do not need to waste resource for duplicate test.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
