### PR TITLE
[no_early_kickoff][tune] Hard deprecate Tune MLflow/W&B mixin/callbacks

### DIFF
--- a/python/ray/air/tests/test_integration_mlflow.py
+++ b/python/ray/air/tests/test_integration_mlflow.py
@@ -202,37 +202,16 @@ class MLflowTest(unittest.TestCase):
         clear_env_vars()
         trial_config = {"par1": 4, "par2": 9.0}
 
-        @mlflow_mixin
-        def train_fn(config):
-            return 1
+        with self.assertRaises(DeprecationWarning):
+
+            @mlflow_mixin
+            def train_fn(config):
+                return 1
 
         train_fn.__mixins__ = (MLflowTrainableMixin,)
 
-        # No MLflow config passed in.
-        with self.assertRaises(ValueError):
+        with self.assertRaises(DeprecationWarning):
             wrap_function(train_fn)(trial_config)
-
-        trial_config.update({"mlflow": {}})
-        # No tracking uri or experiment_id/name passed in.
-        with self.assertRaises(ValueError):
-            wrap_function(train_fn)(trial_config)
-
-        # Invalid experiment-id
-        trial_config["mlflow"].update({"experiment_id": "500"})
-        # No tracking uri or experiment_id/name passed in.
-        with self.assertRaises(ValueError):
-            wrap_function(train_fn)(trial_config)
-
-        # Set to experiment that does not already exist.
-        # This will fail because the experiment has to be created explicitly first.
-        trial_config["mlflow"]["tracking_uri"] = self.tracking_uri
-        trial_config["mlflow"]["experiment_name"] = "new_experiment"
-        with self.assertRaises(ValueError):
-            wrap_function(train_fn)(trial_config)
-
-        # This should now pass
-        trial_config["mlflow"]["experiment_name"] = "existing_experiment"
-        wrap_function(train_fn)(trial_config).stop()
 
     def testMlFlowSetupConfig(self):
         clear_env_vars()

--- a/python/ray/air/tests/test_integration_mlflow.py
+++ b/python/ray/air/tests/test_integration_mlflow.py
@@ -208,10 +208,13 @@ class MLflowTest(unittest.TestCase):
             def train_fn(config):
                 return 1
 
-        train_fn.__mixins__ = (MLflowTrainableMixin,)
+        def train_fn_2(config):
+            return 1
+
+        train_fn_2.__mixins__ = (MLflowTrainableMixin,)
 
         with self.assertRaises(DeprecationWarning):
-            wrap_function(train_fn)(trial_config)
+            wrap_function(train_fn_2)(trial_config)
 
     def testMlFlowSetupConfig(self):
         clear_env_vars()

--- a/python/ray/air/tests/test_integration_wandb.py
+++ b/python/ray/air/tests/test_integration_wandb.py
@@ -49,7 +49,6 @@ import ray
 from ray.exceptions import RayActorError
 from ray.tune import Trainable
 from ray.tune.integration.wandb import WandbTrainableMixin
