### PR TITLE
[Java] Prepend ":job_id:<jobid>" to java-worker-<jobid>-<pid>.log to make Java logging consistent with Python

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/util/LoggingUtil.java
+++ b/java/runtime/src/main/java/io/ray/runtime/util/LoggingUtil.java
@@ -90,7 +90,7 @@ public class LoggingUtil {
           null);
       rootLoggerBuilder.add(globalConfigBuilder.newAppenderRef(javaWorkerLogName));
       globalConfigBuilder.add(rootLoggerBuilder);
-      // write :job_id:<job_id> to the beginning of log file to conform
+      // write `:job_id:<job_id>` to the beginning of log file to conform
       // to PR #31772
       writeJobId(rayConfig.logDir + "/" + logFileName + ".log", jobIdHex);
       /// Setup user loggers.

--- a/java/runtime/src/main/java/io/ray/runtime/util/LoggingUtil.java
+++ b/java/runtime/src/main/java/io/ray/runtime/util/LoggingUtil.java
@@ -3,6 +3,7 @@ package io.ray.runtime.util;
 import com.typesafe.config.Config;
 import io.ray.runtime.config.RayConfig;
 import io.ray.runtime.generated.Common.WorkerType;
+import java.io.FileWriter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -16,8 +17,6 @@ import org.apache.logging.log4j.core.config.builder.api.LayoutComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.LoggerComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.RootLoggerComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
-
-import java.io.FileWriter;
 
 public class LoggingUtil {
   private static boolean setup = false;
@@ -85,9 +84,7 @@ public class LoggingUtil {
           globalConfigBuilder,
           rayConfig.logDir,
           new RayConfig.LoggerConf(
-              javaWorkerLogName,
-              logFileName,
-              config.getString("ray.logging.pattern")),
+              javaWorkerLogName, logFileName, config.getString("ray.logging.pattern")),
           maxFileSize,
           maxBackupFiles,
           null);
@@ -118,8 +115,8 @@ public class LoggingUtil {
     try (FileWriter writer = new FileWriter(logFilePath)) {
       writer.write(":job_id:" + jobIdHex + "\n");
     } catch (Exception e) {
-      throw new RuntimeException("Failed to write job id, " + jobIdHex +
-        ", to log file, " + logFilePath, e);
+      throw new RuntimeException(
+          "Failed to write job id, " + jobIdHex + ", to log file, " + logFilePath, e);
     }
   }
 


### PR DESCRIPTION
## Why are these changes needed?

To make Java logging consistent with PR https://github.com/ray-project/ray/pull/31772 which seems for lazy worker binding. Otherwise, we may print too many logs from different drivers in shell console.

## Related issue number

Closes #33625

## Checks

- [*] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [*] I've run `scripts/format.sh` to lint the changes in this PR.
- [*] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
