### PR TITLE
[Autoscaler] Bump ebs volume size in default configs

### DIFF
--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -358,7 +358,7 @@ Each node type is identified by a user-specified key.
               BlockDeviceMappings:
                   - DeviceName: /dev/sda1
                     Ebs:
-                        VolumeSize: 100
+                        VolumeSize: 140
             resources: {"CPU": 2}
         ray.worker.default:
             node_config:

--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -358,8 +358,7 @@ Each node type is identified by a user-specified key.
               BlockDeviceMappings:
                   - DeviceName: /dev/sda1
                     Ebs:
-                        VolumeSize: 100
-            resources: {"CPU": 2}
+                        volumesize: 140            resources: {"CPU": 2}
         ray.worker.default:
             node_config:
               InstanceType: m5.large

--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -358,7 +358,8 @@ Each node type is identified by a user-specified key.
               BlockDeviceMappings:
                   - DeviceName: /dev/sda1
                     Ebs:
-                        volumesize: 140            resources: {"CPU": 2}
+                        VolumeSize: 100
+            resources: {"CPU": 2}
         ray.worker.default:
             node_config:
               InstanceType: m5.large

--- a/doc/source/ray-core/examples/lm/lm-cluster.yaml
+++ b/doc/source/ray-core/examples/lm/lm-cluster.yaml
@@ -43,7 +43,7 @@ head_node:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
-              VolumeSize: 100
+              VolumeSize: 140
 
     # Additional options in the boto docs.
 

--- a/doc/source/ray-core/examples/lm/lm-cluster.yaml
+++ b/doc/source/ray-core/examples/lm/lm-cluster.yaml
@@ -43,7 +43,8 @@ head_node:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
-              volumesize: 140
+              VolumeSize: 100
+
     # Additional options in the boto docs.
 
 # Provider-specific config for worker nodes, e.g. instance type. By default

--- a/doc/source/ray-core/examples/lm/lm-cluster.yaml
+++ b/doc/source/ray-core/examples/lm/lm-cluster.yaml
@@ -43,8 +43,7 @@ head_node:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
-              VolumeSize: 100
-
+              volumesize: 140
     # Additional options in the boto docs.
 
 # Provider-specific config for worker nodes, e.g. instance type. By default

--- a/python/ray/autoscaler/aliyun/defaults.yaml
+++ b/python/ray/autoscaler/aliyun/defaults.yaml
@@ -61,7 +61,7 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      VolumeSize: 100
+                      VolumeSize: 140
             # Additional options in the boto docs.
     ray.worker.default:
         # The minimum number of nodes of this type to launch.

--- a/python/ray/autoscaler/aliyun/defaults.yaml
+++ b/python/ray/autoscaler/aliyun/defaults.yaml
@@ -61,8 +61,7 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      VolumeSize: 100
-            # Additional options in the boto docs.
+                      volumesize: 140            # Additional options in the boto docs.
     ray.worker.default:
         # The minimum number of nodes of this type to launch.
         # This number should be >= 0.

--- a/python/ray/autoscaler/aliyun/defaults.yaml
+++ b/python/ray/autoscaler/aliyun/defaults.yaml
@@ -61,7 +61,8 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      volumesize: 140            # Additional options in the boto docs.
+                      VolumeSize: 100
+            # Additional options in the boto docs.
     ray.worker.default:
         # The minimum number of nodes of this type to launch.
         # This number should be >= 0.

--- a/python/ray/autoscaler/aliyun/example-full.yaml
+++ b/python/ray/autoscaler/aliyun/example-full.yaml
@@ -67,7 +67,7 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      VolumeSize: 100
+                      VolumeSize: 140
             # Additional options in the boto docs.
     ray.worker.default:
         # The minimum number of nodes of this type to launch.

--- a/python/ray/autoscaler/aliyun/example-full.yaml
+++ b/python/ray/autoscaler/aliyun/example-full.yaml
@@ -67,8 +67,7 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      VolumeSize: 100
-            # Additional options in the boto docs.
+                      volumesize: 140            # Additional options in the boto docs.
     ray.worker.default:
         # The minimum number of nodes of this type to launch.
         # This number should be >= 0.

--- a/python/ray/autoscaler/aliyun/example-full.yaml
+++ b/python/ray/autoscaler/aliyun/example-full.yaml
@@ -67,7 +67,8 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      volumesize: 140            # Additional options in the boto docs.
+                      VolumeSize: 100
+            # Additional options in the boto docs.
     ray.worker.default:
         # The minimum number of nodes of this type to launch.
         # This number should be >= 0.

--- a/python/ray/autoscaler/aliyun/example-linux.yaml
+++ b/python/ray/autoscaler/aliyun/example-linux.yaml
@@ -68,7 +68,7 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      VolumeSize: 100
+                      VolumeSize: 140
             # Additional options in the boto docs.
     ray.worker.default:
         # The minimum number of nodes of this type to launch.

--- a/python/ray/autoscaler/aliyun/example-linux.yaml
+++ b/python/ray/autoscaler/aliyun/example-linux.yaml
@@ -68,8 +68,7 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      VolumeSize: 100
-            # Additional options in the boto docs.
+                      volumesize: 140            # Additional options in the boto docs.
     ray.worker.default:
         # The minimum number of nodes of this type to launch.
         # This number should be >= 0.

--- a/python/ray/autoscaler/aliyun/example-linux.yaml
+++ b/python/ray/autoscaler/aliyun/example-linux.yaml
@@ -68,7 +68,8 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      volumesize: 140            # Additional options in the boto docs.
+                      VolumeSize: 100
+            # Additional options in the boto docs.
     ray.worker.default:
         # The minimum number of nodes of this type to launch.
         # This number should be >= 0.

