### PR TITLE
[RLlib] Improve setting rollout_fragment_length logic to get the expected train_batch_size

### DIFF
--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -389,6 +389,9 @@ class PPO(Algorithm):
         train_batch = train_batch.as_multi_agent()
         self._counters[NUM_AGENT_STEPS_SAMPLED] += train_batch.agent_steps()
         self._counters[NUM_ENV_STEPS_SAMPLED] += train_batch.env_steps()
+        print("agent_steps: ", train_batch.agent_steps())
+        print("train_batch.count: ", len(train_batch["default_policy"]))
+        print("train_batch_size", self.config.train_batch_size)
 
         # Standardize advantages
         train_batch = standardize_fields(train_batch, ["advantages"])

--- a/rllib/algorithms/tests/test_algorithm_config.py
+++ b/rllib/algorithms/tests/test_algorithm_config.py
@@ -72,18 +72,19 @@ class TestAlgorithmConfig(unittest.TestCase):
             AlgorithmConfig()
             .rollouts(
                 num_rollout_workers=4,
-                num_envs_per_worker=3,
+                num_envs_per_worker=2,
                 rollout_fragment_length="auto",
             )
-            .training(train_batch_size=2456)
+            .training(train_batch_size=2500)
         )
-        # 2456 / 3 * 4 -> 204.666 -> 204 or 205 (depending on worker index).
-        # Actual train batch size: 2454 (off by only 2)
-        self.assertTrue(config.get_rollout_fragment_length(worker_index=0) == 205)
-        self.assertTrue(config.get_rollout_fragment_length(worker_index=1) == 205)
-        self.assertTrue(config.get_rollout_fragment_length(worker_index=2) == 205)
-        self.assertTrue(config.get_rollout_fragment_length(worker_index=3) == 204)
-        self.assertTrue(config.get_rollout_fragment_length(worker_index=4) == 204)
+        # 2500 / 2 / 4 -> 312.5 -> 312 or 313 (depending on worker index).
+        # Actual train batch size: 2500
+        # diff = 2500 - 312 * 2 * 4 = 4, workers 0,1,2 get 313, others gets 312.
+        self.assertTrue(config.get_rollout_fragment_length(worker_index=0) == 313)
+        self.assertTrue(config.get_rollout_fragment_length(worker_index=1) == 313)
+        self.assertTrue(config.get_rollout_fragment_length(worker_index=2) == 313)
+        self.assertTrue(config.get_rollout_fragment_length(worker_index=3) == 312)
+        self.assertTrue(config.get_rollout_fragment_length(worker_index=4) == 312)
 
         config = (
             AlgorithmConfig()


### PR DESCRIPTION
fixed the logic for setting the rollout fragments properly for getting the desired train_batch_size. plus a few other improvements in error messages to guide the user in the right direction.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
