### PR TITLE
Revert "[Data] Fix Ragged Tensor Documentation"

### DIFF
--- a/doc/BUILD
+++ b/doc/BUILD
@@ -28,13 +28,6 @@ py_test(
 )
 
 py_test(
-    name = "tensor",
-    size = "small",
-    srcs = ["source/data/doc_code/tensor.py"],
-    tags = ["exclusive", "team:ml"]
-)
-
-py_test(
     name = "big_data_ingestion",
     size = "small",
     main = "test_myst_doc.py",

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1268,14 +1268,6 @@ def from_pandas(
 
     if isinstance(dfs, pd.DataFrame):
         dfs = [dfs]
-
-    from ray.air.util.data_batch_conversion import (
-        _cast_ndarray_columns_to_tensor_extension,
-    )
-
-    context = DatasetContext.get_current()
-    if context.enable_tensor_extension_casting:
-        dfs = [_cast_ndarray_columns_to_tensor_extension(df) for df in dfs]
     return from_pandas_refs([ray.put(df) for df in dfs])
 
 

--- a/python/ray/data/tests/test_dataset_tf.py
+++ b/python/ray/data/tests/test_dataset_tf.py
@@ -7,6 +7,7 @@ import ray
 from ray.air import session
 from ray.air.config import ScalingConfig
 from ray.air.constants import TENSOR_COLUMN_NAME
+from ray.data.extensions import TensorArray
 from ray.data.preprocessors import Concatenator
 from ray.train.tensorflow import TensorflowTrainer
 
@@ -138,7 +139,7 @@ class TestToTF:
     def test_element_spec_shape_with_ragged_tensors(self, batch_size):
         df = pd.DataFrame(
             {
-                "spam": [np.zeros([32, 32, 3]), np.zeros([64, 64, 3])],
+                "spam": TensorArray([np.zeros([32, 32, 3]), np.zeros([64, 64, 3])]),
                 "ham": [0, 0],
             }
         )


### PR DESCRIPTION
Reverts ray-project/ray#33029

The PR in question breaks test_ope.
Afaics, test_ope uses the df as intended, but the df contains strings after casting it to Python integers.

The following two screenshots are taken from executing RLlib's broken test_ope script.
The code diverges in that the `df.astype(int)` operation behaves differently as can be seen in the screenhots:

What the df looks like after 552bbcf745fed53397d0cfe68483a7a568028596:
<img width="1047" alt="Screenshot 2023-03-08 at 05 56 42" src="https://user-images.githubusercontent.com/9356806/223731526-86c7303a-1e67-4ccc-8132-aca15244d6a0.png">

What the df looks like before 
<img width="1047" alt="Screenshot 2023-03-08 at 06 00 18" src="https://user-images.githubusercontent.com/9356806/223732376-21e77753-73ed-4b86-9502-052ea1e3853a.png">

I'm not fully aware of what the _automatic tensor casting to from_pandas API_ does, but I suspect that that is the problem rather than RLLib here.
