### PR TITLE
[RLlib] Introduce initialize subcomponents to rl module base class and ppo

### DIFF
--- a/rllib/algorithms/ppo/ppo_base_rl_module.py
+++ b/rllib/algorithms/ppo/ppo_base_rl_module.py
@@ -15,6 +15,9 @@ class PPORLModuleBase(RLModule, abc.ABC):
 
     def __init__(self, config: RLModuleConfig):
         super().__init__(config)
+        self.initialize_subcomponents()
+
+    def initialize_subcomponents(self):
         catalog = self.config.get_catalog()
 
         # Build models from catalog

--- a/rllib/algorithms/ppo/ppo_base_rl_module.py
+++ b/rllib/algorithms/ppo/ppo_base_rl_module.py
@@ -3,20 +3,58 @@ This file holds framework-agnostic components for PPO's RLModules.
 """
 
 import abc
+from typing import List
 
-from ray.rllib.core.rl_module.rl_module import RLModule, RLModuleConfig
-from ray.rllib.utils.annotations import ExperimentalAPI
 from ray.rllib.core.models.base import ActorCriticEncoder
+from ray.rllib.core.rl_module.rl_module import RLModule
+from ray.rllib.models.distributions import Distribution
+from ray.rllib.models.specs.specs_dict import SpecDict
+from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.utils.annotations import ExperimentalAPI
+from ray.rllib.utils.annotations import OverrideToImplementCustomLogic
+from ray.rllib.utils.annotations import override
 
 
 @ExperimentalAPI
 class PPORLModuleBase(RLModule, abc.ABC):
     framework = None
 
-    def __init__(self, config: RLModuleConfig):
-        super().__init__(config)
-        self.initialize_subcomponents()
+    @override(RLModule)
+    def input_specs_inference(self) -> SpecDict:
+        return self.input_specs_exploration()
 
+    @override(RLModule)
+    def output_specs_inference(self) -> SpecDict:
+        return SpecDict({SampleBatch.ACTION_DIST: Distribution})
+
+    @override(RLModule)
+    def input_specs_exploration(self):
+        return []
+
+    @override(RLModule)
+    def output_specs_exploration(self) -> SpecDict:
+        return [
+            SampleBatch.VF_PREDS,
+            SampleBatch.ACTION_DIST,
+            SampleBatch.ACTION_DIST_INPUTS,
+        ]
+
+    @override(RLModule)
+    def input_specs_train(self) -> List[str]:
+        return [SampleBatch.OBS, SampleBatch.ACTIONS, SampleBatch.ACTION_LOGP]
+
+    @override(RLModule)
+    def output_specs_train(self) -> List[str]:
+        return [
+            SampleBatch.ACTION_DIST_INPUTS,
+            SampleBatch.ACTION_DIST,
+            SampleBatch.ACTION_LOGP,
+            SampleBatch.VF_PREDS,
+            "entropy",
+        ]
+
+    @OverrideToImplementCustomLogic
+    @override(RLModule)
     def initialize_subcomponents(self):
         catalog = self.config.get_catalog()
 

--- a/rllib/algorithms/ppo/tf/ppo_tf_rl_module.py
+++ b/rllib/algorithms/ppo/tf/ppo_tf_rl_module.py
@@ -1,12 +1,10 @@
-from typing import Mapping, Any, List
+from typing import Mapping, Any
 
 from ray.rllib.algorithms.ppo.ppo_base_rl_module import PPORLModuleBase
 from ray.rllib.core.models.base import ACTOR, CRITIC, STATE_IN
 from ray.rllib.core.models.tf.encoder import ENCODER_OUT
-from ray.rllib.models.distributions import Distribution
 from ray.rllib.core.rl_module.rl_module import RLModule
 from ray.rllib.core.rl_module.tf.tf_rl_module import TfRLModule
-from ray.rllib.models.specs.specs_dict import SpecDict
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_tf
@@ -20,7 +18,6 @@ class PPOTfRLModule(PPORLModuleBase, TfRLModule):
 
     def __init__(self, *args, **kwargs):
         TfRLModule.__init__(self, *args, **kwargs)
-        PPORLModuleBase.__init__(self, *args, **kwargs)
 
     # TODO(Artur): Comment in as soon as we support RNNs from Polciy side
     # @override(RLModule)
@@ -29,40 +26,6 @@ class PPOTfRLModule(PPORLModuleBase, TfRLModule):
     #         return self.encoder.get_initial_state()
     #     else:
     #         return NestedDict({})
-
-    @override(RLModule)
-    def input_specs_train(self) -> List[str]:
-        return [SampleBatch.OBS, SampleBatch.ACTIONS, SampleBatch.ACTION_LOGP]
-
-    @override(RLModule)
-    def output_specs_train(self) -> List[str]:
-        return [
-            SampleBatch.ACTION_DIST_INPUTS,
-            SampleBatch.ACTION_DIST,
-            SampleBatch.ACTION_LOGP,
-            SampleBatch.VF_PREDS,
-            "entropy",
-        ]
-
-    @override(RLModule)
-    def input_specs_exploration(self):
-        return []
-
-    @override(RLModule)
-    def output_specs_exploration(self) -> List[str]:
-        return [
-            SampleBatch.ACTION_DIST,
-            SampleBatch.VF_PREDS,
-            SampleBatch.ACTION_DIST_INPUTS,
-        ]
-
-    @override(RLModule)
-    def input_specs_inference(self) -> SpecDict:
-        return self.input_specs_exploration()
-
-    @override(RLModule)
-    def output_specs_inference(self) -> SpecDict:
-        return SpecDict({SampleBatch.ACTION_DIST: Distribution})
 
     @override(RLModule)
     def _forward_inference(self, batch: NestedDict) -> Mapping[str, Any]:

--- a/rllib/algorithms/ppo/torch/ppo_torch_rl_module.py
+++ b/rllib/algorithms/ppo/torch/ppo_torch_rl_module.py
@@ -1,13 +1,9 @@
 from typing import Mapping, Any
 
 from ray.rllib.algorithms.ppo.ppo_base_rl_module import PPORLModuleBase
-
 from ray.rllib.core.models.base import ACTOR, CRITIC, ENCODER_OUT, STATE_IN
 from ray.rllib.core.rl_module.rl_module import RLModule
 from ray.rllib.core.rl_module.torch import TorchRLModule
-from ray.rllib.models.specs.specs_dict import SpecDict
-from ray.rllib.models.specs.specs_torch import TorchTensorSpec
-from ray.rllib.models.distributions import Distribution
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_torch
@@ -16,33 +12,11 @@ from ray.rllib.utils.nested_dict import NestedDict
 torch, nn = try_import_torch()
 
 
-def get_ppo_loss(fwd_in, fwd_out):
-    # TODO: we should replace these components later with real ppo components when
-    #  RLOptimizer and RLModule are integrated together.
-    #  this is not exactly a ppo loss, just something to show that the
-    #  forward train works
-    adv = fwd_in[SampleBatch.REWARDS] - fwd_out[SampleBatch.VF_PREDS]
-    actor_loss = -(fwd_out[SampleBatch.ACTION_LOGP] * adv).mean()
-    critic_loss = (adv**2).mean()
-    loss = actor_loss + critic_loss
-
-    return loss
-
-
 class PPOTorchRLModule(PPORLModuleBase, TorchRLModule):
     framework = "torch"
 
     def __init__(self, *args, **kwargs):
         TorchRLModule.__init__(self, *args, **kwargs)
-        PPORLModuleBase.__init__(self, *args, **kwargs)
-
-    @override(RLModule)
-    def input_specs_inference(self) -> SpecDict:
-        return self.input_specs_exploration()
-
-    @override(RLModule)
-    def output_specs_inference(self) -> SpecDict:
-        return SpecDict({SampleBatch.ACTION_DIST: Distribution})
 
     @override(RLModule)
     def _forward_inference(self, batch: NestedDict) -> Mapping[str, Any]:
@@ -68,18 +42,6 @@ class PPOTorchRLModule(PPORLModuleBase, TorchRLModule):
         output[SampleBatch.ACTION_DIST] = action_dist.to_deterministic()
 
         return output
-
-    @override(RLModule)
-    def input_specs_exploration(self):
-        return []
-
-    @override(RLModule)
-    def output_specs_exploration(self) -> SpecDict:
-        return [
-            SampleBatch.VF_PREDS,
-            SampleBatch.ACTION_DIST,
-            SampleBatch.ACTION_DIST_INPUTS,
-        ]
 
     @override(RLModule)
     def _forward_exploration(self, batch: NestedDict) -> Mapping[str, Any]:
@@ -117,26 +79,6 @@ class PPOTorchRLModule(PPORLModuleBase, TorchRLModule):
             logits=action_logits
         )
         return output
-
-    @override(RLModule)
-    def input_specs_train(self) -> SpecDict:
-        specs = self.input_specs_exploration()
-        specs.append(SampleBatch.ACTIONS)
-        if SampleBatch.OBS in specs:
-            specs.append(SampleBatch.NEXT_OBS)
-        return specs
-
-    @override(RLModule)
-    def output_specs_train(self) -> SpecDict:
-        spec = SpecDict(
-            {
-                SampleBatch.ACTION_DIST: Distribution,
-                SampleBatch.ACTION_LOGP: TorchTensorSpec("b", dtype=torch.float32),
-                SampleBatch.VF_PREDS: TorchTensorSpec("b", dtype=torch.float32),
-                "entropy": TorchTensorSpec("b", dtype=torch.float32),
-            }
-        )
-        return spec
 
     def _forward_train(self, batch: NestedDict) -> Mapping[str, Any]:
         output = {}

--- a/rllib/core/rl_module/marl_module.py
+++ b/rllib/core/rl_module/marl_module.py
@@ -55,11 +55,7 @@ class MultiAgentRLModule(RLModule):
 
         super().__init__(config)
 
-        # self.build() will abstract the construction of rl_modules
-        self._rl_modules = {}
-        self.build()
-
-    def build(self):
+    def setup(self):
         """Builds the underlying RLModules."""
         self.__check_module_configs(self.config.modules)
         for module_id, module_spec in self.config.modules.items():

--- a/rllib/core/rl_module/rl_module.py
+++ b/rllib/core/rl_module/rl_module.py
@@ -1,10 +1,11 @@
 import abc
-from dataclasses import dataclass
 import datetime
-import gymnasium as gym
 import json
 import pathlib
+from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional, Type, TYPE_CHECKING, Union
+
+import gymnasium as gym
 
 if TYPE_CHECKING:
     from ray.rllib.core.rl_module.marl_module import (
@@ -14,6 +15,7 @@ if TYPE_CHECKING:
     from ray.rllib.core.models.catalog import Catalog
 
 import ray
+from ray.rllib.utils.annotations import OverrideToImplementCustomLogic
 from ray.rllib.utils.annotations import (
     ExperimentalAPI,
     OverrideToImplementCustomLogic_CallToSuperRecommended,
@@ -266,6 +268,7 @@ class RLModule(abc.ABC):
 
     def __init__(self, config: RLModuleConfig):
         self.config = config
+        self.initialize_subcomponents()
 
     def __init_subclass__(cls, **kwargs):
         # Automatically add a __post_init__ method to all subclasses of RLModule.
@@ -311,19 +314,9 @@ class RLModule(abc.ABC):
             self.output_specs_inference()
         )
 
-    def initialize_subcomponents(self):
-        """Initializes components such as models and action distribution classes.
-
-        Override this method to customize the initialization of such subcomponents.
-        By default, an RLModule constructs its subcomponents from a Catalog object.
-        For example, if an RLModules requires an encoder, a head and an
-        action distribution class, these would generally be constructed from the
-        catalog here.
-
-        You can use this method to customize the construction of these subcomponents
-        without having to change to constructor of the RLModule you are modifying.
-        """
-        raise NotImplementedError
+    @OverrideToImplementCustomLogic
+    def setup(self):
+        raise NotImplementedError("WIP")
 
     def get_initial_state(self) -> NestedDict:
         """Returns the initial state of the module.

