### PR TITLE
[CI][Clean][2] Make s3 function names more agnostic

### DIFF
--- a/release/ray_release/command_runner/_anyscale_job_wrapper.py
+++ b/release/ray_release/command_runner/_anyscale_job_wrapper.py
@@ -105,7 +105,7 @@ def run_storage_cp(source: str, target: str):
         )
         return True
     except subprocess.SubprocessError:
-        logger.exception("Couldn't upload to s3.")
+        logger.exception("Couldn't upload to cloud storage.")
         return False
 
 
@@ -235,10 +235,10 @@ def main(
     test_workload: str,
     test_workload_timeout: float,
     test_no_raise_on_timeout: bool,
-    results_s3_uri: Optional[str],
-    metrics_s3_uri: Optional[str],
-    output_s3_uri: Optional[str],
-    upload_s3_uri: Optional[str],
+    results_cloud_storage_uri: Optional[str],
+    metrics_cloud_storage_uri: Optional[str],
+    output_cloud_storage_uri: Optional[str],
+    upload_cloud_storage_uri: Optional[str],
     artifact_path: Optional[str],
     prepare_commands: List[str],
     prepare_commands_timeouts: List[str],
@@ -297,7 +297,7 @@ def main(
 
         # Upload results.json
         uploaded_results = run_storage_cp(
-            os.environ.get("TEST_OUTPUT_JSON", None), results_s3_uri
+            os.environ.get("TEST_OUTPUT_JSON", None), results_cloud_storage_uri
         )
 
         # Collect prometheus metrics
@@ -305,12 +305,14 @@ def main(
         if collected_metrics:
             # Upload prometheus metrics
             uploaded_metrics = run_storage_cp(
-                os.environ.get("METRICS_OUTPUT_JSON", None), metrics_s3_uri
+                os.environ.get("METRICS_OUTPUT_JSON", None), metrics_cloud_storage_uri
             )
 
         uploaded_artifact = run_storage_cp(
             artifact_path,
-            os.path.join(upload_s3_uri, os.environ["USER_GENERATED_ARTIFACT"])
+            os.path.join(
+                upload_cloud_storage_uri, os.environ["USER_GENERATED_ARTIFACT"]
+            )
             if "USER_GENERATED_ARTIFACT" in os.environ
             else None,
         )
@@ -339,11 +341,11 @@ def main(
         fp.write(output_json)
 
     # Upload output.json
-    run_storage_cp(str(output_json_file), output_s3_uri)
+    run_storage_cp(str(output_json_file), output_cloud_storage_uri)
 
     logger.info("### Finished ###")
     # This will be read by the AnyscaleJobRunner on the buildkite runner
-    # if output.json cannot be obtained from S3
+    # if output.json cannot be obtained from cloud storage
     logger.info(f"### JSON |{output_json}| ###")
 
     # Flush buffers
@@ -377,27 +379,27 @@ if __name__ == "__main__":
         help="don't fail on timeout",
     )
     parser.add_argument(
-        "--results-s3-uri",
+        "--results-cloud-storage-uri",
         type=str,
         help="bucket address to upload results.json to",
         required=False,
     )
     parser.add_argument(
-        "--metrics-s3-uri",
+        "--metrics-cloud-storage-uri",
         type=str,
         help="bucket address to upload metrics.json to",
         required=False,
     )
     parser.add_argument(
-        "--output-s3-uri",
+        "--output-cloud-storage-uri",
         type=str,
         help="bucket address to upload output.json to",
         required=False,
     )
     parser.add_argument(
-        "--upload-s3-uri",
+        "--upload-cloud-storage-uri",
         type=str,
-        help="root s3 bucket address to upload stuff",
+        help="root cloud-storage bucket address to upload stuff",
         required=False,
     )
     parser.add_argument(

--- a/release/ray_release/command_runner/job_runner.py
+++ b/release/ray_release/command_runner/job_runner.py
@@ -54,22 +54,15 @@ class JobRunner(CommandRunner):
         except Exception as e:
             raise LocalEnvSetupError(f"Error setting up local environment: {e}") from e
 
-    def prepare_remote_env(self):
-        # Copy wait script to working dir
-        wait_script = os.path.join(os.path.dirname(__file__), "_wait_cluster.py")
-        # Copy wait script to working dir
-        if os.path.exists("wait_cluster.py"):
-            os.unlink("wait_cluster.py")
-        os.link(wait_script, "wait_cluster.py")
+    def _copy_script_to_working_dir(self, script_name):
+        script = os.path.join(os.path.dirname(__file__), f"_{script_name}")
+        if os.path.exists(script_name):
+            os.unlink(script_name)
+        os.link(script, script_name)
 
-        # Copy prometheus metrics script to working dir
-        metrics_script = os.path.join(
-            os.path.dirname(__file__), "_prometheus_metrics.py"
-        )
-        # Copy prometheus metrics script to working dir
-        if os.path.exists("prometheus_metrics.py"):
-            os.unlink("prometheus_metrics.py")
-        os.link(metrics_script, "prometheus_metrics.py")
+    def prepare_remote_env(self):
+        self._copy_script_to_working_dir("wait_cluster.py")
+        self._copy_script_to_working_dir("prometheus_metrics.py")
 
         # Do not upload the files here. Instead, we use the job runtime environment
         # to automatically upload the local working dir.

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -52,7 +52,6 @@ from ray_release.util import (
 type_str_to_command_runner = {
     "command": SDKRunner,
     "sdk_command": SDKRunner,
-    "job": JobRunner,
     "anyscale_job": AnyscaleJobRunner,
 }
 

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -52,6 +52,7 @@ from ray_release.util import (
 type_str_to_command_runner = {
     "command": SDKRunner,
     "sdk_command": SDKRunner,
+    "job": JobRunner,
     "anyscale_job": AnyscaleJobRunner,
 }
 

--- a/release/ray_release/tests/test_anyscale_job_wrapper.py
+++ b/release/ray_release/tests/test_anyscale_job_wrapper.py
@@ -8,11 +8,11 @@ from ray_release.command_runner._anyscale_job_wrapper import (
     OUTPUT_JSON_FILENAME,
 )
 
-s3_kwargs = dict(
-    results_s3_uri=None,
-    metrics_s3_uri=None,
-    output_s3_uri=None,
-    upload_s3_uri=None,
+cloud_storage_kwargs = dict(
+    results_cloud_storage_uri=None,
+    metrics_cloud_storage_uri=None,
+    output_cloud_storage_uri=None,
+    upload_cloud_storage_uri=None,
     artifact_path=None,
 )
 
@@ -47,7 +47,7 @@ def test_prepare_commands_validation(tmpdir):
             test_no_raise_on_timeout=False,
             prepare_commands=["exit 0"],
             prepare_commands_timeouts=[],
-            **s3_kwargs
+            **cloud_storage_kwargs
         )
     with pytest.raises(ValueError):
         main(
@@ -56,7 +56,7 @@ def test_prepare_commands_validation(tmpdir):
             test_no_raise_on_timeout=False,
             prepare_commands=[],
             prepare_commands_timeouts=[1],
-            **s3_kwargs
+            **cloud_storage_kwargs
         )
 
 
@@ -69,7 +69,7 @@ def test_end_to_end(tmpdir):
             test_no_raise_on_timeout=False,
             prepare_commands=[],
             prepare_commands_timeouts=[],
-            **s3_kwargs
+            **cloud_storage_kwargs
         )
         == expected_return_code
     )
@@ -85,7 +85,7 @@ def test_end_to_end_prepare_commands(tmpdir):
             test_no_raise_on_timeout=False,
             prepare_commands=["exit 0", "exit 0"],
             prepare_commands_timeouts=[1, 1],
-            **s3_kwargs
+            **cloud_storage_kwargs
         )
         == expected_return_code
     )
@@ -101,7 +101,7 @@ def test_end_to_end_long_running(tmpdir):
             test_no_raise_on_timeout=True,
             prepare_commands=[],
             prepare_commands_timeouts=[],
-            **s3_kwargs
+            **cloud_storage_kwargs
         )
         == expected_return_code
     )
