### PR TITLE
[tune] Raise warning (not an exception) if metadata file not found in checkpoint

### DIFF
--- a/python/ray/tune/trainable/util.py
+++ b/python/ray/tune/trainable/util.py
@@ -176,7 +176,7 @@ class TrainableUtil:
                 raise ValueError(
                     f"The checkpoint {basename} contains more than one metadata file. "
                     f"If this happened without manual intervention, please file an "
-                    f"issue at https://github.com/ray-project/ray/issues."
+                    f"issue at https://github.com/ray-project/ray/issues. "
                     f"Full path: {chkpt_dir}"
                 )
 

--- a/python/ray/tune/trainable/util.py
+++ b/python/ray/tune/trainable/util.py
@@ -148,9 +148,10 @@ class TrainableUtil:
         iter_chkpt_pairs = []
         for marker_path in marker_paths:
             chkpt_dir = os.path.dirname(marker_path)
+            basename = os.path.basename(chkpt_dir)
 
             # Skip temporary checkpoints
-            if os.path.basename(chkpt_dir).startswith("checkpoint_tmp"):
+            if basename.startswith("checkpoint_tmp"):
                 continue
 
             metadata_file = glob.glob(
@@ -162,9 +163,19 @@ class TrainableUtil:
                 os.path.join(glob.escape(chkpt_dir), _TUNE_METADATA_FILENAME)
             )
             metadata_file = list(set(metadata_file))  # avoid duplication
-            if len(metadata_file) != 1:
+            if len(metadata_file) == 0:
+                logger.warning(
+                    f"The checkpoint {basename} does not have a metadata file. "
+                    f"This usually means that the training process was interrupted "
+                    f"while the checkpoint was being written. The checkpoint will be "
+                    f"excluded from analysis. Consider deleting the directory. "
+                    f"Full path: {basename}"
+                )
+            elif len(metadata_file) > 1:
                 raise ValueError(
-                    "{} has zero or more than one tune_metadata.".format(chkpt_dir)
+                    f"The checkpoint {basename} contains more than one metadata file. "
+                    f"If this happened without manual intervention, please file an "
+                    f"issue at https://github.com/ray-project/ray/issues"
                 )
 
             metadata_file = metadata_file[0]

--- a/python/ray/tune/trainable/util.py
+++ b/python/ray/tune/trainable/util.py
@@ -171,6 +171,7 @@ class TrainableUtil:
                     f"excluded from analysis. Consider deleting the directory. "
                     f"Full path: {basename}"
                 )
+                continue
             elif len(metadata_file) > 1:
                 raise ValueError(
                     f"The checkpoint {basename} contains more than one metadata file. "

--- a/python/ray/tune/trainable/util.py
+++ b/python/ray/tune/trainable/util.py
@@ -169,14 +169,15 @@ class TrainableUtil:
                     f"This usually means that the training process was interrupted "
                     f"while the checkpoint was being written. The checkpoint will be "
                     f"excluded from analysis. Consider deleting the directory. "
-                    f"Full path: {basename}"
+                    f"Full path: {chkpt_dir}"
                 )
                 continue
             elif len(metadata_file) > 1:
                 raise ValueError(
                     f"The checkpoint {basename} contains more than one metadata file. "
                     f"If this happened without manual intervention, please file an "
-                    f"issue at https://github.com/ray-project/ray/issues"
+                    f"issue at https://github.com/ray-project/ray/issues."
+                    f"Full path: {chkpt_dir}"
                 )
 
             metadata_file = metadata_file[0]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If a trial is interrupted during checkpointing (e.g. with a timeout, or when firing an interrupt), a half-written checkpoint folder might be left. This checkpoint folder is not cleaned up automatically. If the trial was on the head node, and an ExperimentAnalysis object is subsequently created from the experiment path, the analysis object sometimes will search the local path for existing checkpoints. In that case, it will currently fail because no metadata file has been written.

The correct behavior is to ignore this half-written checkpoint directory. So instead of raising an exception, we should raise a warning instead and ignore the checkpoint.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
