### PR TITLE
Remove use of ATOMIC_VAR_INIT

### DIFF
--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -556,8 +556,7 @@ typedef NTSTATUS WINAPI NtQueryInformationProcess_t(HANDLE ProcessHandle,
                                                     ULONG ProcessInformationLength,
                                                     ULONG *ReturnLength);
 
-static std::atomic<NtQueryInformationProcess_t *> NtQueryInformationProcess_ =
-    ATOMIC_VAR_INIT(NULL);
+static std::atomic<NtQueryInformationProcess_t *> NtQueryInformationProcess_ = NULL;
 
 pid_t GetParentPID() {
   NtQueryInformationProcess_t *NtQueryInformationProcess = NtQueryInformationProcess_;


### PR DESCRIPTION
ATOMIC_VAR_INIT has a trivial definition
`#define ATOMIC_VAR_INIT(value) (value)`,
is deprecated in C17/C++20, and will be removed in newer standards in newer GCC/Clang (e.g. https://reviews.llvm.org/D144196).