### PR TITLE
[data] [streaming] Fix progress bar clobbering shell output

### DIFF
--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -399,6 +399,13 @@ class Executor:
         """
         raise NotImplementedError
 
+    def shutdown(self):
+        """Shutdown an executor, which may still be running.
+
+        This should interrupt execution and clean up any used resources.
+        """
+        pass
+
     def get_stats(self) -> DatasetStats:
         """Return stats for the execution so far.
 

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -37,6 +37,7 @@ from ray.data.context import DatasetContext
 
 if TYPE_CHECKING:
     import pyarrow
+    from ray.data._internal.execution.interfaces import Executor
 
 
 # Scheduling strategy can be inherited from prev stage if not specified.
@@ -458,7 +459,7 @@ class ExecutionPlan:
         self,
         allow_clear_input_blocks: bool = True,
         force_read: bool = False,
-    ) -> Tuple[Iterator[ObjectRef[Block]], DatasetStats]:
+    ) -> Tuple[Iterator[ObjectRef[Block]], "Executor"]:
         """Execute this plan, returning an iterator.
 
         If the streaming execution backend is enabled, this will use streaming
@@ -470,7 +471,7 @@ class ExecutionPlan:
             force_read: Whether to force the read stage to fully execute.
 
         Returns:
-            Tuple of iterator over output blocks and Dataset stats.
+            Tuple of iterator over output blocks and the executor.
         """
 
         ctx = DatasetContext.get_current()
@@ -499,7 +500,7 @@ class ExecutionPlan:
             block_iter = itertools.chain([next(gen)], gen)
         except StopIteration:
             pass
-        return block_iter, executor.get_stats()
+        return block_iter, executor
 
     def execute(
         self,

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -459,7 +459,7 @@ class ExecutionPlan:
         self,
         allow_clear_input_blocks: bool = True,
         force_read: bool = False,
-    ) -> Tuple[Iterator[ObjectRef[Block]], "Executor"]:
+    ) -> Tuple[Iterator[ObjectRef[Block]], DatasetStats, Optional["Executor"]]:
         """Execute this plan, returning an iterator.
 
         If the streaming execution backend is enabled, this will use streaming
@@ -479,6 +479,7 @@ class ExecutionPlan:
             return (
                 self.execute(allow_clear_input_blocks, force_read).iter_blocks(),
                 self._snapshot_stats,
+                None,
             )
 
         from ray.data._internal.execution.streaming_executor import StreamingExecutor
@@ -500,7 +501,7 @@ class ExecutionPlan:
             block_iter = itertools.chain([next(gen)], gen)
         except StopIteration:
             pass
-        return block_iter, executor
+        return block_iter, executor.get_stats(), executor
 
     def execute(
         self,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2130,15 +2130,7 @@ class Dataset(Generic[T]):
         self._shutdown_current_executor()
         return output
 
-<<<<<<< Updated upstream
     @ConsumptionAPI(pattern="Time complexity:")
-=======
-    def _shutdown_current_executor(self):
-        if self._current_executor:
-            self._current_executor.shutdown()
-            self._current_executor = None
-
->>>>>>> Stashed changes
     def take_all(self, limit: Optional[int] = None) -> List[T]:
         """Return all of the records in the dataset.
 
@@ -4459,6 +4451,18 @@ class Dataset(Generic[T]):
                 "The `map`, `flat_map`, and `filter` operations are unvectorized and "
                 "can be very slow. Consider using `.map_batches()` instead."
             )
+
+    def _shutdown_current_executor(self):
+        """Cleanly shutdown the current executor.
+
+        The streaming executor runs in a separate generator / thread, so it is
+        possible the shutdown logic runs even after a call to retrieve rows from the
+        dataset has finished. Explicit shutdown avoids this, which can clobber console
+        output (https://github.com/ray-project/ray/issues/32414).
+        """
+        if self._current_executor:
+            self._current_executor.shutdown()
+            self._current_executor = None
 
 
 def _get_size_bytes(block: Block) -> int:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2868,8 +2868,7 @@ class Dataset(Generic[T]):
                 DeprecationWarning,
             )
 
-        block_iterator, executor = self._plan.execute_to_iterator()
-        stats = executor.get_stats()
+        block_iterator, stats, executor = self._plan.execute_to_iterator()
         self._current_executor = executor
         time_start = time.perf_counter()
 

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -1345,5 +1345,5 @@ class DatasetPipeline(Generic[T]):
             ds._set_uuid(f"{uuid}_{i:06}")
             write_fn(ds)
 
-    def _shutdown_current_executor(self):
+    def _synchronize_progress_bar(self):
         pass

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -1344,3 +1344,6 @@ class DatasetPipeline(Generic[T]):
                 uuid = self._get_uuid() or ds._get_uuid()
             ds._set_uuid(f"{uuid}_{i:06}")
             write_fn(ds)
+
+    def _shutdown_current_executor(self):
+        pass


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The streaming executor runs in a separate generator / thread, so it is possible the shutdown logic runs even after a call to retrieve rows from the dataset has finished. This PR adds an explicit shutdown mechanism so to avoid this delayed shutdown clobbering console output.

## Related issue number

Closes https://github.com/ray-project/ray/issues/32414

## Checks

- [x] Manually tested `ray.data.range(100).show()` has clean console output