### PR TITLE
[Data] Fix Ragged Tensor Documentation

### DIFF
--- a/doc/BUILD
+++ b/doc/BUILD
@@ -28,6 +28,13 @@ py_test(
 )
 
 py_test(
+    name = "tensor",
+    size = "small",
+    srcs = ["source/data/doc_code/tensor.py"],
+    tags = ["exclusive", "team:data"]
+)
+
+py_test(
     name = "big_data_ingestion",
     size = "small",
     main = "test_myst_doc.py",

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -31,7 +31,7 @@ py_test(
     name = "tensor",
     size = "small",
     srcs = ["source/data/doc_code/tensor.py"],
-    tags = ["exclusive", "team:data"]
+    tags = ["exclusive", "team:ml"]
 )
 
 py_test(

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -52,9 +52,6 @@ def convert_ndarray_batch_to_tf_tensor_batch(
 
     Returns: A (dict of) TensorFlow Tensor(s).
     """
-    import pdb
-
-    pdb.set_trace()
     if isinstance(ndarrays, np.ndarray):
         # Single-tensor case.
         if isinstance(dtypes, dict):

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -52,6 +52,9 @@ def convert_ndarray_batch_to_tf_tensor_batch(
 
     Returns: A (dict of) TensorFlow Tensor(s).
     """
+    import pdb
+
+    pdb.set_trace()
     if isinstance(ndarrays, np.ndarray):
         # Single-tensor case.
         if isinstance(dtypes, dict):

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1268,6 +1268,14 @@ def from_pandas(
 
     if isinstance(dfs, pd.DataFrame):
         dfs = [dfs]
+
+    from ray.air.util.data_batch_conversion import (
+        _cast_ndarray_columns_to_tensor_extension,
+    )
+
+    context = DatasetContext.get_current()
+    if context.enable_tensor_extension_casting:
+        dfs = [_cast_ndarray_columns_to_tensor_extension(df) for df in dfs]
     return from_pandas_refs([ray.put(df) for df in dfs])
 
 

--- a/python/ray/data/tests/test_dataset_tf.py
+++ b/python/ray/data/tests/test_dataset_tf.py
@@ -7,7 +7,6 @@ import ray
 from ray.air import session
 from ray.air.config import ScalingConfig
 from ray.air.constants import TENSOR_COLUMN_NAME
-from ray.data.extensions import TensorArray
 from ray.data.preprocessors import Concatenator
 from ray.train.tensorflow import TensorflowTrainer
 
@@ -139,7 +138,7 @@ class TestToTF:
     def test_element_spec_shape_with_ragged_tensors(self, batch_size):
         df = pd.DataFrame(
             {
-                "spam": TensorArray([np.zeros([32, 32, 3]), np.zeros([64, 64, 3])]),
+                "spam": [np.zeros([32, 32, 3]), np.zeros([64, 64, 3])],
                 "ham": [0, 0],
             }
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Closes https://github.com/ray-project/ray/issues/33005

1. Updates ragged tensor documentation to use latest `to_tf` API
2. Adds support for automatic tensor casting to `from_pandas` API
3. Tests all code snippets in Dataset Tensor Support documentation

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
