### PR TITLE
[docker][ci] Downgrade `xgboost` version

### DIFF
--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -47,6 +47,5 @@ transformers==4.19.1; python_version > '3.6'
 # with this pin, so we restrict the version here to <=3.7
 typeguard==2.13.0; python_version <= '3.7'
 wandb==0.13.4
-xgboost==1.6.2; python_version <= '3.7'
-xgboost==1.7.4; python_version > '3.7'
+xgboost==1.3.3
 zoopt==0.4.1

--- a/release/air_tests/air_benchmarks/xgboost_app_config.yaml
+++ b/release/air_tests/air_benchmarks/xgboost_app_config.yaml
@@ -6,7 +6,6 @@ python:
   pip_packages:
     - pytest
     - modin==0.12.1
-    - xgboost==1.3.3
   conda_packages: []
 
 post_build_cmds:

--- a/release/air_tests/air_benchmarks/xgboost_app_config.yaml
+++ b/release/air_tests/air_benchmarks/xgboost_app_config.yaml
@@ -6,6 +6,7 @@ python:
   pip_packages:
     - pytest
     - modin==0.12.1
+    - xgboost==1.3.3
   conda_packages: []
 
 post_build_cmds:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This was updated in https://github.com/ray-project/ray/pull/33169, but the updated versions caused a regression in the release tests. 

Verified in [this commit](https://github.com/ray-project/ray/pull/33532/commits/7903abdf2722ac93fc256c431612b123b1e6e617) that pinning `xgboost==1.3.3` in the release test resulted in a successful run: [air_benchmark_xgboost_cpu_10](https://buildkite.com/ray-project/release-tests-pr/builds/31742#01870545-6d53-489e-8442-02254d7d1e75).

In the future, we will look further into upgrading `xgboost` but with closer monitoring.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
