### PR TITLE
[RLlib][RLModule] Disabled RLModule API in test_model_imports.py

### DIFF
--- a/rllib/tests/test_model_imports.py
+++ b/rllib/tests/test_model_imports.py
@@ -202,7 +202,11 @@ class TestModelImport(unittest.TestCase):
                 PPOConfig()
                 .environment("CartPole-v1")
                 .rollouts(num_rollout_workers=0)
-                .training(model={"vf_share_layers": True})
+                .training(
+                    model={"vf_share_layers": True},
+                    _enable_learner_api=False,
+                )
+                .rl_module(_enable_rl_module_api=False)
             )
         )
 

--- a/rllib/tests/test_model_imports.py
+++ b/rllib/tests/test_model_imports.py
@@ -202,6 +202,8 @@ class TestModelImport(unittest.TestCase):
                 PPOConfig()
                 .environment("CartPole-v1")
                 .rollouts(num_rollout_workers=0)
+                # We need to diable the RLModule / Learner API here, since this test is
+                # overfitted to the ModelV2 API stack.
                 .training(
                     model={"vf_share_layers": True},
                     _enable_learner_api=False,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
