### PR TITLE
[Data] Fix legacy do_write

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2693,7 +2693,7 @@ class Dataset(Generic[T]):
                 soft=False,
             )
 
-        if "write" in type(datasource).__dict__:
+        if type(datasource).write != Datasource.write:
             plan = self._plan.with_stage(
                 OneToOneStage(
                     "write",

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2693,7 +2693,7 @@ class Dataset(Generic[T]):
                 soft=False,
             )
 
-        if "write" in datasource.__dict__:
+        if "write" in type(datasource).__dict__:
             plan = self._plan.with_stage(
                 OneToOneStage(
                     "write",

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2693,7 +2693,7 @@ class Dataset(Generic[T]):
                 soft=False,
             )
 
-        if hasattr(datasource, "write"):
+        if "write" in datasource.__dict__:
             plan = self._plan.with_stage(
                 OneToOneStage(
                     "write",


### PR DESCRIPTION
## Why are these changes needed?

With the new `write` added (from #32015 and #32440), Ray Data intends to support both the `write` and `do_write` functions for now. The check currently uses the `hasattr()` function to ensure the datasource object has a `write` method before using it.

However, this is insufficient for a custom datasource that inherits from `Datasource` since `Datasource` has the `write` method implemented. If the custom datasource only has `do_write` implemented, `hasattr(datasource, "write")` will return True since `hasattr()` will detect methods via inheritance. 

The solution is to check if the `write` method was overwritten from `Datasource.write`. Any class that has not implemented `write` will have the equality check return True

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
