### PR TITLE
Improve reusability of runtime_env.packaging.`download_and_unpack_package`

### DIFF
--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -616,10 +616,17 @@ async def download_and_unpack_package(
         IOError: If the download fails.
         ImportError: If smart_open is not installed and a remote URI is used.
         NotImplementedError: If the protocol of the URI is not supported.
-        ValueError: If the GCS client is not provided when downloading from GCS.
+        ValueError: If the GCS client is not provided when downloading from GCS,
+                    or if package URI is invalid.
 
     """
     pkg_file = Path(_get_local_path(base_directory, pkg_uri))
+    if pkg_file.suffix == "":
+        raise ValueError(
+            f"Invalid package URI: {pkg_uri}."
+            "URI must have a file extension and the URI must be valid."
+        )
+
     async with _AsyncFileLock(str(pkg_file) + ".lock"):
         if logger is None:
             logger = default_logger

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 from zipfile import ZipFile
 
 from filelock import FileLock
-from python.ray.util.annotations import DeveloperAPI
+from ray.util.annotations import DeveloperAPI
 
 from ray._private.ray_constants import (
     RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_DEFAULT,
@@ -594,7 +594,7 @@ def get_local_dir_from_uri(uri: str, base_directory: str) -> Path:
 async def download_and_unpack_package(
     pkg_uri: str,
     base_directory: str,
-    gcs_aio_client: Optional[GcsAioClient],
+    gcs_aio_client: Optional[GcsAioClient] = None,
     logger: Optional[logging.Logger] = default_logger,
 ) -> str:
     """Download the package corresponding to this URI and unpack it if zipped.
@@ -792,7 +792,6 @@ def remove_dir_from_filepaths(base_dir: str, rdir: str):
     # Move rdir to a temporary directory, so its contents can be moved to
     # base_dir without any name conflicts
     with TemporaryDirectory() as tmp_dir:
-
         # shutil.move() is used instead of os.rename() in case rdir and tmp_dir
         # are located on separate file systems
         shutil.move(os.path.join(base_dir, rdir), os.path.join(tmp_dir, rdir))

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -658,6 +658,23 @@ class TestDownloadAndUnpackPackage:
 
         assert f"{protocol.name} is not supported" in str(excinfo.value)
 
+    @pytest.mark.parametrize(
+        "invalid_pkg_uri",
+        [
+            "gcs://gcs-cannot-have-a-folder/my-zipfile.zip",
+            "s3://file-wihout-file-extension",
+        ],
+    )
+    async def test_download_and_unpack_package_with_invalid_uri(
+        self, invalid_pkg_uri: str
+    ):
+        with pytest.raises(ValueError) as excinfo:
+            await download_and_unpack_package(
+                pkg_uri=invalid_pkg_uri, base_directory="/tmp"
+            )
+
+        assert "Invalid package URI" in str(excinfo.value)
+
 
 def test_get_gitignore(tmp_path):
     gitignore_path = tmp_path / ".gitignore"

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -601,7 +601,7 @@ class TestDownloadAndUnpackPackage:
                 # Add a file to the zip file so we can verify the file was extracted.
                 zip.writestr("file.txt", "Hello, world!")
 
-            pkg_uri = f"file://{zipfile_path}"
+            pkg_uri = f"file://{os.path.normpath(zipfile_path)}"
 
             local_dir = await download_and_unpack_package(
                 pkg_uri=pkg_uri, base_directory=temp_dir

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -8,7 +8,6 @@ import tempfile
 import uuid
 from filecmp import dircmp
 from pathlib import Path
-from unittest.mock import mock_open, patch
 from shutil import copytree, make_archive, rmtree
 import zipfile
 import ray
@@ -598,26 +597,6 @@ class TestDownloadAndUnpackPackage:
                 pkg_uri=S3_PACKAGE_URI, base_directory=temp_dest_dir
             )
             assert (Path(local_dir) / "test_module").exists()
-
-    @pytest.mark.parametrize(
-        "pkg_uri",
-        [
-            "gs://my-bucket/my-zipfile.zip",
-            "gs://my-bucket/path/to/my-zipfile.zip",
-            "gs://my-zipfile.zip",
-        ],
-    )
-    @patch("ray._private.runtime_env.packaging.unzip_package", side_effect=None)
-    async def test_download_and_unpack_package_with_gs_uri(
-        self, mock_unzip_package, pkg_uri
-    ):
-        # TODO: remove the mocks and actually test the gs functionality
-        with tempfile.TemporaryDirectory() as temp_dest_dir:
-            with patch("smart_open.open", mock_open(read_data="some contents")):
-                await download_and_unpack_package(
-                    pkg_uri=pkg_uri, base_directory=temp_dest_dir
-                )
-                mock_unzip_package.assert_called_once()
 
     async def test_download_and_unpack_package_with_file_uri(self):
         with tempfile.TemporaryDirectory() as temp_dest_dir:

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -604,7 +604,12 @@ class TestDownloadAndUnpackPackage:
             from urllib.request import pathname2url
             from urllib.parse import urljoin
 
-            pkg_uri = urljoin("file:", pathname2url(str(zipfile_path)))
+            # in windows, file_path = ///C:/Users/...
+            # in linux, file_path = /tmp/...
+            file_path = pathname2url(str(zipfile_path))
+
+            # remove the first slash in file_path to avoid invalid path in windows
+            pkg_uri = urljoin("file:", file_path[1:])
 
             local_dir = await download_and_unpack_package(
                 pkg_uri=pkg_uri, base_directory=temp_dir

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -533,26 +533,25 @@ class TestDownloadAndUnpackPackage:
         self, ray_start_regular
     ):
         # Test the guard clause for giving GCS URIs without a GCS client.
-        with (
-            tempfile.TemporaryDirectory() as temp_dest_dir,
-            tempfile.NamedTemporaryFile(suffix=".zip") as zip_file,
-        ):
-            # Create a temporary file with a zip extension in the temporary directory
-            with zipfile.ZipFile(zip_file.name, "w") as zip:
-                # Add a file to the zip file
-                zip.writestr("file.txt", "Hello, world!")
 
-            # upload the zip file to GCS pkg_uri
-            pkg_uri = "gcs://my-zipfile.zip"
-            upload_package_to_gcs(pkg_uri, zip_file.read())
+        with tempfile.TemporaryDirectory() as temp_dest_dir:
+            with tempfile.NamedTemporaryFile(suffix=".zip") as zip_file:
+                # Create a temporary file with a zip extension in the temp directory
+                with zipfile.ZipFile(zip_file.name, "w") as zip:
+                    # Add a file to the zip file
+                    zip.writestr("file.txt", "Hello, world!")
 
-            with pytest.raises(ValueError):
-                # Download the zip file from GCS pkg_uri
-                await download_and_unpack_package(
-                    pkg_uri=pkg_uri,
-                    base_directory=temp_dest_dir,
-                    gcs_aio_client=None,
-                )
+                # upload the zip file to GCS pkg_uri
+                pkg_uri = "gcs://my-zipfile.zip"
+                upload_package_to_gcs(pkg_uri, zip_file.read())
+
+                with pytest.raises(ValueError):
+                    # Download the zip file from GCS pkg_uri
+                    await download_and_unpack_package(
+                        pkg_uri=pkg_uri,
+                        base_directory=temp_dest_dir,
+                        gcs_aio_client=None,
+                    )
 
     async def test_download_and_unpack_package_with_gcs_uri(self, ray_start_regular):
         # Test downloading and unpacking a GCS package with a GCS client.
@@ -561,28 +560,27 @@ class TestDownloadAndUnpackPackage:
             address=ray._private.worker.global_worker.gcs_client.address
         )
 
