### PR TITLE
[Datasets] Remove the class `Write(AbstractUDFMap)`

### DIFF
--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -142,26 +142,6 @@ class MapRows(AbstractUDFMap):
         )
 
 
-class Write(AbstractUDFMap):
-    """Logical operator for write."""
-
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        datasource: Datasource,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-        **write_args,
-    ):
-        super().__init__(
-            "Write",
-            input_op,
-            fn=lambda x: x,
-            ray_remote_args=ray_remote_args,
-        )
-        self._datasource = datasource
-        self._write_args = write_args
-
-
 class Filter(AbstractUDFMap):
     """Logical operator for filter."""
 

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -8,7 +8,6 @@ from ray.data._internal.compute import (
 )
 from ray.data.block import BatchUDF, RowUDF
 from ray.data.context import DEFAULT_BATCH_SIZE
-from ray.data.datasource import Datasource
 
 
 if sys.version_info >= (3, 8):

--- a/python/ray/data/_internal/logical/util.py
+++ b/python/ray/data/_internal/logical/util.py
@@ -5,7 +5,7 @@ import threading
 from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
 from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data._internal.logical.operators.read_operator import Read
-from ray.data._internal.logical.operators.map_operator import Write
+from ray.data._internal.logical.operators.write_operator import Write
 
 # The dictionary for the operator name and count.
 _recorded_operators = dict()
@@ -70,7 +70,7 @@ def _collect_operators_to_dict(op: LogicalOperator, ops_dict: Dict[str, int]):
     op_name = op.name
 
     # Check read and write operator, and anonymize user-defined data source.
-    if isinstance(op, Read) or isinstance(op, Write):
+    if isinstance(op, Read):
         op_name = f"Read{op._datasource.get_name()}"
         if op_name not in _op_name_white_list:
             op_name = "ReadCustom"

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -14,7 +14,6 @@ from ray.data._internal.logical.operators.map_operator import (
     FlatMap,
     MapBatches,
     MapRows,
-    Write,
 )
 from ray.data._internal.planner.filter import generate_filter_fn
 from ray.data._internal.planner.flat_map import generate_flat_map_fn
@@ -45,8 +44,6 @@ def _plan_udf_map_op(
         transform_fn = generate_flat_map_fn()
     elif isinstance(op, Filter):
         transform_fn = generate_filter_fn()
-    elif isinstance(op, Write):
-        transform_fn = generate_write_fn(op._datasource, **op._write_args)
     else:
         raise ValueError(f"Found unknown logical operator during planning: {op}")
 

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -19,7 +19,6 @@ from ray.data._internal.planner.filter import generate_filter_fn
 from ray.data._internal.planner.flat_map import generate_flat_map_fn
 from ray.data._internal.planner.map_batches import generate_map_batches_fn
 from ray.data._internal.planner.map_rows import generate_map_rows_fn
-from ray.data._internal.planner.write import generate_write_fn
 from ray.data.block import Block, CallableClass
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
When adding unit test for https://github.com/ray-project/ray/pull/33168, found out we still have a `Write(AbstractUDFMap)` class. We should delete this one, as we already have a [`Write(AbstractMap)` class](https://github.com/ray-project/ray/blob/master/python/ray/data/_internal/logical/operators/write_operator.py).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
