### PR TITLE
[Datasets] Support different number of blocks/rows per block in zip().

### DIFF
--- a/python/ray/data/_internal/equalize.py
+++ b/python/ray/data/_internal/equalize.py
@@ -152,7 +152,11 @@ def _split_leftovers(
         prev = split_indices[i]
     split_result: Tuple[
         List[List[ObjectRef[Block]]], List[List[BlockMetadata]]
-    ] = _split_at_indices(leftovers, split_indices)
+    ] = _split_at_indices(
+        leftovers.get_blocks_with_metadata(),
+        split_indices,
+        leftovers._owned_by_consumer,
+    )
     return [list(zip(block_refs, meta)) for block_refs, meta in zip(*split_result)][
         :num_splits
     ]

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -761,7 +761,15 @@ class ExecutionPlan:
                 not self.is_read_stage_equivalent()
                 or trailing_randomize_block_order_stage
             )
-            and self._stages_after_snapshot
+            and (
+                self._stages_after_snapshot
+                # If snapshot is cleared, we'll need to recompute from the source.
+                or (
+                    self._snapshot_blocks is not None
+                    and self._snapshot_blocks.is_cleared()
+                    and self._stages_before_snapshot
+                )
+            )
         )
 
 

--- a/python/ray/data/_internal/stage_impl.py
+++ b/python/ray/data/_internal/stage_impl.py
@@ -1,3 +1,4 @@
+import itertools
 from typing import Any, Dict, Optional, TYPE_CHECKING
 
 import ray
@@ -7,7 +8,9 @@ from ray.data._internal.shuffle_and_partition import (
     PushBasedShufflePartitionOp,
     SimpleShufflePartitionOp,
 )
+from ray.data._internal.split import _calculate_blocks_rows, _split_at_indices
 from ray.data._internal.block_list import BlockList
+from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.sort import sort_impl
@@ -147,48 +150,88 @@ class ZipStage(AllToAllStage):
     """Implementation of `Dataset.zip()`."""
 
     def __init__(self, other: "Dataset"):
-        def do_zip_all(block_list, clear_input_blocks: bool, *_):
-            blocks1 = block_list.get_blocks()
-            blocks2 = other.get_internal_block_refs()
+        def do_zip_all(block_list: BlockList, clear_input_blocks: bool, *_):
+            # Repartition other to align with this dataset, and then zip together the
+            # blocks in parallel.
+            # TODO(Clark): Port this to a streaming zip, e.g. push block pairs through
+            # an actor that buffers and zips.
+            blocks_with_metadata = block_list.get_blocks_with_metadata()
+            # Get the split indices that will align other with self.
+            block_rows = _calculate_blocks_rows(blocks_with_metadata)
+            indices = list(itertools.accumulate(block_rows))
+            indices.pop(-1)
 
+            # Execute other to a block list.
+            other_block_list = other._plan.execute()
+            other_blocks_with_metadata = other_block_list.get_blocks_with_metadata()
+            other_block_rows = _calculate_blocks_rows(other_blocks_with_metadata)
+            # Check that each dataset has the same number of rows.
+            # TODO(Clark): Support different number of rows via user-directed
+            # dropping/padding.
+            if sum(block_rows) != sum(other_block_rows):
+                raise ValueError("Cannot zip datasets of different number of rows.")
+
+            # Split other at the alignment indices, such that for every block in
+            # block_list, we have a list of blocks from other that has the same
+            # cumulative number of rows as that block.
+            # NOTE: _split_at_indices has a no-op fastpath if the blocks are already
+            # aligned.
+            aligned_other_blocks_with_metadata = _split_at_indices(
+                other_blocks_with_metadata,
+                indices,
+                other_block_list._owned_by_consumer,
+                other_block_rows,
+            )
+            del other_blocks_with_metadata
+
+            blocks = [b for b, _ in blocks_with_metadata]
+            other_blocks = aligned_other_blocks_with_metadata[0]
+            del blocks_with_metadata, aligned_other_blocks_with_metadata
             if clear_input_blocks:
                 block_list.clear()
+                other_block_list.clear()
 
-            if len(blocks1) != len(blocks2):
-                # TODO(ekl) consider supporting if num_rows are equal.
-                raise ValueError(
-                    "Cannot zip dataset of different num blocks: {} vs {}".format(
-                        len(blocks1), len(blocks2)
-                    )
-                )
+            do_zip = cached_remote_fn(_do_zip, num_returns=2)
 
-            def do_zip(block1: Block, block2: Block) -> (Block, BlockMetadata):
-                stats = BlockExecStats.builder()
-                b1 = BlockAccessor.for_block(block1)
-                result = b1.zip(block2)
-                br = BlockAccessor.for_block(result)
-                return result, br.get_metadata(input_files=[], exec_stats=stats.build())
-
-            do_zip_fn = cached_remote_fn(do_zip, num_returns=2)
-
-            blocks = []
-            metadata = []
-            for b1, b2 in zip(blocks1, blocks2):
-                res, meta = do_zip_fn.remote(b1, b2)
-                blocks.append(res)
-                metadata.append(meta)
+            out_blocks = []
+            out_metadata = []
+            for block, other_blocks in zip(blocks, other_blocks):
+                # For each block in block_list, zip it together with 1 or more blocks
+                # from other. We're guaranteed to have that block and other_blocks have
+                # the same number of rows.
+                res, meta = do_zip.remote(block, *other_blocks)
+                out_blocks.append(res)
+                out_metadata.append(meta)
 
             # Early release memory.
