### PR TITLE
Don't call ray.init() when num_workers is zero

### DIFF
--- a/rllib/utils/actor_manager.py
+++ b/rllib/utils/actor_manager.py
@@ -458,6 +458,12 @@ class FaultTolerantActorManager:
         # user, since it is not safe to handle such remote actor calls outside the
         # context of this actor manager. These requests are simply dropped.
         timeout = float(timeout_seconds) if timeout_seconds is not None else None
+
+        # This avoids calling ray.init() in the case of 0 remote calls.
+        # This is useful if the number of remote workers is 0.
+        if not remote_calls:
+            return [], RemoteCallResults()
+
         ready, _ = ray.wait(
             remote_calls,
             num_returns=len(remote_calls),


### PR DESCRIPTION
Actor Manager calls ray.wait() even when the list of remote_calls is empty and there is nothing to await.
This triggers a ray.init() which is unnecessary. This can be annoying for users who set num_workers=0.

The following script can be run without hitting ray.init() with these changes:

```
from ray.rllib.algorithms.ppo import PPO, PPOConfig

cfg = PPOConfig().environment("CartPole-v1").framework("torch").rollouts(
    num_rollout_workers=0, validate_workers_after_construction=False)

trainer = PPO(cfg)

trainer.step()
```