### PR TITLE
[tune] Fix resuming from cloud storage (+ test)

### DIFF
--- a/python/ray/tune/execution/experiment_state.py
+++ b/python/ray/tune/execution/experiment_state.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from dataclasses import dataclass
-from typing import Dict, Optional, Union, Callable
+from typing import Callable, Dict, Optional, Tuple, Union
 
 import click
 import logging
@@ -28,7 +28,7 @@ class _ResumeConfig:
     restart_errored: bool = False
 
 
-def _resume_str_to_config(resume_str: str) -> _ResumeConfig:
+def _resume_str_to_config(resume_str: str) -> Tuple[str, _ResumeConfig]:
     if resume_str is True:
         resume_str = "LOCAL"
     elif resume_str == "ERRORED_ONLY":
@@ -61,7 +61,7 @@ def _resume_str_to_config(resume_str: str) -> _ResumeConfig:
     assert resume_str in VALID_RESUME_TYPES, "resume={} is not one of {}".format(
         resume_str, VALID_RESUME_TYPES
     )
-    return resume_config
+    return resume_str, resume_config
 
 
 def _experiment_checkpoint_exists(experiment_dir: str) -> bool:
@@ -406,7 +406,7 @@ class _ExperimentCheckpointManager:
         if not resume_type:
             return None
 
-        resume_config = _resume_str_to_config(resume_type)
+        resume_type, resume_config = _resume_str_to_config(resume_type)
 
         # Not clear if we need this assertion, since we should always have a
         # local checkpoint dir.

--- a/python/ray/tune/execution/trial_runner.py
+++ b/python/ray/tune/execution/trial_runner.py
@@ -227,7 +227,7 @@ class TrialRunner:
                 if has_verbosity(Verbosity.V3_TRIAL_DETAILS):
                     logger.error(str(e))
                 logger.exception("Runner restore failed.")
-                if self._fail_fast or True:
+                if self._fail_fast:
                     raise
                 logger.info("Restarting experiment.")
         else:

--- a/python/ray/tune/execution/trial_runner.py
+++ b/python/ray/tune/execution/trial_runner.py
@@ -227,7 +227,7 @@ class TrialRunner:
                 if has_verbosity(Verbosity.V3_TRIAL_DETAILS):
                     logger.error(str(e))
                 logger.exception("Runner restore failed.")
-                if self._fail_fast:
+                if self._fail_fast or True:
                     raise
                 logger.info("Restarting experiment.")
         else:


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#32457 refactored the experiment checkpoint management but introduced a bug where state is not correctly restored anymore. This was caught by a unit test error. This PR resolves the bug and makes sure the test passes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
