### PR TITLE
[RLlib] fix printing framework instead of eager_tracing in debugging message

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -3060,7 +3060,7 @@ class AlgorithmConfig(_Config):
             # Recommend setting tracing to True for speedups.
             logger.info(
                 f"Executing eagerly (framework='{self.framework_str}'),"
-                f" with eager_tracing={self.framework_str}. For "
+                f" with eager_tracing={self.eager_tracing}. For "
                 "production workloads, make sure to set eager_tracing=True"
                 "  in order to match the speed of tf-static-graph "
                 "(framework='tf'). For debugging purposes, "


### PR DESCRIPTION
## Why are these changes needed?

We accidentally print out the framework string instead of the eager_tracing choice in Algorithm.

## Related issue number

Closes https://github.com/ray-project/ray/issues/33044