### PR TITLE
[Datasets] Run `_get_read_tasks` with NodeAffinitySchedulingStrategy

### DIFF
--- a/python/ray/data/_internal/remote_fn.py
+++ b/python/ray/data/_internal/remote_fn.py
@@ -16,7 +16,7 @@ def cached_remote_fn(fn: Any, **ray_remote_args) -> Any:
 
     Note: Dynamic arguments should not be passed in directly,
     and should be set with ``options`` instead:
-    ``cached_remote_fn(**static_args).options(**dynamic_args)``.
+    ``cached_remote_fn(fn, **static_args).options(**dynamic_args)``.
 
     """
     if fn not in CACHED_FUNCTIONS:

--- a/python/ray/data/_internal/remote_fn.py
+++ b/python/ray/data/_internal/remote_fn.py
@@ -13,6 +13,11 @@ def cached_remote_fn(fn: Any, **ray_remote_args) -> Any:
     This is used in Datasets to avoid circular import issues with ray.remote.
     (ray imports ray.data in order to allow ``ray.data.read_foo()`` to work,
     which means ray.remote cannot be used top-level in ray.data).
+
+    Note: Dynamic arguments should not be passed in directly,
+    and should be set with ``options`` instead:
+    ``cached_remote_fn(**static_args).options(**dynamic_args)``.
+
     """
     if fn not in CACHED_FUNCTIONS:
         ctx = DatasetContext.get_current()

--- a/python/ray/data/_internal/remote_fn.py
+++ b/python/ray/data/_internal/remote_fn.py
@@ -17,7 +17,6 @@ def cached_remote_fn(fn: Any, **ray_remote_args) -> Any:
     Note: Dynamic arguments should not be passed in directly,
     and should be set with ``options`` instead:
     ``cached_remote_fn(fn, **static_args).options(**dynamic_args)``.
-
     """
     if fn not in CACHED_FUNCTIONS:
         ctx = DatasetContext.get_current()

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -312,11 +312,8 @@ def read_datasource(
             soft=False,
         )
         get_read_tasks = cached_remote_fn(
-            _get_read_tasks,
-            retry_exceptions=False,
-            num_cpus=0,
-            scheduling_strategy=scheduling_strategy,
-        )
+            _get_read_tasks, retry_exceptions=False, num_cpus=0
+        ).options(scheduling_strategy=scheduling_strategy)
 
         requested_parallelism, min_safe_parallelism, read_tasks = ray.get(
             get_read_tasks.remote(

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -304,10 +304,18 @@ def read_datasource(
             datasource, ctx, cur_pg, parallelism, local_uri, read_args
         )
     else:
-        # Prepare read in a remote task so that in Ray client mode, we aren't
-        # attempting metadata resolution from the client machine.
+        # Prepare read in a remote task at same node.
+        # NOTE: in Ray client mode, this is expected to be run on head node.
+        # So we aren't attempting metadata resolution from the client machine.
+        scheduling_strategy = NodeAffinitySchedulingStrategy(
+            ray.get_runtime_context().get_node_id(),
+            soft=False,
+        )
         get_read_tasks = cached_remote_fn(
-            _get_read_tasks, retry_exceptions=False, num_cpus=0
+            _get_read_tasks,
+            retry_exceptions=False,
+            num_cpus=0,
+            scheduling_strategy=scheduling_strategy,
         )
 
         requested_parallelism, min_safe_parallelism, read_tasks = ray.get(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to change `_get_read_tasks` always running as a Ray task at same node. For Ray client, the task will be executed on head node. The motivation for this PR is to simplify the logic so we don't run `_get_read_tasks` on arbitrary node.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
