### PR TITLE
[spark] Improve ray on spark options conversion

### DIFF
--- a/python/ray/tests/spark/test_utils.py
+++ b/python/ray/tests/spark/test_utils.py
@@ -7,8 +7,8 @@ from ray.util.spark.utils import (
     get_spark_task_assigned_physical_gpus,
     _calc_mem_per_ray_worker_node,
     _get_avail_mem_per_ray_worker_node,
-    _convert_ray_node_options,
 )
+from ray.util.spark.cluster_init import _convert_ray_node_options
 
 pytestmark = pytest.mark.skipif(
     not sys.platform.startswith("linux"),

--- a/python/ray/tests/spark/test_utils.py
+++ b/python/ray/tests/spark/test_utils.py
@@ -88,15 +88,13 @@ def test_get_avail_mem_per_ray_worker_node(monkeypatch):
 
 
 def test_convert_ray_node_options():
-    assert _convert_ray_node_options({
-        "cluster_name": "aBc",
-        "disable_usage_stats": None,
-        "include_dashboard": False,
-    }) == [
-        "--cluster-name=aBc",
-        "--disable-usage-stats",
-        "--include-dashboard=False"
-    ]
+    assert _convert_ray_node_options(
+        {
+            "cluster_name": "aBc",
+            "disable_usage_stats": None,
+            "include_dashboard": False,
+        }
+    ) == ["--cluster-name=aBc", "--disable-usage-stats", "--include-dashboard=False"]
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/spark/test_utils.py
+++ b/python/ray/tests/spark/test_utils.py
@@ -95,7 +95,7 @@ def test_convert_ray_node_options():
     }) == [
         "--cluster-name=aBc",
         "--disable-usage-stats",
-        "include-dashboard=False"
+        "--include-dashboard=False"
     ]
 
 

--- a/python/ray/tests/spark/test_utils.py
+++ b/python/ray/tests/spark/test_utils.py
@@ -7,6 +7,7 @@ from ray.util.spark.utils import (
     get_spark_task_assigned_physical_gpus,
     _calc_mem_per_ray_worker_node,
     _get_avail_mem_per_ray_worker_node,
+    _convert_ray_node_options,
 )
 
 pytestmark = pytest.mark.skipif(
@@ -84,6 +85,18 @@ def test_get_avail_mem_per_ray_worker_node(monkeypatch):
         num_gpus_per_node=4,
         object_store_memory_per_node=None,
     ) == (280000, 120000, None, None)
+
+
+def test_convert_ray_node_options():
+    assert _convert_ray_node_options({
+        "cluster_name": "aBc",
+        "disable_usage_stats": None,
+        "include_dashboard": False,
+    }) == [
+        "--cluster-name=aBc",
+        "--disable-usage-stats",
+        "include-dashboard=False"
+    ]
 
 
 if __name__ == "__main__":

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -213,7 +213,16 @@ def _convert_ray_node_option_key(key):
 
 
 def _convert_ray_node_options(options):
-    return [f"{_convert_ray_node_option_key(k)}={str(v)}" for k, v in options.items()]
+    if isinstance(options, dict):
+        return [
+            f"{_convert_ray_node_option_key(k)}" if v is None
+            else f"{_convert_ray_node_option_key(k)}={str(v)}"
+            for k, v in options.items()
+        ]
+    elif isinstance(options, list):
+        return options
+    else:
+        raise ValueError("Ray on spark additional options must be a dict, or a list of option strings")
 
 
 _RAY_HEAD_STARTUP_TIMEOUT = 5

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -213,16 +213,11 @@ def _convert_ray_node_option_key(key):
 
 
 def _convert_ray_node_options(options):
-    if isinstance(options, dict):
-        return [
-            f"{_convert_ray_node_option_key(k)}" if v is None
-            else f"{_convert_ray_node_option_key(k)}={str(v)}"
-            for k, v in options.items()
-        ]
-    elif isinstance(options, list):
-        return options
-    else:
-        raise ValueError("Ray on spark additional options must be a dict, or a list of option strings")
+    return [
+        f"{_convert_ray_node_option_key(k)}" if v is None
+        else f"{_convert_ray_node_option_key(k)}={str(v)}"
+        for k, v in options.items()
+    ]
 
 
 _RAY_HEAD_STARTUP_TIMEOUT = 5
@@ -844,10 +839,16 @@ def setup_ray_cluster(
         head_node_options: A dict representing Ray head node extra options, these
             options will be passed to `ray start` script. Note you need to convert
             `ray start` options key from `--foo-bar` format to `foo_bar` format.
+            For flag options (e.g. '--disable-usage-stats'), you should set the value
+            to None in the option dict, like `{"disable_usage_stats": None}`.
+            Note: Short name options (e.g. '-v') are not supported.
         worker_node_options: A dict representing Ray worker node extra options,
             these options will be passed to `ray start` script. Note you need to
             convert `ray start` options key from `--foo-bar` format to `foo_bar`
             format.
+            For flag options (e.g. '--disable-usage-stats'), you should set the value
+            to None in the option dict, like `{"disable_usage_stats": None}`.
+            Note: Short name options (e.g. '-v') are not supported.
         ray_temp_root_dir: A local disk path to store the ray temporary data. The
             created cluster will create a subdirectory
             "ray-{head_port}-{random_suffix}" beneath this path.

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -214,7 +214,8 @@ def _convert_ray_node_option_key(key):
 
 def _convert_ray_node_options(options):
     return [
-        f"{_convert_ray_node_option_key(k)}" if v is None
+        f"{_convert_ray_node_option_key(k)}"
+        if v is None
         else f"{_convert_ray_node_option_key(k)}={str(v)}"
         for k, v in options.items()
     ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Improve ray on spark options conversion.

1. Make the option argument support flag options.
2. Update the doc saying it does not support short name options.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
