### PR TITLE
[Data] [Hotfix] Copy source DataFrame during tensor extension casting of `from_pandas`

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1275,7 +1275,7 @@ def from_pandas(
 
     context = DatasetContext.get_current()
     if context.enable_tensor_extension_casting:
-        dfs = [_cast_ndarray_columns_to_tensor_extension(df) for df in dfs]
+        dfs = [_cast_ndarray_columns_to_tensor_extension(df.copy()) for df in dfs]
     return from_pandas_refs([ray.put(df) for df in dfs])
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
#33029  added automatic tensor extension casting for the pandas API. However, tensor extension casting is in-place, so it would modify the source dataframe, if the users want to use in downstream tasks.

We instead `copy()` the source dataframe before casting to TensorArray, so the source dataframes are not affected.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
