### PR TITLE
[Datasets] [Docs] Fix description of `read_parquet`

### DIFF
--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -77,9 +77,8 @@ Supported File Formats
   Read Parquet files into a tabular ``Dataset``. The Parquet data will be read into
   `Arrow Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__
   blocks. Although this simple example demonstrates reading a single file, note that
-  Datasets can also read directories of Parquet files, with one tabular block created
-  per file. For Parquet in particular, we also support reading partitioned Parquet
-  datasets with partition column values pulled from the file paths.
+  Datasets can also read directories of Parquet files. We also support reading partitioned
+  Parquet datasets with partition column values pulled from the file paths.
 
   .. literalinclude:: ./doc_code/creating_datasets.py
     :language: python


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Our documentation says that if you call `read_parquet`, the number of blocks is equal to the number of input files. This isn't true.

We also claim that partitioning support is unique to `read_parquet`, but https://github.com/ray-project/ray/pull/28413 added partitioning support to other `read_` functions.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/33179

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