-from ray.tune.trainable import wrap_function
 from ray.tune.integration.wandb import wandb_mixin
 from ray.air.integrations.wandb import (
     WandbLoggerCallback,
@@ -63,8 +62,6 @@ from ray.air.integrations.wandb import (
     WANDB_PROJECT_ENV_VAR,
     WANDB_SETUP_API_KEY_HOOK,
 )
-from ray.tune.result import TRIAL_INFO
-from ray.tune.experiment.trial import _TrialInfo
 from ray.tune.execution.placement_groups import PlacementGroupFactory
 
 from ray.air.tests.mocked_wandb_integration import (
@@ -74,14 +71,6 @@ from ray.air.tests.mocked_wandb_integration import (
     WandbTestExperimentLogger,
     get_mock_wandb_logger,
 )
-
-
-class _MockWandbTrainableMixin(WandbTrainableMixin):
-    _wandb = _MockWandbAPI()
-
-
-class WandbTestTrainable(_MockWandbTrainableMixin, Trainable):
-    pass
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -103,17 +92,6 @@ def trial():
         "/tmp",
     )
     yield trial
-
-
-@pytest.fixture
-def train_fn():
-    @wandb_mixin
-    def train_fn(config):
-        return 1
-
-    train_fn.__mixins__ = (_MockWandbTrainableMixin,)
-
-    yield train_fn
 
 
 @pytest.fixture(autouse=True)
@@ -476,120 +454,22 @@ class TestWandbLogger:
 
 
 class TestWandbClassMixin:
-    def test_wandb_mixin_config(self):
-        # Needs at least a project
-        config = {}
-        with pytest.raises(ValueError):
-            WandbTestTrainable(config)
-
-        # No API key
-        config = {"wandb": {"project": "test_project"}}
-        with pytest.raises(ValueError):
-            WandbTestTrainable(config)
-
-        # API Key in config
-        config = {"wandb": {"project": "test_project", "api_key": "1234"}}
-        WandbTestTrainable(config)
-        assert os.environ[WANDB_ENV_VAR] == "1234"
-
-        del os.environ[WANDB_ENV_VAR]
-
-    def test_wandb_mixin_api_key_file(self):
-        # API Key file
-        with tempfile.NamedTemporaryFile("wt") as fp:
-            fp.write("5678")
-            fp.flush()
-
-            config = {"wandb": {"project": "test_project", "api_key_file": fp.name}}
-
-            WandbTestTrainable(config)
-            assert os.environ[WANDB_ENV_VAR] == "5678"
-
-    def test_wandb_mixin_init(self, trial, monkeypatch):
-        # API Key in env
-        monkeypatch.setenv(WANDB_ENV_VAR, "9012")
-        config = {"wandb": {"project": "test_project"}}
-        trainable = WandbTestTrainable(config)
-
-        # From now on, the API key is in the env variable.
-
-        # Default configuration
-        config = {"wandb": {"project": "test_project"}}
-        trial_info = _TrialInfo(trial)
-        config[TRIAL_INFO] = trial_info
-
-        trainable = WandbTestTrainable(config)
-        assert trainable.wandb.kwargs["project"] == "test_project"
-        assert trainable.wandb.kwargs["id"] == trial.trial_id
-        assert trainable.wandb.kwargs["name"] == trial.trial_name
-        assert trainable.wandb.kwargs["group"] == "WandbTestTrainable"
-
-    def test_wandb_mixin_rllib(self):
-        """Test compatibility with RLlib configuration dicts"""
-        # Local import to avoid tune dependency on rllib
-        try:
-            from ray.rllib.algorithms.ppo import PPO
-        except ImportError:
-            pytest.skip("ray[rllib] not available")
-
-        class WandbPPOTrainer(_MockWandbTrainableMixin, PPO):
+    def test_wandb_mixin(self):
+        class WandbTestTrainable(WandbTrainableMixin, Trainable):
             pass
 
-        config = {
-            "env": "CartPole-v0",
-            "wandb": {"project": "test_project", "api_key": "1234"},
-        }
-
-        # Test that trainer object can be initialized
-        WandbPPOTrainer(config)
+        config = {}
+        with pytest.raises(DeprecationWarning):
+            WandbTestTrainable(config)
 
 
 class TestWandbMixinDecorator:
-    def test_wandb_decorator_config(self, train_fn):
-        # Needs at least a project
-        config = {}
-        with pytest.raises(ValueError):
-            wrap_function(train_fn)(config)
+    def test_wandb_decorator(self):
+        with pytest.raises(DeprecationWarning):
 
-        # No API key
-        config = {"wandb": {"project": "test_project"}}
-        with pytest.raises(ValueError):
-            wrap_function(train_fn)(config)
-
-        # API Key in config
-        config = {"wandb": {"project": "test_project", "api_key": "1234"}}
-        wrap_function(train_fn)(config)
-        assert os.environ[WANDB_ENV_VAR] == "1234"
-
-    def test_wandb_decorator_api_key_file(self, train_fn):
-        # API Key file
-        with tempfile.NamedTemporaryFile("wt") as fp:
-            fp.write("5678")
-            fp.flush()
-
-            config = {"wandb": {"project": "test_project", "api_key_file": fp.name}}
-
-            wrap_function(train_fn)(config)
-            assert os.environ[WANDB_ENV_VAR] == "5678"
-
-    def test_wandb_decorator_init(self, trial, train_fn, monkeypatch):
-        trial_info = _TrialInfo(trial)
-
-        # API Key in env
-        monkeypatch.setenv(WANDB_ENV_VAR, "9012")
-        config = {"wandb": {"project": "test_project"}}
-        wrapped = wrap_function(train_fn)(config)
-
-        # From now on, the API key is in the env variable.
-
-        # Default configuration
-        config = {"wandb": {"project": "test_project"}}
-        config[TRIAL_INFO] = trial_info
-
-        wrapped = wrap_function(train_fn)(config)
-        assert wrapped.wandb.kwargs["project"] == "test_project"
-        assert wrapped.wandb.kwargs["id"] == trial.trial_id
-        assert wrapped.wandb.kwargs["name"] == trial.trial_name
+            @wandb_mixin
+            def train_fn(config):
+                return 1
 
 
 def test_wandb_logging_process_run_info_hook(monkeypatch):

--- a/python/ray/tune/integration/mlflow.py
+++ b/python/ray/tune/integration/mlflow.py
@@ -1,22 +1,21 @@
-import warnings
-
-from ray.air.integrations.mlflow import MLflowLoggerCallback as _MLflowLoggerCallback
+# DEPRECATED: Remove whole file in 2.5.
 
 import logging
 from typing import Callable, Dict, Optional
 
-import ray
-from ray.air._internal.mlflow import _MLflowLoggerUtil
-from ray.tune.trainable import Trainable
+from ray.air.integrations.mlflow import MLflowLoggerCallback as _MLflowLoggerCallback
 from ray.util.annotations import Deprecated
 
 logger = logging.getLogger(__name__)
 
 callback_deprecation_message = (
-    "`ray.tune.integration.mlflow.MLflowLoggerCallback` "
-    "is deprecated and will be removed in "
-    "the future. Please use `ray.air.integrations.mlflow.MLflowLoggerCallback` "
-    "instead."
+    "`ray.tune.integration.mlflow.MLflowLoggerCallback` is deprecated. "
+    "Please use `ray.air.integrations.mlflow.MLflowLoggerCallback` instead."
+)
+
+mixin_deprecation_message = (
+    "The `mlflow_mixin`/`MLflowTrainableMixin` is deprecated. "
+    "Use `ray.air.integrations.mlflow.setup_mlflow` instead."
 )
 
 
@@ -30,19 +29,10 @@ class MLflowLoggerCallback(_MLflowLoggerCallback):
         tags: Optional[Dict] = None,
         save_artifact: bool = False,
     ):
