### PR TITLE
[RLlib] [Docs] Change leela chess links in docs and readme

### DIFF
--- a/doc/source/rllib/rllib-algorithms.rst
+++ b/doc/source/rllib/rllib-algorithms.rst
@@ -846,7 +846,7 @@ Tuned examples: `Sparse reward CartPole <https://github.com/ray-project/ray/blob
 MultiAgent LeelaChessZero (LeelaChessZero)
 ------------------------------------------
 |pytorch|
-`[source] <https://lczero.org/>`__ `[implementation] <https://github.com/ray-project/ray/blob/master/rllib/algorithms/leela_chess_zero>`__ LeelaChessZero is an RL agent originally inspired by AlphaZero for playing chess. This version adapts it to handle a MultiAgent competitive environment of chess. The code can be scaled to any number of workers.
+`[source] <https://github.com/LeelaChessZero/lc0/>`__ `[implementation] <https://github.com/ray-project/ray/blob/master/rllib/algorithms/leela_chess_zero>`__ LeelaChessZero is an RL agent originally inspired by AlphaZero for playing chess. This version adapts it to handle a MultiAgent competitive environment of chess. The code can be scaled to any number of workers.
 
 Tuned examples: tbd
 

--- a/rllib/algorithms/leela_chess_zero/README.md
+++ b/rllib/algorithms/leela_chess_zero/README.md
@@ -20,4 +20,4 @@ It assumes that the environment is a MultiAgent Chess environment, that has a di
 ## References
 
 - AlphaZero: https://arxiv.org/abs/1712.01815
-- LeelaChessZero: https://lczero.org/dev/
+- LeelaChessZero: https://github.com/LeelaChessZero/lc0


### PR DESCRIPTION
## Why are these changes needed?

<img width="1030" alt="Screenshot 2023-02-15 at 00 32 17" src="https://user-images.githubusercontent.com/9356806/218974435-4046c02c-852c-4377-9829-e8c5ebaa61b2.png">

https://lczero.org/ seems to be down.
Let's simply redirect to github so that this does not become an issue in the future.