### PR TITLE
[wip][core] Fix many files open issues for GCS.

### DIFF
--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -256,20 +256,6 @@ assert ray.get_runtime_context().get_job_id() == '02000000'
     run_string_as_driver(script.format(address=call_ray_start_2, val=2))
 
 
-def test_gcs_connections(ray_start_regular):
-    head_node = cluster.head_node
-    gcs_server_process = head_node.all_processes["gcs_server"][0].process
-    gcs_server_pid = gcs_server_process.pid
-
-    def get_gcs_connections():
-        import psutil
-
-        p = psutil.Process(gcs_server_pid)
-        return p.num_fds()
-
-    print(get_gcs_connections())
-
-
 if __name__ == "__main__":
     import pytest
     import os

--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -256,6 +256,20 @@ assert ray.get_runtime_context().get_job_id() == '02000000'
     run_string_as_driver(script.format(address=call_ray_start_2, val=2))
 
 
+def test_gcs_connections(ray_start_regular):
+    head_node = cluster.head_node
+    gcs_server_process = head_node.all_processes["gcs_server"][0].process
+    gcs_server_pid = gcs_server_process.pid
+
+    def get_gcs_connections():
+        import psutil
+
+        p = psutil.Process(gcs_server_pid)
+        return p.num_fds()
+
+    print(get_gcs_connections())
+
+
 if __name__ == "__main__":
     import pytest
     import os

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -478,8 +478,7 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
   // Unfortunately the raylet client has to be constructed after the receivers.
   if (direct_task_receiver_ != nullptr) {
     task_argument_waiter_.reset(new DependencyWaiterImpl(*local_raylet_client_));
-    direct_task_receiver_->Init(
-        core_worker_client_pool_, rpc_address_, task_argument_waiter_);
+    direct_task_receiver_->Init(rpc_address_, task_argument_waiter_);
   }
 
   actor_manager_ = std::make_unique<ActorManager>(

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -61,7 +61,6 @@ void CoreWorkerDirectTaskReceiver::Init(
     std::shared_ptr<DependencyWaiter> dependency_waiter) {
   waiter_ = std::move(dependency_waiter);
   rpc_address_ = rpc_address;
-  client_pool_ = client_pool;
 }
 
 void CoreWorkerDirectTaskReceiver::HandleTask(

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -56,8 +56,7 @@ void SerializeReturnObject(const ObjectID &object_id,
 }
 
 void CoreWorkerDirectTaskReceiver::Init(
-    rpc::Address rpc_address,
-    std::shared_ptr<DependencyWaiter> dependency_waiter) {
+    rpc::Address rpc_address, std::shared_ptr<DependencyWaiter> dependency_waiter) {
   waiter_ = std::move(dependency_waiter);
   rpc_address_ = rpc_address;
 }

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -56,7 +56,6 @@ void SerializeReturnObject(const ObjectID &object_id,
 }
 
 void CoreWorkerDirectTaskReceiver::Init(
-    std::shared_ptr<rpc::CoreWorkerClientPool> client_pool,
     rpc::Address rpc_address,
     std::shared_ptr<DependencyWaiter> dependency_waiter) {
   waiter_ = std::move(dependency_waiter);

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -112,8 +112,6 @@ class CoreWorkerDirectTaskReceiver {
   instrumented_io_context &task_main_io_service_;
   /// The callback function to be invoked when finishing a task.
   OnTaskDone task_done_;
-  /// Shared pool for producing new core worker clients.
-  std::shared_ptr<rpc::CoreWorkerClientPool> client_pool_;
   /// Address of our RPC server.
   rpc::Address rpc_address_;
   /// Shared waiter for dependencies required by incoming tasks.

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -72,8 +72,7 @@ class CoreWorkerDirectTaskReceiver {
         pool_manager_(std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>()) {}
 
   /// Initialize this receiver. This must be called prior to use.
-  void Init(std::shared_ptr<rpc::CoreWorkerClientPool>,
-            rpc::Address rpc_address,
+  void Init(rpc::Address rpc_address,
             std::shared_ptr<DependencyWaiter> dependency_waiter);
 
   /// Handle a `PushTask` request. If it's an actor request, this function will enqueue

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -752,12 +752,12 @@ Status CoreWorkerDirectTaskSubmitter::CancelTask(TaskSpecification task_spec,
     }
     // Looks for an RPC handle for the worker executing the task.
     auto maybe_client = client_cache_->GetByID(rpc_client->second.worker_id);
-    if (!maybe_client.has_value()) {
+    if (!maybe_client) {
       // If we don't have a connection to that worker, we can't cancel it.
       // This case is reached for tasks that have unresolved dependencies.
       return Status::OK();
     }
-    client = maybe_client.value();
+    client = maybe_client;
   }
 
   RAY_CHECK(client != nullptr);
@@ -814,12 +814,11 @@ Status CoreWorkerDirectTaskSubmitter::CancelRemoteTask(const ObjectID &object_id
                                                        const rpc::Address &worker_addr,
                                                        bool force_kill,
                                                        bool recursive) {
-  auto maybe_client = client_cache_->GetByID(rpc::WorkerAddress(worker_addr).worker_id);
+  auto client = client_cache_->GetByID(rpc::WorkerAddress(worker_addr).worker_id);
 
-  if (!maybe_client.has_value()) {
+  if (!client) {
     return Status::Invalid("No remote worker found");
   }
-  auto client = maybe_client.value();
   auto request = rpc::RemoteCancelTaskRequest();
   request.set_force_kill(force_kill);
   request.set_recursive(recursive);

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -279,25 +279,12 @@ class CoreWorkerDirectTaskSubmitter {
   /// (7) The task id used to obtain the worker lease.
   struct LeaseEntry {
     std::shared_ptr<WorkerLeaseInterface> lease_client;
-    int64_t lease_expiration_time;
-    bool is_busy = false;
+    std::shared_ptr<rpc::CoreWorkerClientInterface> worker_client;
+    int64_t lease_expiration_time = 0;
     google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> assigned_resources;
-    SchedulingKey scheduling_key;
-    TaskID task_id;
-
-    LeaseEntry(
-        std::shared_ptr<WorkerLeaseInterface> lease_client = nullptr,
-        int64_t lease_expiration_time = 0,
-        google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> assigned_resources =
-            google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry>(),
-        SchedulingKey scheduling_key =
-            std::make_tuple(0, std::vector<ObjectID>(), ActorID::Nil(), 0),
-        TaskID task_id = TaskID::Nil())
-        : lease_client(lease_client),
-          lease_expiration_time(lease_expiration_time),
-          assigned_resources(assigned_resources),
-          scheduling_key(scheduling_key),
-          task_id(task_id) {}
+    SchedulingKey scheduling_key{0, std::vector<ObjectID>(), ActorID::Nil(), 0};
+    TaskID task_id = TaskID::Nil();
+    bool is_busy = false;
   };
 
   // Map from worker address to a LeaseEntry struct containing the lease's metadata.

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -213,10 +213,14 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
     /// \param actor_id ID of the actor associated with this leased worker.
     explicit GcsLeasedWorker(rpc::Address address,
                              std::vector<rpc::ResourceMapEntry> resources,
-                             const ActorID &actor_id)
+                             const ActorID &actor_id,
+                             std::shared_ptr<ray::rpc::CoreWorkerClientInterface> client)
         : address_(std::move(address)),
           resources_(std::move(resources)),
-          assigned_actor_id_(actor_id) {}
+          assigned_actor_id_(actor_id),
+          rpc_client_(client) {
+      RAY_CHECK(rpc_client_);
+    }
     virtual ~GcsLeasedWorker() = default;
 
     /// Get the Address of this leased worker.
@@ -242,6 +246,10 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
       return resources_;
     }
 
+    std::shared_ptr<ray::rpc::CoreWorkerClientInterface> GetClient() const {
+      return rpc_client_;
+    }
+
    protected:
     /// The address of the remote leased worker.
     rpc::Address address_;
@@ -249,6 +257,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
     std::vector<rpc::ResourceMapEntry> resources_;
     /// Id of the actor assigned to this worker.
     ActorID assigned_actor_id_;
+    std::shared_ptr<ray::rpc::CoreWorkerClientInterface> rpc_client_;
   };
 
   /// Lease a worker from the specified node for the specified actor.


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`CoreWorkerClientPool` is a component to connect to core worker. Right now, it's served as a cache to avoid creating multiple connections.

But the connection is never disconnected which means, if GCS schedule 20k actors around, it'll have 20k connections created. This is bad for GCS stability and scalability.

This PR changed the shared ptr to a weak ptr. So if there is no place using this client, it'll be disconnected. But if there is one living, it'll just reuse the existing one. This is to mitigate the issues.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
