### PR TITLE
[CI][Clean][03] Break run_release_test into smaller functions

### DIFF
--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -52,7 +52,6 @@ from ray_release.util import (
 type_str_to_command_runner = {
     "command": SDKRunner,
     "sdk_command": SDKRunner,
-    "job": JobRunner,
     "anyscale_job": AnyscaleJobRunner,
 }
 

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -1,13 +1,15 @@
 import os
 import time
-from typing import Optional, List
+from typing import Optional, List, Tuple
 
 from ray_release.alerts.handle import handle_result, require_result
 from ray_release.anyscale_util import get_cluster_name
 from ray_release.buildkite.output import buildkite_group, buildkite_open_last
+from ray_release.cluster_manager.cluster_manager import ClusterManager
 from ray_release.cluster_manager.full import FullClusterManager
 from ray_release.cluster_manager.minimal import MinimalClusterManager
 from ray_release.command_runner.job_runner import JobRunner
+from ray_release.command_runner.command_runner import CommandRunner
 from ray_release.command_runner.anyscale_job_runner import AnyscaleJobRunner
 from ray_release.command_runner.sdk_runner import SDKRunner
 from ray_release.config import (
@@ -89,43 +91,33 @@ def _get_extra_tags_from_env() -> dict:
     return {key.lower(): os.getenv(key, "") for key in env_vars}
 
 
-def run_release_test(
+def _load_test_configuration(
     test: Test,
     anyscale_project: str,
     result: Result,
     ray_wheels_url: str,
-    reporters: Optional[List[Reporter]] = None,
     smoke_test: bool = False,
-    cluster_id: Optional[str] = None,
-    cluster_env_id: Optional[str] = None,
     no_terminate: bool = False,
-) -> Result:
-    buildkite_group(":spiral_note_pad: Loading test configuration")
-
+) -> Tuple[ClusterManager, CommandRunner, str]:
     validate_test(test)
-
     logger.info(f"Test config: {test}")
 
+    # Populate result paramaters
     result.wheels_url = ray_wheels_url
     result.stable = test.get("stable", True)
     result.smoke_test = smoke_test
-
     buildkite_url = os.getenv("BUILDKITE_BUILD_URL", "")
     buildkite_job_id = os.getenv("BUILDKITE_JOB_ID", "")
-
     if buildkite_url:
         buildkite_url += "#" + buildkite_job_id
-
     result.buildkite_url = buildkite_url
     result.buildkite_job_id = buildkite_job_id
 
+    # Setting up working directory
     working_dir = test["working_dir"]
-
-    old_wd = os.getcwd()
     new_wd = os.path.join(RELEASE_PACKAGE_DIR, working_dir)
     os.chdir(new_wd)
 
-    start_time = time.monotonic()
     run_type = test["run"].get("type", DEFAULT_RUN_TYPE)
 
     # Workaround while Anyscale Jobs don't support leaving cluster alive
@@ -160,7 +152,6 @@ def run_release_test(
 
     logger.info(f"Got command runner cls: {command_runner_cls}")
     logger.info(f"Got file manager cls: {file_manager_cls}")
-
     # Extra tags to be set on resources on cloud provider's side
     extra_tags = _get_extra_tags_from_env()
     # We don't need other attributes as they can be derived from the name
@@ -184,230 +175,356 @@ def run_release_test(
     except Exception as e:
         raise ReleaseTestSetupError(f"Error setting up release test: {e}") from e
 
+    return cluster_manager, command_runner, artifact_path
+
+
+def _setup_cluster_environment(
+    test: Test,
+    result: Result,
+    cluster_manager: ClusterManager,
+    ray_wheels_url: str,
+    cluster_env_id: Optional[str],
+) -> Tuple[str, int, int, int, int]:
+    setup_signal_handling()
+    # Load configs
+    cluster_env = load_test_cluster_env(test, ray_wheels_url=ray_wheels_url)
+    cluster_compute = load_test_cluster_compute(test)
+
+    if cluster_env_id:
+        try:
+            cluster_manager.cluster_env_id = cluster_env_id
+            cluster_manager.build_cluster_env()
+            cluster_manager.fetch_build_info()
+            logger.info(
+                "Using overridden cluster environment with ID "
+                f"{cluster_env_id} and build ID "
+                f"{cluster_manager.cluster_env_build_id}"
+            )
+        except Exception as e:
+            raise ClusterEnvCreateError(
+                f"Could not get existing overridden cluster environment "
+                f"{cluster_env_id}: {e}"
+            ) from e
+    else:
+        cluster_manager.set_cluster_env(cluster_env)
+
+    # Load some timeouts
+    build_timeout = int(test["run"].get("build_timeout", DEFAULT_BUILD_TIMEOUT))
+    command_timeout = int(test["run"].get("timeout", DEFAULT_COMMAND_TIMEOUT))
+    cluster_timeout = int(test["run"].get("session_timeout", DEFAULT_CLUSTER_TIMEOUT))
+
+    # Get prepare command timeout, if any
+    prepare_cmd = test["run"].get("prepare", None)
+    if prepare_cmd:
+        prepare_timeout = test["run"].get("prepare_timeout", command_timeout)
+    else:
+        prepare_timeout = 0
+
+    # Base maximum uptime on the combined command and prepare timeouts
+    command_and_prepare_timeout = command_timeout + prepare_timeout
+
+    # Use default timeout = 0 here if wait_for_nodes is empty. This is to make
+    # sure we don't inflate the maximum_uptime_minutes too much if we don't wait
+    # for nodes at all.
+    # The actual default will be otherwise loaded further down.
+    wait_timeout = int(test["run"].get("wait_for_nodes", {}).get("timeout", 0))
+
+    autosuspend_mins = test["cluster"].get("autosuspend_mins", None)
+    if autosuspend_mins:
+        cluster_manager.autosuspend_minutes = autosuspend_mins
+        autosuspend_base = autosuspend_mins
+    else:
+        cluster_manager.autosuspend_minutes = min(
+            DEFAULT_AUTOSUSPEND_MINS,
+            int(command_and_prepare_timeout / 60) + TIMEOUT_BUFFER_MINUTES,
+        )
+        # Maximum uptime should be based on the command timeout, not the
+        # DEFAULT_AUTOSUSPEND_MINS
+        autosuspend_base = (
+            int(command_and_prepare_timeout / 60) + TIMEOUT_BUFFER_MINUTES
+        )
+
+    maximum_uptime_minutes = test["cluster"].get("maximum_uptime_minutes", None)
+    if maximum_uptime_minutes:
+        cluster_manager.maximum_uptime_minutes = maximum_uptime_minutes
+    else:
+        cluster_manager.maximum_uptime_minutes = (
+            autosuspend_base + wait_timeout + TIMEOUT_BUFFER_MINUTES
+        )
+
+    # Set cluster compute here. Note that this may use timeouts provided
+    # above.
+    cluster_manager.set_cluster_compute(
+        cluster_compute,
+        extra_tags=result.extra_tags,
+    )
+
+    return prepare_cmd, prepare_timeout, build_timeout, cluster_timeout, command_timeout
+
+
+def _setup_local_environment(
+    test: Test,
+    command_runner: CommandRunner,
+    ray_wheels_url: str,
+) -> None:
+    driver_setup_script = test.get("driver_setup", None)
+    if driver_setup_script:
+        try:
+            run_bash_script(driver_setup_script)
+        except Exception as e:
+            raise LocalEnvSetupError(f"Driver setup script failed: {e}") from e
+
+    # Install local dependencies
+    command_runner.prepare_local_env(ray_wheels_url)
+
+    # Re-install anyscale package as local dependencies might have changed
+    # from local env setup
+    reinstall_anyscale_dependencies()
+
+
+def _local_environment_information(
+    result: Result,
+    cluster_manager: ClusterManager,
+    command_runner: CommandRunner,
+    build_timeout: int,
+    cluster_timeout: int,
+    no_terminate: bool,
+    cluster_id: Optional[str],
+    cluster_env_id: Optional[str],
+) -> None:
+    pip_packages = get_pip_packages()
+    pip_package_string = "\n".join(pip_packages)
+    logger.info(f"Installed python packages:\n{pip_package_string}")
+
+    if isinstance(cluster_manager, FullClusterManager):
+        if not no_terminate:
+            register_handler(
+                lambda sig, frame: cluster_manager.terminate_cluster(wait=True)
+            )
+
+    # Start cluster
+    if cluster_id:
+        buildkite_group(":rocket: Using existing cluster")
+        # Re-use existing cluster ID for development
+        cluster_manager.cluster_id = cluster_id
+        cluster_manager.cluster_name = get_cluster_name(cluster_id)
+    else:
+        buildkite_group(":gear: Building cluster environment")
+
+        if cluster_env_id:
+            cluster_manager.cluster_env_id = cluster_env_id
+
+        cluster_manager.build_configs(timeout=build_timeout)
+
+        if isinstance(cluster_manager, FullClusterManager):
+            buildkite_group(":rocket: Starting up cluster")
+            cluster_manager.start_cluster(timeout=cluster_timeout)
+        elif isinstance(command_runner, AnyscaleJobRunner):
+            command_runner.job_manager.cluster_startup_timeout = cluster_timeout
+
+    result.cluster_url = cluster_manager.get_cluster_url()
+    result.cluster_id = cluster_manager.cluster_id
+
+
+def _prepare_remote_environment(
+    test: Test,
+    command_runner: CommandRunner,
+    prepare_cmd: bool,
+    prepare_timeout: int,
+) -> None:
+    command_runner.prepare_remote_env()
+
+    wait_for_nodes = test["run"].get("wait_for_nodes", None)
+
+    if wait_for_nodes:
+        buildkite_group(":stopwatch: Waiting for nodes to come up")
+        # Overwrite wait_timeout from above to account for better default
+        wait_timeout = int(
+            wait_for_nodes.get("timeout", DEFAULT_WAIT_FOR_NODES_TIMEOUT)
+        )
+        num_nodes = test["run"]["wait_for_nodes"]["num_nodes"]
+        command_runner.wait_for_nodes(num_nodes, wait_timeout)
+
+    if prepare_cmd:
+        try:
+            command_runner.run_prepare_command(prepare_cmd, timeout=prepare_timeout)
+        except CommandError as e:
+            raise PrepareCommandError(e)
+        except CommandTimeout as e:
+            raise PrepareCommandTimeout(e)
+
+
+def _running_test_script(
+    test: Test,
+    smoke_test: bool,
+    command_runner: CommandRunner,
+    command_timeout: int,
+) -> None:
+    command = test["run"]["script"]
+    command_env = {}
+
+    if smoke_test:
+        command = f"{command} --smoke-test"
+        command_env["IS_SMOKE_TEST"] = "1"
+
+    is_long_running = test["run"].get("long_running", False)
+
+    try:
+        command_runner.run_command(
+            command,
+            env=command_env,
+            timeout=command_timeout,
+            raise_on_timeout=not is_long_running,
+        )
+    except (
+        TestCommandError,
+        PrepareCommandError,
+        TestCommandTimeout,
+        PrepareCommandTimeout,
+    ) as e:
+        raise e
+    except CommandError as e:
+        raise TestCommandError(e)
+    except CommandTimeout as e:
+        if not is_long_running:
+            # Only raise error if command is not long running
+            raise TestCommandTimeout(e)
+
+
+def _fetching_results(
+    result: Result,
+    command_runner: CommandRunner,
+    artifact_path: Optional[str],
+    smoke_test: bool,
+    start_time_unix: int,
+) -> Tuple[dict, Exception]:
+    fetch_result_exception = None
+    try:
+        command_results = command_runner.fetch_results()
+    except Exception as e:
+        logger.exception(f"Could not fetch results for test command: {e}")
+        command_results = {}
+        fetch_result_exception = e
+
+    if artifact_path:
+        try:
+            command_runner.fetch_artifact()
+        except Exception as e:
+            logger.error("Could not fetch artifact for test command")
+            logger.exception(e)
+
+    # Postprocess result:
+    if "last_update" in command_results:
+        command_results["last_update_diff"] = time.time() - command_results.get(
+            "last_update", 0.0
+        )
+
+    try:
+        # Logic duplicated in ray_release/command_runner/_anyscale_job_wrapper.py
+        # Timeout is the time the test took divided by 200
+        # (~7 minutes for a 24h test) but no less than 30s
+        # and no more than 900s
+        metrics_timeout = max(30, min((time.time() - start_time_unix) / 200, 900))
+        command_runner.save_metrics(start_time_unix, timeout=metrics_timeout)
+        metrics = command_runner.fetch_metrics()
+    except Exception as e:
+        logger.exception(f"Could not fetch metrics for test command: {e}")
+        metrics = {}
+
+    if smoke_test:
+        command_results["smoke_test"] = True
+
+    result.results = command_results
+    result.status = "finished"
+
+    return metrics, fetch_result_exception
+
+
+def run_release_test(
+    test: Test,
+    anyscale_project: str,
+    result: Result,
+    ray_wheels_url: str,
+    reporters: Optional[List[Reporter]] = None,
+    smoke_test: bool = False,
+    cluster_id: Optional[str] = None,
+    cluster_env_id: Optional[str] = None,
+    no_terminate: bool = False,
+) -> Result:
+    old_wd = os.getcwd()
+    start_time = time.monotonic()
+
+    buildkite_group(":spiral_note_pad: Loading test configuration")
+    cluster_manager, command_runner, artifact_path = _load_test_configuration(
+        test,
+        anyscale_project,
+        result,
+        ray_wheels_url,
+        smoke_test,
+        no_terminate,
+    )
+
     pipeline_exception = None
     # non critical for some tests. So separate it from the general one.
     fetch_result_exception = None
     try:
-        setup_signal_handling()
-        # Load configs
-        cluster_env = load_test_cluster_env(test, ray_wheels_url=ray_wheels_url)
-        cluster_compute = load_test_cluster_compute(test)
-
-        if cluster_env_id:
-            try:
-                cluster_manager.cluster_env_id = cluster_env_id
-                cluster_manager.build_cluster_env()
-                cluster_manager.fetch_build_info()
-                logger.info(
-                    "Using overridden cluster environment with ID "
-                    f"{cluster_env_id} and build ID "
-                    f"{cluster_manager.cluster_env_build_id}"
-                )
-            except Exception as e:
-                raise ClusterEnvCreateError(
-                    f"Could not get existing overridden cluster environment "
-                    f"{cluster_env_id}: {e}"
-                ) from e
-        else:
-            cluster_manager.set_cluster_env(cluster_env)
-
-        # Load some timeouts
-        build_timeout = int(test["run"].get("build_timeout", DEFAULT_BUILD_TIMEOUT))
-        command_timeout = int(test["run"].get("timeout", DEFAULT_COMMAND_TIMEOUT))
-        cluster_timeout = int(
-            test["run"].get("session_timeout", DEFAULT_CLUSTER_TIMEOUT)
-        )
-
-        # Get prepare command timeout, if any
-        prepare_cmd = test["run"].get("prepare", None)
-        if prepare_cmd:
-            prepare_timeout = test["run"].get("prepare_timeout", command_timeout)
-        else:
-            prepare_timeout = 0
-
-        # Base maximum uptime on the combined command and prepare timeouts
-        command_and_prepare_timeout = command_timeout + prepare_timeout
-
-        # Use default timeout = 0 here if wait_for_nodes is empty. This is to make
-        # sure we don't inflate the maximum_uptime_minutes too much if we don't wait
-        # for nodes at all.
-        # The actual default will be otherwise loaded further down.
-        wait_timeout = int(test["run"].get("wait_for_nodes", {}).get("timeout", 0))
-
-        autosuspend_mins = test["cluster"].get("autosuspend_mins", None)
-        if autosuspend_mins:
-            cluster_manager.autosuspend_minutes = autosuspend_mins
-            autosuspend_base = autosuspend_mins
-        else:
-            cluster_manager.autosuspend_minutes = min(
-                DEFAULT_AUTOSUSPEND_MINS,
-                int(command_and_prepare_timeout / 60) + TIMEOUT_BUFFER_MINUTES,
-            )
-            # Maximum uptime should be based on the command timeout, not the
-            # DEFAULT_AUTOSUSPEND_MINS
-            autosuspend_base = (
-                int(command_and_prepare_timeout / 60) + TIMEOUT_BUFFER_MINUTES
-            )
-
-        maximum_uptime_minutes = test["cluster"].get("maximum_uptime_minutes", None)
-        if maximum_uptime_minutes:
-            cluster_manager.maximum_uptime_minutes = maximum_uptime_minutes
-        else:
-            cluster_manager.maximum_uptime_minutes = (
-                autosuspend_base + wait_timeout + TIMEOUT_BUFFER_MINUTES
-            )
-
-        # Set cluster compute here. Note that this may use timeouts provided
-        # above.
-        cluster_manager.set_cluster_compute(
-            cluster_compute,
-            extra_tags=extra_tags,
+        buildkite_group(":nut_and_bolt: Setting up cluster environment")
+        (
+            prepare_cmd,
+            prepare_timeout,
+            build_timeout,
+            cluster_timeout,
+            command_timeout,
+        ) = _setup_cluster_environment(
+            test,
+            result,
+            cluster_manager,
+            ray_wheels_url,
+            cluster_env_id,
         )
 
         buildkite_group(":nut_and_bolt: Setting up local environment")
-        driver_setup_script = test.get("driver_setup", None)
-        if driver_setup_script:
-            try:
-                run_bash_script(driver_setup_script)
-            except Exception as e:
-                raise LocalEnvSetupError(f"Driver setup script failed: {e}") from e
-
-        # Install local dependencies
-        command_runner.prepare_local_env(ray_wheels_url)
-
-        # Re-install anyscale package as local dependencies might have changed
-        # from local env setup
-        reinstall_anyscale_dependencies()
+        _setup_local_environment(test, command_runner, ray_wheels_url)
 
         # Print installed pip packages
         buildkite_group(":bulb: Local environment information")
-        pip_packages = get_pip_packages()
-        pip_package_string = "\n".join(pip_packages)
-        logger.info(f"Installed python packages:\n{pip_package_string}")
-
-        if isinstance(cluster_manager, FullClusterManager):
-            if not no_terminate:
-                register_handler(
-                    lambda sig, frame: cluster_manager.terminate_cluster(wait=True)
-                )
-
-        # Start cluster
-        if cluster_id:
-            buildkite_group(":rocket: Using existing cluster")
-            # Re-use existing cluster ID for development
-            cluster_manager.cluster_id = cluster_id
-            cluster_manager.cluster_name = get_cluster_name(cluster_id)
-        else:
-            buildkite_group(":gear: Building cluster environment")
-
-            if cluster_env_id:
-                cluster_manager.cluster_env_id = cluster_env_id
-
-            cluster_manager.build_configs(timeout=build_timeout)
-
-            if isinstance(cluster_manager, FullClusterManager):
-                buildkite_group(":rocket: Starting up cluster")
-                cluster_manager.start_cluster(timeout=cluster_timeout)
-            elif isinstance(command_runner, AnyscaleJobRunner):
-                command_runner.job_manager.cluster_startup_timeout = cluster_timeout
-
-        result.cluster_url = cluster_manager.get_cluster_url()
-        result.cluster_id = cluster_manager.cluster_id
+        _local_environment_information(
+            result,
+            cluster_manager,
+            command_runner,
+            build_timeout,
+            cluster_timeout,
+            no_terminate,
+            cluster_id,
+            cluster_env_id,
+        )
 
         # Upload files
         buildkite_group(":wrench: Preparing remote environment")
-        command_runner.prepare_remote_env()
-
-        wait_for_nodes = test["run"].get("wait_for_nodes", None)
-
-        if wait_for_nodes:
-            buildkite_group(":stopwatch: Waiting for nodes to come up")
-            # Overwrite wait_timeout from above to account for better default
-            wait_timeout = int(
-                wait_for_nodes.get("timeout", DEFAULT_WAIT_FOR_NODES_TIMEOUT)
-            )
-            num_nodes = test["run"]["wait_for_nodes"]["num_nodes"]
-            command_runner.wait_for_nodes(num_nodes, wait_timeout)
-
-        if prepare_cmd:
-            try:
-                command_runner.run_prepare_command(prepare_cmd, timeout=prepare_timeout)
-            except CommandError as e:
-                raise PrepareCommandError(e)
-            except CommandTimeout as e:
-                raise PrepareCommandTimeout(e)
+        _prepare_remote_environment(
+            test,
+            command_runner,
+            prepare_cmd,
+            prepare_timeout,
+        )
 
         buildkite_group(":runner: Running test script")
-        command = test["run"]["script"]
-        command_env = {}
-
-        if smoke_test:
-            command = f"{command} --smoke-test"
-            command_env["IS_SMOKE_TEST"] = "1"
-
-        is_long_running = test["run"].get("long_running", False)
-
         start_time_unix = time.time()
-
-        try:
-            command_runner.run_command(
-                command,
-                env=command_env,
-                timeout=command_timeout,
-                raise_on_timeout=not is_long_running,
-            )
-        except (
-            TestCommandError,
-            PrepareCommandError,
-            TestCommandTimeout,
-            PrepareCommandTimeout,
-        ) as e:
-            raise e
-        except CommandError as e:
-            raise TestCommandError(e)
-        except CommandTimeout as e:
-            if not is_long_running:
-                # Only raise error if command is not long running
-                raise TestCommandTimeout(e)
+        _running_test_script(
+            test,
+            smoke_test,
+            command_runner,
+            command_timeout,
+        )
 
         buildkite_group(":floppy_disk: Fetching results")
-        try:
-            command_results = command_runner.fetch_results()
-        except Exception as e:
-            logger.exception(f"Could not fetch results for test command: {e}")
-            command_results = {}
-            fetch_result_exception = e
-
-        if artifact_path:
-            try:
-                command_runner.fetch_artifact()
-            except Exception as e:
-                logger.error("Could not fetch artifact for test command")
-                logger.exception(e)
-
-        # Postprocess result:
-        if "last_update" in command_results:
-            command_results["last_update_diff"] = time.time() - command_results.get(
-                "last_update", 0.0
-            )
-
-        try:
-            # Logic duplicated in ray_release/command_runner/_anyscale_job_wrapper.py
-            # Timeout is the time the test took divided by 200
-            # (~7 minutes for a 24h test) but no less than 30s
-            # and no more than 900s
-            metrics_timeout = max(30, min((time.time() - start_time_unix) / 200, 900))
-            command_runner.save_metrics(start_time_unix, timeout=metrics_timeout)
-            metrics = command_runner.fetch_metrics()
-        except Exception as e:
-            logger.exception(f"Could not fetch metrics for test command: {e}")
-            metrics = {}
-
-        if smoke_test:
-            command_results["smoke_test"] = True
-
-        result.results = command_results
-        result.status = "finished"
+        metrics, fetch_result_exception = _fetching_results(
+            result,
+            command_runner,
+            artifact_path,
+            smoke_test,
+            start_time_unix,
+        )
 
     except Exception as e:
         logger.exception(e)

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -52,6 +52,7 @@ from ray_release.util import (
 type_str_to_command_runner = {
     "command": SDKRunner,
     "sdk_command": SDKRunner,
+    "job": JobRunner,
     "anyscale_job": AnyscaleJobRunner,
 }
 


### PR DESCRIPTION
## Why are these changes needed?

A purely refactor diff. Break run_release_test in glue.py into smaller functions so they are easier to read, test and change. It helps me to make future change easier too.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests - python -m pytest ray_release/tests/
   - [X] Release tests