### PR TITLE
Optimize submit Ray task with many positional arguments

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -450,7 +450,6 @@ cdef prepare_args_internal(
         CAddress c_owner_address
         CRayStatus op_status
 
-
     worker = ray._private.worker.global_worker
     put_threshold = RayConfig.instance().max_direct_call_object_size()
     total_inlined = 0

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -473,6 +473,7 @@ cdef prepare_args_internal(
             # the DUMMY_TYPE.
             # TODO(fyrestone): Maybe we can remove the DUMMY_TYPE or make the
             # DUMMY_TYPE None.
+            # https://github.com/ray-project/ray/pull/32478/
             if type(arg) is dummy_type_type and arg == dummy_type_value:
                 global dummy_type_serialized_arg
                 if dummy_type_serialized_arg is None:

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -463,7 +463,7 @@ cdef prepare_args_internal(
                     (<ObjectRef>arg).call_site_data)))  # Avoid calling Python function
 
         else:
-            if arg == DUMMY_TYPE:
+            if type(arg) is bytes and arg == DUMMY_TYPE:
                 global dummy_type_serialized_arg
                 if dummy_type_serialized_arg is None:
                     # Cache the serialized dummy arg.

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -463,9 +463,11 @@ cdef prepare_args_internal(
                     (<ObjectRef>arg).call_site_data)))  # Avoid calling Python function
 
         else:
-            # The type check is because some custom types may not implement __eq__ well.
-            # So, we only handle the args which type and value are exactly match the DUMMY_TYPE.
-            # TODO(fyrestone): Maybe we can remove the DUMMY_TYPE or make the DUMMY_TYPE None.
+            # The type check is because some custom types may not implement __eq__
+            # well. So, we only handle the args which type and value are exactly match
+            # the DUMMY_TYPE.
+            # TODO(fyrestone): Maybe we can remove the DUMMY_TYPE or make the
+            # DUMMY_TYPE None.
             if type(arg) is bytes and arg == DUMMY_TYPE:
                 global dummy_type_serialized_arg
                 if dummy_type_serialized_arg is None:

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -463,6 +463,9 @@ cdef prepare_args_internal(
                     (<ObjectRef>arg).call_site_data)))  # Avoid calling Python function
 
         else:
+            # The type check is because some custom types may not implement __eq__ well.
+            # So, we only handle the args which type and value are exactly match the DUMMY_TYPE.
+            # TODO(fyrestone): Maybe we can remove the DUMMY_TYPE or make the DUMMY_TYPE None.
             if type(arg) is bytes and arg == DUMMY_TYPE:
                 global dummy_type_serialized_arg
                 if dummy_type_serialized_arg is None:

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -170,8 +170,12 @@ current_task_id_lock = threading.Lock()
 job_config_initialized = False
 job_config_initialization_lock = threading.Lock()
 
-# The cached serialized dummy arg b`__RAY_DUMMY__`
-dummy_type_serialized_arg = None
+# The cached serialized dummy arg b`__RAY_DUMMY__`.
+cdef dummy_type_serialized_arg = None
+# The type of DUMMY_TYPE.
+cdef dummy_type_type = type(DUMMY_TYPE)
+# The value of DUMMY_TYPE, cdef DUMMY_TYPE to avoid global lookup.
+cdef dummy_type_value = DUMMY_TYPE
 
 
 class ObjectRefGenerator:
@@ -446,6 +450,7 @@ cdef prepare_args_internal(
         CAddress c_owner_address
         CRayStatus op_status
 
+
     worker = ray._private.worker.global_worker
     put_threshold = RayConfig.instance().max_direct_call_object_size()
     total_inlined = 0
@@ -468,7 +473,7 @@ cdef prepare_args_internal(
             # the DUMMY_TYPE.
             # TODO(fyrestone): Maybe we can remove the DUMMY_TYPE or make the
             # DUMMY_TYPE None.
-            if type(arg) is bytes and arg == DUMMY_TYPE:
+            if type(arg) is dummy_type_type and arg == dummy_type_value:
                 global dummy_type_serialized_arg
                 if dummy_type_serialized_arg is None:
                     # Cache the serialized dummy arg.

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -451,9 +451,7 @@ cdef prepare_args_internal(
     total_inlined = 0
     rpc_inline_threshold = RayConfig.instance().task_rpc_inlined_bytes_limit()
     for arg in args:
-        # We only handle the ObjectRef type, because the inherit type will be deserialized
-        # to ObjectRef type which is incorrect.
-        if type(arg) is ObjectRef:
+        if isinstance(arg, ObjectRef):
             c_arg = (<ObjectRef>arg).native()
             op_status = CCoreWorkerProcess.GetCoreWorker().GetOwnerAddress(
                     c_arg, &c_owner_address)
@@ -462,15 +460,15 @@ cdef prepare_args_internal(
                 unique_ptr[CTaskArg](new CTaskArgByReference(
                     c_arg,
                     c_owner_address,
-                    (<ObjectRef>arg).call_site_data)))  # Avoid calling Python function.
+                    (<ObjectRef>arg).call_site_data)))  # Avoid calling Python function
 
         else:
             if arg == DUMMY_TYPE:
                 global dummy_type_serialized_arg
                 if dummy_type_serialized_arg is None:
                     # Cache the serialized dummy arg.
-                    dummy_type_serialized_arg = serialized_arg = worker.get_serialization_context(
-                    ).serialize(arg)
+                    dummy_type_serialized_arg = serialized_arg = \
+                        worker.get_serialization_context().serialize(arg)
                 else:
                     serialized_arg = dummy_type_serialized_arg
             else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray task flatten the Python arguments to `(DUMMY_TYPE, arg)`. When the Ray task has many positional args, the `DUMMY_TYPE` is still being serialized many times which is unnecessary.


A simple example to test submit task.
```python
import ray
import time

ray.init()

values = {
    "values": list(range(1000)),
    "object_ref_values": [ray.put(i) for i in range(1000)]
}


@ray.remote
def foo(*args):
    pass


for n, v in values.items():
    start = time.time()
    print(f"start submit {n}.")
    results = []
    for i in range(2000):
        r = foo.remote(*v)
        results.append(r)
    print(f"submit {n} total cost: {time.time() - start}")
```

 
_Apple M1 Pro, Python 3.8.13_

Before
```
start submit values.
submit values total cost: 10.591974258422852
start submit object_ref_values.
submit object_ref_values total cost: 7.3790199756622314
```

After
```
start submit values.
submit values total cost: 8.287185907363892
start submit object_ref_values.
submit object_ref_values total cost: 3.7379932403564453
```

The time consumption of submitting Ray task with many ObjectRef arguments is reduced by half.

- Known issue

The `DUMMY_TYPE` arg takes up a lot of space, e.g. 1000 `DUMMY_TYPE` cost 13000 bytes.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
