### PR TITLE
[RLlib] Fixes serialization of nested gym spaces

### DIFF
--- a/rllib/utils/serialization.py
+++ b/rllib/utils/serialization.py
@@ -280,7 +280,14 @@ def gym_space_from_dict(d: Dict) -> gym.spaces.Space:
 def space_from_dict(d: Dict) -> gym.spaces.Space:
     space = gym_space_from_dict(d["space"])
     if "original_space" in d:
-        space.original_space = space_from_dict(d["original_space"])
+        assert "space" in d["original_space"]
+        if isinstance(d["original_space"]["space"], str):
+            # For backward compatibility reasons, if d["original_space"]["space"]
+            # is a string, this original space was serialized by gym_space_to_dict.
+            space.original_space = gym_space_from_dict(d["original_space"])
+        else:
+            # Otherwise, this original space was serialized by space_to_dict.
+            space.original_space = space_from_dict(d["original_space"])
     return space
 
 

--- a/rllib/utils/serialization.py
+++ b/rllib/utils/serialization.py
@@ -186,7 +186,7 @@ def gym_space_to_dict(space: gym.spaces.Space) -> Dict:
 def space_to_dict(space: gym.spaces.Space) -> Dict:
     d = {"space": gym_space_to_dict(space)}
     if "original_space" in space.__dict__:
-        d["original_space"] = gym_space_to_dict(space.original_space)
+        d["original_space"] = space_to_dict(space.original_space)
     return d
 
 
@@ -280,7 +280,7 @@ def gym_space_from_dict(d: Dict) -> gym.spaces.Space:
 def space_from_dict(d: Dict) -> gym.spaces.Space:
     space = gym_space_from_dict(d["space"])
     if "original_space" in d:
-        space.original_space = gym_space_from_dict(d["original_space"])
+        space.original_space = space_from_dict(d["original_space"])
     return space
 
 


### PR DESCRIPTION
Fixes a bug that during checkpointing a policy we would lose the nested structure of observation and action space if they had original_space attached to them

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
