### PR TITLE
[Datasets] Improve performance of DefaultFileMetaProvider.

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -136,7 +136,7 @@ def _autodetect_parallelism(
     return parallelism, min_safe_parallelism
 
 
-def _estimate_avail_cpus(cur_pg: Optional["PlacementGroup"]) -> int:
+def _estimate_avail_cpus(cur_pg: Optional["PlacementGroup"] = None) -> int:
     """Estimates the available CPU parallelism for this Dataset in the cluster.
 
     If we aren't in a placement group, this is trivially the number of CPUs in the

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -136,7 +136,7 @@ def _autodetect_parallelism(
     return parallelism, min_safe_parallelism
 
 
-def _estimate_avail_cpus(cur_pg: Optional["PlacementGroup"] = None) -> int:
+def _estimate_avail_cpus(cur_pg: Optional["PlacementGroup"]) -> int:
     """Estimates the available CPU parallelism for this Dataset in the cluster.
 
     If we aren't in a placement group, this is trivially the number of CPUs in the

--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -421,8 +421,8 @@ def _expand_paths(
     # TODO(Clark): Group file paths by parent directory paths and do a prefix
     # fetch + client-side filter if the number of groups is << the total number of
     # paths?
-    # Only request 0.25 CPU since these tasks are I/O-bound.
-    num_cpus = 0.25
+    # Only request 0.5 CPU since these tasks are I/O-bound.
+    num_cpus = 0.5
     get_file_infos_remotely = cached_remote_fn(
         _get_file_infos_remotely,
         num_cpus=num_cpus,
@@ -434,7 +434,7 @@ def _expand_paths(
         # dominates the Ray task overhead while ensuring good parallelism.
         # Always launch at least 2 parallel fetch tasks.
         max(len(paths) // PATHS_PER_FILE_SIZE_FETCH_TASK, 2),
-        # Oversubscribe cluster CPU by 4x since these tasks are I/O-bound.
+        # Oversubscribe cluster CPU by 2x since these tasks are I/O-bound.
         round(available_cpus / num_cpus),
     )
     size_fetch_bar = ProgressBar("Metadata Fetch Progress", total=parallelism)

--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -406,10 +406,10 @@ def _expand_paths(
     # If parent directory (or base directory, if using partitioning) is common to all
     # paths, fetch all file infos at that prefix and filter the response to the provided
     # paths.
-    normalized_base_dir = _unwrap_protocol(partitioning.base_dir)
-    if (partitioning is not None and common_path == normalized_base_dir) or all(
-        str(pathlib.Path(path).parent) == common_path for path in paths
-    ):
+    if (
+        partitioning is not None
+        and common_path == _unwrap_protocol(partitioning.base_dir)
+    ) or all(str(pathlib.Path(path).parent) == common_path for path in paths):
         path_to_size = {path: 0 for path in paths}
         for path, file_size in _get_file_infos(common_path, filesystem):
             if path in path_to_size:

--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -397,7 +397,6 @@ def _expand_paths(
         # 2. Common path prefix case.
         # Get longest common path of all paths.
         common_path = os.path.commonpath(paths)
-        common_path = os.path.normpath(common_path)
         # If parent directory (or base directory, if using partitioning) is common to
         # all paths, fetch all file infos at that prefix and filter the response to the
         # provided paths.
@@ -411,9 +410,6 @@ def _expand_paths(
         # 3. Parallelization case.
         else:
             # Parallelize requests via Ray tasks.
-            # TODO(Clark): Group file paths by parent directory paths and do a prefix
-            # fetch + client-side filter if the number of groups is << the total number
-            # of paths?
             yield from _get_file_infos_parallel(paths, filesystem)
 
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 from typing import TYPE_CHECKING, Callable, Iterator, List, Optional, Union
 
@@ -18,7 +17,6 @@ from ray.data.datasource.file_meta_provider import (
     _handle_read_os_error,
 )
 from ray.data.datasource.parquet_base_datasource import ParquetBaseDatasource
-from ray.types import ObjectRef
 from ray.util.annotations import PublicAPI
 import ray.cloudpickle as cloudpickle
 
@@ -403,29 +401,8 @@ def _read_pieces(
         yield output_buffer.next()
 
 
-def _fetch_metadata_remotely(
-    pieces: List["pyarrow._dataset.ParquetFileFragment"],
-    **ray_remote_args,
-) -> List[ObjectRef["pyarrow.parquet.FileMetaData"]]:
-
-    remote_fetch_metadata = cached_remote_fn(_fetch_metadata_serialization_wrapper)
-    metas = []
-    parallelism = min(len(pieces) // PIECES_PER_META_FETCH, 100)
-    meta_fetch_bar = ProgressBar("Metadata Fetch Progress", total=parallelism)
-    for pcs in np.array_split(pieces, parallelism):
-        if len(pcs) == 0:
-            continue
-        metas.append(
-            remote_fetch_metadata.options(**ray_remote_args).remote(
-                [_SerializedPiece(p) for p in pcs]
-            )
-        )
-    metas = meta_fetch_bar.fetch_until_complete(metas)
-    return list(itertools.chain.from_iterable(metas))
-
-
 def _fetch_metadata_serialization_wrapper(
-    pieces: str,
+    pieces: _SerializedPiece,
 ) -> List["pyarrow.parquet.FileMetaData"]:
 
     pieces: List[

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -185,10 +185,12 @@ def write_partitioned_df():
         partition_keys,
         partition_path_encoder,
         file_writer_fn,
+        file_name_suffix="_1",
     ):
         import urllib.parse
 
         df_partitions = [df for _, df in df.groupby(partition_keys, as_index=False)]
+        paths = []
         for df_partition in df_partitions:
             partition_values = []
             for key in partition_keys:
@@ -197,12 +199,15 @@ def write_partitioned_df():
             partition_path_encoder.scheme.resolved_filesystem.create_dir(path)
             base_dir = partition_path_encoder.scheme.base_dir
             parsed_base_dir = urllib.parse.urlparse(base_dir)
+            file_name = f"test_{file_name_suffix}.tmp"
             if parsed_base_dir.scheme:
                 # replace the protocol removed by the partition path generator
-                path = posixpath.join(f"{parsed_base_dir.scheme}://{path}", "test.tmp")
+                path = posixpath.join(f"{parsed_base_dir.scheme}://{path}", file_name)
             else:
-                path = os.path.join(path, "test.tmp")
+                path = os.path.join(path, file_name)
             file_writer_fn(df_partition, path)
+            paths.append(path)
+        return paths
 
     yield _write_partitioned_df
 
@@ -260,7 +265,7 @@ def assert_base_partitioned_ds():
             ), f"{ds._plan.execute()._num_computed()} != {num_computed}"
 
         # Force a data read.
-        values = ds_take_transform_fn(ds.take())
+        values = ds_take_transform_fn(ds.take_all())
         if num_computed is not None:
             assert (
                 ds._plan.execute()._num_computed() == num_computed

--- a/python/ray/data/tests/test_dataset_csv.py
+++ b/python/ray/data/tests/test_dataset_csv.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import shutil
 from functools import partial
@@ -123,7 +124,7 @@ def test_csv_read(ray_start_regular_shared, fs, data_path, endpoint_url):
     ds = ray.data.read_csv(path, filesystem=fs, partitioning=None)
     df = pd.concat([df1, df2], ignore_index=True)
     dsdf = ds.to_pandas()
-    assert df.equals(dsdf)
+    pd.testing.assert_frame_equal(df, dsdf)
     if fs is None:
         shutil.rmtree(path)
     else:
@@ -257,6 +258,156 @@ def test_csv_read_meta_provider(
             filesystem=fs,
             meta_provider=BaseFileMetadataProvider(),
         )
+
+
+@pytest.mark.parametrize(
+    "fs,data_path,endpoint_url",
+    [
+        (None, lazy_fixture("local_path"), None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path"), None),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path"), lazy_fixture("s3_server")),
+    ],
+)
+def test_csv_read_many_files_basic(
+    ray_start_regular_shared,
+    fs,
+    data_path,
+    endpoint_url,
+):
+    if endpoint_url is None:
+        storage_options = {}
+    else:
+        storage_options = dict(client_kwargs=dict(endpoint_url=endpoint_url))
+
+    paths = []
+    dfs = []
+    for i in range(64):
+        df = pd.DataFrame({"one": list(range(i * 3, (i + 1) * 3))})
+        dfs.append(df)
+        path = os.path.join(data_path, f"test_{i}.csv")
+        paths.append(path)
+        df.to_csv(path, index=False, storage_options=storage_options)
+    ds = ray.data.read_csv(paths, filesystem=fs)
+
+    dsdf = ds.to_pandas()
+    df = pd.concat(dfs).reset_index(drop=True)
+    pd.testing.assert_frame_equal(df, dsdf)
+
+
+@pytest.mark.parametrize(
+    "fs,data_path,endpoint_url",
+    [
+        (None, lazy_fixture("local_path"), None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path"), None),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path"), lazy_fixture("s3_server")),
+    ],
+)
+def test_csv_read_many_files_partitioned(
+    ray_start_regular_shared,
+    fs,
+    data_path,
+    endpoint_url,
+    write_partitioned_df,
+    assert_base_partitioned_ds,
+):
+    if endpoint_url is None:
+        storage_options = {}
+    else:
+        storage_options = dict(client_kwargs=dict(endpoint_url=endpoint_url))
+
+    partition_keys = ["one"]
+    partition_path_encoder = PathPartitionEncoder.of(
+        base_dir=data_path,
+        field_names=partition_keys,
+        filesystem=fs,
+    )
+    paths = []
+    dfs = []
+    num_dfs = 16
+    num_rows = 6 * num_dfs
+    num_files = 2 * num_dfs
+    for i in range(num_dfs):
+        df = pd.DataFrame(
+            {"one": [1, 1, 1, 3, 3, 3], "two": list(range(6 * i, 6 * (i + 1)))}
+        )
+        df_paths = write_partitioned_df(
+            df,
+            partition_keys,
+            partition_path_encoder,
+            partial(df_to_csv, storage_options=storage_options, index=False),
+            file_name_suffix=i,
+        )
+        dfs.append(df)
+        paths.extend(df_paths)
+
+    ds = ray.data.read_csv(
+        paths,
+        filesystem=fs,
+        partitioning=partition_path_encoder.scheme,
+        parallelism=num_files,
+    )
+
+    assert_base_partitioned_ds(
+        ds,
+        count=num_rows,
+        num_input_files=num_files,
+        num_rows=num_rows,
+        schema="{one: int64, two: int64}",
+        num_computed=num_files,
+        sorted_values=sorted(
+            itertools.chain.from_iterable(
+                list(
+                    map(list, zip([1, 1, 1, 3, 3, 3], list(range(6 * i, 6 * (i + 1)))))
+                )
+                for i in range(num_dfs)
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "fs,data_path,endpoint_url",
+    [
+        (None, lazy_fixture("local_path"), None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path"), None),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path"), lazy_fixture("s3_server")),
+    ],
+)
+def test_csv_read_many_files_diff_dirs(
+    ray_start_regular_shared,
+    fs,
+    data_path,
+    endpoint_url,
+):
+    if endpoint_url is None:
+        storage_options = {}
+    else:
+        storage_options = dict(client_kwargs=dict(endpoint_url=endpoint_url))
+
+    dir1 = os.path.join(data_path, "dir1")
+    dir2 = os.path.join(data_path, "dir2")
+    if fs is None:
+        os.mkdir(dir1)
+        os.mkdir(dir2)
+    else:
+        fs.create_dir(_unwrap_protocol(dir1))
+        fs.create_dir(_unwrap_protocol(dir2))
+
+    paths = []
+    dfs = []
+    num_dfs = 32
+    for i, dir_path in enumerate([dir1, dir2]):
+        for j in range(num_dfs * i, num_dfs * (i + 1)):
+            df = pd.DataFrame({"one": list(range(3 * j, 3 * (j + 1)))})
+            dfs.append(df)
+            path = os.path.join(dir_path, f"test_{j}.csv")
+            paths.append(path)
+            df.to_csv(path, index=False, storage_options=storage_options)
+    ds = ray.data.read_csv(paths, filesystem=fs)
+
+    dsdf = ds.to_pandas()
+    df = pd.concat(dfs).reset_index(drop=True)
+    pd.testing.assert_frame_equal(df, dsdf)
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_dataset_csv.py
+++ b/python/ray/data/tests/test_dataset_csv.py
@@ -25,6 +25,7 @@ from ray.data.datasource import (
     PathPartitionFilter,
 )
 from ray.data.datasource.file_based_datasource import (
+    FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD,
     FileExtensionFilter,
     _unwrap_protocol,
 )
@@ -281,7 +282,8 @@ def test_csv_read_many_files_basic(
 
     paths = []
     dfs = []
-    for i in range(64):
+    num_dfs = 4 * FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD
+    for i in range(num_dfs):
         df = pd.DataFrame({"one": list(range(i * 3, (i + 1) * 3))})
         dfs.append(df)
         path = os.path.join(data_path, f"test_{i}.csv")
@@ -323,7 +325,7 @@ def test_csv_read_many_files_partitioned(
     )
     paths = []
     dfs = []
-    num_dfs = 16
+    num_dfs = FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD
     num_rows = 6 * num_dfs
     num_files = 2 * num_dfs
     for i in range(num_dfs):
@@ -395,7 +397,7 @@ def test_csv_read_many_files_diff_dirs(
 
     paths = []
     dfs = []
-    num_dfs = 32
+    num_dfs = 2 * FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD
     for i, dir_path in enumerate([dir1, dir2]):
         for j in range(num_dfs * i, num_dfs * (i + 1)):
             df = pd.DataFrame({"one": list(range(3 * j, 3 * (j + 1)))})

--- a/python/ray/data/tests/test_metadata_provider.py
+++ b/python/ray/data/tests/test_metadata_provider.py
@@ -142,7 +142,9 @@ def test_default_parquet_metadata_provider(fs, data_path):
         ),
     ],
 )
-def test_default_file_metadata_provider(caplog, fs, data_path, endpoint_url):
+def test_default_file_metadata_provider(
+    propagate_logs, caplog, fs, data_path, endpoint_url
+):
     storage_options = (
         {}
         if endpoint_url is None
@@ -193,6 +195,7 @@ def test_default_file_metadata_provider(caplog, fs, data_path, endpoint_url):
     ],
 )
 def test_default_file_metadata_provider_many_files_basic(
+    propagate_logs,
     caplog,
     fs,
     data_path,
@@ -245,6 +248,7 @@ def test_default_file_metadata_provider_many_files_basic(
     ],
 )
 def test_default_file_metadata_provider_many_files_partitioned(
+    propagate_logs,
     caplog,
     fs,
     data_path,
@@ -319,6 +323,8 @@ def test_default_file_metadata_provider_many_files_partitioned(
     ],
 )
 def test_default_file_metadata_provider_many_files_diff_dirs(
+    ray_start_regular,
+    propagate_logs,
     caplog,
     fs,
     data_path,
@@ -388,7 +394,9 @@ def test_default_file_metadata_provider_many_files_diff_dirs(
         ),
     ],
 )
-def test_fast_file_metadata_provider(caplog, fs, data_path, endpoint_url):
+def test_fast_file_metadata_provider(
+    propagate_logs, caplog, fs, data_path, endpoint_url
+):
     storage_options = (
         {}
         if endpoint_url is None

--- a/python/ray/data/tests/test_metadata_provider.py
+++ b/python/ray/data/tests/test_metadata_provider.py
@@ -1,14 +1,26 @@
+from functools import partial
+import logging
+import os
 import pytest
 import posixpath
+from unittest.mock import patch
 import urllib.parse
-import os
-import logging
 
 import pyarrow as pa
+from pyarrow.fs import LocalFileSystem
 import pandas as pd
 import pyarrow.parquet as pq
 from pytest_lazyfixture import lazy_fixture
-from ray.data.datasource.file_based_datasource import _resolve_paths_and_filesystem
+from ray.data.datasource.file_based_datasource import (
+    FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD,
+    _resolve_paths_and_filesystem,
+    _unwrap_protocol,
+)
+from ray.data.datasource.file_meta_provider import (
+    _get_file_infos_serial,
+    _get_file_infos_common_path_prefix,
+    _get_file_infos_parallel,
+)
 
 from ray.tests.conftest import *  # noqa
 from ray.data.datasource import (
@@ -18,9 +30,14 @@ from ray.data.datasource import (
     DefaultFileMetadataProvider,
     DefaultParquetMetadataProvider,
     FastFileMetadataProvider,
+    PathPartitionEncoder,
 )
 
 from ray.data.tests.conftest import *  # noqa
+
+
+def df_to_csv(dataframe, path, **kwargs):
+    dataframe.to_csv(path, **kwargs)
 
 
 def _get_parquet_file_meta_size_bytes(file_metas):
@@ -144,8 +161,12 @@ def test_default_file_metadata_provider(caplog, fs, data_path, endpoint_url):
     df2.to_csv(path2, index=False, storage_options=storage_options)
 
     meta_provider = DefaultFileMetadataProvider()
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.WARNING), patch(
+        "ray.data.datasource.file_meta_provider._get_file_infos_serial",
+        wraps=_get_file_infos_serial,
+    ) as mock_get:
         file_paths, file_sizes = map(list, zip(*meta_provider.expand_paths(paths, fs)))
+    mock_get.assert_called_once_with(paths, fs)
     assert "meta_provider=FastFileMetadataProvider()" in caplog.text
     assert file_paths == paths
     expected_file_sizes = _get_file_sizes_bytes(paths, fs)
@@ -162,6 +183,191 @@ def test_default_file_metadata_provider(caplog, fs, data_path, endpoint_url):
     assert len(paths) == 2
     assert all(path in meta.input_files for path in paths)
     assert meta.schema is None
+
+
+@pytest.mark.parametrize(
+    "fs,data_path,endpoint_url",
+    [
+        (lazy_fixture("local_fs"), lazy_fixture("local_path"), None),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path"), lazy_fixture("s3_server")),
+    ],
+)
+def test_default_file_metadata_provider_many_files_basic(
+    caplog,
+    fs,
+    data_path,
+    endpoint_url,
+):
+    if endpoint_url is None:
+        storage_options = {}
+    else:
+        storage_options = dict(client_kwargs=dict(endpoint_url=endpoint_url))
+
+    paths = []
+    dfs = []
+    num_dfs = 4 * FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD
+    for i in range(num_dfs):
+        df = pd.DataFrame({"one": list(range(i * 3, (i + 1) * 3))})
+        dfs.append(df)
+        path = os.path.join(data_path, f"test_{i}.csv")
+        paths.append(path)
+        df.to_csv(path, index=False, storage_options=storage_options)
+    paths, fs = _resolve_paths_and_filesystem(paths, fs)
+
+    meta_provider = DefaultFileMetadataProvider()
+    if isinstance(fs, LocalFileSystem):
+        patcher = patch(
+            "ray.data.datasource.file_meta_provider._get_file_infos_serial",
+            wraps=_get_file_infos_serial,
+        )
+    else:
+        patcher = patch(
+            "ray.data.datasource.file_meta_provider._get_file_infos_common_path_prefix",
+            wraps=_get_file_infos_common_path_prefix,
+        )
+    with caplog.at_level(logging.WARNING), patcher as mock_get:
+        file_paths, file_sizes = map(list, zip(*meta_provider.expand_paths(paths, fs)))
+    if isinstance(fs, LocalFileSystem):
+        mock_get.assert_called_once_with(paths, fs)
+    else:
+        mock_get.assert_called_once_with(paths, _unwrap_protocol(data_path), fs)
+    assert "meta_provider=FastFileMetadataProvider()" in caplog.text
+    assert file_paths == paths
+    expected_file_sizes = _get_file_sizes_bytes(paths, fs)
+    assert file_sizes == expected_file_sizes
+
+
+@pytest.mark.parametrize(
+    "fs,data_path,endpoint_url",
+    [
+        (lazy_fixture("local_fs"), lazy_fixture("local_path"), None),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path"), lazy_fixture("s3_server")),
+    ],
+)
+def test_default_file_metadata_provider_many_files_partitioned(
+    caplog,
+    fs,
+    data_path,
+    endpoint_url,
+    write_partitioned_df,
+    assert_base_partitioned_ds,
+):
+    if endpoint_url is None:
+        storage_options = {}
+    else:
+        storage_options = dict(client_kwargs=dict(endpoint_url=endpoint_url))
+
+    partition_keys = ["one"]
+    partition_path_encoder = PathPartitionEncoder.of(
+        base_dir=data_path,
+        field_names=partition_keys,
+        filesystem=fs,
+    )
+    paths = []
+    dfs = []
+    num_dfs = FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD
+    for i in range(num_dfs):
+        df = pd.DataFrame(
+            {"one": [1, 1, 1, 3, 3, 3], "two": list(range(6 * i, 6 * (i + 1)))}
+        )
+        df_paths = write_partitioned_df(
+            df,
+            partition_keys,
+            partition_path_encoder,
+            partial(df_to_csv, storage_options=storage_options, index=False),
+            file_name_suffix=i,
+        )
+        dfs.append(df)
+        paths.extend(df_paths)
+    paths, fs = _resolve_paths_and_filesystem(paths, fs)
+    partitioning = partition_path_encoder.scheme
+
+    meta_provider = DefaultFileMetadataProvider()
+    if isinstance(fs, LocalFileSystem):
+        patcher = patch(
+            "ray.data.datasource.file_meta_provider._get_file_infos_serial",
+            wraps=_get_file_infos_serial,
+        )
+    else:
+        patcher = patch(
+            "ray.data.datasource.file_meta_provider._get_file_infos_common_path_prefix",
+            wraps=_get_file_infos_common_path_prefix,
+        )
+    with caplog.at_level(logging.WARNING), patcher as mock_get:
+        file_paths, file_sizes = map(
+            list, zip(*meta_provider.expand_paths(paths, fs, partitioning))
+        )
+    if isinstance(fs, LocalFileSystem):
+        mock_get.assert_called_once_with(paths, fs)
+    else:
+        mock_get.assert_called_once_with(
+            paths,
+            _unwrap_protocol(partitioning.base_dir),
+            fs,
+        )
+    assert "meta_provider=FastFileMetadataProvider()" in caplog.text
+    assert file_paths == paths
+    expected_file_sizes = _get_file_sizes_bytes(paths, fs)
+    assert file_sizes == expected_file_sizes
+
+
+@pytest.mark.parametrize(
+    "fs,data_path,endpoint_url",
+    [
+        (lazy_fixture("local_fs"), lazy_fixture("local_path"), None),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path"), lazy_fixture("s3_server")),
+    ],
+)
+def test_default_file_metadata_provider_many_files_diff_dirs(
+    caplog,
+    fs,
+    data_path,
+    endpoint_url,
+):
+    if endpoint_url is None:
+        storage_options = {}
+    else:
+        storage_options = dict(client_kwargs=dict(endpoint_url=endpoint_url))
+
+    dir1 = os.path.join(data_path, "dir1")
+    dir2 = os.path.join(data_path, "dir2")
+    if fs is None:
+        os.mkdir(dir1)
+        os.mkdir(dir2)
+    else:
+        fs.create_dir(_unwrap_protocol(dir1))
+        fs.create_dir(_unwrap_protocol(dir2))
+
+    paths = []
+    dfs = []
+    num_dfs = 2 * FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD
+    for i, dir_path in enumerate([dir1, dir2]):
+        for j in range(num_dfs * i, num_dfs * (i + 1)):
+            df = pd.DataFrame({"one": list(range(3 * j, 3 * (j + 1)))})
+            dfs.append(df)
+            path = os.path.join(dir_path, f"test_{j}.csv")
+            paths.append(path)
+            df.to_csv(path, index=False, storage_options=storage_options)
+    paths, fs = _resolve_paths_and_filesystem(paths, fs)
+
+    meta_provider = DefaultFileMetadataProvider()
+    if isinstance(fs, LocalFileSystem):
+        patcher = patch(
+            "ray.data.datasource.file_meta_provider._get_file_infos_serial",
+            wraps=_get_file_infos_serial,
+        )
+    else:
+        patcher = patch(
+            "ray.data.datasource.file_meta_provider._get_file_infos_parallel",
+            wraps=_get_file_infos_parallel,
+        )
+    with caplog.at_level(logging.WARNING), patcher as mock_get:
+        file_paths, file_sizes = map(list, zip(*meta_provider.expand_paths(paths, fs)))
+    mock_get.assert_called_once_with(paths, fs)
+    assert "meta_provider=FastFileMetadataProvider()" in caplog.text
+    assert file_paths == paths
+    expected_file_sizes = _get_file_sizes_bytes(paths, fs)
+    assert file_sizes == expected_file_sizes
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_metadata_provider.py
+++ b/python/ray/data/tests/test_metadata_provider.py
@@ -145,7 +145,7 @@ def test_default_file_metadata_provider(caplog, fs, data_path, endpoint_url):
 
     meta_provider = DefaultFileMetadataProvider()
     with caplog.at_level(logging.WARNING):
-        file_paths, file_sizes = meta_provider.expand_paths(paths, fs)
+        file_paths, file_sizes = map(list, zip(*meta_provider.expand_paths(paths, fs)))
     assert "meta_provider=FastFileMetadataProvider()" in caplog.text
     assert file_paths == paths
     expected_file_sizes = _get_file_sizes_bytes(paths, fs)
@@ -202,7 +202,7 @@ def test_fast_file_metadata_provider(caplog, fs, data_path, endpoint_url):
 
     meta_provider = FastFileMetadataProvider()
     with caplog.at_level(logging.WARNING):
-        file_paths, file_sizes = meta_provider.expand_paths(paths, fs)
+        file_paths, file_sizes = map(list, zip(*meta_provider.expand_paths(paths, fs)))
     assert "meta_provider=DefaultFileMetadataProvider()" in caplog.text
     assert file_paths == paths
     assert len(file_sizes) == len(file_paths)


### PR DESCRIPTION
This PR improves the performance of the `DefaultFileMetaProvider`. Previously, `DefaultFileMetaProvider` would serially expand and fetch the file size for a large list of directories and files, respectively. This PR optimizes this by parallelizing directory expansion and file size fetching over Ray tasks. Also, in the common case that all file paths share the same parent directory (or base directory, if using partitioning), we do a single `ListObjectsV2` call on the directory followed by a client-side filter, which reduces a 90 second parallel file size fetch to a 0.8 second request + client-side filter.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
