### PR TITLE
[3/n] Stabilize GCS/Autoscaler interface: Expose task/actor resource demands and node resource usage

### DIFF
--- a/python/ray/tests/test_monitor_service.py
+++ b/python/ray/tests/test_monitor_service.py
@@ -11,7 +11,7 @@ from ray._private.test_utils import wait_for_condition
 @pytest.fixture
 def monitor_stub(ray_start_regular_shared):
     channel = grpc.insecure_channel(ray_start_regular_shared["gcs_address"])
-        
+
     return monitor_pb2_grpc.MonitorGcsServiceStub(channel)
 
 
@@ -56,7 +56,6 @@ def test_scheduling_status(monitor_stub):
     ray.wait([actor.ready.remote() for actor in cpu_actors])
     print("done")
 
-
     def condition():
         request = monitor_pb2.GetSchedulingStatusRequest()
         response = monitor_stub.GetSchedulingStatus(request)
@@ -65,7 +64,10 @@ def test_scheduling_status(monitor_stub):
 
         shapes = [{"CPU": 1}, {"GPU": 1}]
         for request in response.resource_requests:
-            if request.resource_request_type != monitor_pb2.ResourceRequest.TASK_RESERVATION:
+            if (
+                request.resource_request_type
+                != monitor_pb2.ResourceRequest.TASK_RESERVATION
+            ):
                 return False
             if request.count != 2:
                 return False
@@ -93,7 +95,7 @@ def test_drain_and_kill_node(monitor_stub_with_cluster):
     cluster.add_node(num_cpus=2)
     cluster.wait_for_nodes()
 
-    wait_for_condition(lambda : count_live_nodes() == 2)
+    wait_for_condition(lambda: count_live_nodes() == 2)
 
     node_ids = {node["NodeID"] for node in ray.nodes()}
     worker_nodes = node_ids - {head_node}
@@ -107,15 +109,8 @@ def test_drain_and_kill_node(monitor_stub_with_cluster):
     response = monitor_stub.DrainAndKillNode(request)
 
     assert response.drained_nodes == request.node_ids
-    wait_for_condition(lambda : count_live_nodes() == 1)
+    wait_for_condition(lambda: count_live_nodes() == 1)
 
     response = monitor_stub.DrainAndKillNode(request)
     assert response.drained_nodes == request.node_ids
-    wait_for_condition(lambda : count_live_nodes() == 1)
-
-
-
-
-
-    
-    
+    wait_for_condition(lambda: count_live_nodes() == 1)

--- a/python/ray/tests/test_monitor_service.py
+++ b/python/ray/tests/test_monitor_service.py
@@ -5,12 +5,13 @@ import ray
 import grpc
 from ray.core.generated import monitor_pb2, monitor_pb2_grpc
 from ray.cluster_utils import Cluster
+from ray._private.test_utils import wait_for_condition
 
 
 @pytest.fixture
 def monitor_stub(ray_start_regular_shared):
     channel = grpc.insecure_channel(ray_start_regular_shared["gcs_address"])
-
+        
     return monitor_pb2_grpc.MonitorGcsServiceStub(channel)
 
 
@@ -36,8 +37,52 @@ def test_ray_version(monitor_stub):
     assert response.version == ray.__version__
 
 
+def test_scheduling_status(monitor_stub):
+    @ray.remote(num_cpus=0, num_gpus=1)
+    class Foo:
+        pass
+
+    @ray.remote(num_cpus=1)
+    class Bar:
+        def ready(self):
+            pass
+
+    gpu_actors = [Foo.remote() for _ in range(2)]
+    cpu_actors = [Bar.remote() for _ in range(3)]
+
+    refs = [actor.ready.remote() for actor in cpu_actors]
+    print("Waiting for an actor to be ready...", refs)
+    # Wait for one actor to get placed (and therefore take the cpu).
+    ray.wait([actor.ready.remote() for actor in cpu_actors])
+    print("done")
+
+
+    def condition():
+        request = monitor_pb2.GetSchedulingStatusRequest()
+        response = monitor_stub.GetSchedulingStatus(request)
+
+        assert len(response.resource_requests) == 2
+
+        shapes = [{"CPU": 1}, {"GPU": 1}]
+        for request in response.resource_requests:
+            if request.resource_request_type != monitor_pb2.ResourceRequest.TASK_RESERVATION:
+                return False
+            if request.count != 2:
+                return False
+            if len(request.bundles) != 1:
+                return False
+            if request.bundles[0].resources not in shapes:
+                return False
+
+        return True
+
+    wait_for_condition(condition)
+
+
 def count_live_nodes():
-    return sum(1 for node in ray.nodes() if node["Alive"])
+    s = sum(1 for node in ray.nodes() if node["Alive"])
+    print(ray.nodes())
+    return s
 
 
 def test_drain_and_kill_node(monitor_stub_with_cluster):
@@ -48,7 +93,7 @@ def test_drain_and_kill_node(monitor_stub_with_cluster):
     cluster.add_node(num_cpus=2)
     cluster.wait_for_nodes()
 
-    assert count_live_nodes() == 2
+    wait_for_condition(lambda : count_live_nodes() == 2)
 
     node_ids = {node["NodeID"] for node in ray.nodes()}
     worker_nodes = node_ids - {head_node}
@@ -62,8 +107,15 @@ def test_drain_and_kill_node(monitor_stub_with_cluster):
     response = monitor_stub.DrainAndKillNode(request)
 
     assert response.drained_nodes == request.node_ids
-    assert count_live_nodes() == 1
+    wait_for_condition(lambda : count_live_nodes() == 1)
 
     response = monitor_stub.DrainAndKillNode(request)
     assert response.drained_nodes == request.node_ids
-    assert count_live_nodes() == 1
+    wait_for_condition(lambda : count_live_nodes() == 1)
+
+
+
+
+
+    
+    

--- a/python/ray/tests/test_monitor_service.py
+++ b/python/ray/tests/test_monitor_service.py
@@ -116,32 +116,3 @@ def count_live_nodes():
     s = sum(1 for node in ray.nodes() if node["Alive"])
     print(ray.nodes())
     return s
-
-
-def test_drain_and_kill_node(monitor_stub_with_cluster):
-    monitor_stub, cluster = monitor_stub_with_cluster
-
-    head_node = ray.nodes()[0]["NodeID"]
-
-    cluster.add_node(num_cpus=2)
-    cluster.wait_for_nodes()
-
-    wait_for_condition(lambda: count_live_nodes() == 2)
-
-    node_ids = {node["NodeID"] for node in ray.nodes()}
-    worker_nodes = node_ids - {head_node}
-    assert len(worker_nodes) == 1
-
-    worker_node_id = next(iter(worker_nodes))
-
-    request = monitor_pb2.DrainAndKillNodeRequest(
-        node_ids=[binascii.unhexlify(worker_node_id)]
-    )
-    response = monitor_stub.DrainAndKillNode(request)
-
-    assert response.drained_nodes == request.node_ids
-    wait_for_condition(lambda: count_live_nodes() == 1)
-
-    response = monitor_stub.DrainAndKillNode(request)
-    assert response.drained_nodes == request.node_ids
-    wait_for_condition(lambda: count_live_nodes() == 1)

--- a/python/ray/tests/test_monitor_service.py
+++ b/python/ray/tests/test_monitor_service.py
@@ -80,6 +80,8 @@ def test_scheduling_status(monitor_stub):
 
     wait_for_condition(condition)
 
+    del gpu_actors
+
 
 def count_live_nodes():
     s = sum(1 for node in ray.nodes() if node["Alive"])

--- a/src/mock/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_node_manager.h
@@ -43,6 +43,7 @@ class MockGcsNodeManager : public GcsNodeManager {
                rpc::SendReplyCallback send_reply_callback),
               (override));
   MOCK_METHOD(void, DrainNode, (const NodeID &node_id), (override));
+  MOCK_METHOD((const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> &), GetAllAliveNodes, (), (const override));
 };
 
 }  // namespace gcs

--- a/src/mock/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_node_manager.h
@@ -43,7 +43,10 @@ class MockGcsNodeManager : public GcsNodeManager {
                rpc::SendReplyCallback send_reply_callback),
               (override));
   MOCK_METHOD(void, DrainNode, (const NodeID &node_id), (override));
-  MOCK_METHOD((const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> &), GetAllAliveNodes, (), (const override));
+  MOCK_METHOD((const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> &),
+              GetAllAliveNodes,
+              (),
+              (const override));
 };
 
 }  // namespace gcs

