### PR TITLE
[Release] Unpin anyscale version in the OSS release tests

### DIFF
--- a/release/ray_release/util.py
+++ b/release/ray_release/util.py
@@ -144,7 +144,7 @@ def reinstall_anyscale_dependencies() -> None:
 
     # Copy anyscale pin to requirements.txt and requirements_buildkite.txt
     subprocess.check_output(
-        "pip install -U anyscale==0.5.81",
+        "pip install -U anyscale",
         shell=True,
         text=True,
     )

--- a/release/requirements.txt
+++ b/release/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements to run release tests from the local machine (including client tests)
 click
 # Copy anyscale pin to requirements_buildkite.txt and util.py
-anyscale==0.5.81
+anyscale
 slackclient
 boto3
 jinja2

--- a/release/requirements_buildkite.txt
+++ b/release/requirements_buildkite.txt
@@ -1,6 +1,6 @@
 # Requirements to run release tests from buildkite (client dependencies will be installed separately)
 # Copy anyscale pin to requirements.txt and util.py
-anyscale==0.5.81
+anyscale
 click
 boto3
 jinja2


### PR DESCRIPTION
Unpinning the anyscale version so it runs against the latest anyscale version. This makes sure we always runs on the latest anyscale version and testing this flow. 
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
