### PR TITLE
[ci] Make windows test more efficient.

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -349,7 +349,11 @@ _bazel_build_before_install() {
   if [ "${OSTYPE}" = msys ]; then
     # On Windows, we perform as full of a build as possible, to ensure the repository always remains buildable on Windows.
     # (Pip install will not perform a full build.)
-    target="//:*"
+    if [ "${BUILDKITE_PARALLEL_JOB}" = "0" ]; then
+      target="//:*"
+    else
+      target="//:ray_pkg"
+    fi
   else
     # Just build Python on other platforms.
     # This because pip install captures & suppresses the build output, which causes a timeout on CI.


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There is no need to make a full build for all windows sharded tests. This PR make it only run full build in shard 0.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
