### PR TITLE
[core][ci] deflake test_exit_observability:: test_worker_start_end_time

### DIFF
--- a/python/ray/tests/test_exit_observability.py
+++ b/python/ray/tests/test_exit_observability.py
@@ -329,31 +329,37 @@ def test_worker_start_end_time(shutdown_only):
     # Test normal exit.
     worker = Worker.remote()
     pid = ray.get(worker.ready.remote())
+
     def verify():
         workers = list_workers(detail=True, filters=[("pid", "=", pid)])[0]
         print(workers)
         assert workers["start_time_ms"] > 0
         assert workers["end_time_ms"] == 0
         return True
+
     wait_for_condition(verify)
 
     ray.kill(worker)
+
     def verify():
         workers = list_workers(detail=True, filters=[("pid", "=", pid)])[0]
         assert workers["start_time_ms"] > 0
         assert workers["end_time_ms"] > 0
         return True
+
     wait_for_condition(verify)
 
     # Test unexpected exit.
     worker = Worker.remote()
     pid = ray.get(worker.ready.remote())
     os.kill(pid, signal.SIGKILL)
+
     def verify():
         workers = list_workers(detail=True, filters=[("pid", "=", pid)])[0]
         assert workers["start_time_ms"] > 0
         assert workers["end_time_ms"] > 0
         return True
+
     wait_for_condition(verify)
 
 

--- a/python/ray/tests/test_exit_observability.py
+++ b/python/ray/tests/test_exit_observability.py
@@ -329,23 +329,32 @@ def test_worker_start_end_time(shutdown_only):
     # Test normal exit.
     worker = Worker.remote()
     pid = ray.get(worker.ready.remote())
-    workers = list_workers(detail=True, filters=[("pid", "=", pid)])[0]
-    print(workers)
-    assert workers["start_time_ms"] > 0
-    assert workers["end_time_ms"] == 0
+    def verify():
+        workers = list_workers(detail=True, filters=[("pid", "=", pid)])[0]
+        print(workers)
+        assert workers["start_time_ms"] > 0
+        assert workers["end_time_ms"] == 0
+        return True
+    wait_for_condition(verify)
 
     ray.kill(worker)
-    workers = list_workers(detail=True, filters=[("pid", "=", pid)])[0]
-    assert workers["start_time_ms"] > 0
-    assert workers["end_time_ms"] > 0
+    def verify():
+        workers = list_workers(detail=True, filters=[("pid", "=", pid)])[0]
+        assert workers["start_time_ms"] > 0
+        assert workers["end_time_ms"] > 0
+        return True
+    wait_for_condition(verify)
 
     # Test unexpected exit.
     worker = Worker.remote()
     pid = ray.get(worker.ready.remote())
     os.kill(pid, signal.SIGKILL)
-    workers = list_workers(detail=True, filters=[("pid", "=", pid)])[0]
-    assert workers["start_time_ms"] > 0
-    assert workers["end_time_ms"] > 0
+    def verify():
+        workers = list_workers(detail=True, filters=[("pid", "=", pid)])[0]
+        assert workers["start_time_ms"] > 0
+        assert workers["end_time_ms"] > 0
+        return True
+    wait_for_condition(verify)
 
 
 def test_node_start_end_time(ray_start_cluster):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<img width="1551" alt="image" src="https://user-images.githubusercontent.com/11676094/224569769-369d8cf3-e8d9-4b5c-a301-6e5e2a967a18.png">

https://buildkite.com/ray-project/oss-ci-build-branch/builds/2685#0186d38a-009f-4ef0-9148-f98e85f68be7

I believe the worker death info is asynchronously propagated to the GCS on query. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
