### PR TITLE
[RLlib] Fix ReplayBuffer doctest

### DIFF
--- a/rllib/utils/replay_buffers/replay_buffer.py
+++ b/rllib/utils/replay_buffers/replay_buffer.py
@@ -77,46 +77,47 @@ class ReplayBuffer(ParallelIteratorWorker, FaultAwareApply):
     they might not implement all storage_units.
 
     Examples:
-        >>> from ray.rllib.utils.replay_buffers import ReplayBuffer, # doctest: +SKIP
-        ...                         StorageUnit # doctest: +SKIP
-        >>> from ray.rllib.policy.sample_batch import SampleBatch # doctest: +SKIP
-        >>> # Store any batch as a whole
-        >>> buffer = ReplayBuffer(capacity=10,
-        ...                         storage_unit=StorageUnit.FRAGMENTS) # doctest: +SKIP
-        >>> buffer.add(SampleBatch({"a": [1], "b": [2, 3, 4]})) # doctest: +SKIP
-        >>> print(buffer.sample(1)) # doctest: +SKIP
-        >>> # SampleBatch(1: ['a', 'b'])
-        >>> # Store only complete episodes
-        >>> buffer = ReplayBuffer(capacity=10,
-        ...                         storage_unit=StorageUnit.EPISODES) # doctest: +SKIP
-        >>> buffer.add(SampleBatch({"c": [1, 2, 3, 4], # doctest: +SKIP
-        ...                        SampleBatch.T: [0, 1, 0, 1],
-        ...                        SampleBatch.TERMINATEDS: [False, True, False, True],
-        ...                        SampleBatch.EPS_ID: [0, 0, 1, 1]})) # doctest: +SKIP
-        >>> eps_n = buffer.sample(1) # doctest: +SKIP
-        >>> print(eps_n[SampleBatch.EPS_ID]) # doctest: +SKIP
-        >>> # [1 1]
-        >>> # Store single timesteps
-        >>> buffer = ReplayBuffer(capacity=2,  # doctest: +SKIP
-        ...                         storage_unit=StorageUnit.TIMESTEPS) # doctest: +SKIP
-        >>> buffer.add(SampleBatch({"a": [1, 2],
-        ...                         SampleBatch.T: [0, 1]})) # doctest: +SKIP
-        >>> t_n = buffer.sample(1) # doctest: +SKIP
-        >>> print(t_n["a"]) # doctest: +SKIP
-        >>> # [2]
-        >>> buffer.add(SampleBatch({"a": [3], SampleBatch.T: [2]})) # doctest: +SKIP
-        >>> print(buffer._eviction_started) # doctest: +SKIP
-        >>> # True
-        >>> t_n = buffer.sample(1) # doctest: +SKIP
-        >>> print(t_n["a"]) # doctest: +SKIP
-        >>> # [3] # doctest: +SKIP
-        >>> buffer = ReplayBuffer(capacity=10, # doctest: +SKIP
-        ...                         storage_unit=StorageUnit.SEQUENCES) # doctest: +SKIP
-        >>> buffer.add(SampleBatch({"c": [1, 2, 3], # doctest: +SKIP
-        ...                        SampleBatch.SEQ_LENS: [1, 2]})) # doctest: +SKIP
-        >>> seq_n = buffer.sample(1) # doctest: +SKIP
-        >>> print(seq_n["c"]) # doctest: +SKIP
-        >>> # [1]
+
+    .. testcode::
+
+        # Store any batch as a whole
+        buffer = ReplayBuffer(capacity=10, storage_unit=StorageUnit.FRAGMENTS)
+        buffer.add(SampleBatch({"a": [1], "b": [2, 3, 4]}))
+        print(buffer.sample(1))
+
+        # Store only complete episodes
+        buffer = ReplayBuffer(capacity=10,
+                                storage_unit=StorageUnit.EPISODES)
+        buffer.add(SampleBatch({"c": [1, 2, 3, 4],
+                                SampleBatch.T: [0, 1, 0, 1],
+                                SampleBatch.TERMINATEDS: [False, True, False, True],
+                                SampleBatch.EPS_ID: [0, 0, 1, 1]}))
+        eps_n = buffer.sample(1)
+        print(eps_n[SampleBatch.EPS_ID])
+
+        # Store single timesteps
+        buffer = ReplayBuffer(capacity=2, storage_unit=StorageUnit.TIMESTEPS)
+        buffer.add(SampleBatch({"a": [1, 2], SampleBatch.T: [0, 1]}))
+        t_n = buffer.sample(1)
+        print(t_n["a"])
+        buffer.add(SampleBatch({"a": [3], SampleBatch.T: [2]}))
+        print(buffer._eviction_started)
+        t_n = buffer.sample(1)
+        print(t_n["a"])
+        buffer = ReplayBuffer(capacity=10, storage_unit=StorageUnit.SEQUENCES)
+        buffer.add(SampleBatch({"c": [1, 2, 3], SampleBatch.SEQ_LENS: [1, 2]}))
+        seq_n = buffer.sample(1)
+        print(seq_n["c"])
+
+    .. testoutput::
+
+        SampleBatch(1: ['a', 'b'])
+        [0 0]
+        [2]
+        True
+        [2]
+        [2 3]
+
     """
 
     def __init__(

--- a/rllib/utils/replay_buffers/replay_buffer.py
+++ b/rllib/utils/replay_buffers/replay_buffer.py
@@ -87,7 +87,7 @@ class ReplayBuffer(ParallelIteratorWorker, FaultAwareApply):
         # Store any batch as a whole
         buffer = ReplayBuffer(capacity=10, storage_unit=StorageUnit.FRAGMENTS)
         buffer.add(SampleBatch({"a": [1], "b": [2, 3, 4]}))
-        print(buffer.sample(1))
+        buffer.sample(1)
 
         # Store only complete episodes
         buffer = ReplayBuffer(capacity=10,
@@ -96,31 +96,20 @@ class ReplayBuffer(ParallelIteratorWorker, FaultAwareApply):
                                 SampleBatch.T: [0, 1, 0, 1],
                                 SampleBatch.TERMINATEDS: [False, True, False, True],
                                 SampleBatch.EPS_ID: [0, 0, 1, 1]}))
-        eps_n = buffer.sample(1)
-        print(eps_n[SampleBatch.EPS_ID])
+        buffer.sample(1)
 
         # Store single timesteps
         buffer = ReplayBuffer(capacity=2, storage_unit=StorageUnit.TIMESTEPS)
         buffer.add(SampleBatch({"a": [1, 2], SampleBatch.T: [0, 1]}))
-        t_n = buffer.sample(1)
-        print(t_n["a"])
+        buffer.sample(1)
+
         buffer.add(SampleBatch({"a": [3], SampleBatch.T: [2]}))
         print(buffer._eviction_started)
-        t_n = buffer.sample(1)
-        print(t_n["a"])
+        buffer.sample(1)
+
         buffer = ReplayBuffer(capacity=10, storage_unit=StorageUnit.SEQUENCES)
         buffer.add(SampleBatch({"c": [1, 2, 3], SampleBatch.SEQ_LENS: [1, 2]}))
-        seq_n = buffer.sample(1)
-        print(seq_n["c"])
-
-    .. testoutput::
-
-        SampleBatch(1: ['a', 'b'])
-        [0 0]
-        [2]
-        True
-        [2]
-        [2 3]
+        buffer.sample(1)
 
     """
 

