### PR TITLE
[Core] Experimental preload_python_modules flag for preloading modules in default_worker

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1477,6 +1477,18 @@ cc_test(
 )
 
 cc_test(
+    name = "ray_config_test",
+    size = "small",
+    srcs = ["src/ray/common/test/ray_config_test.cc"],
+    copts = COPTS,
+    tags = ["team:core"],
+    deps = [
+        "ray_common",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "id_test",
     size = "small",
     srcs = ["src/ray/common/id_test.cc"],

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -24,7 +24,7 @@ import warnings
 from inspect import signature
 from pathlib import Path
 from subprocess import list2cmdline
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Union, Coroutine
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Union, Coroutine, List
 
 import grpc
 import numpy as np
@@ -1910,3 +1910,14 @@ def run_background_task(coroutine: Coroutine) -> asyncio.Task:
     # completion:
     task.add_done_callback(background_tasks.discard)
     return task
+
+def try_import_each_module(module_names_to_import: List[str]) -> None:
+    """
+    Make a best-effort attempt to import each named Python module.
+    This is used by the Python default_worker.py to preload modules.
+    """
+    for module_to_preload in module_names_to_import:
+        try:
+            importlib.import_module(module_to_preload)
+        except ImportError as e:
+            print(f'Failed to import "{module_to_preload}"', e)

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1931,4 +1931,4 @@ def try_import_each_module(module_names_to_import: List[str]) -> None:
         try:
             importlib.import_module(module_to_preload)
         except ImportError as e:
-            print(f'Failed to import "{module_to_preload}"', e)
+            print(f'Failed to preload the module "{module_to_preload}"', e)

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -24,7 +24,17 @@ import warnings
 from inspect import signature
 from pathlib import Path
 from subprocess import list2cmdline
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Union, Coroutine, List
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    Coroutine,
+    List,
+)
 
 import grpc
 import numpy as np
@@ -1910,6 +1920,7 @@ def run_background_task(coroutine: Coroutine) -> asyncio.Task:
     # completion:
     task.add_done_callback(background_tasks.discard)
     return task
+
 
 def try_import_each_module(module_names_to_import: List[str]) -> None:
     """

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1930,5 +1930,5 @@ def try_import_each_module(module_names_to_import: List[str]) -> None:
     for module_to_preload in module_names_to_import:
         try:
             importlib.import_module(module_to_preload)
-        except ImportError as e:
-            print(f'Failed to preload the module "{module_to_preload}"', e)
+        except ImportError:
+            logger.exception(f'Failed to preload the module "{module_to_preload}"')

--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -145,6 +145,11 @@ parser.add_argument(
     help="The address of web ui",
 )
 
+parser.add_argument(
+    "--worker-preload-modules",
+    nargs='+',
+    default=[],
+)
 
 if __name__ == "__main__":
     # NOTE(sang): For some reason, if we move the code below
@@ -215,6 +220,14 @@ if __name__ == "__main__":
         startup_token=args.startup_token,
         ray_debugger_external=args.ray_debugger_external,
     )
+
+    if mode == ray.WORKER_MODE and args.worker_preload_modules:
+        import importlib
+        for module_to_preload in args.worker_preload_modules:
+            try:
+                importlib.import_module(module_to_preload)
+            except ImportError:
+                pass
 
     # Setup log file.
     out_file, err_file = node.get_log_file_handles(

--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -149,7 +149,10 @@ parser.add_argument(
     "--worker-preload-modules",
     type=str,
     required=False,
-    help="A comma-separated list of Python module names to import before accepting work.",
+    help=(
+        "A comma-separated list of Python module names "
+        "to import before accepting work."
+    ),
 )
 
 if __name__ == "__main__":

--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -147,8 +147,9 @@ parser.add_argument(
 
 parser.add_argument(
     "--worker-preload-modules",
-    nargs='+',
-    default=[],
+    type=str,
+    required=False,
+    help="A comma-separated list of Python module names to import before accepting work.",
 )
 
 if __name__ == "__main__":
@@ -228,17 +229,8 @@ if __name__ == "__main__":
     configure_log_file(out_file, err_file)
 
     if mode == ray.WORKER_MODE and args.worker_preload_modules:
-        # TODO(cade) this splitting should not be necessary.
-        s = args.worker_preload_modules[0].split(',')
-
-        import importlib
-        for module_to_preload in s:
-            try:
-                print('importing', module_to_preload)
-                importlib.import_module(module_to_preload)
-            except ImportError as e:
-                print('Got ImportError', e)
-                pass
+        module_names_to_import = args.worker_preload_modules.split(",")
+        ray._private.utils.try_import_each_module(module_names_to_import)
 
     if mode == ray.WORKER_MODE:
         ray._private.worker.global_worker.main_loop()

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -288,7 +288,8 @@ def test_preload_workers(ray_start_cluster, preload):
     """
     cluster = ray_start_cluster
 
-    expect_succeed_imports = ["tensorflow", "torch"]
+    # Specifying imports not currently imported by default_worker.py
+    expect_succeed_imports = ["html", "webbrowser"]
     expect_fail_imports = ["fake_module_expect_ModuleNotFoundError"]
 
     if preload:

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -289,7 +289,7 @@ def test_preload_workers(ray_start_cluster, preload):
     cluster = ray_start_cluster
 
     # Specifying imports not currently imported by default_worker.py
-    expect_succeed_imports = ["html", "webbrowser"]
+    expect_succeed_imports = ["html.parser", "webbrowser"]
     expect_fail_imports = ["fake_module_expect_ModuleNotFoundError"]
 
     if preload:
@@ -327,16 +327,22 @@ def test_preload_workers(ray_start_cluster, preload):
     def assert_correct_imports():
         import sys
 
-        imported_modules = sys.modules.copy()
+        imported_modules = set(sys.modules.keys())
 
         if preload:
             for expected_import in expect_succeed_imports:
-                assert expected_import in imported_modules
+                assert (
+                    expected_import in imported_modules
+                ), f"Expected {expected_import} to be in {imported_modules}"
             for unexpected_import in expect_fail_imports:
-                assert unexpected_import not in imported_modules
+                assert (
+                    unexpected_import not in imported_modules
+                ), f"Expected {unexpected_import} to not be in {imported_modules}"
         else:
             for unexpected_import in expect_succeed_imports:
-                assert unexpected_import not in imported_modules
+                assert (
+                    unexpected_import not in imported_modules
+                ), f"Expected {unexpected_import} to not be in {imported_modules}"
 
     @ray.remote(num_cpus=0)
     class Actor:

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -10,7 +10,6 @@ from unittest.mock import Mock, patch
 import pytest
 
 import ray
-
 import ray.cluster_utils
 from ray._private.test_utils import (
     run_string_as_driver,

--- a/python/ray/tests/test_utils.py
+++ b/python/ray/tests/test_utils.py
@@ -58,7 +58,7 @@ def test_try_import_each_module():
 
             # Verify modules are imported.
             for lib in modules_to_import:
-                assert lib in patched_sys_modules
+                assert lib in patched_sys_modules, f"lib {lib} not in {patched_sys_modules}"
 
             # Verify import error is printed.
             found = False

--- a/python/ray/tests/test_utils.py
+++ b/python/ray/tests/test_utils.py
@@ -69,14 +69,14 @@ def test_try_import_each_module():
                 if found:
                     break
 
-            assert (
-                found
-            ), f"Did not find print call with import error {mocked_print.call_args_list}"
+            assert found, (
+                "Did not find print call with import "
+                f"error {mocked_print.call_args_list}"
+            )
 
 
 if __name__ == "__main__":
     import os
-    import sys
 
     # Skip test_basic_2_client_mode for now- the test suite is breaking.
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_utils.py
+++ b/python/ray/tests/test_utils.py
@@ -50,7 +50,8 @@ def test_try_import_each_module():
             del mock_sys_modules[lib]
 
     with patch("ray._private.utils.logger.exception") as mocked_log_exception:
-        with patch.dict(sys.modules, mock_sys_modules) as patched_sys_modules:
+        with patch.dict(sys.modules, mock_sys_modules):
+            patched_sys_modules = sys.modules
 
             try_import_each_module(
                 modules_to_import[:1] + [fake_module] + modules_to_import[1:]

--- a/python/ray/tests/test_utils.py
+++ b/python/ray/tests/test_utils.py
@@ -49,7 +49,7 @@ def test_try_import_each_module():
         if lib in mock_sys_modules:
             del mock_sys_modules[lib]
 
-    with patch("builtins.print") as mocked_print:
+    with patch("ray._private.utils.logger.exception") as mocked_log_exception:
         with patch.dict(sys.modules, mock_sys_modules) as patched_sys_modules:
 
             try_import_each_module(
@@ -64,14 +64,14 @@ def test_try_import_each_module():
 
             # Verify import error is printed.
             found = False
-            for args, _ in mocked_print.call_args_list:
+            for args, _ in mocked_log_exception.call_args_list:
                 found = any(fake_module in arg for arg in args)
                 if found:
                     break
 
             assert found, (
                 "Did not find print call with import "
-                f"error {mocked_print.call_args_list}"
+                f"error {mocked_log_exception.call_args_list}"
             )
 
 

--- a/python/ray/tests/test_utils.py
+++ b/python/ray/tests/test_utils.py
@@ -52,7 +52,7 @@ def test_try_import_each_module():
     with patch("builtins.print") as mocked_print:
         with patch.dict(sys.modules, mock_sys_modules) as patched_sys_modules:
 
-            ray._private.utils.try_import_each_module(modules_to_import + [fake_module])
+            try_import_each_module(modules_to_import + [fake_module])
 
             # Verify modules are imported.
             for lib in modules_to_import:

--- a/python/ray/tests/test_utils.py
+++ b/python/ray/tests/test_utils.py
@@ -58,7 +58,9 @@ def test_try_import_each_module():
 
             # Verify modules are imported.
             for lib in modules_to_import:
-                assert lib in patched_sys_modules, f"lib {lib} not in {patched_sys_modules}"
+                assert (
+                    lib in patched_sys_modules
+                ), f"lib {lib} not in {patched_sys_modules}"
 
             # Verify import error is printed.
             found = False

--- a/python/ray/tests/test_utils.py
+++ b/python/ray/tests/test_utils.py
@@ -52,7 +52,9 @@ def test_try_import_each_module():
     with patch("builtins.print") as mocked_print:
         with patch.dict(sys.modules, mock_sys_modules) as patched_sys_modules:
 
-            try_import_each_module(modules_to_import + [fake_module])
+            try_import_each_module(
+                modules_to_import[:1] + [fake_module] + modules_to_import[1:]
+            )
 
             # Verify modules are imported.
             for lib in modules_to_import:

--- a/src/ray/common/ray_config.h
+++ b/src/ray/common/ray_config.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <boost/algorithm/string.hpp>
 #include <cstdint>
 #include <sstream>
 #include <string>
@@ -49,7 +50,11 @@ inline bool ConvertValue<bool>(const std::string &type_string, const std::string
 template <>
 inline std::vector<std::string> ConvertValue<std::vector<std::string>>(
     const std::string &type_string, const std::string &value) {
-  return absl::StrSplit(value, ",");
+  std::vector<std::string> split = absl::StrSplit(value, ",");
+  for (auto &value : split) {
+    boost::algorithm::trim(value);
+  }
+  return split;
 }
 
 class RayConfig {

--- a/src/ray/common/ray_config.h
+++ b/src/ray/common/ray_config.h
@@ -18,8 +18,10 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "absl/strings/escaping.h"
+#include "absl/strings/str_split.h"
 #include "ray/util/logging.h"
 
 template <typename T>
@@ -42,6 +44,11 @@ template <>
 inline bool ConvertValue<bool>(const std::string &type_string, const std::string &value) {
   auto new_value = absl::AsciiStrToLower(value);
   return new_value == "true" || new_value == "1";
+}
+
+template <>
+inline std::vector<std::string> ConvertValue<std::vector<std::string>>(const std::string &type_string, const std::string &value) {
+    return absl::StrSplit(value, ",");
 }
 
 class RayConfig {

--- a/src/ray/common/ray_config.h
+++ b/src/ray/common/ray_config.h
@@ -47,8 +47,9 @@ inline bool ConvertValue<bool>(const std::string &type_string, const std::string
 }
 
 template <>
-inline std::vector<std::string> ConvertValue<std::vector<std::string>>(const std::string &type_string, const std::string &value) {
-    return absl::StrSplit(value, ",");
+inline std::vector<std::string> ConvertValue<std::vector<std::string>>(
+    const std::string &type_string, const std::string &value) {
+  return absl::StrSplit(value, ",");
 }
 
 class RayConfig {

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -782,4 +782,5 @@ RAY_CONFIG(bool, kill_idle_workers_of_terminated_job, true)
 // Instruct the Python default worker to preload the specified imports.
 // This is specified as a comma-separated list.
 // If left empty, no such attempt will be made.
+// Example: RAY_preload_python_modules=tensorflow,pytorch
 RAY_CONFIG(std::vector<std::string>, preload_python_modules, {})

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -778,3 +778,4 @@ RAY_CONFIG(bool, raylet_core_dump_exclude_plasma_store, true)
 
 /// Whether to kill idle workers of a terminated job.
 RAY_CONFIG(bool, kill_idle_workers_of_terminated_job, true)
+RAY_CONFIG(std::vector<std::string>, preload_python_modules, {})

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -778,4 +778,8 @@ RAY_CONFIG(bool, raylet_core_dump_exclude_plasma_store, true)
 
 /// Whether to kill idle workers of a terminated job.
 RAY_CONFIG(bool, kill_idle_workers_of_terminated_job, true)
+
+// Instruct the Python default worker to preload the specified imports.
+// This is specified as a comma-separated list.
+// If left empty, no such attempt will be made.
 RAY_CONFIG(std::vector<std::string>, preload_python_modules, {})

--- a/src/ray/common/test/ray_config_test.cc
+++ b/src/ray/common/test/ray_config_test.cc
@@ -1,0 +1,36 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/common/ray_config.h"
+
+#include "gtest/gtest.h"
+#include "ray/common/grpc_util.h"
+
+namespace ray {
+class RayConfigTest : public ::testing::Test {};
+
+TEST_F(RayConfigTest, ConvertValueTrimsVectorElements) {
+  const std::string type_string = "std::vector";
+  const std::string input = "no_spaces, with spaces ";
+  const std::vector<std::string> expected_output{"no_spaces", "with spaces"};
+  auto output = ConvertValue<std::vector<std::string>>(type_string, input);
+  ASSERT_EQ(output, expected_output);
+}
+
+}  // namespace ray
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -386,13 +386,11 @@ WorkerPool::BuildProcessCommandArgs(const Language &language,
     }
   }
 
-  if (language == Language::PYTHON && worker_type == rpc::WorkerType::WORKER) {
-      auto preload_python_modules = RayConfig::instance().preload_python_modules();
-      std::string serialized_preload_python_modules  = absl::StrJoin(preload_python_modules, ",");
-      RAY_LOG(DEBUG) << "preload_python_modules " << serialized_preload_python_modules;
-      if (preload_python_modules.size() > 0) {
-        worker_command_args.push_back("--worker-preload-modules=" + serialized_preload_python_modules);
-      }
+  if (language == Language::PYTHON && worker_type == rpc::WorkerType::WORKER
+    && RayConfig::instance().preload_python_modules().size() > 0) {
+      std::string serialized_preload_python_modules  = absl::StrJoin(RayConfig::instance().preload_python_modules(), ",");
+      RAY_LOG(DEBUG) << "Starting worker with preload_python_modules " << serialized_preload_python_modules;
+      worker_command_args.push_back("--worker-preload-modules=" + serialized_preload_python_modules);
   }
 
   // We use setproctitle to change python worker process title,

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -18,6 +18,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <fstream>
 
+#include "absl/strings/str_split.h"
 #include "ray/common/constants.h"
 #include "ray/common/network_util.h"
 #include "ray/common/ray_config.h"
@@ -383,6 +384,15 @@ WorkerPool::BuildProcessCommandArgs(const Language &language,
       }
 #endif
     }
+  }
+
+  if (language == Language::PYTHON && worker_type == rpc::WorkerType::WORKER) {
+      auto preload_python_modules = RayConfig::instance().preload_python_modules();
+      std::string serialized_preload_python_modules  = absl::StrJoin(preload_python_modules, ",");
+      RAY_LOG(DEBUG) << "preload_python_modules " << serialized_preload_python_modules;
+      if (preload_python_modules.size() > 0) {
+        worker_command_args.push_back("--worker-preload-modules=" + serialized_preload_python_modules);
+      }
   }
 
   // We use setproctitle to change python worker process title,

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -386,11 +386,14 @@ WorkerPool::BuildProcessCommandArgs(const Language &language,
     }
   }
 
-  if (language == Language::PYTHON && worker_type == rpc::WorkerType::WORKER
-    && RayConfig::instance().preload_python_modules().size() > 0) {
-      std::string serialized_preload_python_modules  = absl::StrJoin(RayConfig::instance().preload_python_modules(), ",");
-      RAY_LOG(DEBUG) << "Starting worker with preload_python_modules " << serialized_preload_python_modules;
-      worker_command_args.push_back("--worker-preload-modules=" + serialized_preload_python_modules);
+  if (language == Language::PYTHON && worker_type == rpc::WorkerType::WORKER &&
+      RayConfig::instance().preload_python_modules().size() > 0) {
+    std::string serialized_preload_python_modules =
+        absl::StrJoin(RayConfig::instance().preload_python_modules(), ",");
+    RAY_LOG(DEBUG) << "Starting worker with preload_python_modules "
+                   << serialized_preload_python_modules;
+    worker_command_args.push_back("--worker-preload-modules=" +
+                                  serialized_preload_python_modules);
   }
 
   // We use setproctitle to change python worker process title,


### PR DESCRIPTION
## What does this PR do?
This PR adds an experimental `RAY_preload_python_modules` environment variable. When set, new Python `default_worker.py`'s are provided an additional argument `--worker-preload-modules` with the list of modules to preload.

## Motivation
Open source users have complained that they have to wait for Ray to fill up their clusters with tasks or actors. On top of this, they must wait further for Python imports to finish before they can begin their application logic. This PR works in tandem with the efforts by @scv119 and @clarng to pre-start Python worker processes once the raylet starts (instead of waiting for a JobID).

With both this PR and https://github.com/ray-project/ray/pull/33623 / https://github.com/ray-project/ray/pull/31848, users will experience much faster time-to-user-code on cold-start (first job after cluster starts). This is because the Python worker processes will be created ahead-of-time, and each will import the specified python modules before executing user code.

## Next steps
We will provide this experimental flag to users experiencing slow cold-start to get feedback on semantics.

## Testing
The following table shows the time to fill up a 64 core machine with 64 tasks/actors that each import tensorflow and torch. This is with prestart _and_ preload vs. without prestart nor preload.
<img width="809" alt="Screen Shot 2023-03-24 at 5 45 06 PM" src="https://user-images.githubusercontent.com/950914/227668831-d08b153a-6ec5-4ca0-8a3f-c17e4e68e395.png">

With both prestart and preload, cold-start time improves significantly.

### Simple case

```bash
$ # RAY_preload_python_modules=torch,tensorflow
$ ./simple_test
(task pid=2962272) import time 0.00

$ # Without preload
$ ./simple_test
(task pid=2967121) import time 2.73
```

```python3
#!/usr/bin/env python3

import ray
import time

@ray.remote
def task():
    start_time = time.time()
    import torch
    import tensorflow
    dur_s = time.time() - start_time
    print(f'import time {dur_s:.02f}')

ray.get(task.remote())
```