### PR TITLE
[Docs] Replace sgboost link with author's pdf

### DIFF
--- a/doc/source/tune/examples/tune-xgboost.ipynb
+++ b/doc/source/tune/examples/tune-xgboost.ipynb
@@ -226,7 +226,7 @@
                 "\n",
                 "To address this fact, XGBoost uses a parameter called *Eta*, which is sometimes called\n",
                 "the *learning rate*. Don't confuse this with learning rates from gradient descent!\n",
-                "The original [paper on stochastic gradient boosting](https://www.sciencedirect.com/science/article/abs/pii/S0167947301000652)\n",
+                "The original [paper on stochastic gradient boosting](https://jerryfriedman.su.domains/ftp/stobst.pdf)\n",
                 "introduces this parameter like so:\n",
                 "\n",
                 "$$\n",


### PR DESCRIPTION
## Why are these changes needed?

The link in question get's a 403: 

This PR replaces it with a link to the author's personal website, where the original doc is published -> https://jerryfriedman.su.domains/ftp/stobst.pdf