### PR TITLE
[air output] check `air_verbosity` against None.

### DIFF
--- a/python/ray/tune/tuner.py
+++ b/python/ray/tune/tuner.py
@@ -150,7 +150,7 @@ class Tuner:
         """Configure and construct a tune run."""
         kwargs = locals().copy()
         self._is_ray_client = ray.util.client.ray.is_connected()
-        if self._is_ray_client and get_air_verbosity():
+        if self._is_ray_client and get_air_verbosity() is not None:
             logger.warning(
                 "Ignoring AIR_VERBOSITY setting, "
                 "as it doesn't support ray client mode yet."

--- a/python/ray/tune/utils/callback.py
+++ b/python/ray/tune/utils/callback.py
@@ -82,7 +82,7 @@ def _create_default_callbacks(
         isinstance(c, TrialProgressCallback) for c in callbacks
     )
 
-    if has_trial_progress_callback and air_verbosity:
+    if has_trial_progress_callback and air_verbosity is not None:
         logger.warning(
             "AIR_VERBOSITY is set, ignoring passed-in TrialProgressCallback."
         )
@@ -90,7 +90,7 @@ def _create_default_callbacks(
             c for c in callbacks if not isinstance(c, TrialProgressCallback)
         ]
         callbacks = new_callbacks
-    if air_verbosity:  # new flow
+    if air_verbosity is not None:  # new flow
         from ray.tune.experimental.output import AirResultCallbackWrapper
 
         callbacks.append(AirResultCallbackWrapper(air_verbosity))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`if air_verbosity` returns `False` when the enum is 0, even though it's set. So explicitly check it against `None`.
also add a warning message for jupyter notebook case (disable the new flow).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#33867

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
