### PR TITLE
2.3.0 performance release logs

### DIFF
--- a/release/release_logs/2.3.0/benchmarks/many_actors.json
+++ b/release/release_logs/2.3.0/benchmarks/many_actors.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 518.770688,
+    "_dashboard_test_success": true,
+    "_peak_memory": 3.58,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n291\t1.75GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2427\t0.85GiB\tpython distributed/test_many_actors.py\n464\t0.31GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n47\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n764\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n2648\t0.07GiB\tray::DashboardTester.run\n44\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-notebook --NotebookApp.token=aph0_CkY\n2564\t0.06GiB\tray::MemoryMonitorActor.run\n391\t0.05GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.206.170:9031 --host=0.0.0.\n663\t0.05GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/log_m",
+    "actors_per_second": 777.2062125146554,
+    "num_actors": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "actors_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 777.2062125146554
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 30.356
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 1313.017
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4925.524
+        }
+    ],
+    "success": "1",
+    "time": 12.866598129272461
+}

--- a/release/release_logs/2.3.0/benchmarks/many_nodes.json
+++ b/release/release_logs/2.3.0/benchmarks/many_nodes.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 253.00992,
+    "_dashboard_test_success": true,
+    "_peak_memory": 1.92,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n291\t0.74GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n464\t0.22GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n3086\t0.2GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n47\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n764\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n3386\t0.07GiB\tray::StateAPIGeneratorActor.start\n3308\t0.07GiB\tray::DashboardTester.run\n3221\t0.07GiB\tray::MemoryMonitorActor.run\n44\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-notebook --NotebookApp.token=agh0_Ckg\n391\t0.05GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.167.22:9031 --host=0.0.0.0",
+    "num_tasks": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 219.0605760959142
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 250.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.356
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 44.061
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 152.793
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 219.0605760959142,
+    "time": 304.5649473667145,
+    "used_cpus": 250.0
+}

--- a/release/release_logs/2.3.0/benchmarks/many_pgs.json
+++ b/release/release_logs/2.3.0/benchmarks/many_pgs.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 241.78688,
+    "_dashboard_test_success": true,
+    "_peak_memory": 2.37,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n291\t1.07GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2413\t0.4GiB\tpython distributed/test_many_pgs.py\n464\t0.21GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n47\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n590\t0.08GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=\n764\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n2551\t0.06GiB\tray::MemoryMonitorActor.run\n2634\t0.06GiB\tray::DashboardTester.run\n44\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-notebook --NotebookApp.token=aph0_Ckc\n391\t0.05GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.255.206:9031 --host=0.0.0.",
+    "num_pgs": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "pgs_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 17.89601570164703
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.192
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 12.196
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 149.699
+        }
+    ],
+    "pgs_per_second": 17.89601570164703,
+    "success": "1",
+    "time": 55.87835955619812
+}

--- a/release/release_logs/2.3.0/benchmarks/many_tasks.json
+++ b/release/release_logs/2.3.0/benchmarks/many_tasks.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 498.393088,
+    "_dashboard_test_success": true,
+    "_peak_memory": 4.39,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n291\t2.09GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2422\t0.86GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n464\t0.59GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n2644\t0.1GiB\tray::DashboardTester.run\n47\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n765\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n2710\t0.07GiB\tray::StateAPIGeneratorActor.start\n2560\t0.06GiB\tray::MemoryMonitorActor.run\n44\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-notebook --NotebookApp.token=aph0_CkY\n391\t0.05GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.223.72:9031 --host=0.0.0.0",
+    "num_tasks": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 210.67184928063165
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2500.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.985
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 665.858
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 1404.251
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 210.67184928063165,
+    "time": 347.46718668937683,
+    "used_cpus": 2500.0
+}

