### PR TITLE
[CI] Don't run Docker CI on every PR

### DIFF
--- a/.buildkite/pipeline.arm64.yml
+++ b/.buildkite/pipeline.arm64.yml
@@ -57,7 +57,7 @@
 
 
 - label: ":mechanical_arm: :docker: Build Images: py37 [aarch64] (1/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: arm64-medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -67,7 +67,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py37 --device-types cpu cu112 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py37 [aarch64] (2/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: arm64-medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -77,7 +77,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py37 --device-types cu113 cu116 cu118 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py38 [aarch64] (1/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: arm64-medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -87,7 +87,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py38 --device-types cpu cu112 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py38 [aarch64] (2/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: arm64-medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -97,7 +97,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py38 --device-types cu113 cu116 cu118 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py39 [aarch64] (1/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: arm64-medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -107,7 +107,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py39 --device-types cpu cu112 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py39 [aarch64] (2/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: arm64-medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -117,7 +117,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py39 --device-types cu113 cu116 cu118 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py310 [aarch64] (1/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: arm64-medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -127,7 +127,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py310 --device-types cpu cu112 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py310 [aarch64] (2/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: arm64-medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -85,7 +85,7 @@
 #     - if [ "$BUILDKITE_BRANCH" == "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
 
 - label: ":docker: Build Images: py37 (1/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -95,7 +95,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py37 --device-types cpu cu101 cu102 cu110 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py37 (2/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -105,7 +105,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py37 --device-types cu111 cu112 cu113 cu116 cu118 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py38 (1/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -115,7 +115,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py38 --device-types cpu cu101 cu102 cu110 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py38 (2/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -125,7 +125,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py38 --device-types cu111 cu112 cu113 cu116 cu118 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py39 (1/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -135,7 +135,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py39 --device-types cpu cu101 cu102 cu110 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py39 (2/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -145,7 +145,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py39 --device-types cu111 cu112 cu113 cu116 cu118 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py310 (1/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: [["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build
@@ -155,7 +155,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py310 --device-types cpu cu101 cu102 cu110 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py310 (2/2)"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -145,7 +145,7 @@
     - python ./ci/build/build-docker-images.py --py-versions py39 --device-types cu111 cu112 cu113 cu116 cu118 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py310 (1/2)"
-  conditions: [["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: medium
   commands:
     - LINUX_WHEELS=1 ./ci/ci.sh build


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
As we have increased our supported python versions, cuda versions, and platform architectures over time, we have increased the number of docker builds in CI.

These builds take some of the longest in the full CI run, and do not need to be run on every single PR. We change the docker builds to only be run on Ray core changes, or changes to the dependencies or the docker files/build processes themselves.

**These tests are still run for every commit on master branch.**

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
