### PR TITLE
[Datasets] [Operator Fusion - 5/N] Add metrics collection to data layer.

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -218,6 +218,9 @@ class ArrowBlockAccessor(TableBlockAccessor):
             view = _copy_table(view)
         return view
 
+    def does_slice_always_copy(self) -> bool:
+        return False
+
     def random_shuffle(self, random_seed: Optional[int]) -> "pyarrow.Table":
         random = np.random.RandomState(random_seed)
         return self.take(random.permutation(self.num_rows()))

--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -3,6 +3,7 @@ from typing import Optional, List
 
 from ray.data.block import Block, BlockAccessor
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
+from ray.data._internal.metrics import DataMungingMetrics
 
 
 class BatcherInterface:
@@ -38,6 +39,10 @@ class BatcherInterface:
         """
         raise NotImplementedError()
 
+    def get_metrics(self) -> DataMungingMetrics:
+        """Returns the batching metrics for this Batcher."""
+        raise NotImplementedError()
+
 
 class Batcher(BatcherInterface):
     """Chunks blocks into batches."""
@@ -63,6 +68,7 @@ class Batcher(BatcherInterface):
         self._buffer_size = 0
         self._done_adding = False
         self._ensure_copy = ensure_copy
+        self._metrics = DataMungingMetrics()
 
     def add(self, block: Block):
         """Add a block to the block buffer.
@@ -102,15 +108,17 @@ class Batcher(BatcherInterface):
             A batch represented as a Block.
         """
         assert self.has_batch() or (self._done_adding and self.has_any())
-        needs_copy = self._ensure_copy
         # If no batch size, short-circuit.
         if self._batch_size is None:
             assert len(self._buffer) == 1
             block = self._buffer[0]
-            if needs_copy:
+            if self._ensure_copy:
                 # Copy block if needing to ensure fresh batch copy.
                 block = BlockAccessor.for_block(block)
-                block = block.slice(0, block.num_rows(), copy=True)
+                num_rows = block.num_rows()
+                block = block.slice(0, num_rows, copy=True)
+                self._metrics.num_rows_sliced += num_rows
+                self._metrics.num_rows_copied += num_rows
             self._buffer = []
             self._buffer_size = 0
             return block
@@ -128,25 +136,40 @@ class Batcher(BatcherInterface):
                 # We need to call `accessor.slice()` to ensure
                 # the subsequent block's type are the same.
                 output.add_block(accessor.slice(0, accessor.num_rows(), copy=False))
+                self._metrics.num_rows_sliced += accessor.num_rows()
+                if accessor.does_slice_always_copy():
+                    self._metrics.num_rows_copied += accessor.num_rows()
                 needed -= accessor.num_rows()
             else:
                 # We only need part of the block to fill out a batch.
                 output.add_block(accessor.slice(0, needed, copy=False))
                 # Add the rest of the block to the leftovers.
                 leftover.append(accessor.slice(needed, accessor.num_rows(), copy=False))
+                self._metrics.num_rows_sliced += accessor.num_rows()
+                if accessor.does_slice_always_copy():
+                    # This includes both the slice added to the output and the slice
+                    # added to the leftovers.
+                    self._metrics.num_rows_copied += accessor.num_rows()
                 needed = 0
 
         # Move the leftovers into the block buffer so they're the first
         # blocks consumed on the next batch extraction.
         self._buffer = leftover
         self._buffer_size -= self._batch_size
-        needs_copy = needs_copy and not output.will_build_yield_copy()
+        build_will_yield_copy = output.will_build_yield_copy()
         batch = output.build()
-        if needs_copy:
+        self._metrics = self._metrics.merge_with(output.get_metrics())
+        if self._ensure_copy and not build_will_yield_copy:
             # Need to ensure that the batch is a fresh copy.
             batch = BlockAccessor.for_block(batch)
-            batch = batch.slice(0, batch.num_rows(), copy=True)
+            num_rows = batch.num_rows()
+            batch = batch.slice(0, num_rows, copy=True)
+            self._metrics.num_rows_sliced += num_rows
+            self._metrics.num_rows_copied += num_rows
         return batch
+
+    def get_metrics(self) -> DataMungingMetrics:
+        return self._metrics
 
 
 class ShufflingBatcher(BatcherInterface):
@@ -215,6 +238,7 @@ class ShufflingBatcher(BatcherInterface):
         self._shuffle_indices: List[int] = None
         self._batch_head = 0
         self._done_adding = False
+        self._metrics = DataMungingMetrics()
 
         if shuffle_seed is not None:
             random.seed(shuffle_seed)
@@ -292,10 +316,15 @@ class ShufflingBatcher(BatcherInterface):
                     self._shuffle_buffer = BlockAccessor.for_block(
                         self._shuffle_buffer
                     ).take(self._shuffle_indices[self._batch_head :])
+                    self._metrics.num_rows_copied += BlockAccessor.for_block(
+                        self._shuffle_buffer
+                    ).num_rows()
                 # Add the unyielded rows from the existing shuffle buffer.
                 self._builder.add_block(self._shuffle_buffer)
             # Build the new shuffle buffer.
             self._shuffle_buffer = self._builder.build()
+            # Propagate block building stats from block builder.
+            self._metrics = self._metrics.merge_with(self._builder.get_metrics())
             # Reset the builder.
             self._builder = DelegatingBlockBuilder()
             # Invalidate the shuffle indices.
@@ -318,4 +347,8 @@ class ShufflingBatcher(BatcherInterface):
         ]
         self._batch_head += batch_size
         # Yield the shuffled batch.
+        self._metrics.num_rows_copied += len(batch_indices)
         return BlockAccessor.for_block(self._shuffle_buffer).take(batch_indices)
+
+    def get_metrics(self) -> DataMungingMetrics:
+        return self._metrics

--- a/python/ray/data/_internal/block_batching/block_batching.py
+++ b/python/ray/data/_internal/block_batching/block_batching.py
@@ -15,6 +15,7 @@ from ray.data._internal.block_batching.util import (
     ActorBlockPrefetcher,
 )
 from ray.data._internal.memory_tracing import trace_deallocation
+from ray.data._internal.metrics import MetricsCollector
 from ray.data._internal.stats import DatasetPipelineStats, DatasetStats
 from ray.data.block import Block, DataBatch
 from ray.data.context import DatasetContext
@@ -131,6 +132,7 @@ def batch_blocks(
     shuffle_buffer_min_size: Optional[int] = None,
     shuffle_seed: Optional[int] = None,
     ensure_copy: bool = False,
+    metrics_collector: Optional[MetricsCollector] = None,
 ) -> Iterator[DataBatch]:
     """Create formatted batches of data from 1 or more blocks.
 
@@ -149,6 +151,7 @@ def batch_blocks(
                 shuffle_buffer_min_size=shuffle_buffer_min_size,
                 shuffle_seed=shuffle_seed,
                 ensure_copy=ensure_copy,
+                metrics_collector=metrics_collector,
             ),
             batch_format=batch_format,
             stats=stats,
