### PR TITLE
[Datasets] Refactor iter_rows() for DatasetIterator classes

### DIFF
--- a/python/ray/data/_internal/dataset_iterator_impl.py
+++ b/python/ray/data/_internal/dataset_iterator_impl.py
@@ -3,7 +3,7 @@ import time
 import warnings
 import sys
 
-from ray.data._internal.util import _best_batch_format
+from ray.data._internal.util import _default_batch_format
 from ray.data.block import DataBatch
 from ray.data.dataset_iterator import DatasetIterator
 from ray.data._internal.block_batching import batch_block_refs
@@ -65,8 +65,8 @@ class DatasetIteratorImpl(DatasetIterator):
     def schema(self) -> Union[type, "pyarrow.lib.Schema"]:
         return self._base_dataset.schema()
 
-    def _best_batch_format(self) -> Literal["default", "pandas", "pyarrow", "numpy"]:
-        return _best_batch_format(self._base_dataset)
+    def _default_batch_format(self) -> Literal["default", "pandas", "pyarrow", "numpy"]:
+        return _default_batch_format(self._base_dataset)
 
     def __getattr__(self, name):
         if name == "_base_dataset":

--- a/python/ray/data/_internal/dataset_iterator_impl.py
+++ b/python/ray/data/_internal/dataset_iterator_impl.py
@@ -1,10 +1,9 @@
 from typing import TYPE_CHECKING, Optional, Union, Iterator, Callable, Any
 import time
 import warnings
+import sys
 
-from ray.data._internal.util import _get_batch_format
-from ray.data.block import BlockAccessor, T
-from ray.data.row import TableRow
+from ray.data._internal.util import _best_batch_format
 from ray.data.block import DataBatch
 from ray.data.dataset_iterator import DatasetIterator
 from ray.data._internal.block_batching import batch_block_refs
@@ -12,6 +11,11 @@ from ray.data._internal.block_batching import batch_block_refs
 if TYPE_CHECKING:
     import pyarrow
     from ray.data import Dataset
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class DatasetIteratorImpl(DatasetIterator):
@@ -55,23 +59,14 @@ class DatasetIteratorImpl(DatasetIterator):
 
         stats.iter_total_s.add(time.perf_counter() - time_start)
 
-    def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[Union[T, TableRow]]:
-        # During row-based ops, we also choose a batch format that lines up with the
-        # current dataset format in order to eliminate unnecessary copies and type
-        # conversions.
-        batch_format = _get_batch_format(self._base_dataset)
-        for batch in self.iter_batches(
-            batch_size=None, prefetch_blocks=prefetch_blocks, batch_format=batch_format
-        ):
-            batch = BlockAccessor.for_block(BlockAccessor.batch_to_block(batch))
-            for row in batch.iter_rows():
-                yield row
-
     def stats(self) -> str:
         return self._base_dataset.stats()
 
     def schema(self) -> Union[type, "pyarrow.lib.Schema"]:
         return self._base_dataset.schema()
+
+    def _best_batch_format(self) -> Literal["default", "pandas", "pyarrow", "numpy"]:
+        return _best_batch_format(self._base_dataset)
 
     def __getattr__(self, name):
         if name == "_base_dataset":

--- a/python/ray/data/_internal/pipelined_dataset_iterator.py
+++ b/python/ray/data/_internal/pipelined_dataset_iterator.py
@@ -1,8 +1,7 @@
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union, Iterator
 import warnings
 
-from ray.data.block import DataBatch, T
-from ray.data.row import TableRow
+from ray.data.block import DataBatch
 from ray.data.dataset_iterator import DatasetIterator
 
 if TYPE_CHECKING:
@@ -48,12 +47,6 @@ class PipelinedDatasetIterator(DatasetIterator):
             local_shuffle_buffer_size=local_shuffle_buffer_size,
             local_shuffle_seed=local_shuffle_seed,
             _collate_fn=_collate_fn,
-        )
-
-    def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[Union[T, TableRow]]:
-        ds = self._get_next_dataset()
-        return ds.iter_rows(
-            prefetch_blocks=prefetch_blocks,
         )
 
     def stats(self) -> str:

--- a/python/ray/data/_internal/stream_split_dataset_iterator.py
+++ b/python/ray/data/_internal/stream_split_dataset_iterator.py
@@ -14,7 +14,7 @@ from typing import (
 )
 
 import ray
-from ray.data._internal.util import _best_batch_format
+from ray.data._internal.util import _default_batch_format
 
 from ray.data.dataset_iterator import DatasetIterator
 from ray.data.block import Block, DataBatch
@@ -124,8 +124,8 @@ class StreamSplitDatasetIterator(DatasetIterator):
         """Implements DatasetIterator."""
         return self._base_dataset.schema()
 
-    def _best_batch_format(self) -> Literal["default", "pandas", "pyarrow", "numpy"]:
-        return _best_batch_format(self._base_dataset)
+    def _default_batch_format(self) -> Literal["default", "pandas", "pyarrow", "numpy"]:
+        return _default_batch_format(self._base_dataset)
 
 
 @ray.remote(num_cpus=0)

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -9,10 +9,17 @@ import numpy as np
 
 import ray
 from ray.air.constants import TENSOR_COLUMN_NAME
