### PR TITLE
[Train] Support returning multiple devices in `train.torch.get_device()`

### DIFF
--- a/python/ray/train/_internal/dataset_iterator.py
+++ b/python/ray/train/_internal/dataset_iterator.py
@@ -41,6 +41,9 @@ class TrainDatasetIterator(DatasetIterator):
             except SessionMisuseError:
                 pass
 
+        if isinstance(device, list):
+            device = device[0]
+
         return self._dataset_iterator.iter_torch_batches(device=device, **kwargs)
 
     def to_tf(self, *args, **kwargs) -> "tf.data.Dataset":

--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -168,6 +168,23 @@ def test_torch_prepare_model(ray_start_4_cpus_2_gpus):
     )
     trainer.fit()
 
+    def train_fn_manual_override():
+        model = torch.nn.Linear(1, 1)
+
+        # Wrap in DDP and manually specify CPU.
+        model = train.torch.prepare_model(model, device=torch.device("cpu"))
+
+        # Make sure model is wrapped in DDP.
+        assert isinstance(model, DistributedDataParallel)
+
+        # Make sure model is NOT on cuda since we manually specified CPU.
+        assert not next(model.parameters()).is_cuda
+
+    trainer = TorchTrainer(
+        train_fn, scaling_config=ScalingConfig(num_workers=2, use_gpu=True)
+    )
+    trainer.fit()
+
 
 def test_torch_prepare_model_uses_device(ray_start_4_cpus_2_gpus):
     """Tests if `prepare_model` uses the train.torch.get_device even if it does not

--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -1,5 +1,4 @@
 import os
-from collections import Counter
 import time
 
 from unittest.mock import patch
@@ -118,7 +117,6 @@ def test_torch_get_device_dist(ray_2_node_2_gpu, num_gpus_per_worker):
     results = trainer.fit()
     devices = [result["devices"] for result in results.metrics["results"]]
 
-    count = Counter(devices)
     # cluster setups: 2 nodes, 2 gpus per node
     # `CUDA_VISIBLE_DEVICES` is set to "0,1" on node 1 and node 2
     if num_gpus_per_worker == 0.5:
@@ -126,21 +124,22 @@ def test_torch_get_device_dist(ray_2_node_2_gpu, num_gpus_per_worker):
         # 4 workers on node 1, 4 workers on node 2
         # `ray.get_gpu_ids()` returns [0], [0], [1], [1] on node 1
         # and [0], [0], [1], [1] on node 2
-        for i in range(2):
-            assert count[i] == 4
+        assert sorted(devices[0]) == [0, 0, 1, 1]
+        assert sorted(devices[1]) == [0, 0, 1, 1]
     elif num_gpus_per_worker == 1:
         # worker gpu topology:
         # 2 workers on node 1, 2 workers on node 2
         # `ray.get_gpu_ids()` returns [0], [1] on node 1 and [0], [1] on node 2
-        for i in range(2):
-            assert count[i] == 2
+        assert sorted(devices[0]) == [0, 1]
+        assert sorted(devices[1]) == [0, 1]
     elif num_gpus_per_worker == 2:
         # worker gpu topology:
         # 1 workers on node 1, 1 workers on node 2
         # `ray.get_gpu_ids()` returns {0, 1} on node 1 and {0, 1} on node 2
         # and `device_id` returns the one index from each set.
         # So total count of devices should be 2.
-        assert sum(count.values()) == 2
+        assert devices[0] == [[0, 1]]
+        assert devices[1] == [[0, 1]]
     else:
         raise RuntimeError(
             "New parameter for this test has been added without checking that the "

--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -77,7 +77,7 @@ def test_torch_get_device(
     trainer = TorchTrainerPatchedMultipleReturns(
         train_fn,
         scaling_config=ScalingConfig(
-            num_workers=2 / num_gpus_per_worker,
+            num_workers=int(2 / num_gpus_per_worker),
             use_gpu=True,
             resources_per_worker={"GPU": num_gpus_per_worker},
         ),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
For model parallel workloads like stable diffusion fine-tuning, we may want to use multiple GPUs per Ray Train worker. This PR implements support for `train.torch.get_device()` returning a List of devices for these use cases so that users do not need to manage device setting themselves.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
