### PR TITLE
[RLlib][RLModule] Disabled the RLModuleAPI in the some export model tests

### DIFF
--- a/rllib/algorithms/tests/test_algorithm_export_checkpoint.py
+++ b/rllib/algorithms/tests/test_algorithm_export_checkpoint.py
@@ -13,6 +13,11 @@ from ray.tune.registry import get_trainable_cls
 tf1, tf, tfv = try_import_tf()
 torch, _ = try_import_torch()
 
+# Keep a set of all RLlib algos that support the RLModule API.
+# For these algos we need to disable the RLModule API in the config for the purpose of
+# this test. This test is made for the ModelV2 API which is not the same as RLModule.
+RLMODULE_SUPPORTED_ALGOS = {"PPO"}
+
 
 def save_test(alg_name, framework="tf", multi_agent=False):
     cls = get_trainable_cls(alg_name)
@@ -21,6 +26,11 @@ def save_test(alg_name, framework="tf", multi_agent=False):
         # Switch on saving native DL-framework (tf, torch) model files.
         .checkpointing(export_native_model_files=True)
     )
+
+    if alg_name in RLMODULE_SUPPORTED_ALGOS:
+        config = config.rl_module(_enable_rl_module_api=False).training(
+            _enable_learner_api=False
+        )
 
     if "DDPG" in alg_name or "SAC" in alg_name:
         config.environment("Pendulum-v1")

--- a/rllib/policy/tests/test_export_checkpoint_and_model.py
+++ b/rllib/policy/tests/test_export_checkpoint_and_model.py
@@ -15,52 +15,10 @@ from ray.tune.registry import get_trainable_cls
 tf1, tf, tfv = try_import_tf()
 torch, _ = try_import_torch()
 
-CONFIGS = {
-    "A3C": {
-        "explore": False,
-        "num_workers": 1,
-    },
-    "APEX_DDPG": {
-        "explore": False,
-        "observation_filter": "MeanStdFilter",
-        "num_workers": 2,
-        "min_time_s_per_iteration": 1,
-        "optimizer": {
-            "num_replay_buffer_shards": 1,
-        },
-    },
-    "ARS": {
-        "explore": False,
-        "num_rollouts": 10,
-        "num_workers": 2,
-        "noise_size": 2500000,
-        "observation_filter": "MeanStdFilter",
-    },
-    "DDPG": {
-        "explore": False,
-        "min_sample_timesteps_per_iteration": 100,
-    },
-    "DQN": {
-        "explore": False,
-    },
-    "ES": {
-        "explore": False,
-        "episodes_per_batch": 10,
-        "train_batch_size": 100,
-        "num_workers": 2,
-        "noise_size": 2500000,
-        "observation_filter": "MeanStdFilter",
-    },
-    "PPO": {
-        "explore": False,
-        "num_sgd_iter": 5,
-        "train_batch_size": 1000,
-        "num_workers": 2,
-    },
-    "SAC": {
-        "explore": False,
-    },
-}
+# Keep a set of all RLlib algos that support the RLModule API.
+# For these algos we need to disable the RLModule API in the config for the purpose of
+# this test. This test is made for the ModelV2 API which is not the same as RLModule.
+RLMODULE_SUPPORTED_ALGOS = {"PPO"}
 
 
 def export_test(
@@ -70,7 +28,12 @@ def export_test(
     tf_expected_to_work=True,
 ):
     cls = get_trainable_cls(alg_name)
-    config = cls.get_default_config().to_dict()
+    config = cls.get_default_config()
+    if alg_name in RLMODULE_SUPPORTED_ALGOS:
+        config = config.rl_module(_enable_rl_module_api=False).training(
+            _enable_learner_api=False
+        )
+    config = config.to_dict()
     config["framework"] = framework
     # Switch on saving native DL-framework (tf, torch) model files.
     config["export_native_model_files"] = True
@@ -193,7 +156,7 @@ def export_test(
 class TestExportCheckpointAndModel(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        ray.init(num_cpus=4, local_mode=True)
+        ray.init()
 
     @classmethod
     def tearDownClass(cls) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
These tests only work for ModelV2 stack. So we should disable RLModule API explicitly in them. 
test_export_ckpt_and_model
test_algorithm_export_checkpoint

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
