### PR TITLE
[tune] [no_early_kickoff] Fix `OrderedDict` import.

### DIFF
--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional, OrderedDict, Tuple, Any, TYPE_CHECKING
+from typing import List, Dict, Optional, Tuple, Any, TYPE_CHECKING
 
 import contextlib
 import collections
@@ -139,7 +139,7 @@ def _get_trials_by_state(trials: List[Trial]) -> Dict[str, List[Trial]]:
 def _infer_user_metrics(trials: List[Trial], limit: int = 4) -> List[str]:
     """Try to infer the metrics to print out."""
     # Using OrderedDict for OrderedSet.
-    result = OrderedDict()
+    result = collections.OrderedDict()
     for t in trials:
         if not t.last_result:
             continue

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -29,20 +29,10 @@ from ray.tune.callback import Callback
 from ray.tune.error import TuneError
 from ray.tune.execution.tune_controller import TuneController
 from ray.tune.experiment import Experiment, _convert_to_experiment_list
-
-try:
-    from ray.tune.experimental.output import (
-        get_air_verbosity,
-        _detect_reporter as _detect_air_reporter,
-    )
-except Exception:
-
-    def get_air_verbosity(*args, **kwargs):
-        return None
-
-    def _detect_air_reporter(*args, **kwargs):
-        return None
-
+from ray.tune.experimental.output import (
+    get_air_verbosity,
+    _detect_reporter as _detect_air_reporter,
+)
 
 from ray.tune.impl.placeholder import create_resolvers_map, inject_placeholders
 from ray.tune.progress_reporter import (

--- a/python/ray/tune/tuner.py
+++ b/python/ray/tune/tuner.py
@@ -10,6 +10,9 @@ from ray.air._internal.remote_storage import list_at_uri
 from ray.air.util.node import _force_on_current_node
 from ray.tune import TuneError
 from ray.tune.execution.experiment_state import _ResumeConfig
+from ray.tune.experimental.output import (
+    get_air_verbosity,
+)
 from ray.tune.result_grid import ResultGrid
 from ray.tune.trainable import Trainable
 from ray.tune.impl.tuner_internal import TunerInternal, _TUNER_PKL
@@ -19,16 +22,6 @@ from ray.tune.progress_reporter import (
     _stream_client_output,
 )
 from ray.util import PublicAPI
-
-try:
-    from ray.tune.experimental.output import (
-        get_air_verbosity,
-    )
-except Exception:
-
-    def get_air_verbosity(*args, **kwargs):
-        return None
-
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Remove `OrderedDict` import.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
