### PR TITLE
[RLlib] Fix bug in Atari `MaxAndSkip` wrapper (dtype of buffer needs to match observation space).

### DIFF
--- a/rllib/env/wrappers/atari_wrappers.py
+++ b/rllib/env/wrappers/atari_wrappers.py
@@ -221,8 +221,17 @@ class MaxAndSkipEnv(gym.Wrapper):
     two skipped frames).
     """
     def __init__(self, env, skip: int = 4, max_over: int = 2):
-        """Return only every `skip`-th frame"""
-        gym.Wrapper.__init__(self, env)
+        """Initializes a MaxAndSkipEnv instance.
+
+        Args:
+            skip: The number of frames to skip with each `step()` call. Note that
+                after `reset()` no frames are skipped.
+            max_over: The number of the last n frames (within the skipped ones) that
+                we max the returned observations over. Each dim in the observation
+                space is maxed over individually, not changing the shape (or dtype)
+                of the observation space.
+        """
+        super().__init__(env)
 
         assert skip >= max_over, (
             f"`skip` ({skip}) value must be larger or equal to `max_over` "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix bug in Atari `MaxAndSkip` wrapper (dtype of buffer needs to match observation space).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
