### PR TITLE
[RLlib] Remove a warning for users that they are using the old gym API

### DIFF
--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -159,16 +159,6 @@ def check_gym_environments(env: Union[gym.Env, "old_gym.Env"]) -> None:
                 "to infinity, and your environment will not be "
                 "reset."
             )
-    # Raise warning if using new reset api introduces in gym 0.24
-    reset_signature = inspect.signature(env.unwrapped.reset).parameters.keys()
-    if any(k in reset_signature for k in ["seed", "return_info"]):
-        if log_once("reset_signature"):
-            logger.warning(
-                "Your env reset() method appears to take 'seed' or 'return_info'"
-                " arguments. Note that these are not yet supported in RLlib."
-                " Seeding will take place using 'env.seed()' and the info dict"
-                " will not be returned from reset."
-            )
 
     # check if sampled actions and observations are contained within their
     # respective action and observation spaces.

--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -1,6 +1,5 @@
 """Common pre-checks for all RLlib experiments."""
 from copy import copy
-import inspect
 import logging
 import numpy as np
 import traceback


### PR DESCRIPTION
## Why are these changes needed?

[We still warn users](https://discuss.ray.io/t/custom-trainable-rllib-for-ray-2-3-0-with-ray-tune/9814/2) when they use a gym(namsium) API that includes the newer reset method arguments.
At the same time, they should be using this new API now, so we have to remove the warning.

