### PR TITLE
[Release tests] Revert all core tests to use anyscale runner

### DIFF
--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -41,9 +41,6 @@ RELEASE_TEST_SCHEMA_FILE = os.path.join(
     RELEASE_PACKAGE_DIR, "ray_release", "schema.json"
 )
 
-DEFAULT_CORE_RUN_TYPE = "sdk_command"
-DEFAULT_CORE_ENV_TYPE = "staging_v1"
-
 
 def read_and_validate_release_test_collection(
     config_file: str, schema_file: Optional[str] = None

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -8,8 +8,6 @@ from ray_release.aws import maybe_fetch_api_token
 from ray_release.config import (
     DEFAULT_PYTHON_VERSION,
     DEFAULT_WHEEL_WAIT_TIMEOUT,
-    DEFAULT_CORE_RUN_TYPE,
-    DEFAULT_CORE_ENV_TYPE,
     as_smoke_test,
     find_test,
     parse_python_version,
@@ -117,13 +115,6 @@ def main(
 
     if smoke_test:
         test = as_smoke_test(test)
-
-    # Several core tests have perf regression from V2 Job submission Runner.
-    # So we stick to the original implementation for now.
-    team = test.get("team")
-    if team == "core":
-        test["run"]["type"] = test["run"].get("type", DEFAULT_CORE_RUN_TYPE)
-        test["env"] = test.get("env", DEFAULT_CORE_ENV_TYPE)
 
     env_to_use = env or test.get("env", DEFAULT_ENVIRONMENT)
     env_dict = load_environment(env_to_use)

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3540,11 +3540,14 @@
     cluster_env: app_config.yaml
     cluster_compute: distributed.yaml
 
+  env: staging_v1
+
   run:
     timeout: 3600
     script: python distributed/test_many_actors.py
     wait_for_nodes:
       num_nodes: 65
+    type: sdk_command
 
 
 - name: many_actors_smoke_test
@@ -3557,11 +3560,14 @@
     cluster_env: app_config.yaml
     cluster_compute: distributed_smoke_test.yaml
 
+  env: staging_v1
+
   run:
     timeout: 3600
     script: SMOKE_TEST=1 python distributed/test_many_actors.py
     wait_for_nodes:
       num_nodes: 2
+    type: sdk_command
 
 
 - name: many_tasks
@@ -3574,11 +3580,14 @@
     cluster_env: app_config.yaml
     cluster_compute: distributed.yaml
 
+  env: staging_v1
+
   run:
     timeout: 3600
     script: python distributed/test_many_tasks.py --num-tasks=10000
     wait_for_nodes:
       num_nodes: 65
+    type: sdk_command
 
 
 - name: many_pgs
@@ -3625,11 +3634,14 @@
     cluster_env: app_config.yaml
     cluster_compute: many_nodes.yaml
 
+  env: staging_v1
+
   run:
     timeout: 3600
     script: python distributed/test_many_tasks.py --num-tasks=1000
     wait_for_nodes:
       num_nodes: 250
+    type: sdk_command
 
 
 - name: scheduling_test_many_0s_tasks_many_nodes


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Due to some regression, we temporarily used V1 for running core tests. This PR moves all core tests that have no performance regression back to the V2 stack. For many actors & many tasks, the active investigation is in progress. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
