### PR TITLE
[RLlib] Fixed Nested key existence checking in SpecDict

### DIFF
--- a/rllib/core/rl_module/marl_module.py
+++ b/rllib/core/rl_module/marl_module.py
@@ -7,7 +7,7 @@ from ray.util.annotations import PublicAPI
 from ray.rllib.utils.annotations import override, ExperimentalAPI
 from ray.rllib.utils.nested_dict import NestedDict
 
-from ray.rllib.models.specs.specs_dict import SpecDict
+from ray.rllib.models.specs.typing import SpecType
 from ray.rllib.policy.sample_batch import MultiAgentBatch
 from ray.rllib.core.rl_module.rl_module import RLModule, SingleAgentRLModuleSpec
 
@@ -235,37 +235,24 @@ class MultiAgentRLModule(RLModule):
         return self._rl_modules[module_id]
 
     @override(RLModule)
-    def output_specs_train(self) -> SpecDict:
-        return self._get_specs_for_modules("output_specs_train")
+    def output_specs_train(self) -> SpecType:
+        return []
 
     @override(RLModule)
-    def output_specs_inference(self) -> SpecDict:
-        return self._get_specs_for_modules("output_specs_inference")
+    def output_specs_inference(self) -> SpecType:
+        return []
 
     @override(RLModule)
-    def output_specs_exploration(self) -> SpecDict:
-        return self._get_specs_for_modules("output_specs_exploration")
+    def output_specs_exploration(self) -> SpecType:
+        return []
 
     @override(RLModule)
-    def input_specs_train(self) -> SpecDict:
-        return self._get_specs_for_modules("input_specs_train")
+    def _default_input_specs(self) -> SpecType:
+        """Multi-agent RLModule should not check the input specs.
 
-    @override(RLModule)
-    def input_specs_inference(self) -> SpecDict:
-        return self._get_specs_for_modules("input_specs_inference")
-
-    @override(RLModule)
-    def input_specs_exploration(self) -> SpecDict:
-        return self._get_specs_for_modules("input_specs_exploration")
-
-    def _get_specs_for_modules(self, method_name: str) -> SpecDict:
-        """Returns a ModelSpec from the given method_name for all modules."""
-        return SpecDict(
-            {
-                module_id: getattr(module, f"_{method_name}")
-                for module_id, module in self._rl_modules.items()
-            }
-        )
+        The underlying single-agent RLModules will check the input specs.
+        """
+        return []
 
     @override(RLModule)
     def _forward_train(

--- a/rllib/models/specs/checker.py
+++ b/rllib/models/specs/checker.py
@@ -90,6 +90,9 @@ def convert_to_canonical_format(spec: SpecType) -> Union[Spec, SpecDict]:
             # if values are types or tuple of types, convert to TypeSpec
             if isinstance(spec[key], (type, tuple)):
                 spec[key] = TypeSpec(spec[key])
+            elif isinstance(spec[key], list):
+                # this enables nested conversion of none-canonical formats
+                spec[key] = convert_to_canonical_format(spec[key])
         return spec
 
     if isinstance(spec, type):

--- a/rllib/models/specs/specs_dict.py
+++ b/rllib/models/specs/specs_dict.py
@@ -108,11 +108,13 @@ class SpecDict(NestedDict[Spec], Spec):
         """
         data = NestedDict(data)
         data_keys_set = set(data.keys())
-        missing_keys = self._keys_set.difference(data_keys_set)
-        if missing_keys:
-            raise ValueError(
-                _MISSING_KEYS_FROM_DATA.format(missing_keys, data_keys_set)
-            )
+
+        for spec_key in self:
+            if spec_key not in data:
+                raise ValueError(
+                    _MISSING_KEYS_FROM_DATA.format(spec_key, data_keys_set)
+                )
+
         if exact_match:
             data_spec_missing_keys = data_keys_set.difference(self._keys_set)
             if data_spec_missing_keys:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR allows you to do the followings:

1. If spec is `["foo", "bar"]` and data is `{"foo": {"tar": 1}, "bar": 2}` it won't fail the check. 
2. Allows you to specify a nested spec as `[("foo", "tar"), "bar"]` as well as `{"foo": ["tar"], "bar": None}`
3. MARL module should not do any spec checking. The forward function of the the underlying modules will do more granular spec checking.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
