### PR TITLE
[RLlib] Fix MultiCallbacks class: To be used only with utility function that returns a class to use in the config.

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -3144,11 +3144,7 @@ class AlgorithmConfig(_Config):
     @staticmethod
     def _serialize_dict(config):
         # Serialize classes to classpaths:
-        if isinstance(config.get("callbacks"), (type, str)):
-            config["callbacks"] = serialize_type(config["callbacks"])
-        else:
-            # TODO(sven): Figure out how to serialize MultiCallbacks.
-            config["callbacks"] = NOT_SERIALIZABLE
+        config["callbacks"] = serialize_type(config["callbacks"])
         config["sample_collector"] = serialize_type(config["sample_collector"])
         if isinstance(config["env"], type):
             config["env"] = serialize_type(config["env"])

--- a/rllib/algorithms/callbacks.py
+++ b/rllib/algorithms/callbacks.py
@@ -480,7 +480,7 @@ def make_multi_callbacks(callback_class_list: List[Type[DefaultCallbacks]]):
         def __init__(self):
             super().__init__()
             self._callback_list = [
-                callback_class() for callback_class in self.callback_class_list
+                callback_class() for callback_class in callback_class_list
             ]
 
         @override(DefaultCallbacks)
@@ -743,7 +743,7 @@ class RE3UpdateCallbacks(DefaultCallbacks):
 
 @Deprecated(
     new="ray.rllib.algorithms.callbacks.make_multi_callback([list of "
-        "`Callbacks` sub-classes to combine into one])",
+    "`Callbacks` sub-classes to combine into one])",
     error=True,
 )
 class MultiCallbacks(DefaultCallbacks):

--- a/rllib/algorithms/callbacks.py
+++ b/rllib/algorithms/callbacks.py
@@ -2,7 +2,7 @@ import gc
 import os
 import platform
 import tracemalloc
-from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 
@@ -454,228 +454,225 @@ class MemoryTrackingCallbacks(DefaultCallbacks):
         episode.custom_metrics["tracemalloc/worker/vms"] = worker_vms
 
 
-class MultiCallbacks(DefaultCallbacks):
-    """MultiCallbacks allows multiple callbacks to be registered at
-    the same time in the config of the environment.
+def make_multi_callbacks(callback_class_list: List[Type[DefaultCallbacks]]):
+    """Allows combining multiple sub-callbacks into one new callbacks class.
 
     Example:
 
         .. code-block:: python
 
