### PR TITLE
[Core][C++ Worker]Add metric API for c++ worker to align the metric API of java and python

### DIFF
--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -348,6 +348,49 @@ cc_binary(
     ],
 )
 
+cc_test(
+    name = "metric_example",
+    srcs = glob([
+        "src/ray/test/examples/metric_example.cc",
+    ]),
+    args = [
+        "--ray_code_search_path $(location metric_example.so)",
+    ],
+    data = [
+        "metric_example.so",
+    ],
+    linkstatic = True,
+    tags = ["team:serverless"],
+    deps = [
+        "ray_cpp_lib",
+        "@boost//:callable_traits",
+        "@boost//:optional",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@msgpack",
+        "@nlohmann_json",
+    ],
+)
+
+cc_binary(
+    name = "metric_example.so",
+    testonly = True,
+    srcs = glob([
+        "src/ray/test/examples/metric_example.cc",
+    ]),
+    linkopts = ["-shared"],
+    linkstatic = True,
+    deps = [
+        "ray_cpp_lib",
+        "@boost//:callable_traits",
+        "@boost//:optional",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@msgpack",
+        "@nlohmann_json",
+    ],
+)
+
 load("//bazel:python.bzl", "py_test_module_list")
 
 py_test_module_list(

--- a/cpp/include/ray/api/metric.h
+++ b/cpp/include/ray/api/metric.h
@@ -1,0 +1,134 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace ray {
+class Metric {
+ public:
+  virtual ~Metric() = 0;
+
+  /// Get the name of this metric.
+  std::string GetName() const;
+
+  /// Record the value for this metric.
+  ///
+  /// \param value The value that we record.
+  /// \param tags The map tag values that we want to record for this metric record.
+  void Record(double value, const std::unordered_map<std::string, std::string> &tags);
+
+ protected:
+  void *metric_ = nullptr;
+};  // class Metric
+
+class Gauge : public Metric {
+ public:
+  /// Gauges keep the last recorded value and drop everything before.
+  /// Unlike counters, gauges can go up or down over time.
+  ///
+  /// This corresponds to Prometheus' gauge metric:
+  /// https://prometheus.io/docs/concepts/metric_types/#gauge
+  ///
+  /// \param[in] name The Name of the metric.
+  /// \param[in] description The Description of the metric.
+  /// \param[in] unit The unit of the metric
+  /// \param[in] tag_keys Tag keys of the metric.
+  Gauge(const std::string &name,
+        const std::string &description,
+        const std::string &unit,
+        const std::vector<std::string> &tag_keys = {});
+
+  ///  Set the gauge to the given `value`.
+  ///
+  /// Tags passed in will take precedence over the metric's default tags.
+  ///
+  /// \param[in] value Value to set the gauge to.
+  /// \param[in] tags Tags to set or override for this gauge.
+  void Set(double value, const std::unordered_map<std::string, std::string> &tags);
+};  // class Gauge
+
+class Histogram : public Metric {
+ public:
+  /// Tracks the size and number of events in buckets.
+  ///
+  /// Histograms allow you to calculate aggregate quantiles
+  /// such as 25, 50, 95, 99 percentile latency for an RPC.
+  ///
+  /// This corresponds to Prometheus' histogram metric:
+  /// https://prometheus.io/docs/concepts/metric_types/#histogram
+  ///
+  /// \param[in] name The Name of the metric.
+  /// \param[in] description The Description of the metric.
+  /// \param[in] unit The unit of the metric
+  /// \param[in] boundaries The Boundaries of histogram buckets.
+  /// \param[in] tag_keys Tag keys of the metric.
+  Histogram(const std::string &name,
+            const std::string &description,
+            const std::string &unit,
+            const std::vector<double> boundaries,
+            const std::vector<std::string> &tag_keys = {});
+
+  /// Observe a given `value` and add it to the appropriate bucket.
+  ///
+  /// Tags passed in will take precedence over the metric's default tags.
+  ///
+  /// \param[in] value The value that we record.
+  /// \param[in] tags The map tag values that we want to record
+  void Observe(double value, const std::unordered_map<std::string, std::string> &Tags);
+};  // class Histogram
+
+class Counter : public Metric {
+ public:
+  /// A cumulative metric that is monotonically increasing.
+  ///
+  /// This corresponds to Prometheus' counter metric:
+  /// https://prometheus.io/docs/concepts/metric_types/#counter
+  ///
+  /// \param[in] name The Name of the metric.
+  /// \param[in] description The Description of the metric.
+  /// \param[in] unit The unit of the metric
+  /// \param[in] tag_keys Tag keys of the metric.
+  Counter(const std::string &name,
+          const std::string &description,
+          const std::string &unit,
+          const std::vector<std::string> &tag_keys = {});
+
+  /// Increment the counter by `value` (defaults to 1).
+  ///
+  /// Tags passed in will take precedence over the metric's default tags.
+  ///
+  /// \param[in] value Value to increment the counter by (default=1).
+  /// \param[in] tags The map tag values that we want to record
+  void Inc(double value, const std::unordered_map<std::string, std::string> &tags);
+};  // class Counter
+
+class Sum : public Metric {
+ public:
+  /// A sum up of the metric points.
+  ///
+  /// \param[in] name The Name of the metric.
+  /// \param[in] description The Description of the metric.
+  /// \param[in] unit The unit of the metric
+  /// \param[in] tag_keys Tag keys of the metric.
+  Sum(const std::string &name,
+      const std::string &description,
+      const std::string &unit,
+      const std::vector<std::string> &tag_keys = {});
+};  // class Sum
+
+}  // namespace ray

--- a/cpp/src/ray/runtime/metric/metric.cc
+++ b/cpp/src/ray/runtime/metric/metric.cc
@@ -1,0 +1,86 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/api/metric.h"
+
+#include "ray/stats/metric.h"
+#include "ray/util/logging.h"
+
+namespace ray {
+
+Metric::~Metric() {
+  if (metric_ != nullptr) {
+    stats::Metric *metric = reinterpret_cast<stats::Metric *>(metric_);
+    delete metric;
+    metric_ = nullptr;
+  }
+}
+
+std::string Metric::GetName() const {
+  RAY_CHECK(metric_ != nullptr) << "The metric_ must not be nullptr.";
+  stats::Metric *metric = reinterpret_cast<stats::Metric *>(metric_);
+  return metric->GetName();
+}
+
+void Metric::Record(double value,
+                    const std::unordered_map<std::string, std::string> &tags) {
+  RAY_CHECK(metric_ != nullptr) << "The metric_ must not be nullptr.";
+  stats::Metric *metric = reinterpret_cast<stats::Metric *>(metric_);
+  metric->Record(value, tags);
+}
+
+Gauge::Gauge(const std::string &name,
+             const std::string &description,
+             const std::string &unit,
+             const std::vector<std::string> &tag_str_keys) {
+  metric_ = new stats::Gauge(name, description, unit, tag_str_keys);
+}
+
+void Gauge::Set(double value, const std::unordered_map<std::string, std::string> &tags) {
+  Record(value, tags);
+}
+
+Histogram::Histogram(const std::string &name,
+                     const std::string &description,
+                     const std::string &unit,
+                     const std::vector<double> boundaries,
+                     const std::vector<std::string> &tag_str_keys) {
+  metric_ = new stats::Histogram(name, description, unit, boundaries, tag_str_keys);
+}
+
+void Histogram::Observe(double value,
+                        const std::unordered_map<std::string, std::string> &tags) {
+  Record(value, tags);
+}
+
+Counter::Counter(const std::string &name,
+                 const std::string &description,
+                 const std::string &unit,
+                 const std::vector<std::string> &tag_str_keys) {
+  metric_ = new stats::Count(name, description, unit, tag_str_keys);
+}
+
+void Counter::Inc(double value,
+                  const std::unordered_map<std::string, std::string> &tags) {
+  Record(value, tags);
+}
+
+Sum::Sum(const std::string &name,
+         const std::string &description,
+         const std::string &unit,
+         const std::vector<std::string> &tag_str_keys) {
+  metric_ = new stats::Sum(name, description, unit, tag_str_keys);
+}
+
+}  // namespace ray

--- a/cpp/src/ray/test/examples/metric_example.cc
+++ b/cpp/src/ray/test/examples/metric_example.cc
@@ -1,0 +1,72 @@
+// Copyright 2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// This is an example of Ray C++ application. Please visit
+/// `https://docs.ray.io/en/master/index.html` for more details.
+#include <ray/api.h>
+#include <ray/api/metric.h>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+
+ABSL_FLAG(int32_t, metric_time, 10, "The total time in seconds for recording metrics");
+
+void test_metric(const std::string &exec_type, int total_time) {
+  ray::Gauge gauge("ray.test.gauge", "test gauge", "unit", {"tag1", "tag2"});
+  ray::Counter counter("ray.test.counter", "test counter", "unit", {"tag1", "tag2"});
+  ray::Histogram histogram(
+      "ray.test.hitogram", "test hitogram", "unit", {1, 10}, {"tag1", "tag2"});
+  ray::Sum sum("ray.test.sum", "test sum", "unit", {"tag1", "tag2"});
+
+  std::unordered_map<std::string, std::string> tag_1 = {{"tag1", "increasing"},
+                                                        {"tag2", exec_type}};
+  std::unordered_map<std::string, std::string> tag_2 = {{"tag1", "steady"},
+                                                        {"tag2", exec_type}};
+  int num = total_time;
+  for (int i = 0; i < num; i++) {
+    gauge.Set(i, tag_1);
+    counter.Inc(i, tag_1);
+    histogram.Observe(i, tag_1);
+    sum.Record(i, tag_1);
+
+    gauge.Set(1, tag_2);
+    counter.Inc(1, tag_2);
+    histogram.Observe(1, tag_2);
+    sum.Record(1, tag_2);
+    sleep(1);
+  }
+}
+
+class MetricActor {
+ public:
+  static MetricActor *FactoryCreate() { return new MetricActor(); }
+  void record_metric(int total_time) { test_metric("actor", total_time); }
+};
+
+RAY_REMOTE(RAY_FUNC(MetricActor::FactoryCreate), &MetricActor::record_metric);
+
+int main(int argc, char **argv) {
+  absl::ParseCommandLine(argc, argv);
+  int total_time = absl::GetFlag(FLAGS_metric_time);
+  // Start ray cluster and ray runtime.
+  ray::RayConfig config;
+  ray::Init(config, argc, argv);
+  auto actor = ray::Actor(MetricActor::FactoryCreate).Remote();
+  auto object_ref = actor.Task(&MetricActor::record_metric).Remote(total_time);
+  test_metric("driver", total_time);
+  object_ref.Get();
+  // Stop ray cluster and ray runtime.
+  ray::Shutdown();
+  return 0;
+}

--- a/src/ray/stats/metric.cc
+++ b/src/ray/stats/metric.cc
@@ -85,6 +85,16 @@ bool StatsConfig::IsInitialized() const { return is_initialized_; }
 /// Metric
 ///
 using MeasureDouble = opencensus::stats::Measure<double>;
+Metric::Metric(const std::string &name,
+               const std::string &description,
+               const std::string &unit,
+               const std::vector<std::string> &tag_keys)
+    : name_(name), description_(description), unit_(unit), measure_(nullptr) {
+  for (const auto &key : tag_keys) {
+    tag_keys_.push_back(opencensus::tags::TagKey::Register(key));
+  }
+}
+
 void Metric::Record(double value, const TagsType &tags) {
   if (StatsConfig::instance().IsStatsDisabled()) {
     return;

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -112,6 +112,11 @@ class Metric {
         tag_keys_(tag_keys),
         measure_(nullptr) {}
 
+  Metric(const std::string &name,
+         const std::string &description,
+         const std::string &unit,
+         const std::vector<std::string> &tag_keys);
+
   virtual ~Metric();
 
   Metric &operator()() { return *this; }
@@ -157,6 +162,12 @@ class Gauge : public Metric {
         const std::vector<opencensus::tags::TagKey> &tag_keys = {})
       : Metric(name, description, unit, tag_keys) {}
 
+  Gauge(const std::string &name,
+        const std::string &description,
+        const std::string &unit,
+        const std::vector<std::string> &tag_keys)
+      : Metric(name, description, unit, tag_keys) {}
+
  private:
   void RegisterView() override;
 
@@ -169,6 +180,13 @@ class Histogram : public Metric {
             const std::string &unit,
             const std::vector<double> boundaries,
             const std::vector<opencensus::tags::TagKey> &tag_keys = {})
+      : Metric(name, description, unit, tag_keys), boundaries_(boundaries) {}
+
+  Histogram(const std::string &name,
+            const std::string &description,
+            const std::string &unit,
+            const std::vector<double> boundaries,
+            const std::vector<std::string> &tag_keys)
       : Metric(name, description, unit, tag_keys), boundaries_(boundaries) {}
 
  private:
@@ -187,6 +205,12 @@ class Count : public Metric {
         const std::vector<opencensus::tags::TagKey> &tag_keys = {})
       : Metric(name, description, unit, tag_keys) {}
 
+  Count(const std::string &name,
+        const std::string &description,
+        const std::string &unit,
+        const std::vector<std::string> &tag_keys)
+      : Metric(name, description, unit, tag_keys) {}
+
  private:
   void RegisterView() override;
 
@@ -198,6 +222,12 @@ class Sum : public Metric {
       const std::string &description,
       const std::string &unit,
       const std::vector<opencensus::tags::TagKey> &tag_keys = {})
+      : Metric(name, description, unit, tag_keys) {}
+
+  Sum(const std::string &name,
+      const std::string &description,
+      const std::string &unit,
+      const std::vector<std::string> &tag_keys)
       : Metric(name, description, unit, tag_keys) {}
 
  private:


### PR DESCRIPTION
## Why are these changes needed?

Now both python and java have metric interfaces,  and complement the metric interfaces of c++ workers.  

Python API:
[python/ray/util/metrics.py](https://github.com/ray-project/ray/blob/master/python/ray/util/metrics.py)

JAVA API:
https://github.com/ray-project/ray/blob/master/java/runtime/src/main/java/io/ray/runtime/metric/Metric.java

### Use case

C++ Worker metric api case:
```
  ray::Gauge gauge("ray.test.gauge", "test gauge", "unit", {"tag1", "tag2"});
  ray::Counter counter("ray.test.counter", "test counter", "unit", {"tag1", "tag2"});
  ray::Histogram histogram(
      "ray.test.hitogram", "test hitogram", "unit", {1, 10}, {"tag1", "tag2"});
  ray::Sum sum("ray.test.sum", "test sum", "unit", {"tag1", "tag2"});

  std::unordered_map<std::string, std::string> tag_1 = {{"tag1", "increasing"},
                                                        {"tag2", exec_type}};
  std::unordered_map<std::string, std::string> tag_2 = {{"tag1", "steady"},
                                                        {"tag2", exec_type}};
  int num = total_time;
  for (int i = 0; i < num; i++) {
    gauge.Set(i, tag_1);
    counter.Inc(i, tag_1);
    histogram.Observe(i, tag_1);
    sum.Record(i, tag_1);

    gauge.Set(1, tag_2);
    counter.Inc(1, tag_2);
    histogram.Observe(1, tag_2);
    sum.Record(1, tag_2);
    sleep(1);
  }
```

## Related issue number

#32691 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
