### PR TITLE
[CI][GCE/4] Add GCE variances for non-GPU critical release tests

### DIFF
--- a/release/air_tests/air_benchmarks/compute_gce_gpu_1.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_1.yaml
@@ -1,0 +1,27 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-32-nvidia-tesla-t4-2 # aws g3.8xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-8 # m5.2xlarge
+      max_workers: 0
+      min_workers: 0
+      use_spot: false
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            Iops: 5000
+#            Throughput: 1000
+#            VolumeSize: 1000
+#            VolumeType: gp3

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
@@ -7,11 +7,11 @@ max_workers: 3
 
 head_node_type:
     name: head_node
-    instance_type: n1-highmem-32-nvidia-tesla-v100-4 # n1-standard-64-nvidia-tesla-t4-4 # aws g3.16xlarge
+    instance_type: n1-standard-64-nvidia-tesla-t4-4 # aws g3.16xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: n1-highmem-32-nvidia-tesla-v100-4 # n1-standard-64-nvidia-tesla-t4-4 # aws g3.16xlarge
+      instance_type: n1-standard-64-nvidia-tesla-t4-4 # aws g3.16xlarge
       max_workers: 3
       min_workers: 3
       use_spot: false

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
@@ -1,0 +1,28 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 3
+
+head_node_type:
+    name: head_node
+    instance_type: n1-highmem-32-nvidia-tesla-v100-4 # n1-standard-64-nvidia-tesla-t4-4 # aws g3.16xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n1-highmem-32-nvidia-tesla-v100-4 # n1-standard-64-nvidia-tesla-t4-4 # aws g3.16xlarge
+      max_workers: 3
+      min_workers: 3
+      use_spot: false
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 800
+#            Iops: 5000
+#            Throughput: 1000
+#            VolumeSize: 1000
+#            VolumeType: gp3

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_1_g4_8xl.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_1_g4_8xl.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-16-nvidia-tesla-t4-1 # aws g4dn.8xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-8 # m5.2xlarge
+      max_workers: 0
+      min_workers: 0
+      use_spot: false

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_4_g4_12xl.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_4_g4_12xl.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-b
+
+max_workers: 3
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-64-nvidia-tesla-t4-4 # g4dn.12xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n1-standard-64-nvidia-tesla-t4-4 # g4dn.12xlarge
+      max_workers: 3
+      min_workers: 3
+      use_spot: false

--- a/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_CPU"] | default("anyscale/ray-ml:2.0.1-py37-cpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_CPU"] | default("anyscale/ray-ml:2.3.1-py37-cpu") }}
 env_vars: {"RAY_task_oom_retries": "50", "RAY_min_memory_free_bytes": "1000000000"}
 debian_packages:
   - curl

--- a/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # aws m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # m5.xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 400

--- a/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16_worker_nodes_2.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16_worker_nodes_2.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 2
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # aws m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # m5.xlarge
+      min_workers: 2
+      max_workers: 2
+      use_spot: false

--- a/release/jobs_tests/compute_tpl_gce_4_xlarge.yaml
+++ b/release/jobs_tests/compute_tpl_gce_4_xlarge.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 4
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-4 # m5.xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # m5.xlarge
+      min_workers: 4
+      max_workers: 4
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '24'

--- a/release/jobs_tests/compute_tpl_gce_gpu_node.yaml
+++ b/release/jobs_tests/compute_tpl_gce_gpu_node.yaml
@@ -1,0 +1,22 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-16-nvidia-tesla-t4-1 # g4dn.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-16 # aws m5.4xlarge
+      min_workers: 1
+      max_workers: 1
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '24'

--- a/release/jobs_tests/compute_tpl_gce_gpu_worker.yaml
+++ b/release/jobs_tests/compute_tpl_gce_gpu_worker.yaml
@@ -1,0 +1,22 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # aws m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n1-standard-16-nvidia-tesla-t4-1 # g4dn.4xlarge
+      min_workers: 1
+      max_workers: 1
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '24'

--- a/release/long_running_distributed_tests/compute_tpl_gce.yaml
+++ b/release/long_running_distributed_tests/compute_tpl_gce.yaml
@@ -1,0 +1,30 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 3
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-32-nvidia-tesla-t4-2 # g3.8xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n1-standard-32-nvidia-tesla-t4-2 # g3.8xlarge
+      min_workers: 2
+      max_workers: 2
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'
+#
+#  BlockDeviceMappings:
+#    - DeviceName: /dev/sda1
+#      Ebs:
+#        VolumeSize: 400
+#        DeleteOnTermination: true

--- a/release/long_running_tests/many_ppo_gce.yaml
+++ b/release/long_running_tests/many_ppo_gce.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-8 # m5.2xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'

