### PR TITLE
[Datasets] Refactor `_SQLReader` to expose `cursor_to_block`

### DIFF
--- a/python/ray/data/datasource/sql_datasource.py
+++ b/python/ray/data/datasource/sql_datasource.py
@@ -16,8 +16,7 @@ def _cursor_to_block(cursor) -> Block:
 
     rows = cursor.fetchall()
     # Each `column_description` is a 7-element sequence. The first element is the
-    # column name. To learn more, read
-    # https://peps.python.org/pep-0249/#description.
+    # column name. To learn more, read https://peps.python.org/pep-0249/#description.
     columns = [column_description[0] for column_description in cursor.description]
     pydict = {column: [row[i] for row in rows] for i, column in enumerate(columns)}
     return pa.Table.from_pydict(pydict)
@@ -34,7 +33,7 @@ class SQLDatasource(Datasource[ArrowRow]):
         self.cursor_to_block = cursor_to_block
 
     def create_reader(self, sql: str) -> "Reader":
-        return SQLReader(sql, self.connection_factory, self.cursor_to_block)
+        return _SQLReader(sql, self.connection_factory, self.cursor_to_block)
 
 
 def _check_connection_is_dbapi2_compliant(connection) -> None:
@@ -88,7 +87,7 @@ def _connect(connection_factory: Callable[[], Connection]) -> Iterator[Cursor]:
         connection.close()
 
 
-class SQLReader(Reader):
+class _SQLReader(Reader):
 
     NUM_SAMPLE_ROWS = 100
     MIN_ROWS_PER_READ_TASK = 50

--- a/python/ray/data/datasource/sql_datasource.py
+++ b/python/ray/data/datasource/sql_datasource.py
@@ -15,8 +15,8 @@ def _cursor_to_block(cursor) -> Block:
     import pyarrow as pa
 
     rows = cursor.fetchall()
-    # Each `column_description` is a 7-element sequence. The first element is the
-    # column name. To learn more, read https://peps.python.org/pep-0249/#description.
+    # Each `column_description` is a 7-element sequence. The first element is the column 
+    # name. To learn more, read https://peps.python.org/pep-0249/#description.
     columns = [column_description[0] for column_description in cursor.description]
     pydict = {column: [row[i] for row in rows] for i, column in enumerate(columns)}
     return pa.Table.from_pydict(pydict)

--- a/python/ray/data/datasource/sql_datasource.py
+++ b/python/ray/data/datasource/sql_datasource.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Iterator, Iterable, List, Optional
 from ray.data._internal.arrow_block import ArrowRow
 from ray.data.block import Block, BlockAccessor, BlockMetadata
 from ray.data.datasource.datasource import Datasource, Reader, ReadTask
-from ray.util.annotations import DeveloperAPI, PublicAPI
+from ray.util.annotations import PublicAPI
 
 Connection = Any  # A Python DB API2-compliant `Connection` object.
 Cursor = Any  # A Python DB API2-compliant `Cursor` object.

--- a/python/ray/data/datasource/sql_datasource.py
+++ b/python/ray/data/datasource/sql_datasource.py
@@ -159,7 +159,7 @@ class _SQLReader(Reader):
         columns = [column_description[0] for column_description in cursor.description]
         pydict = {column: [row[i] for row in rows] for i, column in enumerate(columns)}
         return pa.Table.from_pydict(pydict)
-        
+
     def _get_num_rows(self) -> int:
         with _connect(self.connection_factory) as cursor:
             cursor.execute(f"SELECT COUNT(*) FROM ({self.sql}) as T")

--- a/python/ray/data/datasource/sql_datasource.py
+++ b/python/ray/data/datasource/sql_datasource.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Iterator, Iterable, List, Optional
 from ray.data._internal.arrow_block import ArrowRow
 from ray.data.block import Block, BlockAccessor, BlockMetadata
 from ray.data.datasource.datasource import Datasource, Reader, ReadTask
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI, PublicAPI
 
 Connection = Any  # A Python DB API2-compliant `Connection` object.
 Cursor = Any  # A Python DB API2-compliant `Cursor` object.
@@ -17,7 +17,7 @@ class SQLDatasource(Datasource[ArrowRow]):
         self.connection_factory = connection_factory
 
     def create_reader(self, sql: str) -> "Reader":
-        return _SQLReader(sql, self.connection_factory)
+        return SQLReader(sql, self.connection_factory)
 
 
 def _check_connection_is_dbapi2_compliant(connection) -> None:
@@ -71,7 +71,8 @@ def _connect(connection_factory: Callable[[], Connection]) -> Iterator[Cursor]:
         connection.close()
 
 
-class _SQLReader(Reader):
+@DeveloperAPI
+class SQLReader(Reader):
 
     NUM_SAMPLE_ROWS = 100
     MIN_ROWS_PER_READ_TASK = 50
@@ -154,8 +155,9 @@ class _SQLReader(Reader):
         import pyarrow as pa
 
         rows = cursor.fetchall()
-        # Each `column_description` is a 7-element sequence. The first element is the column
-        # name. To learn more, read https://peps.python.org/pep-0249/#description.
+        # Each `column_description` is a 7-element sequence. The first element is the 
+        # column name. To learn more, read 
+        # https://peps.python.org/pep-0249/#description.
         columns = [column_description[0] for column_description in cursor.description]
         pydict = {column: [row[i] for row in rows] for i, column in enumerate(columns)}
         return pa.Table.from_pydict(pydict)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change allows `_SQLReader` subclasses to override `cursor_to_block` with more performant implementations.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
