### PR TITLE
[spark][bugfix] Fix Ray on Spark running on layered virtualenv python environment

### DIFF
--- a/python/ray/util/spark/start_ray_node.py
+++ b/python/ray/util/spark/start_ray_node.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
 
     temp_dir = os.path.normpath(temp_dir)
 
-    ray_exec_path = os.path.join(os.path.dirname(sys.executable), "ray")
+    ray_cli_cmd = "ray"
 
     lock_file = temp_dir + ".lock"
     lock_fd = os.open(lock_file, os.O_RDWR | os.O_CREAT | os.O_TRUNC)
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # same temp directory, adding a shared lock representing current ray node is
     # using the temp directory.
     fcntl.flock(lock_fd, fcntl.LOCK_SH)
-    process = subprocess.Popen([ray_exec_path, "start", *arg_list], text=True)
+    process = subprocess.Popen([ray_cli_cmd, "start", *arg_list], text=True)
 
     def try_clean_temp_dir_at_exit():
         try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Supposing we create a virtualenv python environment based on the original python environment,
and Ray is installed in the original python environment,
and we run `setup_ray_cluster` on the virtualenv python environment,
then `ray_exec_path = os.path.join(os.path.dirname(sys.executable), "ray")` will get a invalid path,
because the ray script is installed in the original python environment.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
