### PR TITLE
[Datasets] Do not skip duplicated path in DefaultFileMetadataProvider

### DIFF
--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -447,11 +447,13 @@ def _get_file_infos_common_path_prefix(
     ):
         if path in path_to_size:
             path_to_size[path] = file_size
-    # Dictionaries are insertion-ordered, so this path + size pairs should be
-    # yielded in the order of the original paths arg.
-    for path, size in path_to_size.items():
-        assert size is not None
-        yield path, size
+    # Iterate over `paths` to yield each path in original order.
+    # NOTE: do not iterate over `path_to_size` because the dictionary skips duplicated
+    # path, while `paths` might contain duplicated path if one wants to read same file
+    # multiple times.
+    for path in paths:
+        assert path in path_to_size
+        yield path, path_to_size[path]
 
 
 def _get_file_infos_parallel(

--- a/python/ray/data/tests/test_metadata_provider.py
+++ b/python/ray/data/tests/test_metadata_provider.py
@@ -251,7 +251,11 @@ def test_default_file_metadata_provider_many_files_basic(
         df = pd.DataFrame({"one": list(range(i * 3, (i + 1) * 3))})
         dfs.append(df)
         path = os.path.join(data_path, f"test_{i}.csv")
-        paths.append(path)
+        if i % 4 == 0:
+            # Append same path multiple times to test duplicated paths.
+            paths.extend([path, path, path])
+        else:
+            paths.append(path)
         df.to_csv(path, index=False, storage_options=storage_options)
     paths, fs = _resolve_paths_and_filesystem(paths, fs)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to fix the logic that previously we skip the duplicated path in `DefaultFileMetadataProvider`. We should respect users to read the same file multiple times in `read_xxx` API, and not skip duplicated path.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
