### PR TITLE
[Serve] Fix example error with runtime environment

### DIFF
--- a/doc/source/serve/tutorials/serve-ml-models.md
+++ b/doc/source/serve/tutorials/serve-ml-models.md
@@ -60,9 +60,15 @@ Now that we've defined our Serve deployment, let's prepare it so that it can be 
 `TFMnistModel.bind(TRAINED_MODEL_PATH)` binds the argument `TRAINED_MODEL_PATH` to our deployment and returns a `DeploymentNode` object (wrapping an `TFMnistModel` deployment object) that can then be used to connect with other `DeploymentNodes` to form a more complex [deployment graph](serve-model-composition-deployment-graph).
 :::
 
+Open a new YAML file called `tf_env.yaml` for runtime environment.
+```yaml
+pip:
+ - protobuf==3.20.3
+```
+
 Finally, we can deploy our model to Ray Serve through the terminal.
 ```console
-$ serve run tutorial_tensorflow:mnist_model
+$ serve run --runtime-env tf_env.yaml tutorial_tensorflow:mnist_model
 ```
 
 Let's query it! While Serve is running, open a separate terminal window, and run the following in an interactive Python shell or a separate Python script:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I followed the Tensorflow example in this [doc](https://docs.ray.io/en/latest/serve/tutorials/serve-ml-models.html#serving-ml-models-tensorflow-pytorch-scikit-learn-others) with the Docker image `rayproject/ray-ml:2.3.0`. However, it will report the following error when I run `serve run tutorial_tensorflow:mnist_model`.

<img width="1060" alt="Screen Shot 2023-03-03 at 3 44 16 PM" src="https://user-images.githubusercontent.com/20109646/222855782-9a28b2af-6139-44e7-8c78-f569a4a3e4e8.png">

In the image `rayproject/ray-ml:2.3.0`, 
```console
$ pip list | grep protobuf
protobuf                               4.22.0
```

Hence, I use runtime environment to deploy the serve deployment with `protobuf 3.20.3`, and it works.
<img width="1440" alt="Screen Shot 2023-03-03 at 3 48 41 PM" src="https://user-images.githubusercontent.com/20109646/222856274-af85841e-8d22-4cb3-be99-7969a47bec28.png">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