--- a/src/mock/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_node_manager.h
@@ -43,10 +43,6 @@ class MockGcsNodeManager : public GcsNodeManager {
                rpc::SendReplyCallback send_reply_callback),
               (override));
   MOCK_METHOD(void, DrainNode, (const NodeID &node_id), (override));
-  MOCK_METHOD((const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> &),
-              GetAllAliveNodes,
-              (),
-              (const override));
 };
 
 }  // namespace gcs

--- a/src/mock/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -20,13 +20,9 @@ namespace gcs {
 class MockGcsResourceManager : public GcsResourceManager {
  public:
   using GcsResourceManager::GcsResourceManager;
-  MockGcsResourceManager(ClusterResourceManager &cluster_resource_manager) :
-    GcsResourceManager(
-                       io_context_,
-                       cluster_resource_manager,
-                       NodeID::FromRandom(),
-                       nullptr
-                       ) {}
+  MockGcsResourceManager(ClusterResourceManager &cluster_resource_manager)
+      : GcsResourceManager(
+            io_context_, cluster_resource_manager, NodeID::FromRandom(), nullptr) {}
 
   MOCK_METHOD(void,
               HandleGetResources,
@@ -52,14 +48,12 @@ class MockGcsResourceManager : public GcsResourceManager {
                rpc::GetAllResourceUsageReply *reply,
                rpc::SendReplyCallback send_reply_callback),
               (override));
-  MOCK_METHOD(
-              (const absl::flat_hash_map<NodeID, rpc::ResourcesData> &),
+  MOCK_METHOD((const absl::flat_hash_map<NodeID, rpc::ResourcesData> &),
               NodeResourceReportView,
               (),
-              (const override)
-              );
+              (const override));
 
-private:
+ private:
   instrumented_io_context io_context_;
 };
 

--- a/src/mock/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -12,12 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ray/common/asio/instrumented_io_context.h"
+
 namespace ray {
 namespace gcs {
 
 class MockGcsResourceManager : public GcsResourceManager {
  public:
   using GcsResourceManager::GcsResourceManager;
+  MockGcsResourceManager(ClusterResourceManager &cluster_resource_manager) :
+    GcsResourceManager(
+                       io_context_,
+                       cluster_resource_manager,
+                       NodeID::FromRandom(),
+                       nullptr
+                       ) {}
+
   MOCK_METHOD(void,
               HandleGetResources,
               (rpc::GetResourcesRequest request,
@@ -42,6 +52,15 @@ class MockGcsResourceManager : public GcsResourceManager {
                rpc::GetAllResourceUsageReply *reply,
                rpc::SendReplyCallback send_reply_callback),
               (override));
+  MOCK_METHOD(
+              (const absl::flat_hash_map<NodeID, rpc::ResourcesData> &),
+              NodeResourceReportView,
+              (),
+              (const override)
+              );
+
+private:
+  instrumented_io_context io_context_;
 };
 
 }  // namespace gcs

--- a/src/mock/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -48,10 +48,6 @@ class MockGcsResourceManager : public GcsResourceManager {
                rpc::GetAllResourceUsageReply *reply,
                rpc::SendReplyCallback send_reply_callback),
               (override));
-  MOCK_METHOD((const absl::flat_hash_map<NodeID, rpc::ResourcesData> &),
-              NodeResourceReportView,
-              (),
-              (const override));
 
  private:
   instrumented_io_context io_context_;

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.cc
@@ -61,8 +61,8 @@ void GcsMonitorServer::PopulateNodeStatuses(rpc::GetSchedulingStatusReply *reply
       continue;
     }
     const auto &node_resources = it->second.GetLocalView();
-    const auto &available = node_resources.available.ToResourceMap();
-    const auto &total = node_resources.total.ToResourceMap();
+    const auto available = node_resources.available.ToResourceMap();
+    const auto total = node_resources.total.ToResourceMap();
 
     auto node_status = reply->add_node_statuses();
     node_status->set_node_id(node_id.Binary());

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.cc
@@ -19,8 +19,8 @@
 namespace ray {
 namespace gcs {
 
-GcsMonitorServer::GcsMonitorServer(std::shared_ptr<GcsNodeManager> gcs_node_manager)
-    : gcs_node_manager_(gcs_node_manager) {}
+  GcsMonitorServer::GcsMonitorServer(std::shared_ptr<GcsNodeManager> gcs_node_manager, ClusterResourceManager &cluster_resource_manager)
+    : gcs_node_manager_(gcs_node_manager), cluster_resource_manager_(cluster_resource_manager) {}
 
 void GcsMonitorServer::HandleGetRayVersion(rpc::GetRayVersionRequest request,
                                            rpc::GetRayVersionReply *reply,
@@ -44,7 +44,14 @@ void GcsMonitorServer::HandleDrainAndKillNode(
 void GcsMonitorServer::HandleGetSchedulingStatus(
     rpc::GetSchedulingStatusRequest request,
     rpc::GetSchedulingStatusReply *reply,
-    rpc::SendReplyCallback send_reply_callback) {}
+    rpc::SendReplyCallback send_reply_callback) {
+  const absl::flat_hash_map<scheduling::NodeID, Node> scheduling_nodes = cluster_resource_manager_.GetResourceView();
+
+  if (scheduling_nodes.size() == 0) {
+    // TODO Delete
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+}
 
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.cc
@@ -93,9 +93,8 @@ void GcsMonitorServer::PopulateResourceDemands(
         task_load_by_shape[resource_demand.shape()] = request;
         request->set_resource_request_type(
             rpc::ResourceRequest_ResourceRequestType::
-                ResourceRequest_ResourceRequestType_SHORT_RESERVATION);
+                ResourceRequest_ResourceRequestType_TASK_RESERVATION);
         request->set_count(0);
-        request->set_description("tasks/actors");
         request->add_bundles()->mutable_resources()->insert(
             resource_demand.shape().begin(), resource_demand.shape().end());
       } else {

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.cc
@@ -86,7 +86,7 @@ void GcsMonitorServer::PopulateResourceDemands(
   for (const auto &node_report_pair : resources_report_by_node) {
     for (const auto &resource_demand :
          node_report_pair.second.resource_load_by_shape().resource_demands()) {
-      rpc::ResourceRequest *request = task_load_by_shape[resource_demand.shape()];
+      rpc::ResourceRequest *request;
       auto it = task_load_by_shape.find(resource_demand.shape());
       if (it == task_load_by_shape.end()) {
         request = reply->add_resource_requests();

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.cc
@@ -19,8 +19,10 @@
 namespace ray {
 namespace gcs {
 
-  GcsMonitorServer::GcsMonitorServer(std::shared_ptr<GcsNodeManager> gcs_node_manager, ClusterResourceManager &cluster_resource_manager)
-    : gcs_node_manager_(gcs_node_manager), cluster_resource_manager_(cluster_resource_manager) {}
+GcsMonitorServer::GcsMonitorServer(std::shared_ptr<GcsNodeManager> gcs_node_manager,
+                                   ClusterResourceManager &cluster_resource_manager)
+    : gcs_node_manager_(gcs_node_manager),
+      cluster_resource_manager_(cluster_resource_manager) {}
 
 void GcsMonitorServer::HandleGetRayVersion(rpc::GetRayVersionRequest request,
                                            rpc::GetRayVersionReply *reply,
@@ -45,7 +47,8 @@ void GcsMonitorServer::HandleGetSchedulingStatus(
     rpc::GetSchedulingStatusRequest request,
     rpc::GetSchedulingStatusReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  const absl::flat_hash_map<scheduling::NodeID, Node> scheduling_nodes = cluster_resource_manager_.GetResourceView();
+  const absl::flat_hash_map<scheduling::NodeID, Node> scheduling_nodes =
+      cluster_resource_manager_.GetResourceView();
 
   if (scheduling_nodes.size() == 0) {
     // TODO Delete

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.cc
@@ -41,5 +41,12 @@ void GcsMonitorServer::HandleDrainAndKillNode(
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 
+
+  void GcsMonitorServer::HandleGetSchedulingStatus(rpc::GetSchedulingStatusRequest request,
+                                                   rpc::GetSchedulingStatusReply *reply,
+                                                   rpc::SendReplyCallback send_reply_callback) {
+
+}
+
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.cc
@@ -43,12 +43,11 @@ void GcsMonitorServer::HandleDrainAndKillNode(
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 
-
 void GcsMonitorServer::PopulateNodeStatuses(rpc::GetSchedulingStatusReply *reply) const {
   const absl::flat_hash_map<scheduling::NodeID, Node> &scheduling_nodes =
       cluster_resource_manager_.GetResourceView();
   const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>>
-    &gcs_node_manager_nodes = gcs_node_manager_->GetAllAliveNodes();
+      &gcs_node_manager_nodes = gcs_node_manager_->GetAllAliveNodes();
 
   for (const auto &pair : gcs_node_manager_nodes) {
     const auto &node_id = pair.first;
@@ -67,7 +66,8 @@ void GcsMonitorServer::PopulateNodeStatuses(rpc::GetSchedulingStatusReply *reply
     auto node_status = reply->add_node_statuses();
     node_status->set_node_id(node_id.Binary());
     node_status->set_address(gcs_node_info->node_manager_address());
-    node_status->mutable_available_resources()->insert(available.begin(), available.end());
+    node_status->mutable_available_resources()->insert(available.begin(),
+                                                       available.end());
     node_status->mutable_total_resources()->insert(total.begin(), total.end());
   }
 }

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.cc
@@ -20,9 +20,13 @@ namespace ray {
 namespace gcs {
 
 GcsMonitorServer::GcsMonitorServer(std::shared_ptr<GcsNodeManager> gcs_node_manager,
-                                   ClusterResourceManager &cluster_resource_manager)
+                                   ClusterResourceManager &cluster_resource_manager,
+                                   std::shared_ptr<GcsResourceManager> gcs_resource_manager
+                                   )
     : gcs_node_manager_(gcs_node_manager),
-      cluster_resource_manager_(cluster_resource_manager) {}
+      cluster_resource_manager_(cluster_resource_manager),
+      gcs_resource_manager_(gcs_resource_manager)
+{}
 
 void GcsMonitorServer::HandleGetRayVersion(rpc::GetRayVersionRequest request,
                                            rpc::GetRayVersionReply *reply,
@@ -44,9 +48,9 @@ void GcsMonitorServer::HandleDrainAndKillNode(
 }
 
 void GcsMonitorServer::PopulateNodeStatuses(rpc::GetSchedulingStatusReply *reply) const {
-  const absl::flat_hash_map<scheduling::NodeID, Node> &scheduling_nodes =
+  const auto &scheduling_nodes =
       cluster_resource_manager_.GetResourceView();
-  const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>>
+  const auto
       &gcs_node_manager_nodes = gcs_node_manager_->GetAllAliveNodes();
 
   for (const auto &pair : gcs_node_manager_nodes) {
@@ -72,11 +76,40 @@ void GcsMonitorServer::PopulateNodeStatuses(rpc::GetSchedulingStatusReply *reply
   }
 }
 
+void GcsMonitorServer::PopulateResourceDemands(rpc::GetSchedulingStatusReply *reply) const {
+  auto task_load_by_shape = absl::flat_hash_map<google::protobuf::Map<std::string, double>, rpc::ResourceRequest*>();
+  const auto &resources_report_by_node = gcs_resource_manager_->NodeResourceReportView();
+  for (const auto &node_report_pair : resources_report_by_node) {
+    for (const auto &resource_demand : node_report_pair.second.resource_load_by_shape().resource_demands()) {
+      rpc::ResourceRequest *request = task_load_by_shape[resource_demand.shape()];
+      auto it = task_load_by_shape.find(resource_demand.shape());
+      if (it == task_load_by_shape.end()) {
+        request = reply->add_resource_requests();
+        task_load_by_shape[resource_demand.shape()] = request;
+        request->set_resource_request_type(rpc::ResourceRequest_ResourceRequestType::ResourceRequest_ResourceRequestType_SHORT_RESERVATION);
+        request->set_count(0);
+        request->set_description("tasks/actors");
+        request->add_bundles()->mutable_resources()->insert(resource_demand.shape().begin(), resource_demand.shape().end());
+      } else {
+        request = it->second;
+      }
+
+      RAY_CHECK(request) << "Monitor server resource demand could not be properly allocated.";
+      int count = request->count();
+      count += resource_demand.num_ready_requests_queued();
+      count += resource_demand.num_infeasible_requests_queued();
+      count += resource_demand.backlog_size();
+      request->set_count(count);
+    }
+  }
+}
+
 void GcsMonitorServer::HandleGetSchedulingStatus(
     rpc::GetSchedulingStatusRequest request,
     rpc::GetSchedulingStatusReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
   PopulateNodeStatuses(reply);
+  PopulateResourceDemands(reply);
 
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.cc
@@ -41,12 +41,10 @@ void GcsMonitorServer::HandleDrainAndKillNode(
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 
-
-  void GcsMonitorServer::HandleGetSchedulingStatus(rpc::GetSchedulingStatusRequest request,
-                                                   rpc::GetSchedulingStatusReply *reply,
-                                                   rpc::SendReplyCallback send_reply_callback) {
-
-}
+void GcsMonitorServer::HandleGetSchedulingStatus(
+    rpc::GetSchedulingStatusRequest request,
+    rpc::GetSchedulingStatusReply *reply,
+    rpc::SendReplyCallback send_reply_callback) {}
 
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.cc
@@ -79,6 +79,10 @@ void GcsMonitorServer::PopulateResourceDemands(
       absl::flat_hash_map<google::protobuf::Map<std::string, double>,
                           rpc::ResourceRequest *>();
   const auto &resources_report_by_node = gcs_resource_manager_->NodeResourceReportView();
+  // NOTE: The nodes returned in this loop are eventually consistent with the
+  // loop in `PopulateNodeStatuses`. This shouldn't be a problem since nodes
+  // shouldn't have resource demands when nodes are downscaled and there will
+  // always be race conditions if a node with demands dies unexpectedly.
   for (const auto &node_report_pair : resources_report_by_node) {
     for (const auto &resource_demand :
          node_report_pair.second.resource_load_by_shape().resource_demands()) {

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.h
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.h
@@ -40,9 +40,7 @@ class GcsMonitorServer : public rpc::MonitorServiceHandler {
                                  rpc::SendReplyCallback send_reply_callback) override;
 
  private:
-
   void PopulateNodeStatuses(rpc::GetSchedulingStatusReply *reply) const;
-
 
   std::shared_ptr<GcsNodeManager> gcs_node_manager_;
   ClusterResourceManager &cluster_resource_manager_;

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.h
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.h
@@ -25,7 +25,9 @@ namespace gcs {
 class GcsMonitorServer : public rpc::MonitorServiceHandler {
  public:
   explicit GcsMonitorServer(std::shared_ptr<GcsNodeManager> gcs_node_manager,
-                            ClusterResourceManager &cluster_resource_manager);
+                            ClusterResourceManager &cluster_resource_manager,
+                            std::shared_ptr<GcsResourceManager> gcs_resource_manager
+                            );
 
   void HandleGetRayVersion(rpc::GetRayVersionRequest request,
                            rpc::GetRayVersionReply *reply,
@@ -41,9 +43,11 @@ class GcsMonitorServer : public rpc::MonitorServiceHandler {
 
  private:
   void PopulateNodeStatuses(rpc::GetSchedulingStatusReply *reply) const;
+  void PopulateResourceDemands(rpc::GetSchedulingStatusReply *reply) const;
 
   std::shared_ptr<GcsNodeManager> gcs_node_manager_;
   ClusterResourceManager &cluster_resource_manager_;
+  std::shared_ptr<GcsResourceManager> gcs_resource_manager_;
 };
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.h
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.h
@@ -24,7 +24,7 @@ namespace gcs {
 /// GCS and `monitor.py`
 class GcsMonitorServer : public rpc::MonitorServiceHandler {
  public:
-  explicit GcsMonitorServer(std::shared_ptr<GcsNodeManager> gcs_node_manager);
+  explicit GcsMonitorServer(std::shared_ptr<GcsNodeManager> gcs_node_manager, ClusterResourceManager &cluster_resource_manager);
 
   void HandleGetRayVersion(rpc::GetRayVersionRequest request,
                            rpc::GetRayVersionReply *reply,
@@ -40,6 +40,7 @@ class GcsMonitorServer : public rpc::MonitorServiceHandler {
 
  private:
   std::shared_ptr<GcsNodeManager> gcs_node_manager_;
+  ClusterResourceManager &cluster_resource_manager_;
 };
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.h
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.h
@@ -34,6 +34,10 @@ class GcsMonitorServer : public rpc::MonitorServiceHandler {
                               rpc::DrainAndKillNodeReply *reply,
                               rpc::SendReplyCallback send_reply_callback) override;
 
+  void HandleGetSchedulingStatus(rpc::GetSchedulingStatusRequest request,
+                                 rpc::GetSchedulingStatusReply *reply,
+                                 rpc::SendReplyCallback send_reply_callback) override;
+
  private:
   std::shared_ptr<GcsNodeManager> gcs_node_manager_;
 };

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.h
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.h
@@ -40,6 +40,10 @@ class GcsMonitorServer : public rpc::MonitorServiceHandler {
                                  rpc::SendReplyCallback send_reply_callback) override;
 
  private:
+
+  void PopulateNodeStatuses(rpc::GetSchedulingStatusReply *reply) const;
+
+
   std::shared_ptr<GcsNodeManager> gcs_node_manager_;
   ClusterResourceManager &cluster_resource_manager_;
 };

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.h
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.h
@@ -26,8 +26,7 @@ class GcsMonitorServer : public rpc::MonitorServiceHandler {
  public:
   explicit GcsMonitorServer(std::shared_ptr<GcsNodeManager> gcs_node_manager,
                             ClusterResourceManager &cluster_resource_manager,
-                            std::shared_ptr<GcsResourceManager> gcs_resource_manager
-                            );
+                            std::shared_ptr<GcsResourceManager> gcs_resource_manager);
 
   void HandleGetRayVersion(rpc::GetRayVersionRequest request,
                            rpc::GetRayVersionReply *reply,

--- a/src/ray/gcs/gcs_server/gcs_monitor_server.h
+++ b/src/ray/gcs/gcs_server/gcs_monitor_server.h
@@ -24,7 +24,8 @@ namespace gcs {
 /// GCS and `monitor.py`
 class GcsMonitorServer : public rpc::MonitorServiceHandler {
  public:
-  explicit GcsMonitorServer(std::shared_ptr<GcsNodeManager> gcs_node_manager, ClusterResourceManager &cluster_resource_manager);
+  explicit GcsMonitorServer(std::shared_ptr<GcsNodeManager> gcs_node_manager,
+                            ClusterResourceManager &cluster_resource_manager);
 
   void HandleGetRayVersion(rpc::GetRayVersionRequest request,
                            rpc::GetRayVersionReply *reply,

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -96,8 +96,8 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// Get all alive nodes.
   ///
   /// \return all alive nodes.
-  virtual const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> &GetAllAliveNodes()
-      const {
+  virtual const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>>
+      &GetAllAliveNodes() const {
     return alive_nodes_;
   }
 

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -98,8 +98,8 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// Get all alive nodes.
   ///
   /// \return all alive nodes.
-  const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>>
-      &GetAllAliveNodes() const {
+  const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> &GetAllAliveNodes()
+      const {
     return alive_nodes_;
   }
 

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -96,7 +96,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// Get all alive nodes.
   ///
   /// \return all alive nodes.
-  const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> &GetAllAliveNodes()
+  virtual const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> &GetAllAliveNodes()
       const {
     return alive_nodes_;
   }

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <gtest/gtest_prod.h>
+
 #include <boost/bimap.hpp>
 #include <boost/bimap/unordered_set_of.hpp>
 
@@ -96,7 +98,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// Get all alive nodes.
   ///
   /// \return all alive nodes.
-  virtual const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>>
+  const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>>
       &GetAllAliveNodes() const {
     return alive_nodes_;
   }
@@ -173,6 +175,8 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
       boost::bimap<boost::bimaps::unordered_set_of<NodeID, std::hash<NodeID>>,
                    boost::bimaps::unordered_set_of<std::string>>;
   NodeIDAddrBiMap node_map_;
+
+  friend GcsMonitorServerTest;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -142,7 +142,8 @@ void GcsResourceManager::UpdateResourceLoads(const rpc::ResourcesData &data) {
   }
 }
 
-const absl::flat_hash_map<NodeID, rpc::ResourcesData> &GcsResourceManager::NodeResourceReportView() const {
+const absl::flat_hash_map<NodeID, rpc::ResourcesData>
+    &GcsResourceManager::NodeResourceReportView() const {
   return node_resource_usages_;
 }
 

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -142,6 +142,10 @@ void GcsResourceManager::UpdateResourceLoads(const rpc::ResourcesData &data) {
   }
 }
 
+const absl::flat_hash_map<NodeID, rpc::ResourcesData> &GcsResourceManager::NodeResourceReportView() const {
+  return node_resource_usages_;
+}
+
 void GcsResourceManager::HandleReportResourceUsage(
     rpc::ReportResourceUsageRequest request,
     rpc::ReportResourceUsageReply *reply,

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -13,6 +13,8 @@
 // limitations under the License.
 #pragma once
 
+#include <gtest/gtest_prod.h>
+
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "ray/common/id.h"
@@ -27,6 +29,9 @@
 #include "src/ray/protobuf/gcs.pb.h"
 
 namespace ray {
+
+class GcsMonitorServerTest;
+
 using raylet::ClusterTaskManager;
 namespace gcs {
 /// Ideally, the logic related to resource calculation should be moved from
@@ -133,7 +138,10 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
   /// \param data The resource loads reported by raylet.
   void UpdateResourceLoads(const rpc::ResourcesData &data);
 
-  virtual const absl::flat_hash_map<NodeID, rpc::ResourcesData> &NodeResourceReportView()
+  /// Returns the mapping from node id to latest resource report.
+  ///
+  /// \returns The mapping from node id to latest resource report.
+  const absl::flat_hash_map<NodeID, rpc::ResourcesData> &NodeResourceReportView()
       const;
 
  private:
@@ -170,6 +178,8 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
   ClusterResourceManager &cluster_resource_manager_;
   NodeID local_node_id_;
   std::shared_ptr<ClusterTaskManager> cluster_task_manager_;
+
+  friend GcsMonitorServerTest;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -133,6 +133,8 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
   /// \param data The resource loads reported by raylet.
   void UpdateResourceLoads(const rpc::ResourcesData &data);
 
+  virtual const absl::flat_hash_map<NodeID, rpc::ResourcesData> &NodeResourceReportView() const;
+
  private:
   /// Aggregate nodes' pending task info.
   ///

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -141,8 +141,7 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
   /// Returns the mapping from node id to latest resource report.
   ///
   /// \returns The mapping from node id to latest resource report.
-  const absl::flat_hash_map<NodeID, rpc::ResourcesData> &NodeResourceReportView()
-      const;
+  const absl::flat_hash_map<NodeID, rpc::ResourcesData> &NodeResourceReportView() const;
 
  private:
   /// Aggregate nodes' pending task info.

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -133,7 +133,8 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
   /// \param data The resource loads reported by raylet.
   void UpdateResourceLoads(const rpc::ResourcesData &data);
 
-  virtual const absl::flat_hash_map<NodeID, rpc::ResourcesData> &NodeResourceReportView() const;
+  virtual const absl::flat_hash_map<NodeID, rpc::ResourcesData> &NodeResourceReportView()
+      const;
 
  private:
   /// Aggregate nodes' pending task info.

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -595,8 +595,9 @@ void GcsServer::InitGcsTaskManager() {
 
 void GcsServer::InitMonitorServer() {
   monitor_server_ = std::make_unique<GcsMonitorServer>(
-                                                       gcs_node_manager_, cluster_resource_scheduler_->GetClusterResourceManager(),
-                                                       gcs_resource_manager_);
+      gcs_node_manager_,
+      cluster_resource_scheduler_->GetClusterResourceManager(),
+      gcs_resource_manager_);
   monitor_grpc_service_.reset(
       new rpc::MonitorGrpcService(main_service_, *monitor_server_));
   rpc_server_.RegisterService(*monitor_grpc_service_);

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -594,7 +594,8 @@ void GcsServer::InitGcsTaskManager() {
 }
 
 void GcsServer::InitMonitorServer() {
-  monitor_server_ = std::make_unique<GcsMonitorServer>(gcs_node_manager_, cluster_resource_scheduler_->GetClusterResourceManager());
+  monitor_server_ = std::make_unique<GcsMonitorServer>(
+      gcs_node_manager_, cluster_resource_scheduler_->GetClusterResourceManager());
   monitor_grpc_service_.reset(
       new rpc::MonitorGrpcService(main_service_, *monitor_server_));
   rpc_server_.RegisterService(*monitor_grpc_service_);

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -594,7 +594,7 @@ void GcsServer::InitGcsTaskManager() {
 }
 
 void GcsServer::InitMonitorServer() {
-  monitor_server_ = std::make_unique<GcsMonitorServer>(gcs_node_manager_);
+  monitor_server_ = std::make_unique<GcsMonitorServer>(gcs_node_manager_, cluster_resource_scheduler_->GetClusterResourceManager());
   monitor_grpc_service_.reset(
       new rpc::MonitorGrpcService(main_service_, *monitor_server_));
   rpc_server_.RegisterService(*monitor_grpc_service_);

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -595,7 +595,8 @@ void GcsServer::InitGcsTaskManager() {
 
 void GcsServer::InitMonitorServer() {
   monitor_server_ = std::make_unique<GcsMonitorServer>(
-      gcs_node_manager_, cluster_resource_scheduler_->GetClusterResourceManager());
+                                                       gcs_node_manager_, cluster_resource_scheduler_->GetClusterResourceManager(),
+                                                       gcs_resource_manager_);
   monitor_grpc_service_.reset(
       new rpc::MonitorGrpcService(main_service_, *monitor_server_));
   rpc_server_.RegisterService(*monitor_grpc_service_);

--- a/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_mock_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_mock_test.cc
@@ -38,7 +38,7 @@ class GcsActorSchedulerMockTest : public Test {
   void SetUp() override {
     store_client = std::make_shared<MockStoreClient>();
     actor_table = std::make_unique<GcsActorTable>(store_client);
-    gcs_node_manager = std::make_unique<MockGcsNodeManager>();
+    gcs_node_manager = std::make_unique<GcsNodeManager>(nullptr, nullptr, nullptr);
     raylet_client = std::make_shared<MockRayletClientInterface>();
     core_worker_client = std::make_shared<rpc::MockCoreWorkerClientInterface>();
     client_pool = std::make_shared<rpc::NodeManagerClientPool>(
@@ -85,7 +85,7 @@ class GcsActorSchedulerMockTest : public Test {
   std::shared_ptr<MockStoreClient> store_client;
   std::unique_ptr<GcsActorTable> actor_table;
   std::unique_ptr<GcsActorScheduler> actor_scheduler;
-  std::unique_ptr<MockGcsNodeManager> gcs_node_manager;
+  std::unique_ptr<GcsNodeManager> gcs_node_manager;
   std::shared_ptr<rpc::MockCoreWorkerClientInterface> core_worker_client;
   std::shared_ptr<rpc::NodeManagerClientPool> client_pool;
   std::shared_ptr<CounterMap<std::pair<rpc::ActorTableData::ActorState, std::string>>>

--- a/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
@@ -27,11 +27,12 @@ using namespace testing;
 
 namespace ray {
 
-  NodeResources constructNodeResources(absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> available,absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> total) {
-    NodeResources resources;
-    return resources;
-  }
-
+NodeResources constructNodeResources(
+    absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> available,
+    absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> total) {
+  NodeResources resources;
+  return resources;
+}
 
 class GcsMonitorServerTest : public ::testing::Test {
  public:
@@ -50,8 +51,9 @@ TEST_F(GcsMonitorServerTest, TestRayVersion) {
   rpc::GetRayVersionRequest request;
   rpc::GetRayVersionReply reply;
   bool replied = false;
-  auto send_reply_callback =
-    [&replied](ray::Status status, std::function<void()> f1, std::function<void()> f2) { replied = true; };
+  auto send_reply_callback = [&replied](ray::Status status,
+                                        std::function<void()> f1,
+                                        std::function<void()> f2) { replied = true; };
 
   monitor_server_.HandleGetRayVersion(request, &reply, send_reply_callback);
 
@@ -63,8 +65,9 @@ TEST_F(GcsMonitorServerTest, TestDrainAndKillNode) {
   rpc::DrainAndKillNodeRequest request;
   rpc::DrainAndKillNodeReply reply;
   bool replied = false;
-  auto send_reply_callback =
-    [&replied](ray::Status status, std::function<void()> f1, std::function<void()> f2) { replied = true; };
+  auto send_reply_callback = [&replied](ray::Status status,
+                                        std::function<void()> f1,
+                                        std::function<void()> f2) { replied = true; };
 
   *request.add_node_ids() = NodeID::FromRandom().Binary();
   *request.add_node_ids() = NodeID::FromRandom().Binary();
@@ -80,27 +83,30 @@ TEST_F(GcsMonitorServerTest, TestGetSchedulingStatus) {
   rpc::GetSchedulingStatusRequest request;
   rpc::GetSchedulingStatusReply reply;
   bool replied = false;
-  auto send_reply_callback =
-    [&replied](ray::Status status, std::function<void()> f1, std::function<void()> f2) { replied = true; };
+  auto send_reply_callback = [&replied](ray::Status status,
+                                        std::function<void()> f1,
+                                        std::function<void()> f2) { replied = true; };
 
-  const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> gcs_node_manager_nodes;
+  const absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>>
+      gcs_node_manager_nodes;
 
-  // const absl::flat_hash_map<ray::NodeID, std::shared_ptr<ray::rpc::GcsNodeInfo>, absl::hash_internal::Hash<ray::NodeID>, std::equal_to<ray::NodeID>> 
+  // const absl::flat_hash_map<ray::NodeID, std::shared_ptr<ray::rpc::GcsNodeInfo>,
+  // absl::hash_internal::Hash<ray::NodeID>, std::equal_to<ray::NodeID>>
   //   return gcs_node_manager_nodes;
 
-       ON_CALL(*mock_node_manager_, GetAllAliveNodes()).WillByDefault(ReturnRef(gcs_node_manager_nodes));
+  ON_CALL(*mock_node_manager_, GetAllAliveNodes())
+      .WillByDefault(ReturnRef(gcs_node_manager_nodes));
 
   NodeID id_1 = NodeID::FromRandom();
-  cluster_resource_manager_.AddOrUpdateNode(scheduling::NodeID(id_1.Binary()), {{"CPU", 8}, {"custom", 1}}, {{"CPU", 8}, {"custom", 1}});
+  cluster_resource_manager_.AddOrUpdateNode(scheduling::NodeID(id_1.Binary()),
+                                            {{"CPU", 8}, {"custom", 1}},
+                                            {{"CPU", 8}, {"custom", 1}});
 
   // NodeID id_2 = NodeID::FromRandom();
 
+  monitor_server_.HandleGetSchedulingStatus(request, &reply, send_reply_callback);
 
-
-
-    monitor_server_.HandleGetSchedulingStatus(request, &reply, send_reply_callback);
-
-    ASSERT_TRUE(replied);
+  ASSERT_TRUE(replied);
 }
 
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
@@ -42,8 +42,10 @@ class GcsMonitorServerTest : public ::testing::Test {
   GcsMonitorServerTest()
       : mock_node_manager_(std::make_shared<gcs::MockGcsNodeManager>()),
         cluster_resource_manager_(),
-        mock_resource_manager_(std::make_shared<gcs::MockGcsResourceManager>(cluster_resource_manager_)),
-        monitor_server_(mock_node_manager_, cluster_resource_manager_, mock_resource_manager_) {}
+        mock_resource_manager_(
+            std::make_shared<gcs::MockGcsResourceManager>(cluster_resource_manager_)),
+        monitor_server_(
+            mock_node_manager_, cluster_resource_manager_, mock_resource_manager_) {}
 
  protected:
   std::shared_ptr<gcs::MockGcsNodeManager> mock_node_manager_;
@@ -99,10 +101,9 @@ TEST_F(GcsMonitorServerTest, TestGetSchedulingStatus) {
   EXPECT_CALL(*mock_node_manager_, GetAllAliveNodes());
 
   absl::flat_hash_map<NodeID, rpc::ResourcesData> gcs_resource_manager_nodes;
-  ON_CALL(*mock_resource_manager_, NodeResourceReportView).
-    WillByDefault(ReturnRef(gcs_resource_manager_nodes));
+  ON_CALL(*mock_resource_manager_, NodeResourceReportView)
+      .WillByDefault(ReturnRef(gcs_resource_manager_nodes));
   EXPECT_CALL(*mock_resource_manager_, NodeResourceReportView);
-
 
   NodeID id_1 = NodeID::FromRandom();
   cluster_resource_manager_.AddOrUpdateNode(

--- a/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
@@ -203,7 +203,7 @@ TEST_F(GcsMonitorServerTest, TestGetSchedulingStatus) {
       RAY_LOG(ERROR) << request.DebugString();
       ASSERT_EQ(request.resource_request_type(),
                 rpc::ResourceRequest_ResourceRequestType::
-                    ResourceRequest_ResourceRequestType_SHORT_RESERVATION);
+                    ResourceRequest_ResourceRequestType_TASK_RESERVATION);
       ASSERT_EQ(request.bundles().size(), 1);
       const auto &resources = request.bundles()[0].resources();
       if (resources.size() == 1 && resources.begin()->first == "CPU") {

--- a/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
@@ -57,9 +57,10 @@ class GcsMonitorServerTest : public ::testing::Test {
       : mock_node_manager_(std::make_shared<gcs::MockGcsNodeManager>()),
         cluster_resource_manager_(),
         mock_resource_manager_(
-                               std::make_shared<gcs::MockGcsResourceManager>(cluster_resource_manager_)),
+            std::make_shared<gcs::MockGcsResourceManager>(cluster_resource_manager_)),
         // mock_resource_manager_(
-                               // std::make_shared<gcs::MockGcsResourceManager>(io_context_, cluster_resource_manager_, NodeID::FromRandom(), nullptr)),
+        // std::make_shared<gcs::MockGcsResourceManager>(io_context_,
+        // cluster_resource_manager_, NodeID::FromRandom(), nullptr)),
         monitor_server_(
             mock_node_manager_, cluster_resource_manager_, mock_resource_manager_) {}
 
@@ -120,7 +121,8 @@ TEST_F(GcsMonitorServerTest, TestGetSchedulingStatus) {
                                         std::function<void()> f1,
                                         std::function<void()> f2) { replied = true; };
 
-  // absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> gcs_node_manager_nodes;
+  // absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>>
+  // gcs_node_manager_nodes;
 
   // ON_CALL(*mock_node_manager_, GetAllAliveNodes())
   //     .WillByDefault(ReturnRef(gcs_node_manager_nodes));

--- a/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
@@ -127,31 +127,31 @@ TEST_F(GcsMonitorServerTest, TestGetSchedulingStatus) {
     // Setup resource demand mocks.
     rpc::ResourcesData data;
     data.mutable_resource_load_by_shape()->add_resource_demands()->CopyFrom(
-                                                                            constructResourceDemand(
-                                                                                                    {
-                                                                                                      {"CPU", 0.75},
-                                                                                                    },
-                                                                                                    1,
-                                                                                                    2,
-                                                                                                    3));
+        constructResourceDemand(
+            {
+                {"CPU", 0.75},
+            },
+            1,
+            2,
+            3));
     data.mutable_resource_load_by_shape()->add_resource_demands()->CopyFrom(
-                                                                            constructResourceDemand(
-                                                                                                    {
-                                                                                                      {"custom", 0.25},
-                                                                                                    },
-                                                                                                    1,
-                                                                                                    1,
-                                                                                                    1));
+        constructResourceDemand(
+            {
+                {"custom", 0.25},
+            },
+            1,
+            1,
+            1));
 
     data.mutable_resource_load_by_shape()->add_resource_demands()->CopyFrom(
-                                                                            constructResourceDemand(
-                                                                                                    {
-                                                                                                      {"CPU", 0.75},
-                                                                                                      {"custom", 0.25},
-                                                                                                    },
-                                                                                                    1,
-                                                                                                    1,
-                                                                                                    1));
+        constructResourceDemand(
+            {
+                {"CPU", 0.75},
+                {"custom", 0.25},
+            },
+            1,
+            1,
+            1));
     gcs_resource_manager_nodes[id_1] = data;
   }
   {
@@ -171,7 +171,6 @@ TEST_F(GcsMonitorServerTest, TestGetSchedulingStatus) {
 
     gcs_node_manager_nodes[id_3] = Mocker::GenNodeInfo(0, "1.1.1.3", "Node1");
   }
-
 
   monitor_server_.HandleGetSchedulingStatus(request, &reply, send_reply_callback);
 
@@ -202,8 +201,9 @@ TEST_F(GcsMonitorServerTest, TestGetSchedulingStatus) {
 
     for (const auto &request : reply.resource_requests()) {
       RAY_LOG(ERROR) << request.DebugString();
-      ASSERT_EQ(request.resource_request_type(), rpc::ResourceRequest_ResourceRequestType::
-                ResourceRequest_ResourceRequestType_SHORT_RESERVATION);
+      ASSERT_EQ(request.resource_request_type(),
+                rpc::ResourceRequest_ResourceRequestType::
+                    ResourceRequest_ResourceRequestType_SHORT_RESERVATION);
       ASSERT_EQ(request.bundles().size(), 1);
       const auto &resources = request.bundles()[0].resources();
       if (resources.size() == 1 && resources.begin()->first == "CPU") {

--- a/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
@@ -169,6 +169,7 @@ TEST_F(GcsMonitorServerTest, TestGetSchedulingStatus) {
             1,
             1,
             1));
+    gcs_resource_manager_nodes[id_1] = data;
   }
 
   monitor_server_.HandleGetSchedulingStatus(request, &reply, send_reply_callback);

--- a/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
@@ -89,33 +89,28 @@ TEST_F(GcsMonitorServerTest, TestGetSchedulingStatus) {
                                         std::function<void()> f1,
                                         std::function<void()> f2) { replied = true; };
 
-  absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>>
-      gcs_node_manager_nodes;
+  absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> gcs_node_manager_nodes;
 
   ON_CALL(*mock_node_manager_, GetAllAliveNodes())
       .WillByDefault(ReturnRef(gcs_node_manager_nodes));
 
-
-
   NodeID id_1 = NodeID::FromRandom();
-  cluster_resource_manager_.AddOrUpdateNode(scheduling::NodeID(id_1.Binary()),
-                                            constructNodeResources(
-                                                                   {{scheduling::ResourceID::CPU(), 0.5}, {scheduling::ResourceID("custom"), 4}},
-                                                                   {{scheduling::ResourceID::CPU(), 1}, {scheduling::ResourceID("custom"), 8}}
-                                            ));
+  cluster_resource_manager_.AddOrUpdateNode(
+      scheduling::NodeID(id_1.Binary()),
+      constructNodeResources(
+          {{scheduling::ResourceID::CPU(), 0.5}, {scheduling::ResourceID("custom"), 4}},
+          {{scheduling::ResourceID::CPU(), 1}, {scheduling::ResourceID("custom"), 8}}));
   gcs_node_manager_nodes[id_1] = Mocker::GenNodeInfo(0, "1.1.1.1", "Node1");
 
-
   NodeID id_2 = NodeID::FromRandom();
-  cluster_resource_manager_.AddOrUpdateNode(scheduling::NodeID(id_2.Binary()),
-                                            constructNodeResources(
-                                                                   {{scheduling::ResourceID::CPU(), 0.5}, {scheduling::ResourceID("custom"), 4}},
-                                                                   {{scheduling::ResourceID::CPU(), 1}, {scheduling::ResourceID("custom"), 8}}
-                                                                   ));
+  cluster_resource_manager_.AddOrUpdateNode(
+      scheduling::NodeID(id_2.Binary()),
+      constructNodeResources(
+          {{scheduling::ResourceID::CPU(), 0.5}, {scheduling::ResourceID("custom"), 4}},
+          {{scheduling::ResourceID::CPU(), 1}, {scheduling::ResourceID("custom"), 8}}));
 
   NodeID id_3 = NodeID::FromRandom();
   gcs_node_manager_nodes[id_3] = Mocker::GenNodeInfo(0, "1.1.1.3", "Node1");
-
 
   monitor_server_.HandleGetSchedulingStatus(request, &reply, send_reply_callback);
 
@@ -125,8 +120,10 @@ TEST_F(GcsMonitorServerTest, TestGetSchedulingStatus) {
   ASSERT_EQ(reply.node_statuses(0).address(), "1.1.1.1");
 
   ASSERT_EQ(reply.node_statuses()[0].available_resources().size(), 2);
-  ASSERT_EQ(reply.mutable_node_statuses(0)->mutable_available_resources()->at("CPU"), 0.5);
-  ASSERT_EQ(reply.mutable_node_statuses(0)->mutable_available_resources()->at("custom"), 4);
+  ASSERT_EQ(reply.mutable_node_statuses(0)->mutable_available_resources()->at("CPU"),
+            0.5);
+  ASSERT_EQ(reply.mutable_node_statuses(0)->mutable_available_resources()->at("custom"),
+            4);
 
   ASSERT_EQ(reply.node_statuses()[0].total_resources().size(), 2);
   ASSERT_EQ(reply.mutable_node_statuses(0)->mutable_total_resources()->at("CPU"), 1);

--- a/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
@@ -37,8 +37,11 @@ NodeResources constructNodeResources(
   return resources;
 }
 
-rpc::ResourceDemand constructResourceDemand(abls::flat_hash_map<std::string, double> shape, int num_ready_requests_queued, int num_infeasible_requests_queued, int backlog_size) {
-
+rpc::ResourceDemand constructResourceDemand(
+    abls::flat_hash_map<std::string, double> shape,
+    int num_ready_requests_queued,
+    int num_infeasible_requests_queued,
+    int backlog_size) {
   rpc::ResourceDemand demand;
   demand->mutable_shape()->insert(shape.begin(), shape.end());
   demand->set_num_ready_requests_queued(num_ready_requests_queued);
@@ -123,30 +126,50 @@ TEST_F(GcsMonitorServerTest, TestGetSchedulingStatus) {
   {
     // Setup the node management mocks.
     cluster_resource_manager_.AddOrUpdateNode(
-                                              scheduling::NodeID(id_1.Binary()),
-                                              constructNodeResources(
-                                                                     {{scheduling::ResourceID::CPU(), 0.5}, {scheduling::ResourceID("custom"), 4}},
-                                                                     {{scheduling::ResourceID::CPU(), 1}, {scheduling::ResourceID("custom"), 8}}));
+        scheduling::NodeID(id_1.Binary()),
+        constructNodeResources(
+            {{scheduling::ResourceID::CPU(), 0.5}, {scheduling::ResourceID("custom"), 4}},
+            {{scheduling::ResourceID::CPU(), 1}, {scheduling::ResourceID("custom"), 8}}));
     gcs_node_manager_nodes[id_1] = Mocker::GenNodeInfo(0, "1.1.1.1", "Node1");
 
     cluster_resource_manager_.AddOrUpdateNode(
-                                              scheduling::NodeID(id_2.Binary()),
-                                              constructNodeResources(
-                                                                     {{scheduling::ResourceID::CPU(), 0.5}, {scheduling::ResourceID("custom"), 4}},
-                                                                     {{scheduling::ResourceID::CPU(), 1}, {scheduling::ResourceID("custom"), 8}}));
+        scheduling::NodeID(id_2.Binary()),
+        constructNodeResources(
+            {{scheduling::ResourceID::CPU(), 0.5}, {scheduling::ResourceID("custom"), 4}},
+            {{scheduling::ResourceID::CPU(), 1}, {scheduling::ResourceID("custom"), 8}}));
 
     gcs_node_manager_nodes[id_3] = Mocker::GenNodeInfo(0, "1.1.1.3", "Node1");
   }
 
   {
     rpc::ResourcesData data;
-    data->mutable_resource_load_by_shape()->add_resource_demands()->CopyFrom(constructResourceDemand(
-                                                                                                     {},
-                                                                                                     1,1,1
+    data->mutable_resource_load_by_shape()->add_resource_demands()->CopyFrom(
+        constructResourceDemand(
+            {
+                {"CPU", 0.75},
+            },
+            1,
+            2,
+            3));
+    data->mutable_resource_load_by_shape()->add_resource_demands()->CopyFrom(
+        constructResourceDemand(
+            {
+                {"custom", 0.25},
+            },
+            1,
+            1,
+            1));
 
-                                                                                                     ));
+    data->mutable_resource_load_by_shape()->add_resource_demands()->CopyFrom(
+        constructResourceDemand(
+            {
+                {"CPU", 0.75},
+                {"custom", 0.25},
+            },
+            1,
+            1,
+            1));
   }
-
 
   monitor_server_.HandleGetSchedulingStatus(request, &reply, send_reply_callback);
 

--- a/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc
@@ -58,9 +58,6 @@ class GcsMonitorServerTest : public ::testing::Test {
         cluster_resource_manager_(),
         mock_resource_manager_(
             std::make_shared<gcs::MockGcsResourceManager>(cluster_resource_manager_)),
-        // mock_resource_manager_(
-        // std::make_shared<gcs::MockGcsResourceManager>(io_context_,
-        // cluster_resource_manager_, NodeID::FromRandom(), nullptr)),
         monitor_server_(
             mock_node_manager_, cluster_resource_manager_, mock_resource_manager_) {}
 
@@ -120,18 +117,6 @@ TEST_F(GcsMonitorServerTest, TestGetSchedulingStatus) {
   auto send_reply_callback = [&replied](ray::Status status,
                                         std::function<void()> f1,
                                         std::function<void()> f2) { replied = true; };
-
-  // absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>>
-  // gcs_node_manager_nodes;
-
-  // ON_CALL(*mock_node_manager_, GetAllAliveNodes())
-  //     .WillByDefault(ReturnRef(gcs_node_manager_nodes));
-  // EXPECT_CALL(*mock_node_manager_, GetAllAliveNodes());
-
-  // absl::flat_hash_map<NodeID, rpc::ResourcesData> gcs_resource_manager_nodes;
-  // ON_CALL(*mock_resource_manager_, NodeResourceReportView)
-  //     .WillByDefault(ReturnRef(gcs_resource_manager_nodes));
-  // EXPECT_CALL(*mock_resource_manager_, NodeResourceReportView);
 
   NodeID id_1 = NodeID::FromRandom();
   NodeID id_2 = NodeID::FromRandom();

--- a/src/ray/protobuf/monitor.proto
+++ b/src/ray/protobuf/monitor.proto
@@ -32,6 +32,78 @@ message DrainAndKillNodeReply {
   repeated bytes drained_nodes = 2;
 }
 
+message ResourceBundle {
+  // Mapping from resource name to quantity.
+  map<string, double> resources = 1;
+}
+
+message ResourceRequest {
+  enum ResourceRequestType {
+    // A request which needs resources for a short period of time (like a
+    // task). It may make sense for the autoscaler to not provision enough
+    // resources to satisfy these since they could run sequentially on the same
+    // node.
+    SHORT_RESERVATION = 0;
+    // A request which will hold resources for a longer period of time (like an
+    // actor or placement group). The autoscaler should provision enough
+    // resources for all of these to run concurrently if possible.
+    LONG_RESERVATION = 1;
+    // The bundles in this reservation cannot belong on the same node. The
+    // autoscaler may need to launch multiple nodes to satisfy these bundles
+    // even if the nodes aren't completely utilized.
+    STRICT_SPREAD_RESERVATION = 2;
+    // A request to provision resources, even though this request won't use
+    // them. This is useful for API's like
+    // `autoscaler.sdk.request_resources()`.
+    MIN_RESOURCES = 3;
+  }
+
+  // The request type. See enum values for more details.
+  ResourceRequestType resource_request_type = 1;
+
+  // The number of requests of this type. Note this is a performance
+  // optimization. Clients should provide the same semantics as if many
+  // ResourceRequests of count=1 were returned.
+  int32 count = 2;
+
+  // Additional information which about the request type which is not relevant
+  // for scheduling, but may still be interesting for observability. For
+  // example, details about the underlying Ray scheduling strategy.
+  string description = 3;
+
+  // The bundles in this request. By default, there are no placement
+  // constraints on these bundles.
+  repeated ResourceBundle bundles = 4;
+}
+
+message NodeStatus {
+  // The unique id of this node in the cluster.
+  bytes node_id = 1;
+
+  // The address of the node. 
+  string address = 2;
+
+  // An optional node type.
+  optional string node_type = 3;
+
+  // The available resources on the node.
+  map<string,double> available_resources = 4;
+
+  // The corresponding total resources on the node.
+  map<string, double> total_resources = 5;
+}
+
+message GetSchedulingStatusRequest {}
+
+message GetSchedulingStatusReply {
+  // The total resource requests by the cluster.
+  repeated ResourceRequest resource_requests = 1;
+
+  // The status of the nodes in the cluster.
+  repeated NodeStatus node_statuses= 2;
+}
+
+
 // This service provides a stable interface for a monitor/autoscaler process to interact
 // with Ray.
 service MonitorGcsService {
@@ -40,4 +112,6 @@ service MonitorGcsService {
   // Request that GCS drain and kill a node. This call is idempotent, and could
   // need to be retried if the head node fails.
   rpc DrainAndKillNode(DrainAndKillNodeRequest) returns (DrainAndKillNodeReply);
+
+  // rpc GetSchedulingStatus(GetSchedulingStatusRequest) returns (GetSchedulingStatusReply);
 }

--- a/src/ray/protobuf/monitor.proto
+++ b/src/ray/protobuf/monitor.proto
@@ -113,5 +113,5 @@ service MonitorGcsService {
   // need to be retried if the head node fails.
   rpc DrainAndKillNode(DrainAndKillNodeRequest) returns (DrainAndKillNodeReply);
 
-  // rpc GetSchedulingStatus(GetSchedulingStatusRequest) returns (GetSchedulingStatusReply);
+  rpc GetSchedulingStatus(GetSchedulingStatusRequest) returns (GetSchedulingStatusReply);
 }

--- a/src/ray/protobuf/monitor.proto
+++ b/src/ray/protobuf/monitor.proto
@@ -75,11 +75,11 @@ message NodeStatus {
   // The unique id of this node in the cluster.
   bytes node_id = 1;
 
-  // The address of the node. 
+  // The address of the node.
   string address = 2;
 
   // The available resources on the node.
-  map<string,double> available_resources = 3;
+  map<string, double> available_resources = 3;
 
   // The corresponding total resources on the node.
   map<string, double> total_resources = 4;
@@ -92,9 +92,8 @@ message GetSchedulingStatusReply {
   repeated ResourceRequest resource_requests = 1;
 
   // The status of the nodes in the cluster.
-  repeated NodeStatus node_statuses= 2;
+  repeated NodeStatus node_statuses = 2;
 }
-
 
 // This service provides a stable interface for a monitor/autoscaler process to interact
 // with Ray.
@@ -107,4 +106,3 @@ service MonitorGcsService {
 
   rpc GetSchedulingStatus(GetSchedulingStatusRequest) returns (GetSchedulingStatusReply);
 }
-

--- a/src/ray/protobuf/monitor.proto
+++ b/src/ray/protobuf/monitor.proto
@@ -107,3 +107,4 @@ service MonitorGcsService {
 
   rpc GetSchedulingStatus(GetSchedulingStatusRequest) returns (GetSchedulingStatusReply);
 }
+

--- a/src/ray/protobuf/monitor.proto
+++ b/src/ray/protobuf/monitor.proto
@@ -43,19 +43,19 @@ message ResourceRequest {
     // task). It may make sense for the autoscaler to not provision enough
     // resources to satisfy these since they could run sequentially on the same
     // node.
-    SHORT_RESERVATION = 0;
-    // A request which will hold resources for a longer period of time (like a
-    // placement group). The autoscaler should provision enough resources for
-    // all of these to run concurrently if possible.
-    LONG_RESERVATION = 1;
-    // The bundles in this reservation cannot belong on the same node. The
-    // autoscaler may need to launch multiple nodes to satisfy these bundles
-    // even if the nodes aren't completely utilized.
-    STRICT_SPREAD_RESERVATION = 2;
+    TASK_RESERVATION = 0;
+    // A strict spread placement group reservation.
+    STRICT_SPREAD_RESERVATION = 1;
+    // A soft spread placement group reservation.
+    SPREAD_RESERVATION = 2;
+    // A soft pack placement group reservation.
+    PACK_RESERVATION = 3;
+    // A strict pack reservation.
+    STRICT_PACK_RESERVATION = 4;
     // A request to provision resources, even though this request won't use
     // them. This is useful for API's like
     // `autoscaler.sdk.request_resources()`.
-    MIN_RESOURCES = 3;
+    MIN_RESOURCES = 5;
   }
 
   // The request type. See enum values for more details.
@@ -66,14 +66,9 @@ message ResourceRequest {
   // ResourceRequests of count=1 were returned.
   int32 count = 2;
 
-  // Additional information which about the request type which is not relevant
-  // for scheduling, but may still be interesting for observability. For
-  // example, details about the underlying Ray scheduling strategy.
-  string description = 3;
-
   // The bundles in this request. By default, there are no placement
   // constraints on these bundles.
-  repeated ResourceBundle bundles = 4;
+  repeated ResourceBundle bundles = 3;
 }
 
 message NodeStatus {

--- a/src/ray/protobuf/monitor.proto
+++ b/src/ray/protobuf/monitor.proto
@@ -83,14 +83,11 @@ message NodeStatus {
   // The address of the node. 
   string address = 2;
 
-  // An optional node type.
-  optional string node_type = 3;
-
   // The available resources on the node.
-  map<string,double> available_resources = 4;
+  map<string,double> available_resources = 3;
 
   // The corresponding total resources on the node.
-  map<string, double> total_resources = 5;
+  map<string, double> total_resources = 4;
 }
 
 message GetSchedulingStatusRequest {}

--- a/src/ray/protobuf/monitor.proto
+++ b/src/ray/protobuf/monitor.proto
@@ -44,9 +44,9 @@ message ResourceRequest {
     // resources to satisfy these since they could run sequentially on the same
     // node.
     SHORT_RESERVATION = 0;
-    // A request which will hold resources for a longer period of time (like an
-    // actor or placement group). The autoscaler should provision enough
-    // resources for all of these to run concurrently if possible.
+    // A request which will hold resources for a longer period of time (like a
+    // placement group). The autoscaler should provision enough resources for
+    // all of these to run concurrently if possible.
     LONG_RESERVATION = 1;
     // The bundles in this reservation cannot belong on the same node. The
     // autoscaler may need to launch multiple nodes to satisfy these bundles

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -30,6 +30,7 @@
 #include "src/ray/protobuf/gcs.pb.h"
 
 namespace ray {
+  class GcsMonitorServerTest;
 namespace raylet {
 class ClusterTaskManagerTest;
 class SchedulingPolicyTest;
@@ -186,6 +187,7 @@ class ClusterResourceManager {
   FRIEND_TEST(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources);
   FRIEND_TEST(ClusterResourceSchedulerTest, TestForceSpillback);
   FRIEND_TEST(ClusterResourceSchedulerTest, AffinityWithBundleScheduleTest);
+  FRIEND_TEST(GcsMonitorServerTest, TestGetSchedulingStatus);
 
   friend class raylet::SchedulingPolicyTest;
   friend class raylet_scheduling_policy::HybridSchedulingPolicyTest;

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -30,7 +30,7 @@
 #include "src/ray/protobuf/gcs.pb.h"
 
 namespace ray {
-  class GcsMonitorServerTest;
+class GcsMonitorServerTest;
 namespace raylet {
 class ClusterTaskManagerTest;
 class SchedulingPolicyTest;

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -191,7 +191,6 @@ class ClusterResourceManager {
 
   friend class raylet::SchedulingPolicyTest;
   friend class raylet_scheduling_policy::HybridSchedulingPolicyTest;
-  // friend class gcs::GcsMonitorServerTest;
 };
 
 }  // end namespace ray

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -191,6 +191,7 @@ class ClusterResourceManager {
 
   friend class raylet::SchedulingPolicyTest;
   friend class raylet_scheduling_policy::HybridSchedulingPolicyTest;
+  // friend class gcs::GcsMonitorServerTest;
 };
 
 }  // end namespace ray

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -228,8 +228,8 @@ class MonitorGcsServiceHandler {
                                       SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleGetSchedulingStatus(GetSchedulingStatusRequest request,
-                                      GetSchedulingStatusReply *reply,
-                                      SendReplyCallback send_reply_callback) = 0;
+                                         GetSchedulingStatusReply *reply,
+                                         SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `MonitorServer`.

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -226,6 +226,10 @@ class MonitorGcsServiceHandler {
   virtual void HandleDrainAndKillNode(DrainAndKillNodeRequest request,
                                       DrainAndKillNodeReply *reply,
                                       SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleGetSchedulingStatus(GetSchedulingStatusRequest request,
+                                      GetSchedulingStatusReply *reply,
+                                      SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `MonitorServer`.
@@ -246,6 +250,7 @@ class MonitorGrpcService : public GrpcService {
       std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
     MONITOR_SERVICE_RPC_HANDLER(GetRayVersion);
     MONITOR_SERVICE_RPC_HANDLER(DrainAndKillNode);
+    MONITOR_SERVICE_RPC_HANDLER(GetSchedulingStatus);
   }
 
  private:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds a `GetSchedulingStatus` endpoint for `MonitorService`. It populates it with just actor/task demands for now to prevent this PR from getting too complicated. The next follow up will populate placement group and `ray.autoscaler.sdk.request_resources()`. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Related to https://github.com/ray-project/ray/issues/31826

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
