### PR TITLE
[build_base] [Docker] Fix protobuf version to be 3.19.6 on `ray-ml` docker image

### DIFF
--- a/docker/ray-ml/Dockerfile
+++ b/docker/ray-ml/Dockerfile
@@ -24,7 +24,7 @@ RUN sudo apt-get update \
     && $HOME/anaconda3/bin/pip --no-cache-dir install -U \
            -r requirements.txt \
     # Then, keep requirements bounds as constraints and install remaining test dependencies
-    && $HOME/anaconda3/bin/pip --use-deprecated=legacy-resolver --no-cache-dir install -U \
+    && $HOME/anaconda3/bin/pip --no-cache-dir install -U \
            -c requirements.txt \
            -r requirements_rllib.txt \
            -r requirements_train.txt \

--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -30,7 +30,7 @@ optuna==2.10.0
 pymoo==0.5.0
 pytest-remotedata==0.3.2
 lightning-bolts==0.4.0
-protobuf==3.20.3
+protobuf==3.19.6
 pytorch-lightning==1.6.5
 shortuuid==1.0.1
 scikit-optimize==0.9.0

--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -30,7 +30,7 @@ optuna==2.10.0
 pymoo==0.5.0
 pytest-remotedata==0.3.2
 lightning-bolts==0.4.0
-protobuf==3.19.6
+protobuf==3.20.3
 pytorch-lightning==1.6.5
 shortuuid==1.0.1
 scikit-optimize==0.9.0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR fixes the protobuf version on the `ray-ml` docker image so that it's compatible with libraries such as tensorflow, torch, ray lightning, etc.

On 2.3.0 docker images, here are the protobuf versions:
`ray:latest-py39-gpu`: `protobuf==3.20.3`
`ray-ml:latest-py39-gpu`: `protobuf==4.22.0`

Ex: on our ray-ml latest docker image, this version causes problems with certain libraries. See these issues: https://github.com/ray-project/ray/issues/32775, https://github.com/ray-project/ray/pull/33024

```
>>> import ray_lightning

...
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

`pip --use-deprecated=legacy-resolver` with a constraint `-c` and a requirements file `-r` will upgrade to the latest version based on the constraints file, rather than follow what the requirements file wants. In this case, it will upgrade `protobuf` to latest, following the lower bound in `requirements.txt`, and not use `protobuf==3.19.6` as specified in `requirements_tune.txt`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
