### PR TITLE
[Data] Add `iter_rows` to `DatasetIterator`

### DIFF
--- a/python/ray/data/_internal/dataset_iterator_impl.py
+++ b/python/ray/data/_internal/dataset_iterator_impl.py
@@ -2,6 +2,10 @@ from typing import TYPE_CHECKING, Optional, Union, Iterator, Callable, Any
 import time
 import warnings
 
+from ray.air.util.data_batch_conversion import BlockFormat
+from ray.data.block import BlockAccessor, T
+from ray.data.context import DatasetContext
+from ray.data.row import TableRow
 from ray.data.block import DataBatch
 from ray.data.dataset_iterator import DatasetIterator
 from ray.data._internal.block_batching import batch_block_refs
@@ -52,6 +56,35 @@ class DatasetIteratorImpl(DatasetIterator):
 
         stats.iter_total_s.add(time.perf_counter() - time_start)
 
+    def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[Union[T, TableRow]]:
+        # During row-based ops, we also choose a batch format that lines up with the
+        # current dataset format in order to eliminate unnecessary copies and type
+        # conversions.
+        ctx = DatasetContext.get_current()
+        if ctx.use_streaming_executor:
+            # TODO: calling dataset_format() triggers bulk execution.
+            batch_format = "default"
+        else:
+            try:
+                dataset_format = self._base_dataset.dataset_format()
+            except ValueError:
+                # Dataset is empty or cleared, so fall back to "default".
+                batch_format = "default"
+            else:
+                batch_format = (
+                    "pyarrow"
+                    if dataset_format == BlockFormat.ARROW
+                    else "pandas"
+                    if dataset_format == BlockFormat.PANDAS
+                    else "default"
+                )
+        for batch in self.iter_batches(
+            batch_size=None, prefetch_blocks=prefetch_blocks, batch_format=batch_format
+        ):
+            batch = BlockAccessor.for_block(BlockAccessor.batch_to_block(batch))
+            for row in batch.iter_rows():
+                yield row
+
     def stats(self) -> str:
         return self._base_dataset.stats()
 
@@ -60,16 +93,20 @@ class DatasetIteratorImpl(DatasetIterator):
 
     def __getattr__(self, name):
         if name == "_base_dataset":
-            return None
+            raise AttributeError()
 
-        # Warning for backwards compatibility. TODO: remove this method in 2.5.
-        warnings.warn(
-            "session.get_dataset_shard returns a ray.data.DatasetIterator "
-            "instead of a Dataset/DatasetPipeline as of Ray v2.3. "
-            "Use iter_torch_batches(), to_tf(), or iter_batches() to "
-            "iterate over one epoch. See "
-            "https://docs.ray.io/en/latest/data/api/dataset_iterator.html "
-            "for full DatasetIterator docs."
-        )
+        if hasattr(self._base_dataset, name):
+            # Warning for backwards compatibility. TODO: remove this method in 2.5.
+            warnings.warn(
+                "session.get_dataset_shard returns a ray.data.DatasetIterator "
+                "instead of a Dataset/DatasetPipeline as of Ray v2.3. "
+                "Use iter_torch_batches(), to_tf(), or iter_batches() to "
+                "iterate over one epoch. See "
+                "https://docs.ray.io/en/latest/data/api/dataset_iterator.html "
+                "for full DatasetIterator docs.",
+                stacklevel=4,
+            )
 
-        return getattr(self._base_dataset, name)
+            return getattr(self._base_dataset, name)
+        else:
+            return super().__getattr__(name)

--- a/python/ray/data/_internal/pipelined_dataset_iterator.py
+++ b/python/ray/data/_internal/pipelined_dataset_iterator.py
@@ -64,7 +64,7 @@ class PipelinedDatasetIterator(DatasetIterator):
 
     def __getattr__(self, name):
         if name == "_base_dataset_pipeline":
-            raise AttributeError()
+            raise AttributeError
 
         if hasattr(self._base_dataset_pipeline, name):
             # Warning for backwards compatibility. TODO: remove this method in 2.5.

--- a/python/ray/data/_internal/pipelined_dataset_iterator.py
+++ b/python/ray/data/_internal/pipelined_dataset_iterator.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union, Iterator
 import warnings
 
-from ray.data.block import DataBatch
+from ray.data.block import DataBatch, T
+from ray.data.row import TableRow
 from ray.data.dataset_iterator import DatasetIterator
 
 if TYPE_CHECKING:
@@ -49,6 +50,12 @@ class PipelinedDatasetIterator(DatasetIterator):
             _collate_fn=_collate_fn,
         )
 
+    def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[Union[T, TableRow]]:
+        ds = self._get_next_dataset()
+        return ds.iter_rows(
+            prefetch_blocks=prefetch_blocks,
+        )
+
     def stats(self) -> str:
         return self._base_dataset_pipeline.stats()
 
