### PR TITLE
[Datasets] Fix docstring of TFRecordDatasource

### DIFF
--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 
 @PublicAPI(stability="alpha")
 class TFRecordDatasource(FileBasedDatasource):
+    """TFRecord datasource, for reading and writing TFRecord files."""
+
     _FILE_EXTENSION = "tfrecords"
 
     def _read_stream(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As title. The current summary is missing:

<img width="969" alt="Screen Shot 2023-03-22 at 8 19 39 PM" src="https://user-images.githubusercontent.com/4629931/227093473-4a53fd4c-b1b3-4811-a7ae-1e45eebaf064.png">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x]  I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
