### PR TITLE
[K8S] Remove port limitations in the K8S networkpolicies

### DIFF
--- a/doc/source/cluster/kubernetes/configs/static-ray-cluster-networkpolicy.yaml
+++ b/doc/source/cluster/kubernetes/configs/static-ray-cluster-networkpolicy.yaml
@@ -1,15 +1,11 @@
 # If your Kubernetes has a default deny network policy for pods, you need to manually apply this network policy 
 # to allow the bidirectional communication among the head and worker nodes in the Ray cluster.
 
-# The ports between the min-worker-port and max-worker-port are listed separately because targeting a range of
-# ports is only available after Kubernetes v1.25 
-# (https://kubernetes.io/docs/concepts/services-networking/network-policies/#targeting-a-range-of-ports).
-
-# Ingress
+# Ray Head Ingress
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: ray-cluster-ingress
+  name: ray-head-ingress
 spec:
   podSelector:
     matchLabels:
@@ -17,11 +13,6 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 6379
   - from:
     - podSelector: {}
     ports:
@@ -36,129 +27,18 @@ spec:
     - podSelector: {}
     ports:
     - protocol: TCP
-      port: 8076
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 8077
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 8078
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 52365
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
       port: 10001
   - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10002
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10003
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10004
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10005
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10006
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10007
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10008
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10009
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10010
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10011
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10012
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10013
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10014
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10015
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10016
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10017
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10018
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10019
-  - from:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10020
+    - podSelector:
+        matchLabels:
+          app: ray-cluster-worker
 
-# Egress
 ---
+# Ray Head Egress
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: ray-cluster-egress
+  name: ray-head-egress
 spec:
   podSelector:
     matchLabels:
@@ -167,137 +47,49 @@ spec:
     - Egress
   egress:
   - to:
-    - podSelector: {}
+    - podSelector:
+        matchLabels:
+          app: redis
     ports:
     - protocol: TCP
       port: 6379
   - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 6380
+    - podSelector:
+        matchLabels:
+          app: ray-cluster-worker
+
+---
+# Ray Worker Ingress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ray-worker-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app: ray-cluster-worker
+  policyTypes:
+    - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: ray-cluster-head
+
+---
+# Ray Worker Egress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ray-worker-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: ray-cluster-worker
+  policyTypes:
+    - Egress
+  egress:
   - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 8265 
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 8076
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 8077
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 8078
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 52365
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10001
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10002
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10003
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10004
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10005
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10006
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10007
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10008
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10009
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10010
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10011
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10012
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10013
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10014
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10015
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10016
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10017
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10018
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10019
-  - to:
-    - podSelector: {}
-    ports:
-    - protocol: TCP
-      port: 10020
+    - podSelector:
+        matchLabels:
+          app: ray-cluster-head

--- a/doc/source/cluster/kubernetes/configs/static-ray-cluster.with-fault-tolerance.yaml
+++ b/doc/source/cluster/kubernetes/configs/static-ray-cluster.with-fault-tolerance.yaml
@@ -86,98 +86,6 @@ spec:
     protocol: TCP
     port: 6380
     targetPort: 6380
