### PR TITLE
[air output] Add unit test to `experimental/output.py`

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -996,6 +996,19 @@ py_test(
     args = ["--smoke-test"]
 )
 
+# --------------------------------------------------------------------
+# Tests from the python/ray/tune/tests/output directory.
+# Please keep these sorted alphabetically.
+# --------------------------------------------------------------------
+
+py_test(
+    name = "test_output",
+    size = "small",
+    srcs = ["tests/output/test_output.py"],
+    deps = [":tune_lib"],
+    tags = ["team:ml", "exclusive"]
+)
+
 
 # This is a dummy test dependency that causes the above tests to be
 # re-run if any of these files changes.

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -485,14 +485,14 @@ class TuneTerminalReporter(TuneReporterBase):
             all_infos.extend(table.trial_infos)
             if table.more_info:
                 all_infos.append(table.more_info)
-            print(
-                tabulate(
-                    all_infos,
-                    headers=header,
-                    tablefmt="simple",
-                    showindex=False,
-                )
+        print(
+            tabulate(
+                all_infos,
+                headers=header,
+                tablefmt="simple",
+                showindex=False,
             )
+        )
         print()
 
 

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -137,7 +137,11 @@ def _get_trials_by_state(trials: List[Trial]) -> Dict[str, List[Trial]]:
 
 
 def _infer_user_metrics(trials: List[Trial], limit: int = 4) -> List[str]:
-    """Try to infer the metrics to print out."""
+    """Try to infer the metrics to print out.
+
+    By default, only the first 4 meaningful metrics in `last_result` will be
+    inferred as user implied metrics.
+    """
     # Using OrderedDict for OrderedSet.
     result = collections.OrderedDict()
     for t in trials:
@@ -156,12 +160,21 @@ def _infer_user_metrics(trials: List[Trial], limit: int = 4) -> List[str]:
 
 def _current_best_trial(
     trials: List[Trial], metric: Optional[str], mode: Optional[str]
-):
-    if not trials:
-        return None, None
+) -> Tuple[Optional[Trial], Optional[str]]:
+    """
+    Returns the best trial and the metric key. If anything is empty or None,
+    returns a trivial result of None, None.
 
-    if not metric or not mode:
-        return None, metric
+    Args:
+        trials: List of trials.
+        metric: Metric that trials are being ranked.
+        mode: One of "min" or "max".
+
+    Returns:
+         Best trial and the metric key.
+    """
+    if not trials or not metric or not mode:
+        return None, None
 
     metric_op = 1.0 if mode == "max" else -1.0
     best_metric = float("-inf")
@@ -220,7 +233,7 @@ def _max_len(value: Any, max_len: int = 20, wrap: bool = False) -> Any:
     return result
 
 
