### PR TITLE
[RLlib][RLModule] Disabling RLModule API for test_policy_map.py. 

### DIFF
--- a/rllib/policy/tests/test_policy_map.py
+++ b/rllib/policy/tests/test_policy_map.py
@@ -20,7 +20,15 @@ class TestPolicyMap(unittest.TestCase):
         ray.shutdown()
 
     def test_policy_map(self):
-        config = PPOConfig().framework("tf2", eager_tracing=True)
+        # This is testing policy map which is something that will be deprecated in
+        # favor of MultiAgentRLModules in the future. So we'll disable the RLModule API
+        # for this test for now.
+        config = (
+            PPOConfig()
+            .framework("tf2", eager_tracing=True)
+            .rl_module(_enable_rl_module_api=False)
+            .training(_enable_learner_api=False)
+        )
         obs_space = gym.spaces.Box(-1.0, 1.0, (4,), dtype=np.float32)
         dummy_obs = obs_space.sample()
         act_space = gym.spaces.Discrete(10000)


### PR DESCRIPTION
This is testing policy map which is something that will be deprecated in favor of MultiAgentRLModules in the future. So we'll disable the RLModule API for this test for now.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
