### PR TITLE
[Doc] Fix autosummary to show docstring of class members

### DIFF
--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -1,0 +1,6 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+    :members:

--- a/doc/source/_templates/autosummary/class_with_autosummary.rst
+++ b/doc/source/_templates/autosummary/class_with_autosummary.rst
@@ -1,0 +1,45 @@
+{#
+  Generating pages for class methods and attributes
+  significantly increases the doc build time and causes timeouts.
+  For now, opt in explicitly via `:template: autosummary/class_with_autosummary.rst`
+#}
+{#
+  It's a known bug (https://github.com/sphinx-doc/sphinx/issues/9884)
+  that autosummary will generate warning for inherited instance attributes.
+  Those warnings will fail our build.
+  For now, we don't autosummary classes with inherited instance attributes.
+#}
+
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+      :toctree:
+
+   {% for item in methods %}
+      {{ name }}.{{ item }}
+   {%- endfor %}
+
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+      :toctree:
+
+   {% for item in attributes %}
+      {{ name }}.{{ item }}
+   {%- endfor %}
+
+   {% endif %}
+   {% endblock %}

--- a/doc/source/cluster/running-applications/job-submission/jobs-package-ref.rst
+++ b/doc/source/cluster/running-applications/job-submission/jobs-package-ref.rst
@@ -16,6 +16,7 @@ JobSubmissionClient
 
 .. autosummary::
    :toctree: doc/
+   :template: autosummary/class_with_autosummary.rst
 
    JobSubmissionClient
    JobSubmissionClient.submit_job

--- a/doc/source/data/api/dataset.rst
+++ b/doc/source/data/api/dataset.rst
@@ -10,6 +10,7 @@ Constructor
 
 .. autosummary::
    :toctree: doc/
+   :template: autosummary/class_with_autosummary.rst
 
    Dataset
 

--- a/doc/source/data/api/dataset_context.rst
+++ b/doc/source/data/api/dataset_context.rst
@@ -10,6 +10,7 @@ Constructor
 
 .. autosummary::
    :toctree: doc/
+   :template: autosummary/class_with_autosummary.rst
 
    context.DatasetContext
 

--- a/doc/source/data/api/dataset_pipeline.rst
+++ b/doc/source/data/api/dataset_pipeline.rst
@@ -10,6 +10,7 @@ Constructor
 
 .. autosummary::
    :toctree: doc/
+   :template: autosummary/class_with_autosummary.rst
 
    DatasetPipeline
 

--- a/doc/source/data/api/grouped_dataset.rst
+++ b/doc/source/data/api/grouped_dataset.rst
@@ -12,6 +12,7 @@ Constructor
 
 .. autosummary::
    :toctree: doc/
+   :template: autosummary/class_with_autosummary.rst
 
    grouped_dataset.GroupedDataset
 

--- a/doc/source/data/api/random_access_dataset.rst
+++ b/doc/source/data/api/random_access_dataset.rst
@@ -12,6 +12,7 @@ Constructor
 
 .. autosummary::
    :toctree: doc/
+   :template: autosummary/class_with_autosummary.rst
 
    random_access_dataset.RandomAccessDataset
 

--- a/doc/source/serve/api/python_api.md
+++ b/doc/source/serve/api/python_api.md
@@ -24,6 +24,7 @@
 ```{eval-rst}
 .. autosummary::
    :toctree: doc/
+   :template: autosummary/class_with_autosummary.rst
 
    serve.handle.RayServeHandle
    serve.handle.RayServeHandle.remote

--- a/doc/source/tune/api/callbacks.rst
+++ b/doc/source/tune/api/callbacks.rst
@@ -19,6 +19,7 @@ Callback Initialization and Setup
 .. currentmodule:: ray.tune
 .. autosummary::
     :toctree: doc/
+    :template: autosummary/class_with_autosummary.rst
 
     Callback
     Callback.setup

--- a/doc/source/tune/api/execution.rst
+++ b/doc/source/tune/api/execution.rst
@@ -10,6 +10,7 @@ Tuner
 
 .. autosummary::
     :toctree: doc/
+    :template: autosummary/class_with_autosummary.rst
 
     Tuner
     Tuner.fit

--- a/doc/source/tune/api/logging.rst
+++ b/doc/source/tune/api/logging.rst
@@ -75,6 +75,7 @@ LoggerCallback Interface
 
 .. autosummary::
     :toctree: doc/
+    :template: autosummary/class_with_autosummary.rst
 
     tune.logger.LoggerCallback
     tune.logger.LoggerCallback.log_trial_start

--- a/doc/source/tune/api/reporters.rst
+++ b/doc/source/tune/api/reporters.rst
@@ -95,6 +95,7 @@ Reporter Interface (tune.ProgressReporter)
 
 .. autosummary::
     :toctree: doc/
+    :template: autosummary/class_with_autosummary.rst
 
     ProgressReporter
     ProgressReporter.report
@@ -106,6 +107,7 @@ Tune Built-in Reporters
 
 .. autosummary::
     :toctree: doc/
+    :template: autosummary/class_with_autosummary.rst
 
     CLIReporter
     CLIReporter.add_metric_column

--- a/doc/source/tune/api/result_grid.rst
+++ b/doc/source/tune/api/result_grid.rst
@@ -12,6 +12,7 @@ ResultGrid (tune.ResultGrid)
 
 .. autosummary::
     :toctree: doc/
+    :template: autosummary/class_with_autosummary.rst
 
     tune.ResultGrid
     tune.ResultGrid.get_best_result

--- a/doc/source/tune/api/schedulers.rst
+++ b/doc/source/tune/api/schedulers.rst
@@ -335,6 +335,7 @@ TrialScheduler Interface
 
 .. autosummary::
     :toctree: doc/
+    :template: autosummary/class_with_autosummary.rst
 
     TrialScheduler
     TrialScheduler.choose_trial_to_run

--- a/doc/source/tune/api/stoppers.rst
+++ b/doc/source/tune/api/stoppers.rst
@@ -23,8 +23,13 @@ Stopper Interface (tune.Stopper)
 
 .. autosummary::
     :toctree: doc/
+    :template: autosummary/class_with_autosummary.rst
 
     Stopper
+
+.. autosummary::
+    :toctree: doc/
+
     Stopper.__call__
     Stopper.stop_all
 

--- a/doc/source/tune/api/suggestion.rst
+++ b/doc/source/tune/api/suggestion.rst
@@ -331,6 +331,7 @@ If you are interested in implementing or contributing a new Search Algorithm, pr
 
 .. autosummary::
     :toctree: doc/
+    :template: autosummary/class_with_autosummary.rst
 
     Searcher
     Searcher.suggest

--- a/doc/source/tune/api/syncing.rst
+++ b/doc/source/tune/api/syncing.rst
@@ -25,6 +25,7 @@ Remote Storage Syncer Interface (tune.Syncer)
 
 .. autosummary::
     :toctree: doc/
+    :template: autosummary/class_with_autosummary.rst
 
     Syncer
     Syncer.sync_up

--- a/doc/source/tune/api/trainable.rst
+++ b/doc/source/tune/api/trainable.rst
@@ -292,6 +292,7 @@ Trainable (Class API)
 
 .. autosummary::
     :toctree: doc/
+    :template: autosummary/class_with_autosummary.rst
 
     tune.Trainable
     tune.Trainable.setup

--- a/python/ray/air/execution/resources/request.py
+++ b/python/ray/air/execution/resources/request.py
@@ -108,6 +108,7 @@ class ResourceRequest:
     @property
     @DeveloperAPI
     def head_cpus(self) -> float:
+        """Returns the number of cpus in the head bundle."""
         return 0.0 if self._head_bundle_is_empty else self._bundles[0].get("CPU", 0.0)
 
     @property


### PR DESCRIPTION
Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
By default, autosummary only shows one line for each class member instead of the entire docstring. Ideally the fix should be autosummarying class members as well but that generates too many doc pages and causes doc build timeout. For now, default to show docstring of class members in the class pages and an explicit opt-in to autosummary class members.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
