### PR TITLE
[RLlib][RLModule] Fix categorical nested inside multi distribution

### DIFF
--- a/rllib/models/tf/tf_distributions.py
+++ b/rllib/models/tf/tf_distributions.py
@@ -454,7 +454,11 @@ class TfMultiDistribution(Distribution):
 
         def map_(val, dist):
             # Remove extra dimension if present.
-            if len(val.shape) > 1 and val.shape[-1] == 1:
+            if (
+                isinstance(dist, TfCategorical)
+                and len(val.shape) > 1
+                and val.shape[-1] == 1
+            ):
                 val = tf.squeeze(val, axis=-1)
 
             return dist.logp(val)

--- a/rllib/models/torch/torch_distributions.py
+++ b/rllib/models/torch/torch_distributions.py
@@ -459,7 +459,11 @@ class TorchMultiDistribution(Distribution):
 
         def map_(val, dist):
             # Remove extra dimension if present.
-            if val.shape[-1] == 1 and len(val.shape) > 1:
+            if (
+                isinstance(dist, TorchCategorical)
+                and val.shape[-1] == 1
+                and len(val.shape) > 1
+            ):
                 val = torch.squeeze(val, dim=-1)
             return dist.logp(val)
 


### PR DESCRIPTION
## Why are these changes needed?

This PR makes it so that we detect Catetogrical distributions inside the Torch-/Tf- MultiDistributions to squeeze an additional dimension when calculating logps there. So now the caller can decide if the inputs have another dimension except the batch dimension for this case.

Fixes nested_action_spaces_ppo_torch for RL Modules.