### PR TITLE
[Rllib] Enable tf eager tracing on the training side

### DIFF
--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -360,11 +360,6 @@ class PPO(Algorithm):
             return PPOTF1Policy
         else:
             if config._enable_rl_module_api:
-                if config.eager_tracing:
-                    raise ValueError(
-                        "The TensorFlow PPO with RLModule does not support "
-                        "eager tracing yet."
-                    )
                 from ray.rllib.algorithms.ppo.tf.ppo_tf_policy_rlm import (
                     PPOTfPolicyWithRLModule,
                 )

--- a/rllib/algorithms/ppo/tests/test_ppo_learner.py
+++ b/rllib/algorithms/ppo/tests/test_ppo_learner.py
@@ -71,7 +71,7 @@ class TestPPO(unittest.TestCase):
             )
         )
 
-        for fw in framework_iterator(config, ("tf2", "torch")):
+        for fw in framework_iterator(config, ("tf2", "torch"), with_eager_tracing=True):
             trainer = config.build()
             policy = trainer.get_policy()
 

--- a/rllib/algorithms/ppo/tests/test_ppo_with_rl_module.py
+++ b/rllib/algorithms/ppo/tests/test_ppo_with_rl_module.py
@@ -112,8 +112,6 @@ class TestPPO(unittest.TestCase):
 
         num_iterations = 2
 
-        # TODO (avnish): re enable eager tracing when we get this working with the new
-        # sampler.
         for fw in framework_iterator(
             config, frameworks=("torch", "tf2"), with_eager_tracing=True
         ):
@@ -159,7 +157,6 @@ class TestPPO(unittest.TestCase):
         )
         obs = np.array(0)
 
-        # TODO (Kourosh) Test against all frameworks.
         for fw in framework_iterator(
             config, frameworks=("torch", "tf2"), with_eager_tracing=True
         ):

--- a/rllib/algorithms/ppo/tests/test_ppo_with_rl_module.py
+++ b/rllib/algorithms/ppo/tests/test_ppo_with_rl_module.py
@@ -115,7 +115,7 @@ class TestPPO(unittest.TestCase):
         # TODO (avnish): re enable eager tracing when we get this working with the new
         # sampler.
         for fw in framework_iterator(
-            config, frameworks=("torch", "tf2"), with_eager_tracing=False
+            config, frameworks=("torch", "tf2"), with_eager_tracing=True
         ):
             # TODO (Kourosh) Bring back "FrozenLake-v1" and "MsPacmanNoFrameskip-v4"
             for env in ["CartPole-v1", "Pendulum-v1"]:
@@ -160,7 +160,9 @@ class TestPPO(unittest.TestCase):
         obs = np.array(0)
 
         # TODO (Kourosh) Test against all frameworks.
-        for fw in framework_iterator(config, frameworks=("torch", "tf2")):
+        for fw in framework_iterator(
+            config, frameworks=("torch", "tf2"), with_eager_tracing=True
+        ):
             # Default Agent should be setup with StochasticSampling.
             trainer = config.build()
             # explore=False, always expect the same (deterministic) action.

--- a/rllib/core/learner/tf/tf_learner.py
+++ b/rllib/core/learner/tf/tf_learner.py
@@ -270,7 +270,7 @@ class TfLearner(Learner):
             gradients = self.postprocess_gradients(gradients)
             self.apply_gradients(gradients)
 
-            # TODO (Kourosh) The reason for returning fwd_out is that it is optionally
+            # NOTE (Kourosh) The reason for returning fwd_out is that it is optionally
             # needed for compiling the results in a later step (e.g. in
             # compile_results), but it should not contain anything but tensors, None or
             # ExtensionTypes, otherwise the tf.function will yell at us because it

--- a/rllib/core/learner/tf/tf_learner.py
+++ b/rllib/core/learner/tf/tf_learner.py
@@ -1,4 +1,5 @@
 import logging
+import tree  # pip install dm-tree
 from typing import (
     Any,
     Mapping,
@@ -268,9 +269,24 @@ class TfLearner(Learner):
             gradients = self.compute_gradients(loss, tape)
             gradients = self.postprocess_gradients(gradients)
             self.apply_gradients(gradients)
+
+            # TODO (Kourosh) The reason for returning fwd_out is that it is optionally
+            # needed for compiling the results in a later step (e.g. in
+            # compile_results), but it should not contain anything but tensors, None or
+            # ExtensionTypes, otherwise the tf.function will yell at us because it
+            # won't be able to convert the returned objects to a tensor representation
+            # (for internal reasons). So, in here, we remove anything from fwd_out that
+            # is not a tensor, None or ExtensionType.
+            def filter_fwd_out(x):
+                if isinstance(
+                    x, (tf.Tensor, type(None), tf.experimental.ExtensionType)
+                ):
+                    return x
+                return None
+
             return {
                 "loss": loss,
-                "fwd_out": fwd_out,
+                "fwd_out": tree.map_structure(filter_fwd_out, fwd_out),
                 "postprocessed_gradients": gradients,
             }
 

--- a/rllib/policy/eager_tf_policy.py
+++ b/rllib/policy/eager_tf_policy.py
@@ -174,8 +174,15 @@ def _traced_eager_policy(eager_policy_cls):
         ) -> Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
             """Traced version of Policy.compute_actions_from_input_dict."""
 
+            # NOTE: In the new RLModule stack the sampling side is not traced with this
+            # justification that in order to speed up sampling we need to use more
+            # actors.
             # Create a traced version of `self._compute_actions_helper`.
-            if self._traced_compute_actions_helper is False and not self._no_tracing:
+            if (
+                not self.config.get("_enable_rl_module_api", False)
+                and self._traced_compute_actions_helper is False
+                and not self._no_tracing
+            ):
                 self._compute_actions_helper = _convert_eager_inputs(
                     tf.function(
                         super(TracedEagerPolicy, self)._compute_actions_helper,

--- a/rllib/tuned_examples/ppo/cartpole-ppo-with-rl-module.yaml
+++ b/rllib/tuned_examples/ppo/cartpole-ppo-with-rl-module.yaml
@@ -5,7 +5,7 @@ cartpole-ppo:
         episode_reward_mean: 150
         timesteps_total: 100000
     config:
-        # TODO (Kourosh): Works only for torch.
+        # Both torch and tf2 works.
         framework: torch
         gamma: 0.99
         lr: 0.0003
@@ -19,4 +19,5 @@ cartpole-ppo:
             vf_share_layers: true
         enable_connectors: true
         _enable_rl_module_api: true
+        _enable_learner_api: false
         eager_tracing: false


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This enables tf tracing functionality on the training side for algorithms. 

The plot below shows how the new learner API slightly out-performs the old training stack (it has better throughput). It also show that the performance improvements due to enabling tracing on the new learner API stack is on-par with the improvements from enabling tracing on the old stack. 
<img width="1040" alt="image" src="https://user-images.githubusercontent.com/31483498/220499518-558a6dbc-6ac6-4bea-a7c8-c18d86263b71.png">

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