-        with (
-            tempfile.TemporaryDirectory() as temp_dest_dir,
-            tempfile.NamedTemporaryFile(suffix=".zip") as zip_file,
-        ):
-            # Create a temporary file with a zip extension in the temporary directory
-            with zipfile.ZipFile(zip_file.name, "w") as zip:
-                # Add a file to the zip file
-                zip.writestr("file.txt", "Hello, world!")
+        with tempfile.TemporaryDirectory() as temp_dest_dir:
+            with tempfile.NamedTemporaryFile(suffix=".zip") as zip_file:
+                # Create a temporary file with a zip extension in the temp directory
 
-            # upload the zip file to GCS pkg_uri
-            pkg_uri = "gcs://my-zipfile.zip"
-            upload_package_to_gcs(pkg_uri, zip_file.read())
+                with zipfile.ZipFile(zip_file.name, "w") as zip:
+                    # Add a file to the zip file
+                    zip.writestr("file.txt", "Hello, world!")
 
-            # Download the zip file from GCS pkg_uri
-            local_dir = await download_and_unpack_package(
-                pkg_uri=pkg_uri,
-                base_directory=temp_dest_dir,
-                gcs_aio_client=gcs_aio_client,
-            )
+                # upload the zip file to GCS pkg_uri
+                pkg_uri = "gcs://my-zipfile.zip"
+                upload_package_to_gcs(pkg_uri, zip_file.read())
 
