### PR TITLE
RuntimeEnv plugin schema: Close schema after loading and continue on errors

### DIFF
--- a/python/ray/_private/runtime_env/plugin_schema_manager.py
+++ b/python/ray/_private/runtime_env/plugin_schema_manager.py
@@ -24,9 +24,14 @@ class RuntimeEnvPluginSchemaManager:
     def _load_schemas(cls, schema_paths: List[str]):
         for schema_path in schema_paths:
             try:
-                schema = json.load(open(schema_path))
+                with open(schema_path) as f:
+                    schema = json.load(f)
             except json.decoder.JSONDecodeError:
                 logger.error("Invalid runtime env schema %s, skip it.", schema_path)
+                continue
+            except OSError:
+                logger.error("Cannot open runtime env schema %s, skip it.", schema_path)
+                continue
             if "title" not in schema:
                 logger.error(
                     "No valid title in runtime env schema %s, skip it.", schema_path

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -303,11 +303,24 @@ test_env_1 = os.path.join(
 test_env_2 = os.path.join(
     os.path.dirname(__file__), "test_runtime_env_validation_2_schema.json"
 )
+test_env_invalid_path = os.path.join(
+    os.path.dirname(__file__), "test_runtime_env_validation_non_existent.json"
+)
+test_env_bad_json = os.path.join(
+    os.path.dirname(__file__), "test_runtime_env_validation_bad_2_schema.json"
+)
 
 
 @pytest.mark.parametrize(
     "set_runtime_env_plugin_schemas",
-    [schemas_dir, f"{test_env_1},{test_env_2}"],
+    [
+        schemas_dir,
+        f"{test_env_1},{test_env_2}",
+        # Test with an invalid JSON file first in the list
+        f"{test_env_bad_json},{test_env_1},{test_env_2}",
+        # Test with a non-existent JSON file
+        f"{test_env_invalid_path},{test_env_1},{test_env_2}",
+    ],
     indirect=True,
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes a few things:

* A warning from not closing the file opened with `open()`. (We have these warnings as errors and Ray was causing some integration tests to blink)
* Using a custom runtime env schema with `RAY_RUNTIME_ENV_PLUGIN_SCHEMAS` would result in a failure when the JSON file is incorrectly decoded or the file doesn't exist.
    * There was a test for invalid decoded JSON, but by chance it ran *after* a previous schema, meaning the missing `continue` wasn't noticed.


**Steps to Reproduce**
1. Save this script as `test.py`
```python
import ray

@ray.remote(runtime_env={"env_vars": {}})
def my_fn():
    return True

ray.init()
print(ray.get(my_fn.remote()))
```
2. run with `RAY_RUNTIME_ENV_PLUGIN_SCHEMAS=./non-exist.json python test.py`
3.
    a. save `:` or other invalid JSON as `bad-json.json`
    b. run with `RAY_RUNTIME_ENV_PLUGIN_SCHEMAS=./bad-json.json python test.py`
 
This PR fixes the issue and adds a new test case.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
