### PR TITLE
[docs] collapse navbar for speed

### DIFF
--- a/doc/source/_templates/sbt-sidebar-nav.html
+++ b/doc/source/_templates/sbt-sidebar-nav.html
@@ -1,0 +1,21 @@
+<nav class="bd-links" id="bd-docs-nav" aria-label="Main Navigation">
+    <div class="bd-toc-item active">
+        {% if theme_home_page_in_toc == True %}
+        <ul class="nav bd-sidenav bd-sidenav__home-link">
+            <li class="toctree-l1{% if pagename == root_doc %} current active{% endif %}">
+                <a class="reference internal" href="{{ pathto(root_doc) }}">
+                    {{ root_title }}
+                </a>
+            </li>
+        </ul>
+        {% endif -%}
+       {{- generate_nav_html(
+              startdepth=0,
+              kind="sidebar",
+              maxdepth=4,
+              collapse=True,
+              includehidden=True,
+              titles_only=True,
+              show_nav_level=theme_show_navbar_depth) }}
+    </div>
+</nav>


### PR DESCRIPTION
Fully collapses the navigation (meaning: every click on a nav item triggers a dynamic reload, no static drop-downs), as this turns out to be the best option for our needs. Drastically speed up our build, while fully keeping the new API section structure intact. The main drawback of this change is that we lose the visual clues telling you whether a nav item is shallow or nested (drops down).

On my local machine, I see the following build speeds (for reference, right now it's more than an hour):

```
Clean run:
make html  445.64s user 19.38s system 97% cpu 7:58.52 total


Incremental build:
make html  64.10s user 5.28s system 92% cpu 1:15.24 total
```

In other words, with this change we shouldn't have any problems with build times anymore. This is how the nav looks like at first, fully collapsed:

![Screenshot 2023-03-28 at 14 03 42](https://user-images.githubusercontent.com/3462566/228232210-25f078aa-d695-4fd8-afdc-e62c3fd89578.png)

Then, when you click through the nav tree, you see the navigation evolve as before this change:

![Screenshot 2023-03-28 at 14 04 48](https://user-images.githubusercontent.com/3462566/228232395-42427e15-7fcb-42d7-a36a-1ee1c1c7c776.png)

