### PR TITLE
[RLlib] Don't call ray.init() when num_workers is zero

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,9 +29,6 @@ test --test_env=PYENV_VERSION
 test --test_env=PYENV_SHELL
 # Do not send usage stats to the server for tests
 test --test_env=RAY_USAGE_STATS_REPORT_URL="http://127.0.0.1:8000"
-# Enable cluster mode for OSX and Windows. By default, Ray
-# will not allow multinode OSX and Windows clusters.
-test --test_env=RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER="1"
 # This is needed for some core tests to run correctly
 build:windows --enable_runfiles
 # TODO(mehrdadn): Revert the "-\\.(asm|S)$" exclusion when this Bazel bug

--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -46,7 +46,6 @@ steps:
     - export MAC_WHEELS=1
     - export MAC_JARS=1
     - export RAY_INSTALL_JAVA=1
-    - export RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER=1
     - . ./ci/ci.sh init && source ~/.zshenv
     - ./ci/ci.sh build
     # Test wheels

--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -36,7 +36,6 @@ steps:
     - conda init
     - . ./ci/ci.sh init
     - ./ci/ci.sh build
-    - export RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER="1"
     - if [ "${BUILDKITE_PARALLEL_JOB}" = "0" ]; then ./ci/ci.sh test_core; fi
     # The next command will be sharded into $parallelism shards.
     - ./ci/ci.sh test_python

--- a/doc/source/cluster/getting-started.rst
+++ b/doc/source/cluster/getting-started.rst
@@ -22,12 +22,6 @@ Ray provides native cluster deployment support on the following technology stack
 Advanced users may want to :ref:`deploy Ray manually <on-prem>`
 or onto :ref:`platforms not listed here <ref-cluster-setup>`.
 
-.. note::
-
-    Multi-node Ray clusters are only supported on Linux. At your own risk, you
-    may deploy Windows and OSX clusters by setting the environment variable
-    ``RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER=1`` during deployment.
-
 What's next?
 ------------
 

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -203,8 +203,7 @@ You can install and use Ray C++ API as follows.
 M1 Mac (Apple Silicon) Support
 ------------------------------
 
-Ray has experimental support for machines running Apple Silicon (such as M1 macs).
-Multi-node clusters are untested. To get started with local Ray development:
+Ray has experimental support for machines running Apple Silicon (such as M1 macs). To get started:
 
 #. Install `miniforge <https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh>`_.
 
@@ -237,8 +236,7 @@ Multi-node clusters are untested. To get started with local Ray development:
 Windows Support
 ---------------
 
-Windows support is currently in beta, and multi-node Ray clusters are untested.
-Please submit any issues you encounter on
+Windows support is currently in beta. Please submit any issues you encounter on
 `GitHub <https://github.com/ray-project/ray/issues/>`_.
 
 Installing Ray on Arch Linux

--- a/java/test.sh
+++ b/java/test.sh
@@ -82,7 +82,6 @@ MAX_ROUNDS=1
 if [ $MAX_ROUNDS -gt 1 ]; then
   export RAY_BACKEND_LOG_LEVEL=debug
 fi
-export RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER=1
 
 round=1
 while true; do

--- a/java/test/src/main/java/io/ray/test/GcsClientTest.java
+++ b/java/test/src/main/java/io/ray/test/GcsClientTest.java
@@ -6,9 +6,7 @@ import io.ray.api.runtimecontext.NodeInfo;
 import io.ray.runtime.config.RayConfig;
 import io.ray.runtime.gcs.GcsClient;
 import java.util.List;
-import org.apache.commons.lang3.SystemUtils;
 import org.testng.Assert;
