### PR TITLE
[RLLib] Fix Dirichlet `deterministic_sample` and add `TorchDirichlet` to `catalog`

### DIFF
--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -29,6 +29,7 @@ from ray.rllib.models.torch.torch_action_dist import (
     TorchDiagGaussian,
     TorchMultiActionDistribution,
     TorchMultiCategorical,
+    TorchDirichlet,
 )
 from ray.rllib.utils.annotations import DeveloperAPI, PublicAPI
 from ray.rllib.utils.deprecation import (
@@ -315,12 +316,7 @@ class ModelCatalog:
             )
         # Simplex -> Dirichlet.
         elif isinstance(action_space, Simplex):
-            if framework == "torch":
-                # TODO(sven): implement
-                raise NotImplementedError(
-                    "Simplex action spaces not supported for torch."
-                )
-            dist_cls = Dirichlet
+            dist_cls = TorchDirichlet if framework == "torch" else Dirichlet
         # MultiDiscrete -> MultiCategorical.
         elif isinstance(action_space, MultiDiscrete):
             dist_cls = (

--- a/rllib/models/tf/tf_action_dist.py
+++ b/rllib/models/tf/tf_action_dist.py
@@ -704,7 +704,10 @@ class Dirichlet(TFActionDistribution):
 
     @override(ActionDistribution)
     def deterministic_sample(self) -> TensorType:
-        return tf.nn.softmax(self.dist.concentration)
+        self.last_sample = self.dist.concentration / tf.reduce_sum(
+            self.dist.concentration, axis=-1, keepdims=True
+        )
+        return self.last_sample
 
     @override(ActionDistribution)
     def logp(self, x: TensorType) -> TensorType:


### PR DESCRIPTION
## Why are these changes needed?
User requested functionality https://github.com/ray-project/ray/issues/32657

Fix bug:
Torch sample:
```python
>>> samples = torch.stack([Dirichlet(torch.tensor([0.1, 0.9]), validate_args=True).sample() for _ in range(10000)])
>>> torch.sum(samples, dim=0)
tensor([1028.7993, 8971.2012])
```

For RLLib wrapper, the params should be log values, which are `exp`ed into the concentration
```python
>>> dist = TorchDirichlet(torch.tensor([math.log(0.1), math.log(0.9)]), model=None)
>>> samples = torch.stack([dist.sample() for _ in range(1000)])
>>> torch.sum(samples, dim=0)
tensor([ 94.4558, 905.5441])
```

Previous result:
```python
>>> samples = torch.stack([dist.deterministic_sample() for _ in range(1000)])
>>> torch.sum(samples, dim=0)
tensor([310.0255, 689.9745])
```

This PR:
```python
>>> samples = torch.stack([dist.deterministic_sample() for _ in range(1000)])
>>> torch.sum(samples, dim=0)
tensor([100.0000, 899.9997])
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
