### PR TITLE
[Serve] Add hash function of RunningReplicaInfo

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -550,3 +550,11 @@ py_test(
     tags = ["exclusive", "team:serve"],
     deps = [":serve_lib"],
 )
+
+py_test(
+    name = "test_common",
+    size = "small",
+    srcs = serve_tests_srcs,
+    tags = ["exclusive", "team:serve"],
+    deps = [":serve_lib"],
+)

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -292,3 +292,26 @@ class RunningReplicaInfo:
     actor_handle: ActorHandle
     max_concurrent_queries: int
     is_cross_language: bool = False
+
+    def __post_init__(self):
+        # Set hash value when object is constructed.
+        # We use _acotor_id to hash the ActorHandle object
+        # instead of actor_handle itself to make sure
+        # it is consistently same actor handle between different
+        # object ids.
+
+        hash_val = hash(
+            " ".join(
+                [
+                    self.deployment_name,
+                    self.replica_tag,
+                    str(self.actor_handle._actor_id),
+                    str(self.max_concurrent_queries),
+                    str(self.is_cross_language),
+                ]
+            )
+        )
+        object.__setattr__(self, "_hash", hash_val)
+
+    def __hash__(self):
+        return self._hash

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -295,7 +295,7 @@ class RunningReplicaInfo:
 
     def __post_init__(self):
         # Set hash value when object is constructed.
-        # We use _acotor_id to hash the ActorHandle object
+        # We use _actor_id to hash the ActorHandle object
         # instead of actor_handle itself to make sure
         # it is consistently same actor handle between different
         # object ids.

--- a/python/ray/serve/tests/test_common.py
+++ b/python/ray/serve/tests/test_common.py
@@ -9,6 +9,7 @@ from ray.serve._private.common import (
     DeploymentStatusInfo,
     ApplicationStatus,
     ApplicationStatusInfo,
+    RunningReplicaInfo,
 )
 from ray.serve.generated.serve_pb2 import (
     StatusOverview as StatusOverviewProto,
@@ -183,6 +184,23 @@ class TestStatusOverview:
         reconstructed_info = StatusOverview.from_proto(deserialized_proto)
 
         assert status_info == reconstructed_info
+
+
+def test_running_replica_info():
+    """Test hash value of RunningReplicaInfo"""
+
+    class FakeHandler:
+        def __init__(self, actor_id):
+            self._actor_id = actor_id
+
+    fake_h1 = FakeHandler("1")
+    fake_h2 = FakeHandler("1")
+    assert fake_h1 != fake_h2
+    replica1 = RunningReplicaInfo("my_deployment", "1", fake_h1, 1, False)
+    replica2 = RunningReplicaInfo("my_deployment", "1", fake_h2, 1, False)
+    replica3 = RunningReplicaInfo("my_deployment", "1", fake_h2, 1, True)
+    assert replica1._hash == replica2._hash
+    assert replica3._hash != replica1._hash
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_common.py
+++ b/python/ray/serve/tests/test_common.py
@@ -189,12 +189,12 @@ class TestStatusOverview:
 def test_running_replica_info():
     """Test hash value of RunningReplicaInfo"""
 
-    class FakeHandler:
+    class FakeActorHandler:
         def __init__(self, actor_id):
             self._actor_id = actor_id
 
-    fake_h1 = FakeHandler("1")
-    fake_h2 = FakeHandler("1")
+    fake_h1 = FakeActorHandler("1")
+    fake_h2 = FakeActorHandler("1")
     assert fake_h1 != fake_h2
     replica1 = RunningReplicaInfo("my_deployment", "1", fake_h1, 1, False)
     replica2 = RunningReplicaInfo("my_deployment", "1", fake_h2, 1, False)

--- a/python/ray/serve/tests/test_deployment_state.py
+++ b/python/ray/serve/tests/test_deployment_state.py
@@ -7,7 +7,6 @@ from unittest.mock import patch, Mock
 import pytest
 
 import ray
-from ray.actor import ActorHandle
 from ray.serve._private.common import (
     DeploymentConfig,
     DeploymentInfo,
@@ -31,6 +30,11 @@ from ray.serve._private.deployment_state import (
 from ray.serve._private.storage.kv_store import RayInternalKVStore
 from ray.serve._private.utils import get_random_letters
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+
+class MockActorHandle:
+    def __init__(self):
+        self._actor_id = "fake_id"
 
 
 class MockReplicaActorWrapper:
@@ -67,6 +71,7 @@ class MockReplicaActorWrapper:
         self.healthy = True
         self._is_cross_language = False
         self._scheduling_strategy = scheduling_strategy
+        self._actor_handle = MockActorHandle()
 
     @property
     def is_cross_language(self) -> bool:
@@ -81,8 +86,8 @@ class MockReplicaActorWrapper:
         return self._deployment_name
 
     @property
-    def actor_handle(self) -> ActorHandle:
-        return None
+    def actor_handle(self) -> MockActorHandle:
+        return self._actor_handle
 
     @property
     def max_concurrent_queries(self) -> int:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When the longpoll client timeout happens, the all internal objects will be cleaned up. The longpoll client will try to poll again. When this happens, longpoll client will receive another object which having same information but different object id (ActorHandle) from the controller. 
Then after `compute_iterable_delta` is called, it will replace the same replica  in `in_flight_queries`, and cause router clean up ongoing request_ref, and keep assigning new request to the replica, which will break the `max_concurrent_queries` parameter.

## Related issue number

Closes #32652

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
