### PR TITLE
[doc] Don't autosummary undoc members

### DIFF
--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -4,3 +4,4 @@
 
 .. autoclass:: {{ objname }}
     :members:
+    :show-inheritance:

--- a/doc/source/_templates/autosummary/class_with_autosummary.rst
+++ b/doc/source/_templates/autosummary/class_with_autosummary.rst
@@ -24,7 +24,7 @@
       :toctree:
 
    {% for item in methods %}
-      {{ name }}.{{ item }}
+      {{ item | filter_out_undoc_members(name, module) }}
    {%- endfor %}
 
    {% endif %}

--- a/doc/source/_templates/autosummary/class_with_autosummary.rst
+++ b/doc/source/_templates/autosummary/class_with_autosummary.rst
@@ -15,6 +15,7 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
+   :show-inheritance:
 
    {% block methods %}
    {% if methods %}
@@ -24,7 +25,7 @@
       :toctree:
 
    {% for item in methods %}
-      {{ item | filter_out_undoc_members(name, module) }}
+      {{ item | filter_out_undoc_class_members(name, module) }}
    {%- endfor %}
 
    {% endif %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -295,15 +295,17 @@ autodoc_member_order = "bysource"
 # Better typehint formatting (see custom.css)
 autodoc_typehints = "signature"
 
-def filter_out_undoc_members(item, class_name, module_name):
+
+def filter_out_undoc_class_members(member_name, class_name, module_name):
     module = import_module(module_name)
     cls = getattr(module, class_name)
-    if getattr(cls, item).__doc__:
-        return f"~{class_name}.{item}"
+    if getattr(cls, member_name).__doc__:
+        return f"~{class_name}.{member_name}"
     else:
         return ""
 
-FILTERS["filter_out_undoc_members"] = filter_out_undoc_members
+
+FILTERS["filter_out_undoc_class_members"] = filter_out_undoc_class_members
 
 # Add a render priority for doctest
 nb_render_priority = {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -299,7 +299,7 @@ def filter_out_undoc_members(item, class_name, module_name):
     module = import_module(module_name)
     cls = getattr(module, class_name)
     if getattr(cls, item).__doc__:
-        return f"{class_name}.{item}"
+        return f"~{class_name}.{item}"
     else:
         return ""
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 import json
 from pathlib import Path
+from importlib import import_module
 import os
 import sys
+from jinja2.filters import FILTERS
 
 sys.path.insert(0, os.path.abspath("."))
 from custom_directives import *
@@ -293,6 +295,15 @@ autodoc_member_order = "bysource"
 # Better typehint formatting (see custom.css)
 autodoc_typehints = "signature"
 
+def filter_out_undoc_members(item, class_name, module_name):
+    module = import_module(module_name)
+    cls = getattr(module, class_name)
+    if getattr(cls, item).__doc__:
+        return f"{class_name}.{item}"
+    else:
+        return ""
+
+FILTERS["filter_out_undoc_members"] = filter_out_undoc_members
 
 # Add a render priority for doctest
 nb_render_priority = {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Don't generate pages for undoc class methods to reduce doc build time.
This behavior also matches `..autoclass::` with `:members:` option.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
