### PR TITLE
feat: use `jupyterlab` instead of `jupyter` PyPI package

### DIFF
--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -15,7 +15,7 @@ h5py==3.7.0
 hpbandster==0.7.4
 HEBO==0.3.2
 hyperopt==0.2.5
-jupyter==1.0.0
+jupyterlab==3.6.1
 lightgbm==3.2.1
 matplotlib!=3.4.3
 mlflow==1.30.0


### PR DESCRIPTION
The `jupyter` package isn't maintained and hasn't had a release since 2015. https://pypi.org/project/jupyter/#history

https://pypi.org/project/jupyterlab is the official, actively maintained package.

Related [Ray forum question](https://discuss.ray.io/t/curious-why-jupyter-notebook-installed-in-rayproject-ray-ml-image-instead-of-jupyter-lab/9043).

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