--- a/python/ray/autoscaler/aws/example-full.yaml
+++ b/python/ray/autoscaler/aws/example-full.yaml
@@ -79,7 +79,7 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      VolumeSize: 100
+                      VolumeSize: 140GB
             # Additional options in the boto docs.
     ray.worker.default:
         # The minimum number of worker nodes of this type to launch.

--- a/python/ray/autoscaler/aws/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/aws/example-gpu-docker.yaml
@@ -65,7 +65,7 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      VolumeSize: 100
+                      VolumeSize: 140
             # Additional options in the boto docs.
     # CPU workers.
     ray.worker.default:

--- a/python/ray/autoscaler/aws/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/aws/example-gpu-docker.yaml
@@ -65,7 +65,8 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      volumesize: 140            # Additional options in the boto docs.
+                      VolumeSize: 100
+            # Additional options in the boto docs.
     # CPU workers.
     ray.worker.default:
         # Override global docker setting.

--- a/python/ray/autoscaler/aws/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/aws/example-gpu-docker.yaml
@@ -65,8 +65,7 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      VolumeSize: 100
-            # Additional options in the boto docs.
+                      volumesize: 140            # Additional options in the boto docs.
     # CPU workers.
     ray.worker.default:
         # Override global docker setting.

--- a/python/ray/autoscaler/aws/example-ml.yaml
+++ b/python/ray/autoscaler/aws/example-ml.yaml
@@ -72,7 +72,7 @@ available_node_types:
         BlockDeviceMappings:
             - DeviceName: /dev/sda1
               Ebs:
-                  VolumeSize: 100
+                  VolumeSize: 140
 
     ray.worker.default:
       node_config:

--- a/python/ray/autoscaler/aws/example-ml.yaml
+++ b/python/ray/autoscaler/aws/example-ml.yaml
@@ -72,7 +72,8 @@ available_node_types:
         BlockDeviceMappings:
             - DeviceName: /dev/sda1
               Ebs:
-                  volumesize: 140
+                  VolumeSize: 100
+
     ray.worker.default:
       node_config:
         InstanceType: m4.16xlarge

--- a/python/ray/autoscaler/aws/example-ml.yaml
+++ b/python/ray/autoscaler/aws/example-ml.yaml
@@ -72,8 +72,7 @@ available_node_types:
         BlockDeviceMappings:
             - DeviceName: /dev/sda1
               Ebs:
-                  VolumeSize: 100
-
+                  volumesize: 140
     ray.worker.default:
       node_config:
         InstanceType: m4.16xlarge

--- a/python/ray/serve/benchmarks/cluster.yaml
+++ b/python/ray/serve/benchmarks/cluster.yaml
@@ -18,7 +18,7 @@ head_node:
         -
             DeviceName: /dev/sda1
             Ebs:
-                VolumeSize: 100
+                VolumeSize: 140
 worker_nodes:
     InstanceType: m5.xlarge
 initialization_commands: []

--- a/python/ray/serve/benchmarks/cluster.yaml
+++ b/python/ray/serve/benchmarks/cluster.yaml
@@ -18,7 +18,8 @@ head_node:
         -
             DeviceName: /dev/sda1
             Ebs:
-                volumesize: 140worker_nodes:
+                VolumeSize: 100
+worker_nodes:
     InstanceType: m5.xlarge
 initialization_commands: []
 setup_commands:

--- a/python/ray/serve/benchmarks/cluster.yaml
+++ b/python/ray/serve/benchmarks/cluster.yaml
@@ -18,8 +18,7 @@ head_node:
         -
             DeviceName: /dev/sda1
             Ebs:
-                VolumeSize: 100
-worker_nodes:
+                volumesize: 140worker_nodes:
     InstanceType: m5.xlarge
 initialization_commands: []
 setup_commands:

--- a/python/ray/serve/benchmarks/single.yaml
+++ b/python/ray/serve/benchmarks/single.yaml
@@ -17,7 +17,7 @@ head_node:
         -
             DeviceName: /dev/sda1
             Ebs:
-                VolumeSize: 100
+                VolumeSize: 140
 
 initialization_commands: []
 setup_commands:

--- a/python/ray/serve/benchmarks/single.yaml
+++ b/python/ray/serve/benchmarks/single.yaml
@@ -17,7 +17,8 @@ head_node:
         -
             DeviceName: /dev/sda1
             Ebs:
-                volumesize: 140
+                VolumeSize: 100
+
 initialization_commands: []
 setup_commands:
     - sudo apt-get install build-essential libssl-dev git -y

--- a/python/ray/serve/benchmarks/single.yaml
+++ b/python/ray/serve/benchmarks/single.yaml
@@ -17,8 +17,7 @@ head_node:
         -
             DeviceName: /dev/sda1
             Ebs:
-                VolumeSize: 100
-
+                volumesize: 140
 initialization_commands: []
 setup_commands:
     - sudo apt-get install build-essential libssl-dev git -y


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The defaul volume size was too small and caused an error; this PR bumps it to 140gb as specified in the error message:
`ray.autoscaler.node_launch_exception.NodeLaunchException: Node Launch Exception (InvalidBlockDeviceMapping): Volume of size 100GB is smaller than snapshot 'snap-04db122cb9d19ae16', expect size >= 140GB`
We currently don't have tests to catch these regressions, but we plan to add them.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/32707
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