-            del blocks1, blocks2
+            del blocks, other_blocks
 
             # TODO(ekl) it might be nice to have a progress bar here.
-            metadata = ray.get(metadata)
+            out_metadata = ray.get(out_metadata)
             blocks = BlockList(
-                blocks, metadata, owned_by_consumer=block_list._owned_by_consumer
+                out_blocks,
+                out_metadata,
+                owned_by_consumer=block_list._owned_by_consumer,
             )
             return blocks, {}
 
         super().__init__("zip", None, do_zip_all)
+
+
+def _do_zip(block: Block, *other_blocks: Block) -> (Block, BlockMetadata):
+    # Zips together block with other_blocks.
+    stats = BlockExecStats.builder()
+    # Concatenate other blocks.
+    # TODO(Clark): Extend BlockAccessor.zip() to work with N other blocks,
+    # so we don't need to do this concatenation.
+    builder = DelegatingBlockBuilder()
+    for other_block in other_blocks:
+        builder.add_block(other_block)
+    other_block = builder.build()
+    # Zip block and other blocks.
+    result = BlockAccessor.for_block(block).zip(other_block)
+    br = BlockAccessor.for_block(result)
+    return result, br.get_metadata(input_files=[], exec_stats=stats.build())
 
 
 class SortStage(AllToAllStage):

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1368,7 +1368,11 @@ class Dataset(Generic[T]):
             raise ValueError("indices must be positive")
         start_time = time.perf_counter()
         block_list = self._plan.execute()
-        blocks, metadata = _split_at_indices(block_list, indices)
+        blocks, metadata = _split_at_indices(
+            block_list.get_blocks_with_metadata(),
+            indices,
+            block_list._owned_by_consumer,
+        )
         split_duration = time.perf_counter() - start_time
         parent_stats = self._plan.stats()
         splits = []
