### PR TITLE
[data] [streaming] Fix issue where actor pool stalls if we exceed the memory limit

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -266,6 +266,9 @@ def _execution_allowed(
         object_store_memory=global_usage.object_store_memory,
     )
     inc = op.incremental_resource_usage()
+    # If there are no resource demands, always allow execution.
+    if not inc.cpu and not inc.gpu and not inc.object_store_memory:
+        return True
     inc_indicator = ExecutionResources(
         cpu=1 if inc.cpu else 0,
         gpu=1 if inc.gpu else 0,

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -251,6 +251,14 @@ def test_execution_allowed():
         op, ExecutionResources(gpu=2), ExecutionResources(gpu=2)
     )
 
+    # Test zero incremental.
+    op.incremental_resource_usage = MagicMock(
+        return_value=ExecutionResources(cpu=0, gpu=0)
+    )
+    assert _execution_allowed(op, ExecutionResources(gpu=1), ExecutionResources(gpu=2))
+    assert _execution_allowed(op, ExecutionResources(gpu=2), ExecutionResources(gpu=2))
+    assert _execution_allowed(op, ExecutionResources(gpu=3), ExecutionResources(gpu=2))
+
 
 def test_select_ops_ensure_at_least_one_live_operator():
     opt = ExecutionOptions()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, the streaming executor will throttle all operators if the global memory limit is exceeded. While this works well in steady state, in some situations memory can "burst" above the global limit when starting off, leading the entire pipeline to get throttled until the backlog is resolved, which may take a long time.

While the broader issue still remains to be solved completely, this PR at least fixes it in the actor pool case. Actor pools don't acquire "incremental" resources to dispatch tasks, and hence we can exempt them from the throttling if it wouldn't increase the pool size.

Here is a simple reproduction for the issue (note the initial preprocessing 2x'es the memory size of the input):

```
import ray
import numpy as np
import time

NUM_WORKERS = 20
DATA_GB = 1000


class Model:
    def __init__(self):
        time.sleep(5)
        ...  # Can initialize your model here.

    def __call__(self, batch):
        # Return dummy inference results.
        time.sleep(.01)
        return [1. for _  in range(len(batch))]


def preprocess(batch):
    # Return dummy preprocessing results.
    time.sleep(.01)
    return np.ones((len(batch), 2 * 128 * 1024, ))


ctx = ray.data.context.DatasetContext.get_current()
ctx.use_streaming_executor = True
ctx.execution_options.preserve_order = False

ds = ray.data.range_tensor(DATA_GB * 1024, shape=(128 * 1024,), parallelism=1000)
ds = ds.map_batches(preprocess, batch_size=None)
# Set num_cpus differently to force these stages to run separately.
ds = ds.map_batches(
    Model,
    num_cpus=2,  # Replace this with num_gpus for GPU model.
    batch_size=None,
    compute=ray.data.ActorPoolStrategy(
        min_size=NUM_WORKERS,
        max_size=NUM_WORKERS,
    ))

start = time.time()
for result_batch in ds.iter_batches(batch_size=None):
    pass
end = time.time()

time.sleep(1)
print()
print("Average throughput", DATA_GB / (end - start), "GiB/s")
```

Before this PR, execution will stall with 1 active actor task. After this PR, the memory will initially burst higher than the limit, but then level off as the actor pool operator is prioritized.