### PR TITLE
[RLlib] Move to action distribution creation in RLMs to "Distribution.from_logits()"

### DIFF
--- a/rllib/algorithms/ppo/tests/test_ppo_learner.py
+++ b/rllib/algorithms/ppo/tests/test_ppo_learner.py
@@ -33,9 +33,9 @@ FAKE_BATCH = {
     SampleBatch.TERMINATEDS: np.array([False, False, True]),
     SampleBatch.TRUNCATEDS: np.array([False, False, False]),
     SampleBatch.VF_PREDS: np.array([0.5, 0.6, 0.7], dtype=np.float32),
-    SampleBatch.ACTION_DIST_INPUTS: {
-        "logits": np.array([[-2.0, 0.5], [-3.0, -0.3], [-0.1, 2.5]], dtype=np.float32)
-    },
+    SampleBatch.ACTION_DIST_INPUTS: np.array(
+        [[-2.0, 0.5], [-3.0, -0.3], [-0.1, 2.5]], dtype=np.float32
+    ),
     SampleBatch.ACTION_LOGP: np.array([-0.5, -0.1, -0.2], dtype=np.float32),
     SampleBatch.EPS_ID: np.array([0, 0, 0]),
     SampleBatch.AGENT_INDEX: np.array([0, 0, 0]),

--- a/rllib/algorithms/ppo/tf/ppo_tf_learner.py
+++ b/rllib/algorithms/ppo/tf/ppo_tf_learner.py
@@ -33,8 +33,8 @@ class PPOTfLearner(PPOBaseLearner, TfLearner):
 
         curr_action_dist = fwd_out[SampleBatch.ACTION_DIST]
         action_dist_class = type(fwd_out[SampleBatch.ACTION_DIST])
-        prev_action_dist = action_dist_class(
-            **batch[SampleBatch.ACTION_DIST_INPUTS].asdict()
+        prev_action_dist = action_dist_class.from_logits(
+            batch[SampleBatch.ACTION_DIST_INPUTS]
         )
 
         logp_ratio = tf.exp(

--- a/rllib/algorithms/ppo/tf/ppo_tf_policy_rlm.py
+++ b/rllib/algorithms/ppo/tf/ppo_tf_policy_rlm.py
@@ -88,7 +88,9 @@ class PPOTfPolicyWithRLModule(
         dist_class = curr_action_dist.__class__
         value_fn_out = fwd_out[SampleBatch.VF_PREDS]
 
-        prev_action_dist = dist_class(**train_batch[SampleBatch.ACTION_DIST_INPUTS])
+        prev_action_dist = dist_class.from_logits(
+            train_batch[SampleBatch.ACTION_DIST_INPUTS]
+        )
 
         logp_ratio = tf.exp(
             curr_action_dist.logp(train_batch[SampleBatch.ACTIONS])

--- a/rllib/algorithms/ppo/torch/ppo_torch_learner.py
+++ b/rllib/algorithms/ppo/torch/ppo_torch_learner.py
@@ -33,8 +33,8 @@ class PPOTorchLearner(PPOBaseLearner, TorchLearner):
 
         curr_action_dist = fwd_out[SampleBatch.ACTION_DIST]
         action_dist_class = type(fwd_out[SampleBatch.ACTION_DIST])
-        prev_action_dist = action_dist_class(
-            **batch[SampleBatch.ACTION_DIST_INPUTS].asdict()
+        prev_action_dist = action_dist_class.from_logits(
+            batch[SampleBatch.ACTION_DIST_INPUTS]
         )
 
         logp_ratio = torch.exp(

--- a/rllib/algorithms/ppo/torch/ppo_torch_policy_rlm.py
+++ b/rllib/algorithms/ppo/torch/ppo_torch_policy_rlm.py
@@ -127,8 +127,8 @@ class PPOTorchPolicyWithRLModule(
             reduce_mean_valid = torch.mean
 
         action_dist_class = type(fwd_out[SampleBatch.ACTION_DIST])
-        prev_action_dist = action_dist_class(
-            **train_batch[SampleBatch.ACTION_DIST_INPUTS]
+        prev_action_dist = action_dist_class.from_logits(
+            train_batch[SampleBatch.ACTION_DIST_INPUTS]
         )
 
         logp_ratio = torch.exp(

--- a/rllib/models/distributions.py
+++ b/rllib/models/distributions.py
@@ -126,11 +126,52 @@ class Distribution(abc.ABC):
     def from_logits(cls, logits: TensorType, **kwargs) -> "Distribution":
         """Creates a Distribution from logits.
 
-        The callee does not need to have knowledge of the distribution class in order
+        The caller does not need to have knowledge of the distribution class in order
         to create it and sample from it. The passed batched logits vectors might be
         split up and are passed to the distribution class' constructor as kwargs.
 
         Args:
             logits: The logits to create the distribution from.
+            **kwargs: Forward compatibility placeholder.
+
+        Returns:
+            The created distribution.
+
+        .. code-block:: python
+
+            import numpy as np
+            from ray.rllib.models.distributions import Distribution
+
+            class Uniform(Distribution):
+                def __init__(self, lower, upper):
+                    self.lower = lower
+                    self.upper = upper
+
+                def sample(self):
+                    return self.lower + (self.upper - self.lower) * np.random.rand()
+
+                def logp(self, x):
+                    ...
+
+                def kl(self, other):
+                    ...
+
+                def entropy(self):
+                    ...
+
+                @staticmethod
+                def required_model_output_shape(space, model_config):
+                    ...
+
+                def rsample(self):
+                    ...
+
+                @classmethod
+                def from_logits(cls, logits, **kwargs):
+                    return Uniform(logits[:, 0], logits[:, 1])
+
+            logits = np.array([[0.0, 1.0], [2.0, 3.0]])
+            my_dist = Uniform.from_logits(logits)
+            my_dist.sample()
         """
         raise NotImplementedError

--- a/rllib/models/distributions.py
+++ b/rllib/models/distributions.py
@@ -121,3 +121,16 @@ class Distribution(abc.ABC):
         Returns:
             size of the required input vector (minus leading batch dimension).
         """
+
+    @classmethod
+    def from_logits(cls, logits: TensorType, **kwargs) -> "Distribution":
+        """Creates a Distribution from logits.
+
+        The callee does not need to have knowledge of the distribution class in order
+        to create it and sample from it. The passed batched logits vectors might be
+        split up and are passed to the distribution class' constructor as kwargs.
+
+        Args:
+            logits: The logits to create the distribution from.
+        """
+        raise NotImplementedError

--- a/rllib/models/tf/tf_distributions.py
+++ b/rllib/models/tf/tf_distributions.py
@@ -138,7 +138,7 @@ class TfCategorical(TfDistribution):
 
     @classmethod
     @override(Distribution)
-    def from_logits(cls, logits: TensorType) -> "TfCategorical":
+    def from_logits(cls, logits: TensorType, **kwargs) -> "TfCategorical":
         return TfCategorical(logits=logits)
 
 
@@ -210,7 +210,7 @@ class TfDiagGaussian(TfDistribution):
 
     @classmethod
     @override(Distribution)
-    def from_logits(cls, logits: TensorType) -> "TfDiagGaussian":
+    def from_logits(cls, logits: TensorType, **kwargs) -> "TfDiagGaussian":
         loc, log_std = tf.split(logits, num_or_size_splits=2, axis=1)
         scale = tf.math.exp(log_std)
         return TfDiagGaussian(loc=loc, scale=scale)
@@ -285,5 +285,5 @@ class TfDeterministic(Distribution):
 
     @classmethod
     @override(Distribution)
-    def from_logits(cls, logits: TensorType) -> "TfDeterministic":
+    def from_logits(cls, logits: TensorType, **kwargs) -> "TfDeterministic":
         return TfDeterministic(loc=logits)

--- a/rllib/models/tf/tf_distributions.py
+++ b/rllib/models/tf/tf_distributions.py
@@ -136,6 +136,11 @@ class TfCategorical(TfDistribution):
         # TODO (Kourosh) Implement Categorical sampling using grrad-passthrough trick.
         raise NotImplementedError
 
+    @classmethod
+    @override(Distribution)
+    def from_logits(cls, logits: TensorType) -> "TfCategorical":
+        return TfCategorical(logits=logits)
+
 
 @DeveloperAPI
 class TfDiagGaussian(TfDistribution):
@@ -202,6 +207,13 @@ class TfDiagGaussian(TfDistribution):
         """Implements reparameterization trick."""
         eps = tf.random.normal(sample_shape)
         return self._dist.loc + eps * self._dist.scale
+
+    @classmethod
+    @override(Distribution)
+    def from_logits(cls, logits: TensorType) -> "TfDiagGaussian":
+        loc, log_std = tf.split(logits, num_or_size_splits=2, axis=1)
+        scale = tf.math.exp(log_std)
+        return TfDiagGaussian(loc=loc, scale=scale)
 
 
 @DeveloperAPI
@@ -270,3 +282,8 @@ class TfDeterministic(Distribution):
     ) -> Tuple[int, ...]:
         # TODO: This was copied from previous code. Is this correct? add unit test.
         return tuple(np.prod(space.shape, dtype=np.int32))
+
+    @classmethod
+    @override(Distribution)
+    def from_logits(cls, logits: TensorType) -> "TfDeterministic":
+        return TfDeterministic(loc=logits)

--- a/rllib/models/tf/tf_distributions.py
+++ b/rllib/models/tf/tf_distributions.py
@@ -138,8 +138,10 @@ class TfCategorical(TfDistribution):
 
     @classmethod
     @override(Distribution)
-    def from_logits(cls, logits: TensorType, **kwargs) -> "TfCategorical":
-        return TfCategorical(logits=logits)
+    def from_logits(
+        cls, logits: TensorType, temperature: float = 1.0, **kwargs
+    ) -> "TfCategorical":
+        return TfCategorical(logits=logits, temperature=temperature, **kwargs)
 
 
 @DeveloperAPI

--- a/rllib/models/torch/torch_distributions.py
+++ b/rllib/models/torch/torch_distributions.py
@@ -123,8 +123,10 @@ class TorchCategorical(TorchDistribution):
 
     @classmethod
     @override(Distribution)
-    def from_logits(cls, logits: TensorType, **kwargs) -> "TorchCategorical":
-        return TorchCategorical(logits=logits)
+    def from_logits(
+        cls, logits: TensorType, temperature: float = 1.0, **kwargs
+    ) -> "TorchCategorical":
+        return TorchCategorical(logits=logits, temperature=temperature, **kwargs)
 
 
 @DeveloperAPI

--- a/rllib/models/torch/torch_distributions.py
+++ b/rllib/models/torch/torch_distributions.py
@@ -121,6 +121,11 @@ class TorchCategorical(TorchDistribution):
     ) -> Tuple[int, ...]:
         return (space.n,)
 
+    @classmethod
+    @override(Distribution)
+    def from_logits(cls, logits: TensorType) -> "TorchCategorical":
+        return TorchCategorical(logits=logits)
+
 
 @DeveloperAPI
 class TorchDiagGaussian(TorchDistribution):
@@ -182,6 +187,13 @@ class TorchDiagGaussian(TorchDistribution):
         space: gym.Space, model_config: ModelConfigDict
     ) -> Tuple[int, ...]:
         return tuple(np.prod(space.shape, dtype=np.int32) * 2)
+
+    @classmethod
+    @override(Distribution)
+    def from_logits(cls, logits: TensorType) -> "TorchDiagGaussian":
+        loc, log_std = logits.chunk(2, dim=-1)
+        scale = log_std.exp()
+        return TorchDiagGaussian(loc=loc, scale=scale)
 
 
 @DeveloperAPI
@@ -255,3 +267,8 @@ class TorchDeterministic(Distribution):
     ) -> Tuple[int, ...]:
         # TODO: This was copied from previous code. Is this correct? add unit test.
         return tuple(np.prod(space.shape, dtype=np.int32))
+
+    @classmethod
+    @override(Distribution)
+    def from_logits(cls, logits: TensorType) -> "TorchDeterministic":
+        return TorchDeterministic(loc=logits)

--- a/rllib/models/torch/torch_distributions.py
+++ b/rllib/models/torch/torch_distributions.py
@@ -123,7 +123,7 @@ class TorchCategorical(TorchDistribution):
 
     @classmethod
     @override(Distribution)
-    def from_logits(cls, logits: TensorType) -> "TorchCategorical":
+    def from_logits(cls, logits: TensorType, **kwargs) -> "TorchCategorical":
         return TorchCategorical(logits=logits)
 
 
@@ -190,7 +190,7 @@ class TorchDiagGaussian(TorchDistribution):
 
     @classmethod
     @override(Distribution)
-    def from_logits(cls, logits: TensorType) -> "TorchDiagGaussian":
+    def from_logits(cls, logits: TensorType, **kwargs) -> "TorchDiagGaussian":
         loc, log_std = logits.chunk(2, dim=-1)
         scale = log_std.exp()
         return TorchDiagGaussian(loc=loc, scale=scale)
@@ -270,5 +270,5 @@ class TorchDeterministic(Distribution):
 
     @classmethod
     @override(Distribution)
-    def from_logits(cls, logits: TensorType) -> "TorchDeterministic":
+    def from_logits(cls, logits: TensorType, **kwargs) -> "TorchDeterministic":
         return TorchDeterministic(loc=logits)


### PR DESCRIPTION
## Why are these changes needed?

Makes it so that RLMs use a method "Distribution.from_logits" that abstracts the particularities of the distribution from RL Modules such that they don't have to be aware of constructor kwargs etc.
RL Modules become mostly unaware of the particular distribution class but construct all distributions with
a class method `Distribution.from_logits(logits)`.

This is especially powerful since one functionality of the catalog is to communicate the requires input shape of the distribution to be the output shape of the policy head. With this PR, this shape becomes the shape of the logits and is abstracted from the forward methods.