### PR TITLE
Fix linker argument error in cpp example build file.

### DIFF
--- a/cpp/example/BUILD.bazel
+++ b/cpp/example/BUILD.bazel
@@ -33,7 +33,7 @@ cc_library(
         "thirdparty/include/**/*.h",
         "thirdparty/include/**/*.hpp",
     ]),
-    linkopts = ["-Wl,-rpath, ./"],
+    linkopts = ["-Wl,-rpath,./"],
     strip_include_prefix = "thirdparty/include",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
CPP generate-bazel-project-template is failing during build, due to extra space in the BUILD.bazel file. This commit fixes that.

Before fix:
```
$ ray cpp --generate-bazel-project-template-to ray-template
Project template generated to /home/soumitra/opensource/ray-template
To build and run this template, run
    cd /home/soumitra/opensource/ray-template && bash run.sh
$ cd ray-template/
$ bash run.sh
Starting local Bazel server and connecting to it...
INFO: Analyzed target //:example (36 packages loaded, 3391 targets configured).
INFO: Found 1 target...
ERROR: /home/soumitra/opensource/ray-template/BUILD.bazel:15:10: Linking example.so failed: (Exit 1): gcc failed: error executing command (from target //:example.so) /usr/bin/gcc @bazel-out/k8-fastbuild/bin/example.so-2.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
/usr/bin/ld.gold: fatal error: ./: pread failed: Is a directory
collect2: error: ld returned 1 exit status
ERROR: /home/soumitra/opensource/ray-template/BUILD.bazel:1:10: Linking example failed: (Exit 1): gcc failed: error executing command (from target //:example) /usr/bin/gcc @bazel-out/k8-fastbuild/bin/example-2.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
/usr/bin/ld.gold: fatal error: ./: pread failed: Is a directory
collect2: error: ld returned 1 exit status
Target //:example failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 9.026s, Critical Path: 4.57s
INFO: 3241 processes: 3239 internal, 2 linux-sandbox.
FAILED: Build did NOT complete successfully

The problem is seen in ./bazel-bin/example-2.params file:
$ cat ./bazel-bin/example-2.params
...
-Wl,-rpath,
./ ==================>>>> This is the issue
...
```

After fix:
```
$ ray cpp --generate-bazel-project-template-to ray-template
Project template generated to /home/soumitra/opensource/ray-template
To build and run this template, run
    cd /home/soumitra/opensource/ray-template && bash run.sh
$ cd ray-template/
$ bash run.sh
Starting local Bazel server and connecting to it...
INFO: Analyzed target //:example (36 packages loaded, 3391 targets configured).
INFO: Found 1 target...
Target //:example up-to-date:
  bazel-bin/example
INFO: Elapsed time: 3.986s, Critical Path: 0.27s
INFO: 5 processes: 3 internal, 2 linux-sandbox.
INFO: Build completed successfully, 5 total actions
```