### PR TITLE
[core] Slightly reduce the OOM killer threshold

### DIFF
--- a/doc/source/ray-core/scheduling/ray-oom-prevention.rst
+++ b/doc/source/ray-core/scheduling/ray-oom-prevention.rst
@@ -30,7 +30,7 @@ The memory monitor is controlled by the following environment variables:
 
 - ``RAY_memory_monitor_refresh_ms (int, defaults to 250)`` is the interval to check memory usage and kill tasks or actors if needed. Task killing is disabled when this value is 0. The memory monitor selects and kills one task at a time and waits for it to be killed before choosing another one, regardless of how frequent the memory monitor runs.
 
-- ``RAY_memory_usage_threshold (float, defaults to 0.95)`` is the threshold when the node is beyond the memory
+- ``RAY_memory_usage_threshold (float, defaults to 0.9)`` is the threshold when the node is beyond the memory
   capacity. If the memory usage is above this fraction it will start killing processes to free up memory. Ranges from [0, 1].
 
 Using the Memory Monitor

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -71,7 +71,7 @@ RAY_CONFIG(uint64_t, raylet_check_gc_period_milliseconds, 100)
 /// memory_usage_threshold and free space is below the min_memory_free_bytes then
 /// it will start killing processes to free up the space.
 /// Ranging from [0, 1]
-RAY_CONFIG(float, memory_usage_threshold, 0.95)
+RAY_CONFIG(float, memory_usage_threshold, 0.9)
 
 /// The interval between runs of the memory usage monitor.
 /// Monitor is disabled when this value is 0.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We've observed the OOM threshold being a bit too conservative in some user workloads; tweak it to 0.9 to provide a little more headroom for safety.