### PR TITLE
[RLlib][RLModule] Disabled Random Encoder test with RLModuleAPI enabled. 

### DIFF
--- a/rllib/utils/exploration/tests/test_random_encoder.py
+++ b/rllib/utils/exploration/tests/test_random_encoder.py
@@ -26,13 +26,26 @@ class TestRE3(unittest.TestCase):
         Both the on-policy and off-policy setups are validated.
         """
         if rl_algorithm == "PPO":
-            config = ppo.PPOConfig().to_dict()
+            # We need to disable the RLModule / Learner API here, since this test is
+            # overfitted to the ModelV2 API stack. The random encoder is based on
+            # ModelV2 stack.
+            config = (
+                ppo.PPOConfig()
+                .rl_module(_enable_rl_module_api=False)
+                .training(_enable_learner_api=False)
+            )
             algo_cls = ppo.PPO
             beta_schedule = "constant"
         elif rl_algorithm == "SAC":
-            config = sac.SACConfig().to_dict()
+            config = (
+                sac.SACConfig()
+                .rl_module(_enable_rl_module_api=False)
+                .training(_enable_learner_api=False)
+            )
             algo_cls = sac.SAC
             beta_schedule = "linear_decay"
+
+        config = config.to_dict()
 
         class RE3Callbacks(RE3UpdateCallbacks, config["callbacks"]):
             pass


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

RandomEncoder is overfitted to ModelV2 stack and needs to be migrated onto the new stack on a separate PR.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
