### PR TITLE
[RLlin] Add dist_inputs to action sampler fn returns in TorchPolicyV2

### DIFF
--- a/rllib/algorithms/dreamer/dreamer_torch_policy.py
+++ b/rllib/algorithms/dreamer/dreamer_torch_policy.py
@@ -244,7 +244,7 @@ class DreamerTorchPolicy(TorchPolicyV2):
 
         policy.global_timestep += policy.config["env_config"]["frame_skip"]
 
-        return action, logp, state_batches
+        return action, logp, None, state_batches
 
     def make_model(self):
 

--- a/rllib/policy/torch_policy_v2.py
+++ b/rllib/policy/torch_policy_v2.py
@@ -1107,8 +1107,8 @@ class TorchPolicyV2(Policy):
             extra_fetches = fwd_out
             dist_inputs = None
         elif is_overridden(self.action_sampler_fn):
-            action_dist = dist_inputs = None
-            actions, logp, state_out = self.action_sampler_fn(
+            action_dist = None
+            actions, logp, dist_inputs, state_out = self.action_sampler_fn(
                 self.model,
                 obs_batch=input_dict,
                 state_batches=state_batches,


### PR DESCRIPTION
## Why are these changes needed?

This PR adds the action distribution inputs to the values returned by self.action_sampler_fn in TorchPolicyV2.
Before, there where not enough values to unpack when `action_sampler_fn` was implemented correctly.

I also explored unifying all `action_sampler_fn` occurrences in RLlib to four return values but I don't think that makes sense at this point. Most Policy classes will soon be deprecated anyway and we would be harddeprecating something (action_sampler_fn with three returns) that simply works for the time being.

Fixes https://github.com/ray-project/ray/issues/33716 