### PR TITLE
[Datasets] Add meta_provider parameter into read_images

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -62,6 +62,7 @@ from ray.data.datasource.file_based_datasource import (
     _unwrap_arrow_serialization_workaround,
     _wrap_arrow_serialization_workaround,
 )
+from ray.data.datasource.image_datasource import _ImageFileMetadataProvider
 from ray.data.datasource.partitioning import Partitioning
 from ray.types import ObjectRef
 from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
@@ -572,6 +573,7 @@ def read_images(
     *,
     filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     parallelism: int = -1,
+    meta_provider: BaseFileMetadataProvider = _ImageFileMetadataProvider(),
     partition_filter: Optional[
         PathPartitionFilter
     ] = ImageDatasource.file_extension_filter(),
@@ -658,6 +660,7 @@ def read_images(
         paths=paths,
         filesystem=filesystem,
         parallelism=parallelism,
+        meta_provider=meta_provider,
         partition_filter=partition_filter,
         partitioning=partitioning,
         size=size,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Our user found out `read_images` provides a `meta_provider` in docstring, but it does not accept the parameter in code. Turns out we are missing the parameter here, so add the parameter to allow users to provide custom file meta provider. This parameter is provided by all other `read_xxx` APIs.

<img width="1659" alt="Screen Shot 2023-03-27 at 9 06 25 PM" src="https://user-images.githubusercontent.com/4629931/228125500-688a90e4-0ddf-47d8-ae19-558673897436.png">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
