### PR TITLE
[Datasets] Fix the get_name() for ParquetDatasource

### DIFF
--- a/python/ray/data/datasource/parquet_base_datasource.py
+++ b/python/ray/data/datasource/parquet_base_datasource.py
@@ -24,7 +24,7 @@ class ParquetBaseDatasource(FileBasedDatasource):
     def get_name(self):
         """Return a human-readable name for this datasource.
         This will be used as the names of the read tasks.
-        Note: overrides the base `Datasource` method.
+        Note: overrides the base `FileBasedDatasource` method.
         """
         return "ParquetBulk"
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -161,6 +161,13 @@ class ParquetDatasource(ParquetBaseDatasource):
         [{"a": 1, "b": "foo"}, ...]
     """
 
+    def get_name(self):
+        """Return a human-readable name for this datasource.
+        This will be used as the names of the read tasks.
+        Note: overrides the base `ParquetBaseDatasource` method.
+        """
+        return "Parquet"
+
     def create_reader(self, **kwargs):
         return _ParquetDatasourceReader(**kwargs)
 

--- a/python/ray/data/tests/test_dataset_parquet.py
+++ b/python/ray/data/tests/test_dataset_parquet.py
@@ -14,9 +14,11 @@ from ray.data.datasource import (
     DefaultFileMetadataProvider,
     DefaultParquetMetadataProvider,
 )
+from ray.data.datasource.parquet_base_datasource import ParquetBaseDatasource
 from ray.data.datasource.parquet_datasource import (
     PARALLELIZE_META_FETCH_THRESHOLD,
     _ParquetDatasourceReader,
+    ParquetDatasource,
 )
 from ray.data.datasource.file_based_datasource import _unwrap_protocol
 from ray.data.datasource.parquet_datasource import (
@@ -927,6 +929,11 @@ def test_parquet_reader_batch_size(ray_start_regular_shared, tmp_path):
     ray.data.range_tensor(1000, shape=(1000,)).write_parquet(path)
     ds = ray.data.read_parquet(path, batch_size=10)
     assert ds.count() == 1000
+
+
+def test_parquet_datasource_names(ray_start_regular_shared):
+    assert ParquetBaseDatasource().get_name() == "ParquetBulk"
+    assert ParquetDatasource().get_name() == "Parquet"
 
 
 # NOTE: All tests above share a Ray cluster, while the tests below do not. These

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -612,7 +612,7 @@ def test_optimize_callable_classes(shutdown_only, tmp_path):
         pipe,
         1,
         [
-            "ReadParquetBulk->MapBatches(CallableFn)->MapBatches(CallableFn)",
+            "ReadParquet->MapBatches(CallableFn)->MapBatches(CallableFn)",
         ],
     )
 
@@ -648,7 +648,7 @@ def test_optimize_callable_classes(shutdown_only, tmp_path):
         pipe,
         1,
         [
-            "ReadParquetBulk->MapBatches(<lambda>)->MapBatches(CallableFn)",
+            "ReadParquet->MapBatches(<lambda>)->MapBatches(CallableFn)",
         ],
     )
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -289,7 +289,7 @@ def test_dataset_stats_read_parquet(ray_start_regular_shared, tmp_path):
     if context.new_execution_backend:
         assert (
             stats
-            == """Stage N ReadParquetBulk->map: N/N blocks executed in T
+            == """Stage N ReadParquet->map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Uncovered the issue when doing https://github.com/ray-project/ray/pull/32896. Before this PR, `ParquetDatasource.get_name()` returns `ParquetBulk` by mistake, by inheriting from `ParquetBaseDatasource.get_name()` directly without overriding. This PR fixes the issue.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
