### PR TITLE
[RLlib] Fix Getting Started example never returning

### DIFF
--- a/doc/source/rllib/rllib-training.rst
+++ b/doc/source/rllib/rllib-training.rst
@@ -29,7 +29,7 @@ You can train DQN with the following commands:
 
     <div class="termynal" data-termynal>
         <span data-ty="input">pip install "ray[rllib]" tensorflow</span>
-        <span data-ty="input">rllib train --algo DQN --env CartPole-v1</span>
+        <span data-ty="input">rllib train --algo DQN --env CartPole-v1 --stop  '{"training_iteration": 30}'</span>
     </div>
 
 .. margin::
@@ -43,7 +43,7 @@ RLlib supports any Farama-Foundation Gymnasium environment, as well as a number 
 It also supports a large number of algorithms (see :ref:`rllib-algorithms-doc`) to
 choose from.
 
-Running the above will return one of the `checkpoints` that get generated during training,
+Running the above will return one of the `checkpoints` that get generated during training after 30 training iterations,
 as well as a command that you can use to evaluate the trained algorithm.
 You can evaluate the trained algorithm with the following command (assuming the checkpoint path is called ``checkpoint``):
 


### PR DESCRIPTION
## Why are these changes needed?

The example code in question has no stopping condition and is confusing to users.
It simply runs forever and does not fit the text below it, since simply aborting it at some point does not return the checkpoint ->
<img width="1554" alt="Screenshot 2023-03-08 at 11 56 49" src="https://user-images.githubusercontent.com/9356806/223832488-08083341-395e-4357-bf64-d291de66e5aa.png">

This PR makes it so that it does return after 30 iterations (200-300 secs) and should achieve rewards over 100.

## Related issue number

Closes https://github.com/ray-project/ray/issues/32979
