### PR TITLE
[RLlib] Made the check_learning_achieved api more general

### DIFF
--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -530,7 +530,10 @@ def check_inference_w_connectors(policy, env_name, max_steps: int = 100):
 
 
 def check_learning_achieved(
-    tune_results: "tune.ResultGrid", min_reward, evaluation=False
+    tune_results: "tune.ResultGrid",
+    min_value,
+    evaluation=False,
+    metric: str = "episode_reward_mean",
 ):
     """Throws an error if `min_reward` is not reached within tune_results.
 
@@ -546,18 +549,14 @@ def check_learning_achieved(
     """
     # Get maximum reward of all trials
     # (check if at least one trial achieved some learning)
-    avg_rewards = [
-        (
-            row["episode_reward_mean"]
-            if not evaluation
-            else row["evaluation/episode_reward_mean"]
-        )
+    recorded_values = [
+        (row[metric] if not evaluation else row[f"evaluation/{metric}"])
         for _, row in tune_results.get_dataframe().iterrows()
     ]
-    best_avg_reward = max(avg_rewards)
-    if best_avg_reward < min_reward:
-        raise ValueError(f"`stop-reward` of {min_reward} not reached!")
-    print(f"`stop-reward` of {min_reward} reached! ok")
+    best_value = max(recorded_values)
+    if best_value < min_value:
+        raise ValueError(f"`{metric}` of {min_value} not reached!")
+    print(f"`{metric}` of {min_value} reached! ok")
 
 
 def check_off_policyness(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR makes the check_learning_achieved api more general, so that it can be re-used. The PR is meant to be backward compatible. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
