### PR TITLE
Fix Serve Dashboard Tests

### DIFF
--- a/dashboard/modules/serve/sdk.py
+++ b/dashboard/modules/serve/sdk.py
@@ -9,7 +9,6 @@ except ImportError:
     requests = None
 
 from ray.dashboard.modules.dashboard_sdk import SubmissionClient
-from ray.serve.schema import ServeInstanceDetails
 
 
 DEPLOY_PATH = "/api/serve/deployments/"
@@ -93,10 +92,10 @@ class ServeSubmissionClient(SubmissionClient):
         else:
             self._raise_error(response)
 
-    def get_serve_details(self) -> ServeInstanceDetails:
+    def get_serve_details(self) -> Dict:
         response = self._do_request("GET", STATUS_PATH_V2)
         if response.status_code == 200:
-            return ServeInstanceDetails(**response.json())
+            return response.json()
         else:
             self._raise_error(response)
 

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -27,7 +27,11 @@ from ray.serve._private.constants import (
 from ray.serve.deployment import deployment_to_schema
 from ray.serve.deployment_graph import ClassNode, FunctionNode
 from ray.serve._private import api as _private_api
-from ray.serve.schema import ServeApplicationSchema, ServeDeploySchema
+from ray.serve.schema import (
+    ServeApplicationSchema,
+    ServeDeploySchema,
+    ServeInstanceDetails,
+)
 
 APP_DIR_HELP_STR = (
     "Local directory to look for the IMPORT_PATH (will be inserted into "
@@ -439,7 +443,9 @@ def config(address: str, multi_app: bool, name: Optional[str]):
             cli_logger.error("Cannot set both `--multi-app` and `--name`.")
             return
 
-        serve_details = ServeSubmissionClient(address).get_serve_details()
+        serve_details = ServeInstanceDetails(
+            **ServeSubmissionClient(address).get_serve_details()
+        )
 
         # Fetch app configs for all live applications on the cluster
         if multi_app:
@@ -507,7 +513,9 @@ def config(address: str, multi_app: bool, name: Optional[str]):
     ),
 )
 def status(address: str, name: Optional[str]):
-    serve_details = ServeSubmissionClient(address).get_serve_details()
+    serve_details = ServeInstanceDetails(
+        **ServeSubmissionClient(address).get_serve_details()
+    )
 
     # Ensure multi-line strings in app_status is dumped/printed correctly
     yaml.SafeDumper.add_representer(str, str_presenter)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/ray/pull/33300 made the dashboard dependent on Serve.
Causing test failures: https://buildkite.com/ray-project/oss-ci-build-branch/builds/2770#_

```
E                     File "/ray/python/ray/dashboard/utils.py", line 121, in get_all_modules
E                       importlib.import_module(name)
E                     File "/opt/miniconda/lib/python3.7/importlib/__init__.py", line 127, in import_module
E                       return _bootstrap._gcd_import(name[level:], package, level)
E                     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
E                     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
E                     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
E                     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
E                     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
E                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
E                     File "/ray/python/ray/dashboard/modules/serve/sdk.py", line 12, in <module>
E                       from ray.serve.schema import ServeInstanceDetails
E                     File "/ray/python/ray/serve/__init__.py", line 23, in <module>
E                       raise e
E                     File "/ray/python/ray/serve/__init__.py", line 4, in <module>
E                       from ray.serve.api import (
E                     File "/ray/python/ray/serve/api.py", line 6, in <module>
E                       from fastapi import APIRouter, FastAPI
E                   ModuleNotFoundError: No module named 'fastapi'. You can run `pip install "ray[serve]"` to install all Ray Serve dependencies.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
