### PR TITLE
[autoscaler] Fix `autoscaler.sdk.request_resources({"GPU": 0})` edge case 

### DIFF
--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -692,7 +692,6 @@ def _add_min_workers_nodes(
         resource_requests_unfulfilled, _ = get_bin_pack_residual(
             max_node_resources, ensure_min_cluster_size
         )
-        print("alex: ", resource_requests_unfulfilled)
         # Get the nodes to meet the unfulfilled.
         nodes_to_add_request_resources, _ = get_nodes_for(
             node_types,

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -692,6 +692,7 @@ def _add_min_workers_nodes(
         resource_requests_unfulfilled, _ = get_bin_pack_residual(
             max_node_resources, ensure_min_cluster_size
         )
+        print("alex: ", resource_requests_unfulfilled)
         # Get the nodes to meet the unfulfilled.
         nodes_to_add_request_resources, _ = get_nodes_for(
             node_types,
@@ -940,6 +941,10 @@ def _fits(node: ResourceDict, resources: ResourceDict) -> bool:
 
 def _inplace_subtract(node: ResourceDict, resources: ResourceDict) -> None:
     for k, v in resources.items():
+        if v == 0:
+            # This is an edge case since some reasonable programs/computers can
+            # do `ray.autoscaler.sdk.request_resources({"GPU": 0}"})`.
+            continue
         assert k in node, (k, node)
         node[k] -= v
         assert node[k] >= 0.0, (node, k, v)

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -753,7 +753,7 @@ def test_request_resources_gpu_no_gpu_nodes():
 
     # Fully utilized, no requests.
     avail_by_ip = {ip: {} for ip in node_ips}
-    max_by_ip = {ip:{"CPU": 32} for ip in node_ips}
+    max_by_ip = {ip: {"CPU": 32} for ip in node_ips}
     # There aren't any nodes that can satisfy this demand, but we still shouldn't crash.
     demands = [{"CPU": 1, "GPU": 1}] * 1
     to_launch, rem = scheduler.get_nodes_to_launch(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes an edge case when we `autoscaler.sdk.request_resources({"GPU": 0})`, since in some places we were assuming a node which requests 0 of a resource fits on the node and in other places we assume it didn't. Now we'll just always assume it does.

## Related issue number
Closes https://github.com/ray-project/ray/issues/33502

Supports this PR: https://github.com/ray-project/ray/pull/33204

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
