### PR TITLE
[Data] Allow generator UDFs for `map_batches` and `flat_map`

### DIFF
--- a/doc/source/data/doc_code/transforming_datasets.py
+++ b/doc/source/data/doc_code/transforming_datasets.py
@@ -260,6 +260,25 @@ ds.map_batches(ModelUDF, compute="actors").show(2)
 # fmt: on
 
 # fmt: off
+# __writing_generator_udfs_begin__
+import ray
+from typing import Iterator
+
+# Load dataset.
+ds = ray.data.read_csv("example://iris.csv")
+
+# UDF to repeat the dataframe 100 times, in chunks of 20.
+def repeat_dataframe(df: pd.DataFrame) -> Iterator[pd.DataFrame]:
+    for _ in range(5):
+        yield pd.concat([df]*20)
+
+ds.map_batches(repeat_dataframe).show(2)
+# -> {'sepal.length': 5.1, 'sepal.width': 3.5, 'petal.length': 1.4, 'petal.width': 0.2, 'variety': 'Setosa'}
+# -> {'sepal.length': 4.9, 'sepal.width': 3.0, 'petal.length': 1.4, 'petal.width': 0.2, 'variety': 'Setosa'}
+# __writing_generator_udfs_end__
+# fmt: on
+
+# fmt: off
 # __writing_pandas_out_udfs_begin__
 import ray
 import pandas as pd

--- a/doc/source/data/transforming-datasets.rst
+++ b/doc/source/data/transforming-datasets.rst
@@ -97,6 +97,8 @@ Here are the basics that you need to know about UDFs:
 
 Types of UDFs
 =============
+There are three types of UDFs that you can use with Ray Data: Function UDFs, Callable Class UDFs, and Generator UDFs.
+
 .. tabbed:: "Function UDFs"
 
   The most basic UDFs are functions that take in a batch or row as input, and returns a batch or row as output. See :ref:`transform_datasets_batch_formats` for the supported batch formats.
@@ -127,6 +129,9 @@ Types of UDFs
 .. tabbed:: "Generator UDFs"
 
   UDFs can also be written as Python generators, yielding multiple outputs for a batch or row instead of a single item. Generator UDFs are useful UDFs return large objects. Instead of returning a very large output batch, ``fn`` can instead yield the output batch in chunks to avoid excessive heap memory usage.
+
+  .. warning::
+    When applying a generator UDF on individual rows, make sure to use the :meth:`.flat_map() <ray.data.Dataset.flat_map>` API and not the :meth:`.map() <ray.data.Dataset.map>` API.
 
   .. literalinclude:: ./doc_code/transforming_datasets.py
     :language: python

--- a/doc/source/data/transforming-datasets.rst
+++ b/doc/source/data/transforming-datasets.rst
@@ -128,7 +128,7 @@ There are three types of UDFs that you can use with Ray Data: Function UDFs, Cal
 
 .. tabbed:: "Generator UDFs"
 
-  UDFs can also be written as Python generators, yielding multiple outputs for a batch or row instead of a single item. Generator UDFs are useful UDFs return large objects. Instead of returning a very large output batch, ``fn`` can instead yield the output batch in chunks to avoid excessive heap memory usage.
+  UDFs can also be written as Python generators, yielding multiple outputs for a batch or row instead of a single item. Generator UDFs are useful when returning large objects. Instead of returning a very large output batch, ``fn`` can instead yield the output batch in chunks to avoid excessive heap memory usage.
 
   .. warning::
     When applying a generator UDF on individual rows, make sure to use the :meth:`.flat_map() <ray.data.Dataset.flat_map>` API and not the :meth:`.map() <ray.data.Dataset.map>` API.

--- a/doc/source/data/transforming-datasets.rst
+++ b/doc/source/data/transforming-datasets.rst
@@ -89,28 +89,50 @@ API in Datasets.
 
 Here are the basics that you need to know about UDFs:
 
-* A UDF can be either a function, or if using the :ref:`actor compute strategy <transform_datasets_compute_strategy>`, a :ref:`callable class <transform_datasets_callable_classes>`.
+* A UDF can be either a function, a generator, or if using the :ref:`actor compute strategy <transform_datasets_compute_strategy>`, a :ref:`callable class <transform_datasets_callable_classes>`.
 * Select the UDF input :ref:`batch format <transform_datasets_batch_formats>` using the ``batch_format`` argument.
 * The UDF output type determines the Dataset schema of the transformation result.
 
 .. _transform_datasets_callable_classes:
 
