### PR TITLE
[Java] Don't load cpp library in dev model.

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/DefaultRayRuntimeFactory.java
+++ b/java/runtime/src/main/java/io/ray/runtime/DefaultRayRuntimeFactory.java
@@ -6,6 +6,7 @@ import io.ray.runtime.config.RayConfig;
 import io.ray.runtime.config.RunMode;
 import io.ray.runtime.generated.Common.WorkerType;
 import io.ray.runtime.util.LoggingUtil;
+import io.ray.runtime.util.SystemConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,6 +17,7 @@ public class DefaultRayRuntimeFactory implements RayRuntimeFactory {
   public RayRuntime createRayRuntime() {
     RayConfig rayConfig = RayConfig.create();
     LoggingUtil.setupLogging(rayConfig);
+    SystemConfig.setup(rayConfig);
     Logger logger = LoggerFactory.getLogger(DefaultRayRuntimeFactory.class);
 
     if (rayConfig.workerMode == WorkerType.WORKER) {

--- a/java/runtime/src/main/java/io/ray/runtime/task/ArgumentsBuilder.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/ArgumentsBuilder.java
@@ -20,13 +20,6 @@ import java.util.List;
 /** Helper methods to convert arguments from/to objects. */
 public class ArgumentsBuilder {
 
-  /**
-   * If the the size of an argument's serialized data is smaller than this number, the argument will
-   * be passed by value. Otherwise it'll be passed by reference.
-   */
-  public static final long LARGEST_SIZE_PASS_BY_VALUE =
-      ((Double) SystemConfig.get("max_direct_call_object_size")).longValue();
-
   /** This dummy type is also defined in signature.py. Please keep it synced. */
   private static final NativeRayObject PYTHON_DUMMY_TYPE =
       ObjectSerializer.serialize("__RAY_DUMMY__".getBytes());
@@ -59,7 +52,7 @@ public class ArgumentsBuilder {
                     Arrays.toString(value.metadata), language.getValueDescriptor().getName()));
           }
         }
-        if (value.data.length > LARGEST_SIZE_PASS_BY_VALUE) {
+        if (value.data.length > SystemConfig.getLargestSizePassedByValue()) {
           id = ((AbstractRayRuntime) Ray.internal()).getObjectStore().putRaw(value);
           address = ((AbstractRayRuntime) Ray.internal()).getWorkerContext().getRpcAddress();
           value = null;

--- a/java/runtime/src/main/java/io/ray/runtime/util/SystemConfig.java
+++ b/java/runtime/src/main/java/io/ray/runtime/util/SystemConfig.java
@@ -2,17 +2,38 @@ package io.ray.runtime.util;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
+import io.ray.runtime.config.RayConfig;
+import io.ray.runtime.config.RunMode;
 import java.util.HashMap;
 
 /** The utility class to read system config from native code. */
 public class SystemConfig {
+
+  private static RayConfig rayConfig = null;
 
   private static Gson gson = new Gson();
 
   /// A cache to avoid duplicated reading via JNI.
   private static HashMap<String, Object> cachedConfigs = new HashMap<>();
 
+  /**
+   * The string key to use for getting the large size passed by value. If the the size of an
+   * argument's serialized data is smaller than this number, the argument will be passed by value.
+   * Otherwise it'll be passed by reference.
+   */
+  public static final String KEY_TO_LARGEST_SIZE_PASS_BY_VALUE = "max_direct_call_object_size";
+
+  public static synchronized void setup(RayConfig config) {
+    rayConfig = config;
+  }
+
   public static synchronized Object get(String key) {
+    Preconditions.checkNotNull(rayConfig);
+    if (rayConfig.runMode == RunMode.LOCAL) {
+      // Code path of local mode.
+      return getInLocalMode(key);
+    }
+    // Code path of cluster mode.
     if (cachedConfigs.containsKey(key)) {
       return cachedConfigs.get(key);
     }
@@ -21,6 +42,18 @@ public class SystemConfig {
     Preconditions.checkNotNull(val);
     cachedConfigs.put(key, val);
     return val;
+  }
+
+  public static synchronized long getLargestSizePassedByValue() {
+    return ((Double) SystemConfig.get(KEY_TO_LARGEST_SIZE_PASS_BY_VALUE)).longValue();
+  }
+
+  private static Object getInLocalMode(String key) {
+    if (KEY_TO_LARGEST_SIZE_PASS_BY_VALUE.equals(key)) {
+      // Hard code 10K in local mode.
+      return 100.0 * 1024;
+    }
+    throw new RuntimeException(String.format("Unsupported key: %s", key));
   }
 
   private static native String nativeGetSystemConfig(String key);

--- a/java/runtime/src/main/java/io/ray/runtime/util/SystemConfig.java
+++ b/java/runtime/src/main/java/io/ray/runtime/util/SystemConfig.java
@@ -17,7 +17,7 @@ public class SystemConfig {
   private static HashMap<String, Object> cachedConfigs = new HashMap<>();
 
   /**
-   * The string key to use for getting the largest size passed by value. If the the size of an
+   * The string key to use for getting the large size passed by value. If the the size of an
    * argument's serialized data is smaller than this number, the argument will be passed by value.
    * Otherwise it'll be passed by reference.
    */

--- a/java/runtime/src/main/java/io/ray/runtime/util/SystemConfig.java
+++ b/java/runtime/src/main/java/io/ray/runtime/util/SystemConfig.java
@@ -17,7 +17,7 @@ public class SystemConfig {
   private static HashMap<String, Object> cachedConfigs = new HashMap<>();
 
   /**
-   * The string key to use for getting the large size passed by value. If the the size of an
+   * The string key to use for getting the largest size passed by value. If the the size of an
    * argument's serialized data is smaller than this number, the argument will be passed by value.
    * Otherwise it'll be passed by reference.
    */

--- a/java/test/src/main/java/io/ray/test/RayCallTest.java
+++ b/java/test/src/main/java/io/ray/test/RayCallTest.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.ray.api.Ray;
 import io.ray.api.id.ObjectId;
-import io.ray.runtime.task.ArgumentsBuilder;
+import io.ray.runtime.util.SystemConfig;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -20,7 +20,7 @@ public class RayCallTest extends BaseTest {
 
   private static byte[] getLargeRawData() {
     if (LARGE_RAW_DATA == null) {
-      LARGE_RAW_DATA = new byte[(int) ArgumentsBuilder.LARGEST_SIZE_PASS_BY_VALUE + 100];
+      LARGE_RAW_DATA = new byte[(int) SystemConfig.getLargestSizePassedByValue() + 100];
     }
     return LARGE_RAW_DATA;
   }

--- a/java/test/src/main/java/io/ray/test/SystemConfigTest.java
+++ b/java/test/src/main/java/io/ray/test/SystemConfigTest.java
@@ -4,7 +4,7 @@ import io.ray.runtime.util.SystemConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Test
+@Test(groups = "cluster")
 public class SystemConfigTest extends BaseTest {
 
   public void testDefaultConfigs() {

--- a/java/test/src/main/java/io/ray/test/TestUtils.java
+++ b/java/test/src/main/java/io/ray/test/TestUtils.java
@@ -6,7 +6,7 @@ import io.ray.api.Ray;
 import io.ray.runtime.AbstractRayRuntime;
 import io.ray.runtime.config.RayConfig;
 import io.ray.runtime.config.RunMode;
-import io.ray.runtime.task.ArgumentsBuilder;
+import io.ray.runtime.util.SystemConfig;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
@@ -27,7 +27,7 @@ public class TestUtils {
     }
 
     public LargeObject(int size) {
-      Preconditions.checkState(size > ArgumentsBuilder.LARGEST_SIZE_PASS_BY_VALUE);
+      Preconditions.checkState(size > SystemConfig.getLargestSizePassedByValue());
       data = new byte[size];
     }
   }


### PR DESCRIPTION
## Why are these changes needed?
Don't load cpp library in dev model, because it will be error when nativeGetSystemConfig is invoked in local model on the Mac.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
