### PR TITLE
[docs] Ignoring flaky/broken links

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -204,6 +204,14 @@ linkcheck_ignore = [
     r"https://www.pettingzoo.ml/*",  # seems to be flaky
     r"http://localhost[:/].*",  # Ignore localhost links
     r"^http:/$",  # Ignore incomplete links
+
+    # 403 Client Error: Forbidden for url.
+    # They ratelimit bots.
+    "https://www.datanami.com/2018/02/01/rays-new-library-targets-high-speed-reinforcement-learning/",
+
+    # 403 Client Error: Forbidden for url.
+    # They ratelimit bots.
+    "https://www.datanami.com/2019/11/05/why-every-python-developer-will-love-ray/",
 ]
 
 # -- Options for HTML output ----------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -212,6 +212,9 @@ linkcheck_ignore = [
     # 403 Client Error: Forbidden for url.
     # They ratelimit bots.
     "https://www.datanami.com/2019/11/05/why-every-python-developer-will-love-ray/",
+
+    # Returning 522s intermittently.
+    "https://lczero.org/",
 ]
 
 # -- Options for HTML output ----------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -204,15 +204,12 @@ linkcheck_ignore = [
     r"https://www.pettingzoo.ml/*",  # seems to be flaky
     r"http://localhost[:/].*",  # Ignore localhost links
     r"^http:/$",  # Ignore incomplete links
-
     # 403 Client Error: Forbidden for url.
     # They ratelimit bots.
     "https://www.datanami.com/2018/02/01/rays-new-library-targets-high-speed-reinforcement-learning/",
-
     # 403 Client Error: Forbidden for url.
     # They ratelimit bots.
     "https://www.datanami.com/2019/11/05/why-every-python-developer-will-love-ray/",
-
     # Returning 522s intermittently.
     "https://lczero.org/",
 ]


### PR DESCRIPTION
Datanami recently started giving us 403s to our automated linkchecker, and lczero started giving 522s intermittently. We ignore failures for these links.