--- a/release/release_logs/2.3.0/microbenchmark.json
+++ b/release/release_logs/2.3.0/microbenchmark.json
@@ -1,0 +1,283 @@
+{
+    "1_1_actor_calls_async": [
+        8266.227716717382,
+        154.83431912796019
+    ],
+    "1_1_actor_calls_concurrent": [
+        4822.515544345499,
+        69.03417417619077
+    ],
+    "1_1_actor_calls_sync": [
+        2326.919630897046,
+        18.048639582599087
+    ],
+    "1_1_async_actor_calls_async": [
+        3472.864053257764,
+        18.492804155673895
+    ],
+    "1_1_async_actor_calls_sync": [
+        1600.088775357745,
+        41.89765647230385
+    ],
+    "1_1_async_actor_calls_with_args_async": [
+        2350.1130733425607,
+        169.642459588056
+    ],
+    "1_n_actor_calls_async": [
+        10819.31324573512,
+        556.3564152930876
+    ],
+    "1_n_async_actor_calls_async": [
+        10741.070943872623,
+        74.14284598217124
+    ],
+    "client__1_1_actor_calls_async": [
+        916.2458814581453,
+        20.970867830230226
+    ],
+    "client__1_1_actor_calls_concurrent": [
+        925.777467637641,
+        25.193859971158158
+    ],
+    "client__1_1_actor_calls_sync": [
+        521.8726144223089,
+        7.962424357055347
+    ],
+    "client__get_calls": [
+        1149.982480593273,
+        18.207879410048996
+    ],
+    "client__put_calls": [
+        861.7294897745508,
+        20.886660586339037
+    ],
+    "client__put_gigabytes": [
+        0.04579083755671009,
+        0.0011758702466256328
+    ],
+    "client__tasks_and_get_batch": [
+        0.85332224821338,
+        0.009728477126712553
+    ],
+    "client__tasks_and_put_batch": [
+        10926.28867356008,
+        112.00041581027524
+    ],
+    "multi_client_put_calls_Plasma_Store": [
+        11907.518691049167,
+        140.67822025073386
+    ],
+    "multi_client_put_gigabytes": [
+        38.34929639975205,
+        3.8021163438852286
+    ],
+    "multi_client_tasks_async": [
+        29213.877508157526,
+        1402.303220638465
+    ],
+    "n_n_actor_calls_async": [
+        32206.022554465333,
+        1389.5479846707906
+    ],
+    "n_n_actor_calls_with_arg_async": [
+        2569.4536725239686,
+        27.598753015224556
+    ],
+    "n_n_async_actor_calls_async": [
+        27823.30349707046,
+        169.7830788090935
+    ],
+    "perf_metrics": [
+        {
+            "perf_metric_name": "single_client_get_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 6507.325737010699
+        },
+        {
+            "perf_metric_name": "single_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5657.281266012957
+        },
+        {
+            "perf_metric_name": "multi_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 11907.518691049167
+        },
+        {
+            "perf_metric_name": "single_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 20.68898688869432
+        },
+        {
+            "perf_metric_name": "single_client_tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 11.039401889292254
+        },
+        {
+            "perf_metric_name": "multi_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 38.34929639975205
+        },
+        {
+            "perf_metric_name": "single_client_get_object_containing_10k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 13.146682237214058
+        },
+        {
+            "perf_metric_name": "single_client_wait_1k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5.498008946220131
+        },
+        {
+            "perf_metric_name": "single_client_tasks_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1282.1050579108664
+        },
+        {
+            "perf_metric_name": "single_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 10781.5375768007
+        },
+        {
+            "perf_metric_name": "multi_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 29213.877508157526
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2326.919630897046
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8266.227716717382
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 4822.515544345499
+        },
+        {
+            "perf_metric_name": "1_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 10819.31324573512
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 32206.022554465333
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_with_arg_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2569.4536725239686
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1600.088775357745
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 3472.864053257764
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_with_args_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2350.1130733425607
+        },
+        {
+            "perf_metric_name": "1_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 10741.070943872623
+        },
+        {
+            "perf_metric_name": "n_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 27823.30349707046
+        },
+        {
+            "perf_metric_name": "placement_group_create/removal",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 989.8353575694138
+        },
+        {
+            "perf_metric_name": "client__get_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1149.982480593273
+        },
+        {
+            "perf_metric_name": "client__put_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 861.7294897745508
+        },
+        {
+            "perf_metric_name": "client__put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.04579083755671009
+        },
+        {
+            "perf_metric_name": "client__tasks_and_put_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 10926.28867356008
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 521.8726144223089
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 916.2458814581453
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 925.777467637641
+        },
+        {
+            "perf_metric_name": "client__tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.85332224821338
+        }
+    ],
+    "placement_group_create/removal": [
+        989.8353575694138,
+        8.999610265563307
+    ],
+    "single_client_get_calls_Plasma_Store": [
+        6507.325737010699,
+        169.10049512002783
+    ],
+    "single_client_get_object_containing_10k_refs": [
+        13.146682237214058,
+        0.40574499297791244
+    ],
+    "single_client_put_calls_Plasma_Store": [
+        5657.281266012957,
+        65.81470332190243
+    ],
+    "single_client_put_gigabytes": [
+        20.68898688869432,
+        6.118551705446652
+    ],
+    "single_client_tasks_and_get_batch": [
+        11.039401889292254,
+        0.07053691123976474
+    ],
+    "single_client_tasks_async": [
+        10781.5375768007,
+        80.41585546336292
+    ],
+    "single_client_tasks_sync": [
+        1282.1050579108664,
+        25.53646612884218
+    ],
+    "single_client_wait_1k_refs": [
+        5.498008946220131,
+        0.019177007797266794
+    ]
+}

