### PR TITLE
Revert "[AIR/Data] Make `BatchPredictor` lazy"

### DIFF
--- a/doc/source/ray-air/doc_code/air_key_concepts.py
+++ b/doc/source/ray-air/doc_code/air_key_concepts.py
@@ -104,12 +104,12 @@ batch_predictor = BatchPredictor.from_checkpoint(result.checkpoint, XGBoostPredi
 
 # Bulk batch prediction.
 predicted_probabilities = batch_predictor.predict(test_dataset)
-predicted_probabilities.show()
 
 # Pipelined batch prediction: instead of processing the data in bulk, process it
 # incrementally in windows of the given size.
 pipeline = batch_predictor.predict_pipelined(test_dataset, bytes_per_window=1048576)
-pipeline.show()
+for batch in pipeline.iter_batches():
+    print("Pipeline result", batch)
 
 # __air_batch_predictor_end__
 

--- a/doc/source/ray-air/doc_code/statsmodel_predictor.py
+++ b/doc/source/ray-air/doc_code/statsmodel_predictor.py
@@ -66,7 +66,6 @@ predictor = BatchPredictor.from_checkpoint(
 )
 # This is the same data we trained our model on. Don't do this in practice.
 dataset = ray.data.from_pandas(data)
-predictions = predictor.predict(dataset)
-predictions.show()
+predictor.predict(dataset)
 # __statsmodelpredictor_predict_end__
 # fmt: on

--- a/doc/source/ray-air/examples/pytorch_tabular_batch_prediction.py
+++ b/doc/source/ray-air/examples/pytorch_tabular_batch_prediction.py
@@ -40,7 +40,6 @@ batch_predictor = BatchPredictor.from_checkpoint(checkpoint, TorchPredictor)
 predicted_probabilities = batch_predictor.predict(
     dataset, feature_columns=["concat_features"]
 )
-# Call show on the output probabilities to trigger execution.
 predicted_probabilities.show()
 # {'predictions': array([1.], dtype=float32)}
 # {'predictions': array([0.], dtype=float32)}

--- a/doc/source/ray-air/examples/tf_tabular_batch_prediction.py
+++ b/doc/source/ray-air/examples/tf_tabular_batch_prediction.py
@@ -43,7 +43,6 @@ batch_predictor = BatchPredictor.from_checkpoint(
 predicted_probabilities = batch_predictor.predict(
     dataset, feature_columns=["concat_features"]
 )
-# Call show on the output probabilities to trigger execution.
 predicted_probabilities.show()
 # {'predictions': array([1.], dtype=float32)}
 # {'predictions': array([0.], dtype=float32)}

--- a/doc/source/ray-air/examples/torch_image_batch_pretrained.py
+++ b/doc/source/ray-air/examples/torch_image_batch_pretrained.py
@@ -25,6 +25,4 @@ preprocessor = TorchVisionPreprocessor(columns=["image"], transform=transform)
 ckpt = TorchCheckpoint.from_model(model=model, preprocessor=preprocessor)
 
 predictor = BatchPredictor.from_checkpoint(ckpt, TorchPredictor)
-predictions = predictor.predict(dataset, batch_size=80)
-# Call show on the output probabilities to trigger execution.
-predictions.show()
+predictor.predict(dataset, batch_size=80)

--- a/doc/source/ray-air/examples/xgboost_batch_prediction.py
+++ b/doc/source/ray-air/examples/xgboost_batch_prediction.py
@@ -38,5 +38,4 @@ checkpoint = result.checkpoint
 batch_predictor = BatchPredictor.from_checkpoint(checkpoint, XGBoostPredictor)
 
 predicted_probabilities = batch_predictor.predict(test_dataset)
-# Call show on the output probabilities to trigger execution.
 predicted_probabilities.show()

--- a/doc/source/train/doc_code/xgboost_train_predict.py
+++ b/doc/source/train/doc_code/xgboost_train_predict.py
@@ -32,5 +32,4 @@ predictions = batch_predictor.predict(
     batch_size=8,
     min_scoring_workers=2,
 )
-predictions.show()
 # __batch_predict_end__

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -170,6 +170,7 @@ class ExecutionPlan:
         Returns:
             The string representation of this execution plan.
         """
+
         # NOTE: this is used for Dataset.__repr__ to give a user-facing string
         # representation. Ideally ExecutionPlan.__repr__ should be replaced with this
         # method as well.

--- a/python/ray/data/tests/test_dataset_image.py
+++ b/python/ray/data/tests/test_dataset_image.py
@@ -132,10 +132,7 @@ class TestReadImages:
         model = resnet18(pretrained=True)
         checkpoint = TorchCheckpoint.from_model(model=model)
         predictor = BatchPredictor.from_checkpoint(checkpoint, TorchPredictor)
-        predictions = predictor.predict(dataset)
-
-        for _ in predictions.iter_batches():
-            pass
+        predictor.predict(dataset)
 
     @pytest.mark.parametrize(
         "image_size,image_mode,expected_size,expected_ratio",

--- a/python/ray/train/batch_predictor.py
+++ b/python/ray/train/batch_predictor.py
@@ -101,9 +101,6 @@ class BatchPredictor:
     ) -> Union[ray.data.Dataset, ray.data.DatasetPipeline]:
         """Run batch scoring on a Dataset.
 
-        .. note::
-            In Ray 2.4, `BatchPredictor` is lazy by default. Use one of the Datasets consumption APIs, such as iterating through the output, to trigger the execution of prediction.
-
         Args:
             data: Ray dataset or pipeline to run batch prediction on.
             feature_columns: List of columns in the preprocessed dataset to use for
@@ -161,10 +158,9 @@ class BatchPredictor:
 
             .. testoutput::
 
-                MapBatches(ScoringWrapper)
-                +- Dataset(num_blocks=1, num_rows=3, schema={feature_1: int64, label: int64})
+                Dataset(num_blocks=1, num_rows=3, schema={preds: int64, label: int64})
                 Final accuracy: 1.0
-        """  # noqa: E501
+        """
         if num_gpus_per_worker is None:
             num_gpus_per_worker = 0
         if num_cpus_per_worker is None:
@@ -330,6 +326,10 @@ class BatchPredictor:
             fn_constructor_kwargs={"override_prep": override_prep},
             **ray_remote_args,
         )
+
+        if isinstance(prediction_results, ray.data.Dataset):
+            # Force execution because Dataset uses lazy execution by default.
+            prediction_results.fully_executed()
 
         return prediction_results
 

--- a/python/ray/train/tests/test_batch_predictor.py
+++ b/python/ray/train/tests/test_batch_predictor.py
@@ -148,9 +148,7 @@ def test_automatic_enable_gpu_from_num_gpus_per_worker(shutdown_only):
     with pytest.raises(
         ValueError, match="DummyPredictor does not support GPU prediction"
     ):
-        predictions = batch_predictor.predict(test_dataset, num_gpus_per_worker=1)
-        for _ in predictions.iter_batches():
-            pass
+        _ = batch_predictor.predict(test_dataset, num_gpus_per_worker=1)
 
 
 def test_batch_prediction():

--- a/python/ray/train/tests/test_batchpredictor_runtime.py
+++ b/python/ray/train/tests/test_batchpredictor_runtime.py
@@ -79,16 +79,13 @@ def run_predictor(
     checkpoint, data, batch_predictor: Type[BatchPredictor], num_scoring_workers: int
 ):
     predictor = batch_predictor(checkpoint, DummyPredictor)
-    predictions = predictor.predict(
+    predictor.predict(
         data,
         batch_size=1024 // 8,
         min_scoring_workers=num_scoring_workers,
         max_scoring_workers=num_scoring_workers,
         num_cpus_per_worker=0,
     )
-
-    for _ in predictions.iter_batches():
-        pass
 
 
 @pytest.fixture

--- a/python/ray/train/tests/test_tensorflow_checkpoint.py
+++ b/python/ray/train/tests/test_tensorflow_checkpoint.py
@@ -142,10 +142,7 @@ def test_tensorflow_checkpoint_saved_model():
     batch_predictor = BatchPredictor.from_checkpoint(
         result_checkpoint, TensorflowPredictor
     )
-    predictions = batch_predictor.predict(ray.data.range(3))
-
-    for _ in predictions.iter_batches():
-        pass
+    batch_predictor.predict(ray.data.range(3))
 
 
 def test_tensorflow_checkpoint_h5():
@@ -173,10 +170,7 @@ def test_tensorflow_checkpoint_h5():
     batch_predictor = BatchPredictor.from_checkpoint(
         result_checkpoint, TensorflowPredictor
     )
-    predictions = batch_predictor.predict(ray.data.range(3))
-
-    for _ in predictions.iter_batches():
-        pass
+    batch_predictor.predict(ray.data.range(3))
 
 
 if __name__ == "__main__":

--- a/release/air_tests/air_benchmarks/workloads/gpu_batch_prediction.py
+++ b/release/air_tests/air_benchmarks/workloads/gpu_batch_prediction.py
@@ -57,16 +57,13 @@ def main(data_size_gb: int, smoke_test: bool = False):
     ckpt = TorchCheckpoint.from_model(model=model, preprocessor=preprocessor)
 
     predictor = BatchPredictor.from_checkpoint(ckpt, TorchPredictor)
-    predictions = predictor.predict(
+    predictor.predict(
         dataset,
         num_gpus_per_worker=int(not smoke_test),
         min_scoring_workers=1,
         max_scoring_workers=1 if smoke_test else int(ray.cluster_resources()["GPU"]),
         batch_size=512,
     )
-    for _ in predictions.iter_batches():
-        pass
-
     total_time_s = round(time.time() - start, 2)
 
     # For structured output integration with internal tooling

--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -118,10 +118,6 @@ def run_xgboost_prediction(model_path: str, data_path: str):
         # batch size than default 4096
         batch_size=8192,
     )
-
-    for _ in result.iter_batches():
-        pass
-
     return result
 
 


### PR DESCRIPTION
`test_batch_predictor` is failing after merging this into master. Seems there are some divergent changes that need to be reconciled.


Reverts ray-project/ray#32510.