### PR TITLE
Revert "[data] Fix pandas import failures by moving it to a top-level data import"

### DIFF
--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -1,7 +1,3 @@
-# Short term workaround for https://github.com/ray-project/ray/issues/32435
-# Datasets currently has a hard dependency on pandas, so it doesn't need to be delayed.
-import pandas  # noqa
-
 from ray.data._internal.compute import ActorPoolStrategy
 from ray.data._internal.progress_bar import set_progress_bars
 from ray.data.dataset import Dataset


### PR DESCRIPTION
Reverts ray-project/ray#32447

Looks like ray-project/ray#32447 breaks bk://:mac: :apple: Wheels and Jars and linux://python/ray/tests:test_basic

Failed BK: https://buildkite.com/ray-project/oss-ci-build-branch/builds/2327#01864d8e-0ebd-4ef3-bfda-1259dfcfcbbc
```
+ /Library/Frameworks/Python.framework/Versions/3.6/bin/python3.6 /Users/ec2-user/.buildkite-agent/builds/bk-mac1-branch-queue-i-0b5fcfa84a3210bb0-1/ray-project/oss-ci-build-branch/ci/build/../../python/ray/tests/test_microbenchmarks.py

Traceback (most recent call last):
  File "/Users/ec2-user/.buildkite-agent/builds/bk-mac1-branch-queue-i-0b5fcfa84a3210bb0-1/ray-project/oss-ci-build-branch/ci/build/../../python/ray/tests/test_microbenchmarks.py", line 5, in <module>
    import ray
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/ray/__init__.py", line 257, in <module>
    from ray import data  # noqa: F401
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/ray/data/__init__.py", line 3, in <module>
    import pandas  # noqa
ModuleNotFoundError: No module named 'pandas'
```