--- a/rllib/utils/replay_buffers/replay_buffer.py
+++ b/rllib/utils/replay_buffers/replay_buffer.py
@@ -111,6 +111,13 @@ class ReplayBuffer(ParallelIteratorWorker, FaultAwareApply):
         buffer.add(SampleBatch({"c": [1, 2, 3], SampleBatch.SEQ_LENS: [1, 2]}))
         buffer.sample(1)
 
+    .. testoutput::
+
+        True
+
+    `True` is not the output of the above testcode, but an artifact of unexpected
+    behaviour of sphinx doctests.
+    (see https://github.com/ray-project/ray/pull/32477#discussion_r1106776101)
     """
 
     def __init__(

--- a/rllib/utils/replay_buffers/replay_buffer.py
+++ b/rllib/utils/replay_buffers/replay_buffer.py
@@ -80,6 +80,10 @@ class ReplayBuffer(ParallelIteratorWorker, FaultAwareApply):
 
     .. testcode::
 
+        from ray.rllib.utils.replay_buffers.replay_buffer import ReplayBuffer
+        from ray.rllib.utils.replay_buffers.replay_buffer import StorageUnit
+        from ray.rllib.policy.sample_batch import SampleBatch
+
         # Store any batch as a whole
         buffer = ReplayBuffer(capacity=10, storage_unit=StorageUnit.FRAGMENTS)
         buffer.add(SampleBatch({"a": [1], "b": [2, 3, 4]}))


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

While going through other issues, I found that the replay buffer doctest is broken.
it does not fail but a) everything is skipped and b) it clutters the log like this.

<img width="1180" alt="Screenshot 2023-02-12 at 20 42 31" src="https://user-images.githubusercontent.com/9356806/218372490-03b2d146-c53d-4920-8e42-4ea220b96103.png">

