### PR TITLE
[core] Setting ray default handler to use `logging._StderrHandler()`.

### DIFF
--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -22,7 +22,7 @@ def setup_logger(
     logger.setLevel(logging_level)
     global _default_handler
     if _default_handler is None:
-        _default_handler = logging.StreamHandler()
+        _default_handler = logging.lastResort
         logger.addHandler(_default_handler)
     _default_handler.setFormatter(logging.Formatter(logging_format))
     # Setting this will avoid the message

--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -22,7 +22,7 @@ def setup_logger(
     logger.setLevel(logging_level)
     global _default_handler
     if _default_handler is None:
-        _default_handler = logging.lastResort
+        _default_handler = logging._StderrHandler()
         logger.addHandler(_default_handler)
     _default_handler.setFormatter(logging.Formatter(logging_format))
     # Setting this will avoid the message


### PR DESCRIPTION
Setting ray default handler to use `logging._StderrHandler()`, which is *almost* the same as `StreamHandler`.

And the doc string says it all:
"""
    This class is like a StreamHandler using sys.stderr, but always uses
    whatever sys.stderr is currently set to rather than the value of
    sys.stderr at handler construction time.
"""

This is needed for Rich FileProxy redirect to work properly, no matter whether a particular logger is instantiated outside of rich.live.Live() or inside of it.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