-Callable Class UDFs
-===================
+Types of UDFs
+=============
+.. tabbed:: "Function UDFs"
 
-When using the actor compute strategy, per-row and per-batch UDFs can also be
-*callable classes*, i.e. classes that implement the ``__call__`` magic method. The
-constructor of the class can be used for stateful setup, and will be only invoked once
-per worker actor.
+  The most basic UDFs are functions that take in a batch or row as input, and returns a batch or row as output. See :ref:`transform_datasets_batch_formats` for the supported batch formats.
 
-.. note::
-  These transformation APIs take the uninstantiated callable class as an argument,
-  not an instance of the class.
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_default_udfs_tabular_begin__
+    :end-before: __writing_default_udfs_tabular_end__
 
-.. literalinclude:: ./doc_code/transforming_datasets.py
-   :language: python
-   :start-after: __writing_callable_classes_udfs_begin__
-   :end-before: __writing_callable_classes_udfs_end__
+.. tabbed:: "Callable Class UDFs"
+
+  When using the actor compute strategy, per-row and per-batch UDFs can also be
+  *callable classes*, i.e. classes that implement the ``__call__`` magic method. The
+  constructor of the class can be used for stateful setup, and will be only invoked once
+  per worker actor. 
+  
+  Callable classes are useful if there is expensive state (such as a neural network) that need to be loaded for the UDF. By using an actor class, the state only needs to be loaded once in the beginning, rather than for each batch.
+
+  .. note::
+    These transformation APIs take the uninstantiated callable class as an argument,
+    not an instance of the class.
+
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_callable_classes_udfs_begin__
+    :end-before: __writing_callable_classes_udfs_end__
+
+.. tabbed:: "Generator UDFs"
+
+  UDFs can also be written as Python generators, yielding multiple outputs for a batch or row instead of a single item. Generator UDFs are useful UDFs return large objects. Instead of returning a very large output batch, ``fn`` can instead yield the output batch in chunks to avoid excessive heap memory usage.
+
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_generator_udfs_begin__
+    :end-before: __writing_generator_udfs_end__
+
 
 .. _transform_datasets_batch_formats:
 

--- a/python/ray/data/_internal/planner/map_batches.py
+++ b/python/ray/data/_internal/planner/map_batches.py
@@ -1,5 +1,5 @@
-import collections
 import sys
+from types import GeneratorType
 from typing import Callable, Iterator, Optional
 
 from ray.data._internal.block_batching import batch_blocks