--- a/release/long_running_tests/tpl_cpu_1_c5_gce.yaml
+++ b/release/long_running_tests/tpl_cpu_1_c5_gce.yaml
@@ -1,0 +1,30 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: c2-standard-8 # c5.2xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: c2-standard-8 # c5.2xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'
+#
+#  BlockDeviceMappings:
+#    - DeviceName: /dev/sda1
+#      Ebs:
+#        VolumeSize: 300
+#        DeleteOnTermination: true

--- a/release/long_running_tests/tpl_cpu_1_gce.yaml
+++ b/release/long_running_tests/tpl_cpu_1_gce.yaml
@@ -1,0 +1,30 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-8 # m5.2xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-8 # m5.2xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'
+#
+#  BlockDeviceMappings:
+#    - DeviceName: /dev/sda1
+#      Ebs:
+#        VolumeSize: 300
+#        DeleteOnTermination: true

--- a/release/long_running_tests/tpl_cpu_1_large_gce.yaml
+++ b/release/long_running_tests/tpl_cpu_1_large_gce.yaml
@@ -1,0 +1,30 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-16 # m5.4xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'
+#
+#  BlockDeviceMappings:
+#    - DeviceName: /dev/sda1
+#      Ebs:
+#        VolumeSize: 300
+#        DeleteOnTermination: true

--- a/release/long_running_tests/tpl_cpu_3_gce.yaml
+++ b/release/long_running_tests/tpl_cpu_3_gce.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 2
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-8 # m5.2xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-8 # m5.2xlarge
+      min_workers: 2
+      max_workers: 2
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'

--- a/release/microbenchmark/tpl_64_gce.yaml
+++ b/release/microbenchmark/tpl_64_gce.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-64 # aws m5.16xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-2 # aws m5.xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false

--- a/release/nightly_tests/dataset/data_ingest_benchmark_compute_gce.yaml
+++ b/release/nightly_tests/dataset/data_ingest_benchmark_compute_gce.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 19
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # aws m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-16 # aws m5.4xlarge
+      max_workers: 19
+      min_workers: 19
+      use_spot: false

--- a/release/nightly_tests/decision_tree/autoscaling_compute_gce.yaml
+++ b/release/nightly_tests/decision_tree/autoscaling_compute_gce.yaml
@@ -1,0 +1,28 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 10
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 500
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-8 # aws m5.2xlarge
+    resources:
+      cpu: 8
+
+worker_node_types:
+   - name: worker_node
+     instance_type: n2-standard-16 # m5.4xlarge
+     min_workers: 0
+     max_workers: 10
+     use_spot: false
+     resources:
+      cpu: 16

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -1,0 +1,28 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 2000
+#        - DeviceName: /dev/sda2
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 2000
+
+head_node_type:
+    name: head_node
+    instance_type:  n2-standard-32 # aws m5.8xlarge
+    resources: {"cpu": 0}
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-16 # aws m5.4xlarge
+      min_workers: 99
+      max_workers: 99
+      use_spot: false
+      resources: {"cpu": 8}

--- a/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances_gce.yaml
+++ b/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances_gce.yaml
@@ -1,0 +1,22 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 1000
+
+head_node_type:
+    name: head_node
+    instance_type: e2-standard-16 # aws m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: e2-standard-16 # aws m5.4xlarge
+      min_workers: 19
+      max_workers: 19
+      use_spot: false

--- a/release/nightly_tests/shuffle/shuffle_compute_autoscaling_gce.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_autoscaling_gce.yaml
@@ -1,0 +1,22 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 500
+
+head_node_type:
+    name: head_node
+    instance_type: n2-highmem-16 # i3.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-highmem-16 # i3.4xlarge
+      min_workers: 0
+      max_workers: 19
+      use_spot: false

--- a/release/nightly_tests/shuffle/shuffle_compute_multi_gce.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_multi_gce.yaml
@@ -1,0 +1,26 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 3
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 500
+
+head_node_type:
+    name: head_node
+    instance_type: n2-highmem-16 # i3.4xlarge
+    resources: {"object_store_memory": 21474836480}
+
+worker_node_types:
+    - name: worker_node2
+      instance_type: n2-highmem-16 # i3.4xlarge
+      min_workers: 3
+      max_workers: 3
+      use_spot: false
+      resources: {"object_store_memory": 21474836480}

