### PR TITLE
[Serve] Recover PENDING_INITIALIZATION status actor

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -498,7 +498,7 @@ class ActorReplicaWrapper:
                 )
             except Exception:
                 logger.exception(
-                    f"Exception in replica '{self._replica_tag}',"
+                    f"Exception in replica '{self._replica_tag}', "
                     "the replica will be stopped."
                 )
                 return ReplicaStartupStatus.FAILED, None

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -485,6 +485,7 @@ class ActorReplicaWrapper:
                 # TODO(simon): fully implement reconfigure for Java replicas.
                 if self._is_cross_language:
                     return ReplicaStartupStatus.SUCCEEDED, None
+
                 deployment_config, version = ray.get(self._ready_obj_ref)
                 self._max_concurrent_queries = deployment_config.max_concurrent_queries
                 self._graceful_shutdown_timeout_s = (

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -485,7 +485,6 @@ class ActorReplicaWrapper:
                 # TODO(simon): fully implement reconfigure for Java replicas.
                 if self._is_cross_language:
                     return ReplicaStartupStatus.SUCCEEDED, None
-
                 deployment_config, version = ray.get(self._ready_obj_ref)
                 self._max_concurrent_queries = deployment_config.max_concurrent_queries
                 self._graceful_shutdown_timeout_s = (
@@ -497,7 +496,10 @@ class ActorReplicaWrapper:
                     self._allocated_obj_ref
                 )
             except Exception:
-                logger.exception(f"Exception in deployment '{self._deployment_name}'")
+                logger.exception(
+                    f"Exception in replica '{self._replica_tag}',"
+                    "the replica will be stopped."
+                )
                 return ReplicaStartupStatus.FAILED, None
         if self._deployment_is_cross_language:
             # todo: The replica's userconfig whitch java client created

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -252,7 +252,7 @@ def create_replica_wrapper(name: str):
         async def get_metadata(
             self,
         ) -> Tuple[DeploymentConfig, DeploymentVersion]:
-            # Wait for replica initialization finish
+            # Wait for replica initialization to finish
             await self.init_finish_event.wait()
             return self.replica.deployment_config, self.replica.version
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -247,7 +247,7 @@ def create_replica_wrapper(name: str):
 
         async def get_metadata(
             self,
-        ) -> Tuple[Optional[DeploymentConfig], Optional[DeploymentVersion]]:
+        ) -> Tuple[DeploymentConfig, DeploymentVersion]:
             # When the self.replica variable is None, potentially replica is still
             # under initialization. Relying on DeploymentStateManager to
             # timeout the replica.

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -129,7 +129,7 @@ def create_replica_wrapper(name: str):
                 controller_name, namespace=SERVE_NAMESPACE
             )
 
-            # Indicate the replica finish the initialization.
+            # Indicates whether the replica has finished initializing.
             self.init_finish_event = asyncio.Event()
 
             # This closure initializes user code and finalizes replica

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -249,8 +249,9 @@ def create_replica_wrapper(name: str):
         async def get_metadata(
             self,
         ) -> Tuple[Optional[DeploymentConfig], Optional[DeploymentVersion]]:
-            # When the replica is empty, potentially replica is still under initialization.
-            # Relying on DeploymentStateManager to timeout the replica.
+            # When the self.replica variable is None, potentially replica is still
+            # under initialization. Relying on DeploymentStateManager to
+            # timeout the replica.
             while self.replica is None:
                 await asyncio.sleep(0.2)
             return self.replica.deployment_config, self.replica.version

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -130,7 +130,7 @@ def create_replica_wrapper(name: str):
             )
 
             # Indicates whether the replica has finished initializing.
-            self.init_finish_event = asyncio.Event()
+            self._init_finish_event = asyncio.Event()
 
             # This closure initializes user code and finalizes replica
             # startup. By splitting the initialization step like this,
@@ -167,7 +167,7 @@ def create_replica_wrapper(name: str):
                     is_function,
                     controller_handle,
                 )
-                self.init_finish_event.set()
+                self._init_finish_event.set()
 
             # Is it fine that replica is None here?
             # Should we add a check in all methods that use self.replica
@@ -253,7 +253,7 @@ def create_replica_wrapper(name: str):
             self,
         ) -> Tuple[DeploymentConfig, DeploymentVersion]:
             # Wait for replica initialization to finish
-            await self.init_finish_event.wait()
+            await self._init_finish_event.wait()
             return self.replica.deployment_config, self.replica.version
 
         async def prepare_for_shutdown(self):

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -170,7 +170,6 @@ def create_replica_wrapper(name: str):
             # or, alternatively, create an async get_replica() method?
             self.replica = None
             self._initialize_replica = initialize_replica
