### PR TITLE
Fixed typo in check_agent_environments

### DIFF
--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -289,7 +289,7 @@ def check_multiagent_environments(env: "MultiAgentEnv") -> None:
         hasattr(env, "observation_space")
         and hasattr(env, "action_space")
         and hasattr(env, "_agent_ids")
-        and hasattr(env, "_observation_space_in_preferred_format")
+        and hasattr(env, "_obs_space_in_preferred_format")
         and hasattr(env, "_action_space_in_preferred_format")
     ):
         if log_once("ma_env_super_ctor_called"):


### PR DESCRIPTION
The ``check_multiagent_environments`` function checks if ``MultiAgentEnv`` has attribute "observation_space_in_preferred_format". This should be "obs_space_in_preferred_format".

## Why are these changes needed?

The change fixes a small typo which causes incorrect warnings being reported to the user.

## Related issue number

None

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.   (none needed)
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] single typo fix to non-critical fn, tested locally 
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
