### PR TITLE
[Datasets] Add logical operator for aggregate

### DIFF
--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from ray.data._internal.logical.interfaces import LogicalOperator
+from ray.data.aggregate import AggregateFn
 from ray.data.block import KeyFn
 
 
@@ -97,3 +98,20 @@ class Sort(AbstractAllToAll):
         )
         self._key = key
         self._descending = descending
+
+
+class Aggregate(AbstractAllToAll):
+    """Logical operator for aggregate."""
+
+    def __init__(
+        self,
+        input_op: LogicalOperator,
+        key: Optional[KeyFn],
+        aggs: List[AggregateFn],
+    ):
+        super().__init__(
+            "Aggregate",
+            input_op,
+        )
+        self._key = key
+        self._aggs = aggs

--- a/python/ray/data/_internal/planner/aggregate.py
+++ b/python/ray/data/_internal/planner/aggregate.py
@@ -1,0 +1,73 @@
+from typing import List, Optional, Tuple
+
+from ray.data._internal.execution.interfaces import (
+    AllToAllTransformFn,
+    RefBundle,
+    TaskContext,
+)
+from ray.data._internal.planner.exchange.aggregate_task_spec import (
+    SortAggregateTaskSpec,
+)
+from ray.data._internal.planner.exchange.push_based_shuffle_task_scheduler import (
+    PushBasedShuffleTaskScheduler,
+)
+from ray.data._internal.planner.exchange.pull_based_shuffle_task_scheduler import (
+    PullBasedShuffleTaskScheduler,
+)
+from ray.data._internal.planner.exchange.sort_task_spec import SortTaskSpec
+from ray.data._internal.stats import StatsDict
+from ray.data.aggregate import AggregateFn
+from ray.data.block import KeyFn
+from ray.data.context import DatasetContext
+
+
+def generate_aggregate_fn(
+    key: Optional[KeyFn],
+    aggs: List[AggregateFn],
+) -> AllToAllTransformFn:
+    """Generate function to aggregate blocks by the specified key column or key
+    function.
+    """
+    # TODO: validate blocks with AggregateFn._validate.
+    if len(aggs) == 0:
+        raise ValueError("Aggregate requires at least one aggregation")
+
+    def fn(
+        refs: List[RefBundle],
+        ctx: TaskContext,
+    ) -> Tuple[List[RefBundle], StatsDict]:
+        blocks = []
+        for ref_bundle in refs:
+            for block, _ in ref_bundle.blocks:
+                blocks.append(block)
+        if len(blocks) == 0:
+            return (blocks, {})
+
+        num_mappers = len(blocks)
+
+        if key is None:
+            num_outputs = 1
+            boundaries = []
+        else:
+            # Use same number of output partitions.
+            num_outputs = num_mappers
+            # Sample boundaries for aggregate key.
+            boundaries = SortTaskSpec.sample_boundaries(
+                blocks,
+                [(key, "ascending")] if isinstance(key, str) else key,
+                num_outputs,
+            )
+
+        agg_spec = SortAggregateTaskSpec(
+            boundaries=boundaries,
+            key=key,
+            aggs=aggs,
+        )
+        if DatasetContext.get_current().use_push_based_shuffle:
+            scheduler = PushBasedShuffleTaskScheduler(agg_spec)
+        else:
+            scheduler = PullBasedShuffleTaskScheduler(agg_spec)
+
+        return scheduler.execute(refs, num_outputs)
+
+    return fn

