### PR TITLE
[RLlib][RLModule] Fixes check_train_results util to work with the new learner stack

### DIFF
--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -688,6 +688,11 @@ def check_train_results(train_results: PartialAlgorithmConfigDict) -> ResultDict
     for pid, policy_stats in learner_info.items():
         if pid == "batch_count":
             continue
+        
+        # the pid can be __all__ in multi-agent case when the new learner stack is 
+        # enabled.
+        if pid == "__all__":
+            continue
 
         # Make sure each policy has the LEARNER_STATS_KEY under it.
         assert LEARNER_STATS_KEY in policy_stats

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -688,8 +688,8 @@ def check_train_results(train_results: PartialAlgorithmConfigDict) -> ResultDict
     for pid, policy_stats in learner_info.items():
         if pid == "batch_count":
             continue
-        
-        # the pid can be __all__ in multi-agent case when the new learner stack is 
+
+        # the pid can be __all__ in multi-agent case when the new learner stack is
         # enabled.
         if pid == "__all__":
             continue


### PR DESCRIPTION
This PR fixes two failing tests when learner_api is enabled.

```
rllib/models/tests/test_preprocessors.py::TestPreprocessors::test_rlms_and_preprocessing FAILED
rllib/tests/test_supported_multi_agent.py::TestSupportedMultiAgentPG::test_ppo_multiagent FAILED
```

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
