### PR TITLE
[Datasets] Make telemetry record usage by default

### DIFF
--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -113,7 +113,7 @@ def _get_execution_dag(
 ) -> Tuple[PhysicalOperator, DatasetStats]:
     """Get the physical operators DAG from a plan."""
     # Record usage of logical operators if available.
-    if plan._logical_plan is not None:
+    if hasattr(plan, "_logical_plan") and plan._logical_plan is not None:
         record_operators_usage(plan._logical_plan.dag)
 
     # Get DAG of physical operators and input statistics.

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -30,7 +30,6 @@ from ray.data._internal.execution.operators.all_to_all_operator import AllToAllO
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.interfaces import (
     Executor,
-    OutputIterator,
     PhysicalOperator,
     RefBundle,
     TaskContext,

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -8,6 +8,7 @@ from typing import Iterator, Tuple, Any
 
 import ray
 from ray.data._internal.logical.optimizers import get_execution_plan
+from ray.data._internal.logical.util import record_operators_usage
 from ray.data.context import DatasetContext
 from ray.types import ObjectRef
 from ray.data.block import Block, BlockMetadata, List
@@ -29,6 +30,7 @@ from ray.data._internal.execution.operators.all_to_all_operator import AllToAllO
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.interfaces import (
     Executor,
+    OutputIterator,
     PhysicalOperator,
     RefBundle,
     TaskContext,
@@ -71,19 +73,9 @@ def execute_to_legacy_bundle_iterator(
     Returns:
         The output as a bundle iterator.
     """
-
-    if DatasetContext.get_current().optimizer_enabled:
-        dag, stats = get_execution_plan(plan._logical_plan).dag, None
-    else:
-        dag, stats = _to_operator_dag(plan, allow_clear_input_blocks)
+    dag, stats = _get_execution_dag(executor, plan, allow_clear_input_blocks)
     if dag_rewrite:
         dag = dag_rewrite(dag)
-
-    # Enforce to preserve ordering if the plan has stages required to do so, such as
-    # Zip and Sort.
-    # TODO(chengsu): implement this for operator as well.
-    if plan.require_preserve_order():
-        executor._options.preserve_order = True
 
     bundle_iter = executor.execute(dag, initial_stats=stats)
     return bundle_iter
@@ -106,6 +98,25 @@ def execute_to_legacy_block_list(
     Returns:
         The output as a legacy block list.
     """
+    dag, stats = _get_execution_dag(executor, plan, allow_clear_input_blocks)
+    bundles = executor.execute(dag, initial_stats=stats)
+    block_list = _bundles_to_block_list(bundles)
+    # Set the stats UUID after execution finishes.
+    _set_stats_uuid_recursive(executor.get_stats(), dataset_uuid)
+    return block_list
+
+
+def _get_execution_dag(
+    executor: Executor,
+    plan: ExecutionPlan,
+    allow_clear_input_blocks: bool,
+) -> Tuple[PhysicalOperator, DatasetStats]:
+    """Get the physical operators DAG from a plan."""
+    # Record usage of logical operators if available.
+    if plan._logical_plan is not None:
+        record_operators_usage(plan._logical_plan.dag)
+
+    # Get DAG of physical operators and input statistics.
     if DatasetContext.get_current().optimizer_enabled:
         dag, stats = get_execution_plan(plan._logical_plan).dag, None
     else:
@@ -117,16 +128,12 @@ def execute_to_legacy_block_list(
     if plan.require_preserve_order():
         executor._options.preserve_order = True
 
-    bundles = executor.execute(dag, initial_stats=stats)
-    block_list = _bundles_to_block_list(bundles)
-    # Set the stats UUID after execution finishes.
-    _set_stats_uuid_recursive(executor.get_stats(), dataset_uuid)
-    return block_list
+    return dag, stats
 
 
 def _to_operator_dag(
     plan: ExecutionPlan, allow_clear_input_blocks: bool
-) -> (PhysicalOperator, DatasetStats):
+) -> Tuple[PhysicalOperator, DatasetStats]:
     """Translate a plan into an operator DAG for the new execution backend."""
 
     blocks, stats, stages = plan._optimize()

--- a/python/ray/data/_internal/logical/optimizers.py
+++ b/python/ray/data/_internal/logical/optimizers.py
@@ -10,7 +10,6 @@ from ray.data._internal.logical.rules import (
     OperatorFusionRule,
     ReorderRandomizeBlocksRule,
 )
-from ray.data._internal.logical.util import record_operators_usage
 from ray.data._internal.planner.planner import Planner
 
 
@@ -38,9 +37,6 @@ def get_execution_plan(logical_plan: LogicalPlan) -> PhysicalPlan:
     (2) planning: convert logical to physical operators.
     (3) physical optimization: optimize physical operators.
     """
-    # Record usage of logical operators.
-    record_operators_usage(logical_plan.dag)
-
     logical_plan = LogicalOptimizer().optimize(logical_plan)
     physical_plan = Planner().plan(logical_plan)
     return PhysicalOptimizer().optimize(physical_plan)

--- a/python/ray/data/_internal/logical/util.py
+++ b/python/ray/data/_internal/logical/util.py
@@ -45,6 +45,8 @@ _op_name_white_list = [
     "Repartition",
     "Sort",
     "Aggregate",
+    # N-ary
+    "Zip",
 ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
https://github.com/ray-project/ray/pull/32896/ added Ray telemetry as part of optimizer. This PR is to make the telemetry record usage by default even when optimizer is not enabled, so we can start collecting metrics for Ray 2.4, without coupling with optimizer rollout.

Also add unit test in `test_execution_optimizer.py` for telemetry usage recording.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
