### PR TITLE
[serve] Add `log_to_stderr` option to logger and improve internal logging

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -161,21 +161,25 @@ class ApplicationState:
                     return
                 try:
                     ray.get(finished[0])
+                    logger.info("Deploy task for app {self.name} ran successfully.")
                 except RayTaskError as e:
                     self.status = ApplicationStatus.DEPLOY_FAILED
                     # NOTE(zcin): we should use str(e) instead of traceback.format_exc()
                     # here because the full details of the error is not displayed
                     # properly with traceback.format_exc(). RayTaskError has its own
                     # custom __str__ function.
-                    self.app_msg = f"Deployment failed:\n{str(e)}"
+                    self.app_msg = f"Deploying app '{self.name}' failed:\n{str(e)}"
                     self.deploy_obj_ref = None
+                    logger.warning(self.app_msg)
                     return
                 except RuntimeEnvSetupError:
                     self.status = ApplicationStatus.DEPLOY_FAILED
                     self.app_msg = (
-                        f"Runtime env setup failed:\n{traceback.format_exc()}"
+                        f"Runtime env setup for app '{self.name}' "
+                        f"failed:\n{traceback.format_exc()}"
                     )
                     self.deploy_obj_ref = None
+                    logger.warning(self.app_msg)
                     return
             deployments_statuses = (
                 self.deployment_state_manager.get_deployment_statuses(

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -311,7 +311,8 @@ class ActorReplicaWrapper:
 
         logger.info(
             f"Starting replica {self.replica_tag} for deployment "
-            f"{self.deployment_name}.", extra={"log_to_stderr": False}
+            f"{self.deployment_name}.",
+            extra={"log_to_stderr": False},
         )
 
         actor_def = deployment_info.actor_def
@@ -567,7 +568,9 @@ class ActorReplicaWrapper:
                 response = ReplicaHealthCheckResponse.ACTOR_CRASHED
             except RayError as e:
                 # Health check failed due to application-level exception.
-                logger.warning(f"Health check for replica {self._replica_tag} failed: {e}")
+                logger.warning(
+                    f"Health check for replica {self._replica_tag} failed: {e}"
+                )
                 response = ReplicaHealthCheckResponse.APP_FAILURE
         elif time.time() - self._last_health_check_time > self._health_check_timeout_s:
             # Health check hasn't returned and the timeout is up, consider it failed.
@@ -802,7 +805,8 @@ class DeploymentReplica(VersionedReplica):
         """
         logger.info(
             f"Stopping replica {self.replica_tag} for deployment "
-            f"{self.deployment_name}.", extra={"log_to_stderr": False}
+            f"{self.deployment_name}.",
+            extra={"log_to_stderr": False},
         )
         timeout_s = self._actor.graceful_stop()
         if not graceful:
@@ -1529,7 +1533,10 @@ class DeploymentState:
                 # set.
                 self._replicas.add(ReplicaState.RUNNING, replica)
                 transitioned_to_running = True
-                logger.info(f"Replica {replica.replica_tag} started successfully.", extra={"log_to_stderr": False})
+                logger.info(
+                    f"Replica {replica.replica_tag} started successfully.",
+                    extra={"log_to_stderr": False},
+                )
             elif start_status == ReplicaStartupStatus.FAILED:
                 # Replica reconfigure (deploy / upgrade) failed
                 if self._replica_constructor_retry_counter >= 0:

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -309,9 +309,9 @@ class ActorReplicaWrapper:
             deployment_info.deployment_config.is_cross_language
         )
 
-        logger.debug(
+        logger.info(
             f"Starting replica {self.replica_tag} for deployment "
-            f"{self.deployment_name}."
+            f"{self.deployment_name}.", extra={"log_to_stderr": False}
         )
 
         actor_def = deployment_info.actor_def
@@ -429,7 +429,7 @@ class ActorReplicaWrapper:
         Recover states in DeploymentReplica instance by fetching running actor
         status
         """
-        logger.debug(
+        logger.info(
             f"Recovering replica {self.replica_tag} for deployment "
             f"{self.deployment_name}."
         )
@@ -567,11 +567,11 @@ class ActorReplicaWrapper:
                 response = ReplicaHealthCheckResponse.ACTOR_CRASHED
             except RayError as e:
                 # Health check failed due to application-level exception.
-                logger.info(f"Health check for replica {self._replica_tag} failed: {e}")
+                logger.warning(f"Health check for replica {self._replica_tag} failed: {e}")
                 response = ReplicaHealthCheckResponse.APP_FAILURE
         elif time.time() - self._last_health_check_time > self._health_check_timeout_s:
             # Health check hasn't returned and the timeout is up, consider it failed.
-            logger.info(
+            logger.warning(
                 "Didn't receive health check response for replica "
                 f"{self._replica_tag} after "
                 f"{self._health_check_timeout_s}s, marking it unhealthy."
@@ -636,7 +636,7 @@ class ActorReplicaWrapper:
                 self._consecutive_health_check_failures
                 >= REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD
             ):
-                logger.info(
+                logger.warning(
                     f"Replica {self._replica_tag} failed the health "
                     f"check {self._consecutive_health_check_failures}"
                     "times in a row, marking it unhealthy."
@@ -644,7 +644,7 @@ class ActorReplicaWrapper:
                 self._healthy = False
         elif response is ReplicaHealthCheckResponse.ACTOR_CRASHED:
             # Actor crashed, mark the replica unhealthy immediately.
-            logger.info(
+            logger.warning(
                 f"Actor for replica {self._replica_tag} crashed, marking "
                 "it unhealthy immediately."
             )
@@ -800,6 +800,10 @@ class DeploymentReplica(VersionedReplica):
 
         Should handle the case where the replica is already stopped.
         """
+        logger.info(
+            f"Stopping replica {self.replica_tag} for deployment "
+            f"{self.deployment_name}.", extra={"log_to_stderr": False}
+        )
         timeout_s = self._actor.graceful_stop()
         if not graceful:
             timeout_s = 0
@@ -814,7 +818,7 @@ class DeploymentReplica(VersionedReplica):
         if timeout_passed:
             # Graceful period passed, kill it forcefully.
             # This will be called repeatedly until the replica shuts down.
-            logger.debug(
+            logger.info(
                 f"Replica {self.replica_tag} did not shut down after grace "
                 "period, force-killing it. "
             )
@@ -1058,7 +1062,7 @@ class DeploymentState:
         self, target_state_checkpoint: DeploymentTargetState
     ):
         logger.info(
-            "Recovering target state for deployment " f"{self._name} from checkpoint.."
+            f"Recovering target state for deployment {self._name} from checkpoint."
         )
         self._target_state = target_state_checkpoint
 
@@ -1070,10 +1074,9 @@ class DeploymentState:
             "recovering current state from replica actor names."
         )
 
-        logger.debug(
+        logger.info(
             "Recovering current state for deployment "
-            f"{self._name} from {len(replica_actor_names)} actors in "
-            "current ray cluster.."
+            f"{self._name} from {len(replica_actor_names)} total actors."
         )
         # All current states use default value, only attach running replicas.
         for replica_actor_name in replica_actor_names:
@@ -1138,7 +1141,7 @@ class DeploymentState:
         self._curr_status_info = DeploymentStatusInfo(
             self._name, DeploymentStatus.UPDATING
         )
-        logger.debug(f"Deleting {self._name}.")
+        logger.info(f"Deleting deployment {self._name}.")
 
     def _set_target_state(self, target_info: DeploymentInfo) -> None:
         """Set the target state for the deployment to the provided info."""
@@ -1155,7 +1158,7 @@ class DeploymentState:
         self._replica_constructor_retry_counter = 0
         self._backoff_time_s = 1
 
-        logger.debug(f"Deploying new version of {self._name}: {target_state.version}.")
+        logger.info(f"Deploying new version of deployment {self._name}.")
 
     def deploy(self, deployment_info: DeploymentInfo) -> bool:
         """Deploy the deployment.
@@ -1375,7 +1378,7 @@ class DeploymentState:
                 self._last_retry = time.time()
                 logger.info(
                     f"Adding {to_add} replica{'s' if to_add > 1 else ''} "
-                    f"to deployment '{self._name}'."
+                    f"to deployment {self._name}."
                 )
                 for _ in range(to_add):
                     replica_name = ReplicaName(self._name, get_random_letters())
@@ -1526,6 +1529,7 @@ class DeploymentState:
                 # set.
                 self._replicas.add(ReplicaState.RUNNING, replica)
                 transitioned_to_running = True
+                logger.info(f"Replica {replica.replica_tag} started successfully.", extra={"log_to_stderr": False})
             elif start_status == ReplicaStartupStatus.FAILED:
                 # Replica reconfigure (deploy / upgrade) failed
                 if self._replica_constructor_retry_counter >= 0:
@@ -1761,9 +1765,7 @@ class DriverDeploymentState(DeploymentState):
         return get_all_node_ids(self._gcs_client)
 
     def _deploy_driver(self) -> bool:
-        """
-        Deploy the driver deployment to each node
-        """
+        """Deploy the driver deployment to each node."""
         all_nodes = self._get_all_node_ids()
         self.target_info.deployment_config.num_replicas = len(all_nodes)
         deployed_nodes = set()

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -182,7 +182,9 @@ class LongestPrefixRouter:
         return endpoint in self.handles
 
     def update_routes(self, endpoints: Dict[EndpointTag, EndpointInfo]) -> None:
-        logger.info(f"Got updated endpoints: {endpoints}.", extra={"log_to_stderr": False})
+        logger.info(
+            f"Got updated endpoints: {endpoints}.", extra={"log_to_stderr": False}
+        )
 
         existing_handles = set(self.handles.keys())
         routes = []
@@ -197,7 +199,10 @@ class LongestPrefixRouter:
 
         # Clean up any handles that are no longer used.
         if len(existing_handles) > 0:
-            logger.info(f"Deleting {len(existing_handles)} unused handles.", extra={"log_to_stderr": False})
+            logger.info(
+                f"Deleting {len(existing_handles)} unused handles.",
+                extra={"log_to_stderr": False},
+            )
         for endpoint in existing_handles:
             del self.handles[endpoint]
 
@@ -405,7 +410,7 @@ class HTTPProxy:
                 status=str(status_code),
                 latency_ms=latency_ms,
             ),
-            extra={"log_to_stderr": False}
+            extra={"log_to_stderr": False},
         )
         if status_code != "200":
             self.request_error_counter.inc(

--- a/python/ray/serve/_private/http_state.py
+++ b/python/ray/serve/_private/http_state.py
@@ -130,7 +130,8 @@ class HTTPState:
                     "Starting HTTP proxy with name '{}' on node '{}' "
                     "listening on '{}:{}'".format(
                         name, node_id, self._config.host, self._config.port
-                    )
+                    ),
+                    extra={"log_to_stderr": False}
                 )
                 proxy = HTTPProxyActor.options(
                     num_cpus=self._config.num_cpus,

--- a/python/ray/serve/_private/http_state.py
+++ b/python/ray/serve/_private/http_state.py
@@ -131,7 +131,7 @@ class HTTPState:
                     "listening on '{}:{}'".format(
                         name, node_id, self._config.host, self._config.port
                     ),
-                    extra={"log_to_stderr": False}
+                    extra={"log_to_stderr": False},
                 )
                 proxy = HTTPProxyActor.options(
                     num_cpus=self._config.num_cpus,

--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -54,6 +54,7 @@ def log_to_stderr_filter(record: logging.LogRecord) -> bool:
 
     return record.log_to_stderr
 
+
 def configure_component_logger(
     *,
     component_name: str,

--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -47,14 +47,19 @@ def access_log_msg(*, method: str, status: str, latency_ms: float):
     return f"{method.upper()} {status.upper()} {latency_ms:.1f}ms"
 
 
+def log_to_stderr_filter(record: logging.LogRecord) -> bool:
+    """Filters log records based on a parameter in the `extra` dictionary."""
+    if not hasattr(record, "log_to_stderr") or record.log_to_stderr is None:
+        return True
+
+    return record.log_to_stderr
+
 def configure_component_logger(
     *,
     component_name: str,
     component_id: str,
     component_type: Optional[str] = None,
     log_level: int = logging.INFO,
-    log_to_stream: bool = True,
-    log_to_file: bool = True,
     max_bytes: Optional[int] = None,
     backup_count: Optional[int] = None,
 ):
@@ -84,32 +89,31 @@ def configure_component_logger(
 
     logging.setLogRecordFactory(record_factory)
 
-    if log_to_stream:
-        stream_handler = logging.StreamHandler()
-        stream_handler.setFormatter(ServeFormatter(component_name, component_id))
-        logger.addHandler(stream_handler)
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(ServeFormatter(component_name, component_id))
+    stream_handler.addFilter(log_to_stderr_filter)
+    logger.addHandler(stream_handler)
 
-    if log_to_file:
-        logs_dir = os.path.join(
-            ray._private.worker._global_node.get_logs_dir_path(), "serve"
-        )
-        os.makedirs(logs_dir, exist_ok=True)
-        if max_bytes is None:
-            max_bytes = ray._private.worker._global_node.max_bytes
-        if backup_count is None:
-            backup_count = ray._private.worker._global_node.backup_count
-        if component_type is not None:
-            component_name = f"{component_type}_{component_name}"
-        log_file_name = LOG_FILE_FMT.format(
-            component_name=component_name, component_id=component_id
-        )
-        file_handler = logging.handlers.RotatingFileHandler(
-            os.path.join(logs_dir, log_file_name),
-            maxBytes=max_bytes,
-            backupCount=backup_count,
-        )
-        file_handler.setFormatter(ServeFormatter(component_name, component_id))
-        logger.addHandler(file_handler)
+    logs_dir = os.path.join(
+        ray._private.worker._global_node.get_logs_dir_path(), "serve"
+    )
+    os.makedirs(logs_dir, exist_ok=True)
+    if max_bytes is None:
+        max_bytes = ray._private.worker._global_node.max_bytes
+    if backup_count is None:
+        backup_count = ray._private.worker._global_node.backup_count
+    if component_type is not None:
+        component_name = f"{component_type}_{component_name}"
+    log_file_name = LOG_FILE_FMT.format(
+        component_name=component_name, component_id=component_id
+    )
+    file_handler = logging.handlers.RotatingFileHandler(
+        os.path.join(logs_dir, log_file_name),
+        maxBytes=max_bytes,
+        backupCount=backup_count,
+    )
+    file_handler.setFormatter(ServeFormatter(component_name, component_id))
+    logger.addHandler(file_handler)
 
 
 class LoggingContext:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -363,21 +363,6 @@ class RayServeReplica:
                 metrics_process_func=process_remote_func,
             )
 
-        # NOTE(edoakes): we used to recommend that users use the "ray" logger
-        # and tagged the logs with metadata as below. We now recommend using
-        # the "ray.serve" 'component logger' (as of Ray 1.13). This is left to
-        # maintain backwards compatibility with users who were using the
-        # existing logger. We can consider removing it in Ray 2.0.
-        ray_logger = logging.getLogger("ray")
-        for handler in ray_logger.handlers:
-            handler.setFormatter(
-                logging.Formatter(
-                    handler.formatter._fmt
-                    + f" component=serve deployment={self.deployment_name} "
-                    f"replica={self.replica_tag}"
-                )
-            )
-
     async def check_health(self):
         await self.user_health_check()
 
@@ -444,10 +429,9 @@ class RayServeReplica:
         Returns the user-provided output and a boolean indicating if the
         request succeeded (user code didn't raise an exception).
         """
-        logger.debug(
-            "Replica {} started executing request {}".format(
-                self.replica_tag, request_item.metadata.request_id
-            )
+        logger.info(
+            f"Started executing request {request_item.metadata.request_id}",
+            extra={"log_to_stderr": False}
         )
 
         args, kwargs = parse_request_item(request_item)

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -431,7 +431,7 @@ class RayServeReplica:
         """
         logger.info(
             f"Started executing request {request_item.metadata.request_id}",
-            extra={"log_to_stderr": False}
+            extra={"log_to_stderr": False},
         )
 
         args, kwargs = parse_request_item(request_item)

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -581,8 +581,10 @@ class ServeController:
                 updated_versions,
             )
 
-            logger.info("Starting deploy_serve_application "
-                        f"task for application {app_config.name}.")
+            logger.info(
+                "Starting deploy_serve_application "
+                f"task for application {app_config.name}."
+            )
             deploy_obj_ref = deploy_serve_application.options(
                 runtime_env=app_config.runtime_env
             ).remote(

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -116,7 +116,9 @@ def test_user_logs(serve_instance):
 
         def check_stderr_log(replica_tag: str):
             s = f.getvalue()
-            return all([name in s, replica_tag in s, stderr_msg in s, log_file_msg not in s])
+            return all(
+                [name in s, replica_tag in s, stderr_msg in s, log_file_msg not in s]
+            )
 
         # Only the stderr_msg should be logged to stderr.
         wait_for_condition(check_stderr_log, replica_tag=replica_tag)
@@ -124,7 +126,9 @@ def test_user_logs(serve_instance):
         def check_log_file(replica_tag: str):
             with open(log_file_name, "r") as f:
                 s = f.read()
-                return all([name in s, replica_tag in s, stderr_msg in s, log_file_msg in s])
+                return all(
+                    [name in s, replica_tag in s, stderr_msg in s, log_file_msg in s]
+                )
 
         # Both messages should be logged to the file.
         wait_for_condition(check_log_file, replica_tag=replica_tag)

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -190,9 +190,7 @@ def test_context_information_in_logging(serve_instance):
 
         # Check the component log
         expected_log_infos = [
-            f"{resp['request_id']} {resp['route']} http_proxy.py",
             f"{resp['request_id']} {resp['route']} replica.py",
-            f"{resp2['request_id']} {resp2['route']} http_proxy.py",
             f"{resp2['request_id']} {resp2['route']} replica.py",
         ]
 

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -96,64 +96,38 @@ def test_handle_access_log(serve_instance):
         )
 
 
-@pytest.mark.skip("TODO(edoakes): temporarily unblocking merge.")
-def test_http_access_log(serve_instance):
-    prefix = "/test"
-
-    @serve.deployment(route_prefix=prefix)
-    def fn(req):
-        if "throw" in req.query_params:
-            raise RuntimeError("blah blah blah")
-
-        return "hi"
-
-    serve.run(fn.bind())
-
-    f = io.StringIO()
-    with redirect_stderr(f):
-
-        def check_log(fail: bool = False):
-            s = f.getvalue()
-            return all(
-                [
-                    "http_proxy" in s,
-                    "127.0.0.1" in s,
-                    prefix in s,
-                    ("500" if fail else "200") in s,
-                    "ms" in s,
-                ]
-            )
-
-        requests.get(f"http://127.0.0.1:8000{prefix}").raise_for_status()
-        wait_for_condition(check_log, timeout=30)
-
-        with pytest.raises(requests.exceptions.RequestException):
-            requests.get(f"http://127.0.0.1:8000{prefix}?throw=True").raise_for_status()
-
-        wait_for_condition(check_log, timeout=30, fail=True)
-
-
 def test_user_logs(serve_instance):
     logger = logging.getLogger("ray.serve")
-    msg = "user log message"
+    stderr_msg = "user log message"
+    log_file_msg = "in file only"
     name = "user_fn"
 
     @serve.deployment(name=name)
     def fn(*args):
-        logger.info("user log message")
-        return serve.get_replica_context().replica_tag
+        logger.info(stderr_msg)
+        logger.info(log_file_msg, extra={"log_to_stderr": False})
+        return serve.get_replica_context().replica_tag, logger.handlers[1].baseFilename
 
     handle = serve.run(fn.bind())
 
     f = io.StringIO()
     with redirect_stderr(f):
+        replica_tag, log_file_name = ray.get(handle.remote())
 
-        def check_log(replica_tag: str):
+        def check_stderr_log(replica_tag: str):
             s = f.getvalue()
-            return all([name in s, replica_tag in s, msg in s])
+            return all([name in s, replica_tag in s, stderr_msg in s, log_file_msg not in s])
 
-        replica_tag = ray.get(handle.remote())
-        wait_for_condition(check_log, replica_tag=replica_tag)
+        # Only the stderr_msg should be logged to stderr.
+        wait_for_condition(check_stderr_log, replica_tag=replica_tag)
+
+        def check_log_file(replica_tag: str):
+            with open(log_file_name, "r") as f:
+                s = f.read()
+                return all([name in s, replica_tag in s, stderr_msg in s, log_file_msg in s])
+
+        # Both messages should be logged to the file.
+        wait_for_condition(check_log_file, replica_tag=replica_tag)
 
 
 def test_disable_access_log(serve_instance):
@@ -176,32 +150,6 @@ def test_disable_access_log(serve_instance):
         for _ in range(10):
             time.sleep(0.1)
             assert replica_tag not in f.getvalue()
-
-
-def test_deprecated_deployment_logger(serve_instance):
-    # NOTE(edoakes): using this logger is no longer recommended as of Ray 1.13.
-    # The test is maintained for backwards compatibility.
-    logger = logging.getLogger("ray")
-
-    @serve.deployment(name="counter")
-    class Counter:
-        def __init__(self):
-            self.count = 0
-
-        def __call__(self, request):
-            self.count += 1
-            logger.info(f"count: {self.count}")
-
-    serve.run(Counter.bind())
-    f = io.StringIO()
-    with redirect_stderr(f):
-        requests.get("http://127.0.0.1:8000/counter/")
-
-        def counter_log_success():
-            s = f.getvalue()
-            return "deployment" in s and "replica" in s and "count" in s
-
-        wait_for_condition(counter_log_success)
 
 
 def test_context_information_in_logging(serve_instance):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A few improvements to logging:
- add the ability to log certain messages only to log files and not to `stderr` using `extra={"log_to_stderr": False}`. This should be used going forward for things we don't want to spam the console but do want to show up in cluster logs.
- add some more log lines in relevant places (HTTP proxies getting updates, deploy task being launch and finishing, more logs in controller).
- remove the deprecated `"ray"` logger logic & related test case.

Closes https://github.com/ray-project/ray/issues/33203

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
