### PR TITLE
[core] Fix the error message when storage is not set.

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1526,7 +1526,8 @@ def start_raylet(
         ]
     )
 
-    start_worker_command.append(f"--storage={storage}")
+    if storage is not None:
+        start_worker_command.append(f"--storage={storage}")
 
     start_worker_command.append("RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER")
 

--- a/python/ray/_private/storage.py
+++ b/python/ray/_private/storage.py
@@ -357,7 +357,8 @@ def _init_filesystem(create_valid_file: bool = False, check_valid_file: bool = T
     if not _storage_uri:
         raise RuntimeError(
             "No storage URI has been configured for the cluster. "
-            "Specify a storage URI via `ray.init(storage=<uri>)`"
+            "Specify a storage URI via `ray.init(storage=<uri>)` or "
+            "`ray start --head --storage=<uri>`"
         )
 
     import pyarrow.fs

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -30,6 +30,14 @@ def path_eq(a, b):
     return Path(a).resolve() == Path(b).resolve()
 
 
+def test_storage_not_set(shutdown_only):
+    ray.init()
+    with pytest.raises(
+        RuntimeError, match=r".*No storage URI has been configured for the cluster.*"
+    ):
+        fs, prefix = storage.get_filesystem()
+
+
 def test_get_filesystem_local(shutdown_only, tmp_path):
     path = os.path.join(str(tmp_path), "foo/bar")
     ray.init(storage=path)


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Due to incorrect setup, storage is passed even it's None and in the worker it'll be treated as "None" instead of None and thus it'll give wrong error message which mislead the users.

This PR fixed it by passing the storage only when it's setup.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
