### PR TITLE
[Datasets] Add missing passthrough args to read_images()

### DIFF
--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -48,7 +48,7 @@ class ImageDatasource(BinaryDatasource):
         size: Optional[Tuple[int, int]] = None,
         mode: Optional[str] = None,
         include_paths: bool = False,
-        **kwargs,
+        **reader_args,
     ) -> "Reader[T]":
         if size is not None and len(size) != 2:
             raise ValueError(
@@ -63,7 +63,7 @@ class ImageDatasource(BinaryDatasource):
         _check_import(self, module="PIL", package="Pillow")
 
         return _ImageDatasourceReader(
-            self, size=size, mode=mode, include_paths=include_paths, **kwargs
+            self, size=size, mode=mode, include_paths=include_paths, **reader_args
         )
 
     def _convert_block_to_tabular_block(
@@ -82,10 +82,11 @@ class ImageDatasource(BinaryDatasource):
         size: Optional[Tuple[int, int]],
         mode: Optional[str],
         include_paths: bool,
+        **reader_args,
     ) -> "pyarrow.Table":
         from PIL import Image
 
-        records = super()._read_file(f, path, include_paths=True)
+        records = super()._read_file(f, path, include_paths=True, **reader_args)
         assert len(records) == 1
         path, data = records[0]
 

--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -146,7 +146,6 @@ class _ImageDatasourceReader(_FileBasedDatasourceReader):
             paths=paths,
             filesystem=filesystem,
             schema=None,
-            open_stream_args=None,
             meta_provider=meta_provider,
             partition_filter=partition_filter,
             partitioning=partitioning,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -630,11 +630,11 @@ def read_images(
         filesystem: The filesystem implementation to read from.
         parallelism: The requested parallelism of the read. Parallelism may be
             limited by the number of files of the dataset.
+        meta_provider: File metadata provider. Custom metadata providers may
+            be able to resolve file metadata more quickly and/or accurately.
         ray_remote_args: kwargs passed to ray.remote in the read tasks.
         arrow_open_file_args: kwargs passed to
             ``pyarrow.fs.FileSystem.open_input_file``.
-        meta_provider: File metadata provider. Custom metadata providers may
-            be able to resolve file metadata more quickly and/or accurately.
         partition_filter: Path-based partition filter, if any. Can be used
             with a custom callback to read only selected partitions of a dataset.
             By default, this filters out any file paths whose file extension does not

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -575,6 +575,8 @@ def read_images(
     filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     parallelism: int = -1,
     meta_provider: BaseFileMetadataProvider = _ImageFileMetadataProvider(),
+    ray_remote_args: Dict[str, Any] = None,
+    arrow_open_file_args: Optional[Dict[str, Any]] = None,
     partition_filter: Optional[
         PathPartitionFilter
     ] = ImageDatasource.file_extension_filter(),
@@ -628,6 +630,9 @@ def read_images(
         filesystem: The filesystem implementation to read from.
         parallelism: The requested parallelism of the read. Parallelism may be
             limited by the number of files of the dataset.
+        ray_remote_args: kwargs passed to ray.remote in the read tasks.
+        arrow_open_file_args: kwargs passed to
+            ``pyarrow.fs.FileSystem.open_input_file``.
         meta_provider: File metadata provider. Custom metadata providers may
             be able to resolve file metadata more quickly and/or accurately.
         partition_filter: Path-based partition filter, if any. Can be used
@@ -662,6 +667,8 @@ def read_images(
         filesystem=filesystem,
         parallelism=parallelism,
         meta_provider=meta_provider,
+        ray_remote_args=ray_remote_args,
+        open_stream_args=arrow_open_file_args,
         partition_filter=partition_filter,
         partitioning=partitioning,
         size=size,


### PR DESCRIPTION
This PR adds missing passthrough args to `read_images()`, such as `ray_remote_args`, `arrow_open_file_args`, and other misc. args popped in the base `FileBasedDatasource` such as `compression`. This PR also adds a `**read_args` catch-all to `ImageDatasource._read_file()`, which should add support for using the `local://` protocol.

## Related issue number

Closes https://github.com/ray-project/ray/issues/32941

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
