### PR TITLE
[Java] make java worker log file prefix (default to java-worker) configurable

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/util/LoggingUtil.java
+++ b/java/runtime/src/main/java/io/ray/runtime/util/LoggingUtil.java
@@ -79,8 +79,12 @@ public class LoggingUtil {
       RootLoggerComponentBuilder rootLoggerBuilder = globalConfigBuilder.newAsyncRootLogger(level);
       rootLoggerBuilder.addAttribute("RingBufferSize", "1048576");
       final String javaWorkerLogName = "JavaWorkerLogToRollingFile";
-      String logFileName = rayConfig.getInternalConfig().getString("ray.logging.file-prefix")
-        + "-" + jobIdHex + "-" + SystemUtil.pid();
+      String logFileName =
+          rayConfig.getInternalConfig().getString("ray.logging.file-prefix")
+              + "-"
+              + jobIdHex
+              + "-"
+              + SystemUtil.pid();
       setupLogger(
           globalConfigBuilder,
           rayConfig.logDir,

--- a/java/runtime/src/main/java/io/ray/runtime/util/LoggingUtil.java
+++ b/java/runtime/src/main/java/io/ray/runtime/util/LoggingUtil.java
@@ -79,7 +79,8 @@ public class LoggingUtil {
       RootLoggerComponentBuilder rootLoggerBuilder = globalConfigBuilder.newAsyncRootLogger(level);
       rootLoggerBuilder.addAttribute("RingBufferSize", "1048576");
       final String javaWorkerLogName = "JavaWorkerLogToRollingFile";
-      String logFileName = "java-worker-" + jobIdHex + "-" + SystemUtil.pid();
+      String logFileName = rayConfig.getInternalConfig().getString("ray.logging.file-prefix")
+        + "-" + jobIdHex + "-" + SystemUtil.pid();
       setupLogger(
           globalConfigBuilder,
           rayConfig.logDir,

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -89,6 +89,9 @@ ray {
     max-file-size: 500MB
     // Maximum number of backup files to keep around.
     max-backup-files: 10
+    // log file name prefix of default logger
+    // change it to something else other than "java-worker" if you dont want
+    // ray log monitor to poll and publish log to gcs from the log file
     file-prefix: java-worker
 
     // Configuration for the customized loggers.

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -89,6 +89,7 @@ ray {
     max-file-size: 500MB
     // Maximum number of backup files to keep around.
     max-backup-files: 10
+    file-prefix: java-worker
 
     // Configuration for the customized loggers.
     // For example, if you want to customize the file name and the log pattern for a logger

--- a/java/runtime/src/test/java/io/ray/runtime/config/RayConfigTest.java
+++ b/java/runtime/src/test/java/io/ray/runtime/config/RayConfigTest.java
@@ -15,4 +15,14 @@ public class RayConfigTest {
     Assert.assertEquals(
         Collections.singletonList("path/to/ray/job/resource/path"), rayConfig.codeSearchPath);
   }
+
+  @Test
+  public void testGetLogFilePrefix() {
+    String key = "ray.logging.file-prefix";
+    RayConfig rayConfig = RayConfig.create();
+    Assert.assertEquals("java-worker", rayConfig.getInternalConfig().getString(key));
+    System.setProperty(key, "raydp-java-worker");
+    rayConfig = RayConfig.create();
+    Assert.assertEquals("raydp-java-worker", rayConfig.getInternalConfig().getString(key));
+  }
 }


### PR DESCRIPTION
## Why are these changes needed?

For java worker, it's log file always being prefixed with "java-worker". And in python log_monitor.py, it hardcodes "java-worker*.log" to be polled for new log msg periodically. Some configs, like log_to_driver and RAY_BACKEND_LOG_LEVEL, don't prevent the log monitor from polling and publishing logs to gcs. To save some CPU cycle and network bandwidth, especially if there is large amount of logs produced from JVM, we can have an option. like a JVM system property, to set log file prefix for java worker instead of hard coded to "java-worker".

## Related issue number

Closes #33787 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
