### PR TITLE
[CI] Fix Mac OS Pipeline

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -46,7 +46,6 @@ steps:
     - export MAC_WHEELS=1
     - export MAC_JARS=1
     - export RAY_INSTALL_JAVA=1
-    - export RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER=1
     - . ./ci/ci.sh init && source ~/.zshenv
     - ./ci/ci.sh build
     # Test wheels

--- a/rllib/core/models/tf/primitives.py
+++ b/rllib/core/models/tf/primitives.py
@@ -83,7 +83,7 @@ class TfMLP(tf.Module):
 
         assert input_dim is not None, "Input dimension must not be None"
         assert output_dim is not None, "Output dimension must not be None"
-        layers = []
+        layers = list()
 
         # input = tf.keras.layers.Dense(input_dim, activation=activation)
         layers.append(tf.keras.Input(shape=(input_dim,)))


### PR DESCRIPTION
## Why are these changes needed?

I bisected our buildkite history from master (where this kickoff always happens) and found the following:

First time the pipeline did not get kicked off properly:
<img width="1198" alt="Screenshot 2023-02-23 at 06 59 32" src="https://user-images.githubusercontent.com/9356806/220831214-4a18de34-c72a-42ad-ad48-27aa8043304a.png">

Last time the pipeline got kicked off properly:
<img width="1198" alt="Screenshot 2023-02-23 at 06 59 55" src="https://user-images.githubusercontent.com/9356806/220831263-3830be39-0d7d-4ab1-beae-76061d636ea7.png">

The pipeline has been broken since Feb 14th, very close to https://github.com/ray-project/ray/pull/32409.
I don't have enough context on the changes in the PR in question to confirm that it causes this issue so this is sort of a shot in the dark.