### PR TITLE
[RLlib] Make Alan and Praveen codeowners for build-docker-images.py

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,9 @@
 # Docker image build script.
 /ci/build/build-docker-images.py @amogkam @krfricke @gvspraveen @alanwguo @ray-project/ray-core
 
+# Dockerfiles
+/ci/docker/base.gpu.Dockerfile @gvspraveen @alanwguo
+
 # Python worker.
 #/python/ray/ @ray-project/ray-core
 #!/python/ray/tune/ @ray-project/ray-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,9 +46,6 @@
 # Docker image build script.
 /ci/build/build-docker-images.py @amogkam @krfricke @gvspraveen @alanwguo @ray-project/ray-core
 
-# Dockerfiles
-/ci/docker/base.gpu.Dockerfile
-
 # Python worker.
 #/python/ray/ @ray-project/ray-core
 #!/python/ray/tune/ @ray-project/ray-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,7 +44,10 @@
 /ci/lint/format.sh @richardliaw @ericl @edoakes
 
 # Docker image build script.
-/ci/build/build-docker-images.py @amogkam @krfricke @ray-project/ray-core
+/ci/build/build-docker-images.py @amogkam @krfricke @gvspraveen @alanwguo @ray-project/ray-core
+
+# Dockerfiles
+/ci/docker/base.gpu.Dockerfile
 
 # Python worker.
 #/python/ray/ @ray-project/ray-core


### PR DESCRIPTION
## Why are these changes needed?

This PR makes it so that @alanwguo and @gvspraveen are codeowners of the build-docker-images.py file which gets touched every time we add a new base image to the `BASE_IMAGES` list or similar changes so that they can react by forwarding these images to Anyscale.