### PR TITLE
[data] Add iterator batch_format=None support, which will yield batches in the current batch format with zero copies

### DIFF
--- a/doc/source/data/transforming-datasets.rst
+++ b/doc/source/data/transforming-datasets.rst
@@ -245,18 +245,22 @@ is given in the below table:
      - ``"pandas"``
      - ``"numpy"``
      - ``"pyarrow"``
+     - ``None``
    * - ``"pandas"``
      - Zero-copy
      - Zero-copy
      - Copy*
      - Copy*
+     - Zero-copy
    * - ``"arrow"``
      - Copy*
      - Copy*
      - Zero-copy*
      - Zero-copy
-   * - ``"simple"``
      - Zero-copy
+   * - ``"simple"``
+     - Copy
+     - Copy
      - Copy
      - Copy
      - Copy

--- a/python/ray/data/_internal/block_batching.py
+++ b/python/ray/data/_internal/block_batching.py
@@ -37,7 +37,7 @@ def batch_block_refs(
     prefetch_blocks: int = 0,
     clear_block_after_read: bool = False,
     batch_size: Optional[int] = None,
-    batch_format: str = "default",
+    batch_format: Optional[str] = "default",
     drop_last: bool = False,
     collate_fn: Optional[Callable[[DataBatch], Any]] = None,
     shuffle_buffer_min_size: Optional[int] = None,
@@ -129,7 +129,7 @@ def batch_blocks(
     *,
     stats: Optional[Union[DatasetStats, DatasetPipelineStats]] = None,
     batch_size: Optional[int] = None,
-    batch_format: str = "default",
+    batch_format: Optional[str] = "default",
     drop_last: bool = False,
     collate_fn: Optional[Callable[[DataBatch], DataBatch]] = None,
     shuffle_buffer_min_size: Optional[int] = None,
@@ -385,7 +385,7 @@ def _blocks_to_batches(
 
 def _format_batches(
     block_iter: Iterator[Block],
-    batch_format: str,
+    batch_format: Optional[str],
     stats: Optional[Union[DatasetStats, DatasetPipelineStats]] = None,
 ) -> Iterator[DataBatch]:
     """Given an iterator of blocks, returns an iterator of formatted batches.

--- a/python/ray/data/_internal/dataset_iterator_impl.py
+++ b/python/ray/data/_internal/dataset_iterator_impl.py
@@ -69,9 +69,6 @@ class DatasetIteratorImpl(DatasetIterator):
     def schema(self) -> Union[type, "pyarrow.lib.Schema"]:
         return self._base_dataset.schema()
 
-    def _default_batch_format(self) -> Literal["default", "pandas", "pyarrow", "numpy"]:
-        return _default_batch_format(self._base_dataset)
-
     def __getattr__(self, name):
         if name == "_base_dataset":
             raise AttributeError()

--- a/python/ray/data/_internal/dataset_iterator_impl.py
+++ b/python/ray/data/_internal/dataset_iterator_impl.py
@@ -28,7 +28,7 @@ class DatasetIteratorImpl(DatasetIterator):
         *,
         prefetch_blocks: int = 0,
         batch_size: Optional[int] = 256,
-        batch_format: str = "default",
+        batch_format: Optional[str] = "default",
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
         local_shuffle_seed: Optional[int] = None,

--- a/python/ray/data/_internal/dataset_iterator_impl.py
+++ b/python/ray/data/_internal/dataset_iterator_impl.py
@@ -1,9 +1,7 @@
 from typing import TYPE_CHECKING, Optional, Union, Iterator, Callable, Any
 import time
 import warnings
-import sys
 
-from ray.data._internal.util import _default_batch_format
 from ray.data.block import DataBatch
 from ray.data.context import DatasetContext
 from ray.data.dataset_iterator import DatasetIterator
@@ -12,11 +10,6 @@ from ray.data._internal.block_batching import batch_block_refs
 if TYPE_CHECKING:
     import pyarrow
     from ray.data import Dataset
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class DatasetIteratorImpl(DatasetIterator):

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Any, Dict, Iterable, Optional, Union
 
 from ray.data._internal.logical.interfaces import LogicalOperator
@@ -8,12 +7,6 @@ from ray.data._internal.compute import (
 )
 from ray.data.block import BatchUDF, RowUDF
 from ray.data.context import DEFAULT_BATCH_SIZE
-
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class AbstractMap(LogicalOperator):
@@ -93,7 +86,7 @@ class MapBatches(AbstractUDFMap):
         input_op: LogicalOperator,
         fn: BatchUDF,
         batch_size: Optional[int] = DEFAULT_BATCH_SIZE,
-        batch_format: Literal["default", "pandas", "pyarrow", "numpy"] = "default",
+        batch_format: Optional[str] = "default",
         prefetch_batches: int = 0,
         zero_copy_batch: bool = False,
         fn_args: Optional[Iterable[Any]] = None,

--- a/python/ray/data/_internal/pipelined_dataset_iterator.py
+++ b/python/ray/data/_internal/pipelined_dataset_iterator.py
@@ -32,7 +32,7 @@ class PipelinedDatasetIterator(DatasetIterator):
         *,
         prefetch_blocks: int = 0,
         batch_size: Optional[int] = 256,
-        batch_format: str = "default",
+        batch_format: Optional[str] = "default",
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
         local_shuffle_seed: Optional[int] = None,

--- a/python/ray/data/_internal/planner/map_batches.py
+++ b/python/ray/data/_internal/planner/map_batches.py
@@ -1,4 +1,3 @@
-import sys
 from types import GeneratorType
 from typing import Callable, Iterator, Optional
 
@@ -9,15 +8,9 @@ from ray.data.block import BatchUDF, Block, DataBatch
 from ray.data.context import DEFAULT_BATCH_SIZE, DatasetContext
 
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
-
 def generate_map_batches_fn(
     batch_size: Optional[int] = DEFAULT_BATCH_SIZE,
-    batch_format: Literal["default", "pandas", "pyarrow", "numpy"] = "default",
+    batch_format: Optional[str] = "default",
     prefetch_batches: int = 0,
     zero_copy_batch: bool = False,
 ) -> Callable[[Iterator[Block], TaskContext, BatchUDF], Iterator[Block]]:

--- a/python/ray/data/_internal/stream_split_dataset_iterator.py
+++ b/python/ray/data/_internal/stream_split_dataset_iterator.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-import sys
 import time
 import threading
 from typing import (
@@ -33,11 +32,6 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 if TYPE_CHECKING:
     import pyarrow
     from ray.data import Dataset
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +82,7 @@ class StreamSplitDatasetIterator(DatasetIterator):
         *,
         prefetch_blocks: int = 0,
         batch_size: int = 256,
-        batch_format: Literal["default", "numpy", "pandas"] = "default",
+        batch_format: Optional[str] = "default",
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
         local_shuffle_seed: Optional[int] = None,

--- a/python/ray/data/_internal/stream_split_dataset_iterator.py
+++ b/python/ray/data/_internal/stream_split_dataset_iterator.py
@@ -15,7 +15,6 @@ from typing import (
 )
 
 import ray
-from ray.data._internal.util import _default_batch_format
 
 from ray.data.dataset_iterator import DatasetIterator
 from ray.data.block import Block, DataBatch
@@ -133,9 +132,6 @@ class StreamSplitDatasetIterator(DatasetIterator):
     def schema(self) -> Union[type, "pyarrow.lib.Schema"]:
         """Implements DatasetIterator."""
         return self._base_dataset.schema()
-
-    def _default_batch_format(self) -> Literal["default", "pandas", "pyarrow", "numpy"]:
-        return _default_batch_format(self._base_dataset)
 
 
 @ray.remote(num_cpus=0)

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -9,17 +9,10 @@ import numpy as np
 
 import ray
 from ray.air.constants import TENSOR_COLUMN_NAME
-from ray.air.util.data_batch_conversion import BlockFormat
 from ray.data.context import DatasetContext
 from ray._private.utils import _get_pyarrow_version
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 if TYPE_CHECKING:
-    from ray.data.dataset import Dataset
     from ray.data.datasource import Reader
     from ray.util.placement_group import PlacementGroup
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -406,31 +406,6 @@ def _split_list(arr: List[Any], num_splits: int) -> List[List[Any]]:
     return splits
 
 
-def _default_batch_format(
-    ds: "Dataset",
-) -> Literal["default", "pandas", "pyarrow", "numpy"]:
-    """Get the best batch format that lines up with the dataset format."""
-    ctx = DatasetContext.get_current()
-    if ctx.use_streaming_executor:
-        # TODO: calling dataset_format() triggers bulk execution.
-        batch_format = "default"
-    else:
-        try:
-            dataset_format = ds.dataset_format()
-        except ValueError:
-            # Dataset is empty or cleared, so fall back to "default".
-            batch_format = "default"
-        else:
-            batch_format = (
-                "pyarrow"
-                if dataset_format == BlockFormat.ARROW
-                else "pandas"
-                if dataset_format == BlockFormat.PANDAS
-                else "default"
-            )
-    return batch_format
-
-
 def capfirst(s: str):
     """Capitalize the first letter of a string
 

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -150,7 +150,7 @@ BlockPartitionMetadata = List["BlockMetadata"]
 # is on by default. When block splitting is off, the type is a plain block.
 MaybeBlockPartition = Union[Block, ObjectRefGenerator]
 
-VALID_BATCH_FORMATS = ["default", "native", "pandas", "pyarrow", "numpy", "zero-copy"]
+VALID_BATCH_FORMATS = ["default", "native", "pandas", "pyarrow", "numpy", None]
 
 
 @DeveloperAPI
@@ -315,7 +315,7 @@ class BlockAccessor(Generic[T]):
         """Return the default data format for this accessor."""
         return self.to_block()
 
-    def to_batch_format(self, batch_format: str) -> DataBatch:
+    def to_batch_format(self, batch_format: Optional[str]) -> DataBatch:
         """Convert this block into the provided batch format.
 
         Args:
@@ -324,10 +324,10 @@ class BlockAccessor(Generic[T]):
         Returns:
             This block formatted as the provided batch format.
         """
-        if batch_format == "default" or batch_format == "native":
-            return self.to_default()
-        elif batch_format == "zero-copy":
+        if batch_format is None:
             return self.to_block()
+        elif batch_format == "default" or batch_format == "native":
+            return self.to_default()
         elif batch_format == "pandas":
             return self.to_pandas()
         elif batch_format == "pyarrow":

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -150,7 +150,7 @@ BlockPartitionMetadata = List["BlockMetadata"]
 # is on by default. When block splitting is off, the type is a plain block.
 MaybeBlockPartition = Union[Block, ObjectRefGenerator]
 
-VALID_BATCH_FORMATS = ["default", "native", "pandas", "pyarrow", "numpy"]
+VALID_BATCH_FORMATS = ["default", "native", "pandas", "pyarrow", "numpy", "zero-copy"]
 
 
 @DeveloperAPI
@@ -326,6 +326,8 @@ class BlockAccessor(Generic[T]):
         """
         if batch_format == "default" or batch_format == "native":
             return self.to_default()
+        elif batch_format == "zero-copy":
+            return self.to_block()
         elif batch_format == "pandas":
             return self.to_pandas()
         elif batch_format == "pyarrow":

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -379,7 +379,9 @@ class Dataset(Generic[T]):
         *,
         batch_size: Optional[Union[int, Literal["default"]]] = "default",
         compute: Optional[Union[str, ComputeStrategy]] = None,
-        batch_format: Literal["default", "pandas", "pyarrow", "numpy", "zero-copy"] = "default",
+        batch_format: Literal[
+            "default", "pandas", "pyarrow", "numpy", "zero-copy"
+        ] = "default",
         prefetch_batches: int = 0,
         zero_copy_batch: bool = False,
         fn_args: Optional[Iterable[Any]] = None,
@@ -2933,7 +2935,9 @@ class Dataset(Generic[T]):
                 (promotes tables to Pandas and tensors to NumPy), ``"pandas"`` to select
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
                 ``"numpy"`` to select ``numpy.ndarray`` for tensor datasets and
-                ``Dict[str, numpy.ndarray]`` for tabular datasets, or ``"zero-copy"`` to return the underlying block exactly as is with no additional formatting. Default is "default".
+                ``Dict[str, numpy.ndarray]`` for tabular datasets, or ``"zero-copy"``
+                to return the underlying block exactly as is with no additional
+                formatting. Default is "default".
             drop_last: Whether to drop the last batch if it's incomplete.
             local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
                 using a local in-memory shuffle buffer, and this value will serve as the

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2909,7 +2909,7 @@ class Dataset(Generic[T]):
         *,
         prefetch_blocks: int = 0,
         batch_size: Optional[int] = 256,
-        batch_format: str = "default",
+        batch_format: Optional[str] = "default",
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
         local_shuffle_seed: Optional[int] = None,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -379,9 +379,7 @@ class Dataset(Generic[T]):
         *,
         batch_size: Optional[Union[int, Literal["default"]]] = "default",
         compute: Optional[Union[str, ComputeStrategy]] = None,
-        batch_format: Literal[
-            "default", "pandas", "pyarrow", "numpy", "zero-copy"
-        ] = "default",
+        batch_format: Optional[str] = "default",
         prefetch_batches: int = 0,
         zero_copy_batch: bool = False,
         fn_args: Optional[Iterable[Any]] = None,
@@ -542,7 +540,8 @@ class Dataset(Generic[T]):
                 (promotes tables to Pandas and tensors to NumPy), ``"pandas"`` to select
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
                 ``"numpy"`` to select ``numpy.ndarray`` for tensor datasets and
-                ``Dict[str, numpy.ndarray]`` for tabular datasets, or ``"zero-copy"`` to return the underlying block exactly as is with no additional formatting. Default is "default".
+                ``Dict[str, numpy.ndarray]`` for tabular datasets, or None to return
+                the underlying block exactly as is with no additional formatting.
             prefetch_batches: The number of batches to fetch ahead of the current batch
                 to process. If set to greater than 0, a separate thread will be used
                 to fetch the specified amount of formatted batches from blocks. This

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -379,7 +379,7 @@ class Dataset(Generic[T]):
         *,
         batch_size: Optional[Union[int, Literal["default"]]] = "default",
         compute: Optional[Union[str, ComputeStrategy]] = None,
-        batch_format: Literal["default", "pandas", "pyarrow", "numpy"] = "default",
+        batch_format: Literal["default", "pandas", "pyarrow", "numpy", "zero-copy"] = "default",
         prefetch_batches: int = 0,
         zero_copy_batch: bool = False,
         fn_args: Optional[Iterable[Any]] = None,
@@ -540,7 +540,7 @@ class Dataset(Generic[T]):
                 (promotes tables to Pandas and tensors to NumPy), ``"pandas"`` to select
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
                 ``"numpy"`` to select ``numpy.ndarray`` for tensor datasets and
-                ``Dict[str, numpy.ndarray]`` for tabular datasets. Default is "default".
+                ``Dict[str, numpy.ndarray]`` for tabular datasets, or ``"zero-copy"`` to return the underlying block exactly as is with no additional formatting. Default is "default".
             prefetch_batches: The number of batches to fetch ahead of the current batch
                 to process. If set to greater than 0, a separate thread will be used
                 to fetch the specified amount of formatted batches from blocks. This
@@ -2929,12 +2929,11 @@ class Dataset(Generic[T]):
                 as batches (blocks may contain different number of rows).
                 The final batch may include fewer than ``batch_size`` rows if
                 ``drop_last`` is ``False``. Defaults to 256.
-            batch_format: The format in which to return each batch.
-                Specify "default" to use the default block format (promoting
-                tables to Pandas and tensors to NumPy), "pandas" to select
-                ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or "numpy"
-                to select ``numpy.ndarray`` for tensor datasets and
-                ``Dict[str, numpy.ndarray]`` for tabular datasets. Default is "default".
+            batch_format: Specify ``"default"`` to use the default block format
+                (promotes tables to Pandas and tensors to NumPy), ``"pandas"`` to select
+                ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
+                ``"numpy"`` to select ``numpy.ndarray`` for tensor datasets and
+                ``Dict[str, numpy.ndarray]`` for tabular datasets, or ``"zero-copy"`` to return the underlying block exactly as is with no additional formatting. Default is "default".
             drop_last: Whether to drop the last batch if it's incomplete.
             local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
                 using a local in-memory shuffle buffer, and this value will serve as the

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -542,6 +542,7 @@ class Dataset(Generic[T]):
                 ``"numpy"`` to select ``numpy.ndarray`` for tensor datasets and
                 ``Dict[str, numpy.ndarray]`` for tabular datasets, or None to return
                 the underlying block exactly as is with no additional formatting.
+                The default is "default".
             prefetch_batches: The number of batches to fetch ahead of the current batch
                 to process. If set to greater than 0, a separate thread will be used
                 to fetch the specified amount of formatted batches from blocks. This
@@ -2934,9 +2935,9 @@ class Dataset(Generic[T]):
                 (promotes tables to Pandas and tensors to NumPy), ``"pandas"`` to select
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
                 ``"numpy"`` to select ``numpy.ndarray`` for tensor datasets and
-                ``Dict[str, numpy.ndarray]`` for tabular datasets, or ``"zero-copy"``
+                ``Dict[str, numpy.ndarray]`` for tabular datasets, or None
                 to return the underlying block exactly as is with no additional
-                formatting. Default is "default".
+                formatting. The default is "default".
             drop_last: Whether to drop the last batch if it's incomplete.
             local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
                 using a local in-memory shuffle buffer, and this value will serve as the

--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -84,7 +84,9 @@ class DatasetIterator(abc.ABC):
                 tables to Pandas and tensors to NumPy), "pandas" to select
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or "numpy"
                 to select ``numpy.ndarray`` for tensor datasets and
-                ``Dict[str, numpy.ndarray]`` for tabular datasets. Default is "default".
+                ``Dict[str, numpy.ndarray]`` for tabular datasets, or None to return
+                the underlying block exactly as is with no additional formatting.
+                The default is "default".
             drop_last: Whether to drop the last batch if it's incomplete.
             local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
                 using a local in-memory shuffle buffer, and this value will serve as the

--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -16,12 +16,6 @@ if TYPE_CHECKING:
     from ray.data.dataset import TensorFlowTensorBatchType
 
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
-
 @PublicAPI(stability="beta")
 class DatasetIterator(abc.ABC):
     """An iterator for reading items from a :class:`~Dataset` or
@@ -61,7 +55,7 @@ class DatasetIterator(abc.ABC):
         *,
         prefetch_blocks: int = 0,
         batch_size: int = 256,
-        batch_format: Literal["default", "numpy", "pandas"] = "default",
+        batch_format: Optional[str] = "default",
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
         local_shuffle_seed: Optional[int] = None,
@@ -127,7 +121,9 @@ class DatasetIterator(abc.ABC):
             An iterator over rows of the dataset.
         """
         for batch in self.iter_batches(
-            batch_size=None, prefetch_blocks=prefetch_blocks, batch_format="zero-copy"
+            batch_size=None,
+            prefetch_blocks=prefetch_blocks,
+            batch_format=None,
         ):
             batch = BlockAccessor.for_block(BlockAccessor.batch_to_block(batch))
             for row in batch.iter_rows():

--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -1,6 +1,5 @@
 import abc
 import numpy as np
-import sys
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, Iterator
 
 from ray.data.block import BlockAccessor, DataBatch, T

--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -126,9 +126,8 @@ class DatasetIterator(abc.ABC):
         Returns:
             An iterator over rows of the dataset.
         """
-        target_format = self._default_batch_format()
         for batch in self.iter_batches(
-            batch_size=None, prefetch_blocks=prefetch_blocks, batch_format=target_format
+            batch_size=None, prefetch_blocks=prefetch_blocks, batch_format="zero-copy"
         ):
             batch = BlockAccessor.for_block(BlockAccessor.batch_to_block(batch))
             for row in batch.iter_rows():
@@ -704,11 +703,3 @@ class DatasetIterator(abc.ABC):
         if schema is None or isinstance(schema, type):
             return False
         return _is_tensor_schema(schema.names)
-
-    def _default_batch_format(self) -> Literal["default", "pandas", "pyarrow", "numpy"]:
-        """Returns the best batch format that lines up with the dataset format.
-
-        NOTE: Return "default" here. Subclass can override this method to decide best
-        batch format.
-        """
-        return "default"

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -169,7 +169,7 @@ class DatasetPipeline(Generic[T]):
         *,
         prefetch_blocks: int = 0,
         batch_size: Optional[int] = 256,
-        batch_format: str = "default",
+        batch_format: Optional[str] = "default",
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
         local_shuffle_seed: Optional[int] = None,
@@ -192,11 +192,13 @@ class DatasetPipeline(Generic[T]):
                 as batches (blocks may contain different number of rows).
                 The final batch may include fewer than ``batch_size`` rows if
                 ``drop_last`` is ``False``. Defaults to 256.
-            batch_format: The format in which to return each batch.
-                Specify "default" to use the current block format (promoting
-                Arrow to pandas automatically), "pandas" to
-                select ``pandas.DataFrame`` or "pyarrow" to select
-                ``pyarrow.Table``. Default is "default".
+            batch_format: Specify ``"default"`` to use the default block format
+                (promotes tables to Pandas and tensors to NumPy), ``"pandas"`` to select
+                ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
+                ``"numpy"`` to select ``numpy.ndarray`` for tensor datasets and
+                ``Dict[str, numpy.ndarray]`` for tabular datasets, or None to return
+                the underlying block exactly as is with no additional formatting.
+                The default is "default".
             drop_last: Whether to drop the last batch if it's incomplete.
             local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
                 using a local in-memory shuffle buffer, and this value will serve as the
@@ -790,7 +792,7 @@ class DatasetPipeline(Generic[T]):
         *,
         batch_size: Optional[Union[int, Literal["default"]]] = "default",
         compute: Optional[Union[str, ComputeStrategy]] = None,
-        batch_format: Literal["default", "pandas", "pyarrow", "numpy"] = "default",
+        batch_format: Optional[str] = "default",
         prefetch_batches: int = 0,
         fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
@@ -1061,7 +1063,7 @@ class DatasetPipeline(Generic[T]):
         *,
         prefetch_blocks: int = 0,
         batch_size: Optional[int] = 256,
-        batch_format: str = "default",
+        batch_format: Optional[str] = "default",
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
         local_shuffle_seed: Optional[int] = None,

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Generic, List, Tuple, Union
+from typing import Any, Callable, Generic, List, Tuple, Union, Optional
 
 from ray.data._internal import sort
 from ray.data._internal.compute import CallableClass, ComputeStrategy
@@ -270,7 +270,7 @@ class GroupedDataset(Generic[T]):
         fn: Union[CallableClass, Callable[[DataBatch], DataBatch]],
         *,
         compute: Union[str, ComputeStrategy] = None,
-        batch_format: str = "default",
+        batch_format: Optional[str] = "default",
         **ray_remote_args,
     ) -> "Dataset[Any]":
         # TODO AttributeError: 'GroupedDataset' object has no attribute 'map_groups'
@@ -326,9 +326,9 @@ class GroupedDataset(Generic[T]):
                 (promotes tables to Pandas and tensors to NumPy), ``"pandas"`` to select
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
                 ``"numpy"`` to select ``numpy.ndarray`` for tensor datasets and
-                ``Dict[str, numpy.ndarray]`` for tabular datasets, or ``"zero-copy"``
+                ``Dict[str, numpy.ndarray]`` for tabular datasets, or None
                 to return the underlying block exactly as is with no additional
-                formatting. Default is "default".
+                formatting. The default is "default".
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
 

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -326,7 +326,9 @@ class GroupedDataset(Generic[T]):
                 (promotes tables to Pandas and tensors to NumPy), ``"pandas"`` to select
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
                 ``"numpy"`` to select ``numpy.ndarray`` for tensor datasets and
-                ``Dict[str, numpy.ndarray]`` for tabular datasets, or ``"zero-copy"`` to return the underlying block exactly as is with no additional formatting. Default is "default".
+                ``Dict[str, numpy.ndarray]`` for tabular datasets, or ``"zero-copy"``
+                to return the underlying block exactly as is with no additional
+                formatting. Default is "default".
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
 

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -322,10 +322,11 @@ class GroupedDataset(Generic[T]):
                 batch of zero or more records, similar to map_batches().
             compute: The compute strategy, either "tasks" (default) to use Ray
                 tasks, or ActorPoolStrategy(min, max) to use an autoscaling actor pool.
-            batch_format: Specify "default" to use the default block format
-                (promotes Arrow to pandas), "pandas" to select
-                ``pandas.DataFrame`` as the batch format,
-                or "pyarrow" to select ``pyarrow.Table``.
+            batch_format: Specify ``"default"`` to use the default block format
+                (promotes tables to Pandas and tensors to NumPy), ``"pandas"`` to select
+                ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
+                ``"numpy"`` to select ``numpy.ndarray`` for tensor datasets and
+                ``Dict[str, numpy.ndarray]`` for tabular datasets, or ``"zero-copy"`` to return the underlying block exactly as is with no additional formatting. Default is "default".
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
 

--- a/python/ray/data/tests/test_dataset_consumption.py
+++ b/python/ray/data/tests/test_dataset_consumption.py
@@ -391,14 +391,7 @@ def test_convert_types(ray_start_regular_shared):
 
     arrow_ds = ray.data.range_table(1)
     assert arrow_ds.map(lambda x: "plain_{}".format(x["value"])).take() == ["plain_0"]
-    # In streaming, we set batch_format to "default" (because calling
-    # ds.dataset_format() will still invoke bulk execution and we want
-    # to avoid that). As a result, it's receiving PandasRow (the defaut
-    # batch format), which unwraps [0] to plain 0.
-    if ray.data.context.DatasetContext.get_current().use_streaming_executor:
-        assert arrow_ds.map(lambda x: {"a": (x["value"],)}).take() == [{"a": 0}]
-    else:
-        assert arrow_ds.map(lambda x: {"a": (x["value"],)}).take() == [{"a": [0]}]
+    assert arrow_ds.map(lambda x: {"a": (x["value"],)}).take() == [{"a": [0]}]
 
 
 def test_from_items(ray_start_regular_shared):
@@ -483,14 +476,7 @@ def test_iter_rows(ray_start_regular_shared):
     # Default ArrowRows.
     for row, t_row in zip(ds.iter_rows(), to_pylist(t)):
         assert isinstance(row, TableRow)
-        # In streaming, we set batch_format to "default" because calling
-        # ds.dataset_format() will still invoke bulk execution and we want
-        # to avoid that. As a result, it's receiving PandasRow (the defaut
-        # batch format).
-        if ray.data.context.DatasetContext.get_current().use_streaming_executor:
-            assert isinstance(row, PandasRow)
-        else:
-            assert isinstance(row, ArrowRow)
+        assert isinstance(row, ArrowRow)
         assert row == t_row
 
     # PandasRows after conversion.
@@ -504,14 +490,7 @@ def test_iter_rows(ray_start_regular_shared):
     # Prefetch.
     for row, t_row in zip(ds.iter_rows(prefetch_blocks=1), to_pylist(t)):
         assert isinstance(row, TableRow)
-        # In streaming, we set batch_format to "default" because calling
-        # ds.dataset_format() will still invoke bulk execution and we want
-        # to avoid that. As a result, it's receiving PandasRow (the defaut
-        # batch format).
-        if ray.data.context.DatasetContext.get_current().use_streaming_executor:
-            assert isinstance(row, PandasRow)
-        else:
-            assert isinstance(row, ArrowRow)
+        assert isinstance(row, ArrowRow)
         assert row == t_row
 
 
@@ -1586,18 +1565,6 @@ def test_polars_lazy_import(shutdown_only):
 
     finally:
         ctx.use_polars = original_use_polars
-
-
-def test_default_batch_format(shutdown_only):
-    ds = ray.data.range(100)
-    assert ds.default_batch_format() == list
-
-    ds = ray.data.range_tensor(100)
-    assert ds.default_batch_format() == np.ndarray
-
-    df = pd.DataFrame({"foo": ["a", "b"], "bar": [0, 1]})
-    ds = ray.data.from_pandas(df)
-    assert ds.default_batch_format() == pd.DataFrame
 
 
 def test_dataset_schema_after_read_stats(ray_start_cluster):

--- a/python/ray/data/tests/test_dataset_tfrecords.py
+++ b/python/ray/data/tests/test_dataset_tfrecords.py
@@ -269,26 +269,7 @@ def _features_to_schema(features: "tf.train.Features") -> "schema_pb2.Schema":
 
 
 def _ds_eq_streaming(ds_expected, ds_actual) -> bool:
-    if not ray.data.context.DatasetContext.get_current().use_streaming_executor:
-        assert ds_expected.take() == ds_actual.take()
-    else:
-        # In streaming, we set batch_format to "default" (because calling
-        # ds.dataset_format() will still invoke bulk execution and we want
-        # to avoid that). As a result, it's receiving PandasRow (the defaut
-        # batch format), which doesn't have the same ordering of columns as
-        # the ArrowRow.
-        from ray.data.block import BlockAccessor
-
-        def get_rows(ds):
-            rows = []
-            for batch in ds.iter_batches(batch_size=None, batch_format="pyarrow"):
-                batch = BlockAccessor.for_block(BlockAccessor.batch_to_block(batch))
-                for row in batch.iter_rows():
-                    rows.append(row)
-            return rows
-
-        assert get_rows(ds_expected) == get_rows(ds_actual)
-
+    assert ds_expected.take() == ds_actual.take()
 
 @pytest.mark.parametrize("with_tf_schema", (True, False))
 def test_read_tfrecords(

--- a/python/ray/data/tests/test_dataset_tfrecords.py
+++ b/python/ray/data/tests/test_dataset_tfrecords.py
@@ -271,6 +271,7 @@ def _features_to_schema(features: "tf.train.Features") -> "schema_pb2.Schema":
 def _ds_eq_streaming(ds_expected, ds_actual) -> bool:
     assert ds_expected.take() == ds_actual.take()
 
+
 @pytest.mark.parametrize("with_tf_schema", (True, False))
 def test_read_tfrecords(
     with_tf_schema,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR is a cleanup of https://github.com/ray-project/ray/pull/33536

It uses "None" instead of "zero-copy" as a batch format, since None has a similar meaning for batch_size, where it means a system-chosen batch size. Here "None" also means the system chosen optimal batch format.