### PR TITLE
[Data] Optimize metadata creation for `RangeDatasource`

### DIFF
--- a/python/ray/data/tests/test_dataset_tensor.py
+++ b/python/ray/data/tests/test_dataset_tensor.py
@@ -18,6 +18,13 @@ from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
 
 
+# https://github.com/ray-project/ray/issues/33695
+def test_large_tensor_creation(ray_start_regular_shared):
+    """Tests that large tensor read task creation can complete successfully without
+    hanging."""
+    ray.data.range_tensor(1000, parallelism=1000, shape=(80, 80, 100, 100))
+
+
 def test_tensors_basic(ray_start_regular_shared):
     # Create directly.
     tensor_shape = (3, 5)

--- a/python/ray/data/tests/test_dataset_tensor.py
+++ b/python/ray/data/tests/test_dataset_tensor.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+import time
 
 import ray
 from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
@@ -22,7 +23,12 @@ from ray.tests.conftest import *  # noqa
 def test_large_tensor_creation(ray_start_regular_shared):
     """Tests that large tensor read task creation can complete successfully without
     hanging."""
+    start_time = time.time()
     ray.data.range_tensor(1000, parallelism=1000, shape=(80, 80, 100, 100))
+    end_time = time.time()
+
+    # Should not take more than 20 seconds.
+    assert end_time - start_time < 20
 
 
 def test_tensors_basic(ray_start_regular_shared):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
The metadata calculation for range datasources only needs to be calculated once, and not per read task. This avoids long hangings during read task creation if the metadata creations takes a long time.

Closes https://github.com/ray-project/ray/issues/33695

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