+from ray.air.util.data_batch_conversion import BlockFormat
 from ray.data.context import DatasetContext
 from ray._private.utils import _get_pyarrow_version
 
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 if TYPE_CHECKING:
+    from ray.data.dataset import Dataset
     from ray.data.datasource import Reader
     from ray.util.placement_group import PlacementGroup
 
@@ -397,3 +404,28 @@ def _split_list(arr: List[Any], num_splits: int) -> List[List[Any]]:
         arr[i * q + min(i, r) : (i + 1) * q + min(i + 1, r)] for i in range(num_splits)
     ]
     return splits
+
+
+def _get_batch_format(
+    ds: "Dataset",
+) -> Literal["default", "pandas", "pyarrow", "numpy"]:
+    """Get a batch format that lines up with the dataset format."""
+    ctx = DatasetContext.get_current()
+    if ctx.use_streaming_executor:
+        # TODO: calling dataset_format() triggers bulk execution.
+        batch_format = "default"
+    else:
+        try:
+            dataset_format = ds.dataset_format()
+        except ValueError:
+            # Dataset is empty or cleared, so fall back to "default".
+            batch_format = "default"
+        else:
+            batch_format = (
+                "pyarrow"
+                if dataset_format == BlockFormat.ARROW
+                else "pandas"
+                if dataset_format == BlockFormat.PANDAS
+                else "default"
+            )
+    return batch_format

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -406,7 +406,7 @@ def _split_list(arr: List[Any], num_splits: int) -> List[List[Any]]:
     return splits
 
 
-def _get_batch_format(
+def _best_batch_format(
     ds: "Dataset",
 ) -> Literal["default", "pandas", "pyarrow", "numpy"]:
     """Get a batch format that lines up with the dataset format."""

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -406,10 +406,10 @@ def _split_list(arr: List[Any], num_splits: int) -> List[List[Any]]:
     return splits
 
 
-def _best_batch_format(
+def _default_batch_format(
     ds: "Dataset",
 ) -> Literal["default", "pandas", "pyarrow", "numpy"]:
-    """Get a batch format that lines up with the dataset format."""
+    """Get the best batch format that lines up with the dataset format."""
     ctx = DatasetContext.get_current()
     if ctx.use_streaming_executor:
         # TODO: calling dataset_format() triggers bulk execution.

--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -126,7 +126,7 @@ class DatasetIterator(abc.ABC):
         Returns:
             An iterator over rows of the dataset.
         """
-        target_format = self._best_batch_format()
+        target_format = self._default_batch_format()
         for batch in self.iter_batches(
             batch_size=None, prefetch_blocks=prefetch_blocks, batch_format=target_format
         ):
@@ -705,7 +705,7 @@ class DatasetIterator(abc.ABC):
             return False
         return _is_tensor_schema(schema.names)
 
-    def _best_batch_format(self) -> Literal["default", "pandas", "pyarrow", "numpy"]:
+    def _default_batch_format(self) -> Literal["default", "pandas", "pyarrow", "numpy"]:
         """Returns the best batch format that lines up with the dataset format.
 
         NOTE: Return "default" here. Subclass can override this method to decide best

--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -3,7 +3,7 @@ import numpy as np
 import sys
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, Iterator
 
-from ray.data.block import DataBatch, T
+from ray.data.block import BlockAccessor, DataBatch, T
 from ray.data.row import TableRow
 from ray.util.annotations import PublicAPI
 from ray.data._internal.util import _is_tensor_schema
@@ -104,7 +104,6 @@ class DatasetIterator(abc.ABC):
         """
         raise NotImplementedError
 
-    @abc.abstractmethod
     def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[Union[T, TableRow]]:
         """Return a local row iterator over the dataset.
 
@@ -127,8 +126,13 @@ class DatasetIterator(abc.ABC):
         Returns:
             An iterator over rows of the dataset.
         """
-
-        raise NotImplementedError
+        target_format = self._best_batch_format()
+        for batch in self.iter_batches(
+            batch_size=None, prefetch_blocks=prefetch_blocks, batch_format=target_format
+        ):
+            batch = BlockAccessor.for_block(BlockAccessor.batch_to_block(batch))
+            for row in batch.iter_rows():
+                yield row
 
     @abc.abstractmethod
     def stats(self) -> str:
@@ -700,3 +704,11 @@ class DatasetIterator(abc.ABC):
         if schema is None or isinstance(schema, type):
             return False
         return _is_tensor_schema(schema.names)
+
+    def _best_batch_format(self) -> Literal["default", "pandas", "pyarrow", "numpy"]:
+        """Returns the best batch format that lines up with the dataset format.
+
+        NOTE: Return "default" here. Subclass can override this method to decide best
+        batch format.
+        """
+        return "default"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is to fix CI test failure introduced in https://github.com/ray-project/ray/pull/33180 ([example of buildkite failure](https://buildkite.com/ray-project/oss-ci-build-branch/builds/2690#0186da0a-17c7-40dd-a43c-1de36c4894f4)). We need to add `iter_rows()` method for StreamSplitDatasetIterator as well.


<img width="1848" alt="Screen Shot 2023-03-13 at 11 24 05 AM" src="https://user-images.githubusercontent.com/4629931/224795253-ecf4e362-4253-4d60-80ff-f87e138ef773.png">

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #33263 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
