### PR TITLE
[no_early_kickoff] fix `test_usage_stats`

### DIFF
--- a/python/ray/tests/test_usage_stats.py
+++ b/python/ray/tests/test_usage_stats.py
@@ -1214,6 +1214,8 @@ provider:
             "num_drivers": "0",
             "gcs_storage": gcs_storage_type,
             "dashboard_used": "False",
+            "tune_scheduler": "FIFOScheduler",
+            "tune_searcher": "BasicVariantGenerator",
         }
         assert payload["total_num_nodes"] == 1
         assert payload["total_num_running_jobs"] == 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`test_usage_stats` uses Tune flow to check e2e functionality. Adding the new key: Searcher and Scheduler.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
