### PR TITLE
[Datasets] Add logical and physical operator for zip()

### DIFF
--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -110,12 +110,12 @@ class ZipOperator(PhysicalOperator):
         # Check that both sides have the same number of rows.
         # TODO(Clark): Support different number of rows via user-directed
         # dropping/padding.
-        total_base_rows = sum(left_block_rows)
-        total_other_rows = sum(right_block_rows)
-        if total_base_rows != total_other_rows:
+        total_left_rows = sum(left_block_rows)
+        total_right_rows = sum(right_block_rows)
+        if total_left_rows != total_right_rows:
             raise ValueError(
                 "Cannot zip datasets of different number of rows: "
-                f"{total_base_rows}, {total_other_rows}"
+                f"{total_left_rows}, {total_right_rows}"
             )
 
         # Whether the left and right input sides are inverted
@@ -128,8 +128,8 @@ class ZipOperator(PhysicalOperator):
             # _generate_per_block_split_indices) and choosing the plan that splits
             # the least cumulative bytes.
             left_blocks_with_metadata, right_blocks_with_metadata = (
-                left_blocks_with_metadata,
                 right_blocks_with_metadata,
+                left_blocks_with_metadata,
             )
             left_block_rows, right_block_rows = right_block_rows, left_block_rows
             input_side_inverted = True

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -1,0 +1,238 @@
+import itertools
+from typing import Callable, List, Optional, Tuple
+
+import ray
+from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
+from ray.data._internal.remote_fn import cached_remote_fn
+from ray.data._internal.split import _split_at_indices
+from ray.data._internal.stats import StatsDict
+from ray.data._internal.execution.interfaces import (
+    RefBundle,
+    PhysicalOperator,
+)
+from ray.data.block import (
+    Block,
+    BlockAccessor,
+    BlockExecStats,
+    BlockMetadata,
+    BlockPartition,
+)
+
+
+class ZipOperator(PhysicalOperator):
+    """An operator that zips its inputs together."""
+
+    def __init__(
+        self,
+        input_ops: Tuple[PhysicalOperator, PhysicalOperator],
+    ):
+        """Create a ZipOperator.
+
+        Args:
+            input_ops: The pair of operators to zip together.
+        """
+        self._left_buffer: List[RefBundle] = []
+        self._right_buffer: List[RefBundle] = []
+        self._output_buffer: List[RefBundle] = []
+        self._stats: StatsDict = {}
+        super().__init__("Zip", input_ops)
+
+    def num_outputs_total(self) -> Optional[int]:
+        left_num_outputs = self.input_dependencies[0].num_outputs_total()
+        right_num_outputs = self.input_dependencies[1].num_outputs_total()
+        if left_num_outputs is not None and right_num_outputs is not None:
+            return max(left_num_outputs, right_num_outputs)
+        elif left_num_outputs is not None:
+            return left_num_outputs
+        else:
+            return right_num_outputs
+
+    def add_input(self, refs: RefBundle, input_index: int) -> None:
+        assert not self.completed()
+        assert input_index == 0 or input_index == 1, input_index
+        if input_index == 0:
+            self._left_buffer.append(refs)
+        else:
+            self._right_buffer.append(refs)
+
+    def inputs_done(self) -> None:
+        self._output_buffer, self._stats = self._zip(
+            self._left_buffer, self._right_buffer
+        )
+        self._left_buffer.clear()
+        self._right_buffer.clear()
+        super().inputs_done()
+
+    def has_next(self) -> bool:
+        return len(self._output_buffer) > 0
+
+    def get_next(self) -> RefBundle:
+        return self._output_buffer.pop(0)
+
+    def get_stats(self) -> StatsDict:
+        return self._stats
+
+    def get_transformation_fn(self) -> Callable:
+        return self._zip
+
+    def _zip(
+        self, left_input: List[RefBundle], right_input: List[RefBundle]
+    ) -> Tuple[List[RefBundle], StatsDict]:
+        """Zip the RefBundles from `left_input` and `right_input` together.
+
+        Zip is done in 2 steps: aligning blocks, and zipping blocks from
+        both sides.
+
+        Aligning blocks (optional): check the blocks from `left_input` and
+        `right_input` are aligned or not, i.e. if having different number of blocks, or
+        having different number of rows in some blocks. If not aligned, repartition the
+        smaller input with `_split_at_indices` to align with larger input.
+
+        Zipping blocks: after blocks from both sides are aligned, zip
+        blocks from both sides together in parallel.
+        """
+        left_blocks_with_metadata = []
+        for bundle in left_input:
+            for block, meta in bundle.blocks:
+                left_blocks_with_metadata.append((block, meta))
+        right_blocks_with_metadata = []
+        for bundle in right_input:
+            for block, meta in bundle.blocks:
+                right_blocks_with_metadata.append((block, meta))
+
+        left_block_rows, left_block_bytes = self._calculate_blocks_rows_and_bytes(
+            left_blocks_with_metadata
+        )
+        right_block_rows, right_block_bytes = self._calculate_blocks_rows_and_bytes(
+            right_blocks_with_metadata
+        )
+
+        # Check that both sides have the same number of rows.
+        # TODO(Clark): Support different number of rows via user-directed
+        # dropping/padding.
+        total_base_rows = sum(left_block_rows)
+        total_other_rows = sum(right_block_rows)
+        if total_base_rows != total_other_rows:
+            raise ValueError(
+                "Cannot zip datasets of different number of rows: "
+                f"{total_base_rows}, {total_other_rows}"
+            )
+
+        # Whether the left and right input sides are inverted
+        input_side_inverted = False
+        if sum(right_block_bytes) > sum(left_block_bytes):
+            # Make sure that right side is smaller, so we minimize splitting
+            # work when aligning both sides.
+            # TODO(Clark): Improve this heuristic for minimizing splitting work,
+            # e.g. by generating the splitting plans for each route (via
+            # _generate_per_block_split_indices) and choosing the plan that splits
+            # the least cumulative bytes.
+            left_blocks_with_metadata, right_blocks_with_metadata = (
+                left_blocks_with_metadata,
+                right_blocks_with_metadata,
+            )
+            left_block_rows, right_block_rows = right_block_rows, left_block_rows
+            input_side_inverted = True
+
+        # Get the split indices that will align both sides.
+        indices = list(itertools.accumulate(left_block_rows))
+        indices.pop(-1)
+
+        # Split other at the alignment indices, such that for every block from
+        # left side, we have a list of blocks from right side that have the same
+        # cumulative number of rows as that left block.
+        # NOTE: _split_at_indices has a no-op fastpath if the blocks are already
+        # aligned.
+        aligned_right_blocks_with_metadata = _split_at_indices(
+            right_blocks_with_metadata,
+            indices,
+            block_rows=right_block_rows,
+        )
+        del right_blocks_with_metadata
+
+        left_blocks = [b for b, _ in left_blocks_with_metadata]
+        right_blocks_list = aligned_right_blocks_with_metadata[0]
+        del left_blocks_with_metadata, aligned_right_blocks_with_metadata
+
+        zip_one_block = cached_remote_fn(_zip_one_block, num_returns=2)
+
+        output_blocks = []
+        output_metadata = []
+        for left_block, right_blocks in zip(left_blocks, right_blocks_list):
+            # For each block from left side, zip it together with 1 or more blocks from
+            # right side. We're guaranteed to have that left_block has the same number
+            # of rows as right_blocks has cumulatively.
+            res, meta = zip_one_block.remote(
+                left_block, *right_blocks, inverted=input_side_inverted
+            )
+            output_blocks.append(res)
+            output_metadata.append(meta)
+
+        # Early release memory.
+        del left_blocks, right_blocks_list
+
+        # TODO(ekl) it might be nice to have a progress bar here.
+        output_metadata = ray.get(output_metadata)
+        output_refs = []
+        input_owned = all(b.owns_blocks for b in left_input)
+        for block, meta in zip(output_blocks, output_metadata):
+            output_refs.append(
+                RefBundle(
+                    [
+                        (
+                            block,
+                            meta,
+                        )
+                    ],
+                    owns_blocks=input_owned,
+                )
+            )
+        stats = {self._name: output_metadata}
+        return output_refs, stats
+
+    def _calculate_blocks_rows_and_bytes(
+        self,
+        blocks_with_metadata: BlockPartition,
+    ) -> Tuple[List[int], List[int]]:
+        """Calculate the number of rows and size in bytes for a list of blocks with
+        metadata.
+        """
+        get_num_rows_and_bytes = cached_remote_fn(_get_num_rows_and_bytes)
+        block_rows = []
+        block_bytes = []
+        for block, metadata in blocks_with_metadata:
+            if metadata.num_rows is None or metadata.size_bytes is None:
+                # Need to fetch number of rows or size in bytes, so just fetch both.
+                num_rows, size_bytes = ray.get(get_num_rows_and_bytes.remote(block))
+                # Cache on the block metadata.
+                metadata.num_rows = num_rows
+                metadata.size_bytes = size_bytes
+            block_rows.append(metadata.num_rows)
+            block_bytes.append(metadata.size_bytes)
+        return block_rows, block_bytes
+
+
+def _zip_one_block(
+    block: Block, *other_blocks: Block, inverted: bool = False
+) -> Tuple[Block, BlockMetadata]:
+    """Zip together `block` with `other_blocks`."""
+    stats = BlockExecStats.builder()
+    # Concatenate other blocks.
+    # TODO(Clark): Extend BlockAccessor.zip() to work with N other blocks,
+    # so we don't need to do this concatenation.
+    builder = DelegatingBlockBuilder()
+    for other_block in other_blocks:
+        builder.add_block(other_block)
+    other_block = builder.build()
+    if inverted:
+        # Swap blocks if ordering was inverted during block alignment splitting.
+        block, other_block = other_block, block
+    # Zip block and other blocks.
+    result = BlockAccessor.for_block(block).zip(other_block)
+    br = BlockAccessor.for_block(result)
+    return result, br.get_metadata(input_files=[], exec_stats=stats.build())
+
+
+def _get_num_rows_and_bytes(block: Block) -> Tuple[int, int]:
+    block = BlockAccessor.for_block(block)
+    return block.num_rows(), block.size_bytes()

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from ray.data._internal.logical.interfaces import LogicalOperator
 
 
@@ -8,10 +6,12 @@ class Zip(LogicalOperator):
 
     def __init__(
         self,
-        input_ops: Tuple[LogicalOperator, LogicalOperator],
+        left_input_op: LogicalOperator,
+        right_input_op: LogicalOperator,
     ):
         """
         Args:
-            input_ops: The pair of operators to zip together.
+            left_input_ops: The input operator at left hand side.
+            right_input_op: The input operator at right hand side.
         """
