### PR TITLE
[RLlib] Don't serialize config in Policy states (unless needed for msgpack-type checkpoints).

### DIFF
--- a/rllib/algorithms/tests/test_algorithm_export_checkpoint.py
+++ b/rllib/algorithms/tests/test_algorithm_export_checkpoint.py
@@ -20,9 +20,10 @@ RLMODULE_SUPPORTED_ALGOS = {"PPO"}
 
 
 def save_test(alg_name, framework="tf", multi_agent=False):
-    cls = get_trainable_cls(alg_name)
     config = (
-        cls.get_default_config().framework(framework)
+        get_trainable_cls(alg_name)
+        .get_default_config()
+        .framework(framework)
         # Switch on saving native DL-framework (tf, torch) model files.
         .checkpointing(export_native_model_files=True)
     )

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -126,7 +126,6 @@ class PolicySpec:
         )
 
     def serialize(self) -> Dict:
-        from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
         from ray.rllib.algorithms.registry import get_policy_class_name
 
         # Try to figure out a durable name for this policy.
@@ -146,7 +145,7 @@ class PolicySpec:
             "observation_space": space_to_dict(self.observation_space),
             "action_space": space_to_dict(self.action_space),
             # TODO(jungong) : try making the config dict durable by maybe
-            # getting rid of all the fields that are not JSON serializable.
+            #  getting rid of all the fields that are not JSON serializable.
             "config": self.config,
         }
 
@@ -1169,8 +1168,14 @@ class Policy(metaclass=ABCMeta):
             with open(os.path.join(export_dir, state_file), "w+b") as f:
                 pickle.dump(policy_state, f)
         else:
+            from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
+
             msgpack = try_import_msgpack(error=True)
             policy_state["checkpoint_version"] = str(CHECKPOINT_VERSION)
+            # Serialize the config for msgpack dump'ing.
+            policy_state["policy_spec"]["config"] = AlgorithmConfig._serialize_dict(
+                policy_state["policy_spec"]["config"]
+            )
             state_file = "policy_state.msgpck"
             with open(os.path.join(export_dir, state_file), "w+b") as f:
                 msgpack.dump(policy_state, f)

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -145,13 +145,9 @@ class PolicySpec:
             "policy_class": cls,
             "observation_space": space_to_dict(self.observation_space),
             "action_space": space_to_dict(self.action_space),
-            # Make the config dict durable by getting rid of all the fields
-            # that are code (not JSON serializable).
-            "config": (
-                AlgorithmConfig._serialize_dict(self.config)
-                if isinstance(self.config, dict)
-                else self.config.serialize()
-            ),
+            # TODO(jungong) : try making the config dict durable by maybe
+            # getting rid of all the fields that are not JSON serializable.
+            "config": self.config,
         }
 
     @classmethod

--- a/rllib/utils/tests/test_checkpoint_utils.py
+++ b/rllib/utils/tests/test_checkpoint_utils.py
@@ -132,10 +132,7 @@ class TestCheckpointUtils(unittest.TestCase):
         ] = AlgorithmConfig._serialize_dict(
             pickle_w["policy_states"]["default_policy"]["policy_spec"]["config"]
         )
-        check(
-            pickle_state["worker"]["policy_states"],
-            msgpack_state["worker"]["policy_states"],
-        )
+        check(pickle_w["policy_states"], msgpack_w["policy_states"])
         check(pickle_state["config"].serialize(), msgpack_state["config"].serialize())
 
         algo1.stop()
@@ -190,20 +187,27 @@ class TestCheckpointUtils(unittest.TestCase):
         self.assertTrue(pickle_cp_info["format"] == "cloudpickle")
         self.assertTrue(msgpack_cp_info["format"] == "msgpack")
 
+        pickle_w = pickle_state["worker"]
+        msgpack_w = msgpack_state["worker"]
+
         # Make sure recovered-from-pickle state is the same as recovered-from-msgpack
         # state.
         self.assertTrue(
             pickle_state["algorithm_class"] == msgpack_state["algorithm_class"]
         )
         check(pickle_state["counters"], msgpack_state["counters"])
-        check(
-            pickle_state["worker"]["policy_ids"], msgpack_state["worker"]["policy_ids"]
-        )
-        check(pickle_state["worker"]["filters"], msgpack_state["worker"]["filters"])
-        check(
-            pickle_state["worker"]["policy_states"],
-            msgpack_state["worker"]["policy_states"],
-        )
+        check(pickle_w["policy_ids"], msgpack_w["policy_ids"])
+        check(pickle_w["filters"], msgpack_w["filters"])
+
+        # Make sure the (serialized) configs match 100%. Our `check` utility
+        # cannot handle comparing types/classes.
+        for p in ["pol0", "pol1", "pol2"]:
+            pickle_w["policy_states"][p]["policy_spec"][
+                "config"
+            ] = AlgorithmConfig._serialize_dict(
+                pickle_w["policy_states"][p]["policy_spec"]["config"]
+            )
+        check(pickle_w["policy_states"], msgpack_w["policy_states"])
         # Make sure the (serialized) configs match 100%. Our `check` utility cannot
         # handle comparing types/classes.
         # The only exception is the `multiagent.policies` field as it might have gotten

--- a/rllib/utils/tests/test_checkpoint_utils.py
+++ b/rllib/utils/tests/test_checkpoint_utils.py
@@ -5,6 +5,7 @@ import unittest
 
 import ray
 from ray.rllib.algorithms.algorithm import Algorithm
+from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 from ray.rllib.algorithms.dqn import DQNConfig
 from ray.rllib.algorithms.simple_q import SimpleQConfig
 from ray.rllib.examples.env.multi_agent import MultiAgentCartPole
@@ -112,22 +113,29 @@ class TestCheckpointUtils(unittest.TestCase):
         self.assertTrue(pickle_cp_info["format"] == "cloudpickle")
         self.assertTrue(msgpack_cp_info["format"] == "msgpack")
 
+        pickle_w = pickle_state["worker"]
+        msgpack_w = msgpack_state["worker"]
+
         # Make sure recovered-from-pickle state is the same as recovered-from-msgpack
         # state.
         self.assertTrue(
             pickle_state["algorithm_class"] == msgpack_state["algorithm_class"]
         )
         check(pickle_state["counters"], msgpack_state["counters"])
-        check(
-            pickle_state["worker"]["policy_ids"], msgpack_state["worker"]["policy_ids"]
+        check(pickle_w["policy_ids"], msgpack_w["policy_ids"])
+        check(pickle_w["filters"], msgpack_w["filters"])
+
+        # Make sure the (serialized) configs match 100%. Our `check` utility
+        # cannot handle comparing types/classes.
+        pickle_w["policy_states"]["default_policy"]["policy_spec"][
+            "config"
+        ] = AlgorithmConfig._serialize_dict(
+            pickle_w["policy_states"]["default_policy"]["policy_spec"]["config"]
         )
-        check(pickle_state["worker"]["filters"], msgpack_state["worker"]["filters"])
         check(
             pickle_state["worker"]["policy_states"],
             msgpack_state["worker"]["policy_states"],
         )
-        # Make sure the (serialized) configs match 100%. Our `check` utility cannot
-        # handle comparing types/classes.
         check(pickle_state["config"].serialize(), msgpack_state["config"].serialize())
 
         algo1.stop()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Don't serialize config in Policy states (unless needed for msgpack-type checkpoints).
* To avoid possible pitfalls with items in the config that are not serializable (e.g. a env-class, model-class, callbacks-class created on the fly in user code -> these won't be easily translatable into a string classpath).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