-        logger.warning(callback_deprecation_message)
-        super().__init__(
-            tracking_uri, registry_uri, experiment_name, tags, save_artifact
-        )
+        raise DeprecationWarning(callback_deprecation_message)
 
 
-# Deprecate: Remove in 2.4
-@Deprecated(
-    message=(
-        "The MLflowTrainableMixin is deprecated. "
-        "Use `ray.air.integrations.mlflow.setup_mlflow` instead."
-    )
-)
+@Deprecated(message=mixin_deprecation_message)
 def mlflow_mixin(func: Callable):
     """mlflow_mixin
 
@@ -140,93 +130,10 @@ def mlflow_mixin(func: Callable):
         tuner.fit()
 
     """
-    warnings.warn(
-        "The mlflow_mixin/MLflowTrainableMixin is deprecated. "
-        "Use `ray.air.integrations.mlflow.setup_mlflow` instead.",
-        DeprecationWarning,
-    )
-
-    if ray.util.client.ray.is_connected():
-        logger.warning(
-            "When using mlflow_mixin with Ray Client, "
-            "it is recommended to use a remote tracking "
-            "server. If you are using a MLflow tracking server "
-            "backed by the local filesystem, then it must be "
-            "setup on the server side and not on the client "
-            "side."
-        )
-    if hasattr(func, "__mixins__"):
-        func.__mixins__ = func.__mixins__ + (MLflowTrainableMixin,)
-    else:
-        func.__mixins__ = (MLflowTrainableMixin,)
-    return func
+    raise DeprecationWarning(mixin_deprecation_message)
 
 
-@Deprecated(
-    message=(
-        "The MLflowTrainableMixin is deprecated. "
-        "Use `ray.air.integrations.mlflow.setup_mlflow` instead."
-    )
-)
+@Deprecated(message=mixin_deprecation_message)
 class MLflowTrainableMixin:
-    _is_mixin = True
-
     def __init__(self, config: Dict, *args, **kwargs):
