### PR TITLE
[AIR][Docs] Add `BatchPredictor.from_checkpoint` to docs

### DIFF
--- a/doc/source/ray-air/api/predictor.rst
+++ b/doc/source/ray-air/api/predictor.rst
@@ -58,8 +58,14 @@ Supported Data Formats
 Batch Predictor
 ---------------
 
-Constructor
-~~~~~~~~~~~
+Constructor Options
+~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+    :toctree: doc/
+    :template: autosummary/class_with_autosummary.rst
+
+    batch_predictor.BatchPredictor
 
 .. autosummary::
     :toctree: doc/

--- a/doc/source/ray-air/api/predictor.rst
+++ b/doc/source/ray-air/api/predictor.rst
@@ -63,10 +63,9 @@ Constructor
 
 .. autosummary::
     :toctree: doc/
-    :template: autosummary/class_with_autosummary.rst
 
-    batch_predictor.BatchPredictor
-
+    batch_predictor.BatchPredictor.from_checkpoint
+    batch_predictor.BatchPredictor.from_pandas_udf
 
 Batch Prediction API
 ~~~~~~~~~~~~~~~~~~~~

--- a/python/ray/train/batch_predictor.py
+++ b/python/ray/train/batch_predictor.py
@@ -53,6 +53,7 @@ class BatchPredictor:
         Example:
 
             .. testcode::
+
                 from torchvision import models
 
                 from ray.train.batch_predictor import BatchPredictor

--- a/python/ray/train/batch_predictor.py
+++ b/python/ray/train/batch_predictor.py
@@ -47,6 +47,28 @@ class BatchPredictor:
     def from_checkpoint(
         cls, checkpoint: Checkpoint, predictor_cls: Type[Predictor], **kwargs
     ) -> "BatchPredictor":
+        """Create a :class:`BatchPredictor` from a
+        :class:`~ray.air.checkpoint.Checkpoint`.
+
+        Example:
+
+            .. testcode::
+                from torchvision import models
+
+                from ray.train.batch_predictor import BatchPredictor
+                from ray.train.torch import TorchCheckpoint, TorchPredictor
+
+                model = models.resnet50(pretrained=True)
+                checkpoint = TorchCheckpoint.from_model(model)
+                predictor = BatchPredictor.from_checkpoint(checkpoint, TorchPredictor)
+
+        Args:
+            checkpoint: A :class:`~ray.air.checkpoint.Checkpoint` containing model state
+                and optionally a preprocessor.
+            predictor_cls: The type of predictor to use.
+            **kwargs: Optional arguments to pass the ``predictor_cls`` constructor.
+        """
+
         return cls(checkpoint=checkpoint, predictor_cls=predictor_cls, **kwargs)
 
     @classmethod


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`BatchPredictor.from_checkpoint` is the most common way to create `BatchPredictors`,  but it isn't documented. This PR adds the method to the docs.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #32876 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
