### PR TITLE
[ci][core] Do not set flushing thread niceness for task backend #32439

### DIFF
--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -53,6 +53,3 @@ constexpr char kSetupWorkerFilename[] = "setup_worker.py";
 
 /// The version of Ray
 constexpr char kRayVersion[] = "2.3.0rc0";
-
-/// Added niceness for thread in TaskEventBuffer
-constexpr int kTaskEventBufferAdditionalNice = 5;

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -136,18 +136,6 @@ Status TaskEventBufferImpl::Start(bool auto_flush) {
     sigaddset(&mask, SIGINT);
     sigaddset(&mask, SIGTERM);
     pthread_sigmask(SIG_BLOCK, &mask, NULL);
-
-    // Decrease the thread priority to allow worker threads to run.
-    int new_nice = std::min(
-        RayConfig::instance().worker_niceness() + kTaskEventBufferAdditionalNice, 19);
-    new_nice = nice(new_nice);
-    if (new_nice == -1) {
-      RAY_LOG(WARNING) << "Failed to set nice(" << new_nice
-                       << ") for task event buffer io thread: " << strerror(errno);
-    } else {
-      RAY_LOG(INFO) << "Current task event io thread's nice = " << new_nice;
-    }
-
 #endif
     SetThreadName("task_event_buffer.io");
     io_service_.run();


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This breaks macos test with 

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/11676094/217978002-f921dee7-e92a-42c4-9ac0-4539ec951f33.png">


We believe this has minimal impact on the performance.  So reverting for non-necessary code. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/32405
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
