### PR TITLE
[Train] (Bandaid) Mitigate OOMs on checkpointing

### DIFF
--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -118,7 +118,8 @@ class BackendExecutor:
         # See https://github.com/ray-project/ray/issues/33073
         # for more context.
         # TODO remove
-        self.worker_group._move_workers_with_ip_to_front(self._trial_info.driver_ip)
+        if self._trial_info and self._trial_info.driver_ip:
+            self.worker_group._move_workers_with_ip_to_front(self._trial_info.driver_ip)
         try:
             if initialization_hook:
                 self._initialization_hook = initialization_hook

--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -111,6 +111,14 @@ class BackendExecutor:
             actor_cls_kwargs=train_cls_kwargs,
             placement_group=placement_group,
         )
+        # Hack to avoid OOMs.
+        # This is just a temporary solution for Train loading entire checkpoints
+        # into memory by ensuring that the rank 0 worker is on the same node as
+        # trainable, thus allowing for lazy checkpoint transfer to be used.
+        # See https://github.com/ray-project/ray/issues/33073
+        # for more context.
+        # TODO remove
+        self.worker_group._move_workers_with_ip_to_front(self._trial_info.driver_ip)
         try:
             if initialization_hook:
                 self._initialization_hook = initialization_hook

--- a/python/ray/train/_internal/worker_group.py
+++ b/python/ray/train/_internal/worker_group.py
@@ -354,15 +354,17 @@ class WorkerGroup:
         # for more context.
         # TODO remove
         workers_with_ip = []
-        indices_to_remove = []
+        indices_to_remove = set()
         for i, worker in enumerate(self.workers):
             if worker.metadata.node_ip == ip:
                 workers_with_ip.append(worker)
-                indices_to_remove.append(i)
+                indices_to_remove.add(i)
         if workers_with_ip:
-            for i in indices_to_remove:
-                self.workers.pop(i)
-            self.workers = workers_with_ip + self.workers
+            self.workers = workers_with_ip + [
+                worker
+                for i, worker in enumerate(self.workers)
+                if i not in indices_to_remove
+            ]
 
     def __len__(self):
         return len(self.workers)

--- a/python/ray/train/tests/test_worker_group.py
+++ b/python/ray/train/tests/test_worker_group.py
@@ -101,10 +101,9 @@ def test_move_workers_with_ip_to_front(ray_start_2_cpus):
     wg._move_workers_with_ip_to_front("10.1.10.1")
     assert wg.workers[0].metadata.node_ip == "10.1.10.1"
     assert wg.workers[1].metadata.node_ip == "10.1.10.1"
-    assert set([w.metadata.node_ip for w in workers_pre_move]) == set(
+    assert sorted([w.metadata.node_ip for w in workers_pre_move]) == sorted(
         [w.metadata.node_ip for w in wg.workers]
     )
-    assert len(workers_pre_move) == len(wg.workers)
 
 
 def test_execute_single(ray_start_2_cpus):

--- a/python/ray/train/tests/test_worker_group.py
+++ b/python/ray/train/tests/test_worker_group.py
@@ -3,7 +3,9 @@ import time
 import pytest
 
 import ray
-from ray.train._internal.worker_group import WorkerGroup
+from ray.train._internal.worker_group import WorkerGroup, Worker, WorkerMetadata
+from copy import deepcopy
+from random import seed, shuffle
 
 
 @pytest.fixture
@@ -79,6 +81,30 @@ def test_execute_args(ray_start_2_cpus):
     outputs = wg.execute(lambda x: x, 1)
     assert len(outputs) == 2
     assert all(o == 1 for o in outputs)
+
+
+def test_move_workers_with_ip_to_front(ray_start_2_cpus):
+    wg = WorkerGroup(num_workers=2)
+    wg.workers = [
+        Worker(
+            actor=None,
+            metadata=WorkerMetadata(
+                node_id="dummy", node_ip=f"10.1.10.{i}", hostname="dummy", gpu_ids=None
+            ),
+        )
+        for i in range(1, 17)
+    ]
+    wg.workers += deepcopy(wg.workers)
+    workers_pre_move = deepcopy(wg.workers)
+    seed(1)
+    shuffle(wg.workers)
+    wg._move_workers_with_ip_to_front("10.1.10.1")
+    assert wg.workers[0].metadata.node_ip == "10.1.10.1"
+    assert wg.workers[1].metadata.node_ip == "10.1.10.1"
+    assert set([w.metadata.node_ip for w in workers_pre_move]) == set(
+        [w.metadata.node_ip for w in wg.workers]
+    )
+    assert len(workers_pre_move) == len(wg.workers)
 
 
 def test_execute_single(ray_start_2_cpus):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR introduces a tactical mitigation of https://github.com/ray-project/ray/issues/33073 by ensuring that the rank 0 worker is colocated with the Trainable if possible, allowing for lazy checkpointing to be used (and thus avoiding a situation where the entire checkpoint is loaded into memory to be passed to object store).

THIS IS NOT A LONG TERM FIX. It is necessary to unblock LLM use cases for now. A proper solution should be implemented soon.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
