### PR TITLE
[tune] ExperimentAnalysis: Ignore empty checkpoints but don't fail

### DIFF
--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -639,7 +639,8 @@ class Trial:
                 if not isinstance(checkpoint_dir, str):
                     logger.warning(
                         f"No data found in checkpoint for trial {self} and metrics "
-                        f"{checkpoint.metrics}. Skipping."
+                        f"{checkpoint.metrics} (type: {type(checkpoint_dir)}). "
+                        f"Skipping."
                     )
                     continue
 

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -636,7 +636,13 @@ class Trial:
             # relative to the old `local_dir`/`logdir`
             for checkpoint in self.get_trial_checkpoints():
                 checkpoint_dir = checkpoint.dir_or_data
-                assert isinstance(checkpoint_dir, str)
+                if not isinstance(checkpoint_dir, str):
+                    logger.warning(
+                        f"No data found in checkpoint for trial {self} and metrics "
+                        f"{checkpoint.metrics}. Skipping."
+                    )
+                    continue
+
                 relative_checkpoint_dirs.append(
                     os.path.relpath(checkpoint_dir, self.local_path)
                 )

--- a/python/ray/tune/tests/test_experiment_analysis.py
+++ b/python/ray/tune/tests/test_experiment_analysis.py
@@ -411,7 +411,8 @@ class ExperimentAnalysisStubSuite(unittest.TestCase):
         Background: If restore from a checkpoint fails, we overwrite the checkpoint
         data with ``None`` (because we assume the current contents are invalid, e.g.
         an invalid object ref, or a corrupted directory). But ExperimentAnalysis
-        currently fails loading if it is None.
+        currently previously failed loading if it is None. This tests makes
+        sure we can still load the checkpoint.
 
         """
         with create_test_experiment_checkpoint(self.test_path) as creator:

--- a/python/ray/tune/tests/utils/experiment.py
+++ b/python/ray/tune/tests/utils/experiment.py
@@ -1,0 +1,123 @@
+import os
+import tempfile
+from contextlib import contextmanager
+from functools import partial
+from pathlib import Path
+from typing import Any, Dict, Optional, Type
+
+from ray.air._internal.checkpoint_manager import _TrackedCheckpoint, CheckpointStorage
+from ray.tune.execution.trial_runner import TrialRunner, _TuneControllerBase
+from ray.tune.experiment import Trial
+from ray.tune.trainable import TrainableUtil
+
+
+class _ExperimentCheckpointCreator:
+    def __init__(
+        self,
+        runner_cls: Type[_TuneControllerBase],
+        experiment_path: str,
+        experiment_name: str = "test_experiment",
+    ):
+        outer = self
+
+        class _TestRunnerCls(runner_cls):
+            def _get_trial_checkpoints(self):
+                return outer.get_trial_checkpoints()
+
+        self.experiment_path = experiment_path
+        self.experiment_name = experiment_name
+        self.runner = _TestRunnerCls(
+            experiment_path=experiment_path, experiment_dir_name=experiment_name
+        )
+
+    def save_checkpoint(self):
+        self.runner.save_to_dir()
+
+    def get_trials(self):
+        return self.runner.get_trials()
+
+    def get_trial_checkpoints(self):
+        return {
+            trial.trial_id: trial.get_json_state() for trial in self.runner.get_trials()
+        }
+
+    def trial_result(self, trial: Trial, result: Dict):
+        trial.update_last_result(result)
+        trial.invalidate_json_state()
+
+    def trial_checkpoint(
+        self,
+        trial: Trial,
+        checkpoint_data: Any,
+        checkpoint_storage: str = CheckpointStorage.PERSISTENT,
+    ):
+        checkpoint_storage = checkpoint_storage or CheckpointStorage.PERSISTENT
+        checkpoint = _TrackedCheckpoint(
+            dir_or_data=checkpoint_data,
+            storage_mode=checkpoint_storage,
+            metrics=trial.last_result,
+            local_to_remote_path_fn=partial(
+                TrainableUtil.get_remote_storage_path,
+                logdir=trial.local_path,
+                remote_checkpoint_dir=trial.remote_path,
+            ),
+        )
+        trial.on_checkpoint(checkpoint)
+        trial.invalidate_json_state()
+
+    def create_trial(
+        self,
+        trial_id: str,
+        config: Dict,
+        trainable_name: Optional[str] = "trainable",
+        **kwargs,
+    ) -> Trial:
+        trial = Trial(
+            trial_id=trial_id,
+            config=config,
+            experiment_path=self.experiment_path,
+            experiment_dir_name=self.experiment_name,
+            trainable_name=trainable_name,
+            stub=True,
+            **kwargs,
+        )
+        trial.init_local_path()
+        self.runner.add_trial(trial)
+
+        return trial
+
+
+@contextmanager
+def create_test_experiment_checkpoint(
+    local_experiment_path: Optional[str] = None,
+    tune_runner_cls: Type[_TuneControllerBase] = TrialRunner,
+):
+    local_experiment_path = local_experiment_path or tempfile.mkdtemp()
+
+    Path(local_experiment_path).mkdir(exist_ok=True)
+
+    os.environ["TUNE_MAX_PENDING_TRIALS_PG"] = "1"
+    creator = _ExperimentCheckpointCreator(
+        runner_cls=tune_runner_cls, experiment_path=local_experiment_path
+    )
+
+    yield creator
+
+    creator.save_checkpoint()
+
+
+#         with create_test_experiment_checkpoint(self.test_path) as creator:
+#             for i in range(10):
+#                 creator.create_trial(
+#                     f"trial_{i}",
+#                     results_checkpoints=[
+#                         (
+#                             {
+#                                 "training_iteration": 1,
+#                                 "episode_reward_mean": 10 + int(90 * random.random()),
+#                             },
+#                             None,
+#                             None,
+#                         )
+#                     ],
+#                 )

--- a/python/ray/tune/tests/utils/experiment.py
+++ b/python/ray/tune/tests/utils/experiment.py
@@ -104,20 +104,3 @@ def create_test_experiment_checkpoint(
     yield creator
 
     creator.save_checkpoint()
-
-
-#         with create_test_experiment_checkpoint(self.test_path) as creator:
-#             for i in range(10):
-#                 creator.create_trial(
-#                     f"trial_{i}",
-#                     results_checkpoints=[
-#                         (
-#                             {
-#                                 "training_iteration": 1,
-#                                 "episode_reward_mean": 10 + int(90 * random.random()),
-#                             },
-#                             None,
-#                             None,
-#                         )
-#                     ],
-#                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We currently fail when loading a Trial that contains empty checkpoints. We should just warn instead.

Background:

If restore from a checkpoint fails, we overwrite the checkpoint data with ``None`` (because we assume the current contents are invalid, e.g. an invalid object ref, or a corrupted directory). But ExperimentAnalysis currently has an assertion that `checkpoint.dir_or_data` is a string when overwriting its local path. Instead, we should just ignore checkpoints that are not strings.

Side note: This PR also introduces a preliminary testing API to create experiment checkpoints without actually running an experiment. This can potentially drastically increase end to end speed of a large number of our tests. We should iterate on this API and introduce it to more test suite in the future.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
