### PR TITLE
[data] [tdqm] Make bar manager thread-safe

### DIFF
--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -2,8 +2,8 @@ import copy
 import json
 import logging
 import os
-import uuid
 import threading
+import uuid
 from typing import Any, Dict, Iterable, Optional
 
 import colorama

--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -243,8 +243,6 @@ class _BarManager:
             if log_once("no_tqdm"):
                 logger.warning("tqdm is not installed. Progress bars will be disabled.")
             return
-        if self.in_hidden_state:
-            self.unhide_bars()
         if state["ip"] == self.ip:
             if state["pid"] == self.pid:
                 prefix = ""

--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import uuid
+import threading
 from typing import Any, Dict, Iterable, Optional
 
 import colorama
@@ -225,6 +226,7 @@ class _BarManager:
         self.bar_groups = {}
         self.in_hidden_state = False
         self.num_hides = 0
+        self.lock = threading.RLock()
 
     def process_state_update(self, state: ProgressBarState) -> None:
         """Apply the remote progress bar state update.
@@ -233,6 +235,10 @@ class _BarManager:
         created or destroyed, we also recalculate and update the `pos_offset` of each
         BarGroup on the screen.
         """
+        with self.lock:
+            self._process_state_update_locked(state)
+
+    def _process_state_update_locked(self, state: ProgressBarState) -> None:
         if not real_tqdm:
             if log_once("no_tqdm"):
                 logger.warning("tqdm is not installed. Progress bars will be disabled.")
@@ -271,18 +277,20 @@ class _BarManager:
 
     def hide_bars(self) -> None:
         """Temporarily hide visible bars to avoid conflict with other log messages."""
-        if not self.in_hidden_state:
-            self.in_hidden_state = True
-            self.num_hides += 1
-            for group in self.bar_groups.values():
-                group.hide_bars()
+        with self.lock:
+            if not self.in_hidden_state:
+                self.in_hidden_state = True
+                self.num_hides += 1
+                for group in self.bar_groups.values():
+                    group.hide_bars()
 
     def unhide_bars(self) -> None:
         """Opposite of hide_bars()."""
-        if self.in_hidden_state:
-            self.in_hidden_state = False
-            for group in self.bar_groups.values():
-                group.unhide_bars()
+        with self.lock:
+            if self.in_hidden_state:
+                self.in_hidden_state = False
+                for group in self.bar_groups.values():
+                    group.unhide_bars()
 
     def _get_or_allocate_bar_group(self, state: ProgressBarState):
         ptuple = (state["ip"], state["pid"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

On the driver, the bar manager can be accessed both by the logger thread and the main thread.

Closes https://github.com/ray-project/ray/issues/33333