### PR TITLE
[RLlib] Make tf models checkpointable and freezable

### DIFF
--- a/rllib/core/models/tf/encoder.py
+++ b/rllib/core/models/tf/encoder.py
@@ -69,5 +69,5 @@ class TfActorCriticEncoder(TfModel, ActorCriticEncoder):
     framework = "tf"
 
     def __init__(self, config: ModelConfig) -> None:
-        ActorCriticEncoder.__init__(self, config)
         TfModel.__init__(self, config)
+        ActorCriticEncoder.__init__(self, config)

--- a/rllib/core/models/tf/encoder.py
+++ b/rllib/core/models/tf/encoder.py
@@ -69,5 +69,7 @@ class TfActorCriticEncoder(TfModel, ActorCriticEncoder):
     framework = "tf"
 
     def __init__(self, config: ModelConfig) -> None:
+        # We have to call TfModel.__init__ first, because it calls the constructor of
+        # tf.keras.Model, which is required to be called before models are created.
         TfModel.__init__(self, config)
         ActorCriticEncoder.__init__(self, config)

--- a/rllib/core/models/tf/primitives.py
+++ b/rllib/core/models/tf/primitives.py
@@ -24,7 +24,7 @@ def _raise_not_decorated_exception(input_or_output):
     )
 
 
-class TfModel(Model, tf.Module, abc.ABC):
+class TfModel(Model, tf.keras.Model, abc.ABC):
     """Base class for RLlib's TensorFlow models.
 
     This class defines the interface for RLlib's TensorFlow models and checks
@@ -33,7 +33,7 @@ class TfModel(Model, tf.Module, abc.ABC):
     """
 
     def __init__(self, config: ModelConfig):
-        tf.Module.__init__(self)
+        tf.keras.Model.__init__(self)
         Model.__init__(self, config)
 
         # automatically apply spec checking
@@ -59,7 +59,7 @@ class TfModel(Model, tf.Module, abc.ABC):
         return self._forward(input_dict, **kwargs)
 
 
-class TfMLP(tf.Module):
+class TfMLP(tf.keras.Model):
     """A multi-layer perceptron.
 
     Attributes:


### PR DESCRIPTION
## Why are these changes needed?

The tf Models used by our RLModules are currently all tf.Modules.
They therefore can not be properly checkpointed or frozen, because this requires functionality found in tf.keras.Models.
This PR makes it so that all tf Models we produce for RL Modules are tf.keras.Models.