### PR TITLE
[core] Fix the race condition in the new resource broadcasting.

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4624,6 +4624,7 @@
     script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
+
     type: sdk_command
 
 #####################

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3881,7 +3881,6 @@
   run:
     timeout: 3600
     script: python distributed/test_many_actors.py
-    type: sdk_command
     wait_for_nodes:
       num_nodes: 65
 
@@ -4625,7 +4624,6 @@
     script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
-
     type: sdk_command
 
 #####################

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3881,6 +3881,7 @@
   run:
     timeout: 3600
     script: python distributed/test_many_actors.py
+    type: sdk_command
     wait_for_nodes:
       num_nodes: 65
 
@@ -4624,7 +4625,7 @@
     script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
-    
+
     type: sdk_command
 
 #####################

--- a/src/mock/ray/common/ray_syncer/ray_syncer.h
+++ b/src/mock/ray/common/ray_syncer/ray_syncer.h
@@ -47,7 +47,7 @@ class MockRaySyncerBidiReactor : public RaySyncerBidiReactor {
  public:
   using RaySyncerBidiReactor::RaySyncerBidiReactor;
 
-  MOCK_METHOD(void, Disconnect, (), (override));
+  MOCK_METHOD(void, DoDisconnect, (), (override));
 
   MOCK_METHOD(bool,
               PushToSendingQueue,
@@ -60,7 +60,7 @@ class MockRaySyncerBidiReactorBase : public RaySyncerBidiReactorBase<T> {
  public:
   using RaySyncerBidiReactorBase<T>::RaySyncerBidiReactorBase;
 
-  MOCK_METHOD(void, Disconnect, (), (override));
+  MOCK_METHOD(void, DoDisconnect, (), (override));
 };
 
 }  // namespace syncer

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -440,7 +440,7 @@ RAY_CONFIG(uint64_t, gcs_grpc_max_request_queued_max_bytes, 1024UL * 1024 * 1024
 RAY_CONFIG(int32_t, gcs_client_check_connection_status_interval_milliseconds, 1000)
 
 /// Feature flag to use the ray syncer for resource synchronization
-RAY_CONFIG(bool, use_ray_syncer, false)
+RAY_CONFIG(bool, use_ray_syncer, true)
 /// Due to the protocol drawback, raylet needs to refresh the message if
 /// no message is received for a while.
 /// Refer to https://tinyurl.com/n6kvsp87 for more details

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -440,7 +440,7 @@ RAY_CONFIG(uint64_t, gcs_grpc_max_request_queued_max_bytes, 1024UL * 1024 * 1024
 RAY_CONFIG(int32_t, gcs_client_check_connection_status_interval_milliseconds, 1000)
 
 /// Feature flag to use the ray syncer for resource synchronization
-RAY_CONFIG(bool, use_ray_syncer, true)
+RAY_CONFIG(bool, use_ray_syncer, false)
 /// Due to the protocol drawback, raylet needs to refresh the message if
 /// no message is received for a while.
 /// Refer to https://tinyurl.com/n6kvsp87 for more details

--- a/src/ray/common/ray_syncer/ray_syncer-inl.h
+++ b/src/ray/common/ray_syncer/ray_syncer-inl.h
@@ -151,6 +151,8 @@ class RaySyncerBidiReactor {
   virtual void DoDisconnect() = 0;
   std::string remote_node_id_;
   bool disconnected_ = false;
+
+  FRIEND_TEST(SyncerReactorTest, TestReactorFailure);
 };
 
 /// This class implements the communication between two nodes except the initialization

--- a/src/ray/common/ray_syncer/ray_syncer-inl.h
+++ b/src/ray/common/ray_syncer/ray_syncer-inl.h
@@ -138,7 +138,7 @@ class RaySyncerBidiReactor {
   /// Disconnect will terminate the communication between local and remote node.
   /// It also needs to do proper cleanup.
   void Disconnect() {
-    if(!IsDisconnected()) {
+    if (!IsDisconnected()) {
       DoDisconnect();
       disconnected_ = true;
     }
@@ -176,7 +176,7 @@ class RaySyncerBidiReactorBase : public RaySyncerBidiReactor, public T {
         message_processor_(std::move(message_processor)) {}
 
   bool PushToSendingQueue(std::shared_ptr<const RaySyncMessage> message) override {
-    if(IsDisconnected()) {
+    if (IsDisconnected()) {
       return false;
     }
 
@@ -353,7 +353,6 @@ class RayServerBidiReactor : public RaySyncerBidiReactorBase<ServerBidiReactor> 
 
   ~RayServerBidiReactor() override = default;
 
-
  private:
   void DoDisconnect() override;
   void OnCancel() override;
@@ -380,7 +379,6 @@ class RayClientBidiReactor : public RaySyncerBidiReactorBase<ClientBidiReactor> 
       std::unique_ptr<ray::rpc::syncer::RaySyncer::Stub> stub);
 
   ~RayClientBidiReactor() override = default;
-
 
  private:
   void DoDisconnect() override;

--- a/src/ray/common/ray_syncer/ray_syncer-inl.h
+++ b/src/ray/common/ray_syncer/ray_syncer-inl.h
@@ -137,10 +137,20 @@ class RaySyncerBidiReactor {
 
   /// Disconnect will terminate the communication between local and remote node.
   /// It also needs to do proper cleanup.
-  virtual void Disconnect() = 0;
+  void Disconnect() {
+    if(!IsDisconnected()) {
+      DoDisconnect();
+      disconnected_ = true;
+    }
+  };
+
+  /// Return true if it's disconnected.
+  bool IsDisconnected() const { return disconnected_; }
 
  private:
+  virtual void DoDisconnect() = 0;
   std::string remote_node_id_;
+  bool disconnected_ = false;
 };
 
 /// This class implements the communication between two nodes except the initialization
@@ -166,6 +176,10 @@ class RaySyncerBidiReactorBase : public RaySyncerBidiReactor, public T {
         message_processor_(std::move(message_processor)) {}
 
   bool PushToSendingQueue(std::shared_ptr<const RaySyncMessage> message) override {
+    if(IsDisconnected()) {
+      return false;
+    }
+
     // Try to filter out the messages the target node already has.
     // Usually it'll be the case when the message is generated from the
     // target node or it's sent from the target node.
@@ -339,9 +353,9 @@ class RayServerBidiReactor : public RaySyncerBidiReactorBase<ServerBidiReactor> 
 
   ~RayServerBidiReactor() override = default;
 
-  void Disconnect() override;
 
  private:
+  void DoDisconnect() override;
   void OnCancel() override;
   void OnDone() override;
 
@@ -350,7 +364,6 @@ class RayServerBidiReactor : public RaySyncerBidiReactorBase<ServerBidiReactor> 
 
   /// grpc callback context
   grpc::CallbackServerContext *server_context_;
-  bool disconnected_ = false;
   FRIEND_TEST(SyncerReactorTest, TestReactorFailure);
 };
 
@@ -368,9 +381,9 @@ class RayClientBidiReactor : public RaySyncerBidiReactorBase<ClientBidiReactor> 
 
   ~RayClientBidiReactor() override = default;
 
-  void Disconnect() override;
 
  private:
+  void DoDisconnect() override;
   /// Callback from gRPC
   void OnDone(const grpc::Status &status) override;
 
@@ -381,7 +394,6 @@ class RayClientBidiReactor : public RaySyncerBidiReactorBase<ClientBidiReactor> 
   grpc::ClientContext client_context_;
 
   std::unique_ptr<ray::rpc::syncer::RaySyncer::Stub> stub_;
-  bool disconnected_ = false;
 };
 
 }  // namespace syncer

--- a/src/ray/common/ray_syncer/ray_syncer.cc
+++ b/src/ray/common/ray_syncer/ray_syncer.cc
@@ -105,11 +105,7 @@ RayServerBidiReactor::RayServerBidiReactor(
 }
 
 void RayServerBidiReactor::DoDisconnect() {
-  io_context_.dispatch(
-      [this]() {
-        Finish(grpc::Status::OK);
-      },
-      "");
+  io_context_.dispatch([this]() { Finish(grpc::Status::OK); }, "");
 }
 
 void RayServerBidiReactor::OnCancel() { Disconnect(); }

--- a/src/ray/common/ray_syncer/ray_syncer.cc
+++ b/src/ray/common/ray_syncer/ray_syncer.cc
@@ -108,7 +108,11 @@ void RayServerBidiReactor::DoDisconnect() {
   io_context_.dispatch([this]() { Finish(grpc::Status::OK); }, "");
 }
 
-void RayServerBidiReactor::OnCancel() { Disconnect(); }
+void RayServerBidiReactor::OnCancel() {
+  io_context_.dispatch([this]() {
+    Disconnect();
+  }, "");
+}
 
 void RayServerBidiReactor::OnDone() {
   io_context_.dispatch(

--- a/src/ray/common/ray_syncer/ray_syncer.cc
+++ b/src/ray/common/ray_syncer/ray_syncer.cc
@@ -109,9 +109,7 @@ void RayServerBidiReactor::DoDisconnect() {
 }
 
 void RayServerBidiReactor::OnCancel() {
-  io_context_.dispatch([this]() {
-    Disconnect();
-  }, "");
+  io_context_.dispatch([this]() { Disconnect(); }, "");
 }
 
 void RayServerBidiReactor::OnDone() {

--- a/src/ray/common/ray_syncer/ray_syncer.cc
+++ b/src/ray/common/ray_syncer/ray_syncer.cc
@@ -104,13 +104,10 @@ RayServerBidiReactor::RayServerBidiReactor(
   StartPull();
 }
 
-void RayServerBidiReactor::Disconnect() {
+void RayServerBidiReactor::DoDisconnect() {
   io_context_.dispatch(
       [this]() {
-        if (!disconnected_) {
-          disconnected_ = true;
-          Finish(grpc::Status::OK);
-        }
+        Finish(grpc::Status::OK);
       },
       "");
 }
@@ -155,15 +152,12 @@ void RayClientBidiReactor::OnDone(const grpc::Status &status) {
       "");
 }
 
-void RayClientBidiReactor::Disconnect() {
+void RayClientBidiReactor::DoDisconnect() {
   io_context_.dispatch(
       [this]() {
-        if (!disconnected_) {
-          disconnected_ = true;
-          StartWritesDone();
-          // Free the hold to allow OnDone being called.
-          RemoveHold();
-        }
+        StartWritesDone();
+        // Free the hold to allow OnDone being called.
+        RemoveHold();
       },
       "");
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The root cause is that disconnect is called not in io_context which in the end accessing the invalid memory. Disconnect needs to be called exactly once.

In gRPC, read/write might error and OnCancel also means error just with different semantics. But we need to ensure disconnect is only called once. Previously, disconnect might be called in gRPC threads, main thread/... and this PR enforce them called within the io context.



This fix the release test long_running_node_failures.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
