### PR TITLE
[hotfix] fix 3.6 compat test.

### DIFF
--- a/python/ray/tune/tuner.py
+++ b/python/ray/tune/tuner.py
@@ -10,7 +10,6 @@ from ray.air._internal.remote_storage import list_at_uri
 from ray.air.util.node import _force_on_current_node
 from ray.tune import TuneError
 from ray.tune.execution.experiment_state import _ResumeConfig
-from ray.tune.experimental.output import get_air_verbosity
 from ray.tune.result_grid import ResultGrid
 from ray.tune.trainable import Trainable
 from ray.tune.impl.tuner_internal import TunerInternal, _TUNER_PKL
@@ -20,6 +19,16 @@ from ray.tune.progress_reporter import (
     _stream_client_output,
 )
 from ray.util import PublicAPI
+
+try:
+    from ray.tune.experimental.output import (
+        get_air_verbosity,
+    )
+except Exception:
+
+    def get_air_verbosity(*args, **kwargs):
+        return None
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
hotfix 3.6 compat test.
`get_air_verbosity` uses `OrderedDict` that is not in py3.6.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
