### PR TITLE
[ci/mac] Specifically target amd64 architecture in mac jobs

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -28,7 +28,7 @@ epilogue_commands: &epilogue_commands |-
 steps:
 - label: ":mac: :apple: Wheels and Jars"
   <<: *common
-  conditions: ["RAY_CI_MACOS_WHEELS_AFFECTED", "RAY_CI_PYTHON_DEPENDENCIES_AFFECTED"]
+  # conditions: ["RAY_CI_MACOS_WHEELS_AFFECTED", "RAY_CI_PYTHON_DEPENDENCIES_AFFECTED"]
   agents:
     arch: amd64
   commands:

--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -29,6 +29,8 @@ steps:
 - label: ":mac: :apple: Wheels and Jars"
   <<: *common
   conditions: ["RAY_CI_MACOS_WHEELS_AFFECTED", "RAY_CI_PYTHON_DEPENDENCIES_AFFECTED"]
+  agents:
+    arch: amd64
   commands:
     # Cleanup environments
     - rm -rf /tmp/bazel_event_logs
@@ -64,51 +66,11 @@ steps:
     - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
     - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination jars --path ./.jar/darwin; fi
 
-- label: ":mac: :apple: ARM64 Wheels"
-  <<: *common
-  # conditions: ["RAY_CI_MACOS_WHEELS_AFFECTED", "RAY_CI_PYTHON_DEPENDENCIES_AFFECTED"]
-  agents:
-    queue: mac-pr-m2
-  # Skip jars for now
-  commands:
-    # Cleanup environments
-    - rm -rf /tmp/bazel_event_logs
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - (which bazel && bazel clean) || true
-    # TODO(simon): make sure to change both PR and wheel builds
-    # Special setup for jar builds (will be installed to the machine instead)
-    # - brew remove --force java & brew uninstall --force java & rm -rf /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask
-    # - brew install --cask adoptopenjdk/openjdk/adoptopenjdk8
-    - diskutil list external physical
-    - export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
-    - java -version
-    # Build wheels
-    - export UPLOAD_WHEELS_AS_ARTIFACTS=1
-    - export MAC_WHEELS=1
-    # - export MAC_JARS=1
-    # - export RAY_INSTALL_JAVA=1
-    - export RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER=1
-    - . ./ci/ci.sh init && source ~/.zshenv
-    - ./ci/ci.sh build
-    # Test wheels
-    - ./ci/ci.sh test_wheels
-    # Build jars
-    # - bash ./java/build-jar-multiplatform.sh darwin
-    # Upload the wheels and jars
-    # We don't want to push on PRs, in fact, the copy_files will fail because unauthenticated.
-    - if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then exit 0; fi
-    - pip install -q docker aws_requests_auth boto3
-    # Upload to branch directory.
-    - python .buildkite/copy_files.py --destination branch_wheels --path ./.whl
-    # - python .buildkite/copy_files.py --destination branch_jars --path ./.jar/darwin
-    # Upload to latest directory.
-    - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
-    # - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination jars --path ./.jar/darwin; fi
-
-
 - label: ":mac: :apple: Ray Core Unit Tests and Dashboard"
   <<: *common
   conditions: ["RAY_CI_CORE_CPP_AFFECTED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DASHBOARD_AFFECTED"]
+  agents:
+    arch: amd64
   commands:
     - *prelude_commands
     - TORCH_VERSION=1.6 ./ci/env/install-dependencies.sh
@@ -122,6 +84,8 @@ steps:
 - label: ":mac: :apple: Ray C++ and Java"
   <<: *common
   conditions: ["RAY_CI_CPP_AFFECTED", "RAY_CI_JAVA_AFFECTED"]
+  agents:
+    arch: amd64
   commands:
     - export RAY_INSTALL_JAVA=1
     - *prelude_commands
@@ -135,6 +99,8 @@ steps:
 - label: ":mac: :apple: Small & Client"
   <<: *common
   conditions: ["RAY_CI_CORE_CPP_AFFECTED", "RAY_CI_PYTHON_AFFECTED"]
+  agents:
+    arch: amd64
   commands:
     - *prelude_commands
     - bazel test $(./ci/run/bazel_export_options) --config=ci
@@ -148,6 +114,8 @@ steps:
   <<: *common
   parallelism: 3
   conditions: ["RAY_CI_CORE_CPP_AFFECTED", "RAY_CI_PYTHON_AFFECTED"]
+  agents:
+    arch: amd64
   commands:
     - *prelude_commands
     - ./ci/ci.sh test_large
@@ -156,6 +124,8 @@ steps:
 - label: ":mac: :apple: Medium A-J"
   <<: *common
   conditions: ["RAY_CI_CORE_CPP_AFFECTED", "RAY_CI_PYTHON_AFFECTED"]
+  agents:
+    arch: amd64
   commands:
     - *prelude_commands
     - bazel test --config=ci $(./ci/run/bazel_export_options) --test_env=CI
@@ -166,6 +136,8 @@ steps:
 - label: ":mac: :apple: Medium K-Z"
   <<: *common
   conditions: ["RAY_CI_CORE_CPP_AFFECTED", "RAY_CI_PYTHON_AFFECTED"]
+  agents:
+    arch: amd64
   commands:
     - *prelude_commands
     - bazel test --config=ci $(./ci/run/bazel_export_options) --test_env=CI

--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -64,6 +64,47 @@ steps:
     - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
     - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination jars --path ./.jar/darwin; fi
 
+- label: ":mac: :apple: ARM64 Wheels"
+  <<: *common
+  # conditions: ["RAY_CI_MACOS_WHEELS_AFFECTED", "RAY_CI_PYTHON_DEPENDENCIES_AFFECTED"]
+  agents:
+    queue: mac-pr-m2
+  # Skip jars for now
+  commands:
+    # Cleanup environments
+    - rm -rf /tmp/bazel_event_logs
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+    - (which bazel && bazel clean) || true
+    # TODO(simon): make sure to change both PR and wheel builds
+    # Special setup for jar builds (will be installed to the machine instead)
+    # - brew remove --force java & brew uninstall --force java & rm -rf /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask
+    # - brew install --cask adoptopenjdk/openjdk/adoptopenjdk8
+    - diskutil list external physical
+    - export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
+    - java -version
+    # Build wheels
+    - export UPLOAD_WHEELS_AS_ARTIFACTS=1
+    - export MAC_WHEELS=1
+    # - export MAC_JARS=1
+    # - export RAY_INSTALL_JAVA=1
+    - export RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER=1
+    - . ./ci/ci.sh init && source ~/.zshenv
+    - ./ci/ci.sh build
+    # Test wheels
+    - ./ci/ci.sh test_wheels
+    # Build jars
+    # - bash ./java/build-jar-multiplatform.sh darwin
+    # Upload the wheels and jars
+    # We don't want to push on PRs, in fact, the copy_files will fail because unauthenticated.
+    - if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then exit 0; fi
+    - pip install -q docker aws_requests_auth boto3
+    # Upload to branch directory.
+    - python .buildkite/copy_files.py --destination branch_wheels --path ./.whl
+    # - python .buildkite/copy_files.py --destination branch_jars --path ./.jar/darwin
+    # Upload to latest directory.
+    - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
+    # - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination jars --path ./.jar/darwin; fi
+
 
 - label: ":mac: :apple: Ray Core Unit Tests and Dashboard"
   <<: *common


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To prepare for arm64 builds, we should first per default target amd64 architecture in our mac jobs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
