### PR TITLE
[Core] extend conda runtime_env to allow for using mamba as per PR 33596

### DIFF
--- a/python/ray/_private/runtime_env/conda.py
+++ b/python/ray/_private/runtime_env/conda.py
@@ -64,7 +64,6 @@ def _resolve_install_from_source_ray_dependencies():
     # Remove duplicates
     return list(set(deps))
 
-
 def _inject_ray_to_conda_site(
     conda_path, logger: Optional[logging.Logger] = default_logger
 ):
@@ -257,7 +256,6 @@ def _get_conda_dict_with_ray_inserted(
 class CondaPlugin(RuntimeEnvPlugin):
 
     name = "conda"
-
     def __init__(self, resources_dir: str):
         self._resources_dir = os.path.join(resources_dir, "conda")
         try_to_create_directory(self._resources_dir)
@@ -338,7 +336,6 @@ class CondaPlugin(RuntimeEnvPlugin):
             conda_env_name = self._get_path_from_hash(hash)
 
             conda_dict = _get_conda_dict_with_ray_inserted(runtime_env, logger=logger)
-
             logger.info(f"Setting up conda environment with {runtime_env}")
             with FileLock(self._installs_and_deletions_file_lock):
                 try:
@@ -348,7 +345,7 @@ class CondaPlugin(RuntimeEnvPlugin):
                     with open(conda_yaml_file, "w") as file:
                         yaml.dump(conda_dict, file)
                     create_conda_env_if_needed(
-                        conda_yaml_file, prefix=conda_env_name, logger=logger
+                        conda_yaml_file, conda_exe=runtime_env.conda_create_env_executable(), prefix=conda_env_name, logger=logger
                     )
                 finally:
                     os.remove(conda_yaml_file)

--- a/python/ray/_private/runtime_env/conda_utils.py
+++ b/python/ray/_private/runtime_env/conda_utils.py
@@ -84,9 +84,8 @@ def _get_conda_env_name(conda_env_path: str) -> str:
     conda_env_contents = open(conda_env_path).read()
     return "ray-%s" % hashlib.sha1(conda_env_contents.encode("utf-8")).hexdigest()
 
-
 def create_conda_env_if_needed(
-    conda_yaml_file: str, prefix: str, logger: Optional[logging.Logger] = None
+    conda_yaml_file: str, conda_exe: str, prefix: str, logger: Optional[logging.Logger] = None
 ) -> None:
     """
     Given a conda YAML, creates a conda environment containing the required
@@ -100,7 +99,7 @@ def create_conda_env_if_needed(
     """
     if logger is None:
         logger = logging.getLogger(__name__)
-    conda_path = get_conda_bin_executable("conda")
+    conda_path = get_conda_bin_executable(conda_exe)
     try:
         exec_cmd([conda_path, "--help"], throw_on_error=False)
     except (EnvironmentError, FileNotFoundError):

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -448,6 +448,11 @@ class RuntimeEnv(dict):
             return None
         return json.dumps(self["conda"], sort_keys=True)
 
+    def conda_create_env_executable(self) -> str:
+        if not self.has_conda() or not isinstance(self["conda"], dict):
+            return None
+        return self["conda"].get("create_env_exe", "conda")
+
     def has_pip(self) -> bool:
         if self.get("pip"):
             return True

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -776,6 +776,7 @@ def test_runtime_env_interface():
     assert runtime_env.has_conda()
     assert runtime_env.conda_env_name() == conda_name
     assert runtime_env.conda_config() is None
+    assert runtime_env.conda_create_env_executable() is None
     runtime_env["conda"] = modify_conda_name
     runtime_env_dict["conda"] = modify_conda_name
     assert runtime_env_dict == runtime_env.to_dict()
@@ -788,6 +789,10 @@ def test_runtime_env_interface():
     assert runtime_env.has_conda()
     assert runtime_env.conda_env_name() is None
     assert runtime_env.conda_config() == json.dumps(conda_config, sort_keys=True)
+    conda_config = {"create_env_exe": "mamba", "dependencies": ["dep1", "dep2"]}
+    runtime_env["conda"] = conda_config
+    runtime_env_dict["conda"] = conda_config
+    assert runtime_env.conda_create_env_executable() == "mamba"
 
     runtime_env.pop("conda")
     assert runtime_env.to_dict() == {"_ray_commit": "{{RAY_COMMIT_SHA}}"}


### PR DESCRIPTION
This is a starting point PR to find a means of allowing an alternative to conda to be used for creating environments. As per PR #33596 conda can be slow when building non-trivial environments. This PR allows for mamba to be used instead. It takes the form of extending the runtime_env's 'conda' dictionary to allow for an alternative executable to specified for creating environments:

```
runtime_env = {
        "conda": {"create_env_exe": "mamba", "dependencies": ["pip", {"pip": ["pip-install-test==0.5"]}]}
    }
```

The only functions that are altered are ```create_conda_env_if_needed``` to accept the name of exe to use rather than
hardcoding "conda" and CondaPlugin to obtain the executable name from the runtime_env.

I'd like some guidance as to whether this is the best approach for addressing this issue before I go ahead and update the docs. Also, the unit test that I've added ```test_conda_using_mamba_create_task``` doesn't test that mamba is actually used, just that the package creation succeeds since I'm not sure how best to access more detailed logs from within tests.

## Why are these changes needed?

See PR #33596.

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
