### PR TITLE
[Datasets] Remove the assertion for ds.stats() in test_dataset_image.py

### DIFF
--- a/python/ray/data/tests/test_dataset_image.py
+++ b/python/ray/data/tests/test_dataset_image.py
@@ -193,12 +193,10 @@ class TestReadImages:
             ds.fully_executed()
             # Verify dynamic block splitting taking effect to generate more blocks.
             assert ds.num_blocks() == 3
-            wait_for_condition(lambda: "3 blocks executed" in ds.stats(), timeout=20)
 
             # Test union of same datasets
             union_ds = ds.union(ds, ds, ds).fully_executed()
             assert union_ds.num_blocks() == 12
-            assert "3 blocks executed" in union_ds.stats()
         finally:
             ctx.target_max_block_size = target_max_block_size
             ctx.block_splitting_enabled = block_splitting_enabled

--- a/python/ray/data/tests/test_dataset_image.py
+++ b/python/ray/data/tests/test_dataset_image.py
@@ -17,7 +17,6 @@ from ray.data.extensions import ArrowTensorType
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.mock_http_server import *  # noqa
 from ray.tests.conftest import *  # noqa
-from ray._private.test_utils import wait_for_condition
 
 
 class TestReadImages:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The test is very flaky and it's because the async nature from StatsActor for ds.stats() call ([some discssuion in the past](https://github.com/ray-project/ray/pull/29635#discussion_r1018409717)). We can remove the assertion here because the assertion of `ds.num_blocks()` is enough, and we have separate test file stats - `test_stats.py`.

<img width="1632" alt="Screen Shot 2023-03-09 at 11 12 29 AM" src="https://user-images.githubusercontent.com/4629931/224130830-1a891bbe-1a05-484b-9d8a-916ac400d905.png">



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
