### PR TITLE
[Core] Expose KV MultiGet rpc to python GCS client

### DIFF
--- a/python/ray/_private/gcs_utils.py
+++ b/python/ray/_private/gcs_utils.py
@@ -309,7 +309,7 @@ class GcsClient:
         req = gcs_service_pb2.InternalKVMultiGetRequest(namespace=namespace, keys=keys)
         reply = self._kv_stub.InternalKVMultiGet(req, timeout=timeout)
         if reply.status.code == GcsCode.OK:
-            return reply.results
+            return {entry.key: entry.value for entry in reply.results}
         elif reply.status.code == GcsCode.NotFound:
             return {}
         else:
@@ -504,7 +504,7 @@ class GcsAioClient:
         req = gcs_service_pb2.InternalKVMultiGetRequest(namespace=namespace, keys=keys)
         reply = await self._kv_stub.InternalKVMultiGet(req, timeout=timeout)
         if reply.status.code == GcsCode.OK:
-            return reply.results
+            return {entry.key: entry.value for entry in reply.results}
         else:
             raise RuntimeError(
                 f"Failed to get value for keys {keys!r} "

--- a/python/ray/_private/gcs_utils.py
+++ b/python/ray/_private/gcs_utils.py
@@ -309,10 +309,12 @@ class GcsClient:
         req = gcs_service_pb2.InternalKVMultiGetRequest(namespace=namespace, keys=keys)
         reply = self._kv_stub.InternalKVMultiGet(req, timeout=timeout)
         if reply.status.code == GcsCode.OK:
-            return dict(zip(reply.keys, reply.values))
+            return reply.results
+        elif reply.status.code == GcsCode.NotFound:
+            return {}
         else:
             raise RuntimeError(
-                f"Failed to get values for keys {keys!r} "
+                f"Failed to get value for key {keys!r} "
                 f"due to error {reply.status.message}"
             )
 
@@ -502,10 +504,10 @@ class GcsAioClient:
         req = gcs_service_pb2.InternalKVMultiGetRequest(namespace=namespace, keys=keys)
         reply = await self._kv_stub.InternalKVMultiGet(req, timeout=timeout)
         if reply.status.code == GcsCode.OK:
-            return dict(zip(keys, reply.values))
+            return reply.results
         else:
             raise RuntimeError(
-                f"Failed to get values for keys {keys!r} "
+                f"Failed to get value for keys {keys!r} "
                 f"due to error {reply.status.message}"
             )
 

--- a/python/ray/tests/test_gcs_utils.py
+++ b/python/ray/tests/test_gcs_utils.py
@@ -57,6 +57,17 @@ def test_kv_basic(ray_start_regular, monkeypatch):
     assert gcs_utils._called_freq["internal_kv_get"] == 4
     assert gcs_utils._called_freq["internal_kv_put"] == 5
 
+    # Test internal_kv_multi_get
+    assert gcs_client.internal_kv_multi_get([b"A", b"B"], b"NS") == {}
+    assert gcs_client.internal_kv_put(b"A", b"B", False, b"NS") == 1
+    assert gcs_client.internal_kv_put(b"B", b"C", False, b"NS") == 1
+    assert gcs_client.internal_kv_multi_get([b"A", b"B"], b"NS") == {
+        b"A": b"B",
+        b"B": b"C",
+    }
+    assert gcs_client.internal_kv_multi_get([b"A", b"B"], b"NSS") == {}
+    assert gcs_utils._called_freq["internal_kv_multi_get"] == 2
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't have signals.")
 def test_kv_timeout(ray_start_regular):
@@ -103,6 +114,16 @@ async def test_kv_basic_aio(ray_start_regular):
     assert await gcs_client.internal_kv_del(b"A", True, b"NS") == 2
     assert await gcs_client.internal_kv_keys(b"A", b"NS") == []
     assert await gcs_client.internal_kv_del(b"A", False, b"NSS") == 0
+
+    # Test internal_kv_multi_get
+    assert await gcs_client.internal_kv_multi_get([b"A", b"B"], b"NS") == {}
+    assert await gcs_client.internal_kv_put(b"A", b"B", False, b"NS") == 1
+    assert await gcs_client.internal_kv_put(b"B", b"C", False, b"NS") == 1
+    assert await gcs_client.internal_kv_multi_get([b"A", b"B"], b"NS") == {
+        b"A": b"B",
+        b"B": b"C",
+    }
+    assert await gcs_client.internal_kv_multi_get([b"A", b"B"], b"NSS") == {}
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't have signals.")

--- a/python/ray/tests/test_gcs_utils.py
+++ b/python/ray/tests/test_gcs_utils.py
@@ -62,11 +62,18 @@ def test_kv_basic(ray_start_regular, monkeypatch):
     assert gcs_client.internal_kv_put(b"A", b"B", False, b"NS") == 1
     assert gcs_client.internal_kv_put(b"B", b"C", False, b"NS") == 1
     assert gcs_client.internal_kv_multi_get([b"A", b"B"], b"NS") == {
-        "A": b"B",
-        "B": b"C",
+        b"A": b"B",
+        b"B": b"C",
     }
     assert gcs_client.internal_kv_multi_get([b"A", b"B"], b"NSS") == {}
-    assert gcs_utils._called_freq["internal_kv_multi_get"] == 3
+
+    # Test internal_kv_multi_get where some keys don't exist
+    assert gcs_client.internal_kv_multi_get([b"A", b"B", b"C"], b"NS") == {
+        b"A": b"B",
+        b"B": b"C",
+    }
+
+    assert gcs_utils._called_freq["internal_kv_multi_get"] == 4
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't have signals.")
@@ -120,9 +127,16 @@ async def test_kv_basic_aio(ray_start_regular):
     assert await gcs_client.internal_kv_put(b"A", b"B", False, b"NS") == 1
     assert await gcs_client.internal_kv_put(b"B", b"C", False, b"NS") == 1
     assert await gcs_client.internal_kv_multi_get([b"A", b"B"], b"NS") == {
-        "A": b"B",
-        "B": b"C",
+        b"A": b"B",
+        b"B": b"C",
     }
+
+    # Test internal_kv_multi_get where some keys don't exist
+    assert await gcs_client.internal_kv_multi_get([b"A", b"B", b"C"], b"NS") == {
+        b"A": b"B",
+        b"B": b"C",
+    }
+
     assert await gcs_client.internal_kv_multi_get([b"A", b"B"], b"NSS") == {}
 
 

--- a/python/ray/tests/test_gcs_utils.py
+++ b/python/ray/tests/test_gcs_utils.py
@@ -62,11 +62,11 @@ def test_kv_basic(ray_start_regular, monkeypatch):
     assert gcs_client.internal_kv_put(b"A", b"B", False, b"NS") == 1
     assert gcs_client.internal_kv_put(b"B", b"C", False, b"NS") == 1
     assert gcs_client.internal_kv_multi_get([b"A", b"B"], b"NS") == {
-        b"A": b"B",
-        b"B": b"C",
+        "A": b"B",
+        "B": b"C",
     }
     assert gcs_client.internal_kv_multi_get([b"A", b"B"], b"NSS") == {}
-    assert gcs_utils._called_freq["internal_kv_multi_get"] == 2
+    assert gcs_utils._called_freq["internal_kv_multi_get"] == 3
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't have signals.")
@@ -120,8 +120,8 @@ async def test_kv_basic_aio(ray_start_regular):
     assert await gcs_client.internal_kv_put(b"A", b"B", False, b"NS") == 1
     assert await gcs_client.internal_kv_put(b"B", b"C", False, b"NS") == 1
     assert await gcs_client.internal_kv_multi_get([b"A", b"B"], b"NS") == {
-        b"A": b"B",
-        b"B": b"C",
+        "A": b"B",
+        "B": b"C",
     }
     assert await gcs_client.internal_kv_multi_get([b"A", b"B"], b"NSS") == {}
 

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.cc
@@ -57,7 +57,9 @@ void GcsInternalKVManager::HandleInternalKVMultiGet(
   auto callback =
       [reply, send_reply_callback](std::unordered_map<std::string, std::string> results) {
         for (auto &result : results) {
-          (*reply->mutable_results())[result.first] = result.second;
+          auto entry = reply->add_results();
+          entry->set_key(result.first);
+          entry->set_value(result.second);
         }
         GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
       };

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.cc
@@ -61,7 +61,8 @@ void GcsInternalKVManager::HandleInternalKVMultiGet(
         }
         GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
       };
-  kv_instance_->MultiGet(request.namespace_(), request.keys(), std::move(callback));
+  std::vector<std::string> keys(request.keys().begin(), request.keys().end());
+  kv_instance_->MultiGet(request.namespace_(), keys, std::move(callback));
 }
 
 void GcsInternalKVManager::HandleInternalKVPut(

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.cc
@@ -43,6 +43,26 @@ void GcsInternalKVManager::HandleInternalKVGet(
   }
 }
 
