### PR TITLE
[tune] Fix two tests after structure refactor deprecation

### DIFF
--- a/python/ray/tune/tests/test_legacy_import.py
+++ b/python/ray/tune/tests/test_legacy_import.py
@@ -47,7 +47,7 @@ def logging_setup():
 def test_import_module_raises_warnings(module):
     py_cmd = (
         f"import pytest\n"
-        f"with pytest.warns(DeprecationWarning):\n"
+        f"with pytest.raises(DeprecationWarning):\n"
         f"      import {module}\n"
         f"\n"
     )

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -22,7 +22,7 @@ from ray.tune.progress_reporter import (
     _max_len,
 )
 from ray.tune.result import AUTO_RESULT_KEYS
-from ray.tune.trial import Trial
+from ray.tune.experiment.trial import Trial
 
 EXPECTED_RESULT_1 = """Result logdir: /foo
 Number of trials: 5 (1 PENDING, 3 RUNNING, 1 TERMINATED)


### PR DESCRIPTION
Signed-off-by: Kai Fricke <coding@kaifricke.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#32486 introduced two test failures after hard-depracting a structure refactor. This PR fixes these two stale imports.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
