### PR TITLE
[Datasets] Add sub progress bar support for AllToAllOperator

### DIFF
--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -217,8 +217,10 @@ class TaskContext:
     # operator.
     task_idx: int
 
-    # The iterator of sub progress bar that task is responsible to update.
-    sub_progress_bar_iter: Optional[Iterator[ProgressBar]] = None
+    # The dictionary of sub progress bar to update. The key is name of sub progress
+    # bar. Note this is only used on driver side.
+    # TODO(chengsu): clean it up from TaskContext with new optimizer framework.
+    sub_progress_bar_dict: Optional[Dict[str, ProgressBar]] = None
 
 
 # Block transform function applied by task and actor pools in MapOperator.

--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Iterable, Iterator, Tuple, Callable, Un
 import ray
 from ray.data._internal.logical.interfaces import Operator
 from ray.data._internal.memory_tracing import trace_deallocation
+from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.stats import DatasetStats, StatsDict
 from ray.data.block import Block, BlockMetadata
 from ray.data.context import DatasetContext
@@ -215,6 +216,9 @@ class TaskContext:
     # The index of task. Each task has a unique task index within the same
     # operator.
     task_idx: int
+
+    # The iterator of sub progress bar that task is responsible to update.
+    sub_progress_bar_iter: Optional[Iterator[ProgressBar]] = None
 
 
 # Block transform function applied by task and actor pools in MapOperator.

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -309,6 +309,7 @@ def _stage_to_operator(stage: Stage, input_op: PhysicalOperator) -> PhysicalOper
             input_op,
             name=stage.name,
             num_outputs=stage.num_blocks,
+            sub_progress_bar_names=stage.sub_stage_names,
         )
     else:
         raise NotImplementedError

--- a/python/ray/data/_internal/execution/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/execution/operators/all_to_all_operator.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+from ray.data._internal.progress_bar import ProgressBar
 
 from ray.data._internal.stats import StatsDict
 from ray.data._internal.execution.interfaces import (
@@ -20,6 +21,7 @@ class AllToAllOperator(PhysicalOperator):
         bulk_fn: AllToAllTransformFn,
         input_op: PhysicalOperator,
         num_outputs: Optional[int] = None,
+        sub_progress_bar_names: Optional[List[str]] = None,
         name: str = "AllToAll",
     ):
         """Create an AllToAllOperator.
@@ -30,11 +32,14 @@ class AllToAllOperator(PhysicalOperator):
                 and a stats dict.
             input_op: Operator generating input data for this op.
             num_outputs: The number of expected output bundles for progress bar.
+            sub_progress_bar_names: The names of internal sub progress bars.
             name: The name of this operator.
         """
         self._bulk_fn = bulk_fn
         self._next_task_index = 0
         self._num_outputs = num_outputs
+        self._sub_progress_bar_names = sub_progress_bar_names
+        self._sub_progress_bars = []
         self._input_buffer: List[RefBundle] = []
         self._output_buffer: List[RefBundle] = []
         self._stats: StatsDict = {}
@@ -53,7 +58,10 @@ class AllToAllOperator(PhysicalOperator):
         self._input_buffer.append(refs)
 
     def inputs_done(self) -> None:
-        ctx = TaskContext(task_idx=self._next_task_index)
+        ctx = TaskContext(
+            task_idx=self._next_task_index,
+            sub_progress_bar_iter=iter(self._sub_progress_bars),
+        )
         self._output_buffer, self._stats = self._bulk_fn(self._input_buffer, ctx)
         self._next_task_index += 1
         self._input_buffer.clear()
@@ -70,3 +78,19 @@ class AllToAllOperator(PhysicalOperator):
 
     def get_transformation_fn(self) -> AllToAllTransformFn:
         return self._bulk_fn
+
+    def initialize_sub_progress_bars(self, position: int) -> int:
+        """Initialize all internal sub progress bars, and return the number of bars."""
+        if self._sub_progress_bar_names is not None:
+            for name in self._sub_progress_bar_names:
+                bar = ProgressBar(name, self.num_outputs_total() or 1, position)
+                bar.set_description(f"  *- {name}")
+                self._sub_progress_bars.append(bar)
+                position += 1
+        return len(self._sub_progress_bars)
+
+    def close_sub_progress_bars(self):
+        """Close all internal sub progress bars."""
+        if self._sub_progress_bar_names is not None:
+            for sub_bar in self._sub_progress_bars:
+                sub_bar.close()

--- a/python/ray/data/_internal/execution/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/execution/operators/all_to_all_operator.py
@@ -39,7 +39,7 @@ class AllToAllOperator(PhysicalOperator):
         self._next_task_index = 0
         self._num_outputs = num_outputs
         self._sub_progress_bar_names = sub_progress_bar_names
-        self._sub_progress_bar_dict = {}
+        self._sub_progress_bar_dict = None
         self._input_buffer: List[RefBundle] = []
         self._output_buffer: List[RefBundle] = []
         self._stats: StatsDict = {}
@@ -85,6 +85,7 @@ class AllToAllOperator(PhysicalOperator):
     def initialize_sub_progress_bars(self, position: int) -> int:
         """Initialize all internal sub progress bars, and return the number of bars."""
         if self._sub_progress_bar_names is not None:
+            self._sub_progress_bar_dict = {}
             for name in self._sub_progress_bar_names:
                 bar = ProgressBar(name, self.num_outputs_total() or 1, position)
                 # NOTE: call `set_description` to trigger the initial print of progress
@@ -96,6 +97,6 @@ class AllToAllOperator(PhysicalOperator):
 
     def close_sub_progress_bars(self):
         """Close all internal sub progress bars."""
-        if self._sub_progress_bar_names is not None:
+        if self._sub_progress_bar_dict is not None:
             for sub_bar in self._sub_progress_bar_dict.values():
                 sub_bar.close()