+void GcsInternalKVManager::HandleInternalKVMultiGet(
+    rpc::InternalKVMultiGetRequest request,
+    rpc::InternalKVMultiGetReply *reply,
+    rpc::SendReplyCallback send_reply_callback) {
+  auto status = ValidateKey(request.prefix());
+  if (!status.ok()) {
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
+  } else {
+    auto callback = [reply, send_reply_callback](std::vector<std::string> keys,
+                                                 std::vector<std::string> values) {
+      for (size_t i = 0; i < keys.size(); i++) {
+        reply->add_keys(keys[i]);
+        reply->add_values(values[i]);
+      }
+      GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+    };
+    kv_instance_->MultiGet(request.namespace_(), request.keys(), std::move(callback));
+  }
+}
+
 void GcsInternalKVManager::HandleInternalKVPut(
     rpc::InternalKVPutRequest request,
     rpc::InternalKVPutReply *reply,

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.h
@@ -107,6 +107,10 @@ class GcsInternalKVManager : public rpc::InternalKVHandler {
                            rpc::InternalKVGetReply *reply,
                            rpc::SendReplyCallback send_reply_callback) override;
 
+  void HandleInternalKVMultiGet(rpc::InternalKVMultiGetRequest request,
+                                rpc::InternalKVMultiGetReply *reply,
+                                rpc::SendReplyCallback send_reply_callback) override;
+
   void HandleInternalKVPut(rpc::InternalKVPutRequest request,
                            rpc::InternalKVPutReply *reply,
                            rpc::SendReplyCallback send_reply_callback) override;

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -435,7 +435,7 @@ message InternalKVMultiGetReply {
   GcsStatus status = 1;
   // The key-value pairs that are found. Bytes cannot be used as a key in a map, so
   // we use a string instead.
-  map<string, bytes> values = 2;
+  map<string, bytes> results = 2;
 }
 
 message InternalKVPutRequest {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -426,6 +426,18 @@ message InternalKVGetReply {
   bytes value = 2;
 }
 
+message InternalKVMultiGetRequest {
+  repeated bytes keys = 1;
+  bytes namespace = 2;
+}
+
+message InternalKVMultiGetReply {
+  GcsStatus status = 1;
+  // The key-value pairs that are found. Bytes cannot be used as a key in a map, so
+  // we use a string instead.
+  map<string, bytes> values = 2;
+}
+
 message InternalKVPutRequest {
   bytes key = 1;
   bytes value = 2;
@@ -472,6 +484,7 @@ message InternalKVKeysReply {
 // Service for KV storage
 service InternalKVGcsService {
   rpc InternalKVGet(InternalKVGetRequest) returns (InternalKVGetReply);
+  rpc InternalKVMultiGet(InternalKVMultiGetRequest) returns (InternalKVMultiGetReply);
   rpc InternalKVPut(InternalKVPutRequest) returns (InternalKVPutReply);
   rpc InternalKVDel(InternalKVDelRequest) returns (InternalKVDelReply);
   rpc InternalKVExists(InternalKVExistsRequest) returns (InternalKVExistsReply);

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -431,11 +431,17 @@ message InternalKVMultiGetRequest {
   bytes namespace = 2;
 }
 
+message MapFieldEntry {
+  bytes key = 1;
+  bytes value = 2;
+}
+
 message InternalKVMultiGetReply {
   GcsStatus status = 1;
   // The key-value pairs that are found. Bytes cannot be used as a key in a map, so
-  // we use a string instead.
-  map<string, bytes> results = 2;
+  // we use a repeated field of key-value pairs instead. See
+  // https://protobuf.dev/programming-guides/proto3/#backwards-compatibility
+  repeated MapFieldEntry results = 2;
 }
 
 message InternalKVPutRequest {

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -483,6 +483,10 @@ class InternalKVGcsServiceHandler {
                                    InternalKVGetReply *reply,
                                    SendReplyCallback send_reply_callback) = 0;
 
+  virtual void HandleInternalKVMultiGet(InternalKVMultiGetRequest request,
+                                        InternalKVMultiGetReply *reply,
+                                        SendReplyCallback send_reply_callback) = 0;
+
   virtual void HandleInternalKVPut(InternalKVPutRequest request,
                                    InternalKVPutReply *reply,
                                    SendReplyCallback send_reply_callback) = 0;
@@ -508,6 +512,7 @@ class InternalKVGrpcService : public GrpcService {
       const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
       std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
     INTERNAL_KV_SERVICE_RPC_HANDLER(InternalKVGet);
+    INTERNAL_KV_SERVICE_RPC_HANDLER(InternalKVMultiGet);
     INTERNAL_KV_SERVICE_RPC_HANDLER(InternalKVPut);
     INTERNAL_KV_SERVICE_RPC_HANDLER(InternalKVDel);
     INTERNAL_KV_SERVICE_RPC_HANDLER(InternalKVExists);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
Adds a `MultiGet` endpoint to the Python client for the GCS internal KV. 
## Why are these changes needed?
This change was requested in https://github.com/ray-project/ray/pull/32096#issuecomment-1409794973.  The existing interface was incomplete.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/32122
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