-        self.mlflow_util = _MLflowLoggerUtil()
-
-        if not isinstance(self, Trainable):
-            raise ValueError(
-                "The `MLflowTrainableMixin` can only be used as a mixin "
-                "for `tune.Trainable` classes. Please make sure your "
-                "class inherits from both. For example: "
-                "`class YourTrainable(MLflowTrainableMixin)`."
-            )
-
-        super().__init__(config, *args, **kwargs)
-        _config = config.copy()
-        try:
-            mlflow_config = _config.pop("mlflow").copy()
-        except KeyError as e:
-            raise ValueError(
-                "MLflow mixin specified but no configuration has been passed. "
-                "Make sure to include a `mlflow` key in your `config` dict "
-                "containing at least a `tracking_uri` and either "
-                "`experiment_name` or `experiment_id` specification."
-            ) from e
-
-        tracking_uri = mlflow_config.pop("tracking_uri", None)
-        if tracking_uri is None:
-            raise ValueError(
-                "MLflow mixin specified but no "
-                "tracking_uri has been "
-                "passed in. Make sure to include a `mlflow` "
-                "key in your `config` dict containing at "
-                "least a `tracking_uri`"
-            )
-
-        # Set the tracking token if one is passed in.
-        tracking_token = mlflow_config.pop("token", None)
-
-        experiment_id = mlflow_config.pop("experiment_id", None)
-
-        experiment_name = mlflow_config.pop("experiment_name", None)
-
-        # This initialization happens in each of the Trainables/workers.
-        # So we have to set `create_experiment_if_not_exists` to False.
-        # Otherwise there might be race conditions when each worker tries to
-        # create the same experiment.
-        # For the mixin, the experiment must be created beforehand.
-        self.mlflow_util.setup_mlflow(
-            tracking_uri=tracking_uri,
-            experiment_id=experiment_id,
-            experiment_name=experiment_name,
-            tracking_token=tracking_token,
-            create_experiment_if_not_exists=False,
-        )
-
-        run_name = self.trial_name + "_" + self.trial_id
-        run_name = run_name.replace("/", "_")
-        self.mlflow_util.start_run(set_active=True, run_name=run_name)
-
-    def stop(self):
-        self.mlflow_util.end_run()
+        raise DeprecationWarning(mixin_deprecation_message)

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -15,7 +15,7 @@ callback_deprecation_message = (
 
 mixin_deprecation_message = (
     "The `wandb_mixin`/`WandbTrainableMixin` is deprecated. "
-    "Use `ray.air.integrations.wandb.setup_wandb` instead.",
+    "Use `ray.air.integrations.wandb.setup_wandb` instead."
 )
 
 

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -1,27 +1,21 @@
-# Deprecate: Remove whole file in 2.4
-import warnings
-from typing import List, Dict, Callable, Optional
-
-from ray.air.integrations.wandb import _setup_wandb
-from ray.tune import Trainable
-from ray.tune.trainable import FunctionTrainable
-
-from ray.air.integrations.wandb import (
-    wandb,
-    WandbLoggerCallback as _WandbLoggerCallback,
-)
+# DEPRECATED: Remove whole file in 2.5.
 
 import logging
+from typing import List, Dict, Callable, Optional
 
+from ray.air.integrations.wandb import WandbLoggerCallback as _WandbLoggerCallback
 from ray.util.annotations import Deprecated
 
 logger = logging.getLogger(__name__)
 
 callback_deprecation_message = (
-    "`ray.tune.integration.wandb.WandbLoggerCallback` "
-    "is deprecated and will be removed in "
-    "the future. Please use `ray.air.integrations.wandb.WandbLoggerCallback` "
-    "instead."
+    "`ray.tune.integration.wandb.WandbLoggerCallback` is deprecated. "
+    "Please use `ray.air.integrations.wandb.WandbLoggerCallback` instead."
+)
+
+mixin_deprecation_message = (
+    "The `wandb_mixin`/`WandbTrainableMixin` is deprecated. "
+    "Use `ray.air.integrations.wandb.setup_wandb` instead.",
 )
 
 
@@ -38,26 +32,10 @@ class WandbLoggerCallback(_WandbLoggerCallback):
         save_checkpoints: bool = False,
         **kwargs
     ):
-        logger.warning(callback_deprecation_message)
-        super().__init__(
-            project,
-            group,
-            api_key_file,
-            api_key,
-            excludes,
-            log_config,
-            save_checkpoints,
-            **kwargs
-        )
+        raise DeprecationWarning(callback_deprecation_message)
 
 
-# Deprecate: Remove in 2.4
-@Deprecated(
-    message=(
-        "The WandbTrainableMixin is deprecated. "
-        "Use `ray.air.integrations.wandb.setup_wandb` instead."
-    )
-)
+@Deprecated(message=callback_deprecation_message)
 def wandb_mixin(func: Callable):
     """wandb_mixin
 
@@ -126,79 +104,11 @@ def wandb_mixin(func: Callable):
         tuner.fit()
 
     """