--- a/python/ray/data/_internal/execution/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/execution/operators/all_to_all_operator.py
@@ -79,6 +79,9 @@ class AllToAllOperator(PhysicalOperator):
     def get_transformation_fn(self) -> AllToAllTransformFn:
         return self._bulk_fn
 
+    def progress_str(self) -> str:
+        return f"{len(self._output_buffer)} output"
+
     def initialize_sub_progress_bars(self, position: int) -> int:
         """Initialize all internal sub progress bars, and return the number of bars."""
         if self._sub_progress_bar_names is not None:

--- a/python/ray/data/_internal/execution/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/execution/operators/all_to_all_operator.py
@@ -93,7 +93,9 @@ class AllToAllOperator(PhysicalOperator):
                 bar.set_description(f"  *- {name}")
                 self._sub_progress_bar_dict[name] = bar
                 position += 1
-        return len(self._sub_progress_bar_dict)
+            return len(self._sub_progress_bar_dict)
+        else:
+            return 0
 
     def close_sub_progress_bars(self):
         """Close all internal sub progress bars."""

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -133,7 +133,7 @@ class StreamingExecutor(Executor, threading.Thread):
                 self._global_info.close()
             for op, state in self._topology.items():
                 op.shutdown()
-                state.close_progress_bar()
+                state.close_progress_bars()
             if self._output_info:
                 self._output_info.close()
 

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -75,9 +75,11 @@ class StreamingExecutor(Executor, threading.Thread):
             self._global_info = ProgressBar("Resource usage vs limits", 1, 0)
 
         # Setup the streaming DAG topology and start the runner thread.
-        self._topology = build_streaming_topology(dag, self._options)
+        self._topology, progress_bar_position = build_streaming_topology(
+            dag, self._options
+        )
         self._output_info = ProgressBar(
-            "Output", dag.num_outputs_total() or 1, len(self._topology)
+            "Output", dag.num_outputs_total() or 1, progress_bar_position
         )
         _validate_topology(self._topology, self._get_or_refresh_resource_limits())
 
@@ -131,8 +133,7 @@ class StreamingExecutor(Executor, threading.Thread):
                 self._global_info.close()
             for op, state in self._topology.items():
                 op.shutdown()
-                if state.progress_bar:
-                    state.progress_bar.close()
+                state.close_progress_bar()
             if self._output_info:
                 self._output_info.close()
 

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -102,8 +102,8 @@ class OpState:
         self.num_completed_tasks = 0
         self.inputs_done_called = False
 
-    def initialize_progress_bar(self, index: int) -> int:
-        """Create progress bar at the given index (line offset in console).
+    def initialize_progress_bars(self, index: int) -> int:
+        """Create progress bars at the given index (line offset in console).
 
         For AllToAllOperator, zero or more sub progress bar would be created.
         Return the number of progress bars created for this operator.
@@ -116,7 +116,7 @@ class OpState:
             num_bars += self.op.initialize_sub_progress_bars(index + 1)
         return num_bars
 
-    def close_progress_bar(self):
+    def close_progress_bars(self):
         """Close all progress bars for this operator."""
         if self.progress_bar:
             self.progress_bar.close()
