### PR TITLE
[Serve] Enable serve metrics lib working in ray actor

### DIFF
--- a/python/ray/serve/metrics.py
+++ b/python/ray/serve/metrics.py
@@ -8,6 +8,8 @@ REPLICA_TAG = "replica"
 
 def _add_serve_metric_tags(tag_keys: Optional[Tuple[str]] = None):
     """Add serve context tags to the tag_keys"""
+    if context.get_internal_replica_context() is None:
+        return tag_keys
     if DEPLOYMENT_TAG in tag_keys:
         raise ValueError(f"'{DEPLOYMENT_TAG}' tag is reserved for Ray Serve metrics")
     if REPLICA_TAG in tag_keys:
@@ -22,6 +24,8 @@ def _add_serve_metric_tags(tag_keys: Optional[Tuple[str]] = None):
 
 def _add_serve_metric_default_tags(default_tags: Dict[str, str]):
     """Add serve context tags and values to the default_tags"""
+    if context.get_internal_replica_context() is None:
+        return default_tags
     if DEPLOYMENT_TAG in default_tags:
         raise ValueError(f"'{DEPLOYMENT_TAG}' tag is reserved for Ray Serve metrics")
     if REPLICA_TAG in default_tags:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Make sure ray.serve.lib working with ray.actor without serve context.
```
@ray.remote
class MyActor:
    def __init__(self):
        self.my_counter = metrics.Counter(
            "my_ray_actor",
            description=("The number of requests to this deployment."),
            tag_keys=("my_tag",),
        )
    def test(self):
        self.my_counter.inc(tags={"my_tag": "value"})
        return "hello"

@serve.deployment(num_replicas=2)
class Model:
    def __init__(self, model_name):
        self.my_actor = MyActor.remote()

    async def __call__(self, req: starlette.requests.Request):
        await self.my_actor.test.remote()
        return
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
