### PR TITLE
[ci/release] Do not terminate cluster on keyboard interrupt with --no-terminate

### DIFF
--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -290,9 +290,10 @@ def run_release_test(
         logger.info(f"Installed python packages:\n{pip_package_string}")
 
         if isinstance(cluster_manager, FullClusterManager):
-            register_handler(
-                lambda sig, frame: cluster_manager.terminate_cluster(wait=True)
-            )
+            if not no_terminate:
+                register_handler(
+                    lambda sig, frame: cluster_manager.terminate_cluster(wait=True)
+                )
 
         # Start cluster
         if cluster_id:


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We currently terminate clusters always when a keyboard interrupt is registered, but we shouldn't do so if `--no-terminate` is passed on the command line.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
