### PR TITLE
docs serve: remove unused json resolver

### DIFF
--- a/doc/source/serve/doc_code/production_fruit_example.py
+++ b/doc/source/serve/doc_code/production_fruit_example.py
@@ -9,8 +9,7 @@ from ray.serve.handle import RayServeDeploymentHandle
 from ray.serve.http_adapters import json_request
 
 # These imports are used only for type hints:
-from typing import Dict, List
-from starlette.requests import Request
+from typing import Dict
 
 
 @serve.deployment(num_replicas=2)
@@ -86,10 +85,6 @@ class PearStand:
 
     def check_price(self, amount: float) -> float:
         return self.price * amount
-
-
-async def json_resolver(request: Request) -> List:
-    return await request.json()
 
 
 with InputNode() as query:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

### What changed?
Removes unused lines in serve example

### Why?
In this example, there's already an imported json resolver `from ray.serve.http_adapters import json_request` such that these lines are unused.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
