### PR TITLE
[Datasets] Allow read_binary_files(output_arrow_format=True) to return Arrow format

### DIFF
--- a/python/ray/data/datasource/binary_datasource.py
+++ b/python/ray/data/datasource/binary_datasource.py
@@ -5,6 +5,7 @@ if TYPE_CHECKING:
     import pyarrow
 
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
+from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.util.annotations import PublicAPI
 
 
@@ -41,10 +42,21 @@ class BinaryDatasource(FileBasedDatasource):
             data = rawbytes.getvalue()
         else:
             data = f.readall()
-        if include_paths:
-            return [(path, data)]
+
+        output_arrow_format = reader_args.pop("output_arrow_format", False)
+        if output_arrow_format:
+            builder = DelegatingBlockBuilder()
+            if include_paths:
+                item = {self._COLUMN_NAME: data, "path": path}
+            else:
+                item = {self._COLUMN_NAME: data}
+            builder.add(item)
+            return builder.build()
         else:
-            return [data]
+            if include_paths:
+                return [(path, data)]
+            else:
+                return [data]
 
     def _convert_block_to_tabular_block(
         self,
@@ -53,17 +65,20 @@ class BinaryDatasource(FileBasedDatasource):
     ) -> "pyarrow.Table":
         import pyarrow as pa
 
-        if column_name is None:
-            column_name = self._COLUMN_NAME
+        if isinstance(block, pa.Table):
+            return block
+        else:
+            if column_name is None:
+                column_name = self._COLUMN_NAME
 
-        assert len(block) == 1
-        record = block[0]
+            assert len(block) == 1
+            record = block[0]
 
-        if isinstance(record, tuple):
-            path, data = record
-            return pa.table({column_name: [data], "path": [path]})
-
-        return pa.table({column_name: [record]})
+            if isinstance(record, tuple):
+                path, data = record
+                return pa.table({column_name: [data], "path": [path]})
+            else:
+                return pa.table({column_name: [record]})
 
     def _rows_per_file(self):
         return 1

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -10,6 +10,7 @@ from typing import (
     TypeVar,
     Union,
 )
+import warnings
 
 
 import numpy as np
@@ -1257,6 +1258,7 @@ def read_binary_files(
     partition_filter: Optional[PathPartitionFilter] = None,
     partitioning: Partitioning = None,
     ignore_missing_paths: bool = False,
+    output_arrow_format: bool = False,
 ) -> Dataset[Union[Tuple[str, bytes], bytes]]:
     """Create a dataset from binary files of arbitrary contents.
 
@@ -1289,10 +1291,19 @@ def read_binary_files(
             that describes how paths are organized. Defaults to ``None``.
         ignore_missing_paths: If True, ignores any file paths in ``paths`` that are not
             found. Defaults to False.
+        output_arrow_format: If True, returns data in Arrow format, instead of Python
+            list format. Defaults to False.
 
     Returns:
-        Dataset holding Arrow records read from the specified paths.
+        Dataset holding records read from the specified paths.
     """
+    warnings.warn(
+        "read_binary_files() returns Dataset in Python list format as of Ray v2.4. "
+        "Use read_binary_files(output_arrow_format=True) to return Dataset in Arrow "
+        "format.",
+        DeprecationWarning,
+    )
+
     return read_datasource(
         BinaryDatasource(),
         parallelism=parallelism,
@@ -1305,6 +1316,7 @@ def read_binary_files(
         partition_filter=partition_filter,
         partitioning=partitioning,
         ignore_missing_paths=ignore_missing_paths,
+        output_arrow_format=output_arrow_format,
     )
 
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1297,12 +1297,13 @@ def read_binary_files(
     Returns:
         Dataset holding records read from the specified paths.
     """
-    warnings.warn(
-        "read_binary_files() returns Dataset in Python list format as of Ray v2.4. "
-        "Use read_binary_files(output_arrow_format=True) to return Dataset in Arrow "
-        "format.",
-        DeprecationWarning,
-    )
+    if not output_arrow_format:
+        warnings.warn(
+            "read_binary_files() returns Dataset in Python list format as of Ray "
+            "v2.4. Use read_binary_files(output_arrow_format=True) to return Dataset "
+            "in Arrow format.",
+            DeprecationWarning,
+        )
 
     return read_datasource(
         BinaryDatasource(),

--- a/python/ray/data/tests/test_dataset_binary.py
+++ b/python/ray/data/tests/test_dataset_binary.py
@@ -41,12 +41,18 @@ def test_read_binary_files_partitioning(ray_start_regular_shared, tmp_path):
     assert ds.take() == [{"bytes": b"foo", "path": path, "country": "us"}]
 
 
-def test_read_binary_files(ray_start_regular_shared):
+@pytest.mark.parametrize("output_arrow_format", [False, True])
+def test_read_binary_files(ray_start_regular_shared, output_arrow_format):
     with gen_bin_files(10) as (_, paths):
-        ds = ray.data.read_binary_files(paths, parallelism=10)
+        ds = ray.data.read_binary_files(
+            paths, parallelism=10, output_arrow_format=output_arrow_format
+        )
         for i, item in enumerate(ds.iter_rows()):
             expected = open(paths[i], "rb").read()
-            assert expected == item
+            if output_arrow_format:
+                assert expected == item["bytes"]
+            else:
+                assert expected == item
         # Test metadata ops.
         assert ds.count() == 10
         assert "bytes" in str(ds.schema()), ds
@@ -81,13 +87,25 @@ def test_read_binary_files_with_fs(ray_start_regular_shared):
             assert expected == item
 
 
-def test_read_binary_files_with_paths(ray_start_regular_shared):
+@pytest.mark.parametrize("output_arrow_format", [False, True])
+def test_read_binary_files_with_paths(ray_start_regular_shared, output_arrow_format):
     with gen_bin_files(10) as (_, paths):
-        ds = ray.data.read_binary_files(paths, include_paths=True, parallelism=10)
-        for i, (path, item) in enumerate(ds.iter_rows()):
-            assert path == paths[i]
-            expected = open(paths[i], "rb").read()
-            assert expected == item
+        ds = ray.data.read_binary_files(
+            paths,
+            include_paths=True,
+            parallelism=10,
+            output_arrow_format=output_arrow_format,
+        )
+        if output_arrow_format:
+            for i, item in enumerate(ds.iter_rows()):
+                assert paths[i] == item["path"]
+                expected = open(paths[i], "rb").read()
+                assert expected == item["bytes"]
+        else:
+            for i, (path, item) in enumerate(ds.iter_rows()):
+                assert path == paths[i]
+                expected = open(paths[i], "rb").read()
+                assert expected == item
 
 
 # TODO(Clark): Hitting S3 in CI is currently broken due to some AWS


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is a reproposal of https://github.com/ray-project/ray/pull/32809, to allow `read_binary_files` to return Arrow format, by adding a parameter `output_arrow_format`. Default is false, to keep backward compatiblity. Print a warning if `output_arrow_format` is false. A future release will flip the bit to set this parameter to true default.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/32373 .

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
