### PR TITLE
[AIR] Use larger disk size for MLPerf training benchmark

### DIFF
--- a/release/air_tests/air_benchmarks/mlperf-train/compute_cpu_16.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/compute_cpu_16.yaml
@@ -6,6 +6,10 @@ max_workers: 0
 head_node_type:
     name: head_node
     instance_type: m5.4xlarge
+    BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+              VolumeSize: 300
 
 worker_node_types:
     - name: worker_node

--- a/release/air_tests/air_benchmarks/mlperf-train/compute_cpu_16.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/compute_cpu_16.yaml
@@ -10,6 +10,7 @@ head_node_type:
         - DeviceName: /dev/sda1
           Ebs:
               VolumeSize: 300
+              DeleteOnTermination: true
 
 worker_node_types:
     - name: worker_node


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As we migrate to new stack of cluster, the default disk size is reduced from 300 to 150GB. This caused error that running out of disk size ([example](https://buildkite.com/ray-project/release-tests-pr/builds/28435#_)). For MLPerf training benchmark, we want to test large data size, so restore the disk size as before, to keep same behavior.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
