### PR TITLE
[Draft] [Core] Hardcode v2 stack for worker startup benchmark

### DIFF
--- a/release/benchmark-worker-startup/app_config_gpu.yaml
+++ b/release/benchmark-worker-startup/app_config_gpu.yaml
@@ -3,15 +3,6 @@ env_vars: {}
 debian_packages:
     - hdparm
 
-aws:
-    # Fix the volume size so that IOPS is constant even if the default changes.
-    BlockDeviceMappings:
-        - DeviceName: /dev/sda1
-          Ebs:
-            DeleteOnTermination: true
-            # 150GB is the default in Anyscale.
-            VolumeSize: 150
-
 python:
   pip_packages: []
   conda_packages: []

--- a/release/benchmark-worker-startup/app_config_gpu.yaml
+++ b/release/benchmark-worker-startup/app_config_gpu.yaml
@@ -4,7 +4,8 @@ debian_packages:
     - hdparm
 
 python:
-  pip_packages: []
+  pip_packages:
+    - botocore==1.29.94
   conda_packages: []
 
 post_build_cmds:

--- a/release/benchmark-worker-startup/app_config_gpu.yaml
+++ b/release/benchmark-worker-startup/app_config_gpu.yaml
@@ -4,8 +4,7 @@ debian_packages:
     - hdparm
 
 python:
-  pip_packages:
-    - botocore==1.29.94
+  pip_packages: []
   conda_packages: []
 
 post_build_cmds:

--- a/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
+++ b/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
@@ -19,7 +19,7 @@ aws:
         - DeviceName: /dev/sda1
           Ebs:
             DeleteOnTermination: true
-            # This is the default configuration in our infra layer.
+            # Testing 300 to get apples-to-apples comparison on old stack vs new stack
             VolumeSize: 300
             VolumeType: gp3
             Iops: 3000

--- a/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
+++ b/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
@@ -11,3 +11,13 @@ head_node_type:
         gpu: 64
 
 worker_node_types: []
+
+
+aws:
+    # Fix the volume size so that IOPS is constant even if the default changes.
+    BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: true
+            # 150GB is the default in Anyscale.
+            VolumeSize: 150

--- a/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
+++ b/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
@@ -19,8 +19,8 @@ aws:
         - DeviceName: /dev/sda1
           Ebs:
             DeleteOnTermination: true
-            # Testing 300 to get apples-to-apples comparison on old stack vs new stack
-            VolumeSize: 300
+            # Testing 400 to get apples-to-apples comparison on old stack vs new stack
+            VolumeSize: 400
             VolumeType: gp3
             Iops: 3000
             Throughput: 500

--- a/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
+++ b/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
@@ -19,5 +19,8 @@ aws:
         - DeviceName: /dev/sda1
           Ebs:
             DeleteOnTermination: true
-            # 150GB is the default in Anyscale.
+            # This is the default configuration in our infra layer.
             VolumeSize: 150
+            VolumeType: gp3
+            Iops: 3000
+            Throughput: 500

--- a/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
+++ b/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
@@ -20,7 +20,7 @@ aws:
           Ebs:
             DeleteOnTermination: true
             # This is the default configuration in our infra layer.
-            VolumeSize: 150
+            VolumeSize: 300
             VolumeType: gp3
             Iops: 3000
             Throughput: 500

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3078,7 +3078,7 @@
   frequency: nightly
   working_dir: benchmark-worker-startup
   stable: false
-  env: staging_v2
+  env: staging_v1
 
   python: "3.9"
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3078,7 +3078,7 @@
   frequency: nightly
   working_dir: benchmark-worker-startup
   stable: false
-  #env: staging_v2
+  env: staging_v2
 
   python: "3.9"
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3088,6 +3088,7 @@
 
   run:
     timeout: 7200
+    type: anyscale_job
     script: python benchmark_worker_startup.py
         --num_cpus_in_cluster 64
         --num_gpus_in_cluster 64

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3078,7 +3078,7 @@
   frequency: nightly
   working_dir: benchmark-worker-startup
   stable: false
-  env: staging_v2
+  #env: staging_v2
 
   python: "3.9"
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3078,7 +3078,7 @@
   frequency: nightly
   working_dir: benchmark-worker-startup
   stable: false
-  env: staging_v1
+  env: staging_v2
 
   python: "3.9"
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3078,6 +3078,7 @@
   frequency: nightly
   working_dir: benchmark-worker-startup
   stable: false
+  env: staging_v2
 
   python: "3.9"
 


### PR DESCRIPTION
This fixes the large variation in performance of the benchmark. I need to see how much of the variation comes from v1/v2 stack vs. disk size.

* 150GB disk
  * Run with v2 stack and disk config: https://buildkite.com/ray-project/release-tests-pr/builds/31485#0186fbaa-fe8a-462a-9d29-ab363f049d0c
    * 37.466575622558594 p50.seconds_to_cold_start_64_actors-import_torch-with_gpu-single_node-with_runtime_env-64_CPU_64_GPU_cluster 
  * Run with v1 stack and disk config: https://buildkite.com/ray-project/release-tests-pr/builds/31487#0186fbec-7749-44ef-adc8-654b702727ac
    * fails with `RuntimeError: ray.autoscaler.node_launch_exception.NodeLaunchException: Node Launch Exception (InvalidBlockDeviceMapping): Volume of size 150GB is smaller than snapshot 'snap-0b2bc3e755212871d', expect size >= 300GB`
* 300GB disk
  * v2 stack https://buildkite.com/ray-project/release-tests-pr/builds/31570 https://buildkite.com/ray-project/release-tests-pr/builds/31572
  * v1 stack https://buildkite.com/ray-project/release-tests-pr/builds/31584
    * still crashes... running again with 400GB drive https://buildkite.com/ray-project/release-tests-pr/builds/31628
