### PR TITLE
[RLlib] Remove checking config[no_local_replay_buffer]

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2690,7 +2690,7 @@ class Algorithm(Trainable):
             None, if local replay buffer is not needed.
         """
         if not config.get("replay_buffer_config") or config["replay_buffer_config"].get(
-            "no_local_replay_buffer" or config.get("no_local_replay_buffer")
+            "no_local_replay_buffer"
         ):
             return
 


### PR DESCRIPTION
## Why are these changes needed?

Removes a redundant check for config["no_local_replay_buffer"].
This check never worked, but is redundant anyway, because we copy over `config["no_local_replay_buffer"]` to `config["replay_buffer_config"]["no_local_replay_buffer"]` in the config validation anyways.

## Related issue number

Closes https://github.com/ray-project/ray/issues/32905
