### PR TITLE
[Data] Fix quickstart by using S3

### DIFF
--- a/doc/source/data/doc_code/quick_start.py
+++ b/doc/source/data/doc_code/quick_start.py
@@ -47,18 +47,16 @@ ds.schema()
 # fmt: off
 # __create_from_files_begin__
 # Create from CSV.
-# Tip: "example://" is a convenient protocol to access the
-# python/ray/data/examples/data directory.
-ds = ray.data.read_csv("example://iris.csv")
-# Dataset(num_blocks=1, num_rows=150,
-#         schema={sepal.length: float64, sepal.width: float64,
-#                 petal.length: float64, petal.width: float64, variety: object})
+ds = ray.data.read_csv("s3://anonymous@air-example-data/iris.csv")
+# Dataset(num_blocks=1, num_rows=150, 
+#         schema={sepal length (cm): double, sepal width (cm): double, 
+#         petal length (cm): double, petal width (cm): double, target: int64})
 
 # Create from Parquet.
-ds = ray.data.read_parquet("example://iris.parquet")
-# Dataset(num_blocks=1, num_rows=150,
-#         schema={sepal.length: float64, sepal.width: float64,
-#                 petal.length: float64, petal.width: float64, variety: object})
+ds = ray.data.read_parquet("s3://anonymous@air-example-data/iris.parquet")
+# Dataset(num_blocks=1, num_rows=150, 
+#         schema={sepal.length: double, sepal.width: double, 
+#         petal.length: double, petal.width: double, variety: string})
 
 # __create_from_files_end__
 # fmt: on


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Closes https://github.com/ray-project/ray/issues/32901

The quick start example uses the `example://` protocol which routes to the `ray/data/examples/data` directory. While this works on CI or for our local development since we are building Ray from source, this does not work when installing Ray from Pypi since the `examples` directory is not packaged with the wheel.

We instead switch to reading directly from a public S3 bucket for the quickstart.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
