### PR TITLE
[docs] Reminder to add new methods to the API Ref

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,9 @@
 - [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
 - [ ] I've run `scripts/format.sh` to lint the changes in this PR.
 - [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
-- [ ] I've added any new APIs to the API Reference. For example, if I added a method in Tune, I've added it in `doc/source/tune/api/` 
-      under the corresponding `.rst` file.
+    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
+           method in Tune, I've added it in `doc/source/tune/api/` under the 
+           corresponding `.rst` file.
 - [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
 - Testing Strategy
    - [ ] Unit tests

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,8 @@
 - [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
 - [ ] I've run `scripts/format.sh` to lint the changes in this PR.
 - [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
+- [ ] I've added any new APIs to the API Reference. For example, if I added a method in Tune, I've added it in `doc/source/tune/api/` 
+      under the corresponding `.rst` file.
 - [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
 - Testing Strategy
    - [ ] Unit tests


### PR DESCRIPTION
While it's still a manual step to include new methods in the API Ref, this addition to the checklist can be a helpful reminder. Thanks to @justinvyu for the suggestion.

## Why are these changes needed?

Trying to prevent missing API Ref entries.
