### PR TITLE
[RLlib][RLModule] Disable RLModule in test_ppo.py since the test is designed with ModelV2 stack in mind.

### DIFF
--- a/rllib/algorithms/ppo/tests/test_ppo.py
+++ b/rllib/algorithms/ppo/tests/test_ppo.py
@@ -112,6 +112,9 @@ class TestPPO(unittest.TestCase):
                     lstm_cell_size=10,
                     max_seq_len=20,
                 ),
+                # TODO (Kourosh): Enable when the scheduler is supported in the new
+                # Learner API stack.
+                _enable_learner_api=False,
             )
             .rollouts(
                 num_rollout_workers=1,
@@ -120,6 +123,7 @@ class TestPPO(unittest.TestCase):
                 enable_connectors=True,
             )
             .callbacks(MyCallbacks)
+            .rl_module(_enable_rl_module_api=False)
         )  # For checking lr-schedule correctness.
 
         num_iterations = 2
@@ -177,6 +181,9 @@ class TestPPO(unittest.TestCase):
                     lstm_cell_size=10,
                     max_seq_len=20,
                 ),
+                # TODO (Kourosh): Enable when the scheduler is supported in the new
+                # Learner API stack.
+                _enable_learner_api=False,
             )
             .rollouts(
                 num_rollout_workers=1,
@@ -184,6 +191,7 @@ class TestPPO(unittest.TestCase):
                 compress_observations=True,
             )
             .callbacks(MyCallbacks)
+            .rl_module(_enable_rl_module_api=False)
         )  # For checking lr-schedule correctness.
 
         num_iterations = 2
@@ -283,7 +291,13 @@ class TestPPO(unittest.TestCase):
             trainer.stop()
 
     def test_ppo_free_log_std(self):
-        """Tests the free log std option works."""
+        """Tests the free log std option works.
+
+        This test is overfitted to the old ModelV2 stack (e.g.
+        policy.model.trainable_variables is not callable in the new stack)
+        # TODO (Kourosh) we should create a new test for the new RLModule stack.
+        """
+
         config = (
             ppo.PPOConfig()
             .environment("CartPole-v1")
@@ -298,7 +312,9 @@ class TestPPO(unittest.TestCase):
                     free_log_std=True,
                     vf_share_layers=True,
                 ),
+                _enable_learner_api=False,
             )
+            .rl_module(_enable_rl_module_api=False)
         )
 
         for fw, sess in framework_iterator(config, session=True):
@@ -342,7 +358,12 @@ class TestPPO(unittest.TestCase):
             trainer.stop()
 
     def test_ppo_loss_function(self):
-        """Tests the PPO loss function math."""
+        """Tests the PPO loss function math.
+
+        This test is overfitted to the old ModelV2 stack (e.g.
+        policy.model.trainable_variables is not callable in the new stack)
+        # TODO (Kourosh) we should create a new test for the new RLModule stack.
+        """
         config = (
             ppo.PPOConfig()
             .environment("CartPole-v1")
@@ -356,7 +377,9 @@ class TestPPO(unittest.TestCase):
                     fcnet_activation="linear",
                     vf_share_layers=True,
                 ),
+                _enable_learner_api=False,
             )
+            .rl_module(_enable_rl_module_api=False)
         )
 
         for fw, sess in framework_iterator(config, session=True):

--- a/rllib/algorithms/ppo/tests/test_ppo_with_rl_module.py
+++ b/rllib/algorithms/ppo/tests/test_ppo_with_rl_module.py
@@ -99,6 +99,9 @@ class TestPPO(unittest.TestCase):
                 entropy_coeff=100.0,
                 entropy_coeff_schedule=[[0, 0.1], [256, 0.0]],
                 train_batch_size=128,
+                # TODO (Kourosh): Enable when the scheduler is supported in the new
+                # Learner API stack.
+                _enable_learner_api=False,
             )
             .rollouts(
                 num_rollout_workers=1,


### PR DESCRIPTION
Also the schedulers for entropy coeff / learning rate are not supported in the learner yet

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
