### PR TITLE
[Core][C++ Worker] Cross language call support bytes[] type

### DIFF
--- a/cpp/src/ray/test/cluster/cluster_mode_xlang_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_xlang_test.cc
@@ -52,6 +52,17 @@ TEST(RayClusterModeXLangTest, JavaInvocationTest) {
       named_actor_handle.Task(ray::JavaActorMethod<int>{"getValue"}).Remote();
   EXPECT_EQ(0, *named_actor_obj1.Get());
 
+  std::vector<std::byte> bytes = {std::byte{1}, std::byte{2}, std::byte{3}};
+  auto ref_bytes = java_class_actor_handle
+                       .Task(ray::JavaActorMethod<std::vector<std::byte>>{"echoBytes"})
+                       .Remote(bytes);
+  EXPECT_EQ(*ref_bytes.Get(), bytes);
+
+  auto ref_bytes2 = java_class_actor_handle
+                        .Task(ray::JavaActorMethod<std::vector<std::byte>>{"echoBytes"})
+                        .Remote(std::vector<std::byte>());
+  EXPECT_EQ(*ref_bytes2.Get(), std::vector<std::byte>());
+
   // Test get other java actor by actor name.
   auto ref_1 =
       java_class_actor_handle.Task(ray::JavaActorMethod<std::string>{"createChildActor"})
@@ -63,6 +74,14 @@ TEST(RayClusterModeXLangTest, JavaInvocationTest) {
   ray::ActorHandleXlang &child_actor = *child_actor_optional;
   auto ref_2 = child_actor.Task(ray::JavaActorMethod<int>{"getValue"}).Remote();
   EXPECT_EQ(0, *ref_2.Get());
+
+  auto ref_3 =
+      child_actor.Task(ray::JavaActorMethod<std::string>{"echo"}).Remote("C++ worker");
+  EXPECT_EQ("C++ worker", *ref_3.Get());
+
+  auto ref_4 = child_actor.Task(ray::JavaActorMethod<std::vector<std::byte>>{"echoBytes"})
+                   .Remote(bytes);
+  EXPECT_EQ(*ref_4.Get(), bytes);
 }
 
 TEST(RayClusterModeXLangTest, GetXLangActorByNameTest) {

--- a/cpp/src/ray/test/cluster/counter.cc
+++ b/cpp/src/ray/test/cluster/counter.cc
@@ -122,7 +122,9 @@ RAY_REMOTE(RAY_FUNC(Counter::FactoryCreate),
            &Counter::Plus1ForActor,
            &Counter::GetCount,
            &Counter::CreateNestedChildActor,
-           &Counter::GetBytes);
+           &Counter::GetBytes,
+           &Counter::echoBytes,
+           &Counter::echoString);
 
 RAY_REMOTE(ActorConcurrentCall::FactoryCreate, &ActorConcurrentCall::CountDown);
 

--- a/cpp/src/ray/test/cluster/counter.h
+++ b/cpp/src/ray/test/cluster/counter.h
@@ -57,6 +57,10 @@ class Counter {
     return bytes;
   }
 
+  std::vector<std::byte> echoBytes(const std::vector<std::byte> &bytes) { return bytes; }
+
+  std::string echoString(const std::string &str) { return str; }
+
   int GetIntVal(ray::ObjectRef<ray::ObjectRef<int>> obj) {
     auto val = *obj.Get();
     return *val.Get();
@@ -76,9 +80,6 @@ class Counter {
 };
 
 std::string GetEnvVar(std::string key);
-
-inline Counter *CreateCounter() { return new Counter(0); }
-RAY_REMOTE(CreateCounter);
 
 class CountDownLatch {
  public:

--- a/cpp/src/ray/test/serialization_test.cc
+++ b/cpp/src/ray/test/serialization_test.cc
@@ -41,3 +41,23 @@ TEST(SerializationTest, TypeHybridTest) {
   EXPECT_EQ(in_arg1, out_arg1);
   EXPECT_EQ(in_arg2, out_arg2);
 }
+
+TEST(SerializationTest, BoundaryValueTest) {
+  std::string in_arg1 = "", out_arg1;
+  msgpack::sbuffer buffer1 = ray::internal::Serializer::Serialize(in_arg1);
+  out_arg1 =
+      ray::internal::Serializer::Deserialize<std::string>(buffer1.data(), buffer1.size());
+  EXPECT_EQ(in_arg1, out_arg1);
+
+  std::vector<std::byte> in_arg2, out_arg2;
+  msgpack::sbuffer buffer2 = ray::internal::Serializer::Serialize(in_arg2);
+  out_arg2 = ray::internal::Serializer::Deserialize<std::vector<std::byte>>(
+      buffer1.data(), buffer1.size());
+  EXPECT_EQ(in_arg2, out_arg2);
+
+  char *in_arg3 = nullptr;
+  msgpack::sbuffer buffer3 = ray::internal::Serializer::Serialize(in_arg3, 0);
+  auto out_arg3 = ray::internal::Serializer::Deserialize<std::vector<std::byte>>(
+      buffer1.data(), buffer1.size());
+  EXPECT_EQ(std::vector<std::byte>(), out_arg3);
+}

--- a/cpp/test_python_call_cpp.py
+++ b/cpp/test_python_call_cpp.py
@@ -66,7 +66,9 @@ def test_cross_language_cpp():
 
 
 def test_cross_language_cpp_actor():
-    actor = ray.cross_language.cpp_actor_class("CreateCounter", "Counter").remote()
+    actor = ray.cross_language.cpp_actor_class(
+        "RAY_FUNC(Counter::FactoryCreate)", "Counter"
+    ).remote()
     obj = actor.Plus1.remote()
     assert 1 == ray.get(obj)
 

--- a/java/test/src/main/java/io/ray/test/Counter.java
+++ b/java/test/src/main/java/io/ray/test/Counter.java
@@ -31,6 +31,10 @@ public class Counter {
     return str;
   }
 
+  public byte[] echoBytes(byte[] bytes) {
+    return bytes;
+  }
+
   public String createChildActor(String actorName) {
     childActor = Ray.actor(Counter::new, 0).setName(actorName).remote();
     Assert.assertEquals(Integer.valueOf(0), childActor.task(Counter::getValue).remote().get());


### PR DESCRIPTION
## Why are these changes needed?
Cross-language calls between Java and C++ support bytes arrays
java call c++

    ObjectRef<byte[]> b2 =
        actor.task(CppActorMethod.of("echoBytes", byte[].class), "C++ Worker".getBytes()).remote();
    Assert.assertEquals(b2.get(), "C++ Worker".getBytes());


## Related issue number

#32523 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
