### PR TITLE
[ci] Display Core prerelease dependencies

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -815,6 +815,7 @@ run_minimal_test() {
 
 test_minimal() {
   ./ci/env/install-minimal.sh "$1"
+  echo "Installed minimal dependencies."
   ./ci/env/env_info.sh
   python ./ci/env/check_minimal_install.py
   run_minimal_test "$1"
@@ -823,8 +824,11 @@ test_minimal() {
 
 test_latest_core_dependencies() {
   ./ci/env/install-minimal.sh "$1"
+  echo "Installed minimal dependencies."
   ./ci/env/env_info.sh
   ./ci/env/install-core-prerelease-dependencies.sh
+  echo "Installed Core prerelease dependencies."
+  ./ci/env/env_info.sh
   run_minimal_test "$1"
 }
 


### PR DESCRIPTION
## Why are these changes needed?

When minimal installation CI tests fail, it is helpful to be able to compare the exact dependencies that are being used between a successful run and a failed run. Currently `test_latest_core_dependencies` only prints out the dependencies via `env_info.sh` after running `install-minimal.sh`, which does not include the actual pre-release dependencies installed in `install-core-prerelease-dependencies.sh`.

With this change, it is easier to figure out what dependencies are actually being used by searching for the new `Installed Core prerelease dependencies.` string in the logs.


**Result:** [Example](https://buildkite.com/ray-project/oss-ci-build-pr/builds/15083#0186ed4a-395a-42de-8f43-bc4dfe663b1f)

<img width="917" alt="image" src="https://user-images.githubusercontent.com/3967392/225936074-7192fca2-7ea8-4904-929f-b2060bc6055e.png">


**Next Steps:** The minimal install CI tests currently run both `test_minimal` and `test_latest_core_dependencies`. It may be beneficial to split these into separate jobs, so that it is easier to determine if the failure is caused by a pre-release.

## Related issue number

<!-- For example: "Closes #1234" -->
n/a

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
