### PR TITLE
[RLlib][RLModule] Disabled the RLModule API in custom_model_loss_and_metrics.py 

### DIFF
--- a/rllib/examples/custom_model_loss_and_metrics.py
+++ b/rllib/examples/custom_model_loss_and_metrics.py
@@ -64,6 +64,8 @@ if __name__ == "__main__":
         TorchCustomLossModel if args.framework == "torch" else CustomLossModel,
     )
 
+    # TODO (Kourosh): This example needs to be migrated to the new RLModule / Learner
+    # API. Users should just inherit the Learner and extend the loss_fn.
     config = (
         get_trainable_cls(args.run)
         .get_default_config()
@@ -76,10 +78,12 @@ if __name__ == "__main__":
                 "custom_model_config": {
                     "input_files": args.input_files,
                 },
-            }
+            },
+            _enable_learner_api=False,
         )
         # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
         .resources(num_gpus=int(os.environ.get("RLLIB_NUM_GPUS", "0")))
+        .rl_module(_enable_rl_module_api=False)
     )
 
     stop = {


### PR DESCRIPTION
This example needs to be migrated.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