--- a/rllib/core/rl_module/rl_module.py
+++ b/rllib/core/rl_module/rl_module.py
@@ -290,6 +290,10 @@ class RLModule(abc.ABC):
         This is a good place to do any initialization that requires access to the
         subclass's attributes.
         """
+
+        # Create the input and outputs specs from customizable methods.
+        # This makes it so that we don't have to instantiate them every time we check
+        # them.
         self._input_specs_train = convert_to_canonical_format(self.input_specs_train())
         self._output_specs_train = convert_to_canonical_format(
             self.output_specs_train()
@@ -306,6 +310,20 @@ class RLModule(abc.ABC):
         self._output_specs_inference = convert_to_canonical_format(
             self.output_specs_inference()
         )
+
+    def initialize_subcomponents(self):
+        """Initializes components such as models and action distribution classes.
+
+        Override this method to customize the initialization of such subcomponents.
+        By default, an RLModule constructs its subcomponents from a Catalog object.
+        For example, if an RLModules requires an encoder, a head and an
+        action distribution class, these would generally be constructed from the
+        catalog here.
+
+        You can use this method to customize the construction of these subcomponents
+        without having to change to constructor of the RLModule you are modifying.
+        """
+        raise NotImplementedError
 
     def get_initial_state(self) -> NestedDict:
         """Returns the initial state of the module.


### PR DESCRIPTION
## Why are these changes needed?

As Jun dogfed RLModules, he discovered that we should have an overwritable method to initialize models and action distributions and such, rather than simply putting them inside the RLModule init.
That makes then easier to customize.

Related: https://docs.google.com/document/d/1AdVKZJSziFo88pfIGfN-TYLY6SfygpOx9NLfM-5fmg0/edit?disco=AAAAsYN441M

Builds on https://github.com/ray-project/ray/pull/34205/