### PR TITLE
ray.util.tracing.tracing_helper is using deprecated functions

### DIFF
--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -202,9 +202,7 @@ def _function_hydrate_span_args(func: Callable[..., Any]):
 
     # We only get task ID for workers
     if ray._private.worker.global_worker.mode == ray._private.worker.WORKER_MODE:
-        task_id = (
-            runtime_context.get_task_id()
-        )
+        task_id = runtime_context.get_task_id()
         if task_id:
             span_args["ray.task_id"] = task_id
 
@@ -253,9 +251,7 @@ def _actor_hydrate_span_args(class_: _nameable, method: _nameable):
 
     # We only get actor ID for workers
     if ray._private.worker.global_worker.mode == ray._private.worker.WORKER_MODE:
-        actor_id = (
-            runtime_context.get_actor_id()
-        )
+        actor_id = runtime_context.get_actor_id()
 
         if actor_id:
             span_args["ray.actor_id"] = actor_id

--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -190,20 +190,20 @@ def _use_context(
 def _function_hydrate_span_args(func: Callable[..., Any]):
     """Get the Attributes of the function that will be reported as attributes
     in the trace."""
-    runtime_context = get_runtime_context().get()
+    runtime_context = get_runtime_context()
 
     span_args = {
         "ray.remote": "function",
         "ray.function": func,
         "ray.pid": str(os.getpid()),
-        "ray.job_id": runtime_context["job_id"].hex(),
-        "ray.node_id": runtime_context["node_id"].hex(),
+        "ray.job_id": runtime_context.get_job_id(),
+        "ray.node_id": runtime_context.get_node_id(),
     }
 
     # We only get task ID for workers
     if ray._private.worker.global_worker.mode == ray._private.worker.WORKER_MODE:
         task_id = (
-            runtime_context["task_id"].hex() if runtime_context.get("task_id") else None
+            runtime_context.get_task_id()
         )
         if task_id:
             span_args["ray.task_id"] = task_id
@@ -239,7 +239,7 @@ def _actor_hydrate_span_args(class_: _nameable, method: _nameable):
     if callable(method):
         method = method.__name__
 
-    runtime_context = get_runtime_context().get()
+    runtime_context = get_runtime_context()
 
     span_args = {
         "ray.remote": "actor",
@@ -247,16 +247,14 @@ def _actor_hydrate_span_args(class_: _nameable, method: _nameable):
         "ray.actor_method": method,
         "ray.function": f"{class_}.{method}",
         "ray.pid": str(os.getpid()),
-        "ray.job_id": runtime_context["job_id"].hex(),
-        "ray.node_id": runtime_context["node_id"].hex(),
+        "ray.job_id": runtime_context.get_job_id(),
+        "ray.node_id": runtime_context.get_node_id(),
     }
 
     # We only get actor ID for workers
     if ray._private.worker.global_worker.mode == ray._private.worker.WORKER_MODE:
         actor_id = (
-            runtime_context["actor_id"].hex()
-            if runtime_context.get("actor_id")
-            else None
+            runtime_context.get_actor_id()
         )
 
         if actor_id:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`ray.runtime_context.get_runtime_context().get()` is deprecated, but is used in `tracing_helper.py`

## Related issue number

#32987 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
