### PR TITLE
[core][release] threaded_actors_stress_test release lock before sleeping

### DIFF
--- a/release/nightly_tests/stress_tests/test_threaded_actors.py
+++ b/release/nightly_tests/stress_tests/test_threaded_actors.py
@@ -64,7 +64,7 @@ class PiCalculator:
             with self.lock:
                 if not self.result_queue.empty():
                     result = self.result_queue.get(block=False)
-                time.sleep(1)
+            time.sleep(1)
         return result
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The other writer `do_compute` is being starved. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/33219
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
