### PR TITLE
[Core][C++ Worker]Add ray_job_namespace param for c++ worker driver

### DIFF
--- a/cpp/src/ray/config_internal.cc
+++ b/cpp/src/ray/config_internal.cc
@@ -84,6 +84,12 @@ ABSL_FLAG(int,
           -1,
           "The computed hash of the runtime env for this worker.");
 
+ABSL_FLAG(std::string,
+          ray_job_namespace,
+          "",
+          "The namespace of job. If not set,"
+          " a unique value will be randomly generated.");
+
 using json = nlohmann::json;
 
 namespace ray {
@@ -205,8 +211,13 @@ void ConfigInternal::Init(RayConfig &config, int argc, char **argv) {
     }
   }
   if (worker_type == WorkerType::DRIVER) {
-    ray_namespace =
-        config.ray_namespace.empty() ? GenerateUUIDV4() : config.ray_namespace;
+    ray_namespace = config.ray_namespace;
+    if (!FLAGS_ray_job_namespace.CurrentValue().empty()) {
+      ray_namespace = FLAGS_ray_job_namespace.CurrentValue();
+    }
+    if (ray_namespace.empty()) {
+      ray_namespace = GenerateUUIDV4();
+    }
   }
 
   auto job_config_json_string = std::getenv("RAY_JOB_CONFIG_JSON_ENV_VAR");


### PR DESCRIPTION
## Why are these changes needed?

C++ Worker also needs to dynamically set namesapce like java's "ray.job.namespace" parameter. So add the --ray_job_namespace parameter。

Use case
./bazel-bin/cpp/cluster_mode_test --ray_job_namespace="my_namespace"

## Related issue number

#32680 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
