### PR TITLE
[RLlib] Allow only vanilla replay buffer for qmix

### DIFF
--- a/rllib/algorithms/qmix/qmix.py
+++ b/rllib/algorithms/qmix/qmix.py
@@ -93,7 +93,6 @@ class QMixConfig(SimpleQConfig):
         self.target_network_update_freq = 500
         self.num_steps_sampled_before_learning_starts = 1000
         self.replay_buffer_config = {
-            # QMix only supports the vanilla ReplayBuffer
             "type": "ReplayBuffer",
             # Size of the replay buffer in batches (not timesteps!).
             "capacity": 1000,
@@ -220,9 +219,6 @@ class QMixConfig(SimpleQConfig):
     def validate(self) -> None:
         # Call super's validation method.
         super().validate()
-
-        assert self.replay_buffer_config["type"] == "ReplayBuffer", \
-            "Qmix supports only the vanilla ReplayBuffer."
 
         if self.framework_str != "torch":
             raise ValueError(

--- a/rllib/algorithms/qmix/qmix.py
+++ b/rllib/algorithms/qmix/qmix.py
@@ -93,10 +93,8 @@ class QMixConfig(SimpleQConfig):
         self.target_network_update_freq = 500
         self.num_steps_sampled_before_learning_starts = 1000
         self.replay_buffer_config = {
+            # QMix only supports the vanilla ReplayBuffer
             "type": "ReplayBuffer",
-            # Specify prioritized replay by supplying a buffer type that supports
-            # prioritization, for example: MultiAgentPrioritizedReplayBuffer.
-            "prioritized_replay": DEPRECATED_VALUE,
             # Size of the replay buffer in batches (not timesteps!).
             "capacity": 1000,
             # Choosing `fragments` here makes it so that the buffer stores entire
@@ -222,6 +220,9 @@ class QMixConfig(SimpleQConfig):
     def validate(self) -> None:
         # Call super's validation method.
         super().validate()
+
+        assert self.replay_buffer_config["type"] == "ReplayBuffer", \
+            "Qmix supports only the vanilla ReplayBuffer."
 
         if self.framework_str != "torch":
             raise ValueError(

--- a/rllib/algorithms/qmix/qmix.py
+++ b/rllib/algorithms/qmix/qmix.py
@@ -292,6 +292,14 @@ class QMix(SimpleQ):
             else:
                 train_results = multi_gpu_train_one_step(self, train_batch)
 
+            # Update replay buffer priorities.
+            update_priorities_in_replay_buffer(
+                self.local_replay_buffer,
+                self.config,
+                train_batch,
+                train_results,
+            )
+
             # Update target network every `target_network_update_freq` sample steps.
             last_update = self._counters[LAST_TARGET_UPDATE_TS]
             if cur_ts - last_update >= self.config.target_network_update_freq:

--- a/rllib/algorithms/qmix/qmix_policy.py
+++ b/rllib/algorithms/qmix/qmix_policy.py
@@ -461,6 +461,7 @@ class QMixTorchPolicy(TorchPolicy):
         mask_elems = mask.sum().item()
         stats = {
             "loss": loss_out.item(),
+            "td_error": masked_td_error / mask_elems,
             "td_error_abs": masked_td_error.abs().sum().item() / mask_elems,
             "q_taken_mean": (chosen_action_qvals * mask).sum().item() / mask_elems,
             "target_mean": (targets * mask).sum().item() / mask_elems,


### PR DESCRIPTION
## Why are these changes needed?

We advertise using prioritized replay in QMix, when in reality, QMix does not support this.

Root cause:
This is due to the fact that we use a plain buffer there, rather than one that "sits" inside a MA replay buffer that samples with a set beta. 
Our utility method `sample_min_n_steps_from_buffer` uses `batch = replay_buffer.sample(num_items=1)` to sample from the buffer, which lacks the possibility to pass a `beta` argument that the PrioritizedReplayBuffer needs.

Solution:
This PR makes it so that you can pass a default beta through the config that will be used for sampling when no beta is given.

With this PR, one can set:
```
replay_buffer_config={
                    "type": "PrioritizedReplayBuffer",
                    "storage_unit": "fragments",
                    "beta": 0.4
                }
```

## Related issue number

I stumbled across this when a user referred to a related issue on OSS slack.