### PR TITLE
[Core] Add support for async dynamic generators.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,7 +6,8 @@ build --enable_platform_specific_config
 ###############################################################################
 build:windows --action_env=PATH
 # For --compilation_mode=dbg, consider enabling checks in the standard library as well (below).
-build --compilation_mode=opt
+# build --compilation_mode=opt
+build --compilation_mode=dbg
 # Using C++ 17 on all platforms.
 build:linux --cxxopt="-std=c++17"
 build:macos --cxxopt="-std=c++17"

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -750,13 +750,12 @@ class ActorClass:
         if kwargs is None:
             kwargs = {}
         meta = self.__ray_metadata__
+
+        def predicate(obj):
+            return inspect.iscoroutinefunction(obj) or inspect.isasyncgenfunction(obj)
+
         actor_has_async_methods = (
-            len(
-                inspect.getmembers(
-                    meta.modified_class, predicate=inspect.iscoroutinefunction
-                )
-            )
-            > 0
+            len(inspect.getmembers(meta.modified_class, predicate=predicate)) > 0
         )
         is_asyncio = actor_has_async_methods
 

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -56,12 +56,15 @@ cdef class ObjectRef(BaseID):
             if not skip_adding_local_ref:
                 worker.core_worker.add_object_ref_reference(self)
             self.in_core_worker = True
+        print("creating object ref:", str(self))
 
     def __dealloc__(self):
+        print("deallocating object ref:", str(self), threading.get_ident())
         if self.in_core_worker:
             try:
                 worker = ray._private.worker.global_worker
                 worker.core_worker.remove_object_ref_reference(self)
+                print("finished removing reference")
             except Exception as e:
                 # There is a strange error in rllib that causes the above to
                 # fail. Somehow the global 'ray' variable corresponding to the
@@ -70,6 +73,7 @@ cdef class ObjectRef(BaseID):
                 # garbage collection so we can't get a good stack trace. In any
                 # case, there's not much we can do besides ignore it
                 # (re-importing ray won't help).
+                print("dealloc exception:", e, threading.get_ident(), str(self))
                 pass
 
     cdef CObjectID native(self):


### PR DESCRIPTION
This PR adds basic support for dynamic generators for async actors, i.e. [async generators](https://peps.python.org/pep-0525/) with a dynamic number of returns for async actors. This is mostly enabled by converting the async generator to a regular Python generator at task execution time, when processing the (yielded) task outputs in the main execution thread.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
