### PR TITLE
[wip][no_ci][air output] one proposal on hosting both old and new console output flow.

### DIFF
--- a/python/ray/tune/utils/log.py
+++ b/python/ray/tune/utils/log.py
@@ -1,8 +1,15 @@
+from dataclasses import dataclass
 from enum import Enum
+import os
 from typing import Union
 
 from ray.util import PublicAPI
 from ray.util.annotations import DeveloperAPI
+
+
+#################################
+#         OLD FLOW              #
+#################################
 
 
 @PublicAPI
@@ -23,6 +30,14 @@ verbosity: Union[int, Verbosity] = Verbosity.V3_TRIAL_DETAILS
 def set_verbosity(level: Union[int, Verbosity]):
     global verbosity
 
+    if verbosity == Verbosity.V0_MINIMAL:
+        return
+
+    if "AIR_VERBOSITY" in os.environ:
+        # DF traffic - disable the old flow by silencing it.
+        verbosity = Verbosity.V0_MINIMAL
+        return
+
     if isinstance(level, int):
         verbosity = Verbosity(level)
     else:
@@ -38,6 +53,45 @@ def has_verbosity(level: Union[int, Verbosity]) -> bool:
     verbosity_level = int(verbosity)
 
     return verbosity_level >= log_level
+
+
+# TODO: find a file under air instead of tune to host this.
+#################################
+#         NEW FLOW              #
+#################################
+
+
+#  Note: also need to ship this env var to remote actor.
+def has_verbosity_new(level: int) -> bool:
+    if "AIR_VERBOSITY" not in os.environ:
+        # effectively disabling the new flow
+        return False
+    return int(os.environ["AIR_VERBOSITY"]) >= level
+
+
+@dataclass
+class _ExecutionType:
+    """Execution type for logging purposes."""
+
+    rllib: bool = False
+    single_trial: bool = False
+
+
+# TODO: Ideally this should be explicitly passed around.
+#  But due to the current structure of our code (need to check
+#  this everywhere) host it as a global for now.
+_execution_type = _ExecutionType()
+
+
+def set_execution_type(is_rllib, is_single_trial):
+    global _execution_type
+    _execution_type.rllib = is_rllib
+    _execution_type.single_trial = is_single_trial
+
+
+def get_execution_type():
+    global _execution_type
+    return _execution_type
 
 
 @DeveloperAPI


### PR DESCRIPTION
One proposal for hosting both old and new console output flow. (only for scoping purposes, all namings are tentative)

- introduce env var "AIR_VERBOSITY"
- See python/ray/tune/utils/log.py for how new console output flow is enabled.
- also added a logging context (`_execution_type`): training v.s. tuning; rllib or not.
- See `tune.py` for how this logging context is populated.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
