### PR TITLE
[core][state] Adding downloading feature for ray logs 

### DIFF
--- a/doc/source/ray-observability/api/state/api.rst
+++ b/doc/source/ray-observability/api/state/api.rst
@@ -62,6 +62,8 @@ Log APIs
 
     ray.experimental.state.api.list_logs
     ray.experimental.state.api.get_log
+    ray.experimental.state.common.DownloadLogResult
+    ray.experimental.state.common.DownloadLogFileResult
 
 .. _state-api-schema:
 

--- a/python/ray/experimental/state/common.py
+++ b/python/ray/experimental/state/common.py
@@ -46,6 +46,13 @@ STATE_OBS_ALPHA_FEEDBACK_MSG = [
     "==========================================================",
 ]
 
+# Chunk size for streaming logs from the API server to the client.
+RAY_DOWNLOAD_LOG_CHUNK_SIZE = 4096  # 4KiB
+
+# Limit the number of concurrent connections made to the API server
+# when downloading logs.
+RAY_DOWNLOAD_LOG_MAX_NUM_CONNECTIONS = 100
+
 
 @unique
 class StateResource(Enum):
@@ -270,6 +277,31 @@ def filter_fields(data: dict, state_dataclass: StateSchema, detail: bool) -> dic
         else:
             filtered_data[col] = None
     return filtered_data
+
+
+@dataclass(init=True)
+class DownloadLogFileResult:
+    # Filename relative to the log directory (default `/tmp/ray/session_latest/logs`).
+    filename: str
+    # Size of the file.
+    size: int
+    # Local path where the log file is downloaded to.
+    download_path: str
+    # Optional error info if downloading this file errored.
+    error: Optional[Exception] = None
+
+
+@dataclass(init=True)
+class DownloadLogResult:
+    """Return type of state API log downloading."""
+
+    # TODO(rickyx): we should make sure we have the node id info in listing logs reply.
+    # Node id of the node containing the log.
+    node_id: Optional[str] = None
+    # Node ip of the node containing the log.
+    node_ip: Optional[str] = None
+    # List of downloaded log file results.
+    files: List[DownloadLogFileResult] = field(default_factory=list)
 
 
 @dataclass(init=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR adds downloading features for ray logs. 

Example usage 
```
# Will download log files into working directory, or `--download-dir`
ray logs "gcs*" -d  --download-dir /tmp/test-logs001
```

![image](https://user-images.githubusercontent.com/11676094/221961156-7a9a5493-3f5f-4ebb-aff9-bbe67527399c.png)



TODO:
testing scalability and performance on a large cluster with large test files. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