-  - name: object-manager-port
-    protocol: TCP
-    port: 8076
-    targetPort: 8076
-  - name: node-manager-port
-    protocol: TCP
-    port: 8077
-    targetPort: 8077
-  - name: dashboard-agent-grpc-port
-    protocol: TCP
-    port: 8078
-    targetPort: 8078
-  - name: dashboard-agent-listen-port
-    protocol: TCP
-    port: 52365
-    targetPort: 52365
-  - name: worker-port-1
-    protocol: TCP
-    port: 10002
-    targetPort: 10002
-  - name: worker-port-2
-    protocol: TCP
-    port: 10003
-    targetPort: 10003
-  - name: worker-port-3
-    protocol: TCP
-    port: 10004
-    targetPort: 10004
-  - name: worker-port-4
-    protocol: TCP
-    port: 10005
-    targetPort: 10005
-  - name: worker-port-5
-    protocol: TCP
-    port: 10006
-    targetPort: 10006
-  - name: worker-port-6
-    protocol: TCP
-    port: 10007
-    targetPort: 10007
-  - name: worker-port-7
-    protocol: TCP
-    port: 10008
-    targetPort: 10008
-  - name: worker-port-8
-    protocol: TCP
-    port: 10009
-    targetPort: 10009
-  - name: worker-port-9
-    protocol: TCP
-    port: 10010
-    targetPort: 10010
-  - name: worker-port-10
-    protocol: TCP
-    port: 10011
-    targetPort: 10011
-  - name: worker-port-11
-    protocol: TCP
-    port: 10012
-    targetPort: 10012
-  - name: worker-port-12
-    protocol: TCP
-    port: 10013
-    targetPort: 10013
-  - name: worker-port-13
-    protocol: TCP
-    port: 10014
-    targetPort: 10014
-  - name: worker-port-14
-    protocol: TCP
-    port: 10015
-    targetPort: 10015
-  - name: worker-port-15
-    protocol: TCP
-    port: 10016
-    targetPort: 10016
-  - name: worker-port-16
-    protocol: TCP
-    port: 10017
-    targetPort: 10017
-  - name: worker-port-17
-    protocol: TCP
-    port: 10018
-    targetPort: 10018
-  - name: worker-port-18
-    protocol: TCP
-    port: 10019
-    targetPort: 10019
-  - name: worker-port-19
-    protocol: TCP
-    port: 10020
-    targetPort: 10020
   selector:
     app: ray-cluster-head
 ---
@@ -216,39 +124,16 @@ spec:
           medium: Memory
       containers:
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           imagePullPolicy: Always
           command: [ "/bin/bash", "-c", "--" ]
           # if there is no password for Redis, set --redis-password=''
           args:
-            - "ray start --head --port=6380 --num-cpus=$MY_CPU_REQUEST --dashboard-host=0.0.0.0 --object-manager-port=8076 --node-manager-port=8077 --dashboard-agent-grpc-port=8078 --dashboard-agent-listen-port=52365 --min-worker-port=10002 --max-worker-port=10020 --redis-password='' --block"
+            - "ray start --head --port=6380 --num-cpus=$MY_CPU_REQUEST --dashboard-host=0.0.0.0 --object-manager-port=8076 --node-manager-port=8077 --dashboard-agent-grpc-port=8078 --dashboard-agent-listen-port=52365 --redis-password='' --block"
           ports:
             - containerPort: 6380 # GCS server
             - containerPort: 10001 # Used by Ray Client
             - containerPort: 8265 # Used by Ray Dashboard
-            - containerPort: 8076 # Ray object manager port
-            - containerPort: 8077 # Ray node manager port
-            - containerPort: 8078 # Ray dashboard agent grpc port
-            - containerPort: 52365 # Ray dashboard agent listen port
-            - containerPort: 10002 # min worker port
-            - containerPort: 10003 # available worker port
-            - containerPort: 10004 # available worker port
-            - containerPort: 10005 # available worker port
-            - containerPort: 10006 # available worker port
-            - containerPort: 10007 # available worker port
-            - containerPort: 10008 # available worker port
-            - containerPort: 10009 # available worker port
-            - containerPort: 10010 # available worker port
-            - containerPort: 10011 # available worker port
-            - containerPort: 10012 # available worker port
-            - containerPort: 10013 # available worker port
-            - containerPort: 10014 # available worker port
-            - containerPort: 10015 # available worker port
-            - containerPort: 10016 # available worker port
-            - containerPort: 10017 # available worker port
-            - containerPort: 10018 # available worker port
-            - containerPort: 10019 # available worker port
-            - containerPort: 10020 # max worker port
           # This volume allocates shared memory for Ray to use for its plasma
           # object store. If you do not provide this, Ray will fall back to
           # /tmp which cause slowdowns if it's not a shared memory volume.
@@ -309,35 +194,12 @@ spec:
           medium: Memory
       containers:
       - name: ray-worker
