### PR TITLE
[Serve]Make http retries tunable

### DIFF
--- a/doc/source/serve/performance.md
+++ b/doc/source/serve/performance.md
@@ -174,4 +174,4 @@ You can set an end-to-end timeout for HTTP requests by setting the `RAY_SERVE_RE
 
 By default, the Serve HTTP proxy retries up to `10` times when a response is not received due to failures (e.g. network disconnect, request timeout, etc.).
 
-You can set the number of retries based on your requirements by setting the `RAY_SERVE_HTTP_MAX_REPLICA_FAILURE_RETRIES` environment variable. The HTTP proxy will retry that many times at most before sending a task error response to the client. The number of retries will affect the end-to-end latency of your HTTP requests since Ray Serve does exponential backoff for retries.
+You can tune the number of retries by setting the `RAY_SERVE_HTTP_REQUEST_MAX_RETRIES` environment variable. The HTTP proxy will retry that many times at most before sending a task error response to the client. The number of retries will affect the end-to-end latency of your HTTP requests because Ray Serve does exponential backoff for retries.

--- a/doc/source/serve/performance.md
+++ b/doc/source/serve/performance.md
@@ -174,4 +174,4 @@ You can set an end-to-end timeout for HTTP requests by setting the `RAY_SERVE_RE
 
 By default, the Serve HTTP proxy retries up to `10` times when a response is not received due to failures (e.g. network disconnect, request timeout, etc.).
 
-You can set the number of retries based on your requirements by setting the `RAY_SERVE_HTTP_MAX_REPLICA_FAILURE_RETRIES` environment variable. The HTTP proxy will retry that many times at most before sending a task error response to the client. The number of retries will affect end-to-end latency of your HTTP requests. (Ray Serve will do expotential backoff retry).
+You can set the number of retries based on your requirements by setting the `RAY_SERVE_HTTP_MAX_REPLICA_FAILURE_RETRIES` environment variable. The HTTP proxy will retry that many times at most before sending a task error response to the client. The number of retries will affect the end-to-end latency of your HTTP requests since Ray Serve does exponential backoff for retries.

--- a/doc/source/serve/performance.md
+++ b/doc/source/serve/performance.md
@@ -168,3 +168,10 @@ proper backpressure. You can increase the value in the deployment decorator; e.g
 By default, Serve lets client HTTP requests run to completion no matter how long they take. However, slow requests could bottleneck the replica processing, blocking other requests that are waiting. It's recommended that you set an end-to-end timeout, so slow requests can be terminated and retried at another replica.
 
 You can set an end-to-end timeout for HTTP requests by setting the `RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S` environment variable. HTTP Proxies will wait for that many seconds before terminating an HTTP request and retrying it at another replica. This environment variable should be set on every node in your Ray cluster, and it cannot be updated during runtime.
+
+(serve-performance-http-retry)=
+### Set request retry times
+
+By default, Serve HTTP proxy will retry `10` times if the response is not able to be back due to failures (e.g. network disconnect, request timeout etc.).
+
+You can set number of retries based on your requirements by setting the `RAY_SERVE_MAX_REPLICA_FAILURE_RETRIES` environment variable. HTTP proxy will at most retry that times before sending task errors response to the client.

