### PR TITLE
[ci][core] Calculate actor creation time properly for stress_test_many_tasks

### DIFF
--- a/release/nightly_tests/stress_tests/test_many_tasks.py
+++ b/release/nightly_tests/stress_tests/test_many_tasks.py
@@ -104,6 +104,7 @@ def stage3(total_num_remote_cpus, smoke=False):
     ray.get([actor.ready.remote() for actor in actors])
     stage_3_creation_time = time.time() - start_time
     logger.info("Finished stage 3 actor creation in %s seconds.", stage_3_creation_time)
+
     num_tasks = 1000
 
     if smoke:

--- a/release/nightly_tests/stress_tests/test_many_tasks.py
+++ b/release/nightly_tests/stress_tests/test_many_tasks.py
@@ -27,6 +27,8 @@ class Actor(object):
     def method(self, size, *xs):
         return np.ones(size, dtype=np.uint8)
 
+    def ready(self):
+        pass
 
 # Stage 0: Submit a bunch of small tasks with large returns.
 def stage0(smoke=False):
@@ -99,9 +101,9 @@ def stage3(total_num_remote_cpus, smoke=False):
     start_time = time.time()
     logger.info("Creating %s actors.", total_num_remote_cpus)
     actors = [Actor.remote() for _ in range(total_num_remote_cpus)]
+    ray.get([actor.ready.remote() for actor in actors])
     stage_3_creation_time = time.time() - start_time
     logger.info("Finished stage 3 actor creation in %s seconds.", stage_3_creation_time)
-
     num_tasks = 1000
 
     if smoke:

--- a/release/nightly_tests/stress_tests/test_many_tasks.py
+++ b/release/nightly_tests/stress_tests/test_many_tasks.py
@@ -30,6 +30,7 @@ class Actor(object):
     def ready(self):
         pass
 
+
 # Stage 0: Submit a bunch of small tasks with large returns.
 def stage0(smoke=False):
     num_tasks = 1000


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
## Why are these changes needed?

We are calculating **actor creation task submission time**, which is less useful for this test. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number


- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
