### PR TITLE
[Data] Don't automatically move batches to device if `collate_fn` is specified

### DIFF
--- a/python/ray/data/dataset_iterator.py
+++ b/python/ray/data/dataset_iterator.py
@@ -208,12 +208,6 @@ class DatasetIterator(abc.ABC):
             get_device,
         )
 
-        # Automatically move torch tensors to the appropriate device.
-        if device is None:
-            default_device = get_device()
-            if default_device.type != "cpu":
-                device = default_device
-
         if collate_fn is not None and (dtypes is not None or device is not None):
             raise ValueError(
                 "collate_fn cannot be used with dtypes and device. It is expected that"
@@ -222,6 +216,12 @@ class DatasetIterator(abc.ABC):
             )
 
         if collate_fn is None:
+
+            # Automatically move torch tensors to the appropriate device.
+            if device is None:
+                default_device = get_device()
+                if default_device.type != "cpu":
+                    device = default_device
 
             def collate_fn(batch: Union[np.ndarray, Dict[str, np.ndarray]]):
                 return convert_ndarray_batch_to_torch_tensor_batch(

--- a/python/ray/data/tests/test_dataset_iterator.py
+++ b/python/ray/data/tests/test_dataset_iterator.py
@@ -189,6 +189,7 @@ def test_torch_conversion_collate_fn(ray_start_regular_shared):
     ):
         assert ray.air._internal.torch_utils.get_device().type == "cuda"
         for batch in it.iter_torch_batches(collate_fn=collate_fn):
+            assert batch.device.type == "cpu"
             assert isinstance(batch, torch.Tensor)
             assert batch.tolist() == list(range(5, 10))
 

--- a/python/ray/data/tests/test_dataset_iterator.py
+++ b/python/ray/data/tests/test_dataset_iterator.py
@@ -1,5 +1,6 @@
 import pytest
 from typing import Dict
+from unittest.mock import patch
 
 import numpy as np
 import tensorflow as tf
@@ -179,6 +180,15 @@ def test_torch_conversion_collate_fn(ray_start_regular_shared):
 
     with pytest.raises(ValueError):
         for batch in it.iter_torch_batches(collate_fn=collate_fn, device="cpu"):
+            assert isinstance(batch, torch.Tensor)
+            assert batch.tolist() == list(range(5, 10))
+
+    # Test that we don't automatically set device if collate_fn is specified.
+    with patch(
+        "ray.air._internal.torch_utils.get_device", lambda: torch.device("cuda")
+    ):
+        assert ray.air._internal.torch_utils.get_device().type == "cuda"
+        for batch in it.iter_torch_batches(collate_fn=collate_fn):
             assert isinstance(batch, torch.Tensor)
             assert batch.tolist() == list(range(5, 10))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
If the user provides a `collate_fn` to `iter_torch_batches`, it is expected that the `collate_fn` is responsible for moving tensors to the correct device. We remove the automatic device transfer if a `collate_fn` is specified.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