-            'callbacks': MultiCallbacks([
+            config.callbacks(make_multi_callbacks([
                 MyCustomStatsCallbacks,
                 MyCustomVideoCallbacks,
                 MyCustomTraceCallbacks,
                 ....
-            ])
+            ]))
+
+    Args:
+        callback_class_list: The list of sub-classes of DefaultCallbacks to
+            be baked into the to-be-returned class. All of these sub-classes'
+            implemented methods will be called in the given order.
     """
 
-    IS_CALLBACK_CONTAINER = True
+    class _MultiCallbacks(DefaultCallbacks):
+        IS_CALLBACK_CONTAINER = True
 
-    def __init__(self, callback_class_list):
-        super().__init__()
-        self._callback_class_list = callback_class_list
+        def __init__(self):
+            super().__init__()
+            self._callback_list = [
+                callback_class() for callback_class in self.callback_class_list
+            ]
 
-        self._callback_list = []
+        @override(DefaultCallbacks)
+        def on_algorithm_init(self, *, algorithm: "Algorithm", **kwargs) -> None:
+            for callback in self._callback_list:
+                callback.on_algorithm_init(algorithm=algorithm, **kwargs)
 
-    def __call__(self, *args, **kwargs):
-        self._callback_list = [
-            callback_class() for callback_class in self._callback_class_list
-        ]
+        @override(DefaultCallbacks)
+        def on_create_policy(self, *, policy_id: PolicyID, policy: Policy) -> None:
+            for callback in self._callback_list:
+                callback.on_create_policy(policy_id=policy_id, policy=policy)
 
-        return self
+        @override(DefaultCallbacks)
+        def on_sub_environment_created(
+            self,
+            *,
+            worker: "RolloutWorker",
+            sub_environment: EnvType,
+            env_context: EnvContext,
+            env_index: Optional[int] = None,
+            **kwargs,
+        ) -> None:
+            for callback in self._callback_list:
+                callback.on_sub_environment_created(
+                    worker=worker,
+                    sub_environment=sub_environment,
+                    env_context=env_context,
+                    **kwargs,
+                )
 
-    @Deprecated(error=True)
-    def on_trainer_init(self, *args, **kwargs):
-        raise DeprecationWarning
+        @override(DefaultCallbacks)
+        def on_episode_created(
+            self,
+            *,
+            worker: "RolloutWorker",
+            base_env: BaseEnv,
+            policies: Dict[PolicyID, Policy],
+            env_index: int,
+            episode: Union[Episode, EpisodeV2],
+            **kwargs,
+        ) -> None:
+            for callback in self._callback_list:
+                callback.on_episode_created(
+                    worker=worker,
+                    base_env=base_env,
+                    policies=policies,
+                    env_index=env_index,
+                    episode=episode,
+                    **kwargs,
+                )
 
-    @override(DefaultCallbacks)
-    def on_algorithm_init(self, *, algorithm: "Algorithm", **kwargs) -> None:
-        for callback in self._callback_list:
-            callback.on_algorithm_init(algorithm=algorithm, **kwargs)
+        @override(DefaultCallbacks)
+        def on_episode_start(
+            self,
+            *,
+            worker: "RolloutWorker",
+            base_env: BaseEnv,
+            policies: Dict[PolicyID, Policy],
+            episode: Union[Episode, EpisodeV2],
+            env_index: Optional[int] = None,
+            **kwargs,
+        ) -> None:
+            for callback in self._callback_list:
+                callback.on_episode_start(
+                    worker=worker,
+                    base_env=base_env,
+                    policies=policies,
+                    episode=episode,
+                    env_index=env_index,
+                    **kwargs,
+                )
 
-    @override(DefaultCallbacks)
-    def on_create_policy(self, *, policy_id: PolicyID, policy: Policy) -> None:
-        for callback in self._callback_list:
-            callback.on_create_policy(policy_id=policy_id, policy=policy)
+        @override(DefaultCallbacks)
+        def on_episode_step(
+            self,
+            *,
+            worker: "RolloutWorker",
+            base_env: BaseEnv,
+            policies: Optional[Dict[PolicyID, Policy]] = None,
+            episode: Union[Episode, EpisodeV2],
+            env_index: Optional[int] = None,
+            **kwargs,
+        ) -> None:
+            for callback in self._callback_list:
+                callback.on_episode_step(
+                    worker=worker,
+                    base_env=base_env,
+                    policies=policies,
+                    episode=episode,
+                    env_index=env_index,
+                    **kwargs,
+                )
 
-    @override(DefaultCallbacks)
-    def on_sub_environment_created(
-        self,
-        *,
-        worker: "RolloutWorker",
-        sub_environment: EnvType,
-        env_context: EnvContext,
-        env_index: Optional[int] = None,
-        **kwargs,
-    ) -> None:
-        for callback in self._callback_list:
-            callback.on_sub_environment_created(
-                worker=worker,
-                sub_environment=sub_environment,
-                env_context=env_context,
-                **kwargs,
-            )
+        @override(DefaultCallbacks)
+        def on_episode_end(
+            self,
+            *,
+            worker: "RolloutWorker",
+            base_env: BaseEnv,
+            policies: Dict[PolicyID, Policy],
+            episode: Union[Episode, EpisodeV2, Exception],
+            env_index: Optional[int] = None,
+            **kwargs,
+        ) -> None:
+            for callback in self._callback_list:
+                callback.on_episode_end(
+                    worker=worker,
+                    base_env=base_env,
+                    policies=policies,
+                    episode=episode,
+                    env_index=env_index,
+                    **kwargs,
+                )
 
-    @override(DefaultCallbacks)
-    def on_episode_created(
-        self,
-        *,
-        worker: "RolloutWorker",
-        base_env: BaseEnv,
-        policies: Dict[PolicyID, Policy],
-        env_index: int,
-        episode: Union[Episode, EpisodeV2],
-        **kwargs,
-    ) -> None:
-        for callback in self._callback_list:
-            callback.on_episode_created(
-                worker=worker,
-                base_env=base_env,
-                policies=policies,
-                env_index=env_index,
-                episode=episode,
-                **kwargs,
-            )
+        @override(DefaultCallbacks)
+        def on_evaluate_start(
+            self,
+            *,
+            algorithm: "Algorithm",
+            **kwargs,
+        ) -> None:
+            for callback in self._callback_list:
+                callback.on_evaluate_start(
+                    algorithm=algorithm,
+                    **kwargs,
+                )
 
-    @override(DefaultCallbacks)
-    def on_episode_start(
-        self,
-        *,
-        worker: "RolloutWorker",
-        base_env: BaseEnv,
-        policies: Dict[PolicyID, Policy],
-        episode: Union[Episode, EpisodeV2],
-        env_index: Optional[int] = None,
-        **kwargs,
-    ) -> None:
-        for callback in self._callback_list:
-            callback.on_episode_start(
-                worker=worker,
-                base_env=base_env,
-                policies=policies,
-                episode=episode,
-                env_index=env_index,
-                **kwargs,
-            )
+        @override(DefaultCallbacks)
+        def on_evaluate_end(
+            self,
+            *,
+            algorithm: "Algorithm",
+            evaluation_metrics: dict,
+            **kwargs,
+        ) -> None:
+            for callback in self._callback_list:
+                callback.on_evaluate_end(
+                    algorithm=algorithm,
+                    evaluation_metrics=evaluation_metrics,
+                    **kwargs,
+                )
 
-    @override(DefaultCallbacks)
-    def on_episode_step(
-        self,
-        *,
-        worker: "RolloutWorker",
-        base_env: BaseEnv,
-        policies: Optional[Dict[PolicyID, Policy]] = None,
-        episode: Union[Episode, EpisodeV2],
-        env_index: Optional[int] = None,
-        **kwargs,
-    ) -> None:
-        for callback in self._callback_list:
-            callback.on_episode_step(
-                worker=worker,
-                base_env=base_env,
-                policies=policies,
-                episode=episode,
-                env_index=env_index,
-                **kwargs,
-            )
+        @override(DefaultCallbacks)
+        def on_postprocess_trajectory(
+            self,
+            *,
+            worker: "RolloutWorker",
+            episode: Episode,
+            agent_id: AgentID,
+            policy_id: PolicyID,
+            policies: Dict[PolicyID, Policy],
+            postprocessed_batch: SampleBatch,
+            original_batches: Dict[AgentID, Tuple[Policy, SampleBatch]],
+            **kwargs,
+        ) -> None:
+            for callback in self._callback_list:
+                callback.on_postprocess_trajectory(
+                    worker=worker,
+                    episode=episode,
+                    agent_id=agent_id,
+                    policy_id=policy_id,
+                    policies=policies,
+                    postprocessed_batch=postprocessed_batch,
+                    original_batches=original_batches,
+                    **kwargs,
+                )
 
-    @override(DefaultCallbacks)
-    def on_episode_end(
-        self,
-        *,
-        worker: "RolloutWorker",
-        base_env: BaseEnv,
-        policies: Dict[PolicyID, Policy],
-        episode: Union[Episode, EpisodeV2, Exception],
-        env_index: Optional[int] = None,
-        **kwargs,
-    ) -> None:
-        for callback in self._callback_list:
-            callback.on_episode_end(
-                worker=worker,
-                base_env=base_env,
-                policies=policies,
-                episode=episode,
-                env_index=env_index,
-                **kwargs,
-            )
+        @override(DefaultCallbacks)
+        def on_sample_end(
+            self, *, worker: "RolloutWorker", samples: SampleBatch, **kwargs
+        ) -> None:
+            for callback in self._callback_list:
+                callback.on_sample_end(worker=worker, samples=samples, **kwargs)
 
-    @override(DefaultCallbacks)
-    def on_evaluate_start(
-        self,
-        *,
-        algorithm: "Algorithm",
-        **kwargs,
-    ) -> None:
-        for callback in self._callback_list:
-            callback.on_evaluate_start(
-                algorithm=algorithm,
-                **kwargs,
-            )
+        @override(DefaultCallbacks)
+        def on_learn_on_batch(
+            self, *, policy: Policy, train_batch: SampleBatch, result: dict, **kwargs
+        ) -> None:
+            for callback in self._callback_list:
+                callback.on_learn_on_batch(
+                    policy=policy, train_batch=train_batch, result=result, **kwargs
+                )
 
-    @override(DefaultCallbacks)
-    def on_evaluate_end(
-        self,
-        *,
-        algorithm: "Algorithm",
-        evaluation_metrics: dict,
-        **kwargs,
-    ) -> None:
-        for callback in self._callback_list:
-            callback.on_evaluate_end(
-                algorithm=algorithm,
-                evaluation_metrics=evaluation_metrics,
-                **kwargs,
-            )
+        @override(DefaultCallbacks)
+        def on_train_result(self, *, algorithm=None, result: dict, **kwargs) -> None:
 
-    @override(DefaultCallbacks)
-    def on_postprocess_trajectory(
-        self,
-        *,
-        worker: "RolloutWorker",
-        episode: Episode,
-        agent_id: AgentID,
-        policy_id: PolicyID,
-        policies: Dict[PolicyID, Policy],
-        postprocessed_batch: SampleBatch,
-        original_batches: Dict[AgentID, Tuple[Policy, SampleBatch]],
-        **kwargs,
-    ) -> None:
-        for callback in self._callback_list:
-            callback.on_postprocess_trajectory(
-                worker=worker,
-                episode=episode,
-                agent_id=agent_id,
-                policy_id=policy_id,
-                policies=policies,
-                postprocessed_batch=postprocessed_batch,
-                original_batches=original_batches,
-                **kwargs,
-            )
+            for callback in self._callback_list:
+                # TODO: Remove `trainer` arg at some point to fully deprecate the old
+                #  term.
+                callback.on_train_result(algorithm=algorithm, result=result, **kwargs)
 
-    @override(DefaultCallbacks)
-    def on_sample_end(
-        self, *, worker: "RolloutWorker", samples: SampleBatch, **kwargs
-    ) -> None:
-        for callback in self._callback_list:
-            callback.on_sample_end(worker=worker, samples=samples, **kwargs)
-
-    @override(DefaultCallbacks)
-    def on_learn_on_batch(
-        self, *, policy: Policy, train_batch: SampleBatch, result: dict, **kwargs
-    ) -> None:
-        for callback in self._callback_list:
-            callback.on_learn_on_batch(
-                policy=policy, train_batch=train_batch, result=result, **kwargs
-            )
-
-    @override(DefaultCallbacks)
-    def on_train_result(self, *, algorithm=None, result: dict, **kwargs) -> None:
-
-        for callback in self._callback_list:
-            # TODO: Remove `trainer` arg at some point to fully deprecate the old term.
-            callback.on_train_result(algorithm=algorithm, result=result, **kwargs)
+    return _MultiCallbacks
 
 
 # This Callback is used by the RE3 exploration strategy.
@@ -742,3 +739,12 @@ class RE3UpdateCallbacks(DefaultCallbacks):
         RE3UpdateCallbacks._step = result["training_iteration"]
         # TODO: Remove `trainer` arg at some point to fully deprecate the old term.
         super().on_train_result(algorithm=algorithm, result=result, **kwargs)
+
+
+@Deprecated(
+    new="ray.rllib.algorithms.callbacks.make_multi_callback([list of "
+        "`Callbacks` sub-classes to combine into one])",
+    error=True,
+)
+class MultiCallbacks(DefaultCallbacks):
+    pass

--- a/rllib/algorithms/tests/test_algorithm_config.py
+++ b/rllib/algorithms/tests/test_algorithm_config.py
@@ -11,7 +11,6 @@ from ray.rllib.core.rl_module.marl_module import (
     MultiAgentRLModuleSpec,
     MultiAgentRLModule,
 )
-from ray.rllib.utils.serialization import NOT_SERIALIZABLE
 
 
 class TestAlgorithmConfig(unittest.TestCase):
@@ -39,18 +38,20 @@ class TestAlgorithmConfig(unittest.TestCase):
     def test_update_from_dict_works_for_multi_callbacks(self):
         """Test to make sure callbacks config dict works."""
         config_dict = {"callbacks": make_multi_callbacks([])}
-        config = (
-            AlgorithmConfig(algo_class=PPO)
-            .environment("CartPole-v0")
-            .training(lr=0.12345, train_batch_size=3000)
-        )
+        config = AlgorithmConfig()
         # This should work.
         config.update_from_dict(config_dict)
 
         serialized = config.serialize()
 
         # For now, we don't support serializing make_multi_callbacks.
-        self.assertEqual(serialized["callbacks"], NOT_SERIALIZABLE)
+        # It'll turn into a classpath that's not really usable b/c the class
+        # was created on-the-fly.
+        self.assertEqual(
+            serialized["callbacks"],
+            "ray.rllib.algorithms.callbacks.make_multi_callbacks.<locals>."
+            "_MultiCallbacks",
+        )
 
     def test_freezing_of_algo_config(self):
         """Tests, whether freezing an AlgorithmConfig actually works as expected."""

--- a/rllib/algorithms/tests/test_algorithm_config.py
+++ b/rllib/algorithms/tests/test_algorithm_config.py
@@ -3,7 +3,7 @@ import unittest
 
 import ray
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
-from ray.rllib.algorithms.callbacks import MultiCallbacks
+from ray.rllib.algorithms.callbacks import make_multi_callbacks
 from ray.rllib.algorithms.ppo import PPO, PPOConfig
 from ray.rllib.algorithms.ppo.torch.ppo_torch_rl_module import PPOTorchRLModule
 from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
@@ -38,7 +38,7 @@ class TestAlgorithmConfig(unittest.TestCase):
 
     def test_update_from_dict_works_for_multi_callbacks(self):
         """Test to make sure callbacks config dict works."""
-        config_dict = {"callbacks": MultiCallbacks([])}
+        config_dict = {"callbacks": make_multi_callbacks([])}
         config = (
             AlgorithmConfig(algo_class=PPO)
             .environment("CartPole-v0")
@@ -49,7 +49,7 @@ class TestAlgorithmConfig(unittest.TestCase):
 
         serialized = config.serialize()
 
-        # For now, we don't support serializing MultiCallbacks.
+        # For now, we don't support serializing make_multi_callbacks.
         self.assertEqual(serialized["callbacks"], NOT_SERIALIZABLE)
 
     def test_freezing_of_algo_config(self):

--- a/rllib/algorithms/tests/test_callbacks.py
+++ b/rllib/algorithms/tests/test_callbacks.py
@@ -2,7 +2,7 @@ from collections import Counter
 import unittest
 
 import ray
-from ray.rllib.algorithms.callbacks import DefaultCallbacks, MultiCallbacks
+from ray.rllib.algorithms.callbacks import DefaultCallbacks, make_multi_callbacks
 import ray.rllib.algorithms.dqn as dqn
 from ray.rllib.algorithms.pg import PGConfig
 from ray.rllib.evaluation.episode import Episode
@@ -104,7 +104,7 @@ class TestCallbacks(unittest.TestCase):
 
         for callbacks in (
             OnSubEnvironmentCreatedCallback,
-            MultiCallbacks([OnSubEnvironmentCreatedCallback]),
+            make_multi_callbacks([OnSubEnvironmentCreatedCallback]),
         ):
             config.callbacks(callbacks)
 
@@ -144,7 +144,7 @@ class TestCallbacks(unittest.TestCase):
 
         for callbacks in (
             OnSubEnvironmentCreatedCallback,
-            MultiCallbacks([OnSubEnvironmentCreatedCallback]),
+            make_multi_callbacks([OnSubEnvironmentCreatedCallback]),
         ):
             config.callbacks(callbacks)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix MultiCallbacks class: To be used only with utility function that returns a class to use in the config.
* Thus far, when using MultiCallbacks, the user would have to create a callable object (instance) of MultiCallbacks, passing the list of sub-classes to the constructor, then having to call the object's `__call__` method to instantiate these sub-classes.
* This is counterintuitive as Callbacks should always be passed as types (classes) to the config's `.callbacks([your custom class here])` method.
* This PR introcudes a helper utility function that creates the proper multi callbacks class for you. Synopsis is:

```
from ray.rllib.algorithms.ppo import PPOConfig
from ray.rllib.algorithms.callbacks import make_multi_callbacks

config = (
    PPOConfig()
    .environment("CartPole-v1")
    .callbacks(make_multi_callbacks([MyCallbackCls1, MyCallbackCls2])
)

config.build()
```

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
