### PR TITLE
[data] Add tip for validating GCS permissions

### DIFF
--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -302,6 +302,8 @@ are supported for each of these storage systems.
       :start-after: __validate_parquet_gcs_begin__
       :end-before: __validate_parquet_gcs_end__
 
+    For more examples, see `GCSFS Documentation <https://gcsfs.readthedocs.io/en/latest/#examples>`__.
+
 .. tabbed:: ADL/ABS (Azure)
 
   Data can be read from Azure Blob Storage by providing a configured

--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -294,7 +294,7 @@ are supported for each of these storage systems.
     :end-before: __read_parquet_gcs_end__
 
   .. tip::
-    To verify that your GCP project and credentials are set up, you can validate
+    To verify that your GCP project and credentials are set up, validate
     that your GCS `filesystem` has the right permissions to read the input `path`.
 
     .. literalinclude:: ./doc_code/creating_datasets.py

--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -295,7 +295,7 @@ are supported for each of these storage systems.
 
   .. tip::
     To verify that your GCP project and credentials are set up, validate
-    that your GCS `filesystem` has the right permissions to read the input `path`.
+    that the GCS `filesystem` has permissions to read the input `path`.
 
     .. literalinclude:: ./doc_code/creating_datasets.py
       :language: python

--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -293,6 +293,15 @@ are supported for each of these storage systems.
     :start-after: __read_parquet_gcs_begin__
     :end-before: __read_parquet_gcs_end__
 
+  .. tip::
+    To verify that your GCP project and credentials are set up, you can validate
+    that your GCS `filesystem` has the right permissions to read the input `path`.
+
+    .. literalinclude:: ./doc_code/creating_datasets.py
+      :language: python
+      :start-after: __validate_parquet_gcs_begin__
+      :end-before: __validate_parquet_gcs_end__
+
 .. tabbed:: ADL/ABS (Azure)
 
   Data can be read from Azure Blob Storage by providing a configured

--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -302,7 +302,7 @@ are supported for each of these storage systems.
       :start-after: __validate_parquet_gcs_begin__
       :end-before: __validate_parquet_gcs_end__
 
-    For more examples, see `GCSFS Documentation <https://gcsfs.readthedocs.io/en/latest/#examples>`__.
+    For more examples, see the `GCSFS Documentation <https://gcsfs.readthedocs.io/en/latest/#examples>`__.
 
 .. tabbed:: ADL/ABS (Azure)
 

--- a/doc/source/data/doc_code/creating_datasets.py
+++ b/doc/source/data/doc_code/creating_datasets.py
@@ -568,11 +568,20 @@ import gcsfs
 # GCSFileSystem.
 # NOTE: This example is not runnable as-is; you'll need to point it at your GCS bucket
 # and configure your GCP project and credentials.
+path = "gs://path/to/file.parquet"
+filesystem = gcsfs.GCSFileSystem(project="my-google-project")
 ds = ray.data.read_parquet(
-    "gs://path/to/file.parquet",
-    filesystem=gcsfs.GCSFileSystem(project="my-google-project"),
+    path,
+    filesystem=filesystem,
 )
 # __read_parquet_gcs_end__
+# fmt: on
+
+
+# fmt: off
+# __validate_parquet_gcs_begin__
+filesystem.open(path)
+# __validate_parquet_gcs_end__
 # fmt: on
 
 # fmt: off

--- a/doc/source/data/doc_code/creating_datasets.py
+++ b/doc/source/data/doc_code/creating_datasets.py
@@ -570,10 +570,7 @@ import gcsfs
 # and configure your GCP project and credentials.
 path = "gs://path/to/file.parquet"
 filesystem = gcsfs.GCSFileSystem(project="my-google-project")
-ds = ray.data.read_parquet(
-    path,
-    filesystem=filesystem,
-)
+ds = ray.data.read_parquet(path, filesystem=filesystem)
 # __read_parquet_gcs_end__
 # fmt: on
 

--- a/doc/source/data/doc_code/creating_datasets.py
+++ b/doc/source/data/doc_code/creating_datasets.py
@@ -577,7 +577,8 @@ ds = ray.data.read_parquet(path, filesystem=filesystem)
 
 # fmt: off
 # __validate_parquet_gcs_begin__
-filesystem.open(path)
+print(filesystem.open(path))
+# <File-like object GCSFileSystem, path/to/file.parquet>
 # __validate_parquet_gcs_end__
 # fmt: on
 

--- a/doc/source/data/doc_code/creating_datasets.py
+++ b/doc/source/data/doc_code/creating_datasets.py
@@ -566,7 +566,7 @@ import gcsfs
 
 # Create a tabular Dataset by reading a Parquet file from GCS, passing the configured
 # GCSFileSystem.
-# NOTE: This example is not runnable as-is; you'll need to point it at your GCS bucket
+# NOTE: This example is not runnable as-is; you need to point it at your GCS bucket
 # and configure your GCP project and credentials.
 path = "gs://path/to/file.parquet"
 filesystem = gcsfs.GCSFileSystem(project="my-google-project")

--- a/doc/source/data/doc_code/creating_datasets.py
+++ b/doc/source/data/doc_code/creating_datasets.py
@@ -577,6 +577,8 @@ ds = ray.data.read_parquet(path, filesystem=filesystem)
 
 # fmt: off
 # __validate_parquet_gcs_begin__
+print(filesystem.ls(path))
+# ['path/to/file.parquet']
 print(filesystem.open(path))
 # <File-like object GCSFileSystem, path/to/file.parquet>
 # __validate_parquet_gcs_end__


### PR DESCRIPTION
## Why are these changes needed?

When reading from (Google) Cloud Storage, users may run into errors that are raised by the filesystem, e.g. if the user does not have permissions. While it is preferable to raise a descriptive error message here, it may be difficult to capture all the possible error messages raised by the user provided filesystem, which may also change across different versions. This tip is meant to be a catch all to provide users with a quick debugging tip.

![image](https://user-images.githubusercontent.com/3967392/224916036-b5352521-32c4-4be5-860e-2dc621b2158a.png)

Happy to add similar notes for the other providers (S3, HDFS, Azure) if this looks good. (**Note:** These will have different tips depending if they follow the `arrow` or `fsspec` interface.)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
