### PR TITLE
[Doc] Clarify that object_spilling_config only needs to be specified on the head node

### DIFF
--- a/doc/source/ray-core/objects/object-spilling.rst
+++ b/doc/source/ray-core/objects/object-spilling.rst
@@ -54,7 +54,7 @@ usage across multiple physical devices if needed (e.g., SSD devices):
 
 
 .. note::
-  
+
     To optimize the performance, it is recommended to use an SSD instead of an HDD when using object spilling for memory-intensive workloads.
 
 If you are using an HDD, it is recommended that you specify a large buffer size (> 1MB) to reduce IO requests during spilling.
@@ -68,7 +68,7 @@ If you are using an HDD, it is recommended that you specify a large buffer size 
         _system_config={
             "object_spilling_config": json.dumps(
                 {
-                  "type": "filesystem", 
+                  "type": "filesystem",
                   "params": {
                     "directory_path": "/tmp/spill",
                     "buffer_size": 1_000_000,
@@ -116,7 +116,7 @@ To enable object spilling to remote storage (any URI supported by `smart_open <h
             "min_spilling_size": 100 * 1024 * 1024,  # Spill at least 100MB at a time.
             "object_spilling_config": json.dumps(
                 {
-                  "type": "smart_open", 
+                  "type": "smart_open",
                   "params": {
                     "uri": "s3://bucket/path"
                   },
@@ -141,7 +141,7 @@ Spilling to multiple remote storages is also supported.
             "min_spilling_size": 100 * 1024 * 1024,  # Spill at least 100MB at a time.
             "object_spilling_config": json.dumps(
                 {
-                  "type": "smart_open", 
+                  "type": "smart_open",
                   "params": {
                     "uri": ["s3://bucket/path1", "s3://bucket/path2", "s3://bucket/path3"],
                   },
@@ -158,8 +158,9 @@ Cluster mode
 To enable object spilling in multi node clusters:
 
 .. code-block:: bash
-  
+
   # Note that `object_spilling_config`'s value should be json format.
+  # You only need to specify the config when starting the head node, all the worker nodes will get the same config from the head node.
   ray start --head --system-config='{"object_spilling_config":"{\"type\":\"filesystem\",\"params\":{\"directory_path\":\"/tmp/spill\"}}"}'
 
 Stats


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There is user confusion about whether the same config needs to be specified on the worker nodes or not.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
