### PR TITLE
Fix disk metric showing double the actual value

### DIFF
--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -907,10 +907,8 @@ class ReporterAgent(
             value=disk_io_speed_stats[3],
             tags={"ip": ip},
         )
-        used, free = 0, 0
-        for entry in stats["disk"].values():
-            used += entry.used
-            free += entry.free
+        used = stats["disk"]["/"].used
+        free = stats["disk"]["/"].free
         disk_utilization = float(used / (used + free)) * 100
         disk_usage_record = Record(
             gauge=METRICS_GAUGES["node_disk_usage"], value=used, tags={"ip": ip}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
the disks stats returns stats about two paths `/` and `/tmp/ray`. Since both those paths are on the same partition, disk_usage will return the same value. We do not need to combine them.

In the UI, we show the disk stats for `/` so I'll do the same for the metric as well.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
