### PR TITLE
[Doc] fix typo in object spilling doc

### DIFF
--- a/doc/source/ray-core/objects/object-spilling.rst
+++ b/doc/source/ray-core/objects/object-spilling.rst
@@ -98,6 +98,7 @@ The default threshold is 0.95 (95%). You can adjust the threshold by setting ``l
                   "params": {
                     "directory_path": "/tmp/spill",
                 },
+              },
             )
         },
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Typo fix in doc - missing "}" added in example

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
