### PR TITLE
[Doc] Add workaround to Serve docs for broken dependency

### DIFF
--- a/doc/source/serve/tutorials/batch.md
+++ b/doc/source/serve/tutorials/batch.md
@@ -200,7 +200,7 @@ TypeError: Descriptors cannot not be created directly.
      2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
 ```
 
-You can downgrade the protobuf package to 3.20.x or lower by using a [runtime environment](runtime-environments).
+You can downgrade the protobuf package to 3.20.x or lower in your Docker image, or tell Ray to do it at runtime by specifying a [runtime environment](runtime-environments):
 
 Open a new YAML file called `batch_env.yaml` for runtime environment.
 

--- a/doc/source/serve/tutorials/batch.md
+++ b/doc/source/serve/tutorials/batch.md
@@ -187,3 +187,30 @@ $ python tutorial_batch.py
 ```
 
 You should get a similar output like before!
+
+## Troubleshooting
+
+If you see the following error:
+
+```console
+TypeError: Descriptors cannot not be created directly.
+    If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
+    If you cannot immediately regenerate your protos, some other possible workarounds are:   
+     1. Downgrade the protobuf package to 3.20.x or lower.
+     2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
+```
+
+You can downgrade the protobuf package to 3.20.x or lower by using a [runtime environment](runtime-environments).
+
+Open a new YAML file called `batch_env.yaml` for runtime environment.
+
+```yaml
+pip:
+ - protobuf==3.20.3
+```
+
+Then, run the following command to deploy the model with the runtime environment.
+
+```console
+$ serve run --runtime-env batch_env.yaml tutorial_batch:generator
+```

--- a/doc/source/serve/tutorials/serve-ml-models.md
+++ b/doc/source/serve/tutorials/serve-ml-models.md
@@ -60,9 +60,15 @@ Now that we've defined our Serve deployment, let's prepare it so that it can be 
 `TFMnistModel.bind(TRAINED_MODEL_PATH)` binds the argument `TRAINED_MODEL_PATH` to our deployment and returns a `DeploymentNode` object (wrapping an `TFMnistModel` deployment object) that can then be used to connect with other `DeploymentNodes` to form a more complex [deployment graph](serve-model-composition-deployment-graph).
 :::
 
+Open a new YAML file called `tf_env.yaml` for runtime environment.
+```yaml
+pip:
+ - protobuf==3.20.3
+```
+
 Finally, we can deploy our model to Ray Serve through the terminal.
 ```console
-$ serve run tutorial_tensorflow:mnist_model
+$ serve run --runtime-env tf_env.yaml tutorial_tensorflow:mnist_model
 ```
 
 Let's query it! While Serve is running, open a separate terminal window, and run the following in an interactive Python shell or a separate Python script:

--- a/doc/source/serve/tutorials/serve-ml-models.md
+++ b/doc/source/serve/tutorials/serve-ml-models.md
@@ -77,7 +77,7 @@ TypeError: Descriptors cannot not be created directly.
      2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
 ```
 
-You can downgrade the protobuf package to 3.20.x or lower by using a [runtime environment](runtime-environments).
+You can downgrade the protobuf package to 3.20.x or lower in your Docker image, or tell Ray to do it at runtime by specifying a [runtime environment](runtime-environments):
 
 Open a new YAML file called `tf_env.yaml` for runtime environment.
 

--- a/doc/source/serve/tutorials/serve-ml-models.md
+++ b/doc/source/serve/tutorials/serve-ml-models.md
@@ -60,16 +60,39 @@ Now that we've defined our Serve deployment, let's prepare it so that it can be 
 `TFMnistModel.bind(TRAINED_MODEL_PATH)` binds the argument `TRAINED_MODEL_PATH` to our deployment and returns a `DeploymentNode` object (wrapping an `TFMnistModel` deployment object) that can then be used to connect with other `DeploymentNodes` to form a more complex [deployment graph](serve-model-composition-deployment-graph).
 :::
 
+Finally, we can deploy our model to Ray Serve through the terminal.
+
+```console
+$ serve run tutorial_tensorflow:mnist_model
+```
+
+:::{note}
+If you see the following error:
+
+```console
+TypeError: Descriptors cannot not be created directly.
+    If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
+    If you cannot immediately regenerate your protos, some other possible workarounds are:   
+     1. Downgrade the protobuf package to 3.20.x or lower.
+     2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
+```
+
+You can downgrade the protobuf package to 3.20.x or lower by using a [runtime environment](runtime-environments).
+
 Open a new YAML file called `tf_env.yaml` for runtime environment.
+
 ```yaml
 pip:
  - protobuf==3.20.3
 ```
 
-Finally, we can deploy our model to Ray Serve through the terminal.
+Then, run the following command to deploy the model with the runtime environment.
+
 ```console
 $ serve run --runtime-env tf_env.yaml tutorial_tensorflow:mnist_model
 ```
+
+:::
 
 Let's query it! While Serve is running, open a separate terminal window, and run the following in an interactive Python shell or a separate Python script:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The `protobuf` version in the latest Ray ML images is causing issues when importing certain libraries.  This is the second sub-issue of https://github.com/ray-project/ray/issues/32775.

This PR adds a `runtime_env`-based workaround to the Serve examples to unblock users if they run into this issue.  We will cherry pick this into the 2.3.1 branch and revert this PR on master once the underlying issue in the images is fixed on master.

This PR is based on https://github.com/ray-project/ray/pull/33024, thanks @kevin85421 for reporting and opening the PR!
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
