### PR TITLE
fix: pin libffi=3.3 for base-deps

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -51,7 +51,7 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
     && echo 'export PATH=$HOME/anaconda3/bin:$PATH' >> /home/ray/.bashrc \
     && rm /tmp/miniconda.sh \
     && $HOME/anaconda3/bin/conda install -y \
-        libgcc-ng python=$PYTHON_VERSION \
+        libgcc-ng libffi=3.3 python=$PYTHON_VERSION \
     && $HOME/anaconda3/bin/conda clean -y --all \
     && $HOME/anaconda3/bin/pip install --no-cache-dir \
         flatbuffers \


### PR DESCRIPTION
## Why are these changes needed?

Fixes an issue with transient dependencies which can cause failure on 2.3.0 `rayproject/ray` Docker images due to incompatible `libffi`.

This pins the version in the base-deps to `3.3` which installs a supported version.

This is optional for existing 2.3.0 images, but should be cherry-picked to fix 2.3.1.

## Related issue number

(internal issue)
relates-to: https://github.com/anyscale/product/issues/18531

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