--- a/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
@@ -1,0 +1,111 @@
+from typing import List, Optional, Tuple, Union
+
+from ray.data._internal.planner.exchange.interfaces import ExchangeTaskSpec
+from ray.data._internal.table_block import TableBlockAccessor
+from ray.data.aggregate import _AggregateOnKeyBase, AggregateFn, Count
+from ray.data.block import (
+    Block,
+    BlockAccessor,
+    BlockExecStats,
+    BlockMetadata,
+    KeyFn,
+    KeyType,
+)
+
+
+class SortAggregateTaskSpec(ExchangeTaskSpec):
+    """
+    The implementation for sort-based aggregate tasks.
+
+    Aggregate is done in 2 steps: partial aggregate of individual blocks, and
+    final aggregate of sorted blocks.
+
+    Partial aggregate (`map`): each block is sorted locally, then partitioned into
+    smaller blocks according to the boundaries. Each partitioned block is aggregated
+    separately, then passed to a final aggregate task.
+
+    Final aggregate (`reduce`): each task would receive a block from every worker that
+    consists of items in a certain range. It then merges the sorted blocks and
+    aggregates on-the-fly.
+    """
+
+    def __init__(
+        self,
+        boundaries: List[KeyType],
+        key: Optional[KeyFn],
+        aggs: List[AggregateFn],
+    ):
+        super().__init__(
+            map_args=[boundaries, key, aggs],
+            reduce_args=[key, aggs],
+        )
+
+    @staticmethod
+    def map(
+        idx: int,
+        block: Block,
+        output_num_blocks: int,
+        boundaries: List[KeyType],
+        key: Optional[KeyFn],
+        aggs: List[AggregateFn],
+    ) -> List[Union[BlockMetadata, Block]]:
+        stats = BlockExecStats.builder()
+
+        block = SortAggregateTaskSpec._prune_unused_columns(block, key, aggs)
+
+        if key is None:
+            partitions = [block]
+        else:
+            partitions = BlockAccessor.for_block(block).sort_and_partition(
+                boundaries,
+                [(key, "ascending")] if isinstance(key, str) else key,
+                descending=False,
+            )
+        parts = [BlockAccessor.for_block(p).combine(key, aggs) for p in partitions]
+        meta = BlockAccessor.for_block(block).get_metadata(
+            input_files=None, exec_stats=stats.build()
+        )
+        return parts + [meta]
+
+    @staticmethod
+    def reduce(
+        key: Optional[KeyFn],
+        aggs: List[AggregateFn],
+        *mapper_outputs: List[Block],
+        partial_reduce: bool = False,
+    ) -> Tuple[Block, BlockMetadata]:
+        return BlockAccessor.for_block(mapper_outputs[0]).aggregate_combined_blocks(
+            list(mapper_outputs), key, aggs, finalize=not partial_reduce
+        )
+
+    @staticmethod
+    def _prune_unused_columns(
+        block: Block,
+        key: KeyFn,
+        aggs: Tuple[AggregateFn],
+    ) -> Block:
+        """Prune unused columns from block before aggregate."""
+        prune_columns = True
+        columns = set()
+
+        if isinstance(key, str):
+            columns.add(key)
+        elif callable(key):
+            prune_columns = False
+
+        for agg in aggs:
+            if isinstance(agg, _AggregateOnKeyBase) and isinstance(agg._key_fn, str):
+                columns.add(agg._key_fn)
+            elif not isinstance(agg, Count):
+                # Don't prune columns if any aggregate key is not string.
+                prune_columns = False
+
+        block_accessor = BlockAccessor.for_block(block)
+        if (
+            prune_columns
+            and isinstance(block_accessor, TableBlockAccessor)
+            and block_accessor.num_rows() > 0
+        ):
+            return block_accessor.select(list(columns))
+        else:
+            return block

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -2,11 +2,13 @@ from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
 from ray.data._internal.logical.operators.all_to_all_operator import (
     AbstractAllToAll,
+    Aggregate,
     RandomShuffle,
     RandomizeBlocks,
     Repartition,
     Sort,
 )
+from ray.data._internal.planner.aggregate import generate_aggregate_fn
 from ray.data._internal.planner.random_shuffle import generate_random_shuffle_fn
 from ray.data._internal.planner.randomize_blocks import generate_randomize_blocks_fn
 from ray.data._internal.planner.repartition import generate_repartition_fn
@@ -30,6 +32,8 @@ def _plan_all_to_all_op(
         fn = generate_repartition_fn(op._num_outputs, op._shuffle)
     elif isinstance(op, Sort):
         fn = generate_sort_fn(op._key, op._descending)
+    elif isinstance(op, Aggregate):
+        fn = generate_aggregate_fn(op._key, op._aggs)
     else:
         raise ValueError(f"Found unknown logical operator during planning: {op}")
 

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -7,6 +7,7 @@ from ray.data._internal.execution.operators.input_data_buffer import InputDataBu
 from ray.data._internal.logical.interfaces import LogicalPlan
 from ray.data._internal.logical.optimizers import PhysicalOptimizer
 from ray.data._internal.logical.operators.all_to_all_operator import (
+    Aggregate,
     RandomShuffle,
     Repartition,
     Sort,
@@ -19,6 +20,7 @@ from ray.data._internal.logical.operators.map_operator import (
     FlatMap,
 )
 from ray.data._internal.planner.planner import Planner
+from ray.data.aggregate import Count
 from ray.data.datasource.parquet_datasource import ParquetDatasource
 
 from ray.data.tests.conftest import *  # noqa
@@ -537,6 +539,35 @@ def test_sort_e2e(
     # r2 = ds2.select_columns(["one"]).take_all()
     # assert [d["one"] for d in r1] == list(range(100))
     # assert [d["one"] for d in r2] == list(reversed(range(100)))
+
+
+def test_aggregate_operator(ray_start_regular_shared, enable_optimizer):
+    planner = Planner()
+    read_op = Read(ParquetDatasource())
+    op = Aggregate(
+        read_op,
+        key="col1",
+        aggs=[Count()],
+    )
+    plan = LogicalPlan(op)
+    physical_op = planner.plan(plan).dag
+
+    assert op.name == "Aggregate"
+    assert isinstance(physical_op, AllToAllOperator)
+    assert len(physical_op.input_dependencies) == 1
+    assert isinstance(physical_op.input_dependencies[0], MapOperator)
+
+
+def test_aggregate_e2e(
+    ray_start_regular_shared,
+    enable_optimizer,
+    use_push_based_shuffle,
+):
+    ds = ray.data.range_table(100, parallelism=4)
+    ds = ds.groupby("value").count()
+    assert ds.count() == 100
+    for idx, row in enumerate(ds.sort("value").iter_rows()):
+        assert row.as_pydict() == {"value": idx, "count()": 1}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to add logical operator for group-by aggregate. The change includes:
* `Aggregate`: the logical operator for aggregate
* `generate_aggregate_fn`: the generated function for aggregate operator
* `SortAggregateTaskSpec`: the task spec for doing sort-based aggregate, mostly refactored from [_GroupbyOp](https://github.com/ray-project/ray/blob/master/python/ray/data/grouped_dataset.py#L35).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