@@ -2034,8 +2038,7 @@ class Dataset(Generic[T]):
     def zip(self, other: "Dataset[U]") -> "Dataset[(T, U)]":
         """Zip this dataset with the elements of another.
 
-        The datasets must have identical num rows, block types, and block sizes,
-        e.g. one was produced from a :meth:`~.map` of another. For Arrow
+        The datasets must have the same number of rows. For Arrow
         blocks, the schema will be concatenated, and any duplicate column
         names disambiguated with _1, _2, etc. suffixes.
 
@@ -2050,9 +2053,10 @@ class Dataset(Generic[T]):
 
         Examples:
             >>> import ray
-            >>> ds = ray.data.range(5)
-            >>> ds.zip(ds).take()
-            [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]
+            >>> ds1 = ray.data.range(5)
+            >>> ds2 = ray.data.range(5, parallelism=2).map(lambda x: x + 1)
+            >>> ds1.zip(ds2).take()
+            [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)]
 
         Returns:
             A Dataset with (k, v) pairs (or concatenated Arrow schema) where k

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -332,6 +332,19 @@ def test_zip(ray_start_regular_shared):
         ds.zip(ray.data.range(3)).fully_executed()
 
 
+@pytest.mark.parametrize(
+    "num_blocks1,num_blocks2",
+    list(itertools.combinations_with_replacement(range(1, 12), 2)),
+)
+def test_zip_different_num_blocks(ray_start_regular_shared, num_blocks1, num_blocks2):
+    n = 12
+    ds1 = ray.data.range(n, parallelism=num_blocks1)
+    ds2 = ray.data.range(n, parallelism=num_blocks2).map(lambda x: x + 1)
+    ds = ds1.zip(ds2)
+    assert ds.schema() == tuple
+    assert ds.take() == list(zip(range(n), range(1, n + 1)))
+
+
 def test_zip_pandas(ray_start_regular_shared):
     ds1 = ray.data.from_pandas(pd.DataFrame({"col1": [1, 2], "col2": [4, 5]}))
     ds2 = ray.data.from_pandas(pd.DataFrame({"col3": ["a", "b"], "col4": ["d", "e"]}))

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -336,13 +336,49 @@ def test_zip(ray_start_regular_shared):
     "num_blocks1,num_blocks2",
     list(itertools.combinations_with_replacement(range(1, 12), 2)),
 )
-def test_zip_different_num_blocks(ray_start_regular_shared, num_blocks1, num_blocks2):
+def test_zip_different_num_blocks_combinations(
+    ray_start_regular_shared, num_blocks1, num_blocks2
+):
     n = 12
     ds1 = ray.data.range(n, parallelism=num_blocks1)
     ds2 = ray.data.range(n, parallelism=num_blocks2).map(lambda x: x + 1)
     ds = ds1.zip(ds2)
     assert ds.schema() == tuple
     assert ds.take() == list(zip(range(n), range(1, n + 1)))
+
+
+@pytest.mark.parametrize(
+    "num_cols1,num_cols2,should_invert",
+    [
+        (1, 1, False),
+        (4, 1, False),
+        (1, 4, True),
+        (1, 10, True),
+        (10, 10, False),
+    ],
+)
+def test_zip_different_num_blocks_split_smallest(
+    ray_start_regular_shared,
+    num_cols1,
+    num_cols2,
+    should_invert,
+):
+    n = 12
+    num_blocks1 = 4
+    num_blocks2 = 2
+    ds1 = ray.data.from_items(
+        [{str(i): i for i in range(num_cols1)}] * n, parallelism=num_blocks1
+    )
+    ds2 = ray.data.from_items(
+        [{str(i): i for i in range(num_cols1, num_cols1 + num_cols2)}] * n,
+        parallelism=num_blocks2,
+    )
+    ds = ds1.zip(ds2)
+    assert ds.take() == [{str(i): i for i in range(num_cols1 + num_cols2)}] * n
+    if should_invert:
+        assert ds.num_blocks() == num_blocks2
+    else:
+        assert ds.num_blocks() == num_blocks1
 
 
 def test_zip_pandas(ray_start_regular_shared):

--- a/python/ray/data/tests/test_split.py
+++ b/python/ray/data/tests/test_split.py
@@ -523,6 +523,10 @@ def _create_blocklist(blocks):
     return BlockList(block_refs, meta, owned_by_consumer=True)
 
 
+def _create_blocks_with_metadata(blocks):
+    return _create_blocklist(blocks).get_blocks_with_metadata()
+
+
 def test_split_single_block(ray_start_regular_shared):
     block = [1, 2, 3]
     metadata = _create_meta(3)
@@ -618,35 +622,35 @@ def test_generate_global_split_results(ray_start_regular_shared):
 
 
 def test_private_split_at_indices(ray_start_regular_shared):
-    inputs = _create_blocklist([])
+    inputs = _create_blocks_with_metadata([])
     splits = list(zip(*_split_at_indices(inputs, [0])))
     verify_splits(splits, [[], []])
 
     splits = list(zip(*_split_at_indices(inputs, [])))
     verify_splits(splits, [[]])
 
-    inputs = _create_blocklist([[1], [2, 3], [4]])
+    inputs = _create_blocks_with_metadata([[1], [2, 3], [4]])
 
     splits = list(zip(*_split_at_indices(inputs, [1])))
     verify_splits(splits, [[[1]], [[2, 3], [4]]])
 
-    inputs = _create_blocklist([[1], [2, 3], [4]])
+    inputs = _create_blocks_with_metadata([[1], [2, 3], [4]])
     splits = list(zip(*_split_at_indices(inputs, [2])))
     verify_splits(splits, [[[1], [2]], [[3], [4]]])
 
-    inputs = _create_blocklist([[1], [2, 3], [4]])
+    inputs = _create_blocks_with_metadata([[1], [2, 3], [4]])
     splits = list(zip(*_split_at_indices(inputs, [1])))
     verify_splits(splits, [[[1]], [[2, 3], [4]]])
 
-    inputs = _create_blocklist([[1], [2, 3], [4]])
+    inputs = _create_blocks_with_metadata([[1], [2, 3], [4]])
     splits = list(zip(*_split_at_indices(inputs, [2, 2])))
     verify_splits(splits, [[[1], [2]], [], [[3], [4]]])
 
-    inputs = _create_blocklist([[1], [2, 3], [4]])
+    inputs = _create_blocks_with_metadata([[1], [2, 3], [4]])
     splits = list(zip(*_split_at_indices(inputs, [])))
     verify_splits(splits, [[[1], [2, 3], [4]]])
 
-    inputs = _create_blocklist([[1], [2, 3], [4]])
+    inputs = _create_blocks_with_metadata([[1], [2, 3], [4]])
     splits = list(zip(*_split_at_indices(inputs, [0, 4])))
     verify_splits(splits, [[], [[1], [2, 3], [4]], []])
 


### PR DESCRIPTION
This PR adds support for a different number of blocks/rows per block in `ds1.zip(ds2)`, by aligning the blocks in `ds2` to `ds1` with a lightweight repartition/block splitting.

## Design

We heavily utilize the block splitting machinery that's use for `ds.split()` and `ds.split_at_indices()` to avoid an overly expensive repartition. Namely, for `ds1.zip(ds2)`, we:
1. Calculate the block sizes for `ds1` in order to get split indices.
2. Apply `_split_at_indices()` to `ds2` in order to get a list of `ds2` block chunks for every block in `ds1`, such that `self_block.num_rows() == sum(other_block.num_rows() for other_block in other_split_blocks)` for every `self_block` in `ds1`.
3. Zip together each block in `ds1` with the one or more blocks from `ds2` that constitute the block-aligned split for that `ds1` block.

## Related issue number

Closes #32375

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