-            # Check that the file was extracted to the destination directory
-            assert (Path(local_dir) / "file.txt").exists()
+                # Download the zip file from GCS pkg_uri
+                local_dir = await download_and_unpack_package(
+                    pkg_uri=pkg_uri,
+                    base_directory=temp_dest_dir,
+                    gcs_aio_client=gcs_aio_client,
+                )
+
+                # Check that the file was extracted to the destination directory
+                assert (Path(local_dir) / "file.txt").exists()
 
     async def test_download_and_unpack_package_with_https_uri(self):
         with tempfile.TemporaryDirectory() as temp_dest_dir:
@@ -622,24 +620,22 @@ class TestDownloadAndUnpackPackage:
                 mock_unzip_package.assert_called_once()
 
     async def test_download_and_unpack_package_with_file_uri(self):
-        with (
-            tempfile.TemporaryDirectory() as temp_dest_dir,
-            tempfile.NamedTemporaryFile(suffix=".zip") as zip_file,
-        ):
-            # Create a temporary file with a zip extension in the temporary directory
+        with tempfile.TemporaryDirectory() as temp_dest_dir:
+            with tempfile.NamedTemporaryFile(suffix=".zip") as zip_file:
+                # Create a temporary file with a zip extension in the temp directory
 
-            with zipfile.ZipFile(zip_file.name, "w") as zip:
-                # Add a file to the zip file
-                zip.writestr("file.txt", "Hello, world!")
+                with zipfile.ZipFile(zip_file.name, "w") as zip:
+                    # Add a file to the zip file
+                    zip.writestr("file.txt", "Hello, world!")
 
-            pkg_uri = f"file://{zip_file.name}"
+                pkg_uri = f"file://{zip_file.name}"
 
-            local_dir = await download_and_unpack_package(
-                pkg_uri=pkg_uri, base_directory=temp_dest_dir
-            )
+                local_dir = await download_and_unpack_package(
+                    pkg_uri=pkg_uri, base_directory=temp_dest_dir
+                )
 
-            # Check that the file was extracted to the destination directory
-            assert (Path(local_dir) / "file.txt").exists()
+                # Check that the file was extracted to the destination directory
+                assert (Path(local_dir) / "file.txt").exists()
 
     @pytest.mark.parametrize(
         "protocol",

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -601,7 +601,10 @@ class TestDownloadAndUnpackPackage:
                 # Add a file to the zip file so we can verify the file was extracted.
                 zip.writestr("file.txt", "Hello, world!")
 
-            pkg_uri = f"file://{os.path.normpath(zipfile_path)}"
+            from urllib.request import pathname2url
+            from urllib.parse import urljoin
+
+            pkg_uri = urljoin("file:", pathname2url(str(zipfile_path)))
 
             local_dir = await download_and_unpack_package(
                 pkg_uri=pkg_uri, base_directory=temp_dir


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray is able to fetch the working directory from a remote bucket using 'download_and_unpack_package'. We want to reuse this function to perform a similar fetching task in an Anyscale workspace. The argument 'gcs_aio_client' is set to optional so that the function caller does not have to provide the GCS client when fetching the working directory from other remote storages.

### Changes
1. Add DeveloperAPI annotation
2. Make `gcs_aio_client` optional, and throw exception if the remote storage is GCS but the client is not provided.
3. Add unit-tests for `download_and_unpack_package`

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