--- a/doc/source/serve/performance.md
+++ b/doc/source/serve/performance.md
@@ -172,6 +172,6 @@ You can set an end-to-end timeout for HTTP requests by setting the `RAY_SERVE_RE
 (serve-performance-http-retry)=
 ### Set request retry times
 
-By default, Serve HTTP proxy will retry `10` times if the response is not able to be back due to failures (e.g. network disconnect, request timeout etc.).
+By default, the Serve HTTP proxy retries up to `10` times when a response is not received due to failures (e.g. network disconnect, request timeout, etc.).
 
-You can set number of retries based on your requirements by setting the `RAY_SERVE_MAX_REPLICA_FAILURE_RETRIES` environment variable. HTTP proxy will at most retry that times before sending task errors response to the client.
+You can set the number of retries based on your requirements by setting the `RAY_SERVE_HTTP_MAX_REPLICA_FAILURE_RETRIES` environment variable. The HTTP proxy will retry that many times at most before sending a task error response to the client. The number of retries will affect end-to-end latency of your HTTP requests. (Ray Serve will do expotential backoff retry).

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -36,13 +36,11 @@ from ray.serve._private.logging_utils import access_log_msg, configure_component
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
-MAX_REPLICA_FAILURE_RETRIES = int(
-    os.environ.get("RAY_SERVE_HTTP_MAX_REPLICA_FAILURE_RETRIES", 10)
-)
-assert MAX_REPLICA_FAILURE_RETRIES >= 0, (
-    f"Got unexpected value {MAX_REPLICA_FAILURE_RETRIES} for "
-    "MAX_REPLICA_FAILURE_RETRIES environment variable. "
-    "MAX_REPLICA_FAILURE_RETRIES cannot be negative."
+HTTP_REQUEST_MAX_RETRIES = int(os.environ.get("RAY_SERVE_HTTP_REQUEST_MAX_RETRIES", 10))
+assert HTTP_REQUEST_MAX_RETRIES >= 0, (
+    f"Got unexpected value {HTTP_REQUEST_MAX_RETRIES} for "
+    "RAY_SERVE_HTTP_REQUEST_MAX_RETRIES environment variable. "
+    "RAY_SERVE_HTTP_REQUEST_MAX_RETRIES cannot be negative."
 )
 
 DISCONNECT_ERROR_CODE = "disconnection"
@@ -84,7 +82,7 @@ async def _send_request_to_handle(handle, scope, receive, send) -> str:
     # We have received all the http request conent. The next `receive`
     # call might never arrive; if it does, it can only be `http.disconnect`.
     client_disconnection_task = loop.create_task(receive())
-    while retries < MAX_REPLICA_FAILURE_RETRIES + 1:
+    while retries < HTTP_REQUEST_MAX_RETRIES + 1:
         assignment_task: asyncio.Task = handle.remote(request)
         done, _ = await asyncio.wait(
             [assignment_task, client_disconnection_task],
@@ -139,7 +137,7 @@ async def _send_request_to_handle(handle, scope, receive, send) -> str:
         except RayActorError:
             logger.debug(
                 "Request failed due to replica failure. There are "
-                f"{MAX_REPLICA_FAILURE_RETRIES - retries} retries "
+                f"{HTTP_REQUEST_MAX_RETRIES - retries} retries "
                 "remaining."
             )
             backoff = True
@@ -152,7 +150,7 @@ async def _send_request_to_handle(handle, scope, receive, send) -> str:
             retries += 1
             backoff = False
     else:
-        error_message = f"Task failed with {MAX_REPLICA_FAILURE_RETRIES} retries."
+        error_message = f"Task failed with {HTTP_REQUEST_MAX_RETRIES} retries."
         await Response(error_message, status_code=500).send(scope, receive, send)
         return "500"
 

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -36,7 +36,9 @@ from ray.serve._private.logging_utils import access_log_msg, configure_component
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
-MAX_REPLICA_FAILURE_RETRIES = 10
+MAX_REPLICA_FAILURE_RETRIES = int(
+    os.environ.get("RAY_SERVE_MAX_REPLICA_FAILURE_RETRIES", 10)
+)
 DISCONNECT_ERROR_CODE = "disconnection"
 SOCKET_REUSE_PORT_ENABLED = (
     os.environ.get("SERVE_SOCKET_REUSE_PORT_ENABLED", "1") == "1"

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -39,9 +39,11 @@ logger = logging.getLogger(SERVE_LOGGER_NAME)
 MAX_REPLICA_FAILURE_RETRIES = int(
     os.environ.get("RAY_SERVE_HTTP_MAX_REPLICA_FAILURE_RETRIES", 10)
 )
-assert (
-    MAX_REPLICA_FAILURE_RETRIES >= 0
-), f"Got unexpected value {MAX_REPLICA_FAILURE_RETRIES} for MAX_REPLICA_FAILURE_RETRIES environment variable. MAX_REPLICA_FAILURE_RETRIES cannot be negative."
+assert MAX_REPLICA_FAILURE_RETRIES >= 0, (
+    f"Got unexpected value {MAX_REPLICA_FAILURE_RETRIES} for "
+    "MAX_REPLICA_FAILURE_RETRIES environment variable. "
+    "MAX_REPLICA_FAILURE_RETRIES cannot be negative."
+)
 
 DISCONNECT_ERROR_CODE = "disconnection"
 SOCKET_REUSE_PORT_ENABLED = (

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -41,7 +41,7 @@ MAX_REPLICA_FAILURE_RETRIES = int(
 )
 assert (
     MAX_REPLICA_FAILURE_RETRIES >= 0
-), "MAX_REPLICA_FAILURE_RETRIES can't not be negative value"
+), f"Got unexpected value {MAX_REPLICA_FAILURE_RETRIES} for MAX_REPLICA_FAILURE_RETRIES environment variable. MAX_REPLICA_FAILURE_RETRIES cannot be negative."
 
 DISCONNECT_ERROR_CODE = "disconnection"
 SOCKET_REUSE_PORT_ENABLED = (

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -1356,18 +1356,12 @@ class TestServeRequestProcessingTimeoutS:
     "ray_instance",
     [
         {
-<<<<<<< HEAD
             "LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S_LOWER_BOUND": "1",
             "LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S_UPPER_BOUND": "2",
-=======
-            "RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.1",
-            "RAY_SERVE_MAX_REPLICA_FAILURE_RETRIES": "5",
->>>>>>> 1c4cfd5cbb ([Serve] Make http retries tunable)
         },
     ],
     indirect=True,
 )
-<<<<<<< HEAD
 def test_long_poll_timeout_with_max_concurrent_queries(ray_instance):
     """Test max_concurrent_queries can be honorded with long poll timeout
 
@@ -1421,9 +1415,19 @@ def test_long_poll_timeout_with_max_concurrent_queries(ray_instance):
     signal_actor.send.remote()
     assert ray.get(first_ref) == "hello"
 
-=======
+
+@pytest.mark.parametrize(
+    "ray_instance",
+    [
+        {
+            "RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.1",
+            "RAY_SERVE_HTTP_MAX_REPLICA_FAILURE_RETRIES": "5",
+        },
+    ],
+    indirect=True,
+)
 def test_http_request_number_of_retries(ray_instance):
-    """Test HTTP proxy retry requests"""
+    """Test HTTP proxy retry requests."""
 
     signal_actor = SignalActor.remote()
 
@@ -1451,7 +1455,6 @@ def test_http_request_number_of_retries(ray_instance):
 
     wait_for_condition(verify_metrics, timeout=60, retry_interval_ms=500)
     signal_actor.send.remote()
->>>>>>> 1c4cfd5cbb ([Serve] Make http retries tunable)
     serve.shutdown()
 
 

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -1414,6 +1414,7 @@ def test_long_poll_timeout_with_max_concurrent_queries(ray_instance):
     # Unblock the first request.
     signal_actor.send.remote()
     assert ray.get(first_ref) == "hello"
+    serve.shutdown()
 
 
 @pytest.mark.parametrize(
@@ -1449,7 +1450,7 @@ def test_http_request_number_of_retries(ray_instance):
             if "# HELP" in metrics or "# TYPE" in metrics:
                 continue
             if "serve_num_router_requests" in metrics:
-                assert "5.0" in metrics
+                assert "6.0" in metrics
                 verfied = True
         return verfied
 


### PR DESCRIPTION
Signed-off-by: Sihan Wang <sihanwang41@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Make HTTP retry tunable for better controlling the system behavior. 

## Related issue number

https://github.com/ray-project/ray/issues/32543

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
