### PR TITLE
[autoscaler] Hide `accelerator_type` resources in `ray status`

### DIFF
--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -3031,6 +3031,7 @@ def test_info_string():
             "AcceleratorType:V100": (0, 2),
             "memory": (2 * 2**30, 2**33),
             "object_store_memory": (3.14 * 2**30, 2**34),
+            "accelerator_type:T4": (1, 1),
         },
         resource_demand=[({"CPU": 1}, 150)],
         pg_demand=[({"bundles": [({"CPU": 4}, 5)], "strategy": "PACK"}, 420)],
@@ -3089,7 +3090,7 @@ def test_info_string_verbose():
         usage={
             "CPU": (530.0, 544.0),
             "GPU": (2, 2),
-            "AcceleratorType:V100": (1, 2),
+            "accelerator_type:V100": (1, 2),
             "memory": (2 * 2**30, 2**33),
             "object_store_memory": (3.14 * 2**30, 2**34),
         },
@@ -3101,14 +3102,14 @@ def test_info_string_verbose():
             "192.168.1.1": {
                 "CPU": (5.0, 20.0),
                 "GPU": (0.7, 1),
-                "AcceleratorType:V100": (0.1, 1),
+                "accelerator_type:V100": (0.1, 1),
                 "memory": (2**30, 2**32),
                 "object_store_memory": (3.14 * 2**30, 2**32),
             },
             "192.168.1.2": {
                 "CPU": (15.0, 20.0),
                 "GPU": (0.3, 1),
-                "AcceleratorType:V100": (0.9, 1),
+                "accelerator_type:V100": (0.9, 1),
                 "memory": (2**30, 1.5 * 2**33),
                 "object_store_memory": (0, 2**32),
             },
@@ -3144,9 +3145,9 @@ Recent failures:
 Resources
 --------------------------------------------------------
 Total Usage:
- 1/2 AcceleratorType:V100
  530.0/544.0 CPU
  2/2 GPU
+ 1/2 accelerator_type:V100
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
@@ -3157,17 +3158,17 @@ Total Demands:
 
 Node: 192.168.1.1
  Usage:
-  0.1/1 AcceleratorType:V100
   5.0/20.0 CPU
   0.7/1 GPU
+  0.1/1 accelerator_type:V100
   1.00GiB/4.00GiB memory
   3.14GiB/4.00GiB object_store_memory
 
 Node: 192.168.1.2
  Usage:
-  0.9/1 AcceleratorType:V100
   15.0/20.0 CPU
   0.3/1 GPU
+  0.9/1 accelerator_type:V100
   1.00GiB/12.00GiB memory
   0B/4.00GiB object_store_memory
 """.strip()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It seems the `accelerator_type` field in `ray status was confusing people. This PR stops us from displaying it (except in verbose mode, where the user is expected to be more advanced and benefit from seeing a more advanced cluster state similar to how the autoscaler sees it. 

## Related issue number
Partially addresses #33272

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