-        super().__init__("Zip", input_ops)
+        super().__init__("Zip", [left_input_op, right_input_op])

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -1,0 +1,17 @@
+from typing import Tuple
+
+from ray.data._internal.logical.interfaces import LogicalOperator
+
+
+class Zip(LogicalOperator):
+    """Logical operator for zip."""
+
+    def __init__(
+        self,
+        input_ops: Tuple[LogicalOperator, LogicalOperator],
+    ):
+        """
+        Args:
+            input_ops: The pair of operators to zip together.
+        """
+        super().__init__("Zip", input_ops)

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -1,12 +1,14 @@
 from typing import Dict
 
 from ray.data._internal.execution.interfaces import PhysicalOperator
+from ray.data._internal.execution.operators.zip_operator import ZipOperator
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
     LogicalPlan,
     PhysicalPlan,
 )
 from ray.data._internal.logical.operators.all_to_all_operator import AbstractAllToAll
+from ray.data._internal.logical.operators.n_ary_operator import Zip
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.logical.operators.write_operator import Write
 from ray.data._internal.logical.operators.map_operator import AbstractUDFMap
@@ -49,6 +51,9 @@ class Planner:
         elif isinstance(logical_op, AbstractAllToAll):
             assert len(physical_children) == 1
             physical_op = _plan_all_to_all_op(logical_op, physical_children[0])
