### PR TITLE
[Release] no-terminate workaround for anyscale job

### DIFF
--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -136,6 +136,16 @@ def run_release_test(
 
     run_type = test["run"].get("type", DEFAULT_RUN_TYPE)
 
+    # Workaround while Anyscale Jobs don't support leaving cluster alive
+    # after the job has finished.
+    # TODO: Remove once we have support in Anyscale
+    if no_terminate and run_type == "anyscale_job":
+        logger.warning(
+            "anyscale_job run type does not support --no-terminate. "
+            "Switching to job (Ray Job) run type."
+        )
+        run_type = "job"
+
     command_runner_cls = type_str_to_command_runner.get(run_type)
     if not command_runner_cls:
         raise ReleaseTestConfigError(

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -85,7 +85,10 @@ from ray_release.wheels import find_and_wait_for_ray_wheels_url
     default=False,
     type=bool,
     is_flag=True,
-    help="Do not terminate cluster after test.",
+    help=(
+        "Do not terminate cluster after test. "
+        "Will switch `anyscale_job` run type to `job` (Ray Job)."
+    ),
 )
 def main(
     test_name: str,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Anyscale Jobs currently do not support leaving the cluster alive after job completion. For easier debugging, `job` (Ray Job) run type will be used instead with `no-terminate`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
