### PR TITLE
[RLlib] Add option for running multiple sgd iters for impala learner api

### DIFF
--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -863,7 +863,9 @@ class Impala(Algorithm):
             # Then we can't do async updates, so we need to block.
             blocking = self.config.num_learner_workers == 0
             lg_results = self.learner_group.update(
-                batch, reduce_fn=_reduce_impala_results, block=blocking,
+                batch,
+                reduce_fn=_reduce_impala_results,
+                block=blocking,
                 num_iters=self.config.num_sgd_iter,
             )
         else:

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -863,7 +863,8 @@ class Impala(Algorithm):
             # Then we can't do async updates, so we need to block.
             blocking = self.config.num_learner_workers == 0
             lg_results = self.learner_group.update(
-                batch, reduce_fn=_reduce_impala_results, block=blocking
+                batch, reduce_fn=_reduce_impala_results, block=blocking,
+                num_iters=self.config.num_sgd_iter,
             )
         else:
             lg_results = None


### PR DESCRIPTION
Signed-off-by: Avnish <avnishnarayan@gmail.com>

Change in the title. We have an option for running many sgd iters that we don't use in impala with the learner api, but now that the learner group api supports multiple sgd iters we should support this as well.


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
