### PR TITLE
[tune] Evict object cache for actor re-use when search ended

### DIFF
--- a/python/ray/tune/execution/ray_trial_executor.py
+++ b/python/ray/tune/execution/ray_trial_executor.py
@@ -840,6 +840,16 @@ class RayTrialExecutor:
             # (if the search ended).
             return
 
+        if (
+            search_ended
+            and not self._staged_trials
+            and self._actor_cache.num_max_objects == 0
+        ):
+            # If there are no more trials coming in, no trials are pending execution,
+            # and we don't explicitly want to cache objects, we can evict the full
+            # cache.
+            force_all = True
+
         for actor, acquired_resources in self._actor_cache.flush_cached_objects(
             force_all=force_all
         ):

--- a/python/ray/tune/execution/ray_trial_executor.py
+++ b/python/ray/tune/execution/ray_trial_executor.py
@@ -843,7 +843,7 @@ class RayTrialExecutor:
         if (
             search_ended
             and not self._staged_trials
-            and self._actor_cache.num_max_objects == 0
+            and self._actor_cache.total_max_objects == 0
         ):
             # If there are no more trials coming in, no trials are pending execution,
             # and we don't explicitly want to cache objects, we can evict the full

--- a/python/ray/tune/utils/object_cache.py
+++ b/python/ray/tune/utils/object_cache.py
@@ -42,7 +42,8 @@ class _ObjectCache:
 
     @property
     def total_max_objects(self):
-        return self._max_num_objects.total()
+        # Counter.total() is only available for python 3.10+
+        return sum(self._max_num_objects.values())
 
     def increase_max(self, key: T, by: int = 1) -> None:
         """Increase number of max objects for this key.

--- a/python/ray/tune/utils/object_cache.py
+++ b/python/ray/tune/utils/object_cache.py
@@ -40,6 +40,10 @@ class _ObjectCache:
     def num_cached_objects(self):
         return self._num_cached_objects
 
+    @property
+    def num_max_objects(self):
+        return self._max_num_objects.total()
+
     def increase_max(self, key: T, by: int = 1) -> None:
         """Increase number of max objects for this key.
 

--- a/python/ray/tune/utils/object_cache.py
+++ b/python/ray/tune/utils/object_cache.py
@@ -41,7 +41,7 @@ class _ObjectCache:
         return self._num_cached_objects
 
     @property
-    def num_max_objects(self):
+    def total_max_objects(self):
         return self._max_num_objects.total()
 
     def increase_max(self, key: T, by: int = 1) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Similar regression that was originally fixed in #31974, but re-surfaced after #33045.

With actor re-use, we speculatively keep one cached actor around in case it is needed when new trials are added (e.g. if we add trials one-by-one). However, we should only do this when the search has not ended, as otherwise we keep an extra actor until the end of the experiment, wasting resources. This leads the `tune_scale_up_down` release test fail.

In our refactor to #33045 we generalized object caching, but the eviction logic here explicitly keeps one object in cache. Our previous implementation in RayTrialExecutor relied on not calling the eviction function at all when trials were still coming up, essentially not adjusting the number of cached actors down. This is rarely a problem in practice, but does not make a clean contract when separated out into a component.

In this PR, we change the logic as follows: When the search ended, no trials are pending execution, and we don't want to explicitly cache an actor, we force eviction of all cached objects.

We are refactoring our execution backend, thus I believe it's sufficient to keep the release test to catch this regression. In the new backend we can add light weight unit tests to capture this behavior.



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
