### PR TITLE
[data] [streaming] Prerequisite refactoring for supporting streaming split operation

### DIFF
--- a/python/ray/data/_internal/dataset_iterator_impl.py
+++ b/python/ray/data/_internal/dataset_iterator_impl.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ray.data import Dataset
 
 
-class BulkDatasetIterator(DatasetIterator):
+class DatasetIteratorImpl(DatasetIterator):
     def __init__(
         self,
         base_dataset: "Dataset",

--- a/python/ray/data/_internal/execution/bulk_executor.py
+++ b/python/ray/data/_internal/execution/bulk_executor.py
@@ -5,6 +5,7 @@ from ray.data.context import DatasetContext
 from ray.data._internal.execution.interfaces import (
     Executor,
     ExecutionOptions,
+    OutputIterator,
     RefBundle,
     PhysicalOperator,
 )
@@ -81,7 +82,7 @@ class BulkExecutor(Executor):
             )
             return output
 
-        return execute_recursive(dag)
+        return OutputIterator(execute_recursive(dag))
 
     def get_stats(self) -> DatasetStats:
         return self._stats

--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Iterable, Tuple, Callable
+from typing import Dict, List, Optional, Iterable, Iterator, Tuple, Callable, Union
 
 import ray
 from ray.data._internal.logical.interfaces import Operator
@@ -8,6 +8,9 @@ from ray.data._internal.stats import DatasetStats, StatsDict
 from ray.data.block import Block, BlockMetadata
 from ray.data.context import DatasetContext
 from ray.types import ObjectRef
+
+# Node id string returned by `ray.get_runtime_context().get_node_id()`.
+NodeIdStr = str
 
 
 @dataclass
@@ -37,6 +40,9 @@ class RefBundle:
     # This attribute is used by the split() operator to assign bundles to logical
     # output splits. It is otherwise None.
     output_split_idx: Optional[int] = None
+
+    # Cached location, used for get_cached_location().
+    _cached_location: Optional[NodeIdStr] = None
 
     def __post_init__(self):
         for b in self.blocks:
@@ -73,6 +79,28 @@ class RefBundle:
         for b in self.blocks:
             trace_deallocation(b[0], "RefBundle.destroy_if_owned", free=should_free)
         return self.size_bytes() if should_free else 0
+
+    def get_cached_location(self) -> Optional[NodeIdStr]:
+        """Return a location for this bundle's data, if possible.
+
+        Caches the resolved location so multiple calls to this are efficient.
+        """
+        if self._cached_location is None:
+            # Only consider the first block in the bundle for now. TODO(ekl) consider
+            # taking into account other blocks.
+            ref = self.blocks[0][0]
+            # This call is pretty fast for owned objects (~5k/s), so we don't need to
+            # batch it for now.
+            locs = ray.experimental.get_object_locations([ref])
+            nodes = locs[ref]["node_ids"]
+            if nodes:
+                self._cached_location = nodes[0]
+            else:
+                self._cached_location = ""
+        if self._cached_location:
+            return self._cached_location
+        else:
+            return None  # Return None if cached location is "".
 
     def __eq__(self, other) -> bool:
         return self is other
@@ -167,14 +195,16 @@ class ExecutionOptions:
     resource_limits: ExecutionResources = ExecutionResources()
 
     # Set this to prefer running tasks on the same node as the output
-    # node (node driving the execution).
-    locality_with_output: bool = False
+    # node (node driving the execution). It can also be set to a list of node ids
+    # to spread the outputs across those nodes.
+    locality_with_output: Union[bool, List[NodeIdStr]] = False
 
     # Set this to preserve the ordering between blocks processed by operators under the
     # streaming executor. The bulk executor always preserves order.
     preserve_order: bool = False
 
-    # Whether to enable locality-aware task dispatch to actors (on by default).
+    # Whether to enable locality-aware task dispatch to actors (on by default). This
+    # applies to both ActorPoolStrategy map and streaming_split operations.
     actor_locality_enabled: bool = True
 
 
@@ -390,6 +420,33 @@ class PhysicalOperator(Operator):
         return ExecutionResources()
 
 
