### PR TITLE
[tune] Fix new output path with new execution path [no_early_kickoff]

### DIFF
--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -171,8 +171,8 @@ def _report_air_progress(
 ):
     trials = runner.get_trials()
     reporter_args = []
-    executor_debug_str = runner.trial_executor.debug_string()
-    reporter_args.append(executor_debug_str)
+    used_resources_string = runner._used_resources_string()
+    reporter_args.append(used_resources_string)
     reporter.print_heartbeat(trials, *reporter_args, force=force)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The new experimental output path (#33609) and the new experimental execution engine (#33499) currently don't work together because the new output path is calling a trial executor API directly (which does not exist in the experimental execution engine).

This PR calls the correct API on the TrialRunner/TuneController so both features can be tested together.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
