### PR TITLE
Add prefetch stats

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -223,6 +223,16 @@ class DatasetStats:
         self.iter_total_s: Timer = Timer()
         self.extra_metrics = {}
 
+        # Block fetch stats during iteration.
+        # These are stats about locations of blocks when the iterator is trying to
+        # consume them. The iteration performance will be affected depending on
+        # whether the block is in the local object store of the node where the
+        # iterator is running.
+        # This serves as an indicator of block prefetching effectiveness.
+        self.iter_blocks_local: int = 0
+        self.iter_blocks_remote: int = 0
+        self.iter_unknown_location: int = 0
+
     @property
     def stats_actor(self):
         return _get_or_create_stats_actor()
@@ -279,6 +289,9 @@ class DatasetStats:
             self.iter_format_batch_s,
             self.iter_user_s,
             self.iter_total_s,
+            self.iter_blocks_local,
+            self.iter_blocks_remote,
+            self.iter_unknown_location,
         )
         stats_summary_parents = []
         if self.parents is not None:
@@ -616,6 +629,12 @@ class IterStatsSummary:
     user_time: Timer
     # Total time taken by Dataset iterator, in seconds
     total_time: Timer
+    # Num of blocks that are in local object store
+    iter_blocks_local: int
+    # Num of blocks that are in remote node and have to fetch locally
+    iter_blocks_remote: int
+    # Num of blocks with unknown locations
+    iter_unknown_location: int
 
     def __str__(self) -> str:
         out = ""
@@ -629,6 +648,11 @@ class IterStatsSummary:
             out += "\nDataset iterator time breakdown:\n"
             out += "* In ray.wait(): {}\n".format(fmt(self.wait_time.get()))
             out += "* In ray.get(): {}\n".format(fmt(self.get_time.get()))
+            out += "* Num blocks fetch locally: {}\n".format(self.iter_blocks_local)
+            out += "* Num blocks fetch remotely: {}\n".format(self.iter_blocks_remote)
+            out += "* Num blocks unknown location: {}\n".format(
+                self.iter_unknown_location
+            )
             out += "* In next_batch(): {}\n".format(fmt(self.next_time.get()))
             out += "* In format_batch(): {}\n".format(fmt(self.format_time.get()))
             out += "* In user code: {}\n".format(fmt(self.user_time.get()))

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -648,8 +648,8 @@ class IterStatsSummary:
             out += "\nDataset iterator time breakdown:\n"
             out += "* In ray.wait(): {}\n".format(fmt(self.wait_time.get()))
             out += "* In ray.get(): {}\n".format(fmt(self.get_time.get()))
-            out += "* Num blocks fetch locally: {}\n".format(self.iter_blocks_local)
-            out += "* Num blocks fetch remotely: {}\n".format(self.iter_blocks_remote)
+            out += "* Num blocks local: {}\n".format(self.iter_blocks_local)
+            out += "* Num blocks remote: {}\n".format(self.iter_blocks_remote)
             out += "* Num blocks unknown location: {}\n".format(
                 self.iter_unknown_location
             )

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -161,6 +161,9 @@ Stage N map: N/N blocks executed in T
 Dataset iterator time breakdown:
 * In ray.wait(): T
 * In ray.get(): T
+* Num blocks local: Z
+* Num blocks remote: Z
+* Num blocks unknown location: N
 * In next_batch(): T
 * In format_batch(): T
 * In user code: T
@@ -913,6 +916,9 @@ def test_streaming_stats_full(ray_start_regular_shared, restore_dataset_context)
 Dataset iterator time breakdown:
 * In ray.wait(): T
 * In ray.get(): T
+* Num blocks local: Z
+* Num blocks remote: Z
+* Num blocks unknown location: N
 * In next_batch(): T
 * In format_batch(): T
 * In user code: T


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Block prefetching in on the critical path of performance. We saw most users will check this path in performance troubleshooting. So it's important to have visibility in the block fetch stats in iteration.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/24350
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
