### PR TITLE
[tune] Structure refactor: Raise on import of old modules

### DIFF
--- a/python/ray/tune/_structure_refactor.py
+++ b/python/ray/tune/_structure_refactor.py
@@ -1,5 +1,3 @@
-import warnings
-
 from ray.util import log_once
 
 
@@ -8,7 +6,7 @@ def warn_structure_refactor(old_module: str, new_module: str, direct: bool = Tru
     if log_once(f"tune:structure:refactor:{old_module}"):
         warning = (
             f"The module `{old_module}` has been moved to `{new_module}` and the old "
-            f"location will be deprecated soon. Please adjust your imports to point "
+            f"location has been deprecated. Please adjust your imports to point "
             f"to the new location."
         )
 
@@ -24,6 +22,4 @@ def warn_structure_refactor(old_module: str, new_module: str, direct: bool = Tru
                 f"check the contents of `{new_module}` before making changes."
             )
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("always")
-            warnings.warn(warning, DeprecationWarning, stacklevel=3)
+        raise DeprecationWarning(warning)


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Following our tune package restructure (https://github.com/ray-project/ray/pulls?q=is%3Apr+in%3Atitle+%5Btune%2Fstructure%5D), we now had 3 releases where we logged a warning (2.0-2.3). For 2.4, we should raise an error instead. For 2.5, we can remove the old files/packages.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
