### PR TITLE
[AIR] Bump start timeout for Horovod Release Tests

### DIFF
--- a/release/ml_user_tests/horovod/horovod_user_test.py
+++ b/release/ml_user_tests/horovod/horovod_user_test.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
         num_workers=6,
         use_gpu=True,
         placement_group_timeout_s=2000,
-        timeout_s=300,
+        timeout_s=120,
         kwargs={"num_epochs": 20},
     )
 

--- a/release/ml_user_tests/horovod/horovod_user_test.py
+++ b/release/ml_user_tests/horovod/horovod_user_test.py
@@ -22,6 +22,7 @@ if __name__ == "__main__":
         num_workers=6,
         use_gpu=True,
         placement_group_timeout_s=2000,
+        timeout_s=300,
         kwargs={"num_epochs": 20},
     )
 

--- a/release/nightly_tests/dataset/pipelined_training.py
+++ b/release/nightly_tests/dataset/pipelined_training.py
@@ -327,7 +327,7 @@ if __name__ == "__main__":
         ray.get(tasks)
     else:
         print("Create Ray executor")
-        settings = RayExecutor.create_settings(timeout_s=300)
+        settings = RayExecutor.create_settings(timeout_s=120)
         executor = RayExecutor(settings, num_workers=args.num_workers, use_gpu=True)
         executor.start()
         executor.run(train_main, args=[args, splits])

--- a/release/nightly_tests/dataset/pipelined_training.py
+++ b/release/nightly_tests/dataset/pipelined_training.py
@@ -327,7 +327,7 @@ if __name__ == "__main__":
         ray.get(tasks)
     else:
         print("Create Ray executor")
-        settings = RayExecutor.create_settings(timeout_s=30)
+        settings = RayExecutor.create_settings(timeout_s=300)
         executor = RayExecutor(settings, num_workers=args.num_workers, use_gpu=True)
         executor.start()
         executor.run(train_main, args=[args, splits])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Horovod on Ray release tests have been timing out during the initial rendezvous. This PR bumps the timeout configuration from 30 seconds to 120 seconds.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
