### PR TITLE
Remove object store memory from blocked list

### DIFF
--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -738,7 +738,6 @@ _head_node_option_block_keys = {
     "port": None,
     "num_cpus": None,
     "num_gpus": None,
-    "memory": None,
     "dashboard_host": None,
     "dashboard_agent_listen_port": None,
 }

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -739,7 +739,6 @@ _head_node_option_block_keys = {
     "num_cpus": None,
     "num_gpus": None,
     "memory": None,
-    "object_store_memory": None,
     "dashboard_host": None,
     "dashboard_agent_listen_port": None,
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Ray on Spark users can't currently configure object store memory for the head node. It's capped at 128MB.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X] Manual tests: Verified that running `ray start --object-store-memory 134217728 --object-store-memory 1048576000` uses the last specified value (`1048576000`)
