### PR TITLE
[AIR] Allow None in `set_preprocessor`

### DIFF
--- a/python/ray/air/_internal/checkpointing.py
+++ b/python/ray/air/_internal/checkpointing.py
@@ -34,6 +34,16 @@ def load_preprocessor_from_dir(
     return preprocessor
 
 
+def delete_preprocessor_in_dir(
+    parent_dir: Union[os.PathLike, str],
+) -> None:
+    """Deletes preprocessor from directory, if file exists."""
+    parent_dir = Path(parent_dir)
+    preprocessor_path = parent_dir.joinpath(PREPROCESSOR_KEY)
+    if preprocessor_path.exists():
+        os.remove(str(preprocessor_path.absolute()))
+
+
 def add_preprocessor_to_checkpoint(
     checkpoint: "Checkpoint", preprocessor: "Preprocessor"
 ) -> "Checkpoint":

--- a/python/ray/air/_internal/checkpointing.py
+++ b/python/ray/air/_internal/checkpointing.py
@@ -34,16 +34,6 @@ def load_preprocessor_from_dir(
     return preprocessor
 
 
-def delete_preprocessor_in_dir(
-    parent_dir: Union[os.PathLike, str],
-) -> None:
-    """Deletes preprocessor from directory, if file exists."""
-    parent_dir = Path(parent_dir)
-    preprocessor_path = parent_dir.joinpath(PREPROCESSOR_KEY)
-    if preprocessor_path.exists():
-        os.remove(str(preprocessor_path.absolute()))
-
-
 def add_preprocessor_to_checkpoint(
     checkpoint: "Checkpoint", preprocessor: "Preprocessor"
 ) -> "Checkpoint":

--- a/python/ray/air/checkpoint.py
+++ b/python/ray/air/checkpoint.py
@@ -17,7 +17,6 @@ from ray import cloudpickle as pickle
 from ray.air._internal.checkpointing import (
     load_preprocessor_from_dir,
     save_preprocessor_to_dir,
-    delete_preprocessor_in_dir,
 )
 from ray.air._internal.filelock import TempFileLock
 from ray.air._internal.remote_storage import (
@@ -543,11 +542,8 @@ class Checkpoint:
 
         self._save_checkpoint_metadata_in_directory(path)
 
-        if self._override_preprocessor_set:
-            if self._override_preprocessor:
-                save_preprocessor_to_dir(self._override_preprocessor, path)
-            else:
-                delete_preprocessor_in_dir(path)
+        if self._override_preprocessor_set and self._override_preprocessor:
+            save_preprocessor_to_dir(self._override_preprocessor, path)
 
     def _to_directory_safe(self, path: str, move_instead_of_copy: bool = False) -> None:
         try:

--- a/python/ray/air/checkpoint.py
+++ b/python/ray/air/checkpoint.py
@@ -17,6 +17,7 @@ from ray import cloudpickle as pickle
 from ray.air._internal.checkpointing import (
     load_preprocessor_from_dir,
     save_preprocessor_to_dir,
+    delete_preprocessor_in_dir,
 )
 from ray.air._internal.filelock import TempFileLock
 from ray.air._internal.remote_storage import (
@@ -211,6 +212,7 @@ class Checkpoint:
         self._data_dict: Optional[Dict[str, Any]] = data_dict
         self._uri: Optional[str] = uri
         self._override_preprocessor: Optional["Preprocessor"] = None
+        self._override_preprocessor_set = False
 
         self._uuid = uuid.uuid4()
 
@@ -396,7 +398,7 @@ class Checkpoint:
         checkpoint_data[_METADATA_KEY] = self._metadata
 
         # If override_preprocessor is specified, then set that in the output dict.
-        if self._override_preprocessor:
+        if self._override_preprocessor_set:
             checkpoint_data[PREPROCESSOR_KEY] = self._override_preprocessor
         return checkpoint_data
 
@@ -541,8 +543,11 @@ class Checkpoint:
 
         self._save_checkpoint_metadata_in_directory(path)
 
-        if self._override_preprocessor:
-            save_preprocessor_to_dir(self._override_preprocessor, path)
+        if self._override_preprocessor_set:
+            if self._override_preprocessor:
+                save_preprocessor_to_dir(self._override_preprocessor, path)
+            else:
+                delete_preprocessor_in_dir(path)
 
     def _to_directory_safe(self, path: str, move_instead_of_copy: bool = False) -> None:
         try:
@@ -764,7 +769,7 @@ class Checkpoint:
     def get_preprocessor(self) -> Optional["Preprocessor"]:
         """Return the saved preprocessor, if one exists."""
 
-        if self._override_preprocessor:
+        if self._override_preprocessor_set:
             return self._override_preprocessor
 
         # The preprocessor will either be stored in an in-memory dict or
@@ -787,10 +792,11 @@ class Checkpoint:
 
         return preprocessor
 
-    def set_preprocessor(self, preprocessor: "Preprocessor"):
+    def set_preprocessor(self, preprocessor: Optional["Preprocessor"]):
         """Saves the provided preprocessor to this Checkpoint."""
 
         self._override_preprocessor = preprocessor
+        self._override_preprocessor_set = True
 
     @classmethod
     def _get_checkpoint_type(

--- a/python/ray/air/tests/test_checkpoints.py
+++ b/python/ray/air/tests/test_checkpoints.py
@@ -736,6 +736,11 @@ class PreprocessorCheckpointTest(unittest.TestCase):
         preprocessor = checkpoint.get_preprocessor()
         assert preprocessor.multiplier == 1
 
+        # Check that we can set it to None
+        checkpoint.set_preprocessor(None)
+        preprocessor = checkpoint.get_preprocessor()
+        assert preprocessor is None
+
     def testDictCheckpointSetPreprocessorAsDir(self):
         preprocessor = DummyPreprocessor(1)
         data = {"metric": 5}

--- a/python/ray/train/batch_predictor.py
+++ b/python/ray/train/batch_predictor.py
@@ -36,6 +36,7 @@ class BatchPredictor:
         self._predictor_cls = predictor_cls
         self._predictor_kwargs = predictor_kwargs
         self._override_preprocessor: Optional[Preprocessor] = None
+        self._override_preprocessor_set = False
 
     def __repr__(self):
         return (
@@ -98,7 +99,7 @@ class BatchPredictor:
 
     def get_preprocessor(self) -> Preprocessor:
         """Get the preprocessor to use prior to executing predictions."""
-        if self._override_preprocessor:
+        if self._override_preprocessor_set:
             return self._override_preprocessor
 
         return self._checkpoint.get_preprocessor()
@@ -106,6 +107,7 @@ class BatchPredictor:
     def set_preprocessor(self, preprocessor: Preprocessor) -> None:
         """Set the preprocessor to use prior to executing predictions."""
         self._override_preprocessor = preprocessor
+        self._override_preprocessor_set = True
 
     def predict(
         self,

--- a/python/ray/train/huggingface/huggingface_predictor.py
+++ b/python/ray/train/huggingface/huggingface_predictor.py
@@ -98,6 +98,11 @@ class HuggingFacePredictor(Predictor):
 
         The checkpoint is expected to be a result of ``HuggingFaceTrainer``.
 
+        Note that the Transformers ``pipeline`` used internally expects to
+        recieve raw text. If you have any Preprocessors in Checkpoint
+        that tokenize the data, remove them by calling
+        ``Checkpoint.set_preprocessor(None)`` beforehand.
+
         Args:
             checkpoint: The checkpoint to load the model, tokenizer and
                 preprocessor from. It is expected to be from the result of a

--- a/python/ray/train/tests/test_batch_predictor.py
+++ b/python/ray/train/tests/test_batch_predictor.py
@@ -504,6 +504,18 @@ def test_get_and_set_preprocessor():
         12.0,
     ]
 
+    # Remove preprocessor
+    batch_predictor.set_preprocessor(None)
+    assert batch_predictor.get_preprocessor() is None
+
+    output_ds = batch_predictor.predict(test_dataset)
+    assert output_ds.to_pandas().to_numpy().squeeze().tolist() == [
+        0.0,
+        2.0,
+        4.0,
+        6.0,
+    ]
+
 
 def test_batch_prediction_large_predictor_kwarg():
     class StubPredictor(Predictor):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR allows users to remove a preprocessor from `Checkpoint`/`BatchPredictor` by letting `set_preprocessor` take in a `None` value (previously, this resulted in a noop).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
