### PR TITLE
[Tune] Change ExperimentAnlysis default file type from csv to json

### DIFF
--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -38,7 +38,7 @@ from ray.util.annotations import PublicAPI
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_FILE_TYPE = "csv"
+DEFAULT_FILE_TYPE = "json"
 
 
 @PublicAPI(stability="beta")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Some trainables (e.g. LightningTrainer) report different metrics in each `session.report()` call. By default, we use CSVLogger, so metrics that were not reported in the first report() will not be saved in `progress.csv`.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
