### PR TITLE
[RLlib] Change handling of try reset to support ASYNC_RESET_RETURN

### DIFF
--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -833,7 +833,11 @@ class EnvRunnerV2:
         while True:
             resetted_obs, resetted_infos = self._base_env.try_reset(env_id)
 
-            if resetted_obs is None or not isinstance(resetted_obs[env_id], Exception):
+            if (
+                resetted_obs is None
+                or resetted_obs == ASYNC_RESET_RETURN
+                or not isinstance(resetted_obs[env_id], Exception)
+            ):
                 break
             else:
                 # Report a faulty episode.


### PR DESCRIPTION
if a user is using remote base envs, then when reset/try_reset is called on the
env then it returns the constant "async_reset_return".
Our error handler for resets in the env runner v2 didn't catch this because
it makes the assumption that returns from try reset are multi env dicts.

Generally speaking we don't have good test coverage on the remote base env
and we frankly don't plan to as it isn't api that we plan on supporting in
future releases. however in the meantime we'll patch this bug because
a user brought it up as an issue affecting them.

Signed-off-by: Avnish <avnishnarayan@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