@@ -253,7 +253,7 @@ def build_streaming_topology(
     i = 1
     for op_state in list(topology.values()):
         if not isinstance(op_state.op, InputDataBuffer):
-            i += op_state.initialize_progress_bar(i)
+            i += op_state.initialize_progress_bars(i)
 
     return (topology, i)
 

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -7,7 +7,7 @@ import math
 import time
 from collections import deque
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Deque, Union
+from typing import Dict, List, Optional, Deque, Tuple, Union
 
 import ray
 from ray.data._internal.execution.interfaces import (
@@ -16,6 +16,7 @@ from ray.data._internal.execution.interfaces import (
     PhysicalOperator,
     ExecutionOptions,
 )
+from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.progress_bar import ProgressBar
 
@@ -101,11 +102,26 @@ class OpState:
         self.num_completed_tasks = 0
         self.inputs_done_called = False
 
-    def initialize_progress_bar(self, index: int) -> None:
-        """Create a progress bar at the given index (line offset in console)."""
+    def initialize_progress_bar(self, index: int) -> int:
+        """Create progress bar at the given index (line offset in console).
+
+        For AllToAllOperator, zero or more sub progress bar would be created.
+        Return the number of progress bars created for this operator.
+        """
         self.progress_bar = ProgressBar(
             self.op.name, self.op.num_outputs_total() or 1, index
         )
+        num_bars = 1
+        if isinstance(self.op, AllToAllOperator):
+            num_bars += self.op.initialize_sub_progress_bars(index + 1)
+        return num_bars
+
+    def close_progress_bar(self):
+        """Close all progress bars for this operator."""
+        if self.progress_bar:
+            self.progress_bar.close()
+            if isinstance(self.op, AllToAllOperator):
+                self.op.close_sub_progress_bars()
 
     def num_queued(self) -> int:
         """Return the number of queued bundles across all inqueues."""
@@ -194,7 +210,7 @@ class OpState:
 
 def build_streaming_topology(
     dag: PhysicalOperator, options: ExecutionOptions
-) -> Topology:
+) -> Tuple[Topology, int]:
     """Instantiate the streaming operator state topology for the given DAG.
 
     This involves creating the operator state for each operator in the DAG,
@@ -207,6 +223,7 @@ def build_streaming_topology(
 
     Returns:
         The topology dict holding the streaming execution state.
+        The number of progress bars initialized so far.
     """
 
     topology: Topology = {}
@@ -236,10 +253,9 @@ def build_streaming_topology(
     i = 1
     for op_state in list(topology.values()):
         if not isinstance(op_state.op, InputDataBuffer):
-            op_state.initialize_progress_bar(i)
-            i += 1
+            i += op_state.initialize_progress_bar(i)
 
-    return topology
+    return (topology, i)
 
 
 def process_completed_tasks(topology: Topology) -> None:

--- a/python/ray/data/_internal/fast_repartition.py
+++ b/python/ray/data/_internal/fast_repartition.py
@@ -43,8 +43,10 @@ def fast_repartition(blocks, num_blocks, ctx: Optional[TaskContext] = None):
     reduce_task = cached_remote_fn(_ShufflePartitionOp.reduce).options(num_returns=2)
 
     should_close_bar = True
-    if ctx is not None and ctx.sub_progress_bar_iter is not None:
-        reduce_bar = next(ctx.sub_progress_bar_iter)
+    if ctx is not None and ctx.sub_progress_bar_dict is not None:
+        bar_name = "Repartition"
+        assert bar_name in ctx.sub_progress_bar_dict, ctx.sub_progress_bar_dict
+        reduce_bar = ctx.sub_progress_bar_dict[bar_name]
         should_close_bar = False
     else:
         reduce_bar = ProgressBar("Repartition", position=0, total=len(splits))

--- a/python/ray/data/_internal/fast_repartition.py
+++ b/python/ray/data/_internal/fast_repartition.py
@@ -1,4 +1,6 @@
+from typing import Optional
 import ray
+from ray.data._internal.execution.interfaces import TaskContext
 
 from ray.data.block import BlockAccessor
 from ray.data._internal.block_list import BlockList
@@ -9,7 +11,7 @@ from ray.data._internal.shuffle_and_partition import _ShufflePartitionOp
 from ray.data._internal.stats import DatasetStats
 
 
-def fast_repartition(blocks, num_blocks):
+def fast_repartition(blocks, num_blocks, ctx: Optional[TaskContext] = None):
     from ray.data.dataset import Dataset
 
     wrapped_ds = Dataset(
@@ -39,7 +41,14 @@ def fast_repartition(blocks, num_blocks):
 
     # Coalesce each split into a single block.
     reduce_task = cached_remote_fn(_ShufflePartitionOp.reduce).options(num_returns=2)
-    reduce_bar = ProgressBar("Repartition", position=0, total=len(splits))
+
+    should_close_bar = True
+    if ctx is not None and ctx.sub_progress_bar_iter is not None:
+        reduce_bar = next(ctx.sub_progress_bar_iter)
+        should_close_bar = False
+    else:
+        reduce_bar = ProgressBar("Repartition", position=0, total=len(splits))
+
     reduce_out = [
         reduce_task.remote(False, None, *s.get_internal_block_refs())
         for s in splits
@@ -54,7 +63,9 @@ def fast_repartition(blocks, num_blocks):
     new_blocks, new_metadata = zip(*reduce_out)
     new_blocks, new_metadata = list(new_blocks), list(new_metadata)
     new_metadata = reduce_bar.fetch_until_complete(new_metadata)
-    reduce_bar.close()
+
+    if should_close_bar:
+        reduce_bar.close()
 
     # Handle empty blocks.
     if len(new_blocks) < num_blocks:

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -1048,12 +1048,14 @@ class AllToAllStage(Stage):
         supports_block_udf: bool = False,
         block_udf: Optional[BlockTransform] = None,
         remote_args: Optional[Dict[str, Any]] = None,
+        sub_stage_names: Optional[List[str]] = None,
     ):
         super().__init__(name, num_blocks)
         self.fn = fn
         self.supports_block_udf = supports_block_udf
         self.block_udf = block_udf
         self.ray_remote_args = remote_args or {}
+        self.sub_stage_names = sub_stage_names
 
     def can_fuse(self, prev: Stage):
         context = DatasetContext.get_current()
@@ -1100,7 +1102,13 @@ class AllToAllStage(Stage):
                 yield from self_block_udf(blocks, ctx)
 
         return AllToAllStage(
-            name, self.num_blocks, self.fn, True, block_udf, prev.ray_remote_args
+            name,
+            self.num_blocks,
+            self.fn,
+            True,
+            block_udf,
+            prev.ray_remote_args,
+            self.sub_stage_names,
         )
 
     def __call__(

--- a/python/ray/data/_internal/push_based_shuffle.py
+++ b/python/ray/data/_internal/push_based_shuffle.py
@@ -430,8 +430,10 @@ class PushBasedShufflePlan(ShuffleOp):
         )
 
         should_close_bar = True
-        if ctx is not None and ctx.sub_progress_bar_iter is not None:
-            map_bar = next(ctx.sub_progress_bar_iter)
+        if ctx is not None and ctx.sub_progress_bar_dict is not None:
+            bar_name = "ShuffleMap"
+            assert bar_name in ctx.sub_progress_bar_dict, ctx.sub_progress_bar_dict
+            map_bar = ctx.sub_progress_bar_dict[bar_name]
             should_close_bar = False
         else:
             map_bar = ProgressBar(
@@ -477,8 +479,10 @@ class PushBasedShufflePlan(ShuffleOp):
 
         # Execute and wait for the reduce stage.
         should_close_bar = True
-        if ctx is not None and ctx.sub_progress_bar_iter is not None:
-            reduce_bar = next(ctx.sub_progress_bar_iter)
+        if ctx is not None and ctx.sub_progress_bar_dict is not None:
+            bar_name = "ShuffleReduce"
+            assert bar_name in ctx.sub_progress_bar_dict, ctx.sub_progress_bar_dict
+            reduce_bar = ctx.sub_progress_bar_dict[bar_name]
             should_close_bar = False
         else:
             reduce_bar = ProgressBar("Shuffle Reduce", total=output_num_blocks)

--- a/python/ray/data/_internal/push_based_shuffle.py
+++ b/python/ray/data/_internal/push_based_shuffle.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
 import ray
 from ray.data._internal.block_list import BlockList
+from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.shuffle import ShuffleOp
@@ -369,6 +370,7 @@ class PushBasedShufflePlan(ShuffleOp):
         map_ray_remote_args: Optional[Dict[str, Any]] = None,
         reduce_ray_remote_args: Optional[Dict[str, Any]] = None,
         merge_factor: int = 2,
+        ctx: Optional[TaskContext] = None,
     ) -> Tuple[BlockList, Dict[str, List[BlockMetadata]]]:
         logger.info("Using experimental push-based shuffle.")
         # TODO(swang): For jobs whose reduce work is heavier than the map work,
@@ -426,7 +428,16 @@ class PushBasedShufflePlan(ShuffleOp):
             shuffle_map,
             [output_num_blocks, stage.merge_schedule, *self._map_args],
         )
-        map_bar = ProgressBar("Shuffle Map", position=0, total=len(input_blocks_list))
+
+        should_close_bar = True
+        if ctx is not None and ctx.sub_progress_bar_iter is not None:
+            map_bar = next(ctx.sub_progress_bar_iter)
+            should_close_bar = False
+        else:
+            map_bar = ProgressBar(
+                "Shuffle Map", position=0, total=len(input_blocks_list)
+            )
+
         map_stage_executor = _PipelinedStageExecutor(
             map_stage_iter, stage.num_map_tasks_per_round, progress_bar=map_bar
         )
@@ -460,11 +471,18 @@ class PushBasedShufflePlan(ShuffleOp):
                 merge_done = True
                 break
 
-        map_bar.close()
+        if should_close_bar:
+            map_bar.close()
         all_merge_results = merge_stage_iter.pop_merge_results()
 
         # Execute and wait for the reduce stage.
-        reduce_bar = ProgressBar("Shuffle Reduce", total=output_num_blocks)
+        should_close_bar = True
+        if ctx is not None and ctx.sub_progress_bar_iter is not None:
+            reduce_bar = next(ctx.sub_progress_bar_iter)
+            should_close_bar = False
+        else:
+            reduce_bar = ProgressBar("Shuffle Reduce", total=output_num_blocks)
+
         shuffle_reduce = cached_remote_fn(self.reduce)
         reduce_stage_iter = _ReduceStageIterator(
             stage,
@@ -508,7 +526,9 @@ class PushBasedShufflePlan(ShuffleOp):
         assert (
             len(new_blocks) == output_num_blocks
         ), f"Expected {output_num_blocks} outputs, produced {len(new_blocks)}"
-        reduce_bar.close()
+
+        if should_close_bar:
+            reduce_bar.close()
 
         stats = {
             "map": map_stage_metadata,

--- a/python/ray/data/_internal/shuffle.py
+++ b/python/ray/data/_internal/shuffle.py
@@ -79,8 +79,10 @@ class SimpleShufflePlan(ShuffleOp):
         shuffle_reduce = cached_remote_fn(self.reduce)
 
         should_close_bar = True
-        if ctx is not None and ctx.sub_progress_bar_iter is not None:
-            map_bar = next(ctx.sub_progress_bar_iter)
+        if ctx is not None and ctx.sub_progress_bar_dict is not None:
+            bar_name = "ShuffleMap"
+            assert bar_name in ctx.sub_progress_bar_dict, ctx.sub_progress_bar_dict
+            map_bar = ctx.sub_progress_bar_dict[bar_name]
             should_close_bar = False
         else:
             map_bar = ProgressBar("Shuffle Map", total=input_num_blocks)
@@ -111,8 +113,10 @@ class SimpleShufflePlan(ShuffleOp):
             map_bar.close()
 
         should_close_bar = True
-        if ctx is not None and ctx.sub_progress_bar_iter is not None:
-            reduce_bar = next(ctx.sub_progress_bar_iter)
+        if ctx is not None and ctx.sub_progress_bar_dict is not None:
+            bar_name = "ShuffleReduce"
+            assert bar_name in ctx.sub_progress_bar_dict, ctx.sub_progress_bar_dict
+            reduce_bar = ctx.sub_progress_bar_dict[bar_name]
             should_close_bar = False
         else:
             reduce_bar = ProgressBar("Shuffle Reduce", total=output_num_blocks)

--- a/python/ray/data/_internal/shuffle.py
+++ b/python/ray/data/_internal/shuffle.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ray.data._internal.block_list import BlockList
+from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data.block import Block, BlockMetadata
@@ -61,6 +62,7 @@ class SimpleShufflePlan(ShuffleOp):
         *,
         map_ray_remote_args: Optional[Dict[str, Any]] = None,
         reduce_ray_remote_args: Optional[Dict[str, Any]] = None,
+        ctx: Optional[TaskContext] = None,
     ) -> Tuple[BlockList, Dict[str, List[BlockMetadata]]]:
         input_blocks_list = input_blocks.get_blocks()
         input_num_blocks = len(input_blocks_list)
@@ -76,7 +78,12 @@ class SimpleShufflePlan(ShuffleOp):
         shuffle_map = cached_remote_fn(self.map)
         shuffle_reduce = cached_remote_fn(self.reduce)
 
-        map_bar = ProgressBar("Shuffle Map", total=input_num_blocks)
+        should_close_bar = True
+        if ctx is not None and ctx.sub_progress_bar_iter is not None:
+            map_bar = next(ctx.sub_progress_bar_iter)
+            should_close_bar = False
+        else:
+            map_bar = ProgressBar("Shuffle Map", total=input_num_blocks)
 
         shuffle_map_out = [
             shuffle_map.options(
@@ -100,9 +107,16 @@ class SimpleShufflePlan(ShuffleOp):
         if clear_input_blocks:
             input_blocks.clear()
         shuffle_map_metadata = map_bar.fetch_until_complete(shuffle_map_metadata)
-        map_bar.close()
+        if should_close_bar:
+            map_bar.close()
 
-        reduce_bar = ProgressBar("Shuffle Reduce", total=output_num_blocks)
+        should_close_bar = True
+        if ctx is not None and ctx.sub_progress_bar_iter is not None:
+            reduce_bar = next(ctx.sub_progress_bar_iter)
+            should_close_bar = False
+        else:
+            reduce_bar = ProgressBar("Shuffle Reduce", total=output_num_blocks)
+
         shuffle_reduce_out = [
             shuffle_reduce.options(**reduce_ray_remote_args, num_returns=2,).remote(
                 *self._reduce_args,
@@ -115,7 +129,9 @@ class SimpleShufflePlan(ShuffleOp):
         del shuffle_map_out
         new_blocks, new_metadata = zip(*shuffle_reduce_out)
         new_metadata = reduce_bar.fetch_until_complete(list(new_metadata))
-        reduce_bar.close()
+
+        if should_close_bar:
+            reduce_bar.close()
 
         stats = {
             "map": shuffle_map_metadata,

--- a/python/ray/data/_internal/sort.py
+++ b/python/ray/data/_internal/sort.py
@@ -16,12 +16,13 @@ Merging: a merge task would receive a block from every worker that consists
 of items in a certain range. It then merges the sorted blocks into one sorted
 block and becomes part of the new, sorted dataset.
 """
-from typing import Any, Callable, List, Tuple, TypeVar, Union
+from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 
 from ray.data._internal.block_list import BlockList
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
+from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.push_based_shuffle import PushBasedShufflePlan
 from ray.data._internal.remote_fn import cached_remote_fn
@@ -78,7 +79,10 @@ class PushBasedSortOp(_SortOp, PushBasedShufflePlan):
 
 
 def sample_boundaries(
-    blocks: List[ObjectRef[Block]], key: SortKeyT, num_reducers: int
+    blocks: List[ObjectRef[Block]],
+    key: SortKeyT,
+    num_reducers: int,
+    ctx: Optional[TaskContext] = None,
 ) -> List[T]:
     """
     Return (num_reducers - 1) items in ascending order from the blocks that
@@ -93,9 +97,18 @@ def sample_boundaries(
     sample_block = cached_remote_fn(_sample_block)
 
     sample_results = [sample_block.remote(block, n_samples, key) for block in blocks]
-    sample_bar = ProgressBar("Sort Sample", len(sample_results))
+
+    should_close_bar = True
+    if ctx is not None and ctx.sub_progress_bar_iter is not None:
+        sample_bar = next(ctx.sub_progress_bar_iter)
+        should_close_bar = False
+    else:
+        sample_bar = ProgressBar("Sort Sample", len(sample_results))
+
     samples = sample_bar.fetch_until_complete(sample_results)
-    sample_bar.close()
+
+    if should_close_bar:
+        sample_bar.close()
     del sample_results
     samples = [s for s in samples if len(s) > 0]
     # The dataset is empty
@@ -118,7 +131,11 @@ def sample_boundaries(
 # Note: currently the map_groups() API relies on this implementation
 # to partition the same key into the same block.
 def sort_impl(
-    blocks: BlockList, clear_input_blocks: bool, key: SortKeyT, descending: bool = False
+    blocks: BlockList,
+    clear_input_blocks: bool,
+    key: SortKeyT,
+    descending: bool = False,
+    ctx: Optional[TaskContext] = None,
 ) -> Tuple[BlockList, dict]:
     stage_info = {}
     blocks_list = blocks.get_blocks()
@@ -135,7 +152,7 @@ def sort_impl(
     # Use same number of output partitions.
     num_reducers = num_mappers
     # TODO(swang): sample_boundaries could be fused with a previous stage.
-    boundaries = sample_boundaries(blocks_list, key, num_reducers)
+    boundaries = sample_boundaries(blocks_list, key, num_reducers, ctx)
     if descending:
         boundaries.reverse()
 

--- a/python/ray/data/_internal/sort.py
+++ b/python/ray/data/_internal/sort.py
@@ -99,8 +99,10 @@ def sample_boundaries(
     sample_results = [sample_block.remote(block, n_samples, key) for block in blocks]
 
     should_close_bar = True
-    if ctx is not None and ctx.sub_progress_bar_iter is not None:
-        sample_bar = next(ctx.sub_progress_bar_iter)
+    if ctx is not None and ctx.sub_progress_bar_dict is not None:
+        bar_name = "SortSample"
+        assert bar_name in ctx.sub_progress_bar_dict, ctx.sub_progress_bar_dict
+        sample_bar = ctx.sub_progress_bar_dict[bar_name]
         should_close_bar = False
     else:
         sample_bar = ProgressBar("Sort Sample", len(sample_results))

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -76,7 +76,7 @@ DEFAULT_NEW_EXECUTION_BACKEND = bool(
 # Whether to use the streaming executor. This only has an effect if the new execution
 # backend is enabled.
 DEFAULT_USE_STREAMING_EXECUTOR = bool(
-    int(os.environ.get("RAY_DATASET_USE_STREAMING_EXECUTOR", "0"))
+    int(os.environ.get("RAY_DATASET_USE_STREAMING_EXECUTOR", "1"))
 )
 
 # Whether to eagerly free memory (new backend only).

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -76,7 +76,7 @@ DEFAULT_NEW_EXECUTION_BACKEND = bool(
 # Whether to use the streaming executor. This only has an effect if the new execution
 # backend is enabled.
 DEFAULT_USE_STREAMING_EXECUTOR = bool(
-    int(os.environ.get("RAY_DATASET_USE_STREAMING_EXECUTOR", "1"))
+    int(os.environ.get("RAY_DATASET_USE_STREAMING_EXECUTOR", "0"))
 )
 
 # Whether to eagerly free memory (new backend only).

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Generic, List, Tuple, Union
 from ray.data._internal import sort
 from ray.data._internal.compute import CallableClass, ComputeStrategy
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
+from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.logical.interfaces import LogicalPlan
 from ray.data._internal.logical.operators.all_to_all_operator import Aggregate
 from ray.data._internal.plan import AllToAllStage
@@ -180,7 +181,7 @@ class GroupedDataset(Generic[T]):
             If groupby key is ``None`` then the key part of return is omitted.
         """
 
-        def do_agg(blocks, clear_input_blocks: bool, *_):
+        def do_agg(blocks, task_ctx: TaskContext, clear_input_blocks: bool, *_):
             # TODO: implement clear_input_blocks
             stage_info = {}
             if len(aggs) == 0:
@@ -203,6 +204,7 @@ class GroupedDataset(Generic[T]):
                     if isinstance(self._key, str)
                     else self._key,
                     num_reducers,
+                    task_ctx,
                 )
             ctx = DatasetContext.get_current()
             if ctx.use_push_based_shuffle:
@@ -216,9 +218,17 @@ class GroupedDataset(Generic[T]):
                 blocks,
                 num_reducers,
                 clear_input_blocks,
+                ctx=task_ctx,
             )
 
-        plan = self._dataset._plan.with_stage(AllToAllStage("Aggregate", None, do_agg))
+        plan = self._dataset._plan.with_stage(
+            AllToAllStage(
+                "Aggregate",
+                None,
+                do_agg,
+                sub_stage_names=["SortSample", "ShuffleMap", "ShuffleReduce"],
+            )
+        )
 
         logical_plan = self._dataset._logical_plan
         if logical_plan is not None:

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -63,12 +63,22 @@ def test_input_data_buffer(ray_start_regular_shared):
 
 def test_all_to_all_operator():
     def dummy_all_transform(bundles: List[RefBundle], ctx):
+        assert len(ctx.sub_progress_bar_dict) == 2
+        assert list(ctx.sub_progress_bar_dict.keys()) == ["Test1", "Test2"]
         return make_ref_bundles([[1, 2], [3, 4]]), {"FooStats": []}
 
     input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
     op = AllToAllOperator(
-        dummy_all_transform, input_op=input_op, num_outputs=2, name="TestAll"
+        dummy_all_transform,
+        input_op=input_op,
+        num_outputs=2,
+        sub_progress_bar_names=["Test1", "Test2"],
+        name="TestAll"
     )
+
+    # Initialize progress bar.
+    num_bars = op.initialize_sub_progress_bars(0)
+    assert num_bars == 2, num_bars
 
     # Feed data.
     op.start(ExecutionOptions())
@@ -82,6 +92,7 @@ def test_all_to_all_operator():
     stats = op.get_stats()
     assert "FooStats" in stats
     assert op.completed()
+    op.close_sub_progress_bars()
 
 
 def test_num_outputs_total():

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -73,7 +73,7 @@ def test_all_to_all_operator():
         input_op=input_op,
         num_outputs=2,
         sub_progress_bar_names=["Test1", "Test2"],
-        name="TestAll"
+        name="TestAll",
     )
 
     # Initialize progress bar.

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -50,8 +50,9 @@ def test_build_streaming_topology():
     o1 = InputDataBuffer(inputs)
     o2 = MapOperator.create(make_transform(lambda block: [b * -1 for b in block]), o1)
     o3 = MapOperator.create(make_transform(lambda block: [b * 2 for b in block]), o2)
-    topo = build_streaming_topology(o3, ExecutionOptions())
+    topo, num_progress_bars = build_streaming_topology(o3, ExecutionOptions())
     assert len(topo) == 3, topo
+    assert num_progress_bars == 3, num_progress_bars
     assert o1 in topo, topo
     assert not topo[o1].inqueues, topo
     assert topo[o1].outqueue == topo[o2].inqueues[0], topo
@@ -74,7 +75,7 @@ def test_process_completed_tasks():
     inputs = make_ref_bundles([[x] for x in range(20)])
     o1 = InputDataBuffer(inputs)
     o2 = MapOperator.create(make_transform(lambda block: [b * -1 for b in block]), o1)
-    topo = build_streaming_topology(o2, ExecutionOptions())
+    topo, _ = build_streaming_topology(o2, ExecutionOptions())
 
     # Test processing output bundles.
     assert len(topo[o1].outqueue) == 0, topo
@@ -108,7 +109,7 @@ def test_select_operator_to_run():
     o1 = InputDataBuffer(inputs)
     o2 = MapOperator.create(make_transform(lambda block: [b * -1 for b in block]), o1)
     o3 = MapOperator.create(make_transform(lambda block: [b * 2 for b in block]), o2)
-    topo = build_streaming_topology(o3, opt)
+    topo, _ = build_streaming_topology(o3, opt)
 
     # Test empty.
     assert select_operator_to_run(topo, NO_USAGE, ExecutionResources(), True) is None
@@ -167,7 +168,7 @@ def test_debug_dump_topology():
     o1 = InputDataBuffer(inputs)
     o2 = MapOperator.create(make_transform(lambda block: [b * -1 for b in block]), o1)
     o3 = MapOperator.create(make_transform(lambda block: [b * 2 for b in block]), o2)
-    topo = build_streaming_topology(o3, opt)
+    topo, _ = build_streaming_topology(o3, opt)
     # Just a sanity check to ensure it doesn't crash.
     _debug_dump_topology(topo)
 
@@ -186,7 +187,7 @@ def test_validate_topology():
         o2,
         compute_strategy=ray.data.ActorPoolStrategy(4, 4),
     )
-    topo = build_streaming_topology(o3, opt)
+    topo, _ = build_streaming_topology(o3, opt)
     _validate_topology(topo, ExecutionResources())
     _validate_topology(topo, ExecutionResources(cpu=20))
     _validate_topology(topo, ExecutionResources(gpu=0))
@@ -264,7 +265,7 @@ def test_select_ops_ensure_at_least_one_live_operator():
         make_transform(lambda block: [b * 2 for b in block]),
         o2,
     )
-    topo = build_streaming_topology(o3, opt)
+    topo, _ = build_streaming_topology(o3, opt)
     topo[o2].outqueue.append("dummy1")
     o1.num_active_work_refs = MagicMock(return_value=2)
     assert (
@@ -349,7 +350,7 @@ def test_calculate_topology_usage():
     o3.current_resource_usage = MagicMock(
         return_value=ExecutionResources(cpu=10, object_store_memory=1000)
     )
-    topo = build_streaming_topology(o3, ExecutionOptions())
+    topo, _ = build_streaming_topology(o3, ExecutionOptions())
     inputs[0].size_bytes = MagicMock(return_value=200)
     topo[o2].outqueue = [inputs[0]]
     usage = TopologyResourceUsage.of(topo)

--- a/release/nightly_tests/dataset/test.py
+++ b/release/nightly_tests/dataset/test.py
@@ -1,0 +1,69 @@
+from typing import Dict, Iterator, Optional, Union
+
+import ray
+import pandas as pd
+import pyarrow as pa
+from ray.data.aggregate import _AggregateOnKeyBase
+from ray.data.block import Block, BlockAccessor, KeyFn
+from ray.data.row import TableRow
+from tdigest import TDigest
+
+RowType = Union[int, float, TableRow]
+
+def _initialize_tdigest(k: Optional[float]) -> TDigest:
+    digest = TDigest()
+    if k is not None:
+        digest.update(k)
+    return digest
+
+### Aggregator Class
+class PercentileAggregator(_AggregateOnKeyBase):
+    def __init__(self, on: Optional[KeyFn] = None):
+        self._set_key_fn(on)
+
+        def init(row: RowType) -> TDigest:
+            if isinstance(row, TableRow):
+                return _initialize_tdigest(row.get(on, None))
+            elif isinstance(row, int) or isinstance(row, float) or row is None:
+                return _initialize_tdigest(row)
+            else:
+                raise TypeError("Not a supported data row type: {} ({})".format(row, type(row)))
+
+        def merge(left: TDigest, right: TDigest) -> TDigest:
+            sum = left + right
+            return sum
+
+        def accumulate_block(aggregator: TDigest, block: Block) -> TDigest:
+            rows: Iterator[RowType] = BlockAccessor.for_block(block).iter_rows()
+            for row in rows:
+                if isinstance(row, TableRow):
+                    v = row.get(on, None)
+                    if v is not None:
+                        aggregator.update(v)
+                elif isinstance(row, int) or isinstance(row, float) or row is None:
+                    if row is not None:
+                        aggregator.update(row)
+                else:
+                    raise TypeError("Not a supported data row type: {} ({})".format(row, type(row))) 
+
+            aggregator.compress() 
+            return aggregator
+
+        super().__init__(
+            init=init,
+            accumulate_block=accumulate_block,
+            merge=merge,
+            name=f"t-digest({str(on)})",
+        )
+
+### Code to use the custom aggregator
+ray.init(num_cpus=2)
+df = pd.DataFrame({"a": [1, 2, 3, 4, 5], "b": [6, 7, 8, 9, 10]})
+table = pa.Table.from_pandas(df)
+data = ray.data.from_arrow(table)
+aggregator_a = PercentileAggregator("a")
+aggregator_b = PercentileAggregator("b")
+digests = data.aggregate(aggregator_a, aggregator_b)
+
+assert digest_a.n == 5
+assert digest_b.n == 5


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to add sub progress bar support for AllToAllOperator. Before this PR, we don't report AllToAllOperator progress correctly with streaming executor. The sub progress bar was used internally in `AllToAllOperator.bulk_fn`. This PR is to hook the sub progress bar up with overall progress bar reporting, so they are shown up in console properly. 

The change includes:

* `AllToAllStage.sub_stage_names`: to indicate name of each sub-stage / sub-progress bar (e.g. `ShuffleMap`)
*  `AllToAllOperator.sub_progress_bar_names`: same as `AllToAllStage.sub_stage_names`.
*  `AllToAllOperator.initialize_sub_progress_bars()/close_sub_progress_bars()`: called from `OpState` to control initializing and closing thse sub progress bars.
* `TaskContext.sub_progress_bar_iter`: the iterator of sub progress bar to be used in each `AllToAllOperator.bulk_fn`.

Examples:

1. random_shuffle() and repartition()

```py
>>> import ray 
>>> import time
>>> def sleep(x):
...     time.sleep(0.1)
...     return x
... 
>>> 
>>> for _ in (
...     ray.data.range_tensor(5000, shape=(80, 80, 3), parallelism=200)
...     .map_batches(sleep, num_cpus=2)
...     .map_batches(sleep, compute=ray.data.ActorPoolStrategy(2, 4))
...     .random_shuffle()
...     .map_batches(sleep, num_cpus=2)
...     .repartition(400)
...     .map_batches(sleep, num_cpus=2)
...     .iter_batches()
... ):
...     pass


2023-03-14 14:41:19,062	INFO worker.py:1550 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8265 
2023-03-14 14:41:21,218	INFO streaming_executor.py:74 -- Executing DAG InputDataBuffer[Input] -> TaskPoolMapOperator[ReadRange] -> TaskPoolMapOperator[MapBatches(sleep)] -> ActorPoolMapOperator[MapBatches(sleep)] -> AllToAllOperator[RandomShuffle] -> TaskPoolMapOperator[MapBatches(sleep)] -> AllToAllOperator[Repartition] -> TaskPoolMapOperator[MapBatches(sleep)]
Resource usage vs limits: 0.0/10.0 CPU, 0.0/0.0 GPU, 14.5 MiB/512.0 MiB object_store_memory 0:   0%| | 0/1 [00:24<?, ?it/2023-03-14 14:41:45,936 qWARNING plan.py:572 -- Warning: The Ray cluster currently does not have any available CPUs. The Dataset job will hang unless more CPUs are freed up. A common reason is that cluster resources are used by Actors or Tune trials; see the following link for more details: https://docs.ray.io/en/master/data/dataset-internals.html#datasets-and-tune
(raylet) Spilled 2922 MiB, 2208 objects, write throughput 1118 MiB/s. Set RAY_verbose_spill_logs=0 to disable this message.                                                                                                                         
Resource usage vs limits: 2.0/10.0 CPU, 0.0/0.0 GPU, 677.51 MiB/512.0 MiB object_store_memory 0:   0%| | 0/1 [00:31<?, ?it
ReadRange: 0 active, 0 queued 1: 100%|██████████████████████████████████████████████████| 200/200 [00:29<00:00, 16.23it/s]
MapBatches(sleep): 0 active, 0 queued 2: 100%|██████████████████████████████████████████| 200/200 [00:29<00:00, 16.59it/s]
MapBatches(sleep): 0 active, 0 queued, 0 actors [200 locality hits, 0 misses] 3: 100%|██| 200/200 [00:29<00:00, 17.25it/s]
RandomShuffle: 0 active, 0 queued 4: 100%|██████████████████████████████████████████████| 200/200 [00:26<00:00, 19.93s/it]
  *- ShuffleMap 5: 100%|████████████████████████████████████████████████████████████████| 200/200 [00:29<00:00, 80.30it/s]
  *- ShuffleReduce 6: 100%|█████████████████████████████████████████████████████████████| 200/200 [00:29<00:00, 10.66it/s]
MapBatches(sleep): 0 active, 0 queued 7: 100%|██████████████████████████████████████████| 200/200 [00:26<00:00, 42.88it/s]
Repartition: 0 active, 0 queued 8:   0%|                                                | 1/400 [00:28<3:12:04, 28.88s/it]
  *- Repartition 9:  94%|███████████████████████████████████████████████████████████▌   | 378/400 [00:27<00:00, 23.50it/s]
MapBatches(sleep): 5 active, 362 queued 10:   8%|███▎                                    | 33/400 [00:31<00:56,  6.55it/s]
output: 3 queued 11:   8%|█████                                                          | 32/400 [00:31<00:56,  6.57it/s]
```

2. repartition(shuffle=True)

```py
Resource usage vs limits: 0.0/10.0 CPU, 0.0/0.0 GPU, 0.0 MiB/512.0 MiB object_store_memory 0:   0%|                                   | 0/1 [00:00<?, ?it/s]
ReadCSV->Repartition: 0 active, 0 queued, 0 output 1:   0%|                                                                          | 0/10 [00:00<?, ?it/s]
  *- ShuffleMap 2:   0%|                                                                                                             | 0/10 [00:00<?, ?it/s]
  *- ShuffleReduce 3:   0%|                                                                                                          | 0/10 [00:00<?, ?it/s]
output: 0 queued 4:   0%|                                                                                                            | 0/10 [00:00<?, ?it/s]
```

3. sort()

```py
Resource usage vs limits: 0.0/10.0 CPU, 0.0/0.0 GPU, 0.0 MiB/512.0 MiB object_store_memory 0:   0%|                                   | 0/1 [00:00<?, ?it/s]
Sort: 0 active, 0 queued, 0 output 1:   0%|                                                                                     | 0/10 [00:00<?, ?it/s]
  *- SortSample 2: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:01<00:00,  6.72it/s]
  *- ShuffleMap 3:  20%|████████████████████▏                                                                                | 2/10 [00:18<01:00,  7.58s/it]
  *- ShuffleReduce 4:   0%|                                                                                                          | 0/10 [00:00<?, ?it/s]
output: 0 queued 5:   0%|                                                                                                            | 0/10 [00:00<?, ?it/s]
```

4. groupby().aggregate()

```py
Resource usage vs limits: 0.0/10.0 CPU, 0.0/0.0 GPU, 0.0 MiB/512.0 MiB object_store_memory 0:   0%|                                   | 0/1 [00:00<?, ?it/s]
Aggregate: 0 active, 0 queued, 0 output 1:   0%|                                                                                     | 0/10 [00:00<?, ?it/s]
  *- SortSample 2: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:01<00:00,  6.72it/s]
  *- ShuffleMap 3:  20%|████████████████████▏                                                                                | 2/10 [00:18<01:00,  7.58s/it]
  *- ShuffleReduce 4:   0%|                                                                                                          | 0/10 [00:00<?, ?it/s]
output: 0 queued 5:   0%|                                                                                                            | 0/10 [00:00<?, ?it/s]
```

5. groupby().map_groups()

```py
Resource usage vs limits: 4.0/10.0 CPU, 0.0/0.0 GPU, 792.74 MiB/512.0 MiB object_store_memory 0:   0%|                                | 0/1 [00:03<?, ?it/s]
Sort: 0 active, 0 queued, 0 output 1: 0%|                                                                                            | 0/10 [00:00<?, ?it/s]
  *- SortSample 2: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 25.20it/s]
  *- ShuffleMap 3:   0%|                                                                                                             | 0/10 [00:00<?, ?it/s]
  *- ShuffleReduce 4:   0%|                                                                                                          | 0/10 [00:00<?, ?it/s]
MapBatches(group_fn): 4 active, 6 queued 5:   0%|                                                                                    | 0/10 [00:03<?, ?it/s]
output: 0 queued 6:   0%|                                                                                                            | 0/10 [00:00<?, ?it/s]
```

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/32476

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
