### PR TITLE
Revert "[data] [streaming] No preserve order by default"

### DIFF
--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -156,8 +156,9 @@ class ExecutionOptions:
     # node (node driving the execution).
     locality_with_output: bool = False
 
-    # Set this to preserve the ordering between blocks processed by operators.
-    preserve_order: bool = False
+    # Always preserve ordering of blocks, even if using operators that
+    # don't require it.
+    preserve_order: bool = True
 
     # Whether to enable locality-aware task dispatch to actors (on by default).
     actor_locality_enabled: bool = True

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3718,10 +3718,10 @@ class Dataset(Generic[T]):
         Examples:
             >>> import ray
             >>> # Infinite pipeline of numbers [0, 5)
-            >>> ray.data.range(5, parallelism=1).repeat().take()
+            >>> ray.data.range(5).repeat().take()
             [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, ...]
             >>> # Can apply transformations to the pipeline.
-            >>> ray.data.range(5, parallelism=1).repeat().map(lambda x: -x).take()
+            >>> ray.data.range(5).repeat().map(lambda x: -x).take()
             [0, -1, -2, -3, -4, 0, -1, -2, -3, -4, ...]
             >>> # Can shuffle each epoch (dataset) in the pipeline.
             >>> ray.data.range(5).repeat().random_shuffle().take() # doctest: +SKIP

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -150,7 +150,7 @@ class GroupedDataset(Generic[T]):
                     init=lambda k: [],
                     accumulate_row=lambda a, r: a + [r],
                     merge=lambda a1, a2: a1 + a2,
-                    finalize=lambda a: sorted(a)
+                    finalize=lambda a: a
                 ))
                 result.show()
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2391,10 +2391,7 @@ def test_select_columns(ray_start_regular_shared):
         ds3.select_columns(cols=[]).fully_executed()
 
 
-def test_map_batches_basic(ray_start_regular_shared, tmp_path, restore_dataset_context):
-    ctx = DatasetContext.get_current()
-    ctx.execution_options.preserve_order = True
-
+def test_map_batches_basic(ray_start_regular_shared, tmp_path):
     # Test input validation
     ds = ray.data.range(5)
     with pytest.raises(ValueError):
@@ -2723,11 +2720,8 @@ def test_map_batches_actors_preserves_order(ray_start_regular_shared):
     ],
 )
 def test_map_batches_batch_mutation(
-    ray_start_regular_shared, num_rows, num_blocks, batch_size, restore_dataset_context
+    ray_start_regular_shared, num_rows, num_blocks, batch_size
 ):
-    ctx = DatasetContext.get_current()
-    ctx.execution_options.preserve_order = True
-
     # Test that batch mutation works without encountering a read-only error (e.g. if the
     # batch is a zero-copy view on data in the object store).
     def mutate(df):
@@ -4846,9 +4840,7 @@ def test_random_block_order_schema(ray_start_regular_shared):
     ds.schema().names == ["a", "b"]
 
 
-def test_random_block_order(ray_start_regular_shared, restore_dataset_context):
-    ctx = DatasetContext.get_current()
-    ctx.execution_options.preserve_order = True
+def test_random_block_order(ray_start_regular_shared):
 
     # Test BlockList.randomize_block_order.
     ds = ray.data.range(12).repartition(4)

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -38,7 +38,7 @@ def ref_bundles_to_list(bundles: List[RefBundle]) -> List[List[Any]]:
 
 
 def test_pipelined_execution(ray_start_10_cpus_shared):
-    executor = StreamingExecutor(ExecutionOptions(preserve_order=True))
+    executor = StreamingExecutor(ExecutionOptions())
     inputs = make_ref_bundles([[x] for x in range(20)])
     o1 = InputDataBuffer(inputs)
     o2 = MapOperator.create(make_transform(lambda block: [b * -1 for b in block]), o1)

--- a/python/ray/train/tests/test_base_trainer.py
+++ b/python/ray/train/tests/test_base_trainer.py
@@ -14,7 +14,6 @@ from ray import tune
 from ray.air import session
 from ray.air.checkpoint import Checkpoint
 from ray.air.constants import MAX_REPR_LENGTH
-from ray.data.context import DatasetContext
 from ray.data.preprocessor import Preprocessor
 from ray.data.preprocessors import BatchMapper
 from ray.tune.impl import tuner_internal
@@ -98,9 +97,6 @@ def test_trainer_fit(ray_start_4_cpus):
 
 
 def test_preprocess_datasets(ray_start_4_cpus):
-    ctx = DatasetContext.get_current()
-    ctx.execution_options.preserve_order = True
-
     def training_loop(self):
         assert self.datasets["my_dataset"].take() == [2, 3, 4]
 


### PR DESCRIPTION
This reverts ray-project/ray#32300.

ray-project/ray#32300 changes the Ray Data default to no longer preserve order. This causes inconsistent failures in doctests because the floating-point error is accumulated differently, yielding a very slightly different result. For more information on how error can propagate in floating point operations, see https://floating-point-gui.de/errors/propagation/.

To fix this, we need to either 1) loosen doctest constraints or 2) fix Data seed so that the order is deterministic.

Example failure is below. Notice the least significant digits are different.
```
File "../../python/ray/data/dataset.py", line ?, in default
Failed example:
    ray.data.range(100).std()
Expected:
    29.011491975882016
Got:
    29.01149197588202
```

This BK has many different failures: https://buildkite.com/ray-project/oss-ci-build-branch/builds/2227#018632d9-799f-4ffb-9600-3bf51226b0bd
This BK has only one failure: https://buildkite.com/ray-project/oss-ci-build-branch/builds/2279#01863cc2-3332-40ba-bab3-603071c4b6da