+class OutputIterator(Iterator[RefBundle]):
+    """Iterator used to access the output of an Executor execution.
+
+    The default implementation wraps a simple Python iterator.
+    """
+
+    def __init__(self, base: Iterable[RefBundle]):
+        self._it = iter(base)
+
+    def get_next(self, output_split_idx: Optional[int] = None) -> RefBundle:
+        """Can be used to pull outputs by a specified output index.
+
+        This is used to support the streaming_split() API, where the output of a
+        streaming execution is to be consumed by multiple processes.
+
+        Args:
+            output_split_idx: The output split index to get results for. This arg is
+                only allowed for iterators created by `Dataset.streaming_split()`.
+        """
+        if output_split_idx is not None:
+            raise NotImplementedError()
+        return next(self._it)
+
+    def __next__(self) -> RefBundle:
+        return self.get_next()
+
+
 class Executor:
     """Abstract class for executors, which implement physical operator execution.
 
@@ -404,7 +461,7 @@ class Executor:
 
     def execute(
         self, dag: PhysicalOperator, initial_stats: Optional[DatasetStats] = None
-    ) -> Iterable[RefBundle]:
+    ) -> OutputIterator:
         """Start execution.
 
         Args:

--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -423,7 +423,8 @@ class PhysicalOperator(Operator):
 class OutputIterator(Iterator[RefBundle]):
     """Iterator used to access the output of an Executor execution.
 
-    The default implementation wraps a simple Python iterator.
+    This is a blocking iterator, and must be thread-safe (i.e., multiple threads can
+    block on it at the same time).
     """
 
     def __init__(self, base: Iterable[RefBundle]):

