### PR TITLE
[Datasets] Fix failing Documentation tests related to updated `ExecutionPlan.__repr__`

### DIFF
--- a/doc/source/data/getting-started.rst
+++ b/doc/source/data/getting-started.rst
@@ -72,7 +72,7 @@ transform datasets. Ray executes transformations in parallel for performance at 
              petal width (cm): double,
              target: int64
           }
-    )
+       )
 
 To learn more about transforming datasets, read
 :ref:`Transforming datasets <transforming_datasets>`.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -804,10 +804,10 @@ class Dataset(Generic[T]):
             >>> ds
             MapBatches(<lambda>)
             +- Dataset(
-                num_blocks=10,
-                num_rows=10,
-                schema={col1: int64, col2: int64, col3: int64}
-            )
+                  num_blocks=10,
+                  num_rows=10,
+                  schema={col1: int64, col2: int64, col3: int64}
+               )
 
 
         Time complexity: O(dataset size / parallelism)
@@ -3280,16 +3280,16 @@ class Dataset(Generic[T]):
             >>> ds
             Concatenator
             +- Dataset(
-               num_blocks=1,
-               num_rows=150,
-               schema={
-                  sepal length (cm): double,
-                  sepal width (cm): double,
-                  petal length (cm): double,
-                  petal width (cm): double,
-                  target: int64
-               }
-            )
+                  num_blocks=1,
+                  num_rows=150,
+                  schema={
+                     sepal length (cm): double,
+                     sepal width (cm): double,
+                     petal length (cm): double,
+                     petal width (cm): double,
+                     target: int64
+                  }
+               )
             >>> ds.to_tf("features", "target")  # doctest: +SKIP
             <_OptionsDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float64, name='features'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
 

--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -553,16 +553,16 @@ class DatasetIterator(abc.ABC):
             >>> it
             DatasetIterator(Concatenator
             +- Dataset(
-               num_blocks=1,
-               num_rows=150,
-               schema={
-                  sepal length (cm): double,
-                  sepal width (cm): double,
-                  petal length (cm): double,
-                  petal width (cm): double,
-                  target: int64
-               }
-            ))
+                  num_blocks=1,
+                  num_rows=150,
+                  schema={
+                     sepal length (cm): double,
+                     sepal width (cm): double,
+                     petal length (cm): double,
+                     petal width (cm): double,
+                     target: int64
+                  }
+               ))
             >>> it.to_tf("features", "target")  # doctest: +SKIP
             <_OptionsDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float64, name='features'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Fixes up a few remaining docstring changes related to https://github.com/ray-project/ray/pull/33125.

<!-- For example: "Closes #1234" -->
Closes #30719 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
