### PR TITLE
[Datasets][Docs] Fix invalid syntax in `streaming_split` docstring

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1154,8 +1154,8 @@ class Dataset(Generic[T]):
         equal: bool = False,
         locality_hints: Optional[List["NodeIdStr"]] = None,
     ) -> List[DatasetIterator]:
-        """Returns ``n`` :class:`~ray.data.DatasetIterator`s that can be used to read
-        disjoint subsets of the dataset in parallel.
+        """Returns ``n`` :class:`DatasetIterators <ray.data.DatasetIterator>` that can 
+        be used to read disjoint subsets of the dataset in parallel.
 
         This method is the recommended way to consume Datasets from multiple processes
         (e.g., for distributed training). It requires streaming execution mode.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1154,7 +1154,7 @@ class Dataset(Generic[T]):
         equal: bool = False,
         locality_hints: Optional[List["NodeIdStr"]] = None,
     ) -> List[DatasetIterator]:
-        """Returns ``n`` :class:`DatasetIterators <ray.data.DatasetIterator>` that can 
+        """Returns ``n`` :class:`DatasetIterators <ray.data.DatasetIterator>` that can
         be used to read disjoint subsets of the dataset in parallel.
 
         This method is the recommended way to consume Datasets from multiple processes


### PR DESCRIPTION
Signed-off-by: Balaji <balaji@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
