### PR TITLE
[devprod][ci/cd] print request errors on copy_files presigned url 502 failure

### DIFF
--- a/.buildkite/copy_files.py
+++ b/.buildkite/copy_files.py
@@ -23,7 +23,8 @@ def retry(f):
             else:
                 return resp
         if resp is None or resp.status_code >= 500:
-            print("still errorred after many retries")
+            print("still errorred after many retries, response content:")
+            print(resp.content)
             sys.exit(1)
 
     return inner


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
This diff adds more log information to hopefully can be used to fix https://github.com/ray-project/ray/issues/32185.

<!-- Please give a short summary of the change and the problem this solves. -->

For context, copy_files.py is a script to upload build logs and other artifacts to s3. To obscure key credentials, this script connects
to an aws service to does the uploading. The requests to that aws service, however, occasionally fails with 502 (bad gateway)
code.

Signed-off-by: Cuong Nguyen <can@anyscale.com>

## Related issue number

#32158

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X] This PR is not tested :(
