### PR TITLE
[Core] fix lost reference when named actor funciton is inlined with get_actor call.

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -92,9 +92,6 @@ def method(*args, **kwargs):
 class ActorMethod:
     """A class used to invoke an actor method.
 
-    Note: This class only keeps a weak ref to the actor, unless it has been
-    passed to a remote function. This avoids delays in GC of the actor.
-
     Attributes:
         _actor_ref: A weakref handle to the actor.
         _method_name: The name of the actor method.
@@ -1091,6 +1088,7 @@ class ActorHandle:
                     method_name,
                     self._ray_method_num_returns[method_name],
                     decorator=self._ray_method_decorators.get(method_name),
+                    hardref=True,
                 )
                 setattr(self, method_name, method)
 

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -924,6 +924,16 @@ def test_actor_namespace(ray_start_regular_shared):
     del a
 
 
+def test_call_named_actor_inline(ray_start_regular_shared):
+    @ray.remote
+    class Actor:
+        def f(self):
+            return "ok"
+
+    Actor.options(name="foo").remote()
+    assert ray.get(ray.get_actor(name="foo").f.remote()) == "ok"
+
+
 def test_named_actor_cache(ray_start_regular_shared):
     """Verify that named actor cache works well."""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The bug happens because we capture the actor by weak reference in actor method. By changing to normal reference it resolves the bug.  #33020 for more context.

TBD: run actor related benchmark.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #33020
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
