### PR TITLE
[Data] Fix `write_results` type

### DIFF
--- a/python/ray/data/_internal/planner/write.py
+++ b/python/ray/data/_internal/planner/write.py
@@ -1,8 +1,8 @@
-from typing import Callable, Iterator
+from typing import Callable, Iterator, List
 
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data.block import Block
-from ray.data.datasource import Datasource
+from ray.data.datasource import Datasource, WriteResult
 
 
 def generate_write_fn(
@@ -13,6 +13,8 @@ def generate_write_fn(
     # be raised. The Datasource can handle execution outcomes with the
     # on_write_complete() and on_write_failed().
     def fn(blocks: Iterator[Block], ctx) -> Iterator[Block]:
-        return [[datasource.write(blocks, ctx, **write_args)]]
+        # NOTE: `WriteResult` isn't a valid block type, so we need to wrap it in a list.
+        block: List[WriteResult] = [datasource.write(blocks, ctx, **write_args)]
+        return [block]
 
     return fn

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2907,9 +2907,12 @@ class Dataset(Generic[T]):
                 self._write_ds = Dataset(
                     plan, self._epoch, self._lazy, logical_plan
                 ).cache()
-                datasource.on_write_complete(
-                    ray.get(self._write_ds._plan.execute().get_blocks())
+                blocks = ray.get(self._write_ds._plan.execute().get_blocks())
+                assert all(
+                    isinstance(block, list) and len(block) == 1 for block in blocks
                 )
+                write_results = [block[0] for block in blocks]
+                datasource.on_write_complete(write_results)
             except Exception as e:
                 datasource.on_write_failed([], e)
                 raise

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -377,7 +377,7 @@ class DummyOutputDatasource(Datasource[Union[ArrowRow, int]]):
         return "ok"
 
     def on_write_complete(self, write_results: List[WriteResult]) -> None:
-        assert all(w == ["ok"] for w in write_results), write_results
+        assert all(w == "ok" for w in write_results), write_results
         self.num_ok += 1
 
     def on_write_failed(

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -268,7 +268,7 @@ class NodeLoggerOutputDatasource(Datasource[Union[ArrowRow, int]]):
         return "ok"
 
     def on_write_complete(self, write_results: List[WriteResult]) -> None:
-        assert all(w == ["ok"] for w in write_results), write_results
+        assert all(w == "ok" for w in write_results), write_results
         self.num_ok += 1
 
     def on_write_failed(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`Dataset.write_datasource` passes a `list[list[WriteResult]]` to `Datasource.on_write_complete` instead of a `list[WriteResult]`. This PR fixes the bug.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes #33935 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
