### PR TITLE
Fix Ray on Spark node options verification

### DIFF
--- a/python/ray/tests/spark/test_utils.py
+++ b/python/ray/tests/spark/test_utils.py
@@ -106,7 +106,10 @@ def test_verify_node_options():
 
     with pytest.raises(
         ValueError,
-        match="Setting option 'node_ip_address' for head nodes is not allowed.*The option is controlled by Ray on Spark",
+        match=(
+            "Setting the option 'node_ip_address' for head nodes is not allowed.*"
+            "This option is controlled by Ray on Spark"
+        ),
     ):
         _verify_node_options(
             node_options={"node_ip_address": "127.0.0.1"},
@@ -116,7 +119,10 @@ def test_verify_node_options():
 
     with pytest.raises(
         ValueError,
-        match="Setting option 'not_permitted' for worker nodes is not allowed.*You should set the 'permitted' argument instead",
+        match=(
+            "Setting the option 'not_permitted' for worker nodes is not allowed.*"
+            "You should set the 'permitted' option instead",
+        )
     ):
         _verify_node_options(
             node_options={"not_permitted": "bad"},

--- a/python/ray/tests/spark/test_utils.py
+++ b/python/ray/tests/spark/test_utils.py
@@ -122,7 +122,7 @@ def test_verify_node_options():
         match=(
             "Setting the option 'not_permitted' for worker nodes is not allowed.*"
             "You should set the 'permitted' option instead",
-        )
+        ),
     ):
         _verify_node_options(
             node_options={"not_permitted": "bad"},

--- a/python/ray/tests/spark/test_utils.py
+++ b/python/ray/tests/spark/test_utils.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 import os
+import re
 import sys
 
 import pytest
@@ -106,7 +107,7 @@ def test_verify_node_options():
 
     with pytest.raises(
         ValueError,
-        match=(
+        match=re.compile(
             "Setting the option 'node_ip_address' for head nodes is not allowed.*"
             "This option is controlled by Ray on Spark"
         ),
@@ -119,7 +120,7 @@ def test_verify_node_options():
 
     with pytest.raises(
         ValueError,
-        match=(
+        match=re.compile(
             "Setting the option 'not_permitted' for worker nodes is not allowed.*"
             "You should set the 'permitted' option instead",
         ),

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -769,17 +769,17 @@ def _verify_node_options(node_options, block_keys, node_type):
 
         if key in block_keys:
             common_err_msg = (
-                f"Setting option '{key}' for {node_type} nodes is not allowed."
+                f"Setting the option '{key}' for {node_type} nodes is not allowed."
             )
             replacement_arg = block_keys[key]
             if replacement_arg:
                 raise ValueError(
-                    f"{common_err_msg} You should set the '{replacement_arg}' argument "
+                    f"{common_err_msg} You should set the '{replacement_arg}' option "
                     "instead."
                 )
             else:
                 raise ValueError(
-                    f"{common_err_msg} The option is controlled by Ray on Spark."
+                    f"{common_err_msg} This option is controlled by Ray on Spark."
                 )
 
 

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -770,8 +770,7 @@ def _verify_node_options(node_options, block_keys, node_type):
 
         if key in block_keys:
             common_err_msg = (
-                f"Setting option {_convert_ray_node_options(key)} for {node_type} "
-                "is not allowed."
+                f"Setting option {key} for {node_type} is not allowed."
             )
             replacement_arg = block_keys[key]
             if replacement_arg:

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -630,7 +630,6 @@ def _setup_ray_cluster(
     )
 
     def background_job_thread_fn():
-
         try:
             spark.sparkContext.setJobGroup(
                 spark_job_group_id,
@@ -770,18 +769,17 @@ def _verify_node_options(node_options, block_keys, node_type):
 
         if key in block_keys:
             common_err_msg = (
-                f"Setting option {key} for {node_type} is not allowed."
+                f"Setting option '{key}' for {node_type} nodes is not allowed."
             )
             replacement_arg = block_keys[key]
             if replacement_arg:
                 raise ValueError(
-                    f"{common_err_msg} You should set '{replacement_arg}' argument "
+                    f"{common_err_msg} You should set the '{replacement_arg}' argument "
                     "instead."
                 )
             else:
                 raise ValueError(
-                    f"{common_err_msg} The option is controlled by Ray on Spark "
-                    "routine."
+                    f"{common_err_msg} The option is controlled by Ray on Spark."
                 )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current node option verification attempts to convert a string key to a dictionary when constructing an error message for blocked options, resulting in the following unclear / unintended exception:

```
from ray.util.spark import setup_ray_cluster, shutdown_ray_cluster, MAX_NUM_WORKER_NODES

setup_ray_cluster(
  num_worker_nodes=1,
  num_cpus_per_node=4,
  num_gpus_per_node=1,
  collect_log_to_path="/dbfs/tmp/raylogs",
  head_node_options={
    # Blocked / unsupported option
    "object_store_memory": "2097152000",
  }
)
```

```
File /local_disk0/.ephemeral_nfs/envs/pythonEnv-79555ebb-42c8-4f8f-822a-5604058455b9/lib/python3.9/site-packages/ray/util/spark/cluster_init.py:866, in setup_ray_cluster(num_worker_nodes, num_cpus_per_node, num_gpus_per_node, object_store_memory_per_node, head_node_options, worker_node_options, ray_temp_root_dir, strict_mode, collect_log_to_path)
    863 head_node_options = head_node_options or {}
    864 worker_node_options = worker_node_options or {}
--> 866 _verify_node_options(
    867     head_node_options,
    868     _head_node_option_block_keys,
    869     "Ray head node on spark",
    870 )
    871 _verify_node_options(
    872     worker_node_options,
    873     _worker_node_option_block_keys,
    874     "Ray worker node on spark",
    875 )
    877 if _active_ray_cluster is not None:

File /local_disk0/.ephemeral_nfs/envs/pythonEnv-79555ebb-42c8-4f8f-822a-5604058455b9/lib/python3.9/site-packages/ray/util/spark/cluster_init.py:766, in _verify_node_options(node_options, block_keys, node_type)
    758     raise ValueError(
    759         "For a ray node option like '--foo-bar', you should convert it to "
    760         "following format 'foo_bar' in 'head_node_options' / "
    761         "'worker_node_options' arguments."
    762     )
    764 if key in block_keys:
    765     common_err_msg = (
--> 766         f"Setting option {_convert_ray_node_options(key)} for {node_type} "
    767         "is not allowed."
    768     )
    769     replacement_arg = block_keys[key]
    770     if replacement_arg:

File /local_disk0/.ephemeral_nfs/envs/pythonEnv-79555ebb-42c8-4f8f-822a-5604058455b9/lib/python3.9/site-packages/ray/util/spark/cluster_init.py:216, in _convert_ray_node_options(options)
    215 def _convert_ray_node_options(options):
--> 216     return [f"{_convert_ray_node_option_key(k)}={str(v)}" for k, v in options.items()]

AttributeError: 'str' object has no attribute 'items'
```

This PR addresses the issue and makes small naming / grammatical improvements to the error messages while we're at it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