--- a/release/nightly_tests/stress_tests/placement_group_tests_compute_gce.yaml
+++ b/release/nightly_tests/stress_tests/placement_group_tests_compute_gce.yaml
@@ -1,0 +1,31 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 5
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 500
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-64 # aws m4.16xlarge
+    resources:
+      cpu: 64
+
+worker_node_types:
+   - name: worker_node
+     instance_type: n2-standard-2 # aws m4.large
+     min_workers: 5
+     max_workers: 5
+     use_spot: false
+     resources:
+      cpu: 2 
+      custom_resources:
+        pg_custom: 666
+

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import yaml
+import copy
 import pytest
 
 from ray_release.config import (
@@ -70,10 +71,16 @@ def test_definition_parser():
     assert not validate_test(gce_test, schema)
     assert aws_test["name"] == "sample_test.aws"
     assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
+    invalid_test_definition = test_definitions[0]
+    invalid_test_definition['variations'] = []
     with pytest.raises(ReleaseTestConfigError):
-        test_definitions[0]['variations'] = []
-        parse_test_definition(test_definitions)
-
+        parse_test_definition([invalid_test_definition])
+    invalid_test_definition['variations'] = [
+        {'__suffix__': 'aws'},
+        {}
+    ]
+    with pytest.raises(ReleaseTestConfigError):
+        parse_test_definition([invalid_test_definition])
 
 def test_parse_test_definition():
     """

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import yaml
-import copy
 import pytest
 
 from ray_release.config import (
@@ -44,7 +43,12 @@ VALID_TEST = Test(
     }
 )
 
-def test_definition_parser():
+"""
+Unit test for the ray_release.config.parse_test_definition function. In particular,
+we check that the code correctly parse a test definition that have the 'variations' 
+field.
+"""
+def test_parse_test_definition():
     test_definitions = yaml.safe_load('''
         - name: sample_test
           working_dir: sample_dir
@@ -63,6 +67,8 @@ def test_definition_parser():
                 cluster_env: env_gce.yaml
                 cluster_compute: compute_gce.yaml
     ''')
+    # Check that parsing returns two tests, one for each variation (aws and gce). Check
+    # that both tests are valid, and their fields are populated correctly
     tests = parse_test_definition(test_definitions)
     aws_test = tests[0]
     gce_test = tests[1]
@@ -72,9 +78,13 @@ def test_definition_parser():
     assert aws_test["name"] == "sample_test.aws"
     assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
     invalid_test_definition = test_definitions[0]
+    # Intentionally make the test definition invalid by create an empty 'variations'
+    # field. Check that the parser throws exception at runtime
     invalid_test_definition['variations'] = []
     with pytest.raises(ReleaseTestConfigError):
         parse_test_definition([invalid_test_definition])
+    # Intentionally make the test definition invalid by making one 'variation' entry
+    # missing the __suffix__ entry. Check that the parser throws exception at runtime
     invalid_test_definition['variations'] = [
         {'__suffix__': 'aws'},
         {}

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -6,6 +6,7 @@ import pytest
 from ray_release.config import (
     read_and_validate_release_test_collection,
     Test,
+    TestDefinition,
     validate_cluster_compute,
     load_schema_file,
     parse_test_definition,
@@ -41,6 +42,37 @@ VALID_TEST = Test(
         "alert": "default",
     }
 )
+
+def test_definition_parser():
+    test_definitions = yaml.safe_load('''
+        - name: sample_test
+          working_dir: sample_dir
+          frequency: nightly
+          team: sample
+          cluster:
+            cluster_env: env.yaml
+            cluster_compute: compute.yaml
+          run:
+            timeout: 100
+            script: python script.py
+          variations:
+            - __suffix__: aws
+            - __suffix__: gce
+              cluster:
+                cluster_env: env_gce.yaml
+                cluster_compute: compute_gce.yaml
+    ''')
+    tests = parse_test_definition(test_definitions)
+    aws_test = tests[0]
+    gce_test = tests[1]
+    schema = load_schema_file()
+    assert not validate_test(aws_test, schema)
+    assert not validate_test(gce_test, schema)
+    assert aws_test["name"] == "sample_test.aws"
+    assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
+    with pytest.raises(ReleaseTestConfigError):
+        test_definitions[0]['variations'] = []
+        parse_test_definition(test_definitions)
 
 
 def test_parse_test_definition():

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -6,7 +6,6 @@ import pytest
 from ray_release.config import (
     read_and_validate_release_test_collection,
     Test,
-    TestDefinition,
     validate_cluster_compute,
     load_schema_file,
     parse_test_definition,
@@ -43,102 +42,6 @@ VALID_TEST = Test(
     }
 )
 
-"""
-Unit test for the ray_release.config.parse_test_definition function. In particular,
-we check that the code correctly parse a test definition that have the 'variations' 
-field.
-"""
-def test_parse_test_definition():
-    test_definitions = yaml.safe_load('''
-        - name: sample_test
-          working_dir: sample_dir
-          frequency: nightly
-          team: sample
-          cluster:
-            cluster_env: env.yaml
-            cluster_compute: compute.yaml
-          run:
-            timeout: 100
-            script: python script.py
-          variations:
-            - __suffix__: aws
-            - __suffix__: gce
-              cluster:
-                cluster_env: env_gce.yaml
-                cluster_compute: compute_gce.yaml
-    ''')
-    # Check that parsing returns two tests, one for each variation (aws and gce). Check
-    # that both tests are valid, and their fields are populated correctly
-    tests = parse_test_definition(test_definitions)
-    aws_test = tests[0]
-    gce_test = tests[1]
-    schema = load_schema_file()
-    assert not validate_test(aws_test, schema)
-    assert not validate_test(gce_test, schema)
-    assert aws_test["name"] == "sample_test.aws"
-    assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
-    invalid_test_definition = test_definitions[0]
-    # Intentionally make the test definition invalid by create an empty 'variations'
-    # field. Check that the parser throws exception at runtime
-    invalid_test_definition['variations'] = []
-    with pytest.raises(ReleaseTestConfigError):
-        parse_test_definition([invalid_test_definition])
-    # Intentionally make the test definition invalid by making one 'variation' entry
-    # missing the __suffix__ entry. Check that the parser throws exception at runtime
-    invalid_test_definition['variations'] = [
-        {'__suffix__': 'aws'},
-        {}
-    ]
-    with pytest.raises(ReleaseTestConfigError):
-        parse_test_definition([invalid_test_definition])
-
-def test_parse_test_definition():
-    """
-    Unit test for the ray_release.config.parse_test_definition function. In particular,
-    we check that the code correctly parse a test definition that have the 'variations'
-    field.
-    """
-    test_definitions = yaml.safe_load(
-        """
-        - name: sample_test
-          working_dir: sample_dir
-          frequency: nightly
-          team: sample
-          cluster:
-            cluster_env: env.yaml
-            cluster_compute: compute.yaml
-          run:
-            timeout: 100
-            script: python script.py
-          variations:
-            - __suffix__: aws
-            - __suffix__: gce
-              cluster:
-                cluster_env: env_gce.yaml
-                cluster_compute: compute_gce.yaml
-    """
-    )
-    # Check that parsing returns two tests, one for each variation (aws and gce). Check
-    # that both tests are valid, and their fields are populated correctly
-    tests = parse_test_definition(test_definitions)
-    aws_test = tests[0]
-    gce_test = tests[1]
-    schema = load_schema_file()
-    assert not validate_test(aws_test, schema)
-    assert not validate_test(gce_test, schema)
-    assert aws_test["name"] == "sample_test.aws"
-    assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
-    invalid_test_definition = test_definitions[0]
-    # Intentionally make the test definition invalid by create an empty 'variations'
-    # field. Check that the parser throws exception at runtime
-    invalid_test_definition["variations"] = []
-    with pytest.raises(ReleaseTestConfigError):
-        parse_test_definition([invalid_test_definition])
-    # Intentionally make the test definition invalid by making one 'variation' entry
-    # missing the __suffix__ entry. Check that the parser throws exception at runtime
-    invalid_test_definition["variations"] = [{"__suffix__": "aws"}, {}]
-    with pytest.raises(ReleaseTestConfigError):
-        parse_test_definition([invalid_test_definition])
 
 def test_parse_test_definition():
     """

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -288,6 +288,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: compute_gce_gpu_1_g4_8xl.yaml
@@ -503,6 +504,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: compute_gce_gpu_1.yaml
@@ -1273,6 +1275,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_gce_4x8.yaml
@@ -1299,6 +1302,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_gce_4x8.yaml
@@ -1326,6 +1330,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_gce_4x8.yaml
@@ -1492,6 +1497,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_gce_1x16.yaml
@@ -1544,6 +1550,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_gce_1x32_hd.yaml
@@ -1583,6 +1590,7 @@
           num_nodes: 20
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_gce_100x2.yaml
@@ -1611,6 +1619,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_gce_16x64.yaml
@@ -1636,6 +1645,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_gce_1x96.yaml
@@ -1669,6 +1679,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config_data.yaml
         cluster_compute: tpl_gce_16x64.yaml
@@ -1751,6 +1762,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -1785,6 +1797,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: ../rllib_tests/app_config.yaml
         cluster_compute: tpl_cpu_3_gce.yaml
@@ -1816,6 +1829,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: ../rllib_tests/app_config.yaml
         cluster_compute: tpl_cpu_1_large_gce.yaml
@@ -1847,6 +1861,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -1878,6 +1893,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -1914,6 +1930,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: ../rllib_tests/app_config.yaml
         cluster_compute: many_ppo_gce.yaml
@@ -1945,6 +1962,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -1976,6 +1994,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -2007,6 +2026,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -2038,6 +2058,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: ../rllib_tests/app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -2069,6 +2090,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -2130,6 +2152,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -2160,6 +2183,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce.yaml
@@ -2192,6 +2216,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce_4_xlarge.yaml
@@ -2220,6 +2245,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce_4_xlarge.yaml
@@ -2242,6 +2268,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce_4_xlarge.yaml
@@ -2264,6 +2291,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce_gpu_node.yaml
@@ -2286,6 +2314,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce_gpu_worker.yaml
@@ -2317,6 +2346,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: rte_gce_small.yaml
@@ -2345,6 +2375,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: rte_gce_minimal.yaml
@@ -3338,6 +3369,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: 4gpus_544_cpus_gce.yaml 
@@ -3366,6 +3398,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: shuffle/shuffle_app_config.yaml
         cluster_compute: shuffle/shuffle_compute_multi_gce.yaml
@@ -3389,6 +3422,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: stress_tests/stress_tests_app_config.yaml
         cluster_compute: stress_tests/placement_group_tests_compute_gce.yaml
@@ -3411,6 +3445,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: decision_tree/decision_tree_app_config.yaml
         cluster_compute: decision_tree/autoscaling_compute_gce.yaml
@@ -3434,6 +3469,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: shuffle/shuffle_app_config.yaml
         cluster_compute: shuffle/shuffle_compute_autoscaling_gce.yaml
@@ -3459,6 +3495,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_64_gce.yaml
@@ -4158,6 +4195,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: data_ingest_benchmark_compute_gce.yaml
@@ -4376,6 +4414,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: shuffle/shuffle_app_config.yaml
         cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
@@ -4590,6 +4629,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      frequency: manual
       cluster:
         cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml
         cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4413,14 +4413,6 @@
     wait_for_nodes:
       num_nodes: 100
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: shuffle/100tb_shuffle_app_config.yaml
-        cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
-
 ##################
 # Core Chaos tests
 ##################

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1570,7 +1570,7 @@
 
   variations:
     - __suffix__: aws
-    - name: smoke-test
+    - __suffix__: smoke-test
       frequency: nightly
       cluster:
         cluster_env: app_config.yaml

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1551,6 +1551,8 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_gce_1x32_hd.yaml
@@ -1763,6 +1765,8 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -1798,6 +1802,10 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test: 
+        frequency: manual
+        run:
+          timeout: 3600
       cluster:
         cluster_env: ../rllib_tests/app_config.yaml
         cluster_compute: tpl_cpu_3_gce.yaml
@@ -1830,6 +1838,10 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
+        run:
+          timeout: 3600
       cluster:
         cluster_env: ../rllib_tests/app_config.yaml
         cluster_compute: tpl_cpu_1_large_gce.yaml
@@ -1862,6 +1874,10 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
+        run:
+          timeout: 3600
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -1894,6 +1910,10 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
+        run:
+          timeout: 3600
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -1931,6 +1951,10 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
+        run:
+          timeout: 3600
       cluster:
         cluster_env: ../rllib_tests/app_config.yaml
         cluster_compute: many_ppo_gce.yaml
@@ -1963,6 +1987,10 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
+        run:
+          timeout: 3600
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -1995,6 +2023,10 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
+        run:
+          timeout: 3600
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -2027,6 +2059,10 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
+        run:
+          timeout: 3600
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -2059,6 +2095,10 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
+        run:
+          timeout: 3600
       cluster:
         cluster_env: ../rllib_tests/app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -2091,6 +2131,10 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
+        run:
+          timeout: 3600
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -2153,6 +2197,10 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
+        run:
+          timeout: 3600
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
@@ -2184,6 +2232,10 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
+        run:
+          timeout: 3600
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce.yaml
@@ -3370,6 +3422,10 @@
     - __suffix__: gce
       env: gce
       frequency: manual
+      smoke_test:
+        frequency: manual
+        run:
+          timeout: 2000
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: 4gpus_544_cpus_gce.yaml 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3283,14 +3283,6 @@
 
   alert: default
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: 8gpus_96cpus_gce.yaml 
-
 - name: rllib_multi_gpu_with_lstm_learning_tests
   group: RLlib tests
   working_dir: rllib_tests
@@ -3309,14 +3301,6 @@
 
   alert: default
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: 8gpus_96cpus_gce.yaml 
-
 - name: rllib_multi_gpu_with_attention_learning_tests
   group: RLlib tests
   working_dir: rllib_tests
@@ -3334,14 +3318,6 @@
 
 
   alert: default
-
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: 8gpus_96cpus_gce.yaml 
 
 - name: rllib_stress_tests
   group: RLlib tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -284,6 +284,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_gce_gpu_1_g4_8xl.yaml
+
 
 - name: air_benchmark_torch_batch_prediction_gpu_4x4_100gb
   group: AIR tests
@@ -306,6 +314,15 @@
         num_nodes: 4
 
   alert: default
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_gce_gpu_4_g4_12xl.yaml
+
 
 
 - name: air_benchmark_torch_mnist_cpu_4x4
@@ -492,6 +509,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_gce_gpu_1.yaml
+
 
 - name: air_benchmark_pytorch_training_e2e_gpu_4x4_100gb
   group: AIR tests
@@ -513,8 +538,15 @@
     wait_for_nodes:
       num_nodes: 4
 
-
   alert: default
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_gce_gpu_16.yaml
 
 # Test tiny, medium, and huge input files.
 - name: ray-data-bulk-ingest-file-size-benchmark
@@ -1474,6 +1506,14 @@
 
   alert: tune_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_gce_1x16.yaml
+
 - name: tune_scalability_durable_trainable
   group: Tune scalability tests
   working_dir: tune_tests/scalability_tests
@@ -1518,6 +1558,14 @@
 
   alert: tune_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_gce_1x32_hd.yaml
+
 - name: tune_scalability_network_overhead
   group: Tune scalability tests
   working_dir: tune_tests/scalability_tests
@@ -1536,19 +1584,26 @@
     wait_for_nodes:
       num_nodes: 100
 
-  smoke_test:
-    frequency: nightly
-
-    cluster:
-      cluster_compute: tpl_20x2.yaml
-
-    run:
-      timeout: 500
-      prepare_timeout: 600
-      wait_for_nodes:
-        num_nodes: 20
-
   alert: tune_tests
+
+  variations:
+    - __suffix__: aws
+    - name: smoke-test
+      frequency: nightly
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_20x2.yaml
+      run:
+        timeout: 500
+        prepare_timeout: 600
+        script: python workloads/test_network_overhead.py
+        wait_for_nodes:
+          num_nodes: 20
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_gce_100x2.yaml
 
 - name: tune_scalability_result_throughput_cluster
   group: Tune scalability tests
@@ -1570,6 +1625,14 @@
 
   alert: tune_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_gce_16x64.yaml
+
 - name: tune_scalability_result_throughput_single_node
   group: Tune scalability tests
   working_dir: tune_tests/scalability_tests
@@ -1586,6 +1649,18 @@
     script: python workloads/test_result_throughput_single_node.py
 
   alert: tune_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_gce_1x96.yaml
+      run:
+        timeout: 600
+        script: python workloads/test_result_throughput_single_node.py
+        type: anyscale_job
 
 - name: tune_scalability_xgboost_sweep
   group: Tune scalability tests
@@ -1607,6 +1682,14 @@
 
 
   alert: tune_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config_data.yaml
+        cluster_compute: tpl_gce_16x64.yaml
 
 
 ############################
@@ -1682,6 +1765,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
+
 - name: long_running_apex
   group: Long running tests
   working_dir: long_running_tests
@@ -1708,6 +1799,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: ../rllib_tests/app_config.yaml
+        cluster_compute: tpl_cpu_3_gce.yaml
+
 - name: long_running_impala
   group: Long running tests
   working_dir: long_running_tests
@@ -1730,6 +1829,14 @@
       timeout: 3600
 
   alert: long_running_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: ../rllib_tests/app_config.yaml
+        cluster_compute: tpl_cpu_1_large_gce.yaml
 
 - name: long_running_many_actor_tasks
   group: Long running tests
@@ -1754,6 +1861,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
+
 - name: long_running_many_drivers
   group: Long running tests
   working_dir: long_running_tests
@@ -1776,6 +1891,14 @@
       timeout: 3600
 
   alert: long_running_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_many_ppo
   group: Long running tests
@@ -1805,6 +1928,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: ../rllib_tests/app_config.yaml
+        cluster_compute: many_ppo_gce.yaml
+
 - name: long_running_many_tasks
   group: Long running tests
   working_dir: long_running_tests
@@ -1827,6 +1958,14 @@
       timeout: 3600
 
   alert: long_running_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_many_tasks_serialized_ids
   group: Long running tests
@@ -1851,6 +1990,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
+
 - name: long_running_node_failures
   group: Long running tests
   working_dir: long_running_tests
@@ -1873,6 +2020,14 @@
       timeout: 3600
 
   alert: long_running_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_pbt
   group: Long running tests
@@ -1897,6 +2052,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: ../rllib_tests/app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
+
 - name: long_running_serve
   group: Long running tests
   working_dir: long_running_tests
@@ -1919,6 +2082,14 @@
       timeout: 3600
 
   alert: long_running_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_serve_failure
   group: Long running tests
@@ -1948,6 +2119,19 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_c5_gce.yaml
+      run:
+        timeout: 86400
+        script: python workloads/serve_failure.py
+        long_running: true
+        type: anyscale_job
+
 - name: long_running_many_jobs
   group: Long running tests
   working_dir: long_running_tests
@@ -1973,6 +2157,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
+
 - name: long_running_distributed_pytorch_pbt_failure
   group: Long running tests
   working_dir: long_running_distributed_tests
@@ -1994,6 +2186,14 @@
       timeout: 3600
 
   alert: long_running_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_tpl_gce.yaml
 
 ########################
 # Jobs tests
@@ -2019,6 +2219,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_tpl_gce_4_xlarge.yaml
+
 - name: jobs_basic_remote_working_dir
   group: Jobs tests
   working_dir: jobs_tests
@@ -2039,6 +2247,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_tpl_gce_4_xlarge.yaml
+
 - name: jobs_remote_multi_node
   group: Jobs tests
   team: serve
@@ -2052,6 +2268,14 @@
     script: python workloads/jobs_remote_multi_node.py
     wait_for_nodes:
       num_nodes: 4
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_tpl_gce_4_xlarge.yaml
 
 - name: jobs_check_cuda_available
   group: Jobs tests
@@ -2067,6 +2291,14 @@
     wait_for_nodes:
       num_nodes: 2
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_tpl_gce_gpu_node.yaml
+
 - name: jobs_specify_num_gpus
   group: Jobs tests
   team: serve
@@ -2081,6 +2313,13 @@
     wait_for_nodes:
       num_nodes: 2
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_tpl_gce_gpu_worker.yaml
 
 ########################
 # Runtime env tests
@@ -2105,6 +2344,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: rte_gce_small.yaml
+
 - name: runtime_env_wheel_urls
   group: Runtime env tests
   working_dir: runtime_env_tests
@@ -2124,6 +2371,14 @@
 
 
   alert: default
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: rte_gce_minimal.yaml
 
 # It seems like the consensus is that this should be tested in CI, and not in a nightly test.
 
@@ -3046,6 +3301,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: 8gpus_96cpus_gce.yaml 
+
 - name: rllib_multi_gpu_with_lstm_learning_tests
   group: RLlib tests
   working_dir: rllib_tests
@@ -3064,6 +3327,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: 8gpus_96cpus_gce.yaml 
+
 - name: rllib_multi_gpu_with_attention_learning_tests
   group: RLlib tests
   working_dir: rllib_tests
@@ -3081,6 +3352,14 @@
 
 
   alert: default
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: 8gpus_96cpus_gce.yaml 
 
 - name: rllib_stress_tests
   group: RLlib tests
@@ -3110,6 +3389,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: 4gpus_544_cpus_gce.yaml 
+
 ########################
 # Core Nightly Tests
 ########################
@@ -3130,6 +3417,14 @@
     wait_for_nodes:
       num_nodes: 4
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: shuffle/shuffle_app_config.yaml
+        cluster_compute: shuffle/shuffle_compute_multi_gce.yaml
+
 
 - name: stress_test_placement_group
   group: core-multi-test
@@ -3145,6 +3440,14 @@
     timeout: 7200
     script: python stress_tests/test_placement_group.py
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: stress_tests/stress_tests_app_config.yaml
+        cluster_compute: stress_tests/placement_group_tests_compute_gce.yaml
+
 - name: decision_tree_autoscaling_20_runs
   group: core-multi-test
   working_dir: nightly_tests
@@ -3158,6 +3461,14 @@
   run:
     timeout: 9600
     script: python decision_tree/cart_with_tree.py --concurrency=20
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: decision_tree/decision_tree_app_config.yaml
+        cluster_compute: decision_tree/autoscaling_compute_gce.yaml
 
 - name: autoscaling_shuffle_1tb_1000_partitions
   group: core-multi-test
@@ -3173,6 +3484,14 @@
     timeout: 4000
     script: python shuffle/shuffle_test.py --num-partitions=1000 --partition-size=1e9
       --no-streaming
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: shuffle/shuffle_app_config.yaml
+        cluster_compute: shuffle/shuffle_compute_autoscaling_gce.yaml
 
 
 - name: microbenchmark
@@ -3190,6 +3509,14 @@
   run:
     timeout: 1800
     script: OMP_NUM_THREADS=64 RAY_ADDRESS=local python run_microbenchmark.py
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_64_gce.yaml
 
 
 - name: microbenchmark_staging
@@ -3866,6 +4193,13 @@
     wait_for_nodes:
       num_nodes: 20
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: data_ingest_benchmark_compute_gce.yaml
 
 - name: streaming_data_ingest_benchmark_1tb
   group: data-tests
@@ -3883,6 +4217,13 @@
     wait_for_nodes:
       num_nodes: 20
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: data_ingest_benchmark_compute_gce.yaml
 
 - name: aggregate_benchmark
   group: data-tests
@@ -4094,6 +4435,15 @@
     wait_for_nodes:
       num_nodes: 20
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: shuffle/shuffle_app_config.yaml
+        cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
+
+
 - name: dataset_shuffle_push_based_sort_1tb
   group: data-tests
   working_dir: nightly_tests
@@ -4125,6 +4475,14 @@
     script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=100000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 100
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: shuffle/100tb_shuffle_app_config.yaml
+        cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
 
 ##################
 # Core Chaos tests
@@ -4298,6 +4656,14 @@
     script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml
+        cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
 
 #####################
 # Observability tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -530,14 +530,6 @@
 
   alert: default
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: compute_gce_gpu_16.yaml
-
 # Test tiny, medium, and huge input files.
 - name: ray-data-bulk-ingest-file-size-benchmark
   group: AIR tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2101,19 +2101,6 @@
 
   alert: long_running_tests
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: tpl_cpu_1_c5_gce.yaml
-      run:
-        timeout: 86400
-        script: python workloads/serve_failure.py
-        long_running: true
-        type: anyscale_job
-
 - name: long_running_many_jobs
   group: Long running tests
   working_dir: long_running_tests
@@ -4150,14 +4137,6 @@
     script: python data_ingest_benchmark.py --dataset-size-gb=1000 --num-workers=20 --streaming
     wait_for_nodes:
       num_nodes: 20
-
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: data_ingest_benchmark_compute_gce.yaml
 
 - name: streaming_data_ingest_benchmark_1tb
   group: data-tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -315,16 +315,6 @@
 
   alert: default
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: compute_gce_gpu_4_g4_12xl.yaml
-
-
-
 - name: air_benchmark_torch_mnist_cpu_4x4
   group: AIR tests
   working_dir: air_tests/air_benchmarks

--- a/release/rllib_tests/4gpus_544_cpus_gce.yaml
+++ b/release/rllib_tests/4gpus_544_cpus_gce.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 5
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-64-nvidia-tesla-t4-4 # g3.16xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-96 # m5.24xlarge
+      min_workers: 5
+      max_workers: 5
+      use_spot: false
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 500

--- a/release/rllib_tests/8gpus_96cpus_gce.yaml
+++ b/release/rllib_tests/8gpus_96cpus_gce.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n1-highmem-96-nvidia-tesla-v100-8 # g4dn.metal
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # m5.xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 500

--- a/release/runtime_env_tests/rte_gce_minimal.yaml
+++ b/release/runtime_env_tests/rte_gce_minimal.yaml
@@ -1,0 +1,18 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-4 # aws m5.xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # aws m5.xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+

--- a/release/runtime_env_tests/rte_gce_small.yaml
+++ b/release/runtime_env_tests/rte_gce_small.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 3
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-4 # aws m5.xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # aws m5.xlarge
+      min_workers: 3
+      max_workers: 3
+      use_spot: false

--- a/release/tune_tests/scalability_tests/tpl_gce_100x2.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_100x2.yaml
@@ -1,0 +1,17 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 99
+
+head_node_type:
+    name: head_node
+    instance_type: n2d-standard-16
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2d-standard-2
+      min_workers: 99
+      max_workers: 99
+      use_spot: true

--- a/release/tune_tests/scalability_tests/tpl_gce_16x2.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_16x2.yaml
@@ -1,0 +1,17 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 15
+
+head_node_type:
+    name: head_node
+    instance_type: n2d-standard-2
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2d-standard-2
+      min_workers: 15
+      max_workers: 15
+      use_spot: false

--- a/release/tune_tests/scalability_tests/tpl_gce_16x64.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_16x64.yaml
@@ -1,0 +1,17 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 15
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-64 # n2d-standard-64
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-64 # n2d-standard-64
+      min_workers: 15
+      max_workers: 15
+      use_spot: false

--- a/release/tune_tests/scalability_tests/tpl_gce_1x16.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_1x16.yaml
@@ -1,0 +1,17 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # n2d-standard-16
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # n2d-standard-4
+      min_workers: 0
+      max_workers: 0
+      use_spot: false

--- a/release/tune_tests/scalability_tests/tpl_gce_1x32_hd.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_1x32_hd.yaml
@@ -1,0 +1,24 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2d-standard-16
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2d-standard-32
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'

--- a/release/tune_tests/scalability_tests/tpl_gce_1x96.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_1x96.yaml
@@ -1,0 +1,17 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2d-standard-96
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2d-standard-4
+      min_workers: 0
+      max_workers: 0
+      use_spot: false

--- a/release/tune_tests/scalability_tests/tpl_gce_20x2.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_20x2.yaml
@@ -1,0 +1,17 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 19
+
+head_node_type:
+    name: head_node
+    instance_type: n2d-standard-2
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2d-standard-2
+      min_workers: 19
+      max_workers: 19
+      use_spot: true


### PR DESCRIPTION
## Why are these changes needed?

This diff adds GCE variations to some of the critical release tests, to test anyscale GCE stack. These variations run as the same cadence and run script as the original AWS tests.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Release tests:https://buildkite.com/ray-project/release-tests-pr/builds/33347
   