### PR TITLE
[RLlib][RLModule] The flattening of 2D spaces is deprecated in the new stack, so we need to properly apply CNNs to PettingZoo pixel-based envs, even if they are grayscale

### DIFF
--- a/rllib/tests/test_pettingzoo_env.py
+++ b/rllib/tests/test_pettingzoo_env.py
@@ -1,13 +1,31 @@
 from numpy import float32
 from pettingzoo.butterfly import pistonball_v6
 from pettingzoo.mpe import simple_spread_v2
-from supersuit import normalize_obs_v0, dtype_v0, color_reduction_v0
+from supersuit import (
+    color_reduction_v0,
+    dtype_v0,
+    normalize_obs_v0,
+    observation_lambda_v0,
+    resize_v1,
+)
+from supersuit.utils.convert_box import convert_box
+
 import unittest
 
 import ray
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.env import PettingZooEnv
 from ray.tune.registry import register_env
+
+
+def change_observation(obs, obs_space):
+    # convert all images to a 3d array with 1 channel
+    obs = obs[..., None]
+    return obs
+
+
+def change_obs_space(obs_space):
+    return convert_box(lambda obs: change_observation(obs, obs_space), obs_space)
 
 
 # TODO(sven): Move into rllib/env/wrappers/tests/.
@@ -24,6 +42,11 @@ class TestPettingZooEnv(unittest.TestCase):
             env = dtype_v0(env, dtype=float32)
             env = color_reduction_v0(env, mode="R")
             env = normalize_obs_v0(env)
+            # add a wrapper to convert the observation space to a 3d array
+            env = observation_lambda_v0(env, change_observation, change_obs_space)
+            # resize the observation space to 84x84 so that RLlib defauls CNN can
+            # process it
+            env = resize_v1(env, x_size=84, y_size=84, linear_interp=True)
             return env
 
         # Register env


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