-import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -17,9 +15,6 @@ public class GcsClientTest extends BaseTest {
 
   @BeforeClass
   public void setUp() {
-    if (SystemUtils.IS_OS_MAC) {
-      throw new SkipException("Skip NodeIpTest on Mac OS");
-    }
     System.setProperty("ray.head-args.0", "--resources={\"A\":8}");
   }
 

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import sys
 
 logger = logging.getLogger(__name__)
 
@@ -24,16 +23,8 @@ def env_integer(key, default):
 
 def env_bool(key, default):
     if key in os.environ:
-        return (
-            True
-            if os.environ[key].lower() == "true" or os.environ[key] == "1"
-            else False
-        )
+        return True if os.environ[key].lower() == "true" else False
     return default
-
-
-def env_set_by_user(key):
-    return key in os.environ
 
 
 # Whether event logging to driver is enabled. Set to 0 to disable.
@@ -379,11 +370,3 @@ DEFAULT_RESOURCES = {"CPU", "GPU", "memory", "object_store_memory"}
 # Ray wheels into the conda environment, so the Ray wheels for these Python
 # versions must be available online.
 RUNTIME_ENV_CONDA_PY_VERSIONS = [(3, 6), (3, 7), (3, 8), (3, 9), (3, 10)]
-
-# Whether to enable Ray clusters (in addition to local Ray).
-# Ray clusters are not explicitly supported for Windows and OSX.
-ENABLE_RAY_CLUSTERS_ENV_VAR = "RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER"
-ENABLE_RAY_CLUSTER = env_bool(
-    ENABLE_RAY_CLUSTERS_ENV_VAR,
-    not (sys.platform == "darwin" or sys.platform == "win32"),
-)

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -607,11 +607,8 @@ def resolve_ip_for_localhost(address: str):
     if not address:
         raise ValueError(f"Malformed address: {address}")
     address_parts = address.split(":")
+    # Make sure localhost isn't resolved to the loopback ip
     if address_parts[0] == "127.0.0.1" or address_parts[0] == "localhost":
-        # Clusters are disabled by default for OSX and Windows.
-        if not ray_constants.ENABLE_RAY_CLUSTER:
-            return address
-        # Make sure localhost isn't resolved to the loopback ip
         ip_address = get_node_ip_address()
         return ":".join([ip_address] + address_parts[1:])
     else:
@@ -654,10 +651,10 @@ def node_ip_address_from_perspective(address: str):
 def get_node_ip_address(address="8.8.8.8:53"):
     if ray._private.worker._global_node is not None:
         return ray._private.worker._global_node.node_ip_address
-    if not ray_constants.ENABLE_RAY_CLUSTER:
-        # Use loopback IP as the local IP address to prevent bothersome
-        # firewall popups on OSX and Windows.
-        # https://github.com/ray-project/ray/issues/18730.
+    if sys.platform == "darwin" or sys.platform == "win32":
+        # Due to the mac osx/windows firewall,
+        # we use loopback ip as the ip address
+        # to prevent security popups.
         return "127.0.0.1"
     return node_ip_address_from_perspective(address)
 

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1353,19 +1353,15 @@ def init(
                 job_config = ray.job_config.JobConfig()
             job_config.set_runtime_env(runtime_env)
 
+    if _node_ip_address is not None:
+        node_ip_address = services.resolve_ip_for_localhost(_node_ip_address)
+    raylet_ip_address = node_ip_address
+
     redis_address, gcs_address = None, None
     bootstrap_address = services.canonicalize_bootstrap_address(address, _temp_dir)
     if bootstrap_address is not None:
         gcs_address = bootstrap_address
         logger.info("Connecting to existing Ray cluster at address: %s...", gcs_address)
-
-    # NOTE(swang): We must set the node IP address *after* we determine whether
-    # this is an existing cluster or not. For Windows and OSX, the resolved IP
-    # is localhost for new clusters and the usual public IP for existing
-    # clusters.
-    if _node_ip_address is not None:
-        node_ip_address = services.resolve_ip_for_localhost(_node_ip_address)
-    raylet_ip_address = node_ip_address
 
     if local_mode:
         driver_mode = LOCAL_MODE

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -578,7 +578,10 @@ def start(
             cf.bold("--port"),
         )
 
+    # Whether the original arguments include node_ip_address.
+    include_node_ip_address = False
     if node_ip_address is not None:
+        include_node_ip_address = True
         node_ip_address = services.resolve_ip_for_localhost(node_ip_address)
 
     resources = parse_resources_json(resources, cli_logger, cf)
@@ -746,121 +749,68 @@ def start(
         cli_logger.success("-" * len(startup_msg))
         cli_logger.newline()
         with cli_logger.group("Next steps"):
-            dashboard_url = node.address_info["webui_url"]
+            cli_logger.print("To connect to this Ray runtime from another node, run")
+            # NOTE(kfstorm): Java driver rely on this line to get the address
+            # of the cluster. Please be careful when updating this line.
+            cli_logger.print(
+                cf.bold("  ray start --address='{}'"),
+                bootstrap_address,
+            )
             if bootstrap_address.startswith("127.0.0.1:"):
-                if ray_constants.ENABLE_RAY_CLUSTER:
-                    cli_logger.print(
-                        "This Ray runtime only accepts connections from local host."
-                    )
-                    cli_logger.print(
-                        "To accept connections from remote hosts, "
-                        "specify a public ip when starting"
-                    )
-                    cli_logger.print(
-                        "the head node: ray start --head --node-ip-address=<public-ip>."
-                    )
-                else:
-                    cli_logger.print(
-                        "Multi-node Ray clusters are not supported on OSX and Windows."
-                    )
-                    cli_logger.print(
-                        "If you would like to proceed anyway, restart Ray with:"
-                    )
-                    cli_logger.print(
-                        cf.bold("  ray stop"),
-                    )
-                    cli_logger.print(
-                        cf.bold("  {}=true ray start"),
-                        ray_constants.ENABLE_RAY_CLUSTERS_ENV_VAR,
-                    )
-                cli_logger.newline()
-            else:
-                cli_logger.print("To add another node to this Ray cluster, run")
-                # NOTE(kfstorm): Java driver rely on this line to get the address
-                # of the cluster. Please be careful when updating this line.
                 cli_logger.print(
-                    cf.bold("  ray start --address='{}'"),
-                    bootstrap_address,
-                )
-                cli_logger.newline()
-            if ray_constants.ENABLE_RAY_CLUSTER:
-                cli_logger.print(
-                    "To connect to this Ray cluster, run `ray.init()` as usual:"
-                )
-                with cli_logger.indented():
-                    cli_logger.print("{} ray", cf.magenta("import"))
-                    cli_logger.print(
-                        "ray{}init()",
-                        cf.magenta("."),
-                    )
-                cli_logger.newline()
-                cli_logger.print(
-                    "To connect to this Ray instance from outside of "
-                    "the cluster, for example "
+                    "This Ray runtime only accepts connections from local host."
                 )
                 cli_logger.print(
-                    "when connecting to a remote cluster from your laptop, "
-                    "make sure the"
+                    "To accept connections from remote hosts, "
+                    "specify a public ip when starting"
                 )
                 cli_logger.print(
-                    "dashboard {}is accessible and use the Ray Jobs API. For example:",
-                    f"({dashboard_url}) " if dashboard_url else "",
+                    "the head node: ray start --head --node-ip-address=<public-ip>."
                 )
-                if dashboard_url:
-                    cli_logger.print(
-                        cf.bold(
-                            "  RAY_ADDRESS='http://<dashboard URL>:{}' ray job submit "
-                            "--working-dir . "
-                            "-- python my_script.py"
-                        ),
-                        ray_params.dashboard_port,
+            cli_logger.newline()
+            cli_logger.print("Alternatively, use the following Python code:")
+            with cli_logger.indented():
+                cli_logger.print("{} ray", cf.magenta("import"))
+                # Note: In the case of joining an existing cluster using
+                # `address="auto"`, the _node_ip_address parameter is
+                # unnecessary.
+                cli_logger.print(
+                    "ray{}init(address{}{}{})",
+                    cf.magenta("."),
+                    cf.magenta("="),
+                    cf.yellow("'auto'"),
+                    ", _node_ip_address{}{}".format(
+                        cf.magenta("="), cf.yellow("'" + node_ip_address + "'")
                     )
-                cli_logger.newline()
-                cli_logger.print(
-                    "See https://docs.ray.io/en/latest/cluster/running-applications"
-                    "/job-submission/index.html"
+                    if include_node_ip_address
+                    else "",
                 )
+
+            cli_logger.newline()
+            cli_logger.print("To see the status of the cluster, use")
+            cli_logger.print("  {}".format(cf.bold("ray status")))
+            dashboard_url = node.address_info["webui_url"]
+            if dashboard_url:
+                cli_logger.print("To monitor and debug Ray, view the dashboard at ")
                 cli_logger.print(
-                    "for more information on connecting to the Ray cluster from "
-                    "a remote client."
-                )
-                cli_logger.newline()
-                cli_logger.print("To see the status of the cluster, use")
-                cli_logger.print("  {}".format(cf.bold("ray status")))
-                if dashboard_url:
-                    cli_logger.print("To monitor and debug Ray, view the dashboard at ")
-                    cli_logger.print(
-                        "  {}".format(
-                            cf.bold(dashboard_url),
-                        )
-                    )
-                cli_logger.newline()
-                cli_logger.print(
-                    cf.underlined(
-                        "If connection fails, check your "
-                        "firewall settings and "
-                        "network configuration."
+                    "  {}".format(
+                        cf.bold(dashboard_url),
                     )
                 )
-                cli_logger.newline()
+            cli_logger.newline()
+            cli_logger.print(
+                cf.underlined(
+                    "If connection fails, check your "
+                    "firewall settings and "
+                    "network configuration."
+                )
+            )
+            cli_logger.newline()
             cli_logger.print("To terminate the Ray runtime, run")
             cli_logger.print(cf.bold("  ray stop"))
         ray_params.gcs_address = bootstrap_address
     else:
         # Start worker node.
-        if not ray_constants.ENABLE_RAY_CLUSTER:
-            cli_logger.abort(
-                "Multi-node Ray clusters are not supported on Windows and OSX. "
-                "Restart the Ray cluster with the environment variable `{}=1` "
-                "to proceed anyway.",
-                cf.bold(ray_constants.ENABLE_RAY_CLUSTERS_ENV_VAR),
-            )
-            raise Exception(
-                "Multi-node Ray clusters are not supported on Windows and OSX. "
-                "Restart the Ray cluster with the environment variable "
-                f"`{ray_constants.ENABLE_RAY_CLUSTERS_ENV_VAR}=1` to proceed "
-                "anyway.",
-            )
 
         # Ensure `--address` flag is specified.
         if address is None:

--- a/python/ray/tests/test_basic_4.py
+++ b/python/ray/tests/test_basic_4.py
@@ -4,11 +4,9 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-import os
 
 import numpy as np
 import pytest
-from unittest import mock
 
 import ray
 import ray.cluster_utils
@@ -165,8 +163,6 @@ def test_fork_support(shutdown_only):
     sys.platform not in ["win32", "darwin"],
     reason="Only listen on localhost by default on mac and windows.",
 )
-@mock.patch("ray._private.services.ray_constants.ENABLE_RAY_CLUSTER", False)
-@mock.patch.dict(os.environ, {"RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER": "0"})
 @pytest.mark.parametrize("start_ray", ["ray_start_regular", "call_ray_start"])
 def test_listen_on_localhost(start_ray, request):
     """All ray processes should listen on localhost by default

--- a/python/ray/tests/test_cli_patterns/test_ray_start.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_start.txt
@@ -7,28 +7,19 @@ Ray runtime started.
 --------------------
 
 Next steps
-  To add another node to this Ray cluster, run
+  To connect to this Ray runtime from another node, run
     ray start --address='.+'
 
-  To connect to this Ray cluster, run `ray.init\(\)` as usual:
+  Alternatively, use the following Python code:
     import ray
-    ray\.init\(\)
-
-  To connect to this Ray instance from outside of the cluster, for example
-  when connecting to a remote cluster from your laptop, make sure the
-  dashboard (.*) is accessible and use the Ray Jobs API\. For example:
-    RAY_ADDRESS='http://<dashboard URL>:8265' ray job submit --working-dir \. -- python my_script\.py
-
-  See https://docs\.ray\.io/en/latest/cluster/running-applications/job-submission/index\.html
-  for more information on connecting to the Ray cluster from a remote client\.
+    ray\.init\(address='auto'\)
 
   To see the status of the cluster, use
     ray status
-  To monitor and debug Ray, view the dashboard at
+  To monitor and debug Ray, view the dashboard at 
     127.0.0.1:8265
 
   If connection fails, check your firewall settings and network configuration.
 
   To terminate the Ray runtime, run
     ray stop
-

--- a/rllib/utils/actor_manager.py
+++ b/rllib/utils/actor_manager.py
@@ -458,6 +458,12 @@ class FaultTolerantActorManager:
         # user, since it is not safe to handle such remote actor calls outside the
         # context of this actor manager. These requests are simply dropped.
         timeout = float(timeout_seconds) if timeout_seconds is not None else None
+
+        # This avoids calling ray.init() in the case of 0 remote calls.
+        # This is useful if the number of remote workers is 0.
+        if not remote_calls:
+            return [], RemoteCallResults()
+
         ready, _ = ray.wait(
             remote_calls,
             num_returns=len(remote_calls),

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -354,9 +354,9 @@ ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
 
       if (relevant_client_index < 0 && head_node_client_index >= 0) {
         RAY_LOG(INFO) << "This node has an IP address of " << node_ip_address
-                      << ", but we cannot find a local Raylet with the same address. "
-                      << "This can happen when you connect to the Ray cluster "
-                      << "with a different IP address or when connecting to a container.";
+                      << ", while we can not find the matched Raylet address. "
+                      << "This maybe come from when you connect the Ray cluster "
+                      << "with a different IP address or connect a container.";
         relevant_client_index = head_node_client_index;
       }
       if (relevant_client_index < 0) {


### PR DESCRIPTION
## Why are these changes needed?

Actor Manager calls `ray.wait()` even when the list of remote_calls is empty and there is nothing to await.
This triggers a ray.init() which is unnecessary. This can be annoying for users who set num_workers=0.

The following script can be run without hitting ray.init() with these changes:

```
from ray.rllib.algorithms.ppo import PPO, PPOConfig

cfg = PPOConfig().environment("CartPole-v1").framework("torch").rollouts(
    num_rollout_workers=0, validate_workers_after_construction=False)

trainer = PPO(cfg)

trainer.step()

a = 10
```