### PR TITLE
[core][state] Task backend - Profile events capping 

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -480,7 +480,7 @@ RAY_CONFIG(uint64_t, task_events_send_batch_size, 10 * 1000)
 /// report gRPC call. A task could have more profile events in GCS from multiple
 /// report gRPC call.
 /// Setting the value to -1 allows unlimited profile events to be sent.
-RAY_CONFIG(int64_t, task_events_max_num_profile_events_for_task, 100)
+RAY_CONFIG(int64_t, task_events_max_num_profile_events_for_task, 1000)
 
 /// The delay in ms that GCS should mark any running tasks from a job as failed.
 /// Setting this value too smaller might result in some finished tasks marked as failed by

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -53,7 +53,7 @@ TaskProfileEvent::TaskProfileEvent(TaskID task_id,
       event_name_(event_name),
       start_time_(start_time) {}
 
-void TaskStatusEvent::ToRpcTaskEvents(rpc::TaskEvents *rpc_task_events) {
+bool TaskStatusEvent::ToRpcTaskEventsOrDrop(rpc::TaskEvents *rpc_task_events) {
   // Base fields
   rpc_task_events->set_task_id(task_id_.Binary());
   rpc_task_events->set_job_id(job_id_.Binary());
@@ -69,7 +69,7 @@ void TaskStatusEvent::ToRpcTaskEvents(rpc::TaskEvents *rpc_task_events) {
   gcs::FillTaskStatusUpdateTime(task_status_, timestamp_, dst_state_update);
 
   if (!state_update_.has_value()) {
-    return;
+    return false;
   }
 
   if (state_update_->node_id_.has_value()) {
@@ -89,16 +89,29 @@ void TaskStatusEvent::ToRpcTaskEvents(rpc::TaskEvents *rpc_task_events) {
   if (state_update_->error_info_.has_value()) {
     dst_state_update->set_error_type(state_update_->error_info_->error_type());
   }
+  return false;
 }
 
-void TaskProfileEvent::ToRpcTaskEvents(rpc::TaskEvents *rpc_task_events) {
+bool TaskProfileEvent::ToRpcTaskEventsOrDrop(rpc::TaskEvents *rpc_task_events) {
+  // Rate limit on the number of profiling events from the task. This is especially the
+  // case if a driver has many profiling events when submitting tasks
+  auto profile_events = rpc_task_events->mutable_profile_events();
+  auto profile_event_max_num =
+      RayConfig::instance().task_events_max_num_profile_events_for_task();
+  if (profile_event_max_num >= 0 &&
+      profile_events->events_size() >= profile_event_max_num) {
+    // Data loss.
+    RAY_LOG_EVERY_N(WARNING, 100000)
+        << "Dropping profiling events for task: " << task_id_
+        << ", set a higher value for RAY_task_events_max_num_profile_events_for_task("
+        << profile_event_max_num << ").";
+    return true;
+  }
+
   // Base fields
   rpc_task_events->set_task_id(task_id_.Binary());
   rpc_task_events->set_job_id(job_id_.Binary());
   rpc_task_events->set_attempt_number(attempt_number_);
-
-  // Profile data
-  auto profile_events = rpc_task_events->mutable_profile_events();
   profile_events->set_component_type(std::move(component_type_));
   profile_events->set_component_id(std::move(component_id_));
   profile_events->set_node_ip_address(std::move(node_ip_address_));
@@ -107,6 +120,7 @@ void TaskProfileEvent::ToRpcTaskEvents(rpc::TaskEvents *rpc_task_events) {
   event_entry->set_start_time(start_time_);
   event_entry->set_end_time(end_time_);
   event_entry->set_extra_data(std::move(extra_data_));
+  return false;
 }
 
 TaskEventBufferImpl::TaskEventBufferImpl(std::unique_ptr<gcs::GcsClient> gcs_client)
@@ -187,25 +201,38 @@ void TaskEventBufferImpl::AddTaskEvent(std::unique_ptr<TaskEvent> task_event) {
   if (!enabled_) {
     return;
   }
-  absl::MutexLock lock(&mutex_);
+  size_t num_profile_events_dropped = 0;
+  size_t num_status_events_dropped = 0;
+  size_t num_add = 0;
 
-  if (buffer_.full()) {
-    const auto &to_evict = buffer_.front();
-    if (to_evict->IsProfileEvent()) {
-      num_profile_task_events_dropped_++;
-    } else {
-      num_status_task_events_dropped_++;
+  absl::MutexLock lock(&mutex_);
+  size_t prev_size = buffer_.size();
+  {
+    if (buffer_.full()) {
+      const auto &to_evict = buffer_.front();
+      if (to_evict->IsProfileEvent()) {
+        num_profile_events_dropped++;
+      } else {
+        num_status_events_dropped++;
+      }
     }
+    buffer_.push_back(std::move(task_event));
+    num_add = buffer_.size() - prev_size;
   }
-  buffer_.push_back(std::move(task_event));
+
+  stats_counter_.Increment(
+      TaskEventBufferCounter::kNumTaskProfileEventDroppedSinceLastFlush,
+      num_profile_events_dropped);
+  stats_counter_.Increment(
+      TaskEventBufferCounter::kNumTaskStatusEventDroppedSinceLastFlush,
+      num_status_events_dropped);
+  stats_counter_.Increment(TaskEventBufferCounter::kNumTaskEventsStored, num_add);
 }
 
 void TaskEventBufferImpl::FlushEvents(bool forced) {
   if (!enabled_) {
     return;
   }
-  size_t num_status_task_events_dropped = 0;
-  size_t num_profile_task_events_dropped = 0;
   std::vector<std::unique_ptr<TaskEvent>> to_send;
   to_send.reserve(RayConfig::instance().task_events_send_batch_size());
 
@@ -234,48 +261,74 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
                    std::make_move_iterator(buffer_.begin()),
                    std::make_move_iterator(buffer_.begin() + num_to_send));
     buffer_.erase(buffer_.begin(), buffer_.begin() + num_to_send);
-
-    // Send and reset the counters
-    num_profile_task_events_dropped = num_profile_task_events_dropped_;
-    num_profile_task_events_dropped_ = 0;
-
-    num_status_task_events_dropped = num_status_task_events_dropped_;
-    num_status_task_events_dropped_ = 0;
   }
+
+  // Aggregate
+  absl::flat_hash_map<TaskAttempt, rpc::TaskEvents> agg_task_events;
+  auto to_rpc_event_fn = [this, &agg_task_events](std::unique_ptr<TaskEvent> &event) {
+    if (!agg_task_events.count(event->GetTaskAttempt())) {
+      auto inserted =
+          agg_task_events.insert({event->GetTaskAttempt(), rpc::TaskEvents()});
+      RAY_CHECK(inserted.second);
+    }
+
+    auto itr = agg_task_events.find(event->GetTaskAttempt());
+
+    if (event->ToRpcTaskEventsOrDrop(&(itr->second))) {
+      RAY_CHECK(event->IsProfileEvent());
+      stats_counter_.Increment(
+          TaskEventBufferCounter::kNumTaskProfileEventDroppedSinceLastFlush);
+    }
+  };
+  std::for_each(to_send.begin(), to_send.end(), to_rpc_event_fn);
 
   // Convert to rpc::TaskEventsData
   auto data = std::make_unique<rpc::TaskEventData>();
-  data->set_num_profile_task_events_dropped(num_profile_task_events_dropped);
-  data->set_num_status_task_events_dropped(num_status_task_events_dropped);
-
   size_t num_task_events = to_send.size();
   size_t num_profile_event_to_send = 0;
   size_t num_status_event_to_send = 0;
-  for (auto &task_event : to_send) {
+  for (auto &[_task_attempt, task_event] : agg_task_events) {
     auto events_by_task = data->add_events_by_task();
-    if (task_event->IsProfileEvent()) {
+    if (task_event.has_profile_events()) {
       num_profile_event_to_send++;
-    } else {
+    }
+    if (task_event.has_state_updates()) {
       num_status_event_to_send++;
     }
-    task_event->ToRpcTaskEvents(events_by_task);
+    *events_by_task = std::move(task_event);
   }
-  size_t data_size = data->ByteSizeLong();
+
+  // Send and reset the counters
+  stats_counter_.Decrement(TaskEventBufferCounter::kNumTaskEventsStored, to_send.size());
+  size_t num_profile_task_events_dropped = stats_counter_.Get(
+      TaskEventBufferCounter::kNumTaskProfileEventDroppedSinceLastFlush);
+  stats_counter_.Decrement(
+      TaskEventBufferCounter::kNumTaskProfileEventDroppedSinceLastFlush,
+      num_profile_task_events_dropped);
+  stats_counter_.Increment(TaskEventBufferCounter::kTotalNumTaskProfileEventDropped,
+                           num_profile_task_events_dropped);
+
+  size_t num_status_task_events_dropped = stats_counter_.Get(
+      TaskEventBufferCounter::kNumTaskStatusEventDroppedSinceLastFlush);
+  stats_counter_.Decrement(
+      TaskEventBufferCounter::kNumTaskStatusEventDroppedSinceLastFlush,
+      num_status_task_events_dropped);
+  stats_counter_.Increment(TaskEventBufferCounter::kTotalNumTaskStatusEventDropped,
+                           num_status_task_events_dropped);
+
+  data->set_num_profile_task_events_dropped(num_profile_task_events_dropped);
+  data->set_num_status_task_events_dropped(num_status_task_events_dropped);
 
   gcs::TaskInfoAccessor *task_accessor;
   {
     // Sending the protobuf to GCS.
     absl::MutexLock lock(&mutex_);
-    // Some debug tracking.
-    total_num_events_ += num_task_events;
-    total_events_bytes_ += data_size;
     // The flag should be unset when on_complete is invoked.
-    grpc_in_progress_ = true;
     task_accessor = &gcs_client_->Tasks();
   }
 
+  grpc_in_progress_ = true;
   auto on_complete = [this, num_task_events](const Status &status) {
-    absl::MutexLock lock(&mutex_);
     if (!status.ok()) {
       RAY_LOG(WARNING) << "Failed to push " << num_task_events
                        << " task state events to GCS. Data will be lost. [status="
@@ -286,7 +339,6 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
 
   auto status = task_accessor->AsyncAddTaskEventData(std::move(data), on_complete);
   {
-    absl::MutexLock lock(&mutex_);
     if (!status.ok()) {
       // If we couldn't even send the data by invoking client side callbacks, there's
       // something seriously wrong, and losing data in this case should not be too
@@ -297,8 +349,10 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
       grpc_in_progress_ = false;
 
       // Fail to send, currently dropping events.
-      num_status_task_events_dropped_ += num_status_event_to_send;
-      num_profile_task_events_dropped_ += num_profile_event_to_send;
+      stats_counter_.Increment(TaskEventBufferCounter::kTotalNumTaskProfileEventDropped,
+                               num_profile_event_to_send);
+      stats_counter_.Increment(TaskEventBufferCounter::kTotalNumTaskStatusEventDropped,
+                               num_status_event_to_send);
     }
   }
 }
@@ -311,31 +365,22 @@ const std::string TaskEventBufferImpl::DebugString() {
     return ss.str();
   }
 
-  bool grpc_in_progress;
-  size_t num_status_task_events_dropped, num_profile_task_events_dropped,
-      data_buffer_size;
-  uint64_t total_events_bytes, total_num_events;
-
-  {
-    absl::MutexLock lock(&mutex_);
-    grpc_in_progress = grpc_in_progress_;
-    num_status_task_events_dropped = num_status_task_events_dropped_;
-    num_profile_task_events_dropped = num_profile_task_events_dropped_;
-    total_events_bytes = total_events_bytes_;
-    total_num_events = total_num_events_;
-    data_buffer_size = buffer_.size();
-  }
-
+  auto stats = stats_counter_.GetAll();
   ss << "\nIO Service Stats:\n";
   ss << io_service_.stats().StatsString();
   ss << "\nOther Stats:"
-     << "\n\tgrpc_in_progress:" << grpc_in_progress
-     << "\n\tcurrent number of task events in buffer: " << data_buffer_size
-     << "\n\ttotal task events sent: " << 1.0 * total_events_bytes / 1024 / 1024 << " MiB"
-     << "\n\ttotal number of task events sent: " << total_num_events
-     << "\n\tnum status task events dropped: " << num_status_task_events_dropped
-     << "\n\tnum profile task events dropped: " << num_profile_task_events_dropped
-     << "\n";
+     << "\n\tgrpc_in_progress:" << grpc_in_progress_
+     << "\n\tcurrent number of task events in buffer: "
+     << stats[TaskEventBufferCounter::kNumTaskEventsStored]
+     << "\n\ttotal task events sent: "
+     << 1.0 * stats[TaskEventBufferCounter::kTotalTaskEventsBytesReported] / 1024 / 1024
+     << " MiB"
+     << "\n\ttotal number of task events sent: "
+     << stats[TaskEventBufferCounter::kTotalTaskEventsReported]
+     << "\n\tnum status task events dropped: "
+     << stats[TaskEventBufferCounter::kTotalNumTaskProfileEventDropped]
+     << "\n\tnum profile task events dropped: "
+     << stats[TaskEventBufferCounter::kTotalNumTaskStatusEventDropped] << "\n";
 
   return ss.str();
 }

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -100,7 +100,12 @@ bool TaskProfileEvent::ToRpcTaskEventsOrDrop(rpc::TaskEvents *rpc_task_events) {
       RayConfig::instance().task_events_max_num_profile_events_for_task();
   if (profile_event_max_num >= 0 &&
       profile_events->events_size() >= profile_event_max_num) {
-    // Data loss.
+    // Data loss. We are dropping the newly reported profile event.
+    // This will likely happen on a driver task since the driver has a fixed placeholder
+    // driver task id and it could generate large number of profile events when submitting
+    // many tasks.
+    // We are only dropping this TaskEvent (which corresponds to a single profile event),
+    // rather than others. We will likely change the GC logic in the future as well.
     RAY_LOG_EVERY_N(WARNING, 100000)
         << "Dropping profiling events for task: " << task_id_
         << ", set a higher value for RAY_task_events_max_num_profile_events_for_task("

--- a/src/ray/core_worker/task_event_buffer.h
+++ b/src/ray/core_worker/task_event_buffer.h
@@ -26,12 +26,15 @@
 #include "ray/common/id.h"
 #include "ray/common/task/task_spec.h"
 #include "ray/gcs/gcs_client/gcs_client.h"
+#include "ray/util/counter_map.h"
 #include "src/ray/protobuf/gcs.pb.h"
 
 namespace ray {
 namespace core {
 
 namespace worker {
+
+using TaskAttempt = std::pair<TaskID, int32_t>;
 
 /// A  wrapper class that will be converted to rpc::TaskEvents
 ///
@@ -47,15 +50,20 @@ class TaskEvent {
 
   virtual ~TaskEvent() = default;
 
-  /// Convert itself a rpc::TaskEvents
+  /// Convert itself a rpc::TaskEvents or drop itself due to data limit.
   ///
   /// NOTE: this method will modify internal states by moving fields to the
   /// rpc::TaskEvents.
   /// \param[out] rpc_task_events The rpc task event to be filled.
-  virtual void ToRpcTaskEvents(rpc::TaskEvents *rpc_task_events) = 0;
+  /// \return If it's dropped due to data limit.
+  virtual bool ToRpcTaskEventsOrDrop(rpc::TaskEvents *rpc_task_events) = 0;
 
   /// If it is a profile event.
   virtual bool IsProfileEvent() const = 0;
+
+  virtual TaskAttempt GetTaskAttempt() const {
+    return std::make_pair(task_id_, attempt_number_);
+  }
 
  protected:
   /// Task Id.
@@ -97,7 +105,7 @@ class TaskStatusEvent : public TaskEvent {
       const std::shared_ptr<const TaskSpecification> &task_spec = nullptr,
       absl::optional<const TaskStateUpdate> state_update = absl::nullopt);
 
-  void ToRpcTaskEvents(rpc::TaskEvents *rpc_task_events) override;
+  bool ToRpcTaskEventsOrDrop(rpc::TaskEvents *rpc_task_events) override;
 
   bool IsProfileEvent() const override { return false; }
 
@@ -124,7 +132,7 @@ class TaskProfileEvent : public TaskEvent {
                             const std::string &event_name,
                             int64_t start_time);
 
-  void ToRpcTaskEvents(rpc::TaskEvents *rpc_task_events) override;
+  bool ToRpcTaskEventsOrDrop(rpc::TaskEvents *rpc_task_events) override;
 
   bool IsProfileEvent() const override { return true; }
 
@@ -141,6 +149,18 @@ class TaskProfileEvent : public TaskEvent {
   const int64_t start_time_;
   int64_t end_time_;
   std::string extra_data_;
+};
+
+/// @brief An enum class defining counters to be used in TaskEventBufferImpl.
+enum TaskEventBufferCounter {
+  kNumTaskProfileEventDroppedSinceLastFlush,
+  kNumTaskStatusEventDroppedSinceLastFlush,
+  kNumTaskEventsStored,
+  /// Below stats are updated every flush.
+  kTotalNumTaskProfileEventDropped,
+  kTotalNumTaskStatusEventDropped,
+  kTotalTaskEventsReported,
+  kTotalTaskEventsBytesReported,
 };
 
 /// An interface for a buffer that stores task status changes and profiling events,
@@ -232,30 +252,34 @@ class TaskEventBufferImpl : public TaskEventBuffer {
 
   bool Enabled() const override;
 
-  const std::string DebugString() LOCKS_EXCLUDED(mutex_) override;
+  const std::string DebugString() override;
 
  private:
   /// Test only functions.
-  std::vector<std::reference_wrapper<const TaskEvent>> GetAllTaskEvents()
-      LOCKS_EXCLUDED(mutex_) {
-    absl::MutexLock lock(&mutex_);
-    std::vector<std::reference_wrapper<const TaskEvent>> copy;
-    for (const auto &e : buffer_) {
-      copy.push_back(std::cref(*e));
-    }
-    return copy;
+  size_t GetNumTaskEventsStored() {
+    return stats_counter_.Get(TaskEventBufferCounter::kNumTaskEventsStored);
   }
 
   /// Test only functions.
-  size_t GetNumStatusTaskEventsDropped() LOCKS_EXCLUDED(mutex_) {
-    absl::MutexLock lock(&mutex_);
-    return num_status_task_events_dropped_;
+  size_t GetTotalNumStatusTaskEventsDropped() {
+    return stats_counter_.Get(TaskEventBufferCounter::kTotalNumTaskStatusEventDropped);
   }
 
   /// Test only functions.
-  size_t GetNumProfileTaskEventsDropped() LOCKS_EXCLUDED(mutex_) {
-    absl::MutexLock lock(&mutex_);
-    return num_profile_task_events_dropped_;
+  size_t GetNumStatusTaskEventsDroppedSinceLastFlush() {
+    return stats_counter_.Get(
+        TaskEventBufferCounter::kNumTaskStatusEventDroppedSinceLastFlush);
+  }
+
+  /// Test only functions.
+  size_t GetTotalNumProfileTaskEventsDropped() {
+    return stats_counter_.Get(TaskEventBufferCounter::kTotalNumTaskProfileEventDropped);
+  }
+
+  /// Test only functions.
+  size_t GetNumProfileTaskEventsDroppedSinceLastFlush() {
+    return stats_counter_.Get(
+        TaskEventBufferCounter::kNumTaskProfileEventDroppedSinceLastFlush);
   }
 
   /// Test only functions.
@@ -288,22 +312,13 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   /// Circular buffered task events.
   boost::circular_buffer<std::unique_ptr<TaskEvent>> buffer_ GUARDED_BY(mutex_);
 
-  /// Number of profile task events dropped since the last report flush.
-  size_t num_profile_task_events_dropped_ GUARDED_BY(mutex_) = 0;
-
-  /// Number of status task events dropped since the last report flush.
-  size_t num_status_task_events_dropped_ GUARDED_BY(mutex_) = 0;
+  /// Stats counter map.
+  CounterMapThreadSafe<TaskEventBufferCounter> stats_counter_;
 
   /// True if there's a pending gRPC call. It's a simple way to prevent overloading
   /// GCS with too many calls. There is no point sending more events if GCS could not
   /// process them quick enough.
-  bool grpc_in_progress_ GUARDED_BY(mutex_) = false;
-
-  /// Debug stats: total number of bytes of task events sent so far to GCS.
-  uint64_t total_events_bytes_ GUARDED_BY(mutex_) = 0;
-
-  /// Debug stats: total number of task events sent so far to GCS.
-  uint64_t total_num_events_ GUARDED_BY(mutex_) = 0;
+  std::atomic<bool> grpc_in_progress_ = false;
 
   FRIEND_TEST(TaskEventBufferTestManualStart, TestGcsClientFail);
   FRIEND_TEST(TaskEventBufferTestBatchSend, TestBatchedSend);
@@ -313,6 +328,7 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   FRIEND_TEST(TaskEventBufferTest, TestBackPressure);
   FRIEND_TEST(TaskEventBufferTest, TestForcedFlush);
   FRIEND_TEST(TaskEventBufferTest, TestBufferSizeLimit);
+  FRIEND_TEST(TaskEventBufferTestLimitProfileEvents, TestLimitProfileEventsPerTask);
 };
 
 }  // namespace worker

--- a/src/ray/core_worker/test/task_event_buffer_test.cc
+++ b/src/ray/core_worker/test/task_event_buffer_test.cc
@@ -71,8 +71,28 @@ class TaskEventBufferTest : public ::testing::Test {
         task_id, JobID::FromInt(0), attempt_num, "", "", "", "test_event", 1);
   }
 
-  static bool SortTaskEvents(const rpc::TaskEvents &a, const rpc::TaskEvents &b) {
-    return a.task_id() < b.task_id() || a.attempt_number() < b.attempt_number();
+  static void CompareTaskEventData(const rpc::TaskEventData &actual_data,
+                                   const rpc::TaskEventData &expect_data) {
+    // Sort and compare
+    std::vector<std::string> actual_events;
+    std::vector<std::string> expect_events;
+    for (const auto &e : actual_data.events_by_task()) {
+      actual_events.push_back(e.DebugString());
+    }
+    for (const auto &e : expect_data.events_by_task()) {
+      expect_events.push_back(e.DebugString());
+    }
+    std::sort(actual_events.begin(), actual_events.end());
+    std::sort(expect_events.begin(), expect_events.end());
+    EXPECT_EQ(actual_events.size(), expect_events.size());
+    for (size_t i = 0; i < actual_events.size(); ++i) {
+      EXPECT_EQ(actual_events[i], expect_events[i]);
+    }
+
+    EXPECT_EQ(actual_data.num_profile_task_events_dropped(),
+              expect_data.num_profile_task_events_dropped());
+    EXPECT_EQ(actual_data.num_status_task_events_dropped(),
+              expect_data.num_status_task_events_dropped());
   }
 
   std::unique_ptr<TaskEventBufferImpl> task_event_buffer_ = nullptr;
@@ -91,6 +111,19 @@ class TaskEventBufferTestBatchSend : public TaskEventBufferTest {
   "task_events_report_interval_ms": 1000,
   "task_events_max_buffer_size": 100,
   "task_events_send_batch_size": 10
+}
+  )");
+  }
+};
+
+class TaskEventBufferTestLimitProfileEvents : public TaskEventBufferTest {
+ public:
+  TaskEventBufferTestLimitProfileEvents() : TaskEventBufferTest() {
+    RayConfig::instance().initialize(
+        R"(
+{
+  "task_events_report_interval_ms": 1000,
+  "task_events_max_num_profile_events_for_task": 10
 }
   )");
   }
@@ -117,17 +150,17 @@ TEST_F(TaskEventBufferTestManualStart, TestGcsClientFail) {
 }
 
 TEST_F(TaskEventBufferTest, TestAddEvent) {
-  ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), 0);
+  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), 0);
 
   // Test add status event
   auto task_id_1 = RandomTaskId();
   task_event_buffer_->AddTaskEvent(GenStatusTaskEvent(task_id_1, 0));
 
-  ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), 1);
+  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), 1);
 
   // Test add profile events
   task_event_buffer_->AddTaskEvent(GenProfileTaskEvent(task_id_1, 1));
-  ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), 2);
+  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), 2);
 }
 
 TEST_F(TaskEventBufferTest, TestFlushEvents) {
@@ -145,14 +178,14 @@ TEST_F(TaskEventBufferTest, TestFlushEvents) {
   expected_data.set_num_status_task_events_dropped(0);
   for (const auto &task_event : task_events) {
     auto event = expected_data.add_events_by_task();
-    task_event->ToRpcTaskEvents(event);
+    task_event->ToRpcTaskEventsOrDrop(event);
   }
 
   for (auto &task_event : task_events) {
     task_event_buffer_->AddTaskEvent(std::move(task_event));
   }
 
-  ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), num_events);
+  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), num_events);
 
   // Manually call flush should call GCS client's flushing grpc.
   auto task_gcs_accessor =
@@ -162,22 +195,14 @@ TEST_F(TaskEventBufferTest, TestFlushEvents) {
   EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData(_, _))
       .WillOnce([&](std::unique_ptr<rpc::TaskEventData> actual_data,
                     ray::gcs::StatusCallback callback) {
-        // Sort and compare
-        std::sort(actual_data->mutable_events_by_task()->begin(),
-                  actual_data->mutable_events_by_task()->end(),
-                  SortTaskEvents);
-        std::sort(expected_data.mutable_events_by_task()->begin(),
-                  expected_data.mutable_events_by_task()->end(),
-                  SortTaskEvents);
-        EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(*actual_data,
-                                                                       expected_data));
+        CompareTaskEventData(*actual_data, expected_data);
         return Status::OK();
       });
 
   task_event_buffer_->FlushEvents(false);
 
   // Expect no more events.
-  ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), 0);
+  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), 0);
 }
 
 TEST_F(TaskEventBufferTest, TestFailedFlush) {
@@ -207,8 +232,9 @@ TEST_F(TaskEventBufferTest, TestFailedFlush) {
   task_event_buffer_->FlushEvents(false);
 
   // Expect the number of dropped events incremented.
-  ASSERT_EQ(task_event_buffer_->GetNumStatusTaskEventsDropped(), num_status_events);
-  ASSERT_EQ(task_event_buffer_->GetNumProfileTaskEventsDropped(), num_profile_events);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumStatusTaskEventsDropped(), num_status_events);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumProfileTaskEventsDropped(),
+            num_profile_events);
 
   // Adding some more events
   for (size_t i = 0; i < num_status_events + num_profile_events; ++i) {
@@ -222,8 +248,9 @@ TEST_F(TaskEventBufferTest, TestFailedFlush) {
 
   // Flush successfully will reset the num events dropped.
   task_event_buffer_->FlushEvents(false);
-  ASSERT_EQ(task_event_buffer_->GetNumStatusTaskEventsDropped(), 0);
-  ASSERT_EQ(task_event_buffer_->GetNumProfileTaskEventsDropped(), 0);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumStatusTaskEventsDropped(), num_status_events);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumProfileTaskEventsDropped(),
+            num_profile_events);
 }
 
 TEST_F(TaskEventBufferTest, TestBackPressure) {
@@ -298,22 +325,18 @@ TEST_F(TaskEventBufferTestBatchSend, TestBatchedSend) {
           [&i, &batch_size, &task_ids](std::unique_ptr<rpc::TaskEventData> actual_data,
                                        ray::gcs::StatusCallback callback) {
             EXPECT_EQ(actual_data->events_by_task_size(), batch_size);
-            for (const auto &task : actual_data->events_by_task()) {
-              // Assert sent data in order.
-              EXPECT_EQ(task_ids[i++].Binary(), task.task_id());
-            }
             callback(Status::OK());
             return Status::OK();
           });
 
   for (int i = 0; i * batch_size < num_events; i++) {
-    task_event_buffer_->FlushEvents(false);
-    EXPECT_EQ(task_event_buffer_->GetAllTaskEvents().size(),
+    task_event_buffer_->FlushEvents(true);
+    EXPECT_EQ(task_event_buffer_->GetNumTaskEventsStored(),
               num_events - (i + 1) * batch_size);
   }
 
   // With last flush, there should be no more events in the buffer and as data.
-  EXPECT_EQ(task_event_buffer_->GetAllTaskEvents().size(), 0);
+  EXPECT_EQ(task_event_buffer_->GetNumTaskEventsStored(), 0);
 }
 
 TEST_F(TaskEventBufferTest, TestBufferSizeLimit) {
@@ -338,15 +361,22 @@ TEST_F(TaskEventBufferTest, TestBufferSizeLimit) {
   rpc::TaskEventData expected_data;
   expected_data.set_num_profile_task_events_dropped(num_profile);
   expected_data.set_num_status_task_events_dropped(num_status);
-  for (const auto &event : profile_events_2) {
+  for (const auto &event_ptr : profile_events_2) {
     auto expect_event = expected_data.add_events_by_task();
-    event->ToRpcTaskEvents(expect_event);
+    // Copy the data
+    auto event = std::make_unique<TaskProfileEvent>(
+        *static_cast<TaskProfileEvent *>(event_ptr.get()));
+    event->ToRpcTaskEventsOrDrop(expect_event);
   }
-  for (const auto &event : status_events_2) {
+  for (const auto &event_ptr : status_events_2) {
     auto expect_event = expected_data.add_events_by_task();
-    event->ToRpcTaskEvents(expect_event);
+    // Copy the data
+    auto event = std::make_unique<TaskStatusEvent>(
+        *static_cast<TaskStatusEvent *>(event_ptr.get()));
+    event->ToRpcTaskEventsOrDrop(expect_event);
   }
 
+  // Add the data
   for (auto &event : profile_events_1) {
     task_event_buffer_->AddTaskEvent(std::move(event));
   }
@@ -359,9 +389,8 @@ TEST_F(TaskEventBufferTest, TestBufferSizeLimit) {
   for (auto &event : status_events_2) {
     task_event_buffer_->AddTaskEvent(std::move(event));
   }
-
   // Expect only limit in buffer.
-  ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), num_limit);
+  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), num_limit);
 
   // Expect the reported data to match.
   auto task_gcs_accessor =
@@ -372,26 +401,41 @@ TEST_F(TaskEventBufferTest, TestBufferSizeLimit) {
       .WillOnce([&](std::unique_ptr<rpc::TaskEventData> actual_data,
                     ray::gcs::StatusCallback callback) {
         // Sort and compare
-        std::sort(actual_data->mutable_events_by_task()->begin(),
-                  actual_data->mutable_events_by_task()->end(),
-                  SortTaskEvents);
-        std::sort(expected_data.mutable_events_by_task()->begin(),
-                  expected_data.mutable_events_by_task()->end(),
-                  SortTaskEvents);
-
-        EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(*actual_data,
-                                                                       expected_data));
+        CompareTaskEventData(*actual_data, expected_data);
         return Status::OK();
       });
 
-  ASSERT_EQ(task_event_buffer_->GetNumProfileTaskEventsDropped(), num_profile);
-  ASSERT_EQ(task_event_buffer_->GetNumStatusTaskEventsDropped(), num_status);
   task_event_buffer_->FlushEvents(false);
 
   // Expect data flushed.
-  ASSERT_EQ(task_event_buffer_->GetAllTaskEvents().size(), 0);
-  ASSERT_EQ(task_event_buffer_->GetNumProfileTaskEventsDropped(), 0);
-  ASSERT_EQ(task_event_buffer_->GetNumStatusTaskEventsDropped(), 0);
+  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), 0);
+  ASSERT_EQ(task_event_buffer_->GetNumProfileTaskEventsDroppedSinceLastFlush(), 0);
+  ASSERT_EQ(task_event_buffer_->GetNumStatusTaskEventsDroppedSinceLastFlush(), 0);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumProfileTaskEventsDropped(), num_profile);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumStatusTaskEventsDropped(), num_status);
+}
+
+TEST_F(TaskEventBufferTestLimitProfileEvents, TestLimitProfileEventsPerTask) {
+  size_t num_profile_events_per_task = 10;
+  size_t num_total_profile_events = 1000;
+  std::vector<std::unique_ptr<TaskEvent>> profile_events;
+  auto task_id = RandomTaskId();
+
+  // Generate data for the same task attempts.
+  for (size_t i = 0; i < num_total_profile_events; ++i) {
+    profile_events.push_back(GenProfileTaskEvent(task_id, 0));
+  }
+
+  // Add all
+  for (auto &event : profile_events) {
+    task_event_buffer_->AddTaskEvent(std::move(event));
+  }
+
+  // Assert dropped count
+  task_event_buffer_->FlushEvents(false);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumProfileTaskEventsDropped(),
+            num_total_profile_events - num_profile_events_per_task);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumStatusTaskEventsDropped(), 0);
 }
 
 }  // namespace worker


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
1. This PR restricts the number of profile events to be sent and aggregates task events from the same task attempt on the worker side to reduce the data sent to GCS. 
2. This PR also refactos the metrics tracking to reduce lock contention on the core worker. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Release tests:
https://buildkite.com/ray-project/release-tests-pr/builds/30968#0186e373-19ec-4335-a4af-b82d5e9e0e42

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
