### PR TITLE
[Datasets] [Operator Fusion - 4/N] Add metrics collection abstractions, without instrumentation.

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -412,6 +412,14 @@ py_test(
 )
 
 py_test(
+    name = "test_metrics",
+    size = "small",
+    srcs = ["tests/test_metrics.py"],
+    tags = ["team:data", "exclusive"],
+    deps = ["//:ray_lib", ":conftest"],
+)
+
+py_test(
     name = "test_streaming_executor",
     size = "small",
     srcs = ["tests/test_streaming_executor.py"],

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -253,7 +253,7 @@ class ActorPoolMapOperator(MapOperator):
         return ExecutionResources(
             cpu=self._ray_remote_args.get("num_cpus", 0) * num_active_workers,
             gpu=self._ray_remote_args.get("num_gpus", 0) * num_active_workers,
-            object_store_memory=self._metrics.cur,
+            object_store_memory=self._metrics.object_store_metrics.cur,
         )
 
     def incremental_resource_usage(self) -> ExecutionResources:

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -98,7 +98,7 @@ class TaskPoolMapOperator(MapOperator):
         return ExecutionResources(
             cpu=self._ray_remote_args.get("num_cpus", 0) * num_active_workers,
             gpu=self._ray_remote_args.get("num_gpus", 0) * num_active_workers,
-            object_store_memory=self._metrics.cur,
+            object_store_memory=self._metrics.object_store_metrics.cur,
         )
 
     def incremental_resource_usage(self) -> ExecutionResources:

--- a/python/ray/data/_internal/metrics.py
+++ b/python/ray/data/_internal/metrics.py
@@ -51,9 +51,9 @@ class DataMungingMetrics(Metrics):
     """
 
     num_rows_copied: int = 0
-    num_format_conversions: int = 0
     num_rows_sliced: int = 0
     num_rows_concatenated: int = 0
+    num_rows_format_converted: int = 0
 
 
 @dataclass

--- a/python/ray/data/_internal/metrics.py
+++ b/python/ray/data/_internal/metrics.py
@@ -1,0 +1,94 @@
+from abc import ABC
+from dataclasses import dataclass, fields
+import operator
+
+from typing import Dict, Callable
+
+
+@dataclass
+class Metrics(ABC):
+    """Internal metrics struct, with helpers for merging metrics and returning a
+    user-friendly dict representation.
+    """
+
+    def merge_with(self, other: "Metrics"):
+        """Merge with provided metrics."""
+        if not isinstance(other, type(self)):
+            raise ValueError(f"Expected {type(self)}, got: {type(other)}")
+
+        merged_metrics = {}
+        for metric_field in fields(other):
+            metric_name = metric_field.name
+            self_metric = getattr(self, metric_name)
+            other_metric = getattr(other, metric_name)
+            if isinstance(self_metric, Metrics):
+                assert isinstance(other_metric, Metrics)
+                new_metric = self_metric.merge_with(other_metric)
+            else:
+                metric_merger = self._get_metric_merger(metric_name)
+                new_metric = metric_merger(self_metric, other_metric)
+            merged_metrics[metric_name] = new_metric
+        return type(other)(**merged_metrics)
+
+    def _get_metric_merger(self, metric: str) -> Callable[[int, int], int]:
+        return operator.add
+
+    def to_metrics_dict(self) -> Dict[str, int]:
+        """Return a dictionary view of these metrics."""
+        metrics = {}
+        for metric in fields(self):
+            metric_value = getattr(self, metric.name)
+            if isinstance(metric_value, Metrics):
+                metric_value = metric_value.to_metrics_dict()
+            metrics[metric.name] = metric_value
+        return metrics
+
+
+@dataclass
+class DataMungingMetrics(Metrics):
+    """
+    Metrics for data munging, e.g. data slicing, concatenation, format conversions.
+    """
+
+    num_rows_copied: int = 0
+    num_format_conversions: int = 0
+    num_rows_sliced: int = 0
+    num_rows_concatenated: int = 0
+
+
+@dataclass
+class ObjectStoreMetrics(Metrics):
+    """Metrics for object store memory allocations."""
+
+    alloc: int
+    freed: int
+    cur: int
+    peak: int
+
+    def _get_metric_merger(self, metric: str) -> Callable[[int, int], int]:
+        if metric == "peak":
+            # Take the max of the peak metric.
+            return max
+        else:
+            # Otherwise sum.
+            return operator.add
+
+    def to_metrics_dict(self) -> Dict[str, int]:
+        return {
+            "obj_store_mem_alloc": self.alloc,
+            "obj_store_mem_freed": self.freed,
+            "obj_store_mem_peak": self.peak,
+        }
+
+
+class MetricsCollector:
+    """Metrics collector, for recording and returning merged metrics."""
+
+    def __init__(self):
+        self._metrics = DataMungingMetrics()
+
+    def record_metrics(self, metrics: DataMungingMetrics):
+        self._metrics = self._metrics.merge_with(metrics)
+
+    def get_metrics(self) -> DataMungingMetrics:
+        return self._metrics

--- a/python/ray/data/_internal/metrics.py
+++ b/python/ray/data/_internal/metrics.py
@@ -82,7 +82,13 @@ class ObjectStoreMetrics(Metrics):
 
 
 class MetricsCollector:
-    """Metrics collector, for recording and returning merged metrics."""
+    """
+    Metrics collector, for recording and returning merged data munging metrics.
+
+    An instance of this MetricsCollector is passed throughout the data layer, with data
+    munging metrics recorded after batching, formatting, output buffering, etc. The
+    merged metrics are then materialized at the end of execution.
+    """
 
     def __init__(self):
         self._metrics = DataMungingMetrics()

--- a/python/ray/data/tests/test_metrics.py
+++ b/python/ray/data/tests/test_metrics.py
@@ -89,25 +89,25 @@ def test_data_munging_metrics():
     # Test DataMungingMetrics merging and dict view.
     m1 = DataMungingMetrics(
         num_rows_copied=6,
-        num_format_conversions=1,
+        num_rows_format_converted=5,
         num_rows_sliced=2,
         num_rows_concatenated=4,
     )
     m2 = DataMungingMetrics(
         num_rows_copied=8,
-        num_format_conversions=1,
+        num_rows_format_converted=7,
         num_rows_sliced=3,
         num_rows_concatenated=5,
     )
 
     m = m1.merge_with(m2)
     assert m.num_rows_copied == 14
-    assert m.num_format_conversions == 2
+    assert m.num_rows_format_converted == 12
     assert m.num_rows_sliced == 5
     assert m.num_rows_concatenated == 9
     assert m.to_metrics_dict() == {
         "num_rows_copied": 14,
-        "num_format_conversions": 2,
+        "num_rows_format_converted": 12,
         "num_rows_sliced": 5,
         "num_rows_concatenated": 9,
     }
@@ -135,14 +135,14 @@ def test_metrics_collector():
     metrics_collector = MetricsCollector()
     m1 = DataMungingMetrics(
         num_rows_copied=6,
-        num_format_conversions=1,
+        num_rows_format_converted=5,
         num_rows_sliced=2,
         num_rows_concatenated=4,
     )
     metrics_collector.record_metrics(m1)
     m2 = DataMungingMetrics(
         num_rows_copied=8,
-        num_format_conversions=1,
+        num_rows_format_converted=7,
         num_rows_sliced=3,
         num_rows_concatenated=5,
     )
@@ -150,12 +150,12 @@ def test_metrics_collector():
 
     m = metrics_collector.get_metrics()
     assert m.num_rows_copied == 14
-    assert m.num_format_conversions == 2
+    assert m.num_rows_format_converted == 12
     assert m.num_rows_sliced == 5
     assert m.num_rows_concatenated == 9
     assert m.to_metrics_dict() == {
         "num_rows_copied": 14,
-        "num_format_conversions": 2,
+        "num_rows_format_converted": 12,
         "num_rows_sliced": 5,
         "num_rows_concatenated": 9,
     }

--- a/python/ray/data/tests/test_metrics.py
+++ b/python/ray/data/tests/test_metrics.py
@@ -1,0 +1,161 @@
+from dataclasses import dataclass
+from typing import Callable
+
+import pytest
+
+from ray.data._internal.metrics import (
+    Metrics,
+    DataMungingMetrics,
+    ObjectStoreMetrics,
+    MetricsCollector,
+)
+from ray.tests.conftest import *  # noqa
+
+
+@dataclass
+class TestMetrics(Metrics):
+    a: int = 1
+    b: int = 2
+
+
+def test_metrics_to_dict():
+    # Test that dictionary view of metrics is as expected.
+    metrics = TestMetrics(a=2, b=3)
+
+    assert metrics.to_metrics_dict() == {"a": 2, "b": 3}
+
+
+def test_metrics_merge():
+    # Test metrics merging.
+    m1 = TestMetrics()
+    m2 = TestMetrics(a=3, b=5)
+
+    m = m1.merge_with(m2)
+    assert m.a == 4
+    assert m.b == 7
+    assert m.to_metrics_dict() == {"a": 4, "b": 7}
+
+
+@dataclass
+class TestMetricsWithCustomMerger(Metrics):
+    a: int = 0
+    b: int = 2
+
+    def _get_metric_merger(self, metric: str) -> Callable[[int, int], int]:
+        if metric == "a":
+            return max
+        else:
+            return super()._get_metric_merger(metric)
+
+
+def test_metrics_custom_merger():
+    # Test metrics merging with custom merger function.
+    m1 = TestMetricsWithCustomMerger(a=3, b=3)
+    m2 = TestMetricsWithCustomMerger(a=4, b=7)
+
+    m = m1.merge_with(m2)
+    assert m.a == 4
+    assert m.b == 10
+    assert m.to_metrics_dict() == {"a": 4, "b": 10}
+
+
+def test_metrics_merging_different_types_fails():
+    # Test that merging Metrics subclasses with different types fails.
+    m1 = TestMetrics()
+    m2 = TestMetricsWithCustomMerger()
+    with pytest.raises(ValueError):
+        m1.merge_with(m2)
+
+
+@dataclass
+class TestNestedMetrics(Metrics):
+    a: int
+    sub_metrics: TestMetrics
+
+
+def test_metrics_nested():
+    # Test that nested metrics are merged correctly and have the correct dict view.
+    m1 = TestNestedMetrics(a=1, sub_metrics=TestMetrics())
+    m2 = TestNestedMetrics(a=2, sub_metrics=TestMetrics(a=3, b=4))
+
+    m = m1.merge_with(m2)
+    assert m.a == 3
+    assert m.sub_metrics.a == 4
+    assert m.sub_metrics.b == 6
+    assert m.to_metrics_dict() == {"a": 3, "sub_metrics": {"a": 4, "b": 6}}
+
+
+def test_data_munging_metrics():
+    # Test DataMungingMetrics merging and dict view.
+    m1 = DataMungingMetrics(
+        num_rows_copied=6,
+        num_format_conversions=1,
+        num_rows_sliced=2,
+        num_rows_concatenated=4,
+    )
+    m2 = DataMungingMetrics(
+        num_rows_copied=8,
+        num_format_conversions=1,
+        num_rows_sliced=3,
+        num_rows_concatenated=5,
+    )
+
+    m = m1.merge_with(m2)
+    assert m.num_rows_copied == 14
+    assert m.num_format_conversions == 2
+    assert m.num_rows_sliced == 5
+    assert m.num_rows_concatenated == 9
+    assert m.to_metrics_dict() == {
+        "num_rows_copied": 14,
+        "num_format_conversions": 2,
+        "num_rows_sliced": 5,
+        "num_rows_concatenated": 9,
+    }
+
+
+def test_object_store_metrics():
+    # Test ObjectStoreMetrics merging and dict view.
+    m1 = ObjectStoreMetrics(alloc=8, freed=2, cur=3, peak=4)
+    m2 = ObjectStoreMetrics(alloc=16, freed=6, cur=4, peak=8)
+
+    m = m1.merge_with(m2)
+    assert m.alloc == 24
+    assert m.freed == 8
+    assert m.cur == 7
+    assert m.peak == 8
+    assert m.to_metrics_dict() == {
+        "obj_store_mem_alloc": 24,
+        "obj_store_mem_freed": 8,
+        "obj_store_mem_peak": 8,
+    }
+
+
+def test_metrics_collector():
+    # Test MetricsCollector metrics recording/merging.
+    metrics_collector = MetricsCollector()
+    m1 = DataMungingMetrics(
+        num_rows_copied=6,
+        num_format_conversions=1,
+        num_rows_sliced=2,
+        num_rows_concatenated=4,
+    )
+    metrics_collector.record_metrics(m1)
+    m2 = DataMungingMetrics(
+        num_rows_copied=8,
+        num_format_conversions=1,
+        num_rows_sliced=3,
+        num_rows_concatenated=5,
+    )
+    metrics_collector.record_metrics(m2)
+
+    m = metrics_collector.get_metrics()
+    assert m.num_rows_copied == 14
+    assert m.num_format_conversions == 2
+    assert m.num_rows_sliced == 5
+    assert m.num_rows_concatenated == 9
+    assert m.to_metrics_dict() == {
+        "num_rows_copied": 14,
+        "num_format_conversions": 2,
+        "num_rows_sliced": 5,
+        "num_rows_concatenated": 9,
+    }


### PR DESCRIPTION
This PR adds the metrics collection abstractions that will be used for instrumenting the Datasets data layer; this PR is a precursor to https://github.com/ray-project/ray/pull/32749.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
