### PR TITLE
[RLlib] Don't import jax in long runnign release tests

### DIFF
--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -1,5 +1,5 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
-env_vars: {}
+env_vars: {"RLLIB_TEST_NO_JAX_IMPORT": "1"}
 
 debian_packages:
   - curl

--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -7,8 +7,7 @@ debian_packages:
 
 python:
   pip_packages:
-    # These dependencies should be handled by requirements_rllib.txt and
-    # requirements_ml_docker.txt and removed here
+    # These dependencies should be handled by requirements_rllib.txt and requirements_ml_docker.txt and removed here
     - gym>=0.21.0,<0.24.1
     - ale-py==0.7.5
     - pytest

--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -12,9 +12,8 @@ python:
     - ale-py==0.7.5
     - pytest
     - tensorflow
-    # AutoROM downloads ROMs via torrent when they are built. The torrent is unreliable,
-    # so we built it for py3 and use that instead. This wheel was tested for python 3.7, 3.8,
-    # and 3.9.
+    # AutoROM downloads ROMs via torrent when they are built. The torrent is unreliable, so we built it for py3 and 
+    # use that instead. This wheel was tested for python 3.7, 3.8, and 3.9.
     - https://ray-ci-deps-wheels.s3.us-west-2.amazonaws.com/AutoROM.accept_rom_license-0.5.4-py3-none-any.whl
   conda_packages: []
 


### PR DESCRIPTION
## Why are these changes needed?

Just like in https://github.com/ray-project/ray/pull/33023, we need to limit imports of the jax module in release tests, but this time for long_running ones.