### PR TITLE
[Serve] Migrate long running serve failure release test to v2 stack

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -615,3 +615,4 @@ def delete(name: str, _blocking: bool = True):
     """
     client = get_global_client()
     client.delete_apps([name], blocking=_blocking)
+

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -615,4 +615,3 @@ def delete(name: str, _blocking: bool = True):
     """
     client = get_global_client()
     client.delete_apps([name], blocking=_blocking)
-

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -32,7 +32,8 @@ RAY_UNIT_TEST = "RAY_UNIT_TEST" in os.environ
 
 # RAY_OVERRIDE_RESOURCES will prevent "num_cpus" working
 # when adding customized resource node to Cluster.
-del os.environ["RAY_OVERRIDE_RESOURCES"]
+if "RAY_OVERRIDE_RESOURCES" in os.environ:
+    del os.environ["RAY_OVERRIDE_RESOURCES"]
 
 
 def update_progress(result):

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -19,8 +19,8 @@ MAX_BATCH_SIZE = 16
 
 # Cluster setup constants
 NUM_REDIS_SHARDS = 1
-REDIS_MAX_MEMORY = 10 ** 8
-OBJECT_STORE_MEMORY = 10 ** 8
+REDIS_MAX_MEMORY = 10**8
+OBJECT_STORE_MEMORY = 10**8
 NUM_NODES = 4
 
 # RandomTest setup constants

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -19,8 +19,8 @@ MAX_BATCH_SIZE = 16
 
 # Cluster setup constants
 NUM_REDIS_SHARDS = 1
-REDIS_MAX_MEMORY = 10**8
-OBJECT_STORE_MEMORY = 10**8
+REDIS_MAX_MEMORY = 10 ** 8
+OBJECT_STORE_MEMORY = 10 ** 8
 NUM_NODES = 4
 
 # RandomTest setup constants
@@ -29,6 +29,10 @@ NUM_ITERATIONS = 350
 ACTIONS_PER_ITERATION = 20
 
 RAY_UNIT_TEST = "RAY_UNIT_TEST" in os.environ
+
+# RAY_OVERRIDE_RESOURCES will prevent "num_cpus" working
+# when adding customized resource node to Cluster.
+del os.environ["RAY_OVERRIDE_RESOURCES"]
 
 
 def update_progress(result):

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -30,7 +30,7 @@ ACTIONS_PER_ITERATION = 20
 
 RAY_UNIT_TEST = "RAY_UNIT_TEST" in os.environ
 
-# RAY_OVERRIDE_RESOURCES will prevent "num_cpus" working
+# RAY_OVERRIDE_RESOURCES will prevent "num_cpus" from working
 # when adding customized resource node to Cluster.
 if "RAY_OVERRIDE_RESOURCES" in os.environ:
     del os.environ["RAY_OVERRIDE_RESOURCES"]

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -31,7 +31,7 @@ ACTIONS_PER_ITERATION = 20
 RAY_UNIT_TEST = "RAY_UNIT_TEST" in os.environ
 
 # RAY_OVERRIDE_RESOURCES will prevent "num_cpus" from working
-# when adding customized resource node to Cluster.
+# when adding a node with custom resources to Cluster.
 if "RAY_OVERRIDE_RESOURCES" in os.environ:
     del os.environ["RAY_OVERRIDE_RESOURCES"]
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1985,7 +1985,7 @@
   team: serve
   cluster:
     cluster_env: app_config.yaml
-    cluster_compute: tpl_cpu_1_c5.yaml
+    cluster_compute: tpl_cpu_1.yaml
 
   run:
     timeout: 86400

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1985,7 +1985,7 @@
   team: serve
   cluster:
     cluster_env: app_config.yaml
-    cluster_compute: tpl_cpu_1.yaml
+    cluster_compute: tpl_cpu_1_c5.yaml
 
   run:
     timeout: 86400

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1980,8 +1980,6 @@
   working_dir: long_running_tests
 
   stable: true
-  # TODO: Migrate this test to Anyscale Jobs / staging_v2
-  env: staging_v1
 
   frequency: weekly
   team: serve
@@ -1993,7 +1991,6 @@
     timeout: 86400
     script: python workloads/serve_failure.py
     long_running: true
-    type: sdk_command
 
   smoke_test:
     frequency: nightly


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Migrate test to v2 stack

Release test succeed: https://buildkite.com/ray-project/release-tests-pr/builds/33594#018744aa-5036-4bcd-b991-775755ab6128

## Related issue number

Closes #33868
Closes #32717

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
