### PR TITLE
[core] pin grpcio <= 1.51.3

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -25,8 +25,9 @@ dataclasses; python_version < '3.7'
 # Tracking issue: https://github.com/ray-project/ray/issues/30984
 grpcio >= 1.32.0, <= 1.49.1; python_version < '3.10' and sys_platform == 'darwin'
 grpcio >= 1.42.0, <= 1.49.1; python_version >= '3.10' and sys_platform == 'darwin'
-grpcio >= 1.32.0; python_version < '3.10' and sys_platform != 'darwin'
-grpcio >= 1.42.0; python_version >= '3.10' and sys_platform != 'darwin'
+# Original issue: https://github.com/ray-project/ray/issues/33833
+grpcio >= 1.32.0, <= 1.51.3; python_version < '3.10' and sys_platform != 'darwin'
+grpcio >= 1.42.0, <= 1.51.3; python_version >= '3.10' and sys_platform != 'darwin'
 numpy>=1.16; python_version < '3.9'
 numpy>=1.19.3; python_version >= '3.9'
 packaging; python_version >= '3.10'

--- a/python/setup.py
+++ b/python/setup.py
@@ -319,10 +319,11 @@ if setup_spec.type == SetupType.RAY:
         "dataclasses; python_version < '3.7'",
         "filelock",
         # Tracking issue: https://github.com/ray-project/ray/issues/30984
-        "grpcio >= 1.32.0, <= 1.49.1; python_version < '3.10' and sys_platform == 'darwin'",  # noqa
-        "grpcio >= 1.42.0, <= 1.49.1; python_version >= '3.10' and sys_platform == 'darwin'",  # noqa
-        "grpcio >= 1.32.0; python_version < '3.10' and sys_platform != 'darwin'",
-        "grpcio >= 1.42.0; python_version >= '3.10' and sys_platform != 'darwin'",
+        "grpcio >= 1.32.0, <= 1.49.1; python_version < '3.10' and sys_platform == 'darwin'",  # noqa:E501
+        "grpcio >= 1.42.0, <= 1.49.1; python_version >= '3.10' and sys_platform == 'darwin'",  # noqa:E501
+        # Original issue: https://github.com/ray-project/ray/issues/33833
+        "grpcio >= 1.32.0, <= 1.51.3; python_version < '3.10' and sys_platform != 'darwin'",  # noqa:E501
+        "grpcio >= 1.42.0, <= 1.51.3; python_version >= '3.10' and sys_platform != 'darwin'",  # noqa:E501
         "jsonschema",
         "msgpack >= 1.0.0, < 2.0.0",
         "numpy >= 1.16; python_version < '3.9'",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Two tests started failing when `grpcio` 1.53.0 was released:
- [test_cifar10_pytorch](https://github.com/ray-project/ray/blob/adb67759459bb3b69402bf9b21a3fb7f6791c628/python/ray/tune/tests/test_client.py#L54-L58)
- [ext_pytorch.py](https://github.com/ray-project/ray/blob/master/python/ray/tune/tests/ext_pytorch.py) 

Both of these are failing due to PyTorch `DataLoader(..., num_workers=8)` multiprocessing hitting a segmentation fault.

From [investigation](https://github.com/ray-project/ray/issues/33833#issuecomment-1489663475), initializing Ray Client consistently reproduces this issue.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/33833

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