@@ -57,16 +64,19 @@ class PipelinedDatasetIterator(DatasetIterator):
 
     def __getattr__(self, name):
         if name == "_base_dataset_pipeline":
-            return None
+            raise AttributeError()
 
-        # Warning for backwards compatibility. TODO: remove this method in 2.5.
-        warnings.warn(
-            "session.get_dataset_shard returns a ray.data.DatasetIterator "
-            "instead of a Dataset/DatasetPipeline as of Ray v2.3. "
-            "Use iter_torch_batches(), to_tf(), or iter_batches() to "
-            "iterate over one epoch. See "
-            "https://docs.ray.io/en/latest/data/api/dataset_iterator.html "
-            "for full DatasetIterator docs."
-        )
+        if hasattr(self._base_dataset_pipeline, name):
+            # Warning for backwards compatibility. TODO: remove this method in 2.5.
+            warnings.warn(
+                "session.get_dataset_shard returns a ray.data.DatasetIterator "
+                "instead of a Dataset/DatasetPipeline as of Ray v2.3. "
+                "Use iter_torch_batches(), to_tf(), or iter_batches() to "
+                "iterate over one epoch. See "
+                "https://docs.ray.io/en/latest/data/api/dataset_iterator.html "
+                "for full DatasetIterator docs."
+            )
 
-        return getattr(self._base_dataset_pipeline, name)
+            return getattr(self._base_dataset_pipeline, name)
+        else:
+            return super().__getattr__(name)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2854,33 +2854,8 @@ class Dataset(Generic[T]):
         Returns:
             A local iterator over the entire dataset.
         """
-        # During row-based ops, we also choose a batch format that lines up with the
-        # current dataset format in order to eliminate unnecessary copies and type
-        # conversions.
-        ctx = DatasetContext.get_current()
-        if ctx.use_streaming_executor:
-            # TODO: calling dataset_format() triggers bulk execution.
-            batch_format = "default"
-        else:
-            try:
-                dataset_format = self.dataset_format()
-            except ValueError:
-                # Dataset is empty or cleared, so fall back to "default".
-                batch_format = "default"
-            else:
-                batch_format = (
-                    "pyarrow"
-                    if dataset_format == BlockFormat.ARROW
-                    else "pandas"
-                    if dataset_format == BlockFormat.PANDAS
-                    else "default"
-                )
-        for batch in self.iter_batches(
-            batch_size=None, prefetch_blocks=prefetch_blocks, batch_format=batch_format
-        ):
-            batch = BlockAccessor.for_block(BlockAccessor.batch_to_block(batch))
-            for row in batch.iter_rows():
-                yield row
+
+        return self.iterator().iter_rows(prefetch_blocks=prefetch_blocks)
 
     @ConsumptionAPI
     def iter_batches(

--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -3,7 +3,8 @@ import numpy as np
 import sys
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, Iterator
 
-from ray.data.block import DataBatch
+from ray.data.block import DataBatch, T
+from ray.data.row import TableRow
 from ray.util.annotations import PublicAPI
 from ray.data._internal.util import _is_tensor_schema
 
@@ -101,6 +102,31 @@ class DatasetIterator(abc.ABC):
         Returns:
             An iterator over record batches.
         """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[Union[T, TableRow]]:
+        """Return a local row iterator over the dataset.
+
+        If the dataset is a tabular dataset (Arrow/Pandas blocks), dict-like mappings
+        :py:class:`~ray.data.row.TableRow` are yielded for each row by the iterator.
+        If the dataset is not tabular, the raw row is yielded.
+
+        Examples:
+            >>> import ray
+            >>> for i in ray.data.range(1000000).iterator().iter_rows(): # doctest: +SKIP
+            ...     print(i) # doctest: +SKIP
+
+        Time complexity: O(1)
+
+        Args:
+            prefetch_blocks: The number of blocks to prefetch ahead of the
+                current block during the scan.
+
+        Returns:
+            An iterator over rows of the dataset.
+        """
+
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -114,7 +114,9 @@ class DatasetIterator(abc.ABC):
 
         Examples:
             >>> import ray
-            >>> for i in ray.data.range(1000000).iterator().iter_rows(): # doctest: +SKIP
+            >>> for i in ray.data.range(1000000)
+                .iterator()
+                .iter_rows(): # doctest: +SKIP
             ...     print(i) # doctest: +SKIP
 
         Time complexity: O(1)
@@ -162,13 +164,10 @@ class DatasetIterator(abc.ABC):
 
         Examples:
             >>> import ray
