### PR TITLE
[data] [streaming] Fix inability to pickle Dataset in the middle of streaming execution

### DIFF
--- a/python/ray/data/_internal/dataset_iterator_impl.py
+++ b/python/ray/data/_internal/dataset_iterator_impl.py
@@ -76,7 +76,7 @@ class DatasetIteratorImpl(DatasetIterator):
         if name == "_base_dataset":
             raise AttributeError()
 
-        if hasattr(self._base_dataset, name):
+        if hasattr(self._base_dataset, name) and not name.startswith("_"):
             # Warning for backwards compatibility. TODO: remove this method in 2.5.
             warnings.warn(
                 "session.get_dataset_shard returns a ray.data.DatasetIterator "

--- a/python/ray/data/_internal/pipelined_dataset_iterator.py
+++ b/python/ray/data/_internal/pipelined_dataset_iterator.py
@@ -59,7 +59,7 @@ class PipelinedDatasetIterator(DatasetIterator):
         if name == "_base_dataset_pipeline":
             raise AttributeError
 
-        if hasattr(self._base_dataset_pipeline, name):
+        if hasattr(self._base_dataset_pipeline, name) and not name.startswith("_"):
             # Warning for backwards compatibility. TODO: remove this method in 2.5.
             warnings.warn(
                 "session.get_dataset_shard returns a ray.data.DatasetIterator "

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4433,6 +4433,23 @@ class Dataset(Generic[T]):
             self._current_executor.shutdown()
             self._current_executor = None
 
+    def __getstate__(self):
+        # Note: excludes _current_executor which is not serializable.
+        return {
+            "plan": self._plan,
+            "uuid": self._uuid,
+            "epoch": self._epoch,
+            "lazy": self._lazy,
+            "logical_plan": self._logical_plan,
+        }
+
+    def __setstate__(self, state):
+        self._plan = state["plan"]
+        self._uuid = state["uuid"]
+        self._epoch = state["epoch"]
+        self._lazy = state["lazy"]
+        self._logical_plan = state["logical_plan"]
+
 
 def _get_size_bytes(block: Block) -> int:
     block = BlockAccessor.for_block(block)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4449,6 +4449,7 @@ class Dataset(Generic[T]):
         self._epoch = state["epoch"]
         self._lazy = state["lazy"]
         self._logical_plan = state["logical_plan"]
+        self._current_executor = None
 
 
 def _get_size_bytes(block: Block) -> int:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Executor is not serializable; avoid this by defining getstate/setstate.