### PR TITLE
[Metrics] Fix the incorrect object store size from dashboard vs metrics

### DIFF
--- a/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -163,14 +163,14 @@ GRAFANA_PANELS = [
         id=29,
         title="Object Store Memory",
         description="Object store memory usage by location. The dotted line indicates the object store memory capacity.\n\nLocation: where the memory was allocated, which is MMAP_SHM or MMAP_DISK to indicate memory-mapped page, SPILLED to indicate spillage to disk, and WORKER_HEAP for objects small enough to be inlined in worker memory. Refer to metric_defs.cc for more information.",
-        unit="gbytes",
+        unit="bytes",
         targets=[
             Target(
-                expr="sum(ray_object_store_memory{{{global_filters}}} / 1e9) by (Location)",
+                expr="sum(ray_object_store_memory{{{global_filters}}}) by (Location)",
                 legend="{{Location}}",
             ),
             Target(
-                expr='sum(ray_resources{{Name="object_store_memory",{global_filters}}} / 1e9)',
+                expr='sum(ray_resources{{Name="object_store_memory",{global_filters}}})',
                 legend="MAX",
             ),
         ],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In the metrics page, we used GB (value / 1e9), but we are using GiB (value / 1024 ^ 3) for the dashboard object store memory usage.

This PR fixes the issue by just not dividing the object store memory by 1e9. By default, Grafana automatically translates the bytes into GiB, so there's no need to do `object store memory /1e9` ourselves for the metrics report. 

Here's the screenshot
<img width="604" alt="Screen Shot 2023-03-13 at 1 20 06 AM" src="https://user-images.githubusercontent.com/18510752/224645249-cf88ba04-38a7-4fb6-bb3c-75a00c56a8e2.png">


## Related issue number

Closes https://github.com/ray-project/ray/issues/32092

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
