### PR TITLE
[data] [distributed tqdm] Avoid corrupting tqdm output when log monitor prints worker logs

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1814,8 +1814,6 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
                     ),
                     file=print_file,
                 )
-        # Restore once at end of batch to avoid excess hiding/unhiding of tqdm.
-        restore_tqdm()
     else:
         for line in lines:
             if RAY_TQDM_MAGIC in line:
@@ -1834,8 +1832,8 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
                     ),
                     file=print_file,
                 )
-        # Restore once at end of batch to avoid excess hiding/unhiding of tqdm.
-        restore_tqdm()
+    # Restore once at end of batch to avoid excess hiding/unhiding of tqdm.
+    restore_tqdm()
 
 
 def process_tqdm(line):

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1802,6 +1802,7 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
             if RAY_TQDM_MAGIC in line:
                 process_tqdm(line)
             else:
+                hide_tqdm()
                 print(
                     "{}{}({}{}){} {}".format(
                         colorama.Style.DIM,
@@ -1818,6 +1819,7 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
             if RAY_TQDM_MAGIC in line:
                 process_tqdm(line)
             else:
+                hide_tqdm()
                 print(
                     "{}{}({}{}, ip={}){} {}".format(
                         colorama.Style.DIM,
@@ -1840,6 +1842,11 @@ def process_tqdm(line):
     except Exception:
         print("[tqdm_ray] Failed to decode", line)
         raise
+
+
+def hide_tqdm():
+    """Hide distributed tqdm bars temporarily to avoid conflicts with other logs."""
+    tqdm_ray.instance().hide_bars()
 
 
 def listen_error_messages(worker, threads_stopped):

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1814,7 +1814,8 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
                     ),
                     file=print_file,
                 )
-                restore_tqdm()
+        # Restore once at end of batch to avoid excess hiding/unhiding of tqdm.
+        restore_tqdm()
     else:
         for line in lines:
             if RAY_TQDM_MAGIC in line:
@@ -1833,7 +1834,8 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
                     ),
                     file=print_file,
                 )
-                restore_tqdm()
+        # Restore once at end of batch to avoid excess hiding/unhiding of tqdm.
+        restore_tqdm()
 
 
 def process_tqdm(line):

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1814,6 +1814,7 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
                     ),
                     file=print_file,
                 )
+                restore_tqdm()
     else:
         for line in lines:
             if RAY_TQDM_MAGIC in line:
@@ -1832,6 +1833,7 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
                     ),
                     file=print_file,
                 )
+                restore_tqdm()
 
 
 def process_tqdm(line):
@@ -1847,6 +1849,11 @@ def process_tqdm(line):
 def hide_tqdm():
     """Hide distributed tqdm bars temporarily to avoid conflicts with other logs."""
     tqdm_ray.instance().hide_bars()
+
+
+def restore_tqdm():
+    """Undo hide_tqdm()."""
+    tqdm_ray.instance().unhide_bars()
 
 
 def listen_error_messages(worker, threads_stopped):

--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -185,6 +185,16 @@ class _BarGroup:
             for bar in self.bars_by_uuid.values():
                 bar.update_offset(offset)
 
+    def hide_bars(self) -> None:
+        """Temporarily hide visible bars to avoid conflict with other log messages."""
+        for bar in self.bars_by_uuid.values():
+            bar.bar.clear()
+
+    def unhide_bars(self) -> None:
+        """Opposite of hide_bars()."""
+        for bar in self.bars_by_uuid.values():
+            bar.bar.refresh()
+
 
 class _BarManager:
     """Central tqdm manager run on the driver.
@@ -200,6 +210,7 @@ class _BarManager:
         self.ip = services.get_node_ip_address()
         self.pid = os.getpid()
         self.bar_groups = {}
+        self.in_hidden_state = False
 
     def process_state_update(self, state: ProgressBarState) -> None:
         """Apply the remote progress bar state update.
@@ -208,6 +219,8 @@ class _BarManager:
         created or destroyed, we also recalculate and update the `pos_offset` of each
         BarGroup on the screen.
         """
+        if self.in_hidden_state:
+            self.unhide_bars()
         if state["ip"] == self.ip:
             if state["pid"] == self.pid:
                 prefix = ""
@@ -238,6 +251,20 @@ class _BarManager:
             process.allocate_bar(state)
             self._update_offsets()
 
+    def hide_bars(self) -> None:
+        """Temporarily hide visible bars to avoid conflict with other log messages."""
+        if not self.in_hidden_state:
+            self.in_hidden_state = True
+            for group in self.bar_groups.values():
+                group.hide_bars()
+
+    def unhide_bars(self) -> None:
+        """Opposite of hide_bars()."""
+        if self.in_hidden_state:
+            self.in_hidden_state = False
+            for group in self.bar_groups.values():
+                group.unhide_bars()
+
     def _get_or_allocate_bar_group(self, state: ProgressBarState):
         ptuple = (state["ip"], state["pid"])
         if ptuple not in self.bar_groups:
@@ -266,6 +293,8 @@ if __name__ == "__main__":
     @ray.remote
     def processing(delay):
         def sleep(x):
+            if x % 100 == 0:
+                print("Intermediate result", x)
             time.sleep(delay)
             return x
 

--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -211,6 +211,7 @@ class _BarManager:
         self.pid = os.getpid()
         self.bar_groups = {}
         self.in_hidden_state = False
+        self.num_hides = 0
 
     def process_state_update(self, state: ProgressBarState) -> None:
         """Apply the remote progress bar state update.
