### PR TITLE
[RLlib] Fix apex dqn deprecated add_batch call

### DIFF
--- a/rllib/algorithms/apex_dqn/apex_dqn.py
+++ b/rllib/algorithms/apex_dqn/apex_dqn.py
@@ -426,7 +426,7 @@ class ApexDQN(DQN):
                 batch = local_sampling_worker.sample()
                 actor_id = random.choice(self._replay_actor_manager.healthy_actor_ids())
                 self._replay_actor_manager.foreach_actor(
-                    lambda actor: actor.add_batch(batch),
+                    lambda actor: actor.add(batch),
                     remote_actor_ids=[actor_id],
                     timeout_seconds=0,
                 )


### PR DESCRIPTION
Signed-off-by: Avnish <avnishnarayan@gmail.com>

Inside of the apex dqn training step, we called actor.add_batch when using remote replay buffers, which is a deprecated api. Though it was hard deprecated, our apex examples did not fail since the actor manager attempts to bring this actor back up every time this call happens and subsequently fails. 

This pr closes this issue by using the buffer.add call instead, though there should be some thought that we give to when we should force actors to fail and when we shouldn't 


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