--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -423,8 +423,8 @@ class PhysicalOperator(Operator):
 class OutputIterator(Iterator[RefBundle]):
     """Iterator used to access the output of an Executor execution.
 
-    This is a blocking iterator, and must be thread-safe (i.e., multiple threads can
-    block on it at the same time).
+    This is a blocking iterator. Datasets guarantees that all its iterators are
+    thread-safe (i.e., multiple threads can block on them at the same time).
     """
 
     def __init__(self, base: Iterable[RefBundle]):

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -52,10 +52,35 @@ def execute_to_legacy_block_iterator(
     Returns:
         The output as a block iterator.
     """
+    bundle_iter = execute_to_legacy_bundle_iterator(
+        executor, plan, allow_clear_input_blocks, dataset_uuid
+    )
+    for bundle in bundle_iter:
+        for block, _ in bundle.blocks:
+            yield block
+
+
+def execute_to_legacy_bundle_iterator(
+    executor: Executor,
+    plan: ExecutionPlan,
+    allow_clear_input_blocks: bool,
+    dataset_uuid: str,
+    dag_rewrite=None,
+) -> Iterator[RefBundle]:
+    """Same as execute_to_legacy_block_iterator but returning bundles.
+
+    Args:
+        dag_rewrite: Callback that can be used to mutate the DAG prior to execution.
+            This is currently used as a legacy hack to inject the OutputSplit operator
+            for `Dataset.streaming_split()`.
+    """
+
     if DatasetContext.get_current().optimizer_enabled:
         dag, stats = get_execution_plan(plan._logical_plan).dag, None
     else:
         dag, stats = _to_operator_dag(plan, allow_clear_input_blocks)
+    if dag_rewrite:
+        dag = dag_rewrite(dag)
 
     # Enforce to preserve ordering if the plan has stages required to do so, such as
     # Zip and Sort.
@@ -64,10 +89,7 @@ def execute_to_legacy_block_iterator(
         executor._options.preserve_order = True
 
     bundle_iter = executor.execute(dag, initial_stats=stats)
-
-    for bundle in bundle_iter:
-        for block, _ in bundle.blocks:
-            yield block
+    return bundle_iter
 
 
 def execute_to_legacy_block_list(

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -52,35 +52,10 @@ def execute_to_legacy_block_iterator(
     Returns:
         The output as a block iterator.
     """
-    bundle_iter = execute_to_legacy_bundle_iterator(
-        executor, plan, allow_clear_input_blocks, dataset_uuid
-    )
-    for bundle in bundle_iter:
-        for block, _ in bundle.blocks:
-            yield block
-
-
-def execute_to_legacy_bundle_iterator(
-    executor: Executor,
-    plan: ExecutionPlan,
-    allow_clear_input_blocks: bool,
-    dataset_uuid: str,
-    dag_rewrite=None,
-) -> Iterator[RefBundle]:
-    """Same as execute_to_legacy_block_iterator but returning bundles.
-
-    Args:
-        dag_rewrite: Callback that can be used to mutate the DAG prior to execution.
-            This is currently used as a legacy hack to inject the OutputSplit operator
-            for `Dataset.streaming_split()`.
-    """
-
     if DatasetContext.get_current().optimizer_enabled:
         dag, stats = get_execution_plan(plan._logical_plan).dag, None
     else:
         dag, stats = _to_operator_dag(plan, allow_clear_input_blocks)
-    if dag_rewrite:
-        dag = dag_rewrite(dag)
 
     # Enforce to preserve ordering if the plan has stages required to do so, such as
     # Zip and Sort.
@@ -89,7 +64,10 @@ def execute_to_legacy_bundle_iterator(
         executor._options.preserve_order = True
 
     bundle_iter = executor.execute(dag, initial_stats=stats)
-    return bundle_iter
+
+    for bundle in bundle_iter:
+        for block, _ in bundle.blocks:
+            yield block
 
 
 def execute_to_legacy_block_list(

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -12,6 +12,7 @@ from ray.data._internal.execution.interfaces import (
     ExecutionOptions,
     PhysicalOperator,
     TaskContext,
+    NodeIdStr,
 )
 from ray.data._internal.execution.operators.map_operator import (
     MapOperator,
@@ -20,9 +21,6 @@ from ray.data._internal.execution.operators.map_operator import (
 )
 from ray.types import ObjectRef
 from ray._raylet import ObjectRefGenerator
-
-# Type alias for a node id.
-NodeIdStr = str
 
 # Higher values here are better for prefetching and locality. It's ok for this to be
 # fairly high since streaming backpressure prevents us from overloading actors.
@@ -656,14 +654,4 @@ class _ActorPool:
         Returns:
             A node id associated with the bundle, or None if unknown.
         """
-        # Only consider the first block in the bundle for now. TODO(ekl) consider
-        # taking into account other blocks.
-        ref = bundle.blocks[0][0]
-        # This call is pretty fast for owned objects (~5k/s), so we don't need to
-        # batch it for now.
-        locs = ray.experimental.get_object_locations([ref])
-        nodes = locs[ref]["node_ids"]
-        if nodes:
-            return nodes[0]
-        else:
-            return None
+        return bundle.get_cached_location()

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -1,5 +1,5 @@
 import math
-from typing import List
+from typing import List, Dict
 
 from ray.data.block import Block, BlockMetadata, BlockAccessor
 from ray.data._internal.remote_fn import cached_remote_fn
@@ -47,6 +47,9 @@ class OutputSplitter(PhysicalOperator):
         return self._output_queue.pop()
 
     def get_stats(self) -> StatsDict:
+        return {"split": []}  # TODO(ekl) add split metrics?
+
+    def get_metrics(self) -> Dict[str, int]:
         stats = {}
         for i, num in enumerate(self._num_output):
             stats[f"num_output_{i}"] = num
@@ -59,6 +62,7 @@ class OutputSplitter(PhysicalOperator):
         self._dispatch_bundles()
 
     def inputs_done(self) -> None:
+        super().inputs_done()
         if not self._equal:
             # There shouldn't be any buffered data if we're not in equal split mode.
             assert not self._buffer

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -52,9 +52,9 @@ class TaskPoolMapOperator(MapOperator):
         map_task = cached_remote_fn(_map_task, num_returns="dynamic")
         input_blocks = [block for block, _ in bundle.blocks]
         ctx = TaskContext(task_idx=self._next_task_idx)
-        ref = map_task.options(**self._ray_remote_args, name=self.name).remote(
-            self._transform_fn_ref, ctx, *input_blocks
-        )
+        ref = map_task.options(
+            **self._get_runtime_ray_remote_args(), name=self.name
+        ).remote(self._transform_fn_ref, ctx, *input_blocks)
         self._next_task_idx += 1
         task = _TaskState(bundle)
         self._tasks[ref] = task

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -93,11 +93,14 @@ class StreamingExecutor(Executor, threading.Thread):
                     item = self._outer._output_node.get_output_blocking(
                         output_split_idx
                     )
+                    # Translate the special sentinel values for MaybeRefBundle into
+                    # exceptions.
                     if item is None:
                         raise StopIteration
                     elif isinstance(item, Exception):
                         raise item
                     else:
+                        # Otherwise return a concrete RefBundle.
                         self._outer._output_info.update(1)
                         return item
                 except Exception:

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -10,6 +10,7 @@ from ray.data._internal.execution.interfaces import (
     Executor,
     ExecutionOptions,
     ExecutionResources,
+    OutputIterator,
     RefBundle,
     PhysicalOperator,
 )
@@ -83,18 +84,27 @@ class StreamingExecutor(Executor, threading.Thread):
         self._output_node: OpState = self._topology[dag]
         self.start()
 
-        # Drain items from the runner thread until completion.
-        try:
-            item = self._output_node.get_output_blocking()
-            while item is not None:
-                if isinstance(item, Exception):
-                    raise item
-                else:
-                    self._output_info.update(1)
-                    yield item
-                item = self._output_node.get_output_blocking()
-        finally:
-            self.shutdown()
+        class StreamIterator(OutputIterator):
+            def __init__(self, outer: Executor):
+                self._outer = outer
+
+            def get_next(self, output_split_idx: Optional[int] = None) -> RefBundle:
+                try:
+                    item = self._outer._output_node.get_output_blocking(
+                        output_split_idx
+                    )
+                    if item is None:
+                        raise StopIteration
+                    elif isinstance(item, Exception):
+                        raise item
+                    else:
+                        self._outer._output_info.update(1)
+                        return item
+                except Exception:
+                    self._outer.shutdown()
+                    raise
+
+        return StreamIterator(self)
 
     def shutdown(self):
         with self._shutdown_lock:

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -144,7 +144,7 @@ class OpState:
                 return
         assert False, "Nothing to dispatch"
 
-    def get_output_blocking(self) -> MaybeRefBundle:
+    def get_output_blocking(self, output_split_idx: Optional[int]) -> MaybeRefBundle:
         """Get an item from this node's output queue, blocking as needed.
 
         Returns:
@@ -152,9 +152,19 @@ class OpState:
         """
         while True:
             try:
-                return self.outqueue.popleft()
+                if output_split_idx is None:
+                    return self.outqueue.popleft()
+                else:
+                    for i in range(len(self.outqueue)):
+                        bundle = self.outqueue[i]
+                        if bundle is None:
+                            return None  # End of stream for this index!
+                        elif bundle.output_split_idx == output_split_idx:
+                            self.outqueue.remove(bundle)
+                            return bundle
             except IndexError:
-                time.sleep(0.01)
+                pass
+            time.sleep(0.01)
 
     def outqueue_memory_usage(self) -> int:
         """Return the object store memory of this operator's outqueue.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -50,7 +50,7 @@ from ray.data._internal.planner.map_rows import generate_map_rows_fn
 from ray.data._internal.planner.write import generate_write_fn
 from ray.data.dataset_iterator import DatasetIterator
 from ray.data._internal.block_list import BlockList
-from ray.data._internal.bulk_dataset_iterator import BulkDatasetIterator
+from ray.data._internal.dataset_iterator_impl import DatasetIteratorImpl
 from ray.data._internal.compute import (
     ActorPoolStrategy,
     CallableClass,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2819,7 +2819,7 @@ class Dataset(Generic[T]):
             It is recommended to use ``DatasetIterator`` methods over directly
             calling methods such as ``iter_batches()``.
         """
-        return BulkDatasetIterator(self)
+        return DatasetIteratorImpl(self)
 
     @ConsumptionAPI
     def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[Union[T, TableRow]]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR contains interface changes and some refactoring split out from https://github.com/ray-project/ray/pull/32991/files:
- Rename BulkDatasetIterator to DatasetIteratorImpl, given that it is used for streaming exec too.
- Add OutputIterator interface in order to efficiently support multiple output consumers.
- Move NodeIdStr and bundle location API to common location.
- Support round robin node assignment for locality_with_output.