### PR TITLE
fix: pin `sympy==1.10.1` for Python 3.7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,11 +23,21 @@ updates:
       - "ray-project/ray-tune"
   # compat requirements should not be updated
   - package-ecosystem: "pip"
+    schedule:
+      # Automatic upgrade checks Saturday at 12 AM.
+      # Dependabot updates can still be manually triggered via Github at any time.
+      interval: "weekly"
+      day: "saturday"
+      # 12 AM
+      time: "00:00"
+      # Use Pacific Standard Time.
+      timezone: "America/Los_Angeles"
     directory: "/python/requirements/compat"
     commit-message:
       prefix: "[air/do-not-merge]"
       include: "scope"
-    ignore: *
+    ignore:
+      - dependency-name: "*"
     open-pull-requests-limit: 0
     reviewers:
       - "ray-project/ray-tune"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -30,6 +30,7 @@ numpy>=1.16; python_version < '3.9'
 numpy>=1.19.3; python_version >= '3.9'
 packaging; python_version >= '3.10'
 typing_extensions; python_version < '3.8'
+sympy==1.10.1; python_version < '3.8'
 
 # ray[all]
 uvicorn


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
A transitive dependency has changed which is causing `sympy 1.11.1` to be installed instead of the expected/supported `sympy 1.10.1`.

This patch forces `1.10.1` for py37. py38+ supports `1.11.1` without detected issues. I can also pin it across all Python versions if desired.

## Related issue number

No related issue, found as part of 2.3.1 testing.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
