### PR TITLE
[ci] Split docker image tagging in build script

### DIFF
--- a/.buildkite/pipeline.arm64.yml
+++ b/.buildkite/pipeline.arm64.yml
@@ -64,7 +64,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py37 --device-types cpu cu112 --build-type BUILDKITE --build-base --suffix aarch64
+    - python ./ci/build/build-docker-images.py --py-versions py37 -T cpu -T cu112 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py37 [aarch64] (2/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -74,7 +74,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py37 --device-types cu113 cu116 cu118 --build-type BUILDKITE --build-base --suffix aarch64
+    - python ./ci/build/build-docker-images.py --py-versions py37 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py38 [aarch64] (1/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -84,7 +84,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py38 --device-types cpu cu112 --build-type BUILDKITE --build-base --suffix aarch64
+    - python ./ci/build/build-docker-images.py --py-versions py38 -T cpu -T cu112 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py38 [aarch64] (2/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -94,7 +94,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py38 --device-types cu113 cu116 cu118 --build-type BUILDKITE --build-base --suffix aarch64
+    - python ./ci/build/build-docker-images.py --py-versions py38 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py39 [aarch64] (1/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -104,7 +104,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py39 --device-types cpu cu112 --build-type BUILDKITE --build-base --suffix aarch64
+    - python ./ci/build/build-docker-images.py --py-versions py39 -T cpu -T cu112 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py39 [aarch64] (2/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -114,7 +114,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py39 --device-types cu113 cu116 cu118 --build-type BUILDKITE --build-base --suffix aarch64
+    - python ./ci/build/build-docker-images.py --py-versions py39 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py310 [aarch64] (1/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -124,7 +124,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py310 --device-types cpu cu112 --build-type BUILDKITE --build-base --suffix aarch64
+    - python ./ci/build/build-docker-images.py --py-versions py310 -T cpu -T cu112 --build-type BUILDKITE --build-base --suffix aarch64
 
 - label: ":mechanical_arm: :docker: Build Images: py310 [aarch64] (2/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -133,4 +133,4 @@
     - LINUX_WHEELS=1 ./ci/ci.sh build
     - pip install -q docker aws_requests_auth boto3
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py310 --device-types cu113 cu116 cu118 --build-type BUILDKITE --build-base --suffix aarch64
+    - python ./ci/build/build-docker-images.py --py-versions py310 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base --suffix aarch64

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -92,7 +92,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py37 --device-types cpu cu101 cu102 cu110 --build-type BUILDKITE --build-base
+    - python ./ci/build/build-docker-images.py --py-versions py37 -T cpu -T cu101 -T cu102 -T cu110 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py37 (2/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -102,7 +102,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py37 --device-types cu111 cu112 cu113 cu116 cu118 --build-type BUILDKITE --build-base
+    - python ./ci/build/build-docker-images.py --py-versions py37 -T cu111 -T cu112 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py38 (1/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -112,7 +112,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py38 --device-types cpu cu101 cu102 cu110 --build-type BUILDKITE --build-base
+    - python ./ci/build/build-docker-images.py --py-versions py38 -T cpu -T cu101 -T cu102 -T cu110 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py38 (2/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -122,7 +122,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py38 --device-types cu111 cu112 cu113 cu116 cu118 --build-type BUILDKITE --build-base
+    - python ./ci/build/build-docker-images.py --py-versions py38 -T cu111 -T cu112 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py39 (1/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -132,7 +132,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py39 --device-types cpu cu101 cu102 cu110 --build-type BUILDKITE --build-base
+    - python ./ci/build/build-docker-images.py --py-versions py39 -T cpu -T cu101 -T cu102 -T cu110 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py39 (2/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -142,7 +142,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py39 --device-types cu111 cu112 cu113 cu116 cu118 --build-type BUILDKITE --build-base
+    - python ./ci/build/build-docker-images.py --py-versions py39 -T cu111 -T cu112 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py310 (1/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -152,7 +152,7 @@
     - pip install -q docker aws_requests_auth boto3
     - ./ci/env/env_info.sh
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py310 --device-types cpu cu101 cu102 cu110 --build-type BUILDKITE --build-base
+    - python ./ci/build/build-docker-images.py --py-versions py310 -T cpu -T cu101 -T cu102 -T cu110 --build-type BUILDKITE --build-base
 
 - label: ":docker: Build Images: py310 (2/2)"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -161,7 +161,7 @@
     - LINUX_WHEELS=1 ./ci/ci.sh build
     - pip install -q docker aws_requests_auth boto3
     - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py310 --device-types cu111 cu112 cu113 cu116 cu118 --build-type BUILDKITE --build-base
+    - python ./ci/build/build-docker-images.py --py-versions py310 -T cu111 -T cu112 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base
 
 - label: ":java: Java"
   conditions: ["RAY_CI_JAVA_AFFECTED"]

--- a/ci/build/build-docker-images.py
+++ b/ci/build/build-docker-images.py
@@ -710,6 +710,7 @@ BUILD_TYPES = [MERGE, HUMAN, PR, BUILDKITE, LOCAL]
 @click.command()
 @click.option(
     "--py-versions",
+    "-V",
     default=["py37"],
     type=click.Choice(list(PY_MATRIX.keys())),
     multiple=True,
@@ -718,6 +719,7 @@ BUILD_TYPES = [MERGE, HUMAN, PR, BUILDKITE, LOCAL]
 )
 @click.option(
     "--device-types",
+    "-T",
     default=[],
     type=click.Choice(list(BASE_IMAGES.keys())),
     multiple=True,
@@ -746,17 +748,21 @@ BUILD_TYPES = [MERGE, HUMAN, PR, BUILDKITE, LOCAL]
     help="Whether only to build ray-worker-container",
 )
 def main(
-    py_versions: List[str],
-    device_types: List[str],
+    py_versions: Tuple[str],
+    device_types: Tuple[str],
     build_type: str,
     suffix: Optional[str] = None,
     build_base: bool = True,
     only_build_worker_container: bool = False,
 ):
-    py_versions = py_versions
-    py_versions = py_versions if isinstance(py_versions, list) else [py_versions]
-
-    image_types = device_types if device_types else list(BASE_IMAGES.keys())
+    py_versions = (
+        list(py_versions) if isinstance(py_versions, (list, tuple)) else [py_versions]
+    )
+    image_types = (
+        list(device_types)
+        if isinstance(device_types, (list, tuple))
+        else list(BASE_IMAGES.keys())
+    )
 
     assert set(list(CUDA_FULL.keys()) + ["cpu"]) == set(BASE_IMAGES.keys())
 

--- a/ci/build/build-docker-images.py
+++ b/ci/build/build-docker-images.py
@@ -1,4 +1,3 @@
-import argparse
 import datetime
 import json
 import functools
@@ -13,6 +12,7 @@ import sys
 from collections import defaultdict
 from typing import List, Optional, Tuple
 
+import click
 import docker
 
 print = functools.partial(print, file=sys.stderr, flush=True)
@@ -469,6 +469,79 @@ def _create_new_tags(all_tags, old_str, new_str):
     return new_tags
 
 
+def create_image_tags(
+    image_name: str,
+    py_versions: List[str],
+    image_types: List[str],
+    specific_tag: Optional[str] = None,
+    version: str = "nightly",
+    suffix: Optional[str] = None,
+):
+    # Mapping from old tags to new tags.
+    # These are the tags we will push.
+    # The key is the full image name, and the values are all the tags
+    # for that image.
+    tag_mapping = defaultdict(list)
+    for py_name in py_versions:
+        for image_type in image_types:
+            if image_name == "ray-ml" and image_type not in [
+                ML_CUDA_VERSION,
+                "cpu",
+            ]:
+                print(
+                    "ML Docker image is not built for the following "
+                    f"device type: {image_type}"
+                )
+                continue
+
+            tag = _with_suffix(f"{version}-{py_name}-{image_type}", suffix=suffix)
+
+            tag_mapping[tag].append(tag)
+
+    # If no device is specified, it should map to CPU image.
+    # For ray-ml image, if no device specified, it should map to GPU image.
+    # "-gpu" tag should refer to the ML_CUDA_VERSION
+    for old_tag in tag_mapping.keys():
+        if "cpu" in old_tag and image_name != "ray-ml":
+            new_tags = _create_new_tags(
+                tag_mapping[old_tag], old_str="-cpu", new_str=""
+            )
+            tag_mapping[old_tag].extend(new_tags)
+        elif ML_CUDA_VERSION in old_tag:
+            new_tags = _create_new_tags(
+                tag_mapping[old_tag], old_str=f"-{ML_CUDA_VERSION}", new_str="-gpu"
+            )
+            tag_mapping[old_tag].extend(new_tags)
+
+            if image_name == "ray-ml":
+                new_tags = _create_new_tags(
+                    tag_mapping[old_tag], old_str=f"-{ML_CUDA_VERSION}", new_str=""
+                )
+                tag_mapping[old_tag].extend(new_tags)
+
+    # No Python version specified should refer to DEFAULT_PYTHON_VERSION
+    for old_tag in tag_mapping.keys():
+        if DEFAULT_PYTHON_VERSION in old_tag:
+            new_tags = _create_new_tags(
+                tag_mapping[old_tag],
+                old_str=f"-{DEFAULT_PYTHON_VERSION}",
+                new_str="",
+            )
+            tag_mapping[old_tag].extend(new_tags)
+
+    # For all tags, create Date/Sha tags
+    if specific_tag:
+        for old_tag in tag_mapping.keys():
+            new_tags = _create_new_tags(
+                tag_mapping[old_tag],
+                old_str=version,
+                new_str=specific_tag,
+            )
+            tag_mapping[old_tag].extend(new_tags)
+
+    return tag_mapping
+
+
 # For non-release builds, push "nightly" & "sha"
 # For release builds, push "nightly" & "latest" & "x.x.x"
 def push_and_tag_images(
@@ -489,66 +562,14 @@ def push_and_tag_images(
     for image_name in image_list:
         full_image_name = f"rayproject/{image_name}"
 
-        # Mapping from old tags to new tags.
-        # These are the tags we will push.
-        # The key is the full image name, and the values are all the tags
-        # for that image.
-        tag_mapping = defaultdict(list)
-        for py_name in py_versions:
-            for image_type in image_types:
-                if image_name == "ray-ml" and image_type not in [
-                    ML_CUDA_VERSION,
-                    "cpu",
-                ]:
-                    print(
-                        "ML Docker image is not built for the following "
-                        f"device type: {image_type}"
-                    )
-                    continue
-
-                tag = _with_suffix(f"nightly-{py_name}-{image_type}", suffix=suffix)
-
-                tag_mapping[tag].append(tag)
-
-        # If no device is specified, it should map to CPU image.
-        # For ray-ml image, if no device specified, it should map to GPU image.
-        # "-gpu" tag should refer to the ML_CUDA_VERSION
-        for old_tag in tag_mapping.keys():
-            if "cpu" in old_tag and image_name != "ray-ml":
-                new_tags = _create_new_tags(
-                    tag_mapping[old_tag], old_str="-cpu", new_str=""
-                )
-                tag_mapping[old_tag].extend(new_tags)
-            elif ML_CUDA_VERSION in old_tag:
-                new_tags = _create_new_tags(
-                    tag_mapping[old_tag], old_str=f"-{ML_CUDA_VERSION}", new_str="-gpu"
-                )
-                tag_mapping[old_tag].extend(new_tags)
-
-                if image_name == "ray-ml":
-                    new_tags = _create_new_tags(
-                        tag_mapping[old_tag], old_str=f"-{ML_CUDA_VERSION}", new_str=""
-                    )
-                    tag_mapping[old_tag].extend(new_tags)
-
-        # No Python version specified should refer to DEFAULT_PYTHON_VERSION
-        for old_tag in tag_mapping.keys():
-            if DEFAULT_PYTHON_VERSION in old_tag:
-                new_tags = _create_new_tags(
-                    tag_mapping[old_tag],
-                    old_str=f"-{DEFAULT_PYTHON_VERSION}",
-                    new_str="",
-                )
-                tag_mapping[old_tag].extend(new_tags)
-
-        # For all tags, create Date/Sha tags
-        for old_tag in tag_mapping.keys():
-            new_tags = _create_new_tags(
-                tag_mapping[old_tag],
-                old_str="nightly",
-                new_str=date_tag if "-deps" in image_name else sha_tag,
-            )
-            tag_mapping[old_tag].extend(new_tags)
+        tag_mapping = create_image_tags(
+            image_name=image_name,
+            py_versions=py_versions,
+            image_types=image_types,
+            specific_tag=date_tag if "-deps" in image_name else sha_tag,
+            version="nightly",
+            suffix=suffix,
+        )
 
         print(f"These tags will be created for {image_name}: ", tag_mapping)
 
@@ -685,57 +706,57 @@ BUILDKITE = "BUILDKITE"
 LOCAL = "LOCAL"
 BUILD_TYPES = [MERGE, HUMAN, PR, BUILDKITE, LOCAL]
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--py-versions",
-        choices=list(PY_MATRIX.keys()),
-        default="py37",
-        nargs="*",
-        help="Which python versions to build. "
-        "Must be in (py36, py37, py38, py39, py310, py311)",
-    )
-    parser.add_argument(
-        "--device-types",
-        choices=list(BASE_IMAGES.keys()),
-        default=None,
-        nargs="*",
-        help="Which device types (CPU/CUDA versions) to build images for. "
-        "If not specified, images will be built for all device types.",
-    )
-    parser.add_argument(
-        "--build-type",
-        choices=BUILD_TYPES,
-        required=True,
-        help="Whether to bypass checking if docker is affected",
-    )
-    parser.add_argument(
-        "--suffix",
-        required=False,
-        choices=ADDITIONAL_PLATFORMS,
-        help="Suffix to append to the build tags",
-    )
-    parser.add_argument(
-        "--build-base",
-        dest="base",
-        action="store_true",
-        help="Whether to build base-deps & ray-deps",
-    )
-    parser.add_argument("--no-build-base", dest="base", action="store_false")
-    parser.set_defaults(base=True)
-    parser.add_argument(
-        "--only-build-worker-container",
-        dest="only_build_worker_container",
-        action="store_true",
-        help="Whether only to build ray-worker-container",
-    )
-    parser.set_defaults(only_build_worker_container=False)
 
-    args = parser.parse_args()
-    py_versions = args.py_versions
+@click.command()
+@click.option(
+    "--py-versions",
+    default=["py37"],
+    type=click.Choice(list(PY_MATRIX.keys())),
+    multiple=True,
+    help="Which python versions to build. "
+    "Must be in (py36, py37, py38, py39, py310, py311)",
+)
+@click.option(
+    "--device-types",
+    default=[],
+    type=click.Choice(list(BASE_IMAGES.keys())),
+    multiple=True,
+    help="Which device types (CPU/CUDA versions) to build images for. "
+    "If not specified, images will be built for all device types.",
+)
+@click.option(
+    "--build-type",
+    type=click.Choice(BUILD_TYPES),
+    required=True,
+    help="Whether to bypass checking if docker is affected",
+)
+@click.option(
+    "--suffix",
+    type=click.Choice(ADDITIONAL_PLATFORMS),
+    help="Suffix to append to the build tags",
+)
+@click.option(
+    "--build-base/--no-build-base",
+    default=True,
+    help="Whether to build base-deps & ray-deps",
+)
+@click.option(
+    "--only-build-worker-container/--no-only-build-worker-container",
+    default=False,
+    help="Whether only to build ray-worker-container",
+)
+def main(
+    py_versions: List[str],
+    device_types: List[str],
+    build_type: str,
+    suffix: Optional[str] = None,
+    build_base: bool = True,
+    only_build_worker_container: bool = False,
+):
+    py_versions = py_versions
     py_versions = py_versions if isinstance(py_versions, list) else [py_versions]
 
-    image_types = args.device_types if args.device_types else list(BASE_IMAGES.keys())
+    image_types = device_types if device_types else list(BASE_IMAGES.keys())
 
     assert set(list(CUDA_FULL.keys()) + ["cpu"]) == set(BASE_IMAGES.keys())
 
@@ -767,9 +788,8 @@ if __name__ == "__main__":
         [PY_MATRIX[py_version] for py_version in py_versions],
     )
     print("Building images for the following devices: ", image_types)
-    print("Building base images: ", args.base)
+    print("Building base images: ", build_base)
 
-    build_type = args.build_type
     is_buildkite = build_type == BUILDKITE
     is_local = build_type == LOCAL
 
@@ -785,7 +805,7 @@ if __name__ == "__main__":
     if (
         build_type in {HUMAN, MERGE, BUILDKITE, LOCAL}
         or _check_if_docker_files_modified()
-        or args.only_build_worker_container
+        or only_build_worker_container
     ):
         DOCKER_CLIENT = docker.from_env()
         is_merge = build_type == MERGE
@@ -797,17 +817,17 @@ if __name__ == "__main__":
             DOCKER_CLIENT.api.login(username=username, password=password)
         copy_wheels(build_type == HUMAN)
         is_base_images_built = build_or_pull_base_images(
-            py_versions, image_types, args.base, suffix=args.suffix
+            py_versions, image_types, build_base, suffix=suffix
         )
 
-        if args.only_build_worker_container:
+        if only_build_worker_container:
             build_for_all_versions(
-                "ray-worker-container", py_versions, image_types, suffix=args.suffix
+                "ray-worker-container", py_versions, image_types, suffix=suffix
             )
             # TODO Currently don't push ray_worker_container
         else:
             # Build Ray Docker images.
-            build_for_all_versions("ray", py_versions, image_types, suffix=args.suffix)
+            build_for_all_versions("ray", py_versions, image_types, suffix=suffix)
 
             # List of images to tag and push to docker hub
             images_to_tag_and_push = []
@@ -835,7 +855,7 @@ if __name__ == "__main__":
                     "ray-ml",
                     py_versions,
                     image_types=ml_image_types,
-                    suffix=args.suffix,
+                    suffix=suffix,
                 )
                 images_to_tag_and_push += ["ray-ml"]
 
@@ -848,9 +868,13 @@ if __name__ == "__main__":
                     image_types,
                     merge_build=valid_branch and is_merge,
                     image_list=images_to_tag_and_push,
-                    suffix=args.suffix,
+                    suffix=suffix,
                 )
 
         # TODO(ilr) Re-Enable Push READMEs by using a normal password
         # (not auth token :/)
         # push_readmes(build_type is MERGE)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/build/build-docker-images.py
+++ b/ci/build/build-docker-images.py
@@ -17,7 +17,7 @@ import docker
 
 print = functools.partial(print, file=sys.stderr, flush=True)
 DOCKER_USERNAME = "raytravisbot"
-DOCKER_CLIENT = None
+DOCKER_CLIENT = docker.from_env()
 PYTHON_WHL_VERSION = "cp3"
 ADDITIONAL_PLATFORMS = ["aarch64"]
 
@@ -813,7 +813,6 @@ def main(
         or _check_if_docker_files_modified()
         or only_build_worker_container
     ):
-        DOCKER_CLIENT = docker.from_env()
         is_merge = build_type == MERGE
         # Buildkite is authenticated in the background.
         if is_merge and not is_buildkite and not is_local:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In order to re-use the docker tags (e.g. for fixing already published images) the code to generate said tags should be split.

This PR also refactors the script to use click instead of argparse.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
