### PR TITLE
[Release Tests] Update tags to conform to new requirements

### DIFF
--- a/release/air_tests/horovod/compute_tpl.yaml
+++ b/release/air_tests/horovod/compute_tpl.yaml
@@ -18,9 +18,7 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'
 
   BlockDeviceMappings:

--- a/release/dashboard/agent_stress_compute.yaml
+++ b/release/dashboard/agent_stress_compute.yaml
@@ -5,9 +5,7 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'
 
 head_node_type:

--- a/release/jobs_tests/compute_tpl_4_xlarge.yaml
+++ b/release/jobs_tests/compute_tpl_4_xlarge.yaml
@@ -20,7 +20,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/jobs_tests/compute_tpl_gpu_node.yaml
+++ b/release/jobs_tests/compute_tpl_gpu_node.yaml
@@ -17,7 +17,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/jobs_tests/compute_tpl_gpu_worker.yaml
+++ b/release/jobs_tests/compute_tpl_gpu_worker.yaml
@@ -17,7 +17,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/k8s_tests/compute_tpl.yaml
+++ b/release/k8s_tests/compute_tpl.yaml
@@ -18,7 +18,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_2D"]}}'

--- a/release/long_running_distributed_tests/compute_tpl.yaml
+++ b/release/long_running_distributed_tests/compute_tpl.yaml
@@ -18,9 +18,7 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_2D"]}}'
 
   BlockDeviceMappings:

--- a/release/long_running_tests/many_ppo.yaml
+++ b/release/long_running_tests/many_ppo.yaml
@@ -18,7 +18,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_2D"]}}'

--- a/release/long_running_tests/tpl_cpu_1.yaml
+++ b/release/long_running_tests/tpl_cpu_1.yaml
@@ -18,9 +18,7 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_2D"]}}'
 
   BlockDeviceMappings:

--- a/release/long_running_tests/tpl_cpu_1_c5.yaml
+++ b/release/long_running_tests/tpl_cpu_1_c5.yaml
@@ -18,9 +18,7 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_2D"]}}'
 
   BlockDeviceMappings:

--- a/release/long_running_tests/tpl_cpu_1_large.yaml
+++ b/release/long_running_tests/tpl_cpu_1_large.yaml
@@ -18,9 +18,7 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_2D"]}}'
 
   BlockDeviceMappings:

--- a/release/long_running_tests/tpl_cpu_2.yaml
+++ b/release/long_running_tests/tpl_cpu_2.yaml
@@ -18,7 +18,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_2D"]}}'

--- a/release/long_running_tests/tpl_cpu_3.yaml
+++ b/release/long_running_tests/tpl_cpu_3.yaml
@@ -18,7 +18,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_2D"]}}'

--- a/release/ml_user_tests/horovod/compute_tpl.yaml
+++ b/release/ml_user_tests/horovod/compute_tpl.yaml
@@ -18,7 +18,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/ml_user_tests/ray-lightning/compute_tpl.yaml
+++ b/release/ml_user_tests/ray-lightning/compute_tpl.yaml
@@ -18,7 +18,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_stress_compute_k8s.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_stress_compute_k8s.yaml
@@ -5,9 +5,7 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'
   BlockDeviceMappings:
     - DeviceName: /dev/sda1

--- a/release/serve_tests/compute_tpl_32_cpu.yaml
+++ b/release/serve_tests/compute_tpl_32_cpu.yaml
@@ -21,7 +21,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/serve_tests/compute_tpl_32_cpu_autoscaling.yaml
+++ b/release/serve_tests/compute_tpl_32_cpu_autoscaling.yaml
@@ -24,7 +24,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
@@ -24,7 +24,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/serve_tests/compute_tpl_gpu_node.yaml
+++ b/release/serve_tests/compute_tpl_gpu_node.yaml
@@ -17,7 +17,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/serve_tests/compute_tpl_single_node.yaml
+++ b/release/serve_tests/compute_tpl_single_node.yaml
@@ -21,7 +21,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/serve_tests/compute_tpl_single_node_32_cpu.yaml
+++ b/release/serve_tests/compute_tpl_single_node_32_cpu.yaml
@@ -20,7 +20,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/serve_tests/compute_tpl_single_node_k8s.yaml
+++ b/release/serve_tests/compute_tpl_single_node_k8s.yaml
@@ -23,7 +23,5 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_1D"]}}'

--- a/release/tune_tests/scalability_tests/tpl_1x32_hd.yaml
+++ b/release/tune_tests/scalability_tests/tpl_1x32_hd.yaml
@@ -18,9 +18,7 @@ aws:
   TagSpecifications:
     - ResourceType: "instance"
       Tags:
-        - Key: anyscale-user
-          Value: '{{env["ANYSCALE_USER"]}}'
-        - Key: anyscale-expiration
+        - Key: ttl-hours
           Value: '{{env["EXPIRATION_2D"]}}'
 #
 #  BlockDeviceMappings:


### PR DESCRIPTION
Signed-off-by: Shomil Jain <shomil@anyscale.com>

## Why are these changes needed?

Anyscale no longer allows setting tags starting with `anyscale-*` - so we update the release tests here to:

1. Stop setting `anyscale-user`, since `anyscale-username` is already being set by the product.
2. Change `anyscale-ttl-hours` to `ttl-hours` (this tag is used for anti-garbage-collection purposes).

Kicked off a release test here to verify that the changes kicked in and the cluster was successfully created: https://buildkite.com/ray-project/release-tests-pr/builds/28939#01867214-70e6-4ffa-a495-de39043ca6af