@@ -255,6 +256,7 @@ class _BarManager:
         """Temporarily hide visible bars to avoid conflict with other log messages."""
         if not self.in_hidden_state:
             self.in_hidden_state = True
+            self.num_hides += 1
             for group in self.bar_groups.values():
                 group.hide_bars()
 
@@ -293,8 +295,7 @@ if __name__ == "__main__":
     @ray.remote
     def processing(delay):
         def sleep(x):
-            if x % 100 == 0:
-                print("Intermediate result", x)
+            print("Intermediate result", x)
             time.sleep(delay)
             return x
 

--- a/python/ray/tests/test_tqdm.py
+++ b/python/ray/tests/test_tqdm.py
@@ -12,7 +12,6 @@ def test_distributed_tqdm_remote():
     @ray.remote
     class Actor:
         def __init__(self):
-            print("Actor started")
             try:
                 self.bar = tqdm_ray.tqdm(desc="foo", total=100, position=0)
                 self.bar.update(42)
@@ -35,12 +34,10 @@ def test_distributed_tqdm_remote():
     assert "foo" in bar.bar.desc, bar.bar.desc
     assert not mgr.in_hidden_state
 
-    # Test stdout clearing.
+    # Test stdout save/restore clearing.
+    assert mgr.num_hides == 0
     ray.get(a.print_something.remote())
-    wait_for_condition(lambda: mgr.in_hidden_state)
-
-    # Test bar restore on next update.
-    ray.get(a.update.remote())
+    wait_for_condition(lambda: mgr.num_hides == 1)
     wait_for_condition(lambda: not mgr.in_hidden_state)
 
 

--- a/python/ray/tests/test_tqdm.py
+++ b/python/ray/tests/test_tqdm.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import time
 
 import pytest
 
@@ -11,18 +10,22 @@ from ray._private.test_utils import wait_for_condition
 
 def test_distributed_tqdm_remote():
     @ray.remote
-    def foo():
-        print("foo started")
-        try:
-            foo = tqdm_ray.tqdm(desc="foo", total=100, position=0)
-            foo.update(42)
-        except Exception as e:
-            print(e)
-        print("foo wait")
-        time.sleep(999)  # Keep the bar open.
+    class Actor:
+        def __init__(self):
+            print("Actor started")
+            try:
+                self.bar = tqdm_ray.tqdm(desc="foo", total=100, position=0)
+                self.bar.update(42)
+            except Exception as e:
+                print(e)
 
-    foo.remote()
+        def print_something(self):
+            print("hello there")
 
+        def update(self):
+            self.bar.update(1)
+
+    a = Actor.remote()
     mgr = tqdm_ray.instance()
     wait_for_condition(lambda: len(mgr.bar_groups) == 1)
     bar_group = list(mgr.bar_groups.values())[0]
@@ -30,6 +33,15 @@ def test_distributed_tqdm_remote():
     bar = list(bar_group.bars_by_uuid.values())[0]
     assert bar.bar.n == 42, bar.bar.n
     assert "foo" in bar.bar.desc, bar.bar.desc
+    assert not mgr.in_hidden_state
+
+    # Test stdout clearing.
+    ray.get(a.print_something.remote())
+    wait_for_condition(lambda: mgr.in_hidden_state)
+
+    # Test bar restore on next update.
+    ray.get(a.update.remote())
+    wait_for_condition(lambda: not mgr.in_hidden_state)
 
 
 def test_distributed_tqdm_local():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As a followup for https://github.com/ray-project/ray/pull/33122, temporarily hide the TQDM bars when the log monitor is printing other output, to avoid corrupting the progress bars.

We do this by calling `bar.clear()` on all bars when an incoming log message is seen, and then `bar.refresh()` afterwards.

Before this PR:
![Screenshot from 2023-03-13 13-49-21](https://user-images.githubusercontent.com/14922/224829138-790e4cc9-7eca-4c77-bfff-711a80050a98.png)

After this PR:
![Screenshot from 2023-03-13 13-49-51](https://user-images.githubusercontent.com/14922/224832455-fea1a379-7300-45a4-9e1a-57a84a9acd79.png)


