### PR TITLE
Deprecate RuntimeContext.get(), use `RuntimeContext.context` instead.

### DIFF
--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -17,6 +17,7 @@ class RuntimeContext(object):
         assert worker is not None
         self.worker = worker
 
+    @Deprecated(message="Use context property instead", warning=True)
     def get(self) -> Dict[str, Any]:
         """Get a dictionary of the current context.
 
@@ -33,6 +34,26 @@ class RuntimeContext(object):
                 context["task_id"] = self.task_id
             if self.actor_id is not None:
                 context["actor_id"] = self.actor_id
+
+        return context
+
+    @property
+    def context(self) -> Dict[str, Any]:
+        """Get a dictionary of the current context.
+
+        Returns:
+            dict: Dictionary of the current context.
+        """
+        context = {
+            "job_id": self.get_job_id(),
+            "node_id": self.get_node_id(),
+            "namespace": self.namespace,
+        }
+        if self.worker.mode == ray._private.worker.WORKER_MODE:
+            if self.task_id is not None:
+                context["task_id"] = self.get_task_id()
+            if self.actor_id is not None:
+                context["actor_id"] = self.get_actor_id()
 
         return context
 

--- a/python/ray/tests/test_client_metadata.py
+++ b/python/ray/tests/test_client_metadata.py
@@ -38,7 +38,7 @@ def test_get_runtime_context(ray_start_regular_shared):
         assert isinstance(rtc.namespace, str)
 
         # Ensure this doesn't throw
-        ray.get_runtime_context().get()
+        ray.get_runtime_context().runtime_context
 
         with pytest.raises(Exception):
             _ = rtc.task_id

--- a/python/ray/tests/test_get_locations.py
+++ b/python/ray/tests/test_get_locations.py
@@ -26,7 +26,7 @@ def test_get_locations_timeout(ray_start_regular):
 
 
 def test_get_locations(ray_start_regular):
-    node_id = ray.runtime_context.get_runtime_context().get()["node_id"]
+    node_id = ray.runtime_context.get_runtime_context().get_node_id()
     sizes = [100, 1000]
     obj_refs = [ray.put(np.zeros(s, dtype=np.uint8)) for s in sizes]
     ray.wait(obj_refs)
@@ -35,17 +35,17 @@ def test_get_locations(ray_start_regular):
     for idx, obj_ref in enumerate(obj_refs):
         location = locations[obj_ref]
         assert location["object_size"] > sizes[idx]
-        assert location["node_ids"] == [node_id.hex()]
+        assert location["node_ids"] == [node_id]
 
 
 def test_get_locations_inlined(ray_start_regular):
-    node_id = ray.runtime_context.get_runtime_context().get()["node_id"]
+    node_id = ray.runtime_context.get_runtime_context().get_node_id()
     obj_refs = [ray.put("123")]
     ray.wait(obj_refs)
     locations = ray.experimental.get_object_locations(obj_refs)
     for idx, obj_ref in enumerate(obj_refs):
         location = locations[obj_ref]
-        assert location["node_ids"] == [node_id.hex()]
+        assert location["node_ids"] == [node_id]
         assert location["object_size"] > 0
 
 
@@ -55,7 +55,7 @@ def test_spilled_locations(ray_start_cluster_enabled):
     ray.init(cluster.address)
     cluster.wait_for_nodes()
 
-    node_id = ray.runtime_context.get_runtime_context().get()["node_id"]
+    node_id = ray.runtime_context.get_runtime_context().get_node_id()
 
     @ray.remote
     def task():
@@ -71,7 +71,7 @@ def test_spilled_locations(ray_start_cluster_enabled):
     locations = ray.experimental.get_object_locations(object_refs)
     for obj_ref in object_refs:
         location = locations[obj_ref]
-        assert location["node_ids"] == [node_id.hex()]
+        assert location["node_ids"] == [node_id]
         assert location["object_size"] > 0
 
 
@@ -87,7 +87,7 @@ def test_get_locations_multi_nodes(ray_start_cluster_enabled):
     cluster.wait_for_nodes()
 
     all_node_ids = list(map(lambda node: node["NodeID"], ray.nodes()))
-    driver_node_id = ray.runtime_context.get_runtime_context().get()["node_id"].hex()
+    driver_node_id = ray.runtime_context.get_runtime_context().get_node_id()
     all_node_ids.remove(driver_node_id)
     worker_node_id = all_node_ids[0]
 

--- a/python/ray/tests/test_namespace.py
+++ b/python/ray/tests/test_namespace.py
@@ -229,7 +229,7 @@ def test_runtime_context(shutdown_only):
     ray.init(namespace="abc")
     namespace = ray.get_runtime_context().namespace
     assert namespace == "abc"
-    assert namespace == ray.get_runtime_context().get()["namespace"]
+    assert namespace == ray.get_runtime_context().context["namespace"]
 
 
 def test_namespace_validation(shutdown_only):

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -59,7 +59,7 @@ def test_was_current_actor_reconstructed(shutdown_only):
         assert ray.get_runtime_context().task_id is not None
         assert ray.get_runtime_context().node_id is not None
         assert ray.get_runtime_context().job_id is not None
-        context = ray.get_runtime_context().get()
+        context = ray.get_runtime_context().context
         assert "actor_id" not in context
         assert context["task_id"] == ray.get_runtime_context().task_id
         assert context["node_id"] == ray.get_runtime_context().node_id
@@ -72,7 +72,7 @@ def test_was_current_actor_reconstructed(shutdown_only):
 
 
 def test_get_context_dict(ray_start_regular):
-    context_dict = ray.get_runtime_context().get()
+    context_dict = ray.get_runtime_context().context
     assert context_dict["node_id"] is not None
     assert context_dict["job_id"] is not None
     assert "actor_id" not in context_dict
@@ -81,7 +81,7 @@ def test_get_context_dict(ray_start_regular):
     @ray.remote
     class Actor:
         def check(self, node_id, job_id):
-            context_dict = ray.get_runtime_context().get()
+            context_dict = ray.get_runtime_context().context
             assert context_dict["node_id"] == node_id
             assert context_dict["job_id"] == job_id
             assert context_dict["actor_id"] is not None
@@ -93,7 +93,7 @@ def test_get_context_dict(ray_start_regular):
 
     @ray.remote
     def task(node_id, job_id):
-        context_dict = ray.get_runtime_context().get()
+        context_dict = ray.get_runtime_context().context
         assert context_dict["node_id"] == node_id
         assert context_dict["job_id"] == job_id
         assert context_dict["task_id"] is not None

--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -190,14 +190,14 @@ def _use_context(
 def _function_hydrate_span_args(func: Callable[..., Any]):
     """Get the Attributes of the function that will be reported as attributes
     in the trace."""
-    runtime_context = get_runtime_context().get()
+    runtime_context = get_runtime_context().context
 
     span_args = {
         "ray.remote": "function",
         "ray.function": func,
         "ray.pid": str(os.getpid()),
         "ray.job_id": runtime_context["job_id"].hex(),
-        "ray.node_id": runtime_context["node_id"].hex(),
+        "ray.node_id": runtime_context["node_id"],
     }
 
     # We only get task ID for workers
@@ -239,7 +239,7 @@ def _actor_hydrate_span_args(class_: _nameable, method: _nameable):
     if callable(method):
         method = method.__name__
 
-    runtime_context = get_runtime_context().get()
+    runtime_context = get_runtime_context().context
 
     span_args = {
         "ray.remote": "actor",
@@ -248,7 +248,7 @@ def _actor_hydrate_span_args(class_: _nameable, method: _nameable):
         "ray.function": f"{class_}.{method}",
         "ray.pid": str(os.getpid()),
         "ray.job_id": runtime_context["job_id"].hex(),
-        "ray.node_id": runtime_context["node_id"].hex(),
+        "ray.node_id": runtime_context["node_id"],
     }
 
     # We only get actor ID for workers


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