-            >>> for batch in ray.data.range( # doctest: +SKIP
-            ...     12,
-            ... ).iterator().iter_torch_batches(batch_size=4):
-            ...     print(batch.shape) # doctest: +SKIP
-            torch.Size([4, 1])
-            torch.Size([4, 1])
-            torch.Size([4, 1])
+            >>> for row in ray.data.range(
+            ...     1000000
+            ... ).iterator().iter_rows(): # doctest: +SKIP
+            ...     print(row) # doctest: +SKIP
 
         Time complexity: O(1)
 

--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -114,10 +114,9 @@ class DatasetIterator(abc.ABC):
 
         Examples:
             >>> import ray
-            >>> for i in ray.data.range(1000000)
-                .iterator()
-                .iter_rows(): # doctest: +SKIP
-            ...     print(i) # doctest: +SKIP
+            >>> dataset = ray.data.range(10)
+            >>> next(iter(dataset.iterator().iter_rows()))
+            0
 
         Time complexity: O(1)
 

--- a/python/ray/data/tests/test_dataset_iterator.py
+++ b/python/ray/data/tests/test_dataset_iterator.py
@@ -46,6 +46,11 @@ def test_basic_dataset_iter_rows(ray_start_regular_shared):
             result.append(row)
         assert result == list(range(100))
 
+    # TODO(swang): This check currently fails nondeterministically because
+    # stats are stored in an actor.
+    # https://github.com/ray-project/ray/issues/31571
+    # assert it.stats() == ds.stats()
+
 
 def test_basic_dataset_pipeline(ray_start_regular_shared):
     ds = ray.data.range(100).window(bytes_per_window=1).repeat()

--- a/python/ray/data/tests/test_dataset_iterator.py
+++ b/python/ray/data/tests/test_dataset_iterator.py
@@ -37,6 +37,16 @@ def test_basic_dataset(ray_start_regular_shared):
     # assert it.stats() == ds.stats()
 
 
+def test_basic_dataset_iter_rows(ray_start_regular_shared):
+    ds = ray.data.range(100)
+    it = ds.iterator()
+    for _ in range(3):
+        result = []
+        for row in it.iter_rows():
+            result.append(row)
+        assert result == list(range(100))
+
+
 def test_basic_dataset_pipeline(ray_start_regular_shared):
     ds = ray.data.range(100).window(bytes_per_window=1).repeat()
     it = ds.iterator()
@@ -44,6 +54,18 @@ def test_basic_dataset_pipeline(ray_start_regular_shared):
         result = []
         for batch in it.iter_batches():
             result += batch
+        assert result == list(range(100))
+
+    assert it.stats() == ds.stats()
+
+
+def test_basic_dataset_pipeline_iter_rows(ray_start_regular_shared):
+    ds = ray.data.range(100).window(bytes_per_window=1).repeat()
+    it = ds.iterator()
+    for _ in range(3):
+        result = []
+        for row in it.iter_rows():
+            result.append(row)
         assert result == list(range(100))
 
     assert it.stats() == ds.stats()

--- a/python/ray/data/tests/test_dataset_iterator.py
+++ b/python/ray/data/tests/test_dataset_iterator.py
@@ -25,7 +25,7 @@ def build_model():
 def test_basic_dataset(ray_start_regular_shared):
     ds = ray.data.range(100)
     it = ds.iterator()
-    for _ in range(3):
+    for _ in range(2):
         result = []
         for batch in it.iter_batches():
             result += batch
@@ -40,7 +40,7 @@ def test_basic_dataset(ray_start_regular_shared):
 def test_basic_dataset_iter_rows(ray_start_regular_shared):
     ds = ray.data.range(100)
     it = ds.iterator()
-    for _ in range(3):
+    for _ in range(2):
         result = []
         for row in it.iter_rows():
             result.append(row)
@@ -55,7 +55,7 @@ def test_basic_dataset_iter_rows(ray_start_regular_shared):
 def test_basic_dataset_pipeline(ray_start_regular_shared):
     ds = ray.data.range(100).window(bytes_per_window=1).repeat()
     it = ds.iterator()
-    for _ in range(3):
+    for _ in range(2):
         result = []
         for batch in it.iter_batches():
             result += batch
@@ -67,7 +67,7 @@ def test_basic_dataset_pipeline(ray_start_regular_shared):
 def test_basic_dataset_pipeline_iter_rows(ray_start_regular_shared):
     ds = ray.data.range(100).window(bytes_per_window=1).repeat()
     it = ds.iterator()
-    for _ in range(3):
+    for _ in range(2):
         result = []
         for row in it.iter_rows():
             result.append(row)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
The `iter_rows` API that HuggingfaceTrainer uses internally is not available in `DatasetIterator`, which falls back to the base dataset and outputs User warnings about the change to `DatasetIterator`.

This PR adds an `iter_rows` API to `DatasetIterator` so we don't fallback to the base dataset.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
