### PR TITLE
Revert "[core] Allow worker Python interpeters to inherit -S and -s flags"

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -100,30 +100,6 @@ ProcessInfo = collections.namedtuple(
 )
 
 
-def _site_flags() -> List[str]:
-    """Detect whether flags related to site packages are enabled for the current
-    interpreter. To run Ray in hermetic build environments, it helps to pass these flags
-    down to Python workers.
-    """
-    flags = []
-    # sys.flags hidden behind helper methods for unit testing.
-    if _no_site():
-        flags.append("-S")
-    if _no_user_site():
-        flags.append("-s")
-    return flags
-
-
-# sys.flags hidden behind helper methods for unit testing.
-def _no_site():
-    return sys.flags.no_site
-
-
-# sys.flags hidden behind helper methods for unit testing.
-def _no_user_site():
-    return sys.flags.no_user_site
-
-
 def _build_python_executable_command_memory_profileable(
     component: str, session_dir: str, unbuffered: bool = True
 ):
@@ -1502,29 +1478,24 @@ def start_raylet(
     # TODO(architkulkarni): Pipe in setup worker args separately instead of
     # inserting them into start_worker_command and later erasing them if
     # needed.
-    start_worker_command = (
-        [
-            sys.executable,
-            setup_worker_path,
-        ]
-        + _site_flags()  # Inherit "-S" and "-s" flags from current Python interpreter.
-        + [
-            worker_path,
-            f"--node-ip-address={node_ip_address}",
-            "--node-manager-port=RAY_NODE_MANAGER_PORT_PLACEHOLDER",
-            f"--object-store-name={plasma_store_name}",
-            f"--raylet-name={raylet_name}",
-            f"--redis-address={redis_address}",
-            f"--temp-dir={temp_dir}",
-            f"--metrics-agent-port={metrics_agent_port}",
-            f"--logging-rotate-bytes={max_bytes}",
-            f"--logging-rotate-backup-count={backup_count}",
-            f"--gcs-address={gcs_address}",
-            f"--session-name={session_name}",
-            f"--temp-dir={temp_dir}",
-            f"--webui={webui}",
-        ]
-    )
+    start_worker_command = [
+        sys.executable,
+        setup_worker_path,
+        worker_path,
+        f"--node-ip-address={node_ip_address}",
+        "--node-manager-port=RAY_NODE_MANAGER_PORT_PLACEHOLDER",
+        f"--object-store-name={plasma_store_name}",
+        f"--raylet-name={raylet_name}",
+        f"--redis-address={redis_address}",
+        f"--temp-dir={temp_dir}",
+        f"--metrics-agent-port={metrics_agent_port}",
+        f"--logging-rotate-bytes={max_bytes}",
+        f"--logging-rotate-backup-count={backup_count}",
+        f"--gcs-address={gcs_address}",
+        f"--session-name={session_name}",
+        f"--temp-dir={temp_dir}",
+        f"--webui={webui}",
+    ]
 
     start_worker_command.append(f"--storage={storage}")
 

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -5,7 +5,6 @@ import os
 import sys
 import time
 import subprocess
-from unittest.mock import Mock, patch
 
 import pytest
 
@@ -249,34 +248,6 @@ def test_worker_kv_calls(monkeypatch, shutdown_only):
     """
     # !!!If you want to increase this number, please let ray-core knows this!!!
     assert freqs["internal_kv_get"] == 4
-
-
-@pytest.mark.parametrize("root_process_no_site", [0, 1])
-@pytest.mark.parametrize("root_process_no_user_site", [0, 1])
-def test_site_flag_inherited(
-    shutdown_only, monkeypatch, root_process_no_site, root_process_no_user_site
-):
-    # The flags we're testing could prevent Python workers in the test environment
-    # from locating site packages; the workers would fail to find Ray and would thus
-    # fail to start. To prevent that, set the PYTHONPATH env. The env will be inherited
-    # by the Python workers, so that they are able to import Ray.
-    monkeypatch.setenv("PYTHONPATH", ":".join(sys.path))
-
-    @ray.remote
-    def get_flags():
-        return sys.flags.no_site, sys.flags.no_user_site
-
-    with patch.multiple(
-        "ray._private.services",
-        _no_site=Mock(return_value=root_process_no_site),
-        _no_user_site=Mock(return_value=root_process_no_user_site),
-    ):
-        ray.init()
-        worker_process_no_site, worker_process_no_user_site = ray.get(
-            get_flags.remote()
-        )
-        assert worker_process_no_site == root_process_no_site
-        assert worker_process_no_user_site == root_process_no_user_site
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reverts ray-project/ray#32690

<img width="495" alt="image" src="https://user-images.githubusercontent.com/74173148/221088034-21c94748-07a9-42d9-9e7b-519e3bd08dbe.png">



Break the windows test.