### PR TITLE
[Test] Fix the failing workflow test_dataset after streaming executor is enabled. 

### DIFF
--- a/python/ray/workflow/tests/test_dataset.py
+++ b/python/ray/workflow/tests/test_dataset.py
@@ -36,6 +36,15 @@ def sum_dataset(ds):
     return ds.sum()
 
 
+@pytest.mark.parametrize(
+    "workflow_start_regular_shared",
+    [
+        {
+            "num_cpus": 2,  # increase CPUs schedule dataset tasks
+        }
+    ],
+    indirect=True,
+)
 def test_dataset(workflow_start_regular_shared):
     ds_ref = gen_dataset.bind()
     transformed_ref = transform_dataset.bind(ds_ref)
@@ -45,6 +54,15 @@ def test_dataset(workflow_start_regular_shared):
     assert result == 2 * sum(range(1000))
 
 
+@pytest.mark.parametrize(
+    "workflow_start_regular_shared",
+    [
+        {
+            "num_cpus": 2,  # increase CPUs schedule dataset tasks
+        }
+    ],
+    indirect=True,
+)
 def test_dataset_1(workflow_start_regular_shared):
     ds_ref = gen_dataset_1.bind()
     transformed_ref = transform_dataset.bind(ds_ref)
@@ -54,6 +72,15 @@ def test_dataset_1(workflow_start_regular_shared):
     assert result == 2 * sum(range(1000))
 
 
+@pytest.mark.parametrize(
+    "workflow_start_regular_shared",
+    [
+        {
+            "num_cpus": 2,  # increase CPUs schedule dataset tasks
+        }
+    ],
+    indirect=True,
+)
 def test_dataset_2(workflow_start_regular_shared):
     ds_ref = gen_dataset_2.bind()
     transformed_ref = transform_dataset_1.bind(ds_ref)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Looks like the workflow will start 1 CPU cluster, and it has its own remote task that uses 1 CPU which blocks scheduling dataset tasks that require CPUs. There was an option to make workflow remote task to use 0 CPU, but I think that doesn't really make sense (since user probably just writes regular function inside). 

I fixed the issue by explicitly allocating 2 CPUs to the cluster. It is mysterious why it worked before streaming executor was enabled (cc @jianoaix if you have good theory. )

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
