### PR TITLE
[RLlib][RLModule] Deprecate explore=False in favor of RLModule API.

### DIFF
--- a/rllib/tests/test_algorithm_checkpoint_restore.py
+++ b/rllib/tests/test_algorithm_checkpoint_restore.py
@@ -20,11 +20,17 @@ from ray.tune.registry import get_trainable_cls
 
 def get_mean_action(alg, obs):
     out = []
-    for _ in range(2000):
+    for _ in range(5000):
         out.append(float(alg.compute_single_action(obs)))
     return np.mean(out)
 
 
+# As we transition things to RLModule API the explore=False will get
+# deprecated. For now, we will just not set it. The reason is that the RLModule
+# API has forward_exploration() method that can be overriden if user needs to
+# really turn of the stochasticity. This test in particular is robust to
+# explore=None if we compare the mean of the distribution of actions for the
+# same observation to be the same.
 algorithms_and_configs = {
     "A3C": (A3CConfig().exploration(explore=False).rollouts(num_rollout_workers=1)),
     "APEX_DDPG": (
@@ -61,8 +67,9 @@ algorithms_and_configs = {
         .rollouts(observation_filter="MeanStdFilter", num_rollout_workers=2)
     ),
     "PPO": (
+        # See the comment before the `algorithms_and_configs` dict.
+        # explore is set to None for PPO in favor of RLModule API support.
         PPOConfig()
-        .exploration(explore=False)
         .training(num_sgd_iter=5, train_batch_size=1000)
         .rollouts(num_rollout_workers=2)
     ),


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Explore parameter cannot be False with RLModule API enabled. The reason is that the explore is not just a parameter that will get passed down to the policy.compute_actions() anymore. It is a phase in which RLModule. forward_exploration() will get called during smapling. If user needs to really disable the stochasticity during this phase, they need to override the RLModule.forward_exploration() method or setup model parameters such that it will disable the stocalisticity of this method (e.g. by setting the std to 0 or setting temprature to 0 for the Categorical distribution).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
