### PR TITLE
[CI] Disable Ray log deduplication for doctests

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -310,7 +310,7 @@ build_sphinx_docs() {
     else
       FAST=True make html
       pip install datasets==2.0.0
-      RAY_MOCK_MODULES=0 make doctest
+      RAY_MOCK_MODULES=0 RAY_DEDUP_LOGS=0 make doctest
     fi
   )
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

**tl;dr** This PR fixes `:book: Documentation`

https://github.com/ray-project/ray/pull/33403 introduced Ray log deduplication. This feature causes `testcode` outputs to get buffered and printed in later `testcode`s.

> However, subsequent log messages of the same pattern (ignoring words with numeric components) will be buffered for up to five seconds and printed in batch.

To prevent non-deterministic doctests, this PR disables the feature entirely in CI.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
