### PR TITLE
[AIR/Data] Make `Preprocessor.transform` lazy by default

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3315,7 +3315,8 @@ class Dataset(Generic[T]):
             >>> preprocessor = Concatenator(output_column_name="features", exclude="target")
             >>> ds = preprocessor.transform(ds)
             >>> ds
-            Dataset(num_blocks=1, num_rows=150, schema={target: int64, features: TensorDtype(shape=(4,), dtype=float64)})
+            Concatenator
+            +- Dataset(num_blocks=1, num_rows=150, schema={sepal length (cm): double, sepal width (cm): double, petal length (cm): double, petal width (cm): double, target: int64})
             >>> ds.to_tf("features", "target")  # doctest: +SKIP
             <_OptionsDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float64, name='features'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
 

--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -195,8 +195,7 @@ class DatasetIterator(abc.ABC):
             ...     "s3://anonymous@air-example-data/iris.csv"
             ... )
             >>> it = ds.iterator(); it
-            DatasetIterator(Concatenator
-            +- Dataset(num_blocks=1, num_rows=150, schema={sepal length (cm): double, sepal width (cm): double, petal length (cm): double, petal width (cm): double, target: int64}))
+            DatasetIterator(Dataset(num_blocks=1, num_rows=150, schema={sepal length (cm): double, sepal width (cm): double, petal length (cm): double, petal width (cm): double, target: int64}))
 
             If your model accepts a single tensor as input, specify a single feature column.
 
@@ -216,7 +215,8 @@ class DatasetIterator(abc.ABC):
             >>> preprocessor = Concatenator(output_column_name="features", exclude="target")
             >>> it = preprocessor.transform(ds).iterator()
             >>> it
-            DatasetIterator(Dataset(num_blocks=1, num_rows=150, schema={target: int64, features: TensorDtype(shape=(4,), dtype=float64)}))
+            DatasetIterator(Concatenator
+            +- Dataset(num_blocks=1, num_rows=150, schema={sepal length (cm): double, sepal width (cm): double, petal length (cm): double, petal width (cm): double, target: int64}))
             >>> it.to_tf("features", "target")  # doctest: +SKIP
             <_OptionsDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float64, name='features'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
 

--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -195,7 +195,8 @@ class DatasetIterator(abc.ABC):
             ...     "s3://anonymous@air-example-data/iris.csv"
             ... )
             >>> it = ds.iterator(); it
-            DatasetIterator(Dataset(num_blocks=1, num_rows=150, schema={sepal length (cm): double, sepal width (cm): double, petal length (cm): double, petal width (cm): double, target: int64}))
+            DatasetIterator(Concatenator
+            +- Dataset(num_blocks=1, num_rows=150, schema={sepal length (cm): double, sepal width (cm): double, petal length (cm): double, petal width (cm): double, target: int64}))
 
             If your model accepts a single tensor as input, specify a single feature column.
 

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Optional, Union, Dict, Any
 
 from ray.air.util.data_batch_conversion import BatchFormat, BlockFormat
-from ray.util.annotations import DeveloperAPI, PublicAPI
+from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:
     from ray.data import Dataset, DatasetPipeline
@@ -67,6 +67,7 @@ class Preprocessor(abc.ABC):
         else:
             return Preprocessor.FitStatus.NOT_FITTED
 
+    @Deprecated
     def transform_stats(self) -> Optional[str]:
         """Return Dataset stats for the most recent transform call, if any."""
 

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -69,9 +69,15 @@ class Preprocessor(abc.ABC):
 
     def transform_stats(self) -> Optional[str]:
         """Return Dataset stats for the most recent transform call, if any."""
