### PR TITLE
[K8S] Make Ray head service headless

### DIFF
--- a/doc/source/cluster/kubernetes/configs/static-ray-cluster.with-fault-tolerance.yaml
+++ b/doc/source/cluster/kubernetes/configs/static-ray-cluster.with-fault-tolerance.yaml
@@ -73,6 +73,7 @@ metadata:
   labels:
     app: ray-cluster-head
 spec:
+  clusterIP: None
   ports:
   - name: client
     protocol: TCP
@@ -198,7 +199,7 @@ spec:
         imagePullPolicy: Always
         command: ["/bin/bash", "-c", "--"]
         args:
-          - "ray start --num-cpus=$MY_CPU_REQUEST --address=$SERVICE_RAY_CLUSTER_SERVICE_HOST:$SERVICE_RAY_CLUSTER_SERVICE_PORT_GCS_SERVER --object-manager-port=8076 --node-manager-port=8077 --dashboard-agent-grpc-port=8078 --dashboard-agent-listen-port=52365 --block"
+          - "ray start --num-cpus=$MY_CPU_REQUEST --address=service-ray-cluster:6380 --object-manager-port=8076 --node-manager-port=8077 --dashboard-agent-grpc-port=8078 --dashboard-agent-listen-port=52365 --block"
 
         # This volume allocates shared memory for Ray to use for its plasma
         # object store. If you do not provide this, Ray will fall back to


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We have recently discovered that some submitted jobs may remain pending for up to two minutes before failing. And once the first job has this issue, the coming up jobs always have the same problem. This issue arises from the random allocation of the job agent, which can be located in either the head or the workers. Our investigation revealed that when the job agent is in a worker, the job will be left pending and then eventually fail. 

This is because the worker attempts to utilize the head service IP as the GCS address. Although the head initially uses the external IP as the GCS address, it fails to connect to the GCS when using the GcsAioClient because it fails to reach the service IP (GCS address) from its own pod. 

In addition, the `choose_agent` code to choose the job_agent caches the job_agent reference. That is the reason why if the first job fails, the coming up jobs always have the same problem.

To address this problem, this PR makes the Ray head service headless, allowing the Ray head to access the service IP from its own pod.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Tested locally and in a cluster
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
