### PR TITLE
[docs] fix typo

### DIFF
--- a/doc/source/train/dl_guide.rst
+++ b/doc/source/train/dl_guide.rst
@@ -61,7 +61,7 @@ training.
        and :func:`ray.train.torch.prepare_data_loader` utilities below,
        and instead handle the logic directly inside your training function.
 
-    First, use the :func:~ray.train.torch.prepare_model` function to automatically move your model to the right device and wrap it in
+    First, use the :func:`~ray.train.torch.prepare_model` function to automatically move your model to the right device and wrap it in
     ``DistributedDataParallel``
 
     .. code-block:: diff


### PR DESCRIPTION
adding a missing back tick