### PR TITLE
[Datasets] Revert "Enable streaming executor by default (#32493)"

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -76,7 +76,7 @@ DEFAULT_NEW_EXECUTION_BACKEND = bool(
 # Whether to use the streaming executor. This only has an effect if the new execution
 # backend is enabled.
 DEFAULT_USE_STREAMING_EXECUTOR = bool(
-    int(os.environ.get("RAY_DATASET_USE_STREAMING_EXECUTOR", "1"))
+    int(os.environ.get("RAY_DATASET_USE_STREAMING_EXECUTOR", "0"))
 )
 
 # Whether to eagerly free memory (new backend only).


### PR DESCRIPTION
This reverts commit 8c64af47ecd0553eec0bf92c5622e09066fbdfd6.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The reverted commit broke some RL tests.

![image](https://user-images.githubusercontent.com/26107013/226484663-c30f3466-80cf-4e98-84dc-b6250cf60a13.png)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
