### PR TITLE
[Data] Fix `iter_tensor_batches` benchmarks

### DIFF
--- a/release/nightly_tests/dataset/iter_tensor_batches_benchmark.py
+++ b/release/nightly_tests/dataset/iter_tensor_batches_benchmark.py
@@ -155,6 +155,7 @@ if __name__ == "__main__":
         "--data-size-gb",
         choices=[1, 10],
         type=int,
+        default=1,
         help="The data size to use for the dataset.",
     )
 

--- a/release/nightly_tests/dataset/iter_tensor_batches_benchmark.py
+++ b/release/nightly_tests/dataset/iter_tensor_batches_benchmark.py
@@ -11,6 +11,7 @@ def iter_torch_batches(
     ds: Dataset,
     batch_size: Optional[int] = None,
     local_shuffle_buffer_size: Optional[int] = None,
+    prefetch_batches: int = 0,
     use_default_params: bool = False,
 ) -> Dataset:
     num_batches = 0
@@ -21,6 +22,7 @@ def iter_torch_batches(
         for batch in ds.iter_torch_batches(
             batch_size=batch_size,
             local_shuffle_buffer_size=local_shuffle_buffer_size,
+            prefetch_batches=prefetch_batches,
         ):
             num_batches += 1
     print(
@@ -103,7 +105,7 @@ def run_iter_tensor_batches_benchmark(benchmark: Benchmark, data_size_gb: int):
             batch_size=batch_size,
         )
 
-    prefetch_batches = [1, 10]
+    prefetch_batches = [1, 4]
     # Test with varying prefetching for iter_torch_batches()
     for prefetch_batch in prefetch_batches:
         test_name = f"iter-torch-batches-prefetch-{32}-{prefetch_batches}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Closes https://github.com/ray-project/ray/issues/33830
Closes #33851 

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
