### PR TITLE
[Conda][dependency] pin libffi=3.3 for base-deps (#33294)

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -51,7 +51,8 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
     && echo 'export PATH=$HOME/anaconda3/bin:$PATH' >> /home/ray/.bashrc \
     && rm /tmp/miniconda.sh \
     && $HOME/anaconda3/bin/conda install -y \
-        libgcc-ng python=$PYTHON_VERSION \
+        # remove libffi pinning when fixed upstream #33299
+        libgcc-ng libffi=3.3 python=$PYTHON_VERSION \
     && $HOME/anaconda3/bin/conda clean -y --all \
     && $HOME/anaconda3/bin/pip install --no-cache-dir \
         flatbuffers \


### PR DESCRIPTION
Why are these changes needed?

Fixes an issue with transient dependencies which can cause failure on 2.3.0 rayproject/ray Docker images due to incompatible libffi and `psychpg2` packages.

This pins the version in the base-deps to 3.3 which installs a supported version.

This should be cherry-picked to fix 2.3.1.

CC: @zcin 