### PR TITLE
[Serve] Fix the max_concurrent_queries issue

### DIFF
--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -323,10 +323,6 @@ class RunningReplicaInfo:
         return all(
             [
                 isinstance(other, RunningReplicaInfo),
-                self.deployment_name == other.deployment_name,
-                self.replica_tag == other.replica_tag,
-                self.actor_handle._actor_id == other.actor_handle._actor_id,
-                self.max_concurrent_queries == other.max_concurrent_queries,
-                self.is_cross_language == other.is_cross_language,
+                self._hash == other._hash,
             ]
         )

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -311,7 +311,22 @@ class RunningReplicaInfo:
                 ]
             )
         )
+
+        # RunningReplicaInfo class set frozen=True, this is the hacky way to set
+        # new attribute for the class.
         object.__setattr__(self, "_hash", hash_val)
 
     def __hash__(self):
         return self._hash
+
+    def __eq__(self, other):
+        return all(
+            [
+                isinstance(other, RunningReplicaInfo),
+                self.deployment_name == other.deployment_name,
+                self.replica_tag == other.replica_tag,
+                self.actor_handle._actor_id == other.actor_handle._actor_id,
+                self.max_concurrent_queries == other.max_concurrent_queries,
+                self.is_cross_language == other.is_cross_language,
+            ]
+        )

--- a/python/ray/serve/tests/test_router.py
+++ b/python/ray/serve/tests/test_router.py
@@ -3,6 +3,7 @@ Unit tests for the router class. Please don't add any test that will involve
 controller or the actual replica wrapper, use mock if necessary.
 """
 import asyncio
+import copy
 
 import pytest
 
@@ -117,6 +118,23 @@ async def test_replica_set(ray_instance):
     # pending after some time.
     await asyncio.sleep(0.2)
     assert not third_ref_pending_task.done()
+
+    # Let's make sure in flight queries is 1 for each replica.
+    assert len(rs.in_flight_queries[replicas[0]]) == 1
+    assert len(rs.in_flight_queries[replicas[1]]) == 1
+
+    # Let's copy a new RunningReplicaInfo object and update the router
+    cur_replicas_info = list(rs.in_flight_queries.keys())
+    replicas = copy.deepcopy(cur_replicas_info)
+    assert id(replicas[0].actor_handle) != id(cur_replicas_info[0].actor_handle)
+    assert replicas[0].replica_tag == cur_replicas_info[0].replica_tag
+    assert id(replicas[1].actor_handle) != id(cur_replicas_info[1].actor_handle)
+    assert replicas[1].replica_tag == cur_replicas_info[1].replica_tag
+    rs.update_running_replicas(replicas)
+
+    # Let's make sure in flight queries is 1 for each replica even if replicas update
+    assert len(rs.in_flight_queries[replicas[0]]) == 1
+    assert len(rs.in_flight_queries[replicas[1]]) == 1
 
     # Let's unblock the two replicas
     await signal.send.remote()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For the `hashable` object, __eq__ and __hash__ both need to be provided for correctness.  https://docs.python.org/3.9/glossary.html#term-hashable

And add tests to make sure the long poll timeout issue won't happen.  

## Related issue number

Closes #32652

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