@@ -184,6 +187,7 @@ def _prefetch_blocks(
         num_blocks_to_prefetch: The number of blocks to prefetch ahead of the
             current block during the scan.
         stats: Dataset stats object used to store block wait time.
+        metrics_collector: Collector for batching metrics.
     """
     if num_blocks_to_prefetch == 0:
         for block_ref in block_ref_iter:

--- a/python/ray/data/_internal/block_builder.py
+++ b/python/ray/data/_internal/block_builder.py
@@ -1,6 +1,7 @@
 from typing import Generic
 
 from ray.data.block import Block, BlockAccessor, T
+from ray.data._internal.metrics import DataMungingMetrics
 
 
 class BlockBuilder(Generic[T]):
@@ -32,4 +33,8 @@ class BlockBuilder(Generic[T]):
 
     def get_estimated_memory_usage(self) -> int:
         """Return the estimated memory usage so far in bytes."""
+        raise NotImplementedError
+
+    def get_metrics(self) -> DataMungingMetrics:
+        """Return the data munging metrics for this builder."""
         raise NotImplementedError

--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -7,6 +7,7 @@ import ray
 from ray.data._internal.block_list import BlockList
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.interfaces import TaskContext
+from ray.data._internal.metrics import MetricsCollector
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data.block import (
@@ -37,8 +38,11 @@ BlockTransform = Union[
     # transform type.
     # Callable[[Block, ...], Iterable[Block]]
     # Callable[[Block, BatchUDF, ...], Iterable[Block]],
-    Callable[[Iterable[Block], TaskContext], Iterable[Block]],
-    Callable[[Iterable[Block], TaskContext, Union[BatchUDF, RowUDF]], Iterable[Block]],
+    Callable[[Iterable[Block], TaskContext, MetricsCollector], Iterable[Block]],
+    Callable[
+        [Iterable[Block], TaskContext, MetricsCollector, Union[BatchUDF, RowUDF]],
+        Iterable[Block],
+    ],
     Callable[..., Iterable[Block]],
 ]
 

--- a/python/ray/data/_internal/delegating_block_builder.py
+++ b/python/ray/data/_internal/delegating_block_builder.py
@@ -3,6 +3,7 @@ from typing import Any
 import numpy as np
 
 from ray.data.block import Block, DataBatch, T, BlockAccessor
+from ray.data._internal.metrics import DataMungingMetrics
 from ray.data._internal.block_builder import BlockBuilder
 from ray.data._internal.simple_block import SimpleBlockBuilder
 from ray.data._internal.arrow_block import ArrowRow, ArrowBlockBuilder
@@ -76,3 +77,6 @@ class DelegatingBlockBuilder(BlockBuilder[T]):
         if self._builder is None:
             return 0
         return self._builder.get_estimated_memory_usage()
+
+    def get_metrics(self) -> DataMungingMetrics:
+        return self._builder.get_metrics()

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -17,6 +17,7 @@ from ray.data._internal.stats import StatsDict, DatasetStats
 from ray.data._internal.stage_impl import RandomizeBlocksStage
 from ray.data._internal.block_list import BlockList
 from ray.data._internal.lazy_block_list import LazyBlockList
+from ray.data._internal.metrics import MetricsCollector
 from ray.data._internal.compute import (
     get_compute,
     CallableClass,
@@ -214,7 +215,11 @@ def _blocks_to_input_buffer(blocks: BlockList, owns_blocks: bool) -> PhysicalOpe
             for b in i.blocks:
                 trace_allocation(b[0], "legacy_compat.blocks_to_input_buf[0]")
 
-        def do_read(blocks: Iterator[Block], ctx: TaskContext) -> Iterator[Block]:
+        def do_read(
+            blocks: Iterator[Block],
+            ctx: TaskContext,
+            metrics_collector: MetricsCollector,
+        ) -> Iterator[Block]:
             for read_task in blocks:
                 yield from read_task()
 
@@ -283,8 +288,12 @@ def _stage_to_operator(stage: Stage, input_op: PhysicalOperator) -> PhysicalOper
             fn_args += stage.fn_args
         fn_kwargs = stage.fn_kwargs or {}
 
-        def do_map(blocks: Iterator[Block], ctx: TaskContext) -> Iterator[Block]:
-            yield from block_fn(blocks, ctx, *fn_args, **fn_kwargs)
+        def do_map(
+            blocks: Iterator[Block],
+            ctx: TaskContext,
+            metrics_collector: MetricsCollector,
+        ) -> Iterator[Block]:
+            yield from block_fn(blocks, ctx, metrics_collector, *fn_args, **fn_kwargs)
 
         return MapOperator.create(
             do_map,

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -253,7 +253,7 @@ class ActorPoolMapOperator(MapOperator):
         return ExecutionResources(
             cpu=self._ray_remote_args.get("num_cpus", 0) * num_active_workers,
             gpu=self._ray_remote_args.get("num_gpus", 0) * num_active_workers,
-            object_store_memory=self._metrics.cur,
+            object_store_memory=self._metrics.object_store_metrics.cur,
         )
 
     def incremental_resource_usage(self) -> ExecutionResources:

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -20,6 +20,12 @@ from ray.data._internal.execution.interfaces import (
     MapTransformFn,
 )
 from ray.data._internal.memory_tracing import trace_allocation
+from ray.data._internal.metrics import (
+    Metrics,
+    MetricsCollector,
+    DataMungingMetrics,
+    ObjectStoreMetrics,
+)
 from ray.data._internal.stats import StatsDict
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from ray.types import ObjectRef
@@ -52,7 +58,10 @@ class MapOperator(PhysicalOperator, ABC):
         # Bundles block references up to the min_rows_per_bundle target.
         self._block_ref_bundler = _BlockRefBundler(min_rows_per_bundle)
         # Object store allocation stats.
-        self._metrics = _ObjectStoreMetrics(alloc=0, freed=0, cur=0, peak=0)
+        self._metrics = _MapOperatorMetrics(
+            ObjectStoreMetrics(alloc=0, freed=0, cur=0, peak=0),
+            DataMungingMetrics(),
+        )
 
         # Queue for task outputs, either ordered or unordered (this is set by start()).
         self._output_queue: _OutputQueue = None
@@ -166,9 +175,10 @@ class MapOperator(PhysicalOperator, ABC):
     def add_input(self, refs: RefBundle, input_index: int):
         assert input_index == 0, input_index
         # Add ref bundle allocation to operator's object store metrics.
-        self._metrics.cur += refs.size_bytes()
-        if self._metrics.cur > self._metrics.peak:
-            self._metrics.peak = self._metrics.cur
+        metrics = self._metrics.object_store_metrics
+        metrics.cur += refs.size_bytes()
+        if metrics.cur > metrics.peak:
+            metrics.peak = metrics.cur
         # Add RefBundle to the bundler.
         self._block_ref_bundler.add_bundle(refs)
         if self._block_ref_bundler.has_bundle():
@@ -237,13 +247,14 @@ class MapOperator(PhysicalOperator, ABC):
         task.inputs.destroy_if_owned()
         # Update object store metrics.
         allocated = task.output.size_bytes()
-        self._metrics.alloc += allocated
-        self._metrics.cur += allocated
+        metrics = self._metrics.object_store_metrics
+        metrics.alloc += allocated
+        metrics.cur += allocated
         freed = task.inputs.size_bytes()
-        self._metrics.freed += freed
-        self._metrics.cur -= freed
-        if self._metrics.cur > self._metrics.peak:
-            self._metrics.peak = self._metrics.cur
+        metrics.freed += freed
+        metrics.cur -= freed
+        if metrics.cur > metrics.peak:
+            metrics.peak = metrics.cur
 
     def inputs_done(self):
         self._block_ref_bundler.done_adding_bundles()
@@ -260,7 +271,7 @@ class MapOperator(PhysicalOperator, ABC):
     def get_next(self) -> RefBundle:
         assert self._started
         bundle = self._output_queue.get_next()
-        self._metrics.cur -= bundle.size_bytes()
+        self._metrics.object_store_metrics.cur -= bundle.size_bytes()
         for _, meta in bundle.blocks:
             self._output_metadata.append(meta)
         return bundle
@@ -280,6 +291,7 @@ class MapOperator(PhysicalOperator, ABC):
         raise NotImplementedError
 
     def get_metrics(self) -> Dict[str, int]:
+        # Return a flattened metrics dict.
         return self._metrics.to_metrics_dict()
 
     def get_stats(self) -> StatsDict:
@@ -306,8 +318,7 @@ class MapOperator(PhysicalOperator, ABC):
     def incremental_resource_usage(self) -> ExecutionResources:
         raise NotImplementedError
 
-    @staticmethod
-    def _map_ref_to_ref_bundle(ref: ObjectRef[ObjectRefGenerator]) -> RefBundle:
+    def _map_ref_to_ref_bundle(self, ref: ObjectRef[ObjectRefGenerator]) -> RefBundle:
         """Utility for converting a generator ref to a RefBundle.
 
         This function blocks on the completion of the underlying generator task via
@@ -316,7 +327,9 @@ class MapOperator(PhysicalOperator, ABC):
         all_refs = list(ray.get(ref))
         del ref
         block_refs = all_refs[:-1]
-        block_metas = ray.get(all_refs[-1])
+        block_metas, metrics = ray.get(all_refs[-1])
+        metrics = self._metrics.data_munging_metrics.merge_with(metrics)
+        self._metrics.data_munging_metrics = metrics
         assert len(block_metas) == len(block_refs), (block_refs, block_metas)
         for ref in block_refs:
             trace_allocation(ref, "map_operator_work_completed")
@@ -337,20 +350,13 @@ class _TaskState:
 
 
 @dataclass
-class _ObjectStoreMetrics:
-    """Metrics for object store memory allocations."""
+class _MapOperatorMetrics(Metrics):
+    """Metrics for the MapOperator, including object store allocation metrics as well as
+    batching metrics.
+    """
 
-    alloc: int
-    freed: int
-    cur: int
-    peak: int
-
-    def to_metrics_dict(self) -> Dict[str, int]:
-        return {
-            "obj_store_mem_alloc": self.alloc,
-            "obj_store_mem_freed": self.freed,
-            "obj_store_mem_peak": self.peak,
-        }
+    object_store_metrics: ObjectStoreMetrics
+    data_munging_metrics: DataMungingMetrics
 
 
 def _map_task(
@@ -371,14 +377,15 @@ def _map_task(
     """
     output_metadata = []
     stats = BlockExecStats.builder()
-    for b_out in fn(iter(blocks), ctx):
+    metrics_collector = MetricsCollector()
+    for b_out in fn(iter(blocks), ctx, metrics_collector):
         # TODO(Clark): Add input file propagation from input blocks.
         m_out = BlockAccessor.for_block(b_out).get_metadata([], None)
         m_out.exec_stats = stats.build()
         output_metadata.append(m_out)
         yield b_out
         stats = BlockExecStats.builder()
-    yield output_metadata
+    yield output_metadata, metrics_collector.get_metrics()
 
 
 class _BlockRefBundler:

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -98,7 +98,7 @@ class TaskPoolMapOperator(MapOperator):
         return ExecutionResources(
             cpu=self._ray_remote_args.get("num_cpus", 0) * num_active_workers,
             gpu=self._ray_remote_args.get("num_gpus", 0) * num_active_workers,
-            object_store_memory=self._metrics.cur,
+            object_store_memory=self._metrics.object_store_metrics.cur,
         )
 
     def incremental_resource_usage(self) -> ExecutionResources:

--- a/python/ray/data/_internal/metrics.py
+++ b/python/ray/data/_internal/metrics.py
@@ -1,0 +1,94 @@
+from abc import ABC
+from dataclasses import dataclass, fields
+import operator
+
+from typing import Dict, Callable
+
+
+@dataclass
+class Metrics(ABC):
+    """Internal metrics struct, with helpers for merging metrics and returning a
+    user-friendly dict representation.
+    """
+
+    def merge_with(self, other: "Metrics"):
+        """Merge with provided metrics."""
+        if not isinstance(other, type(self)):
+            raise ValueError(f"Expected {type(self)}, got: {type(other)}")
+
+        merged_metrics = {}
+        for metric_field in fields(other):
+            metric_name = metric_field.name
+            self_metric = getattr(self, metric_name)
+            other_metric = getattr(other, metric_name)
+            if isinstance(self_metric, Metrics):
+                assert isinstance(other_metric, Metrics)
+                new_metric = self_metric.merge_with(other_metric)
+            else:
+                metric_merger = self._get_metric_merger(metric_name)
+                new_metric = metric_merger(self_metric, other_metric)
+            merged_metrics[metric_name] = new_metric
+        return type(other)(**merged_metrics)
+
+    def _get_metric_merger(self, metric: str) -> Callable[[int, int], int]:
+        return operator.add
+
+    def to_metrics_dict(self) -> Dict[str, int]:
+        """Return a dictionary view of these metrics."""
+        metrics = {}
+        for metric in fields(self):
+            metric_value = getattr(self, metric.name)
+            if isinstance(metric_value, Metrics):
+                metric_value = metric_value.to_metrics_dict()
+            metrics[metric.name] = metric_value
+        return metrics
+
+
+@dataclass
+class DataMungingMetrics(Metrics):
+    """
+    Metrics for data munging, e.g. data slicing, concatenation, format conversions.
+    """
+
+    num_rows_copied: int = 0
+    num_format_conversions: int = 0
+    num_rows_sliced: int = 0
+    num_rows_concatenated: int = 0
+
+
+@dataclass
+class ObjectStoreMetrics(Metrics):
+    """Metrics for object store memory allocations."""
+
+    alloc: int
+    freed: int
+    cur: int
+    peak: int
+
+    def _get_metric_merger(self, metric: str) -> Callable[[int, int], int]:
+        if metric == "peak":
+            # Take the max of the peak metric.
+            return max
+        else:
+            # Otherwise sum.
+            return operator.add
+
+    def to_metrics_dict(self) -> Dict[str, int]:
+        return {
+            "obj_store_mem_alloc": self.alloc,
+            "obj_store_mem_freed": self.freed,
+            "obj_store_mem_peak": self.peak,
+        }
+
+
+class MetricsCollector:
+    """Metrics collector, for recording and returning merged metrics."""
+
+    def __init__(self):
+        self._metrics = DataMungingMetrics()
+
+    def record_metrics(self, metrics: DataMungingMetrics):
+        self._metrics = self._metrics.merge_with(metrics)
+
+    def get_metrics(self) -> DataMungingMetrics:
+        return self._metrics

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -156,6 +156,9 @@ class PandasBlockAccessor(TableBlockAccessor):
             view = view.copy(deep=True)
         return view
 
+    def does_slice_always_copy(self) -> bool:
+        return False
+
     def take(self, indices: List[int]) -> "pandas.DataFrame":
         table = self._table.take(indices)
         table.reset_index(drop=True, inplace=True)

--- a/python/ray/data/_internal/planner/flat_map.py
+++ b/python/ray/data/_internal/planner/flat_map.py
@@ -1,6 +1,7 @@
 from typing import Callable, Iterator
 
 from ray.data._internal.execution.interfaces import TaskContext
+from ray.data._internal.metrics import MetricsCollector
 from ray.data._internal.output_buffer import BlockOutputBuffer
 from ray.data.block import Block, BlockAccessor, RowUDF
 from ray.data.context import DatasetContext
@@ -16,7 +17,10 @@ def generate_flat_map_fn() -> Callable[
     context = DatasetContext.get_current()
 
     def fn(
-        blocks: Iterator[Block], ctx: TaskContext, row_fn: RowUDF
+        blocks: Iterator[Block],
+        ctx: TaskContext,
+        metrics_collector: MetricsCollector,
+        row_fn: RowUDF,
     ) -> Iterator[Block]:
         DatasetContext._set_current(context)
         output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
@@ -30,5 +34,7 @@ def generate_flat_map_fn() -> Callable[
         output_buffer.finalize()
         if output_buffer.has_next():
             yield output_buffer.next()
+        if metrics_collector is not None:
+            metrics_collector.record_metrics(output_buffer.get_metrics())
 
     return fn

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -10,6 +10,7 @@ from ray.data._internal.execution.interfaces import (
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.logical.operators.read_operator import Read
+from ray.data._internal.metrics import MetricsCollector
 from ray.data.block import Block, BlockMetadata
 from ray.data.datasource.datasource import ReadTask
 
@@ -47,7 +48,11 @@ def _plan_read_op(op: Read) -> PhysicalOperator:
 
     inputs = InputDataBuffer(input_data_factory=get_input_data)
 
-    def do_read(blocks: Iterator[ReadTask], ctx: TaskContext) -> Iterator[Block]:
+    def do_read(
+        blocks: Iterator[ReadTask],
+        ctx: TaskContext,
+        metrics_collector: MetricsCollector,
+    ) -> Iterator[Block]:
         for read_task in blocks:
             yield from read_task()
 

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -15,6 +15,7 @@ from ray.data._internal.logical.operators.map_operator import (
     MapBatches,
     MapRows,
 )
+from ray.data._internal.metrics import MetricsCollector
 from ray.data._internal.planner.filter import generate_filter_fn
 from ray.data._internal.planner.flat_map import generate_flat_map_fn
 from ray.data._internal.planner.map_batches import generate_map_batches_fn
@@ -81,8 +82,12 @@ def _plan_udf_map_op(
         fn_args += op._fn_args
     fn_kwargs = op._fn_kwargs or {}
 
-    def do_map(blocks: Iterator[Block], ctx: TaskContext) -> Iterator[Block]:
-        yield from transform_fn(blocks, ctx, *fn_args, **fn_kwargs)
+    def do_map(
+        blocks: Iterator[Block],
+        ctx: TaskContext,
+        metrics_collector: MetricsCollector,
+    ) -> Iterator[Block]:
+        yield from transform_fn(blocks, ctx, metrics_collector, *fn_args, **fn_kwargs)
 
     return MapOperator.create(
         do_map,

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -5,6 +5,7 @@ from ray.data._internal.execution.interfaces import (
     TaskContext,
 )
 from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.metrics import MetricsCollector
 from ray.data.block import Block
 from ray.data._internal.planner.write import generate_write_fn
 from ray.data._internal.logical.operators.write_operator import Write
@@ -13,8 +14,10 @@ from ray.data._internal.logical.operators.write_operator import Write
 def _plan_write_op(op: Write, input_physical_dag: PhysicalOperator) -> PhysicalOperator:
     transform_fn = generate_write_fn(op._datasource, **op._write_args)
 
-    def do_write(blocks: Iterator[Block], ctx: TaskContext) -> Iterator[Block]:
-        yield from transform_fn(blocks, ctx)
+    def do_write(
+        blocks: Iterator[Block], ctx: TaskContext, metrics_collector: MetricsCollector
+    ) -> Iterator[Block]:
+        yield from transform_fn(blocks, ctx, metrics_collector)
 
     return MapOperator.create(
         do_write,

--- a/python/ray/data/_internal/planner/write.py
+++ b/python/ray/data/_internal/planner/write.py
@@ -1,6 +1,7 @@
 from typing import Callable, Iterator
 
 from ray.data._internal.execution.interfaces import TaskContext
+from ray.data._internal.metrics import MetricsCollector
 from ray.data.block import Block
 from ray.data.datasource import Datasource
 
@@ -12,7 +13,9 @@ def generate_write_fn(
     # WriteResult (one element per write task). Otherwise, an error will
     # be raised. The Datasource can handle execution outcomes with the
     # on_write_complete() and on_write_failed().
-    def fn(blocks: Iterator[Block], ctx) -> Iterator[Block]:
+    def fn(
+        blocks: Iterator[Block], ctx: TaskContext, metrics_collector: MetricsCollector
+    ) -> Iterator[Block]:
         return [[datasource.write(blocks, ctx, **write_args)]]
 
     return fn

--- a/python/ray/data/_internal/shuffle_and_partition.py
+++ b/python/ray/data/_internal/shuffle_and_partition.py
@@ -39,7 +39,7 @@ class _ShufflePartitionOp(ShuffleOp):
         if block_udf:
             ctx = TaskContext(task_idx=idx)
             # TODO(ekl) note that this effectively disables block splitting.
-            blocks = list(block_udf([block], ctx))
+            blocks = list(block_udf([block], ctx, None))
             if len(blocks) > 1:
                 builder = BlockAccessor.for_block(blocks[0]).builder()
                 for b in blocks:

--- a/python/ray/data/_internal/simple_block.py
+++ b/python/ray/data/_internal/simple_block.py
@@ -25,6 +25,7 @@ from ray.data.block import (
     KeyFn,
 )
 from ray.data._internal.block_builder import BlockBuilder
+from ray.data._internal.metrics import DataMungingMetrics
 from ray.data._internal.size_estimator import SizeEstimator
 
 
@@ -32,6 +33,7 @@ class SimpleBlockBuilder(BlockBuilder[T]):
     def __init__(self):
         self._items = []
         self._size_estimator = SizeEstimator()
+        self._metrics = DataMungingMetrics()
 
     def add(self, item: T) -> None:
         self._items.append(item)
@@ -47,6 +49,8 @@ class SimpleBlockBuilder(BlockBuilder[T]):
             )
         self._items.extend(block)
         self._size_estimator.add_block(block)
+        self._metrics.num_rows_concatenated += len(block)
+        self._metrics.num_rows_copied += len(block)
 
     def num_rows(self) -> int:
         return len(self._items)
@@ -55,10 +59,15 @@ class SimpleBlockBuilder(BlockBuilder[T]):
         return True
 
     def build(self) -> Block:
+        self._metrics.num_rows_copied += len(self._items)
+        # TODO(Clark): Remove this additional copy?
         return list(self._items)
 
     def get_estimated_memory_usage(self) -> int:
         return self._size_estimator.size_bytes()
+
+    def get_metrics(self) -> DataMungingMetrics:
+        return self._metrics
 
 
 class SimpleBlockAccessor(BlockAccessor):
@@ -72,10 +81,10 @@ class SimpleBlockAccessor(BlockAccessor):
         return iter(self._items)
 
     def slice(self, start: int, end: int, copy: bool = False) -> List[T]:
-        view = self._items[start:end]
-        if copy:
-            view = view.copy()
-        return view
+        return self._items[start:end]
+
+    def does_slice_always_copy(self) -> bool:
+        return True
 
     def take(self, indices: List[int]) -> List[T]:
         return [self._items[i] for i in indices]

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -7,6 +7,7 @@ from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.data.block import Block, BlockAccessor
 from ray.data.row import TableRow
 from ray.data._internal.block_builder import BlockBuilder
+from ray.data._internal.metrics import DataMungingMetrics
 from ray.data._internal.size_estimator import SizeEstimator
 from ray.data._internal.util import _is_tensor_schema
 
@@ -43,6 +44,7 @@ class TableBlockBuilder(BlockBuilder[T]):
         self._num_rows = 0
         self._num_compactions = 0
         self._block_type = block_type
+        self._metrics = DataMungingMetrics()
 
     def add(self, item: Union[dict, TableRow, np.ndarray]) -> None:
         if isinstance(item, TableRow):
@@ -109,15 +111,23 @@ class TableBlockBuilder(BlockBuilder[T]):
         return self._concat_would_copy() and len(self._tables) > 1
 
     def build(self) -> Block:
+        if self.will_build_yield_copy():
+            self._metrics.num_rows_copied += self._num_rows
         if self._columns:
             tables = [self._table_from_pydict(self._columns)]
         else:
             tables = []
         tables.extend(self._tables)
-        if len(tables) > 0:
-            return self._concat_tables(tables)
-        else:
+        if len(tables) == 0:
             return self._empty_table()
+        else:
+            if len(tables) > 1:
+                # No concatenation if there's only a single table.
+                self._metrics.num_rows_concatenated += self._num_rows
+            # NOTE: We need to go through self._concat_tables() even if there's only a
+            # single table, since this is currently our narrow waist for things like
+            # tensor extension casting; see PandasBlockAccessor._concat_tables().
+            return self._concat_tables(tables)
 
     def num_rows(self) -> int:
         return self._num_rows
@@ -129,6 +139,9 @@ class TableBlockBuilder(BlockBuilder[T]):
             self._tables_size_bytes += BlockAccessor.for_block(table).size_bytes()
         self._tables_size_cursor = len(self._tables)
         return self._tables_size_bytes + self._uncompacted_size.size_bytes()
+
+    def get_metrics(self) -> DataMungingMetrics:
+        return self._metrics
 
     def _compact_if_needed(self) -> None:
         assert self._columns

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -268,6 +268,10 @@ class BlockAccessor(Generic[T]):
         """
         raise NotImplementedError
 
+    def does_slice_always_copy(self) -> bool:
+        """Whether slicing this block always copies, even of copy=False is given."""
+        raise NotImplementedError
+
     def take(self, indices: List[int]) -> Block:
         """Return a new block containing the provided row indices.
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2884,8 +2884,10 @@ class Dataset(Generic[T]):
         if type(datasource).write != Datasource.write:
             write_fn = generate_write_fn(datasource, **write_args)
 
-            def write_fn_wrapper(blocks: Iterator[Block], ctx, fn) -> Iterator[Block]:
-                return write_fn(blocks, ctx)
+            def write_fn_wrapper(
+                blocks: Iterator[Block], ctx, metrics_collector, fn
+            ) -> Iterator[Block]:
+                return write_fn(blocks, ctx, metrics_collector)
 
             plan = self._plan.with_stage(
                 OneToOneStage(

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -55,12 +55,15 @@ class Datasource(Generic[T]):
     def write(
         self,
         blocks: Iterable[Block],
+        ctx: TaskContext,
         **write_args,
     ) -> WriteResult:
         """Write blocks out to the datasource. This is used by a single write task.
 
         Args:
             blocks: List of data blocks.
+            ctx: A context containing information for this write task, such as the
+                global task index.
             write_args: Additional kwargs to pass to the datasource impl.
 
         Returns:

--- a/python/ray/data/tests/test_batcher.py
+++ b/python/ray/data/tests/test_batcher.py
@@ -1,12 +1,273 @@
 import pytest
 
 import pyarrow as pa
+import pandas as pd
 
-from ray.data._internal.batcher import ShufflingBatcher
+from ray.data._internal.batcher import Batcher, ShufflingBatcher
 
 
-def gen_block(num_rows):
-    return pa.table({"foo": [1] * num_rows})
+def gen_block(num_rows: int, block_format: str = "pyarrow"):
+    if block_format == "pyarrow":
+        return pa.table({"foo": [1] * num_rows})
+    elif block_format == "pandas":
+        return pd.DataFrame({"foo": [1] * num_rows})
+    elif block_format == "simple":
+        return [1] * num_rows
+    else:
+        raise ValueError("No such block format: ", block_format)
+
+
+@pytest.mark.parametrize("block_format", ["pyarrow", "pandas", "simple"])
+@pytest.mark.parametrize("ensure_copy", [False, True])
+def test_batcher(block_format, ensure_copy):
+    # Test Batcher's batching logic, including when copies are made.
+    batch_size = 5
+    batcher = Batcher(batch_size=batch_size, ensure_copy=ensure_copy)
+
+    def add_and_check(num_rows, expect_has_batch=False):
+        block = gen_block(num_rows, block_format)
+        assert batcher.can_add(block)
+
+        before_metrics = batcher.get_metrics()
+        before_num_rows_sliced = before_metrics.num_rows_sliced
+        before_num_rows_concatenated = before_metrics.num_rows_concatenated
+        before_num_rows_copied = before_metrics.num_rows_copied
+
+        batcher.add(block)
+        assert not expect_has_batch or batcher.has_batch()
+
+        # Check that no slices, concatenations, or copies take place on block add.
+        after_metrics = batcher.get_metrics()
+        num_rows_sliced = after_metrics.num_rows_sliced - before_num_rows_sliced
+        num_rows_concatenated = (
+            after_metrics.num_rows_concatenated - before_num_rows_concatenated
+        )
+        num_rows_copied = after_metrics.num_rows_copied - before_num_rows_copied
+        assert num_rows_sliced == 0
+        assert num_rows_concatenated == 0
+        assert num_rows_copied == 0
+
+    def next_and_check(
+        expected_batch_size=batch_size,
+        should_have_batch_after=True,
+        expected_num_rows_sliced=0,
+        expected_num_rows_concatenated=0,
+        expected_num_rows_copied=0,
+    ):
+        if expected_batch_size == batch_size:
+            assert batcher.has_batch()
+        else:
+            assert batcher.has_any()
+            assert batcher._done_adding
+        before_metrics = batcher.get_metrics()
+        before_num_rows_sliced = before_metrics.num_rows_sliced
+        before_num_rows_concatenated = before_metrics.num_rows_concatenated
+        before_num_rows_copied = before_metrics.num_rows_copied
+
+        batch = batcher.next_batch()
+
+        assert len(batch) == expected_batch_size
+
+        if should_have_batch_after:
+            assert batcher.has_batch()
+        else:
+            assert not batcher.has_batch()
+        after_metrics = batcher.get_metrics()
+        num_rows_sliced = after_metrics.num_rows_sliced - before_num_rows_sliced
+        num_rows_concatenated = (
+            after_metrics.num_rows_concatenated - before_num_rows_concatenated
+        )
+        num_rows_copied = after_metrics.num_rows_copied - before_num_rows_copied
+        assert num_rows_sliced == expected_num_rows_sliced
+        assert num_rows_concatenated == expected_num_rows_concatenated
+        assert num_rows_copied == expected_num_rows_copied
+
+    # The following adds blocks of sizes 2, 2, 3, 6, ..., 1, 4 to the Batcher, with
+    # nexting interleaved at the ... point and with a batch_size=5 configured.
+
+    # First two blocks do not yet make a batch.
+    add_and_check(2)
+    add_and_check(2)
+    # This block puts us over the batch threshold.
+    add_and_check(3, True)
+    # Add another block.
+    add_and_check(6, True)
+
+    # Should have 13 rows (2 + 2 + 3 + 6) in the buffer at this point.
+    # Get first batch, with more than a batch remaining.
+    if block_format == "simple":
+        # First 3 blocks are all sliced.
+        expected_num_rows_sliced = 7
+        # First 2 blocks and slice of third block are concatenated to create a batch.
+        expected_num_rows_concatenated = batch_size
+        # Copies:
+        # - Slice copies.
+        # - Add block (concatenation) copies.
+        # - Final build copy.
+        expected_num_rows_copied = (
+            expected_num_rows_sliced + expected_num_rows_concatenated + batch_size
+        )
+    elif block_format == "pandas":
+        # No extra slice/copy for ensure_copy=True, since Pandas concatenation will
+        # already produce a copy.
+        # First 3 blocks are all sliced.
+        expected_num_rows_sliced = 7
+        # First 2 blocks and slice of third block are concatenated to create a batch.
+        expected_num_rows_concatenated = batch_size
+        # Concatenation to create the batch.
+        expected_num_rows_copied = expected_num_rows_concatenated
+    else:
+        # First 3 blocks are all sliced.
+        expected_num_rows_sliced = 7
+        if ensure_copy:
+            # If ensure_copy, we slice-copy the batch before returning it.
+            expected_num_rows_sliced += batch_size
+        # First 2 blocks and slice of third block are concatenated to create a batch.
+        expected_num_rows_concatenated = batch_size
+        # Only copied if ensure_copy=True.
+        expected_num_rows_copied = batch_size if ensure_copy else 0
+
+    next_and_check(
+        batch_size,
+        True,
+        expected_num_rows_sliced=expected_num_rows_sliced,
+        expected_num_rows_concatenated=expected_num_rows_concatenated,
+        expected_num_rows_copied=expected_num_rows_copied,
+    )
+
+    # Should have 8 rows (2 + 6) in the buffer at this point.
+    # Get second batch, with no full batch remaining.
+    if block_format == "simple":
+        # Both (two) blocks are sliced.
+        expected_num_rows_sliced = 8
+        # First block and slice of second block are concatenated to create a batch.
+        expected_num_rows_concatenated = batch_size
+        # Copies:
+        # - Slice copies.
+        # - Add block (concatenation) copies.
+        # - Final build copy.
+        expected_num_rows_copied = (
+            expected_num_rows_sliced + expected_num_rows_concatenated + batch_size
+        )
+    elif block_format == "pandas":
+        # No extra slice/copy for ensure_copy=True, since Pandas concatenation will
+        # already produce a copy.
+        # Both blocks are all sliced.
+        expected_num_rows_sliced = 8
+        # First block and slice of second block are concatenated to create a batch.
+        expected_num_rows_concatenated = batch_size
+        # Concatenation to create the batch.
+        expected_num_rows_copied = expected_num_rows_concatenated
+    else:
+        assert block_format == "pyarrow"
+        # If ensure_copy=True, there will be an extra slice-copy.
+        # Both blocks are all sliced.
+        expected_num_rows_sliced = 8
+        if ensure_copy:
+            # If ensure_copy, we slice-copy the batch before returning it.
+            expected_num_rows_sliced += batch_size
+        # First block and slice of second block are concatenated to create a batch.
+        expected_num_rows_concatenated = batch_size
+        # Only copied if ensure_copy=True.
+        expected_num_rows_copied = batch_size if ensure_copy else 0
+
+    next_and_check(
+        batch_size,
+        False,
+        expected_num_rows_sliced=expected_num_rows_sliced,
+        expected_num_rows_concatenated=expected_num_rows_concatenated,
+        expected_num_rows_copied=expected_num_rows_copied,
+    )
+
+    assert not batcher.has_batch()
+
+    # Interleave block add with nexting.
+    # NOTE: 3 rows carried over from last block adding run.
+    add_and_check(1)
+    add_and_check(4, True)
+
+    # Indicate to the batcher that we're done adding blocks.
+    batcher.done_adding()
+
+    # Should have 8 rows (3 + 1 + 4) in the buffer at this point.
+    # Get first batch, with no full batch remaining.
+    if block_format == "simple":
+        # All three blocks are fully sliced.
+        expected_num_rows_sliced = 8
+        # First 2 blocks and slice of third block are concatenated to create a batch.
+        expected_num_rows_concatenated = batch_size
+        # Copies:
+        # - Slice copies.
+        # - Add block (concatenation) copies.
+        # - Final build copy.
+        expected_num_rows_copied = (
+            expected_num_rows_sliced + expected_num_rows_concatenated + batch_size
+        )
+    elif block_format == "pandas":
+        # No extra slice/copy for ensure_copy=True, since Pandas concatenation will
+        # already produce a copy.
+        # First 3 blocks are all sliced.
+        expected_num_rows_sliced = 8
+        # First 2 blocks and slice of third block are concatenated to create a batch.
+        expected_num_rows_concatenated = batch_size
+        # Concatenation to create the batch.
+        expected_num_rows_copied = expected_num_rows_concatenated
+    else:
+        assert block_format == "pyarrow"
+        # If ensure_copy=True, there will be an extra slice-copy.
+        # First 3 blocks are all sliced.
+        expected_num_rows_sliced = 8
+        if ensure_copy:
+            # If ensure_copy, we slice-copy the batch before returning it.
+            expected_num_rows_sliced += batch_size
+        # First 2 blocks and slice of third block are concatenated to create a batch.
+        expected_num_rows_concatenated = batch_size
+        # Only copied if ensure_copy=True.
+        expected_num_rows_copied = batch_size if ensure_copy else 0
+
+    next_and_check(
+        batch_size,
+        False,
+        expected_num_rows_sliced=expected_num_rows_sliced,
+        expected_num_rows_concatenated=expected_num_rows_concatenated,
+        expected_num_rows_copied=expected_num_rows_copied,
+    )
+
+    # Should have 3 rows in the buffer at this point.
+    # Get remainder batch.
+    if block_format == "simple":
+        # Single block sliced.
+        expected_num_rows_sliced = 3
+        # Single block concatenated.
+        expected_num_rows_concatenated = 3
+        # Copies:
+        # - Slice copies.
+        # - Add block (concatenation) copies.
+        # - Final build copy.
+        expected_num_rows_copied = (
+            expected_num_rows_sliced + expected_num_rows_concatenated + 3
+        )
+    else:
+        if ensure_copy:
+            # Ensuring copy will force an extra slice-copy.
+            expected_num_rows_sliced = 6
+            expected_num_rows_copied = 3
+        else:
+            expected_num_rows_sliced = 3
+            expected_num_rows_copied = 0
+        # No concatenation for a single remainder block.
+        expected_num_rows_concatenated = 0
+
+    next_and_check(
+        3,
+        False,
+        expected_num_rows_sliced=expected_num_rows_sliced,
+        expected_num_rows_concatenated=expected_num_rows_concatenated,
+        expected_num_rows_copied=expected_num_rows_copied,
+    )
+
+    # Batcher should have no rows in its buffer at this point.
+    assert not batcher.has_any()
 
 
 def test_shuffling_batcher():
@@ -47,7 +308,8 @@ def test_shuffling_batcher():
         if should_batch_be_full:
             assert batcher.has_batch()
         else:
-            batcher.has_any()
+            assert batcher.has_any()
+            assert batcher._done_adding
         if new_data_added:
             # If new data was added, the builder should be non-empty.
             assert batcher._builder.num_rows() > 0

--- a/python/ray/data/tests/test_bulk_executor.py
+++ b/python/ray/data/tests/test_bulk_executor.py
@@ -16,7 +16,7 @@ from ray.data.tests.conftest import *  # noqa
 
 
 def make_transform(block_fn):
-    def map_fn(block_iter, ctx):
+    def map_fn(block_iter, *_):
         for block in block_iter:
             yield block_fn(block)
 
@@ -58,7 +58,7 @@ def test_multi_stage_execution(ray_start_10_cpus_shared, preserve_order):
     o2 = MapOperator.create(make_transform(delay_first), o1)
     o3 = MapOperator.create(make_transform(lambda block: [b * 2 for b in block]), o2)
 
-    def reverse_sort(inputs: List[RefBundle], ctx):
+    def reverse_sort(inputs: List[RefBundle], *_):
         reversed_list = inputs[::-1]
         return reversed_list, {}
 

--- a/python/ray/data/tests/test_metrics.py
+++ b/python/ray/data/tests/test_metrics.py
@@ -1,0 +1,133 @@
+from dataclasses import dataclass
+from typing import Callable
+
+from ray.data._internal.metrics import (
+    Metrics,
+    DataMungingMetrics,
+    ObjectStoreMetrics,
+    MetricsCollector,
+)
+from ray.tests.conftest import *  # noqa
+
+
+@dataclass
+class TestMetrics(Metrics):
+    a: int = 1
+    b: int = 2
+
+
+def test_metrics_to_dict():
+    # Test that dictionary view of metrics is as expected.
+    metrics = TestMetrics(a=2, b=3)
+
+    assert metrics.to_metrics_dict() == {"a": 2, "b": 3}
+
+
+def test_metrics_merge():
+    # Test metrics merging.
+    m1 = TestMetrics()
+    m2 = TestMetrics(a=3, b=5)
+
+    m = m1.merge_with(m2)
+    assert m.a == 4
+    assert m.b == 7
+    assert m.to_metrics_dict() == {"a": 4, "b": 7}
+
+
+@dataclass
+class TestMetricsWithCustomMerger(Metrics):
+    a: int = 0
+    b: int = 2
+
+    def _get_metric_merger(self, metric: str) -> Callable[[int, int], int]:
+        if metric == "a":
+            return max
+        else:
+            return super()._get_metric_merger(metric)
+
+
+def test_metrics_custom_merger():
+    # Test metrics merging with custom merger function.
+    m1 = TestMetricsWithCustomMerger(a=3, b=3)
+    m2 = TestMetricsWithCustomMerger(a=4, b=7)
+
+    m = m1.merge_with(m2)
+    assert m.a == 4
+    assert m.b == 10
+    assert m.to_metrics_dict() == {"a": 4, "b": 10}
+
+
+def test_data_munging_metrics():
+    # Test DataMungingMetrics merging and dict view.
+    m1 = DataMungingMetrics(
+        num_rows_copied=6,
+        num_format_conversions=1,
+        num_rows_sliced=2,
+        num_rows_concatenated=4,
+    )
+    m2 = DataMungingMetrics(
+        num_rows_copied=8,
+        num_format_conversions=1,
+        num_rows_sliced=3,
+        num_rows_concatenated=5,
+    )
+
+    m = m1.merge_with(m2)
+    assert m.num_rows_copied == 14
+    assert m.num_format_conversions == 2
+    assert m.num_rows_sliced == 5
+    assert m.num_rows_concatenated == 9
+    assert m.to_metrics_dict() == {
+        "num_rows_copied": 14,
+        "num_format_conversions": 2,
+        "num_rows_sliced": 5,
+        "num_rows_concatenated": 9,
+    }
+
+
+def test_object_store_metrics():
+    # Test ObjectStoreMetrics merging and dict view.
+    m1 = ObjectStoreMetrics(alloc=8, freed=2, cur=3, peak=4)
+    m2 = ObjectStoreMetrics(alloc=16, freed=6, cur=4, peak=8)
+
+    m = m1.merge_with(m2)
+    assert m.alloc == 24
+    assert m.freed == 8
+    assert m.cur == 7
+    assert m.peak == 8
+    assert m.to_metrics_dict() == {
+        "obj_store_mem_alloc": 24,
+        "obj_store_mem_freed": 8,
+        "obj_store_mem_peak": 8,
+    }
+
+
+def test_metrics_collector():
+    # Test MetricsCollector metrics recording/merging.
+    metrics_collector = MetricsCollector()
+    m1 = DataMungingMetrics(
+        num_rows_copied=6,
+        num_format_conversions=1,
+        num_rows_sliced=2,
+        num_rows_concatenated=4,
+    )
+    metrics_collector.record_metrics(m1)
+    m2 = DataMungingMetrics(
+        num_rows_copied=8,
+        num_format_conversions=1,
+        num_rows_sliced=3,
+        num_rows_concatenated=5,
+    )
+    metrics_collector.record_metrics(m2)
+
+    m = metrics_collector.get_metrics()
+    assert m.num_rows_copied == 14
+    assert m.num_format_conversions == 2
+    assert m.num_rows_sliced == 5
+    assert m.num_rows_concatenated == 9
+    assert m.to_metrics_dict() == {
+        "num_rows_copied": 14,
+        "num_format_conversions": 2,
+        "num_rows_sliced": 5,
+        "num_rows_concatenated": 9,
+    }

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -69,8 +69,10 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': N, \
+'num_rows_concatenated': N}}
 """
                 )
             else:
@@ -100,8 +102,10 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': Z, \
+'num_rows_concatenated': Z}}
 """
                 )
             else:
@@ -131,8 +135,10 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': N, \
+'num_rows_concatenated': N}}
 
 Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
@@ -141,8 +147,10 @@ Stage N Map: N/N blocks executed in T
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': Z, \
+'num_rows_concatenated': Z}}
 
 Dataset iterator time breakdown:
 * Total time user code is blocked: T
@@ -167,8 +175,10 @@ Dataset iterator time breakdown:
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': N, \
+'num_rows_concatenated': N}}
 
 Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
@@ -177,8 +187,10 @@ Stage N Map: N/N blocks executed in T
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': Z, \
+'num_rows_concatenated': Z}}
 
 Dataset iterator time breakdown:
 * In ray.wait(): T
@@ -358,8 +370,10 @@ def test_dataset_stats_read_parquet(ray_start_regular_shared, tmp_path):
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': Z, \
+'num_rows_concatenated': Z}}
 """
         )
     else:
@@ -394,8 +408,10 @@ def test_dataset_split_stats(ray_start_regular_shared, tmp_path):
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': Z, \
+'num_rows_concatenated': Z}}
 
 Stage N Split: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
@@ -412,8 +428,10 @@ Stage N Map: N/N blocks executed in T
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': Z, \
+'num_rows_concatenated': Z}}
 """
             )
         else:
@@ -485,8 +503,10 @@ def test_dataset_pipeline_stats_basic(ray_start_regular_shared, enable_auto_log_
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': N, \
+'num_rows_concatenated': N}}
 """
                 )
             else:
@@ -517,8 +537,10 @@ def test_dataset_pipeline_stats_basic(ray_start_regular_shared, enable_auto_log_
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': N, \
+'num_rows_concatenated': N}}
 """
                 )
             else:
@@ -552,8 +574,10 @@ def test_dataset_pipeline_stats_basic(ray_start_regular_shared, enable_auto_log_
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': Z, \
+'num_rows_concatenated': Z}}
 """
                 )
             else:
@@ -581,8 +605,10 @@ Stage N ReadRange->MapBatches(dummy_map_batches): N/N blocks executed in T
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': N, \
+'num_rows_concatenated': N}}
 
 Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
@@ -591,13 +617,17 @@ Stage N Map: N/N blocks executed in T
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': Z, \
+'num_rows_concatenated': Z}}
 
 == Pipeline Window N ==
 Stage N ReadRange->MapBatches(dummy_map_batches): [execution cached]
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': N, \
+'num_rows_concatenated': N}}
 
 Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
@@ -606,13 +636,17 @@ Stage N Map: N/N blocks executed in T
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': Z, \
+'num_rows_concatenated': Z}}
 
 == Pipeline Window N ==
 Stage N ReadRange->MapBatches(dummy_map_batches): [execution cached]
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': N, \
+'num_rows_concatenated': N}}
 
 Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
@@ -621,8 +655,10 @@ Stage N Map: N/N blocks executed in T
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': Z, \
+'num_rows_concatenated': Z}}
 
 ##### Overall Pipeline Time Breakdown #####
 * Time stalled waiting for next dataset: T min, T max, T mean, T total
@@ -741,8 +777,10 @@ Stage N ReadRange: N/N blocks executed in T
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': Z, 'num_format_conversions': Z, 'num_rows_sliced': Z, \
+'num_rows_concatenated': Z}}
 
 == Pipeline Window N ==
 Stage N ReadRange: N/N blocks executed in T
@@ -752,8 +790,10 @@ Stage N ReadRange: N/N blocks executed in T
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
-'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': Z, 'num_format_conversions': Z, 'num_rows_sliced': Z, \
+'num_rows_concatenated': Z}}
 
 ##### Overall Pipeline Time Breakdown #####
 * Time stalled waiting for next dataset: T min, T max, T mean, T total
@@ -969,8 +1009,10 @@ def test_streaming_stats_full(ray_start_regular_shared, restore_dataset_context)
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: \
-{'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, 'obj_store_mem_peak': N}
+* Extra metrics: {'object_store_metrics': {'obj_store_mem_alloc': N, \
+'obj_store_mem_freed': N, 'obj_store_mem_peak': N}, 'data_munging_metrics': \
+{'num_rows_copied': N, 'num_format_conversions': Z, 'num_rows_sliced': Z, \
+'num_rows_concatenated': Z}}
 
 Dataset iterator time breakdown:
 * Total time user code is blocked: T

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -26,7 +26,7 @@ from ray.data.tests.conftest import *  # noqa
 
 
 def make_transform(block_fn):
-    def map_fn(block_iter, ctx):
+    def map_fn(block_iter, *_):
         for block in block_iter:
             yield block_fn(block)
 
@@ -48,7 +48,7 @@ def test_pipelined_execution(ray_start_10_cpus_shared):
     o2 = MapOperator.create(make_transform(lambda block: [b * -1 for b in block]), o1)
     o3 = MapOperator.create(make_transform(lambda block: [b * 2 for b in block]), o2)
 
-    def reverse_sort(inputs: List[RefBundle], ctx):
+    def reverse_sort(inputs: List[RefBundle], *_):
         reversed_list = inputs[::-1]
         return reversed_list, {}
 


### PR DESCRIPTION
This PR adds basic metrics collection to the Datasets data layer, focusing on batching and block building. This allows us to capture metrics around data slicing, concatenation, copying, etc.

This PR is partially stacked on changes in https://github.com/ray-project/ray/pull/32744. This PR is an e2e instrumentation successor to https://github.com/ray-project/ray/pull/33831.

## TODOs

- [x] Add copy instrumentation of zero-copy slicing; currently `num_copies` isn't incremented for slicing, even though `SimpleBlocks` always copy on `.slice()`, even if `copy=False`.
- [x] Add metrics test coverage at the batcher/builder level around expected number of slices, concatenations, copies, format conversions, etc. This already exists in the adapters PR, but only at the adapters level, and only for simple blocks.
- [x] Move to row-based metrics for slicing and concatenation.
- [x] Add unit tests of metrics abstractions.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
