### PR TITLE
[Datasets] Disable two failed tests in test_dataset.py

### DIFF
--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -6,7 +6,6 @@ import random
 import signal
 import time
 from typing import Iterator
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -16,7 +15,6 @@ import pytest
 
 import ray
 from ray._private.test_utils import wait_for_condition
-from ray.data._internal.dataset_logger import DatasetLogger
 from ray.data._internal.stats import _StatsActor
 from ray.data._internal.arrow_block import ArrowRow
 from ray.data._internal.block_builder import BlockBuilder
@@ -107,12 +105,15 @@ def test_basic_actors(shutdown_only, pipelined):
     # Test setting custom max inflight tasks.
     ds = ray.data.range(10, parallelism=5)
     ds = maybe_pipeline(ds, pipelined)
-    assert sorted(
-        ds.map(
-            lambda x: x + 1,
-            compute=ray.data.ActorPoolStrategy(max_tasks_in_flight_per_actor=3),
-        ).take()
-    ) == list(range(1, 11))
+    assert (
+        sorted(
+            ds.map(
+                lambda x: x + 1,
+                compute=ray.data.ActorPoolStrategy(max_tasks_in_flight_per_actor=3),
+            ).take()
+        )
+        == list(range(1, 11))
+    )
 
     # Test invalid max tasks inflight arg.
     with pytest.raises(ValueError):
@@ -4555,16 +4556,17 @@ def test_dataset_schema_after_read_stats(ray_start_cluster):
     assert schema == ds.schema()
 
 
+# TODO: re-enable the followed tests once they pass in CI consistently.
+"""
 class LoggerWarningCalled(Exception):
-    """Custom exception used in test_warning_execute_with_no_cpu() and
+    Custom exception used in test_warning_execute_with_no_cpu() and
     test_nowarning_execute_with_cpu(). Raised when the `logger.warning` method
     is called, so that we can kick out of `plan.execute()` by catching this Exception
-    and check logging was done properly."""
+    and check logging was done properly.
 
     pass
 
 
-"""
 def test_warning_execute_with_no_cpu(ray_start_cluster):
     Tests ExecutionPlan.execute() to ensure a warning is logged
     when no CPU resources are available.

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -105,15 +105,12 @@ def test_basic_actors(shutdown_only, pipelined):
     # Test setting custom max inflight tasks.
     ds = ray.data.range(10, parallelism=5)
     ds = maybe_pipeline(ds, pipelined)
-    assert (
-        sorted(
-            ds.map(
-                lambda x: x + 1,
-                compute=ray.data.ActorPoolStrategy(max_tasks_in_flight_per_actor=3),
-            ).take()
-        )
-        == list(range(1, 11))
-    )
+    assert sorted(
+        ds.map(
+            lambda x: x + 1,
+            compute=ray.data.ActorPoolStrategy(max_tasks_in_flight_per_actor=3),
+        ).take()
+    ) == list(range(1, 11))
 
     # Test invalid max tasks inflight arg.
     with pytest.raises(ValueError):

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -4564,9 +4564,10 @@ class LoggerWarningCalled(Exception):
     pass
 
 
+"""
 def test_warning_execute_with_no_cpu(ray_start_cluster):
-    """Tests ExecutionPlan.execute() to ensure a warning is logged
-    when no CPU resources are available."""
+    Tests ExecutionPlan.execute() to ensure a warning is logged
+    when no CPU resources are available.
     # Create one node with no CPUs to trigger the Dataset warning
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=0)
@@ -4597,8 +4598,8 @@ def test_warning_execute_with_no_cpu(ray_start_cluster):
 
 
 def test_nowarning_execute_with_cpu(ray_start_cluster_init):
-    """Tests ExecutionPlan.execute() to ensure no warning is logged
-    when there are available CPU resources."""
+    Tests ExecutionPlan.execute() to ensure no warning is logged
+    when there are available CPU resources.
     # Create one node with CPUs to avoid triggering the Dataset warning
     ray.init(ray_start_cluster_init.address)
 
@@ -4612,6 +4613,7 @@ def test_nowarning_execute_with_cpu(ray_start_cluster_init):
         ds = ds.map_batches(lambda x: x)
         ds.take()
         mock_logger.assert_not_called()
+"""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to disable two failed tests: `test_warning_execute_with_no_cpu` and `test_nowarning_execute_with_cpu`, which ran indefinitely long, and caused the `ValueError: When connecting to an existing cluster, num_cpus and num_gpus must not be provided.` error when bazel reran the whole test suite.

The followup is to re-enable the test after making them successful. We need to unblock the CI as soon as possible. The failed unit tests are checking if warning message printed out when no CPU available, whose impact is low.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
