### PR TITLE
[RLlib][RLModule] Disabled rl_module in one of the subtests in test_curiosity

### DIFF
--- a/rllib/utils/exploration/tests/test_curiosity.py
+++ b/rllib/utils/exploration/tests/test_curiosity.py
@@ -240,7 +240,7 @@ class TestCuriosity(unittest.TestCase):
                     "fcnet_activation": "relu",
                 },
                 num_sgd_iter=8,
-                # TODO (Kourosh): We need to provide examples on how we do curiosity 
+                # TODO (Kourosh): We need to provide examples on how we do curiosity
                 # with RLModule API
                 _enable_learner_api=False,
             )

--- a/rllib/utils/exploration/tests/test_curiosity.py
+++ b/rllib/utils/exploration/tests/test_curiosity.py
@@ -240,6 +240,9 @@ class TestCuriosity(unittest.TestCase):
                     "fcnet_activation": "relu",
                 },
                 num_sgd_iter=8,
+                # TODO (Kourosh): We need to provide examples on how we do curiosity 
+                # with RLModule API
+                _enable_learner_api=False,
             )
             .exploration(
                 exploration_config={
@@ -260,6 +263,7 @@ class TestCuriosity(unittest.TestCase):
                     },
                 }
             )
+            .rl_module(_enable_rl_module_api=False)
         )
 
         min_reward = 0.001


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
