### PR TITLE
[Datasets] Force all operator/stage name to be in PascalCase

### DIFF
--- a/python/ray/air/tests/test_dataset_config.py
+++ b/python/ray/air/tests/test_dataset_config.py
@@ -285,7 +285,7 @@ def test_stream_finite_window_nocache_prep(ray_start_4_cpus):
         assert results[0] != results[1], results
         stats = shard.stats()
         assert (
-            "Stage 1 ReadRange->randomize_block_order->"
+            "Stage 1 ReadRange->RandomizeBlockOrder->"
             "BatchMapper: 1/1 blocks executed " in stats
         ), stats
 
@@ -325,7 +325,7 @@ def test_global_shuffle(ray_start_4_cpus):
         assert len(results[0]) == 5, results
         assert results[0] != results[1], results
         stats = shard.stats()
-        assert "randomize_block_order->random_shuffle" in stats, stats
+        assert "RandomizeBlockOrder->RandomShuffle" in stats, stats
 
     ds = ray.data.range_table(5)
     test = TestStream(
@@ -339,7 +339,7 @@ def test_global_shuffle(ray_start_4_cpus):
         assert len(results[0]) == 5, results
         assert results[0] != results[1], results
         stats = shard.stats()
-        assert "Stage 1 ReadRange->random_shuffle" in stats, stats
+        assert "Stage 1 ReadRange->RandomShuffle" in stats, stats
 
     ds = ray.data.range_table(5)
     test = TestBatch(
@@ -355,7 +355,7 @@ def test_randomize_block_order(ray_start_4_cpus):
         assert len(results[0]) == 5, results
         assert results[0] != results[1], results
         stats = shard.stats()
-        assert "randomize_block_order: 5/5 blocks executed in 0s" in stats, stats
+        assert "RandomizeBlockOrder: 5/5 blocks executed in 0s" in stats, stats
 
     ds = ray.data.range_table(5)
     test = TestStream(
@@ -366,7 +366,7 @@ def test_randomize_block_order(ray_start_4_cpus):
 
     def checker(shard, results):
         stats = shard.stats()
-        assert "randomize_block_order" not in stats, stats
+        assert "RandomizeBlockOrder" not in stats, stats
 
     ds = ray.data.range_table(5)
     test = TestStream(
@@ -382,7 +382,7 @@ def test_randomize_block_order(ray_start_4_cpus):
         # beginning, not once per epoch.
         assert results[0] == results[1], results
         stats = shard.stats()
-        assert "randomize_block_order: 5/5 blocks executed" in stats, stats
+        assert "RandomizeBlockOrder: 5/5 blocks executed" in stats, stats
 
     ds = ray.data.range_table(5)
     test = TestBatch(
@@ -397,7 +397,7 @@ def test_make_local_dataset_iterator(ray_start_4_cpus):
         assert len(results[0]) == 5, results
         assert results[0] != results[1], results
         stats = shard.stats()
-        assert "randomize_block_order: 5/5 blocks executed in 0s" in stats, stats
+        assert "RandomizeBlockOrder: 5/5 blocks executed in 0s" in stats, stats
 
     ds = ray.data.range_table(5)
     test = TestStream(

--- a/python/ray/data/_internal/lazy_block_list.py
+++ b/python/ray/data/_internal/lazy_block_list.py
@@ -123,7 +123,7 @@ class LazyBlockList(BlockList):
         """Create DatasetStats for this LazyBlockList."""
         return DatasetStats(
             # Make a copy of metadata, as the DatasetStats may mutate it in-place.
-            stages={"read": self.get_metadata(fetch_if_missing=False).copy()},
+            stages={"Read": self.get_metadata(fetch_if_missing=False).copy()},
             parent=None,
             needs_stats_actor=True,
             stats_uuid=self._stats_uuid,

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 import ray
+from ray.data._internal.util import capitalize
 from ray.types import ObjectRef
 from ray.data._internal.arrow_ops.transform_pyarrow import unify_schemas
 from ray.data._internal.block_list import BlockList
@@ -46,30 +47,6 @@ INHERITABLE_REMOTE_ARGS = ["scheduling_strategy"]
 
 
 logger = DatasetLogger(__name__)
-
-
-def capfirst(s: str):
-    """Capitalize the first letter of a string
-
-    Args:
-        s: String to capitalize
-
-    Returns:
-       Capitalized string
-    """
-    return s[0].upper() + s[1:]
-
-
-def capitalize(s: str):
-    """Capitalize a string, removing '_' and keeping camelcase.
-
-    Args:
-        s: String to capitalize
-
-    Returns:
-        Capitalized string with no underscores.
-    """
-    return "".join(capfirst(x) for x in s.split("_"))
 
 
 class Stage:
@@ -182,7 +159,7 @@ class ExecutionPlan:
         if self._stages_after_snapshot:
             # Get string representation of each stage in reverse order.
             for stage in self._stages_after_snapshot[::-1]:
-                # Get name of each stage in camel case.
+                # Get name of each stage in pascal case.
                 # The stage representation should be in "<stage-name>(...)" format,
                 # e.g. "MapBatches(my_udf)".
                 #
@@ -1213,7 +1190,7 @@ def _rewrite_read_stage(
         if stages and isinstance(stages[0], RandomizeBlocksStage):
             block_list, _ = stages[0].do_randomize(block_list)
             stages = stages[1:]
-        name += "->randomize_block_order"
+        name += "->RandomizeBlockOrder"
 
     stage = OneToOneStage(
         name,
@@ -1248,7 +1225,7 @@ def _reorder_stages(stages: List[Stage]) -> List[Stage]:
             reorder_buf.append(s)
         else:
             # Barrier: flush the reorder buffer.
-            if isinstance(s, AllToAllStage) or s.name == "write":
+            if isinstance(s, AllToAllStage) or s.name == "Write":
                 output.extend(reorder_buf)
                 reorder_buf = []
             output.append(s)

--- a/python/ray/data/_internal/stage_impl.py
+++ b/python/ray/data/_internal/stage_impl.py
@@ -62,7 +62,7 @@ class RepartitionStage(AllToAllStage):
                 )
 
             super().__init__(
-                "repartition", num_blocks, do_shuffle, supports_block_udf=True
+                "Repartition", num_blocks, do_shuffle, supports_block_udf=True
             )
 
         else:
@@ -75,7 +75,7 @@ class RepartitionStage(AllToAllStage):
                     blocks = block_list
                 return fast_repartition(blocks, num_blocks)
 
-            super().__init__("repartition", num_blocks, do_fast_repartition)
+            super().__init__("Repartition", num_blocks, do_fast_repartition)
 
 
 class RandomizeBlocksStage(AllToAllStage):
@@ -84,7 +84,7 @@ class RandomizeBlocksStage(AllToAllStage):
     def __init__(self, seed: Optional[int]):
         self._seed = seed
 
-        super().__init__("randomize_block_order", None, self.do_randomize)
+        super().__init__("RandomizeBlockOrder", None, self.do_randomize)
 
     def do_randomize(self, block_list, *_):
         num_blocks = block_list.initial_num_blocks()
@@ -139,7 +139,7 @@ class RandomShuffleStage(AllToAllStage):
             )
 
         super().__init__(
-            "random_shuffle",
+            "RandomShuffle",
             output_num_blocks,
             do_shuffle,
             supports_block_udf=True,
@@ -241,7 +241,7 @@ class ZipStage(AllToAllStage):
             )
             return blocks, {}
 
-        super().__init__("zip", None, do_zip_all)
+        super().__init__("Zip", None, do_zip_all)
 
 
 def _calculate_blocks_rows_and_bytes(
@@ -313,4 +313,4 @@ class SortStage(AllToAllStage):
                 _validate_key_fn(ds, key)
             return sort_impl(blocks, clear_input_blocks, key, descending)
 
-        super().__init__("sort", None, do_sort)
+        super().__init__("Sort", None, do_sort)

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import ray
 from ray.data._internal.block_list import BlockList
+from ray.data._internal.util import capfirst
 from ray.data.block import BlockMetadata
 from ray.data.context import DatasetContext
 from ray.util.annotations import DeveloperAPI
@@ -69,11 +70,12 @@ class _DatasetStatsBuilder:
     def build_multistage(self, stages: StatsDict) -> "DatasetStats":
         stage_infos = {}
         for i, (k, v) in enumerate(stages.items()):
+            capped_k = capfirst(k)
             if len(stages) > 1:
                 if i == 0:
-                    stage_infos[self.stage_name + "_" + k] = v
+                    stage_infos[self.stage_name + capped_k] = v
                 else:
-                    stage_infos[self.stage_name.split("->")[-1] + "_" + k] = v
+                    stage_infos[self.stage_name.split("->")[-1] + capped_k] = v
             else:
                 stage_infos[self.stage_name] = v
         stats = DatasetStats(
@@ -262,13 +264,13 @@ class DatasetStats:
             if DatasetContext.get_current().block_splitting_enabled:
                 # Only populate stats when stats from all read tasks are ready at
                 # stats actor.
-                if len(stats_map.items()) == len(self.stages["read"]):
-                    self.stages["read"] = []
+                if len(stats_map.items()) == len(self.stages["Read"]):
+                    self.stages["Read"] = []
                     for _, blocks_metadata in sorted(stats_map.items()):
-                        self.stages["read"] += blocks_metadata
+                        self.stages["Read"] += blocks_metadata
             else:
                 for i, metadata in stats_map.items():
-                    self.stages["read"][i] = metadata[0]
+                    self.stages["Read"][i] = metadata[0]
 
         stages_stats = []
         is_substage = len(self.stages) > 1

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -429,3 +429,27 @@ def _default_batch_format(
                 else "default"
             )
     return batch_format
+
+
+def capfirst(s: str):
+    """Capitalize the first letter of a string
+
+    Args:
+        s: String to capitalize
+
+    Returns:
+       Capitalized string
+    """
+    return s[0].upper() + s[1:]
+
+
+def capitalize(s: str):
+    """Capitalize a string, removing '_' and keeping camelcase.
+
+    Args:
+        s: String to capitalize
+
+    Returns:
+        Capitalized string with no underscores.
+    """
+    return "".join(capfirst(x) for x in s.split("_"))

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -353,7 +353,7 @@ class Dataset(Generic[T]):
 
         plan = self._plan.with_stage(
             OneToOneStage(
-                "map",
+                "Map",
                 transform_fn,
                 compute,
                 ray_remote_args,
@@ -891,7 +891,7 @@ class Dataset(Generic[T]):
         transform_fn = generate_flat_map_fn()
 
         plan = self._plan.with_stage(
-            OneToOneStage("flat_map", transform_fn, compute, ray_remote_args, fn=fn)
+            OneToOneStage("FlatMap", transform_fn, compute, ray_remote_args, fn=fn)
         )
 
         logical_plan = self._logical_plan
@@ -957,7 +957,7 @@ class Dataset(Generic[T]):
         transform_fn = generate_filter_fn()
 
         plan = self._plan.with_stage(
-            OneToOneStage("filter", transform_fn, compute, ray_remote_args, fn=fn)
+            OneToOneStage("Filter", transform_fn, compute, ray_remote_args, fn=fn)
         )
 
         logical_plan = self._logical_plan
@@ -1435,7 +1435,7 @@ class Dataset(Generic[T]):
         parent_stats = self._plan.stats()
         splits = []
         for bs, ms in zip(blocks, metadata):
-            stats = DatasetStats(stages={"split": ms}, parent=parent_stats)
+            stats = DatasetStats(stages={"Split": ms}, parent=parent_stats)
             stats.time_total_s = split_duration
             splits.append(
                 Dataset(
@@ -1657,7 +1657,7 @@ class Dataset(Generic[T]):
                     "be shown again.".format(set(epochs), max_epoch)
                 )
         dataset_stats = DatasetStats(
-            stages={"union": []},
+            stages={"Union": []},
             parent=[d._plan.stats() for d in datasets],
         )
         dataset_stats.time_total_s = time.perf_counter() - start_time
@@ -2190,7 +2190,7 @@ class Dataset(Generic[T]):
             for m in metadata
         ]
         dataset_stats = DatasetStats(
-            stages={"limit": meta_for_stats},
+            stages={"Limit": meta_for_stats},
             parent=self._plan.stats(),
         )
         dataset_stats.time_total_s = split_duration
@@ -2790,7 +2790,7 @@ class Dataset(Generic[T]):
 
             plan = self._plan.with_stage(
                 OneToOneStage(
-                    "write",
+                    "Write",
                     write_fn_wrapper,
                     "tasks",
                     ray_remote_args,

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -218,7 +218,7 @@ class GroupedDataset(Generic[T]):
                 clear_input_blocks,
             )
 
-        plan = self._dataset._plan.with_stage(AllToAllStage("aggregate", None, do_agg))
+        plan = self._dataset._plan.with_stage(AllToAllStage("Aggregate", None, do_agg))
 
         logical_plan = self._dataset._logical_plan
         if logical_plan is not None:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -132,7 +132,7 @@ def from_items(items: List[Any], *, parallelism: int = -1) -> Dataset[Any]:
     return Dataset(
         ExecutionPlan(
             BlockList(blocks, metadata, owned_by_consumer=False),
-            DatasetStats(stages={"from_items": metadata}, parent=None),
+            DatasetStats(stages={"FromItems": metadata}, parent=None),
             run_by_consumer=False,
         ),
         0,
@@ -1324,7 +1324,7 @@ def from_pandas_refs(
         return Dataset(
             ExecutionPlan(
                 BlockList(dfs, metadata, owned_by_consumer=False),
-                DatasetStats(stages={"from_pandas_refs": metadata}, parent=None),
+                DatasetStats(stages={"FromPandasRefs": metadata}, parent=None),
                 run_by_consumer=False,
             ),
             0,
@@ -1339,7 +1339,7 @@ def from_pandas_refs(
     return Dataset(
         ExecutionPlan(
             BlockList(blocks, metadata, owned_by_consumer=False),
-            DatasetStats(stages={"from_pandas_refs": metadata}, parent=None),
+            DatasetStats(stages={"FromPandasRefs": metadata}, parent=None),
             run_by_consumer=False,
         ),
         0,
@@ -1398,7 +1398,7 @@ def from_numpy_refs(
     return Dataset(
         ExecutionPlan(
             BlockList(blocks, metadata, owned_by_consumer=False),
-            DatasetStats(stages={"from_numpy_refs": metadata}, parent=None),
+            DatasetStats(stages={"FromNumpyRefs": metadata}, parent=None),
             run_by_consumer=False,
         ),
         0,
@@ -1450,7 +1450,7 @@ def from_arrow_refs(
     return Dataset(
         ExecutionPlan(
             BlockList(tables, metadata, owned_by_consumer=False),
-            DatasetStats(stages={"from_arrow_refs": metadata}, parent=None),
+            DatasetStats(stages={"FromArrowRefs": metadata}, parent=None),
             run_by_consumer=False,
         ),
         0,

--- a/python/ray/data/tests/test_bulk_executor.py
+++ b/python/ray/data/tests/test_bulk_executor.py
@@ -89,7 +89,7 @@ def test_basic_stats(ray_start_10_cpus_shared):
     expected = [[x * 4] for x in range(20)]
     assert output == expected, (output, expected)
     stats_str = executor.get_stats().to_summary().to_string()
-    assert "Stage 0 read:" in stats_str, stats_str
+    assert "Stage 0 Read:" in stats_str, stats_str
     assert "Stage 1 Foo:" in stats_str, stats_str
     assert "Stage 2 Bar:" in stats_str, stats_str
     assert "Extra metrics:" in stats_str, stats_str

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -47,7 +47,7 @@ def test_from_arrow(ray_start_regular_shared):
     rows = [(r.one, r.two) for _, r in pd.concat([df1, df2]).iterrows()]
     assert values == rows
     # Check that metadata fetch is included in stats.
-    assert "from_arrow_refs" in ds.stats()
+    assert "FromArrowRefs" in ds.stats()
 
     # test from single pyarrow table
     ds = ray.data.from_arrow(pa.Table.from_pandas(df1))
@@ -55,7 +55,7 @@ def test_from_arrow(ray_start_regular_shared):
     rows = [(r.one, r.two) for _, r in df1.iterrows()]
     assert values == rows
     # Check that metadata fetch is included in stats.
-    assert "from_arrow_refs" in ds.stats()
+    assert "FromArrowRefs" in ds.stats()
 
 
 def test_from_arrow_refs(ray_start_regular_shared):
@@ -68,7 +68,7 @@ def test_from_arrow_refs(ray_start_regular_shared):
     rows = [(r.one, r.two) for _, r in pd.concat([df1, df2]).iterrows()]
     assert values == rows
     # Check that metadata fetch is included in stats.
-    assert "from_arrow_refs" in ds.stats()
+    assert "FromArrowRefs" in ds.stats()
 
     # test from single pyarrow table ref
     ds = ray.data.from_arrow_refs(ray.put(pa.Table.from_pandas(df1)))
@@ -76,7 +76,7 @@ def test_from_arrow_refs(ray_start_regular_shared):
     rows = [(r.one, r.two) for _, r in df1.iterrows()]
     assert values == rows
     # Check that metadata fetch is included in stats.
-    assert "from_arrow_refs" in ds.stats()
+    assert "FromArrowRefs" in ds.stats()
 
 
 def test_to_arrow_refs(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset_numpy.py
+++ b/python/ray/data/tests/test_dataset_numpy.py
@@ -46,7 +46,7 @@ def test_from_numpy(ray_start_regular_shared, from_ref):
     values = np.stack(ds.take(8))
     np.testing.assert_array_equal(values, np.concatenate((arr1, arr2)))
     # Check that conversion task is included in stats.
-    assert "from_numpy_refs" in ds.stats()
+    assert "FromNumpyRefs" in ds.stats()
 
     # Test from single NumPy ndarray.
     if from_ref:
@@ -56,7 +56,7 @@ def test_from_numpy(ray_start_regular_shared, from_ref):
     values = np.stack(ds.take(4))
     np.testing.assert_array_equal(values, arr1)
     # Check that conversion task is included in stats.
-    assert "from_numpy_refs" in ds.stats()
+    assert "FromNumpyRefs" in ds.stats()
 
 
 def test_from_numpy_variable_shaped(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset_pandas.py
+++ b/python/ray/data/tests/test_dataset_pandas.py
@@ -29,7 +29,7 @@ def test_from_pandas(ray_start_regular_shared, enable_pandas_block):
         rows = [(r.one, r.two) for _, r in pd.concat([df1, df2]).iterrows()]
         assert values == rows
         # Check that metadata fetch is included in stats.
-        assert "from_pandas_refs" in ds.stats()
+        assert "FromPandasRefs" in ds.stats()
 
         # test from single pandas dataframe
         ds = ray.data.from_pandas(df1)
@@ -38,7 +38,7 @@ def test_from_pandas(ray_start_regular_shared, enable_pandas_block):
         rows = [(r.one, r.two) for _, r in df1.iterrows()]
         assert values == rows
         # Check that metadata fetch is included in stats.
-        assert "from_pandas_refs" in ds.stats()
+        assert "FromPandasRefs" in ds.stats()
     finally:
         ctx.enable_pandas_block = old_enable_pandas_block
 
@@ -57,7 +57,7 @@ def test_from_pandas_refs(ray_start_regular_shared, enable_pandas_block):
         rows = [(r.one, r.two) for _, r in pd.concat([df1, df2]).iterrows()]
         assert values == rows
         # Check that metadata fetch is included in stats.
-        assert "from_pandas_refs" in ds.stats()
+        assert "FromPandasRefs" in ds.stats()
 
         # test from single pandas dataframe ref
         ds = ray.data.from_pandas_refs(ray.put(df1))
@@ -66,7 +66,7 @@ def test_from_pandas_refs(ray_start_regular_shared, enable_pandas_block):
         rows = [(r.one, r.two) for _, r in df1.iterrows()]
         assert values == rows
         # Check that metadata fetch is included in stats.
-        assert "from_pandas_refs" in ds.stats()
+        assert "FromPandasRefs" in ds.stats()
     finally:
         ctx.enable_pandas_block = old_enable_pandas_block
 

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -303,12 +303,12 @@ def test_stage_linking(ray_start_regular_shared):
     assert ds._plan._last_optimized_stages is None
     ds = ds.map(lambda x: x + 1)
     assert len(ds._plan._stages_before_snapshot) == 0
-    _assert_has_stages(ds._plan._stages_after_snapshot, ["map"])
+    _assert_has_stages(ds._plan._stages_after_snapshot, ["Map"])
     assert ds._plan._last_optimized_stages is None
     ds = ds.fully_executed()
-    _assert_has_stages(ds._plan._stages_before_snapshot, ["map"])
+    _assert_has_stages(ds._plan._stages_before_snapshot, ["Map"])
     assert len(ds._plan._stages_after_snapshot) == 0
-    _assert_has_stages(ds._plan._last_optimized_stages, ["ReadRange->map"])
+    _assert_has_stages(ds._plan._last_optimized_stages, ["ReadRange->Map"])
 
 
 def test_optimize_reorder(ray_start_regular_shared):
@@ -326,7 +326,7 @@ def test_optimize_reorder(ray_start_regular_shared):
     expect_stages(
         ds,
         2,
-        ["ReadRange->MapBatches(dummy_map)", "randomize_block_order"],
+        ["ReadRange->MapBatches(dummy_map)", "RandomizeBlockOrder"],
     )
 
     ds2 = (
@@ -339,7 +339,7 @@ def test_optimize_reorder(ray_start_regular_shared):
     expect_stages(
         ds2,
         3,
-        ["ReadRange->randomize_block_order", "repartition", "MapBatches(dummy_map)"],
+        ["ReadRange->RandomizeBlockOrder", "Repartition", "MapBatches(dummy_map)"],
     )
 
 
@@ -352,7 +352,7 @@ def test_window_randomize_fusion(ray_start_regular_shared):
     pipe = ray.data.range(100).randomize_block_order().window().map_batches(dummy_map)
     pipe.take()
     stats = pipe.stats()
-    assert "ReadRange->randomize_block_order->MapBatches(dummy_map)" in stats, stats
+    assert "ReadRange->RandomizeBlockOrder->MapBatches(dummy_map)" in stats, stats
 
 
 def test_write_fusion(ray_start_regular_shared, tmp_path):
@@ -365,7 +365,7 @@ def test_write_fusion(ray_start_regular_shared, tmp_path):
     ds = ray.data.range(100).map_batches(lambda x: x)
     ds.write_csv(path)
     stats = ds._write_ds.stats()
-    assert "ReadRange->MapBatches(<lambda>)->write" in stats, stats
+    assert "ReadRange->MapBatches(<lambda>)->Write" in stats, stats
 
     ds = (
         ray.data.range(100)
@@ -376,8 +376,8 @@ def test_write_fusion(ray_start_regular_shared, tmp_path):
     ds.write_csv(path)
     stats = ds._write_ds.stats()
     assert "ReadRange->MapBatches(<lambda>)" in stats, stats
-    assert "random_shuffle" in stats, stats
-    assert "MapBatches(<lambda>)->write" in stats, stats
+    assert "RandomShuffle" in stats, stats
+    assert "MapBatches(<lambda>)->Write" in stats, stats
 
 
 def test_write_doesnt_reorder_randomize_block(ray_start_regular_shared, tmp_path):
@@ -389,8 +389,8 @@ def test_write_doesnt_reorder_randomize_block(ray_start_regular_shared, tmp_path
     # The randomize_block_order will switch order with the following map_batches,
     # but not the tailing write operator.
     assert "ReadRange->MapBatches(<lambda>)" in stats, stats
-    assert "randomize_block_order" in stats, stats
-    assert "write" in stats, stats
+    assert "RandomizeBlockOrder" in stats, stats
+    assert "Write" in stats, stats
 
 
 def test_optimize_fuse(ray_start_regular_shared):
@@ -412,8 +412,8 @@ def test_optimize_fuse(ray_start_regular_shared):
         build_pipe(),
         1,
         [
-            "ReadRange->MapBatches(dummy_map)->MapBatches(dummy_map)->random_shuffle_map",  # noqa: E501
-            "random_shuffle_reduce",
+            "ReadRange->MapBatches(dummy_map)->MapBatches(dummy_map)->RandomShuffleMap",  # noqa: E501
+            "RandomShuffleReduce",
         ],
     )
 
@@ -424,9 +424,9 @@ def test_optimize_fuse(ray_start_regular_shared):
         build_pipe(),
         1,
         [
-            "read",
-            "MapBatches(dummy_map)->MapBatches(dummy_map)->random_shuffle_map",
-            "random_shuffle_reduce",
+            "Read",
+            "MapBatches(dummy_map)->MapBatches(dummy_map)->RandomShuffleMap",
+            "RandomShuffleReduce",
         ],
     )
 
@@ -437,10 +437,10 @@ def test_optimize_fuse(ray_start_regular_shared):
         build_pipe(),
         2,
         [
-            "read",
+            "Read",
             "MapBatches(dummy_map)->MapBatches(dummy_map)",
-            "random_shuffle_map",
-            "random_shuffle_reduce",
+            "RandomShuffleMap",
+            "RandomShuffleReduce",
         ],
     )
 
@@ -451,11 +451,11 @@ def test_optimize_fuse(ray_start_regular_shared):
         build_pipe(),
         3,
         [
-            "read",
+            "Read",
             "MapBatches(dummy_map)",
             "MapBatches(dummy_map)",
-            "random_shuffle_map",
-            "random_shuffle_reduce",
+            "RandomShuffleMap",
+            "RandomShuffleReduce",
         ],
     )
 
@@ -502,8 +502,8 @@ def test_optimize_equivalent_remote_args(ray_start_regular_shared):
                 pipe,
                 1,
                 [
-                    "ReadRange->MapBatches(dummy_map)->random_shuffle_map",
-                    "random_shuffle_reduce",
+                    "ReadRange->MapBatches(dummy_map)->RandomShuffleMap",
+                    "RandomShuffleReduce",
                 ],
             )
 
@@ -528,8 +528,8 @@ def test_optimize_incompatible_stages(shutdown_only):
         2,
         [
             "ReadRange->MapBatches(dummy_map)",
-            "MapBatches(dummy_map)->random_shuffle_map",
-            "random_shuffle_reduce",
+            "MapBatches(dummy_map)->RandomShuffleMap",
+            "RandomShuffleReduce",
         ],
     )
 
@@ -544,8 +544,8 @@ def test_optimize_incompatible_stages(shutdown_only):
         [
             "ReadRange->MapBatches(dummy_map)",
             "MapBatches(dummy_map)",
-            "random_shuffle_map",
-            "random_shuffle_reduce",
+            "RandomShuffleMap",
+            "RandomShuffleReduce",
         ],
     )
 

--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -308,14 +308,14 @@ def test_push_based_shuffle_stats(ray_start_cluster):
         parallelism = 100
         ds = ray.data.range(1000, parallelism=parallelism).random_shuffle()
         ds = ds.fully_executed()
-        assert "random_shuffle_merge" in ds.stats()
+        assert "RandomShuffleMerge" in ds.stats()
         # Check all nodes used.
         assert "2 nodes used" in ds.stats()
         assert "1 nodes used" not in ds.stats()
 
         # Check all merge tasks are included in stats.
         internal_stats = ds._plan.stats()
-        num_merge_tasks = len(internal_stats.stages["random_shuffle_merge"])
+        num_merge_tasks = len(internal_stats.stages["RandomShuffleMerge"])
         # Merge factor is 2 for random_shuffle ops.
         merge_factor = 2
         assert (

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -76,7 +76,7 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
             else:
                 assert (
                     canonicalize(logger_args[0])
-                    == """Stage N read->MapBatches(dummy_map_batches): N/N blocks executed in T
+                    == """Stage N Read->MapBatches(dummy_map_batches): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -93,7 +93,7 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
             if context.new_execution_backend:
                 assert (
                     canonicalize(logger_args[0])
-                    == """Stage N map: N/N blocks executed in T
+                    == """Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -107,7 +107,7 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
             else:
                 assert (
                     canonicalize(logger_args[0])
-                    == """Stage N map: N/N blocks executed in T
+                    == """Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -148,7 +148,7 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
 * Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
 'obj_store_mem_peak': N}
 
-Stage N map: N/N blocks executed in T
+Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -173,7 +173,7 @@ Dataset iterator time breakdown:
     else:
         assert (
             stats
-            == """Stage N read->MapBatches(dummy_map_batches): N/N blocks executed in T
+            == """Stage N Read->MapBatches(dummy_map_batches): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -181,7 +181,7 @@ Dataset iterator time breakdown:
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N map: N/N blocks executed in T
+Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -208,9 +208,9 @@ def test_dataset_stats_shuffle(ray_start_regular_shared):
     stats = canonicalize(ds.fully_executed().stats())
     assert (
         stats
-        == """Stage N ReadRange->random_shuffle: executed in T
+        == """Stage N ReadRange->RandomShuffle: executed in T
 
-    Substage Z ReadRange->random_shuffle_map: N/N blocks executed
+    Substage Z ReadRange->RandomShuffleMap: N/N blocks executed
     * Remote wall time: T min, T max, T mean, T total
     * Remote cpu time: T min, T max, T mean, T total
     * Peak heap memory usage (MiB): N min, N max, N mean
@@ -218,7 +218,7 @@ def test_dataset_stats_shuffle(ray_start_regular_shared):
     * Output size bytes: N min, N max, N mean, N total
     * Tasks per node: N min, N max, N mean; N nodes used
 
-    Substage N random_shuffle_reduce: N/N blocks executed
+    Substage N RandomShuffleReduce: N/N blocks executed
     * Remote wall time: T min, T max, T mean, T total
     * Remote cpu time: T min, T max, T mean, T total
     * Peak heap memory usage (MiB): N min, N max, N mean
@@ -226,9 +226,9 @@ def test_dataset_stats_shuffle(ray_start_regular_shared):
     * Output size bytes: N min, N max, N mean, N total
     * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N repartition: executed in T
+Stage N Repartition: executed in T
 
-    Substage Z repartition_map: N/N blocks executed
+    Substage Z RepartitionMap: N/N blocks executed
     * Remote wall time: T min, T max, T mean, T total
     * Remote cpu time: T min, T max, T mean, T total
     * Peak heap memory usage (MiB): N min, N max, N mean
@@ -236,7 +236,7 @@ Stage N repartition: executed in T
     * Output size bytes: N min, N max, N mean, N total
     * Tasks per node: N min, N max, N mean; N nodes used
 
-    Substage N repartition_reduce: N/N blocks executed
+    Substage N RepartitionReduce: N/N blocks executed
     * Remote wall time: T min, T max, T mean, T total
     * Remote cpu time: T min, T max, T mean, T total
     * Peak heap memory usage (MiB): N min, N max, N mean
@@ -251,35 +251,35 @@ def test_dataset_stats_repartition(ray_start_regular_shared):
     ds = ray.data.range(1000, parallelism=10)
     ds = ds.repartition(1, shuffle=False)
     stats = ds.fully_executed().stats()
-    assert "repartition" in stats, stats
+    assert "Repartition" in stats, stats
 
 
 def test_dataset_stats_union(ray_start_regular_shared):
     ds = ray.data.range(1000, parallelism=10)
     ds = ds.union(ds)
     stats = ds.fully_executed().stats()
-    assert "union" in stats, stats
+    assert "Union" in stats, stats
 
 
 def test_dataset_stats_zip(ray_start_regular_shared):
     ds = ray.data.range(1000, parallelism=10)
     ds = ds.zip(ds)
     stats = ds.fully_executed().stats()
-    assert "zip" in stats, stats
+    assert "Zip" in stats, stats
 
 
 def test_dataset_stats_sort(ray_start_regular_shared):
     ds = ray.data.range(1000, parallelism=10)
     ds = ds.sort()
     stats = ds.fully_executed().stats()
-    assert "sort_map" in stats, stats
-    assert "sort_reduce" in stats, stats
+    assert "SortMap" in stats, stats
+    assert "SortReduce" in stats, stats
 
 
 def test_dataset_stats_from_items(ray_start_regular_shared):
     ds = ray.data.from_items(range(10))
     stats = ds.fully_executed().stats()
-    assert "from_items" in stats, stats
+    assert "FromItems" in stats, stats
 
 
 def test_dataset_stats_read_parquet(ray_start_regular_shared, tmp_path):
@@ -292,7 +292,7 @@ def test_dataset_stats_read_parquet(ray_start_regular_shared, tmp_path):
     if context.new_execution_backend:
         assert (
             stats
-            == """Stage N ReadParquet->map: N/N blocks executed in T
+            == """Stage N ReadParquet->Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -306,7 +306,7 @@ def test_dataset_stats_read_parquet(ray_start_regular_shared, tmp_path):
     else:
         assert (
             stats
-            == """Stage N read->map: N/N blocks executed in T
+            == """Stage N Read->Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -328,7 +328,7 @@ def test_dataset_split_stats(ray_start_regular_shared, tmp_path):
         if context.new_execution_backend:
             assert (
                 stats
-                == """Stage N ReadRange->map: N/N blocks executed in T
+                == """Stage N ReadRange->Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -338,7 +338,7 @@ def test_dataset_split_stats(ray_start_regular_shared, tmp_path):
 * Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
 'obj_store_mem_peak': N}
 
-Stage N split: N/N blocks executed in T
+Stage N Split: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -346,7 +346,7 @@ Stage N split: N/N blocks executed in T
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N map: N/N blocks executed in T
+Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -360,7 +360,7 @@ Stage N map: N/N blocks executed in T
         else:
             assert (
                 stats
-                == """Stage N read->map: N/N blocks executed in T
+                == """Stage N Read->Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -368,7 +368,7 @@ Stage N map: N/N blocks executed in T
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N split: N/N blocks executed in T
+Stage N Split: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -376,7 +376,7 @@ Stage N split: N/N blocks executed in T
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N map: N/N blocks executed in T
+Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -433,7 +433,7 @@ def test_dataset_pipeline_stats_basic(ray_start_regular_shared, enable_auto_log_
             else:
                 assert (
                     canonicalize(logger_args[0])
-                    == """Stage N read->MapBatches(dummy_map_batches): N/N blocks executed in T
+                    == """Stage N Read->MapBatches(dummy_map_batches): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -465,7 +465,7 @@ def test_dataset_pipeline_stats_basic(ray_start_regular_shared, enable_auto_log_
             else:
                 assert (
                     canonicalize(logger_args[0])
-                    == """Stage N read->MapBatches(dummy_map_batches): N/N blocks executed in T
+                    == """Stage N Read->MapBatches(dummy_map_batches): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -486,7 +486,7 @@ def test_dataset_pipeline_stats_basic(ray_start_regular_shared, enable_auto_log_
             if context.new_execution_backend:
                 assert (
                     canonicalize(logger_args[0])
-                    == """Stage N map: N/N blocks executed in T
+                    == """Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -500,7 +500,7 @@ def test_dataset_pipeline_stats_basic(ray_start_regular_shared, enable_auto_log_
             else:
                 assert (
                     canonicalize(logger_args[0])
-                    == """Stage N map: N/N blocks executed in T
+                    == """Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -525,7 +525,7 @@ Stage N ReadRange->MapBatches(dummy_map_batches): N/N blocks executed in T
 * Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
 'obj_store_mem_peak': N}
 
-Stage N map: N/N blocks executed in T
+Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -540,7 +540,7 @@ Stage N ReadRange->MapBatches(dummy_map_batches): [execution cached]
 * Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
 'obj_store_mem_peak': N}
 
-Stage N map: N/N blocks executed in T
+Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -555,7 +555,7 @@ Stage N ReadRange->MapBatches(dummy_map_batches): [execution cached]
 * Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
 'obj_store_mem_peak': N}
 
-Stage N map: N/N blocks executed in T
+Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -582,7 +582,7 @@ DatasetPipeline iterator time breakdown:
             assert (
                 stats
                 == """== Pipeline Window N ==
-Stage N read->MapBatches(dummy_map_batches): N/N blocks executed in T
+Stage N Read->MapBatches(dummy_map_batches): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -590,18 +590,7 @@ Stage N read->MapBatches(dummy_map_batches): N/N blocks executed in T
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N map: N/N blocks executed in T
-* Remote wall time: T min, T max, T mean, T total
-* Remote cpu time: T min, T max, T mean, T total
-* Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
-* Tasks per node: N min, N max, N mean; N nodes used
-
-== Pipeline Window N ==
-Stage N read->MapBatches(dummy_map_batches): [execution cached]
-
-Stage N map: N/N blocks executed in T
+Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -610,9 +599,20 @@ Stage N map: N/N blocks executed in T
 * Tasks per node: N min, N max, N mean; N nodes used
 
 == Pipeline Window N ==
-Stage N read->MapBatches(dummy_map_batches): [execution cached]
+Stage N Read->MapBatches(dummy_map_batches): [execution cached]
 
-Stage N map: N/N blocks executed in T
+Stage N Map: N/N blocks executed in T
+* Remote wall time: T min, T max, T mean, T total
+* Remote cpu time: T min, T max, T mean, T total
+* Peak heap memory usage (MiB): N min, N max, N mean
+* Output num rows: N min, N max, N mean, N total
+* Output size bytes: N min, N max, N mean, N total
+* Tasks per node: N min, N max, N mean; N nodes used
+
+== Pipeline Window N ==
+Stage N Read->MapBatches(dummy_map_batches): [execution cached]
+
+Stage N Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -713,7 +713,7 @@ DatasetPipeline iterator time breakdown:
         assert (
             canonicalize(stats[0])
             == """== Pipeline Window Z ==
-Stage N read: N/N blocks executed in T
+Stage N Read: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -722,7 +722,7 @@ Stage N read: N/N blocks executed in T
 * Tasks per node: N min, N max, N mean; N nodes used
 
 == Pipeline Window N ==
-Stage N read: N/N blocks executed in T
+Stage N Read: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -751,7 +751,7 @@ def test_calculate_blocks_stats(ray_start_regular_shared, stage_two_block):
 
     block_params, block_meta_list = stage_two_block
     stats = DatasetStats(
-        stages={"read": block_meta_list},
+        stages={"Read": block_meta_list},
         parent=None,
     )
     calculated_stats = stats.to_summary().stages_stats[0]
@@ -796,7 +796,7 @@ def test_summarize_blocks(ray_start_regular_shared, stage_two_block):
 
     block_params, block_meta_list = stage_two_block
     stats = DatasetStats(
-        stages={"read": block_meta_list},
+        stages={"Read": block_meta_list},
         parent=None,
     )
     stats.dataset_uuid = "test-uuid"
@@ -805,7 +805,7 @@ def test_summarize_blocks(ray_start_regular_shared, stage_two_block):
     summarized_lines = calculated_stats.to_string().split("\n")
 
     assert (
-        "Stage 0 read: 2/2 blocks executed in {}s".format(
+        "Stage 0 Read: 2/2 blocks executed in {}s".format(
             max(round(stats.time_total_s, 2), 0)
         )
         == summarized_lines[0]
@@ -878,7 +878,7 @@ def test_get_total_stats(ray_start_regular_shared, stage_two_block):
 
     block_params, block_meta_list = stage_two_block
     stats = DatasetStats(
-        stages={"read": block_meta_list},
+        stages={"Read": block_meta_list},
         parent=None,
     )
 
@@ -903,7 +903,7 @@ def test_streaming_stats_full(ray_start_regular_shared, restore_dataset_context)
     stats = canonicalize(ds.stats())
     assert (
         stats
-        == """Stage N ReadRange->map: N/N blocks executed in T
+        == """Stage N ReadRange->Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -124,7 +124,7 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
         if context.use_streaming_executor:
             assert (
                 stats
-                == """Stage N ReadRange->MapBatches(dummy_map_batches)->map: N/N blocks executed in T
+                == """Stage N ReadRange->MapBatches(dummy_map_batches)->Map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to force all operator/stage name to be in PascalCase. Before this PR, we have a mix of PascalCase (e.g. `MapBatches`, `ReadRange`), and snake case (e.g. `random_shuffle`, `flat_map`). This would be confusing to users when looking at progress bar and `Dataset.stats()`.

This is split out from https://github.com/ray-project/ray/pull/33302 , for easier review.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
