### PR TITLE
[data] Fix use of deprecated API in new batching code path

### DIFF
--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -299,7 +299,7 @@ class ActorBlockPrefetcher(BlockPrefetcher):
 
     @staticmethod
     def _get_or_create_actor_prefetcher() -> "ActorHandle":
-        node_id = ray.get_runtime_context().node_id
+        node_id = ray.get_runtime_context().get_node_id()
         actor_name = f"dataset-block-prefetcher-{node_id}"
         return _BlockPretcher.options(
             scheduling_strategy=NodeAffinitySchedulingStrategy(node_id, soft=False),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, you get a very ugly

(Consumer pid=14975, ip=10.0.1.27) /home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/block_batching/util.py:302: RayDeprecationWarning: This API is deprecated and may be removed in future Ray releases. You could suppress this warning by setting env variable PYTHONWARNINGS="ignore::DeprecationWarning"

warning when using Datasets.