+        elif isinstance(logical_op, Zip):
+            assert len(physical_children) == 2
+            physical_op = ZipOperator(physical_children)
         else:
             raise ValueError(
                 f"Found unknown logical operator during planning: {logical_op}"

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -53,7 +53,7 @@ class Planner:
             physical_op = _plan_all_to_all_op(logical_op, physical_children[0])
         elif isinstance(logical_op, Zip):
             assert len(physical_children) == 2
-            physical_op = ZipOperator(physical_children)
+            physical_op = ZipOperator(physical_children[0], physical_children[1])
         else:
             raise ValueError(
                 f"Found unknown logical operator during planning: {logical_op}"

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2102,7 +2102,7 @@ class Dataset(Generic[T]):
         logical_plan = self._logical_plan
         other_logical_plan = other._logical_plan
         if logical_plan is not None and other_logical_plan is not None:
-            op = Zip((logical_plan.dag, other_logical_plan.dag))
+            op = Zip(logical_plan.dag, other_logical_plan.dag)
             logical_plan = LogicalPlan(op)
         return Dataset(plan, self._epoch, self._lazy, logical_plan)
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -35,6 +35,7 @@ from ray.data._internal.logical.operators.all_to_all_operator import (
     Repartition,
     Sort,
 )
+from ray.data._internal.logical.operators.n_ary_operator import Zip
 from ray.data._internal.logical.optimizers import LogicalPlan
 from ray.data._internal.logical.operators.map_operator import (
     Filter,
@@ -2097,7 +2098,13 @@ class Dataset(Generic[T]):
         """
 
         plan = self._plan.with_stage(ZipStage(other))
-        return Dataset(plan, self._epoch, self._lazy)
+
+        logical_plan = self._logical_plan
+        other_logical_plan = other._logical_plan
+        if logical_plan is not None and other_logical_plan is not None:
+            op = Zip((logical_plan.dag, other_logical_plan.dag))
+            logical_plan = LogicalPlan(op)
+        return Dataset(plan, self._epoch, self._lazy, logical_plan)
 
     @ConsumptionAPI
     def limit(self, limit: int) -> "Dataset[T]":

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -1,8 +1,10 @@
+import itertools
 import pytest
 
 import ray
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
+from ray.data._internal.execution.operators.zip_operator import ZipOperator
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.logical.interfaces import LogicalPlan
 from ray.data._internal.logical.optimizers import PhysicalOptimizer
@@ -20,6 +22,7 @@ from ray.data._internal.logical.operators.map_operator import (
     Filter,
     FlatMap,
 )
+from ray.data._internal.logical.operators.n_ary_operator import Zip
 from ray.data._internal.planner.planner import Planner
 from ray.data.aggregate import Count
 from ray.data.datasource.parquet_datasource import ParquetDatasource
@@ -592,6 +595,33 @@ def test_aggregate_e2e(
     assert ds.count() == 100
     for idx, row in enumerate(ds.sort("value").iter_rows()):
         assert row.as_pydict() == {"value": idx, "count()": 1}
+
+
+def test_zip_operator(ray_start_regular_shared, enable_optimizer):
+    planner = Planner()
+    read_op1 = Read(ParquetDatasource())
+    read_op2 = Read(ParquetDatasource())
+    op = Zip((read_op1, read_op2))
+    plan = LogicalPlan(op)
+    physical_op = planner.plan(plan).dag
+
+    assert op.name == "Zip"
+    assert isinstance(physical_op, ZipOperator)
+    assert len(physical_op.input_dependencies) == 2
+    assert isinstance(physical_op.input_dependencies[0], MapOperator)
+    assert isinstance(physical_op.input_dependencies[1], MapOperator)
+
+
+@pytest.mark.parametrize(
+    "num_blocks1,num_blocks2",
+    list(itertools.combinations_with_replacement(range(1, 12), 2)),
+)
+def test_zip_e2e(ray_start_regular_shared, enable_optimizer, num_blocks1, num_blocks2):
+    n = 12
+    ds1 = ray.data.range(n, parallelism=num_blocks1)
+    ds2 = ray.data.range(n, parallelism=num_blocks2).map(lambda x: x + 1)
+    ds = ds1.zip(ds2)
+    assert ds.take() == list(zip(range(n), range(1, n + 1)))
 
 
 def test_streaming_executor(

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -601,7 +601,7 @@ def test_zip_operator(ray_start_regular_shared, enable_optimizer):
     planner = Planner()
     read_op1 = Read(ParquetDatasource())
     read_op2 = Read(ParquetDatasource())
-    op = Zip((read_op1, read_op2))
+    op = Zip(read_op1, read_op2)
     plan = LogicalPlan(op)
     physical_op = planner.plan(plan).dag
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to add logical and physical operator for `zip()`. The current physical operator implementation is same as `ZipStage`, i.e. bulk implementation. The code change includes:

* `n_ary_operator.py`: file to include logical N-ary operator, add `Zip` here. Future PR will add `Union` in this file.
* `zip_operator.py`: `ZipOperator` is the physical operator for zip.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
