### PR TITLE
[Datasets] Change from warnings.warn to logger.warning

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -19,7 +19,6 @@ from typing import (
     Union,
 )
 from uuid import uuid4
-import warnings
 
 import numpy as np
 
@@ -594,10 +593,7 @@ class Dataset(Generic[T]):
         """  # noqa: E501
 
         if batch_format == "native":
-            warnings.warn(
-                "The 'native' batch format has been renamed 'default'.",
-                DeprecationWarning,
-            )
+            logger.warning("The 'native' batch format has been renamed 'default'.")
 
         target_block_size = None
         if batch_size == "default":
@@ -3050,10 +3046,7 @@ class Dataset(Generic[T]):
             An iterator over record batches.
         """
         if batch_format == "native":
-            warnings.warn(
-                "The 'native' batch format has been renamed 'default'.",
-                DeprecationWarning,
-            )
+            logger.warning("The 'native' batch format has been renamed 'default'.")
 
         return self.iterator().iter_batches(
             prefetch_batches=prefetch_batches,
@@ -4067,17 +4060,15 @@ class Dataset(Generic[T]):
 
     @Deprecated(message="Use `Dataset.cache()` instead.")
     def fully_executed(self) -> "Dataset[T]":
-        warnings.warn(
+        logger.warning(
             "The 'fully_executed' call has been renamed to 'cache'.",
-            DeprecationWarning,
         )
         return self.cache()
 
     @Deprecated(message="Use `Dataset.is_cached()` instead.")
     def is_fully_executed(self) -> bool:
-        warnings.warn(
+        logger.warning(
             "The 'is_fully_executed' call has been renamed to 'is_cached'.",
-            DeprecationWarning,
         )
         return self.is_cached()
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -10,7 +10,6 @@ from typing import (
     TypeVar,
     Union,
 )
-import warnings
 
 
 import numpy as np
@@ -1308,11 +1307,10 @@ def read_binary_files(
         Dataset holding records read from the specified paths.
     """
     if not output_arrow_format:
-        warnings.warn(
+        logger.warning(
             "read_binary_files() returns Dataset in Python list format as of Ray "
             "v2.4. Use read_binary_files(output_arrow_format=True) to return Dataset "
             "in Arrow format.",
-            DeprecationWarning,
         )
 
     return read_datasource(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`warnings.warn` does not print warning on console when used in Ray Data, so change to `logger.warning` to be consistent with rest of codebase. https://github.com/ray-project/ray/issues/33899 is to follow up for investigation, but right now let's just make sure our warning can be seen by users. Especially for `is_fully_executed()`/`fully_executed()`, those are important.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