-            self._replica_tag = replica_tag
 
         @ray.method(num_returns=2)
         async def handle_request(

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -240,7 +240,7 @@ def test_controller_recover_initializing_actor(serve_instance):
 
     assert controller_tag1 != controller_tag2
 
-    # Let the actor proceed initialization
+    # Let the actor finish initializing
     signal.send.remote()
     client._wait_for_deployment_healthy(V1.name)
     # Make sure the actor before controller dead is staying alive.

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -243,7 +243,8 @@ def test_controller_recover_initializing_actor(serve_instance):
     # Let the actor finish initializing
     signal.send.remote()
     client._wait_for_deployment_healthy(V1.name)
-    # Make sure the actor before controller dead is staying alive.
+    # Make sure the running replica actor is the same as one as before the controller died.
+    # The replica should not have been restarted.
     actor_tag2 = get_actor_tag(V1.name)
     assert actor_tag == actor_tag2
 

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -214,9 +214,9 @@ def test_controller_recover_initializing_actor(serve_instance):
 
     @serve.deployment
     class V1:
-        def __init__(self):
+        async def __init__(self):
             signal2.send.remote()
-            ray.get(signal.wait.remote())
+            await signal.wait.remote()
 
         def __call__(self, request):
             return f"1|{os.getpid()}"
@@ -233,7 +233,7 @@ def test_controller_recover_initializing_actor(serve_instance):
     actor_tag = get_actor_tag(V1.name)
 
     ray.kill(serve.context._global_client._controller, no_restart=False)
-
+    time.sleep(1)
     # Let the actor proceed initialization
     signal.send.remote()
     client._wait_for_deployment_healthy(V1.name)

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -216,7 +216,7 @@ def test_controller_recover_initializing_actor(serve_instance):
     @serve.deployment
     class V1:
         async def __init__(self):
-            signal2.send.remote()
+            ray.get(signal2.send.remote())
             await signal.wait.remote()
 
         def __call__(self, request):
@@ -241,11 +241,11 @@ def test_controller_recover_initializing_actor(serve_instance):
     assert controller_tag1 != controller_tag2
 
     # Let the actor proceed initialization
-    signal.send.remote()
+    ray.get(signal.send.remote())
     client._wait_for_deployment_healthy(V1.name)
     # Make sure the actor before controller dead is staying alive.
-    actor_tag2 = get_actor_tag(V1.name)
-    assert actor_tag == actor_tag2
+    assert actor_tag == get_actor_tag(V1.name)
+
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -229,7 +229,6 @@ def test_controller_recover_initializing_actor(serve_instance):
         for actor in all_current_actors:
             if name in actor["name"]:
                 return actor["name"]
-        return None
 
     actor_tag = get_actor_tag(V1.name)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Then replica is under initializing state and the controller is dead, user will see 
```
(ServeController pid=458318) ERROR 2023-03-29 08:44:42,547 controller 458318 deployment_state.py:500 - Exception in deployment 'xqHWInctmH'
(ServeController pid=458318) Traceback (most recent call last):
(ServeController pid=458318)   File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/serve/_private/deployment_state.py", line 489, in check_ready
(ServeController pid=458318)     deployment_config, version = ray.get(self._ready_obj_ref)
(ServeController pid=458318)   File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/client_mode_hook.py", line 105, in wrapper
(ServeController pid=458318)     return func(*args, **kwargs)
(ServeController pid=458318)   File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/worker.py", line 2508, in get
(ServeController pid=458318)     raise value.as_instanceof_cause()
(ServeController pid=458318) ray.exceptions.RayTaskError(AttributeError): ray::ServeReplica:xqHWInctmH.get_metadata() (pid=458148, ip=172.31.126.222, repr=<ray.serve._private.replica.ServeReplica:xqHWInctmH object at 0x7f57ae0f0110>)
(ServeController pid=458318)   File "/home/ray/anaconda3/lib/python3.7/concurrent/futures/_base.py", line 428, in result
(ServeController pid=458318)     return self.__get_result()
(ServeController pid=458318)   File "/home/ray/anaconda3/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
(ServeController pid=458318)     raise self._exception
(ServeController pid=458318)   File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/serve/_private/replica.py", line 249, in get_metadata
(ServeController pid=458318)     return self.replica.deployment_config, self.replica.version
(ServeController pid=458318) AttributeError: 'NoneType' object has no attribute 'deployment_config'
```

- Fix the NoneType bug when recover happens, no matter the actor is under any state, user would not see the traceback. Instead user will see the 
1.  slow startup warning, and then replica will be terminated, and new replica will be provisioned.
2. If actor succeed in `PENDING_INITIALIZATION`, no error pops out.

This is observed from long_running_serve_failure: https://console.anyscale-staging.com/o/anyscale-internal/projects/prj_qC3ZfndQWYYjx2cz8KWGNUL4/clusters/ses_u7xeve33e2djg9grgr9qcs9l4x?command-history-section=command_history

**Note**: If user constructor initialization just needs very long time to finish, it is recommended to increase the `SERVE_SLOW_STARTUP_WARNING_S`, (if the user doesn't change, the deployment manager will terminate the old replica and start new replica after the timeout.) 


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