-        if not hasattr(self, "_transform_stats"):
-            return None
-        return self._transform_stats
+
+        raise DeprecationWarning(
+            "`preprocessor.transform_stats()` is no longer supported in Ray 2.4 "
+            "with Datasets now lazy by default. The stats for the Dataset "
+            "can instead be accessed directly from the transformed dataset "
+            "(`ds.stats()`), or can be viewed in the ray-data.log "
+            "file saved in the Ray logs directory "
+            "(defaults to /tmp/ray/session_{SESSION_ID}/logs/)."
+        )
 
     def fit(self, dataset: "Dataset") -> "Preprocessor":
         """Fit this Preprocessor to the Dataset.
@@ -141,8 +147,7 @@ class Preprocessor(abc.ABC):
                 "`fit` must be called before `transform`, "
                 "or simply use fit_transform() to run both steps"
             )
-        transformed_ds = self._transform(dataset).fully_executed()
-        self._transform_stats = transformed_ds.stats()
+        transformed_ds = self._transform(dataset)
         return transformed_ds
 
     def transform_batch(self, data: "DataBatchType") -> "DataBatchType":

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -72,9 +72,10 @@ class Preprocessor(abc.ABC):
         """Return Dataset stats for the most recent transform call, if any."""
 
         raise DeprecationWarning(
-            "`preprocessor.transform_stats()` is no longer supported in Ray 2.4 "
-            "with Datasets now lazy by default. The stats for the Dataset "
-            "can instead be accessed directly from the transformed dataset "
+            "`preprocessor.transform_stats()` is no longer supported in Ray 2.4. "
+            "With Datasets now lazy by default, the stats are only populated "
+            "after execution. Once the dataset transform is executed, the "
+            "stats can be accessed directly from the transformed dataset "
             "(`ds.stats()`), or can be viewed in the ray-data.log "
             "file saved in the Ray logs directory "
             "(defaults to /tmp/ray/session_{SESSION_ID}/logs/)."

--- a/python/ray/data/preprocessors/chain.py
+++ b/python/ray/data/preprocessors/chain.py
@@ -78,7 +78,6 @@ class Chain(Preprocessor):
     def fit_transform(self, ds: Dataset) -> Dataset:
         for preprocessor in self.preprocessors:
             ds = preprocessor.fit_transform(ds)
-        self._transform_stats = preprocessor.transform_stats()
         return ds
 
     def _transform(

--- a/python/ray/data/tests/preprocessors/test_concatenator.py
+++ b/python/ray/data/tests/preprocessors/test_concatenator.py
@@ -28,7 +28,7 @@ class TestConcatenator:
         )
 
         with pytest.raises(ValueError, match="'b'"):
-            prep.transform(ds)
+            prep.transform(ds).fully_executed()
 
     @pytest.mark.parametrize("exclude", ("b", ["b"]))
     def test_exclude(self, exclude):

--- a/python/ray/data/tests/preprocessors/test_encoder.py
+++ b/python/ray/data/tests/preprocessors/test_encoder.py
@@ -97,7 +97,7 @@ def test_ordinal_encoder():
 
     # Verify transform fails for null values.
     with pytest.raises(ValueError):
-        null_encoder.transform(null_ds)
+        null_encoder.transform(null_ds).fully_executed()
     null_encoder.transform(nonnull_ds)
 
     # Verify transform_batch fails for null values.
@@ -299,7 +299,7 @@ def test_one_hot_encoder():
 
     # Verify transform fails for null values.
     with pytest.raises(ValueError):
-        null_encoder.transform(null_ds)
+        null_encoder.transform(null_ds).fully_executed()
     null_encoder.transform(nonnull_ds)
 
     # Verify transform_batch fails for null values.
@@ -408,7 +408,7 @@ def test_multi_hot_encoder():
 
     # Verify transform fails for null values.
     with pytest.raises(ValueError):
-        null_encoder.transform(null_ds)
+        null_encoder.transform(null_ds).fully_executed()
     null_encoder.transform(nonnull_ds)
 
     # Verify transform_batch fails for null values.
@@ -511,7 +511,7 @@ def test_label_encoder():
 
     # Verify transform fails for null values.
     with pytest.raises(ValueError):
-        null_encoder.transform(null_ds)
+        null_encoder.transform(null_ds).fully_executed()
     null_encoder.transform(nonnull_ds)
 
     # Verify transform_batch fails for null values.

--- a/python/ray/data/tests/preprocessors/test_preprocessors.py
+++ b/python/ray/data/tests/preprocessors/test_preprocessors.py
@@ -383,6 +383,13 @@ def test_numpy_pandas_support_transform_batch_tensor(create_dummy_preprocessors)
     assert isinstance(with_pandas_and_numpy.transform_batch(np_multi_column), dict)
 
 
+def test_transform_stats_raises_deprecation_warning(create_dummy_preprocessors):
+    with_nothing, _, _, _ = create_dummy_preprocessors
+
+    with pytest.raises(DeprecationWarning):
+        with_nothing.transform_stats()
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/preprocessors/test_torch.py
+++ b/python/ray/data/tests/preprocessors/test_torch.py
@@ -118,7 +118,7 @@ class TestTorchVisionPreprocessor:
         preprocessor = TorchVisionPreprocessor(columns=["image"], transform=transform)
 
         with pytest.raises(ValueError):
-            preprocessor.transform(dataset)
+            preprocessor.transform(dataset).fully_executed()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Change `Preprocessor.transform` to be lazy by default, aligning with the default execution pattern for Datasets. This allows preprocessors to be used in either training or inference pipelines in a streaming fashion. 

This PR also deprecates `Preprocessor.transform_stats`. Stats can now be accessed directly from the Dataset after execution.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