@@ -83,11 +83,11 @@ def generate_map_batches_fn(
                 else:
                     raise e from None
 
-            if not isinstance(batch, collections.Iterable):
+            if not isinstance(batch, GeneratorType):
                 batch = [batch]
 
-
             for b in batch:
+                validate_batch(b)
                 # Add output batch to output buffer.
                 output_buffer.add_batch(b)
                 if output_buffer.has_next():

--- a/python/ray/data/_internal/planner/map_batches.py
+++ b/python/ray/data/_internal/planner/map_batches.py
@@ -112,4 +112,3 @@ def generate_map_batches_fn(
             yield output_buffer.next()
 
     return fn
-g

--- a/python/ray/data/_internal/planner/map_batches.py
+++ b/python/ray/data/_internal/planner/map_batches.py
@@ -1,3 +1,4 @@
+import collections
 import sys
 from typing import Callable, Iterator, Optional
 
@@ -82,11 +83,15 @@ def generate_map_batches_fn(
                 else:
                     raise e from None
 
-            validate_batch(batch)
-            # Add output batch to output buffer.
-            output_buffer.add_batch(batch)
-            if output_buffer.has_next():
-                yield output_buffer.next()
+            if not isinstance(batch, collections.Iterable):
+                batch = [batch]
+
+
+            for b in batch:
+                # Add output batch to output buffer.
+                output_buffer.add_batch(b)
+                if output_buffer.has_next():
+                    yield output_buffer.next()
 
         # Ensure that zero-copy batch views are copied so mutating UDFs don't error.
         formatted_batch_iter = batch_blocks(
@@ -107,3 +112,4 @@ def generate_map_batches_fn(
             yield output_buffer.next()
 
     return fn
+g

--- a/python/ray/data/_internal/planner/map_rows.py
+++ b/python/ray/data/_internal/planner/map_rows.py
@@ -1,4 +1,3 @@
-from types import GeneratorType
 from typing import Callable, Iterator
 
 from ray.data._internal.execution.interfaces import TaskContext
@@ -22,13 +21,9 @@ def generate_map_rows_fn() -> Callable[
         for block in blocks:
             block = BlockAccessor.for_block(block)
             for row in block.iter_rows():
-                row = row_fn(row)
-                if not isinstance(row, GeneratorType):
-                    row = [row]
-                for r in row:
-                    output_buffer.add(r)
-                    if output_buffer.has_next():
-                        yield output_buffer.next()
+                output_buffer.add(row_fn(row))
+                if output_buffer.has_next():
+                    yield output_buffer.next()
         output_buffer.finalize()
         if output_buffer.has_next():
             yield output_buffer.next()

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -109,7 +109,7 @@ CallableClass = type
 
 
 class _CallableClassProtocol(Protocol[T, U]):
-    def __call__(self, __arg: T) -> U:
+    def __call__(self, __arg: T) -> Union[U, Iterator[U]]:
         ...
 
 
@@ -119,6 +119,7 @@ BatchUDF = Union[
     # UDF type.
     # Callable[[DataBatch, ...], DataBatch]
     Callable[[DataBatch], DataBatch],
+    Callable[[DataBatch], Iterator[DataBatch]],
     "_CallableClassProtocol",
 ]
 
@@ -128,6 +129,7 @@ RowUDF = Union[
     # UDF type.
     # Callable[[T, ...], U]
     Callable[[T], U],
+    Callable[[T], Iterator[U]],
     "_CallableClassProtocol[T, U]",
 ]
 

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -129,8 +129,13 @@ RowUDF = Union[
     # UDF type.
     # Callable[[T, ...], U]
     Callable[[T], U],
-    Callable[[T], Iterator[U]],
     "_CallableClassProtocol[T, U]",
+]
+
+
+FlatMapUDF = Union[
+    RowUDF,
+    Callable[[T], Iterator[U]],
 ]
 
 # A list of block references pending computation by a single task. For example,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -92,6 +92,7 @@ from ray.data.block import (
     BlockMetadata,
     BlockPartition,
     DataBatch,
+    FlatMapUDF,
     KeyFn,
     RowUDF,
     T,
@@ -824,7 +825,7 @@ class Dataset(Generic[T]):
 
     def flat_map(
         self,
-        fn: RowUDF[T, U],
+        fn: FlatMapUDF[T, U],
         *,
         compute: Union[str, ComputeStrategy] = None,
         **ray_remote_args,
@@ -844,7 +845,7 @@ class Dataset(Generic[T]):
         Time complexity: O(dataset size / parallelism)
 
         Args:
-            fn: The function to apply to each record, or a class type
+            fn: The function or generator to apply to each record, or a class type
                 that can be instantiated to create such a callable. Callable classes are
                 only supported for the actor compute strategy.
             compute: The compute strategy, either "tasks" (default) to use Ray

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -513,7 +513,7 @@ class Dataset(Generic[T]):
             ...     for i in range(3):
             ...         yield batch * 100
             >>> ds = ray.data.from_items([1])
-            >>> ds = ds.map_batches(map_fn)
+            >>> ds = ds.map_batches(map_fn_with_large_output)
             >>> ds
             MapBatches(map_fn_with_large_output)
             +- Dataset(num_blocks=1, num_rows=1, schema=<class 'int'>)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -505,8 +505,21 @@ class Dataset(Generic[T]):
             ...     num_gpus=1,
             ... ) # doctest: +SKIP
 
+            ``fn`` can also be a generator, yielding multiple batches in a single invocation. This is useful when returning large objects. Instead of returning a very large output batch, ``fn`` can instead yield the output batch in chunks.
+
+            >>> from typing import Iterator
+            >>> def map_fn_with_large_output(batch: List[int]) -> Iterator[List[int]]:
+            ...     for i in range(3):
+            ...         yield batch * 100
+            >>> ds = ray.data.from_items([1])
+            >>> ds = ds.map_batches(map_fn)
+            >>> ds
+            MapBatches(map_fn_with_large_output)
+            +- Dataset(num_blocks=1, num_rows=1, schema=<class 'int'>)
+
+
         Args:
-            fn: The function to apply to each record batch, or a class type
+            fn: The function or generator to apply to each record batch, or a class type
                 that can be instantiated to create such a callable. Callable classes are
                 only supported for the actor compute strategy. Note ``fn`` must be
                 pickle-able.

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -4,6 +4,7 @@ import os
 import random
 import signal
 import time
+from typing import Iterator
 from unittest.mock import patch
 
 import numpy as np
@@ -320,6 +321,16 @@ def test_basic(ray_start_regular_shared, pipelined):
     assert ds.count() == 5
     ds = maybe_pipeline(ds0, pipelined)
     assert sorted(ds.iter_rows()) == [0, 1, 2, 3, 4]
+
+
+def test_map_generator(ray_start_regular_shared):
+    ds = ray.data.range(3)
+
+    def map_generator(item: int) -> Iterator[int]:
+        for _ in range(2):
+            yield item + 1
+
+    assert sorted(ds.map(map_generator).take()) == [1, 1, 2, 2, 3, 3]
 
 
 def test_zip(ray_start_regular_shared):
@@ -2569,6 +2580,40 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
     assert values == [7, 11, 15]
     values = [s["two"] for s in ds_list]
     assert values == [11, 15, 19]
+
+
+def test_map_batches_generator(ray_start_regular_shared, tmp_path):
+    ctx = DatasetContext.get_current()
+    ctx.execution_options.preserve_order = True
+
+    # Set up.
+    df = pd.DataFrame({"one": [1, 2, 3], "two": [2, 3, 4]})
+    table = pa.Table.from_pandas(df)
+    pq.write_table(table, os.path.join(tmp_path, "test1.parquet"))
+
+    def pandas_generator(batch: pd.DataFrame) -> Iterator[pd.DataFrame]:
+        for i in range(len(batch)):
+            yield batch.iloc[[i]] + 1
+
+    ds = ray.data.read_parquet(str(tmp_path))
+    ds2 = ds.map_batches(pandas_generator, batch_size=1, batch_format="pandas")
+    assert ds2.dataset_format() == "pandas"
+    ds_list = ds2.take()
+    values = [s["one"] for s in ds_list]
+    assert values == [2, 3, 4]
+    values = [s["two"] for s in ds_list]
+    assert values == [3, 4, 5]
+
+    def fail_generator(batch):
+        for i in range(len(batch)):
+            yield i
+
+    # Test the wrong return value raises an exception.
+    ds = ray.data.read_parquet(str(tmp_path))
+    with pytest.raises(ValueError):
+        ds_list = ds.map_batches(
+            fail_generator, batch_size=2, batch_format="pyarrow"
+        ).take()
 
 
 def test_map_batches_actors_preserves_order(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -323,14 +323,14 @@ def test_basic(ray_start_regular_shared, pipelined):
     assert sorted(ds.iter_rows()) == [0, 1, 2, 3, 4]
 
 
-def test_map_generator(ray_start_regular_shared):
+def test_flat_map_generator(ray_start_regular_shared):
     ds = ray.data.range(3)
 
     def map_generator(item: int) -> Iterator[int]:
         for _ in range(2):
             yield item + 1
 
-    assert sorted(ds.map(map_generator).take()) == [1, 1, 2, 2, 3, 3]
+    assert sorted(ds.flat_map(map_generator).take()) == [1, 1, 2, 2, 3, 3]
 
 
 def test_zip(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2583,9 +2583,6 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
 
 
 def test_map_batches_generator(ray_start_regular_shared, tmp_path):
-    ctx = DatasetContext.get_current()
-    ctx.execution_options.preserve_order = True
-
     # Set up.
     df = pd.DataFrame({"one": [1, 2, 3], "two": [2, 3, 4]})
     table = pa.Table.from_pandas(df)
@@ -2599,9 +2596,9 @@ def test_map_batches_generator(ray_start_regular_shared, tmp_path):
     ds2 = ds.map_batches(pandas_generator, batch_size=1, batch_format="pandas")
     assert ds2.dataset_format() == "pandas"
     ds_list = ds2.take()
-    values = [s["one"] for s in ds_list]
+    values = sorted([s["one"] for s in ds_list])
     assert values == [2, 3, 4]
-    values = [s["two"] for s in ds_list]
+    values = sorted([s["two"] for s in ds_list])
     assert values == [3, 4, 5]
 
     def fail_generator(batch):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
UDFs may return very large objects (for example when converting videos stored as bytes into multiple tensors for each window frame). This can lead to large amounts of heap memory usage and possibly cause OOMs.

By allowing generator UDFs, users can instead yield chunks of the large object at a time. 

Closes https://github.com/ray-project/ray/issues/32746

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