--- a/release/release_logs/2.3.0/scalability/object_store.json
+++ b/release/release_logs/2.3.0/scalability/object_store.json
@@ -1,0 +1,13 @@
+{
+    "broadcast_time": 92.42755234200001,
+    "num_nodes": 50,
+    "object_size": 1073741824,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 92.42755234200001
+        }
+    ],
+    "success": "1"
+}

--- a/release/release_logs/2.3.0/scalability/single_node.json
+++ b/release/release_logs/2.3.0/scalability/single_node.json
@@ -1,0 +1,40 @@
+{
+    "args_time": 16.49447203899996,
+    "get_time": 24.665624744000013,
+    "large_object_size": 107374182400,
+    "large_object_time": 325.56598805499993,
+    "num_args": 10000,
+    "num_get_args": 10000,
+    "num_queued": 1000000,
+    "num_returns": 3000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "10000_args_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 16.49447203899996
+        },
+        {
+            "perf_metric_name": "3000_returns_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 6.200411088999999
+        },
+        {
+            "perf_metric_name": "10000_get_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 24.665624744000013
+        },
+        {
+            "perf_metric_name": "1000000_queued_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 190.882864026
+        },
+        {
+            "perf_metric_name": "107374182400_large_object_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 325.56598805499993
+        }
+    ],
+    "queued_time": 190.882864026,
+    "returns_time": 6.200411088999999,
+    "success": "1"
+}

--- a/release/release_logs/2.3.0/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.3.0/stress_tests/stress_test_dead_actors.json
@@ -1,0 +1,14 @@
+{
+    "avg_iteration_time": 1.9298896980285645,
+    "max_iteration_time": 7.609254598617554,
+    "min_iteration_time": 0.8152294158935547,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 1.9298896980285645
+        }
+    ],
+    "success": 1,
+    "total_time": 192.9892761707306
+}

--- a/release/release_logs/2.3.0/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.3.0/stress_tests/stress_test_many_tasks.json
@@ -1,0 +1,47 @@
+{
+    "perf_metrics": [
+        {
+            "perf_metric_name": "stage_0_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 10.636847257614136
+        },
+        {
+            "perf_metric_name": "stage_1_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 22.78462884426117
+        },
+        {
+            "perf_metric_name": "stage_2_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 63.28760423660278
+        },
+        {
+            "perf_metric_name": "stage_3_creation_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.05330848693847656
+        },
+        {
+            "perf_metric_name": "stage_3_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2655.176714658737
+        },
+        {
+            "perf_metric_name": "stage_4_spread",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.7394418476633471
+        }
+    ],
+    "stage_0_time": 10.636847257614136,
+    "stage_1_avg_iteration_time": 22.78462884426117,
+    "stage_1_max_iteration_time": 23.30313539505005,
+    "stage_1_min_iteration_time": 21.94757604598999,
+    "stage_1_time": 227.84637260437012,
+    "stage_2_avg_iteration_time": 63.28760423660278,
+    "stage_2_max_iteration_time": 64.29542255401611,
+    "stage_2_min_iteration_time": 61.036946058273315,
+    "stage_2_time": 316.43891644477844,
+    "stage_3_creation_time": 0.05330848693847656,
+    "stage_3_time": 2655.176714658737,
+    "stage_4_spread": 0.7394418476633471,
+    "success": 1
+}

--- a/release/release_logs/2.3.0/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.3.0/stress_tests/stress_test_placement_group.json
@@ -1,0 +1,17 @@
+{
+    "avg_pg_create_time_ms": 0.8553733138129204,
+    "avg_pg_remove_time_ms": 0.8286827042024993,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_pg_create_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.8553733138129204
+        },
+        {
+            "perf_metric_name": "avg_pg_remove_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.8286827042024993
+        }
+    ],
+    "success": 1
+}


### PR DESCRIPTION
I forgot to merge in the final performance release logs. The summary of regressions is here (signed off by the core team): https://docs.google.com/spreadsheets/d/14_KGtDBxeSf1Tf9rkoujpFzpxfB4GlAUOlBn7-rPePE/edit#gid=0.