### PR TITLE
[core][state] do not prepend task_id for non list tasks CLI usage #32853

### DIFF
--- a/python/ray/experimental/state/state_cli.py
+++ b/python/ray/experimental/state/state_cli.py
@@ -287,13 +287,6 @@ def format_get_api_output(
     if not state_data or len(state_data) == 0:
         return f"Resource with id={id} not found in the cluster."
 
-    if schema == TaskState and format == AvailableFormat.YAML:
-        augmented_task_state_data = [
-            {("task_id: " + state["task_id"]): state} for state in state_data
-        ]
-        return output_with_format(
-            augmented_task_state_data, schema=schema, format=format
-        )
     return output_with_format(state_data, schema=schema, format=format)
 
 

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -1827,6 +1827,13 @@ def test_cli_apis_sanity_check(ray_start_cluster):
         )
     )
 
+    # Test get task by ID
+    wait_for_condition(
+        lambda: verify_output(
+            ray_get, ["tasks", task.task_id().hex()], ["task_id", task.task_id().hex()]
+        )
+    )
+
     # Test get placement groups by id
     wait_for_condition(
         lambda: verify_output(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In a previous PR: https://github.com/ray-project/ray/pull/32353, we added a feature where "task id" gets put at the top when running "ray list" commands. 

The code that does the prepending works for list, but it shouldn't be used for "get" commands. In fact, that causes a runtime error. This is a fix to address the sloppy PR (from me) before haha. 

The added unit test should now catch a case in ray_get() when we introduce runtime errors due to bad input parsing. 
<img width="750" alt="Screen Shot 2023-03-19 at 9 56 43 PM" src="https://user-images.githubusercontent.com/43735701/226250294-e3734973-ab0b-41ca-9185-aa6187b2352e.png">



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(