### PR TITLE
[Core] Write ray address even if ray node is started with --block

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -933,6 +933,9 @@ def start(
         cli_logger.print(cf.bold("  ray stop"))
         cli_logger.flush()
 
+    assert ray_params.gcs_address is not None
+    ray._private.utils.write_ray_address(ray_params.gcs_address, temp_dir)
+
     if block:
         cli_logger.newline()
         with cli_logger.group(cf.bold("--block")):
@@ -986,9 +989,6 @@ def start(
                 node.kill_all_processes(check_alive=False, allow_graceful=False)
                 os._exit(1)
         # not-reachable
-
-    assert ray_params.gcs_address is not None
-    ray._private.utils.write_ray_address(ray_params.gcs_address, temp_dir)
 
 
 @cli.command()

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -98,16 +98,20 @@ def test_ray_init_existing_instance_via_blocked_ray_start():
                 if ray.cluster_resources().get("CPU", 0) == 1999:
                     return True
                 else:
-                    ray.shutdown()
                     return False
             except Exception:
                 return False
+            finally:
+                ray.shutdown()
 
     try:
-        wait_for_condition(_connect_to_existing_instance)
+        wait_for_condition(
+            _connect_to_existing_instance, timeout=30, retry_interval_ms=1000
+        )
     finally:
         blocked.terminate()
         blocked.wait()
+        subprocess.check_output("ray stop --force", shell=True)
 
 
 @pytest.mark.skipif(

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -118,7 +118,7 @@ ray::Status Raylet::RegisterGcs() {
                   << ":" << self_node_info_.node_manager_port()
                   << " object_manager address: " << self_node_info_.node_manager_address()
                   << ":" << self_node_info_.object_manager_port()
-                  << " hostname: " << self_node_info_.node_manager_address();
+                  << " hostname: " << self_node_info_.node_manager_hostname();
     RAY_CHECK_OK(node_manager_.RegisterGcs());
   };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
With #26678, when a ray cluster is started, its address is written to `/tmp/ray/ray_current_cluster` so `ray.init()` can find the existing cluster and connect to it by default. However if a node is started with `ray start --block`, the file is not created so `ray.init()` will create a new cluster instead of connecting to the existing one, which is unexpected.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
