### PR TITLE
[RLlib] DM control suite wrapper fix: dtype of obs needs to be pinned to float32.

### DIFF
--- a/rllib/env/wrappers/dm_control_wrapper.py
+++ b/rllib/env/wrappers/dm_control_wrapper.py
@@ -163,7 +163,7 @@ class DMCEnv(core.Env):
                 obs = obs / 255.0 - 0.5
         else:
             obs = _flatten_obs(time_step.observation)
-        return obs
+        return obs.astype(np.float32)
 
     def _convert_action(self, action):
         action = action.astype(np.float64)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

DM control suite wrapper fix: dtype of observation returned by `_get_obs()` method needs to be pinned to float32.
If not, this might lead to a type mismatch (float32 matrix vs float64 observation) in a network that processes these observations, especially after an env reset.


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