-def _get_trial_info(trial: Trial, metric_keys: List[str]):
+def _get_trial_info(trial: Trial, metric_keys: List[str]) -> List[str]:
     """Returns the following information about a trial:
 
     name | status | metrics...
@@ -253,7 +266,7 @@ def _get_trial_table_data_per_status(
     Args:
         status: The trial status of interest.
         trials: all the trials of that status.
-        metric_keys: Ordered list of metrics to be displayed in the table.
+        metric_keys: *Ordered* list of metrics to be displayed in the table.
             Including both default and user defined.
         force_max_rows: Whether or not to enforce a max row number for this status.
             If True, only a max of `5` rows will be shown.
@@ -335,7 +348,7 @@ def _best_trial_str(
 ):
     """Returns a readable message stating the current best trial."""
     # returns something like
-    # Current best trial: 18ae7_00005 with loss=0.5918508041056858 and parameters={'train_loop_config': {'lr': 0.059253447253394785}}. # noqa
+    # Current best trial: 18ae7_00005 with loss=0.5918508041056858 and params={'train_loop_config': {'lr': 0.059253447253394785}}. # noqa
     val = unflattened_lookup(metric, trial.last_result, default=None)
     config = trial.last_result.get("config", {})
     parameter_columns = list(config.keys())
@@ -550,7 +563,7 @@ class TuneRichReporter(TuneReporterBase):
         if not self._live:
             logger.warning(
                 "`print_heartbeat` is not supposed to "
-                "be called within `with_live` context manager."
+                "be called without `with_live` context manager."
             )
             return
         heartbeat_strs, table_data = self._get_heartbeat(trials, *args)
@@ -699,6 +712,7 @@ class AirResultProgressCallback(Callback):
     ):
         if self._verbosity < self._intermediate_result_verbosity:
             return
+        # don't think this is supposed to happen but just to be save.
         saved_iter = "?"
         if trial.last_result and TRAINING_ITERATION in trial.last_result:
             saved_iter = trial.last_result[TRAINING_ITERATION]

--- a/python/ray/tune/tests/output/conftest.py
+++ b/python/ray/tune/tests/output/conftest.py
@@ -1,0 +1,3 @@
+# Trigger pytest hook to automatically zip test cluster logs to archive dir on failure
+from ray.tests.conftest import pytest_runtest_makereport  # noqa
+from ray.tests.conftest import propagate_logs  # noqa

--- a/python/ray/tune/tests/output/test_output.py
+++ b/python/ray/tune/tests/output/test_output.py
@@ -1,0 +1,168 @@
+import pytest
+import sys
+
+import time
+from freezegun import freeze_time
+
+from ray.tune.experimental.output import (
+    _get_time_str,
+    _get_trials_by_state,
+    _get_trial_info,
+    _infer_user_metrics,
+    _max_len,
+    _current_best_trial,
+    _best_trial_str,
+    _get_trial_table_data,
+)
+from ray.tune.experiment.trial import Trial
+
+
+LAST_RESULT = {
+    "custom_metrics": {},
+    "episode_media": {},
+    "info": {
+        "learner": {
+            "default_policy": {
+                "allreduce_latency": 0.0,
+                "grad_gnorm": 40.0,
+                "cur_lr": 0.001,
+                "total_loss": 93.35336303710938,
+                "policy_loss": -18.39633560180664,
+                "entropy": 0.5613694190979004,
+                "entropy_coeff": 0.01,
+                "var_gnorm": 23.452943801879883,
+                "vf_loss": 223.5106201171875,
+                "vf_explained_var": -0.0017577409744262695,
+                "mean_IS": 0.9987365007400513,
+                "var_IS": 0.0007558994111604989,
+            },
+        }
+    },
+    "sampler_results": {
+        "episode_reward_max": 500.0,
+        "episode_reward_min": 54.0,
+        "episode_reward_mean": 214.45,
+    },
+    "episode_reward_max": 500.0,
+    "episode_reward_min": 54.0,
+    "episode_reward_mean": 214.45,
+    "episode_len_mean": 214.45,
+    "episodes_this_iter": 66,
+    "timesteps_total": 33000,
+}
+
+
+@freeze_time("Mar 27th, 2023", auto_tick_seconds=15)
+def test_get_time_str():
+    result = _get_time_str(time.time(), time.time())
+    assert result == ("2023-03-27 00:00:15", "00:00:15.00")
+
+
+def test_get_trials_by_state():
+    t1 = Trial("__fake")
+    t1.set_status(Trial.RUNNING)
+    t2 = Trial("__fake")
+    t2.set_status(Trial.PENDING)
+    trials = [t1, t2]
+    assert _get_trials_by_state(trials) == {"RUNNING": [t1], "PENDING": [t2]}
+
+
+def test_infer_user_metrics():
+    t = Trial("__fake")
+    t.last_result = LAST_RESULT
+    result = [
+        "episode_reward_max",
+        "episode_reward_min",
+        "episode_len_mean",
+        "episodes_this_iter",
+    ]
+    assert _infer_user_metrics([t]) == result
+
+
+def test_max_len():
+    assert _max_len("long_metrics_name", max_len=5) == "...me"
+    assert _max_len("long_metrics_name", max_len=10) == "...cs_name"
+    assert _max_len("long_metrics_name", max_len=9, wrap=True) == "long_metr\nics_name"
+    assert _max_len("long_metrics_name", max_len=8, wrap=True) == "..._metr\nics_name"
+
+
+def test_current_best_trial():
+    t1 = Trial("__fake")
+    t2 = Trial("__fake")
+    t1.last_result = {"metric": 2}
+    t2.last_result = {"metric": 1}
+    assert _current_best_trial([t1, t2], metric="metric", mode="min") == (t2, "metric")
+
+
+def test_best_trial_str():
+    t = Trial("__fake")
+    t.trial_id = "18ae7_00005"
+    t.last_result = {
+        "loss": 0.5918508041056858,
+        "config": {"train_loop_config": {"lr": 0.059253447253394785}},
+    }
+    assert (
+        _best_trial_str(t, "loss")
+        == "Current best trial: 18ae7_00005 with loss=0.5918508041056858"
+        " and params={'train_loop_config': {'lr': 0.059253447253394785}}"
+    )
+
+
+def test_get_trial_info():
+    t = Trial("__fake")
+    t.trial_id = "af42b609"
+    t.set_status(Trial.RUNNING)
+    t.last_result = LAST_RESULT
+    assert _get_trial_info(
+        t,
+        [
+            "episode_reward_mean",
+            "episode_reward_max",
+            "episode_reward_min",
+            "episode_len_mean",
+            "episodes_this_iter",
+        ],
+    ) == ["__fake_af42b609", "RUNNING", 214.45, 500.0, 54.0, 214.45, 66]
+
+
+def test_get_trial_table_data_less_than_20():
+    trials = []
+    for i in range(20):
+        t = Trial("__fake")
+        t.trial_id = str(i)
+        t.set_status(Trial.RUNNING)
+        t.last_result = {"episode_reward_mean": 100 + i}
+        trials.append(t)
+    table_data = _get_trial_table_data(trials, ["episode_reward_mean"])
+    header = table_data.header
+    assert header == ["Trial name", "status", "reward"]
+    table_data = table_data.data
+    assert len(table_data) == 1  # only the running category
+    assert len(table_data[0].trial_infos) == 20
+    assert not table_data[0].more_info
+
+
+def test_get_trial_table_data_more_than_20():
+    trials = []
+    # total of 30 trials.
+    for status in [Trial.RUNNING, Trial.TERMINATED, Trial.PENDING]:
+        for i in range(10):
+            t = Trial("__fake")
+            t.trial_id = str(i)
+            t.set_status(status)
+            t.last_result = {"episode_reward_mean": 100 + i}
+            trials.append(t)
+    table_data = _get_trial_table_data(trials, ["episode_reward_mean"])
+    header = table_data.header
+    assert header == ["Trial name", "status", "reward"]
+    table_data = table_data.data
+    assert len(table_data) == 3  # only the running category
+    for i in range(3):
+        assert len(table_data[i].trial_infos) == 5
+    assert table_data[0].more_info == "... and 5 more RUNNING ..."
+    assert table_data[1].more_info == "... and 5 more TERMINATED ..."
+    assert table_data[2].more_info == "... and 5 more PENDING ..."
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add unit test to `experimental/output.py`.
Add some type hinting to methods.
Also fix a bug for rendering table.

These only cover basic unit testing. Will add separately some sort of integration test for the following scenarios:
* rich + tune
* non-rich + tune
* train

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
