### PR TITLE
[Train] Deflake `test_gpu` by sorting the devices

### DIFF
--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -54,7 +54,9 @@ def get_device() -> Union[torch.device, List[torch.device]]:
             # 0th device.
             device_ids.append(0)
 
-        devices = [torch.device(f"cuda:{device_id}") for device_id in device_ids]
+        devices = sorted(
+            [torch.device(f"cuda:{device_id}") for device_id in device_ids]
+        )
         device = devices[0] if len(devices) == 1 else devices
     else:
         device = torch.device("cpu")

--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -54,9 +54,7 @@ def get_device() -> Union[torch.device, List[torch.device]]:
             # 0th device.
             device_ids.append(0)
 
-        devices = sorted(
-            [torch.device(f"cuda:{device_id}") for device_id in device_ids]
-        )
+        devices = [torch.device(f"cuda:{device_id}") for device_id in device_ids]
         device = devices[0] if len(devices) == 1 else devices
     else:
         device = torch.device("cpu")

--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -68,7 +68,11 @@ def test_torch_get_device(
             assert sorted_devices == "1,2"
         if num_gpus_per_worker > 1:
             session.report(
-                dict(devices=[device.index for device in train.torch.get_device()])
+                dict(
+                    devices=sorted(
+                        [device.index for device in train.torch.get_device()]
+                    )
+                )
             )
         else:
             session.report(dict(devices=train.torch.get_device().index))
@@ -103,7 +107,11 @@ def test_torch_get_device_dist(ray_2_node_2_gpu, num_gpus_per_worker):
     def train_fn():
         if num_gpus_per_worker > 1:
             session.report(
-                dict(devices=[device.index for device in train.torch.get_device()])
+                dict(
+                    devices=sorted(
+                        [device.index for device in train.torch.get_device()]
+                    )
+                )
             )
         else:
             session.report(dict(devices=train.torch.get_device().index))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Deflake test_gpu by sorting the devices during assertion.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
