### PR TITLE
[Datasets] Fix zip stage to preserve order when executing the other side

### DIFF
--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -85,6 +85,7 @@ def execute_to_legacy_block_list(
     plan: ExecutionPlan,
     allow_clear_input_blocks: bool,
     dataset_uuid: str,
+    preserve_order: bool,
 ) -> BlockList:
     """Execute a plan with the new executor and translate it into a legacy block list.
 
@@ -93,11 +94,17 @@ def execute_to_legacy_block_list(
         plan: The legacy plan to execute.
         allow_clear_input_blocks: Whether the executor may consider clearing blocks.
         dataset_uuid: UUID of the dataset for this execution.
+        preserve_order: Whether to preserve order in execution.
 
     Returns:
         The output as a legacy block list.
     """
-    dag, stats = _get_execution_dag(executor, plan, allow_clear_input_blocks)
+    dag, stats = _get_execution_dag(
+        executor,
+        plan,
+        allow_clear_input_blocks,
+        preserve_order,
+    )
     bundles = executor.execute(dag, initial_stats=stats)
     block_list = _bundles_to_block_list(bundles)
     # Set the stats UUID after execution finishes.
@@ -109,6 +116,7 @@ def _get_execution_dag(
     executor: Executor,
     plan: ExecutionPlan,
     allow_clear_input_blocks: bool,
+    preserve_order: bool = False,
 ) -> Tuple[PhysicalOperator, DatasetStats]:
     """Get the physical operators DAG from a plan."""
     # Record usage of logical operators if available.
@@ -125,7 +133,7 @@ def _get_execution_dag(
     # Enforce to preserve ordering if the plan has stages required to do so, such as
     # Zip and Sort.
     # TODO(chengsu): implement this for operator as well.
-    if plan.require_preserve_order():
+    if preserve_order or plan.require_preserve_order():
         executor._options.preserve_order = True
 
     return dag, stats

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -72,7 +72,12 @@ def execute_to_legacy_bundle_iterator(
     Returns:
         The output as a bundle iterator.
     """
-    dag, stats = _get_execution_dag(executor, plan, allow_clear_input_blocks)
+    dag, stats = _get_execution_dag(
+        executor,
+        plan,
+        allow_clear_input_blocks,
+        preserve_order=False,
+    )
     if dag_rewrite:
         dag = dag_rewrite(dag)
 
@@ -116,7 +121,7 @@ def _get_execution_dag(
     executor: Executor,
     plan: ExecutionPlan,
     allow_clear_input_blocks: bool,
-    preserve_order: bool = False,
+    preserve_order: bool,
 ) -> Tuple[PhysicalOperator, DatasetStats]:
     """Get the physical operators DAG from a plan."""
     # Record usage of logical operators if available.

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -530,15 +530,15 @@ class ExecutionPlan:
         self,
         allow_clear_input_blocks: bool = True,
         force_read: bool = False,
+        preserve_order: bool = False,
     ) -> BlockList:
         """Execute this plan.
-
-        This will always execute the plan using bulk execution.
 
         Args:
             allow_clear_input_blocks: Whether we should try to clear the input blocks
                 for each stage.
             force_read: Whether to force the read stage to fully execute.
+            preserve_order: Whether to preserve order in execution.
 
         Returns:
             The blocks of the output dataset.
@@ -575,6 +575,7 @@ class ExecutionPlan:
                     self,
                     allow_clear_input_blocks=allow_clear_input_blocks,
                     dataset_uuid=self._dataset_uuid,
+                    preserve_order=preserve_order,
                 )
                 # TODO(ekl) we shouldn't need to set this in the future once we move
                 # to a fully lazy execution model, unless .cache() is used. The reason

--- a/python/ray/data/_internal/stage_impl.py
+++ b/python/ray/data/_internal/stage_impl.py
@@ -179,7 +179,9 @@ class ZipStage(AllToAllStage):
                 base_blocks_with_metadata
             )
             # Execute other to a block list.
-            other_block_list = other._plan.execute()
+            # NOTE: Require to preserve order when executing the other side,
+            # because streaming execution does not preserve order by default.
+            other_block_list = other._plan.execute(preserve_order=True)
             other_blocks_with_metadata = other_block_list.get_blocks_with_metadata()
             other_block_rows, other_block_bytes = _calculate_blocks_rows_and_bytes(
                 other_blocks_with_metadata

--- a/python/ray/data/tests/test_dataset_all_to_all.py
+++ b/python/ray/data/tests/test_dataset_all_to_all.py
@@ -111,6 +111,23 @@ def test_zip_arrow(ray_start_regular_shared):
     assert result[0] == {"id": 0, "id_1": 0, "id_2": 0}
 
 
+def test_zip_preserve_order(ray_start_regular_shared):
+    def foo(x):
+        import time
+
+        if x[0] < 5:
+            time.sleep(1)
+        return x
+
+    num_items = 10
+    items = list(range(num_items))
+    ds1 = ray.data.from_items(items, parallelism=num_items)
+    ds2 = ray.data.from_items(items, parallelism=num_items)
+    ds2 = ds2.map_batches(foo, batch_size=1)
+    result = ds1.zip(ds2).take_all()
+    assert result == list(zip(range(num_items), range(num_items))), result
+
+
 def test_empty_shuffle(ray_start_regular_shared):
     ds = ray.data.range(100, parallelism=100)
     ds = ds.filter(lambda x: x)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Found bug that `ZipStage` not preserve order when executing the right side. Though previously we have check if plan has zip or sort stage, that only enforces order from left side, but not enforces order from right side.

See the added unit test for a reproduce example. User encounter the issue when enabling streaming execution on their workload.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
