### PR TITLE
[Datasets] Require preserving order if plan has Zip or Sort stage

### DIFF
--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -56,6 +56,13 @@ def execute_to_legacy_block_iterator(
         dag, stats = get_execution_plan(plan._logical_plan).dag, None
     else:
         dag, stats = _to_operator_dag(plan, allow_clear_input_blocks)
+
+    # Enforce to preserve ordering if the plan has stages required to do so, such as
+    # Zip and Sort.
+    # TODO(chengsu): implement this for operator as well.
+    if plan.require_preserve_order():
+        executor._options.preserve_order = True
+
     bundle_iter = executor.execute(dag, initial_stats=stats)
 
     for bundle in bundle_iter:
@@ -84,6 +91,13 @@ def execute_to_legacy_block_list(
         dag, stats = get_execution_plan(plan._logical_plan).dag, None
     else:
         dag, stats = _to_operator_dag(plan, allow_clear_input_blocks)
+
+    # Enforce to preserve ordering if the plan has stages required to do so, such as
+    # Zip and Sort.
+    # TODO(chengsu): implement this for operator as well.
+    if plan.require_preserve_order():
+        executor._options.preserve_order = True
+
     bundles = executor.execute(dag, initial_stats=stats)
     block_list = _bundles_to_block_list(bundles)
     # Set the stats UUID after execution finishes.

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -764,6 +764,17 @@ class ExecutionPlan:
             and self._stages_after_snapshot
         )
 
+    def require_preserve_order(self) -> bool:
+        """Whether this plan requires to preserve order when running with new
+        backend.
+        """
+        from ray.data._internal.stage_impl import SortStage, ZipStage
+
+        for stage in self._stages_after_snapshot:
+            if isinstance(stage, ZipStage) or isinstance(stage, SortStage):
+                return True
+        return False
+
 
 def _pack_args(
     self_fn_args: Iterable[Any],

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -710,6 +710,15 @@ def test_optimize_lazy_reuse_base_data(
     assert num_reads == num_blocks, num_reads
 
 
+def test_require_preserve_order(ray_start_regular_shared):
+    ds = ray.data.range(100).map_batches(lambda x: x).sort()
+    assert ds._plan.require_preserve_order()
+    ds2 = ray.data.range(100).map_batches(lambda x: x).zip(ds)
+    assert ds2._plan.require_preserve_order()
+    ds3 = ray.data.range(100).map_batches(lambda x: x).repartition(10)
+    assert not ds3._plan.require_preserve_order()
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to require preserving order when plan has either Zip or Sort stage. This applies to both bulk and streaming executor. Given streaming executor is not preserving order by default, this PR is more of a bugfix to prevent regression. A followup PR is to add the corresponding check inside optimizer (probably as an optimizer rule). Don't want to couple the change of optimizer here, because we want to enable streaming executor by default in 2.4.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