-    warnings.warn(
-        "The wandb_mixin/WandbTrainableMixin is deprecated. "
-        "Use `ray.air.integrations.wandb.setup_wandb` instead.",
-        DeprecationWarning,
-    )
-
-    if hasattr(func, "__mixins__"):
-        func.__mixins__ = func.__mixins__ + (WandbTrainableMixin,)
-    else:
-        func.__mixins__ = (WandbTrainableMixin,)
-    return func
+    raise DeprecationWarning(mixin_deprecation_message)
 
 
 # Deprecate: Remove in 2.4
-@Deprecated(
-    message=(
-        "The WandbTrainableMixin is deprecated. "
-        "Use `ray.air.integrations.wandb.setup_wandb` instead."
-    )
-)
+@Deprecated(message=mixin_deprecation_message)
 class WandbTrainableMixin:
-    _wandb = wandb
-    _is_mixin = True
-
     def __init__(self, config: Dict, *args, **kwargs):
-        if not isinstance(self, Trainable):
-            raise ValueError(
-                "The `WandbTrainableMixin` can only be used as a mixin "
-                "for `tune.Trainable` classes. Please make sure your "
-                "class inherits from both. For example: "
-                "`class YourTrainable(WandbTrainableMixin)`."
-            )
-
-        _config = config.copy()
-
-        try:
-            wandb_config = _config.pop("wandb").copy()
-        except KeyError:
-            raise ValueError(
-                "Wandb mixin specified but no configuration has been passed. "
-                "Make sure to include a `wandb` key in your `config` dict "
-                "containing at least a `project` specification."
-            )
-
-        # Init without wandb_config
-        super().__init__(_config, *args, **kwargs)
-
-        # Project name for Wandb
-        try:
-            wandb_project = wandb_config.pop("project")
-        except KeyError:
-            raise ValueError(
-                "You need to specify a `project` in your wandb `config` dict."
-            )
-
-        # Grouping
-        if isinstance(self, FunctionTrainable):
-            default_group = self._name
-        else:
-            default_group = type(self).__name__
-
-        group = wandb_config.pop("group", default_group)
-
-        self.wandb = _setup_wandb(
-            trial_id=self.trial_id,
-            trial_name=self.trial_name,
-            group=group,
-            project=wandb_project,
-            config=config,
-            _wandb=self._wandb,
-        )
-
-    def stop(self):
-        self.wandb.finish()
-        if hasattr(super(), "stop"):
-            super().stop()
+        raise DeprecationWarning(mixin_deprecation_message)

--- a/python/ray/tune/tests/test_actor_reuse.py
+++ b/python/ray/tune/tests/test_actor_reuse.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Callable
 import pytest
 import sys
 import time
@@ -394,7 +395,12 @@ def test_multi_trial_reuse_heterogeneous(ray_start_4_cpus_extra):
 
 
 def test_detect_reuse_mixins():
-    from ray.tune.integration.mlflow import mlflow_mixin
+    class DummyMixin:
+        pass
+
+    def dummy_mixin(func: Callable):
+        func.__mixins__ = (DummyMixin,)
+        return func
 
     assert not _check_mixin("PPO")
 
@@ -402,13 +408,13 @@ def test_detect_reuse_mixins():
         pass
 
     assert not _check_mixin(train)
-    assert _check_mixin(mlflow_mixin(train))
+    assert _check_mixin(dummy_mixin(train))
 
     class MyTrainable(Trainable):
         pass
 
     assert not _check_mixin(MyTrainable)
-    assert _check_mixin(mlflow_mixin(MyTrainable))
+    assert _check_mixin(dummy_mixin(MyTrainable))
 
 
 def test_remote_trial_dir_with_reuse_actors(ray_start_2_cpus, tmp_path):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

**TODO:** Finish running tests and update as needed.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
These were soft deprecated in favor as their AIR counterparts in the following PRs: 

- **(Ray 2.2)** https://github.com/ray-project/ray/pull/29828
- **(Ray 2.3)** https://github.com/ray-project/ray/pull/31295

For Ray 2.4, these will be hard deprecated.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
