### PR TITLE
[Doc] Make front page images non clickable

### DIFF
--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -22,7 +22,7 @@ Learn how to install Ray, compute an example with the Ray Core API, and use Ray'
 {link-badge}`ray-overview/getting-started.html,"Getting started",cls=badge-light`
 
 ---
-<img src="images/user_guide.svg" alt="user_guide" height="40px" style="pointer-events: none;">
+<img src="images/user_guide.svg" alt="user_guide" height="40px" class="no-scaled-link">
 
 **User guides**
 ^^^^^^^^^^^
@@ -38,7 +38,7 @@ Learn about the key concepts and features. Get in-depth information about Ray's 
 {link-badge}`ray-core/user-guide.html,"Core",cls=badge-light`
 {link-badge}`cluster/running-applications/index.html,"Clusters",cls=badge-light`
 ---
-<img src="images/api.svg" alt="api" height="40px" style="pointer-events: none;">
+<img src="images/api.svg" alt="api" height="40px" class="no-scaled-link">
 
 **API reference**
 ^^^^^^^^^^^^^
@@ -51,7 +51,7 @@ The reference assumes familiarity with the key concepts.
 {link-badge}`ray-references/api.html,"API reference",cls=badge-light`
 
 ---
-<img src="images/contribute.svg" alt="contribute" height="40px" style="pointer-events: none;">
+<img src="images/contribute.svg" alt="contribute" height="40px" class="no-scaled-link">
 
 **Developer guides**
 ^^^^^^^^^^^^^^^

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -9,7 +9,7 @@
 :card:
 
 ---
-<img src="images/getting_started.svg" alt="getting_started" height="40px" style="pointer-events: none;">
+<img src="images/getting_started.svg" alt="getting_started" height="40px" class="no-scaled-link">
 
 **Getting started**
 ^^^^^^^^^^^^^^^

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -9,7 +9,7 @@
 :card:
 
 ---
-<img src="images/getting_started.svg" alt="getting_started" height="40px">
+<img src="images/getting_started.svg" alt="getting_started" height="40px" style="pointer-events: none;">
 
 **Getting started**
 ^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ Learn how to install Ray, compute an example with the Ray Core API, and use Ray'
 {link-badge}`ray-overview/getting-started.html,"Getting started",cls=badge-light`
 
 ---
-<img src="images/user_guide.svg" alt="user_guide" height="40px">
+<img src="images/user_guide.svg" alt="user_guide" height="40px" style="pointer-events: none;">
 
 **User guides**
 ^^^^^^^^^^^
@@ -38,7 +38,7 @@ Learn about the key concepts and features. Get in-depth information about Ray's 
 {link-badge}`ray-core/user-guide.html,"Core",cls=badge-light`
 {link-badge}`cluster/running-applications/index.html,"Clusters",cls=badge-light`
 ---
-<img src="images/api.svg" alt="api" height="40px">
+<img src="images/api.svg" alt="api" height="40px" style="pointer-events: none;">
 
 **API reference**
 ^^^^^^^^^^^^^
@@ -51,7 +51,7 @@ The reference assumes familiarity with the key concepts.
 {link-badge}`ray-references/api.html,"API reference",cls=badge-light`
 
 ---
-<img src="images/contribute.svg" alt="contribute" height="40px">
+<img src="images/contribute.svg" alt="contribute" height="40px" style="pointer-events: none;">
 
 **Developer guides**
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
A Sphinx issue automatically makes images clickable whenever they're scaled (see https://stackoverflow.com/questions/40096251/disable-click-behavior-for-images). Clicking takes you to a full size version of the image.

On the front page of the docs, there are four prominent images that look like buttons. The user would expect clicking them to take you to a docs page, but instead it just takes you to the image. (See the linked issue for details)  

Since there's no single docs page corresponding to each of these four images, in this PR we opt to make these images non clickable.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/32737
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