@@ -117,7 +117,7 @@ def test_end_to_end_timeout(tmpdir):
             test_no_raise_on_timeout=False,
             prepare_commands=[],
             prepare_commands_timeouts=[],
-            **s3_kwargs
+            **cloud_storage_kwargs
         )
         == expected_return_code
     )
@@ -133,7 +133,7 @@ def test_end_to_end_prepare_timeout(tmpdir):
             test_no_raise_on_timeout=False,
             prepare_commands=["exit 0", "sleep 10"],
             prepare_commands_timeouts=[1, 1],
-            **s3_kwargs
+            **cloud_storage_kwargs
         )
         == expected_return_code
     )
@@ -150,7 +150,7 @@ def test_end_to_end_failure(tmpdir, long_running):
             test_no_raise_on_timeout=long_running,
             prepare_commands=[],
             prepare_commands_timeouts=[],
-            **s3_kwargs
+            **cloud_storage_kwargs
         )
         == expected_return_code
     )
@@ -166,7 +166,7 @@ def test_end_to_end_prepare_failure(tmpdir):
             test_no_raise_on_timeout=False,
             prepare_commands=["exit 0", "exit 1"],
             prepare_commands_timeouts=[1, 1],
-            **s3_kwargs
+            **cloud_storage_kwargs
         )
         == expected_return_code
     )

--- a/release/ray_release/util.py
+++ b/release/ray_release/util.py
@@ -25,6 +25,9 @@ class DeferredEnvVar:
 
 
 ANYSCALE_HOST = DeferredEnvVar("ANYSCALE_HOST", "https://console.anyscale.com")
+S3_CLOUD_STORAGE = "s3"
+GS_CLOUD_STORAGE = "gs"
+GS_BUCKET = "anyscale-oss-dev-bucket"
 
 
 def deep_update(d, u) -> Dict:
@@ -161,11 +164,11 @@ def python_version_str(python_version: Tuple[int, int]) -> str:
     return "".join([str(x) for x in python_version])
 
 
-def generate_tmp_s3_path() -> str:
+def generate_tmp_cloud_storage_path() -> str:
     return "".join(random.choice(string.ascii_lowercase) for i in range(10))
 
 
-def join_s3_paths(*paths: str):
+def join_cloud_storage_paths(*paths: str):
     paths = list(paths)
     if len(paths) > 1:
         for i in range(1, len(paths)):


### PR DESCRIPTION
## Why are these changes needed?

Some existing functions that work with both s3 and gs but has the word s3 in his name. Refactor those. Also create constants for commonly used values, reduce duplications, etc.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] python -m pytest ray_release/tests/ 
   - [X] Release tests