### PR TITLE
[RLlib] Make it so that the learner update allows for multiple sgd updates always

### DIFF
--- a/rllib/core/learner/learner.py
+++ b/rllib/core/learner/learner.py
@@ -704,11 +704,23 @@ class Learner:
                 f"{missing_module_ids}"
             )
 
-        batch_iter = (
-            MiniBatchCyclicIterator
-            if minibatch_size is not None
-            else MiniBatchDummyIterator
-        )
+        if num_iters < 1:
+            # we must do at least one pass on the batch for training
+            raise ValueError("num_iters must be >= 1")
+
+        if minibatch_size:
+            batch_iter = MiniBatchCyclicIterator
+        elif num_iters > 1:
+            # minibatch size was not set but num_iters > 1
+            # Under the old training stack, users could do multiple sgd passes
+            # over a batch without specifying a minibatch size. We enable
+            # this behavior here by setting the minibatch size to be the size
+            # of the batch (e.g. 1 minibatch of size batch.count)
+            minibatch_size = batch.count
+            batch_iter = MiniBatchCyclicIterator
+        else:
+            # minibatch_size and num_iters are not set by the user
+            batch_iter = MiniBatchDummyIterator
 
         results = []
         for minibatch in batch_iter(batch, minibatch_size, num_iters):


### PR DESCRIPTION
The learner would not allow multiple sgd passes on a batch if the minibatch size is not set.
This is different than the update rule of our current training stack, which allows multiple sgd passes
even if minibatch size isn't set (multiple updates on the same batch)

This pr addresses this problem by closing this gap

Signed-off-by: Avnish <avnishnarayan@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
