### PR TITLE
[docs] fix top nav bug

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -8,6 +8,7 @@
 /* Make the book theme secondary nav stick below the new main top nav */
 .header-article {
     top: 58px;
+    z-index: 900 !important;
 }
 
 .toctree-l1.has-children {


### PR DESCRIPTION
On master, the top nav items can't be selected:

![Screenshot 2023-03-30 at 15 57 48](https://user-images.githubusercontent.com/3462566/228860057-4c3b2961-b6af-459d-ba7d-d2bd265c27c9.png)

This PR fixes that:

![Screenshot 2023-03-30 at 15 56 49](https://user-images.githubusercontent.com/3462566/228860124-b8a7690a-a874-472a-8037-bba010488237.png)