-        image: rayproject/ray:2.2.0
+        image: rayproject/ray:2.3.0
         imagePullPolicy: Always
         command: ["/bin/bash", "-c", "--"]
         args:
-          - "ray start --num-cpus=$MY_CPU_REQUEST --address=$SERVICE_RAY_CLUSTER_SERVICE_HOST:$SERVICE_RAY_CLUSTER_SERVICE_PORT_GCS_SERVER --object-manager-port=8076 --node-manager-port=8077 --dashboard-agent-grpc-port=8078 --dashboard-agent-listen-port=52365 --min-worker-port=10002 --max-worker-port=10020 --block"
-        ports:
-          - containerPort: 8076
-          - containerPort: 8077
-          - containerPort: 8078
-          - containerPort: 52365
-          - containerPort: 10002
-          - containerPort: 10003
-          - containerPort: 10004
-          - containerPort: 10005
-          - containerPort: 10006
-          - containerPort: 10007
-          - containerPort: 10008
-          - containerPort: 10009
-          - containerPort: 10010
-          - containerPort: 10011
-          - containerPort: 10012
-          - containerPort: 10013
-          - containerPort: 10014
-          - containerPort: 10015
-          - containerPort: 10016
-          - containerPort: 10017
-          - containerPort: 10018
-          - containerPort: 10019
-          - containerPort: 10020 
+          - "ray start --num-cpus=$MY_CPU_REQUEST --address=$SERVICE_RAY_CLUSTER_SERVICE_HOST:$SERVICE_RAY_CLUSTER_SERVICE_PORT_GCS_SERVER --object-manager-port=8076 --node-manager-port=8077 --dashboard-agent-grpc-port=8078 --dashboard-agent-listen-port=52365 --block"
+
         # This volume allocates shared memory for Ray to use for its plasma
         # object store. If you do not provide this, Ray will fall back to
         # /tmp which cause slowdowns if it's not a shared memory volume.

--- a/doc/source/cluster/kubernetes/user-guides/static-ray-cluster-without-kuberay.md
+++ b/doc/source/cluster/kubernetes/user-guides/static-ray-cluster-without-kuberay.md
@@ -96,10 +96,6 @@ Note that in production scenarios, you will want to use larger Ray pods. In fact
 If your Kubernetes has a default deny network policy for pods, you need to manually create a network policy to allow bidirectional
 communication among the head and worker nodes in the Ray cluster as mentioned in [the ports configurations doc](https://docs.ray.io/en/latest/ray-core/configure.html#ports-configurations).
 
-Note that the statically set port ranges for the worker ports in [the Kubernetes deployment config file](https://raw.githubusercontent.com/ray-project/ray/master/doc/source/cluster/kubernetes/configs/static-ray-cluster.with-fault-tolerance.yaml)
-are only required when there is a corresponding network policy created for the default deny behavior.
-Otherwise the statically set worker port ranges are not required.
-
 ```
 # Create a sample network policy for the static Ray cluster from the Ray repo:
 ! kubectl apply -f https://raw.githubusercontent.com/ray-project/ray/master/doc/source/cluster/kubernetes/configs/static-ray-cluster-networkpolicy.yaml
@@ -111,8 +107,10 @@ Once the network policy has been deployed, you can view the network policy for t
 ! kubectl get networkpolicies
 
 # NAME                               POD-SELECTOR                           AGE
-# ray-cluster-egress                 app=ray-cluster-head                   XXs
-# ray-cluster-ingress                app=ray-cluster-head                   XXs
+# ray-head-egress                    app=ray-cluster-head                   XXs
+# ray-head-ingress                   app=ray-cluster-head                   XXs
+# ray-worker-egress                  app=ray-cluster-worker                 XXs
+# ray-worker-ingress                 app=ray-cluster-worker                 XXs
 ```
 
 ### External Redis Integration for fault tolerance


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We have observed that there are usually some jobs hanging if only a small range of ports are opened in the K8S networkpolicies. This PR allows all ports between the head and workers in the networkpolicies to resolve the job hanging issue.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/32215 and https://github.com/ray-project/ray/issues/28071
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Test locally
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
