### PR TITLE
Fix broken `test_serve_head` test

### DIFF
--- a/dashboard/modules/serve/tests/test_serve_head.py
+++ b/dashboard/modules/serve/tests/test_serve_head.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 
 from ray._private.test_utils import wait_for_condition
+from ray.serve.config import DeploymentMode
 from ray.serve.tests.conftest import *  # noqa: F401 F403
 from ray.serve.schema import ServeInstanceDetails
 from ray.serve._private.common import ApplicationStatus, DeploymentStatus
@@ -29,8 +30,11 @@ def test_get_serve_instance_details(ray_start_stop):
     world_import_path = "ray.serve.tests.test_config_files.world.DagNode"
     fastapi_import_path = "ray.serve.tests.test_config_files.fastapi_deployment.node"
     config1 = {
-        "host": "127.0.0.1",
-        "port": 8000,
+        "proxy_location": "HeadOnly",
+        "http_options": {
+            "host": "127.0.0.1",
+            "port": 8005,
+        },
         "applications": [
             {
                 "name": "app1",
@@ -70,8 +74,9 @@ def test_get_serve_instance_details(ray_start_stop):
         **requests.get("http://localhost:8265/api/serve_head/applications/").json()
     )
     # CHECK: host and port
-    assert serve_details.host == "127.0.0.1"
-    assert serve_details.port == 8000
+    assert serve_details.http_options.host == "127.0.0.1"
+    assert serve_details.http_options.port == 8005
+    assert serve_details.proxy_location == DeploymentMode.HeadOnly
     print('Confirmed fetched host and port metadata are "127.0.0.1" and "8000".')
 
     app_details = serve_details.applications


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
test_serve_head has been broken since I merged #33238 . This is a fix forward.

<img width="1674" alt="Screenshot 2023-03-21 at 10 43 53 AM" src="https://user-images.githubusercontent.com/711935/226696396-1df7d927-f17a-4bd2-80a8-325bde97255f.png">

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
