### PR TITLE
[docs] Add links to nightly macOS arm64 images 

### DIFF
--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -63,7 +63,7 @@ You can install the nightly Ray wheels via the following links. These daily rele
     `Linux Python 3.11 (x86_64) (EXPERIMENTAL)`_     `Linux Python 3.11 (aarch64) (EXPERIMENTAL)`_
     =============================================== ================================================  
 
-.. tabbed:: macOS
+.. tabbed:: MacOS
 
     ================================  ================================
      MacOS (x86_64)                    MacOS (arm64)
@@ -75,17 +75,17 @@ You can install the nightly Ray wheels via the following links. These daily rele
     `MacOS Python 3.6 (x86_64)`_
     ================================  ================================
 
-
 .. tabbed:: Windows (beta)
 
-    =======================
-     Windows (beta)
-    =======================
-    `Windows Python 3.10`_
-    `Windows Python 3.9`_
-    `Windows Python 3.8`_
-    `Windows Python 3.7`_
-    =======================
+    .. list-table:: Title
+        :header-rows: 1
+
+       * - Windows (beta)
+       * - `Windows Python 3.10`_
+       * - `Windows Python 3.9`_
+       * - `Windows Python 3.8`_
+       * - `Windows Python 3.7`_
+
 
 .. note::
 

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -49,16 +49,43 @@ You can install the nightly Ray wheels via the following links. These daily rele
   # pip install -U LINK_TO_WHEEL.whl
 
 
-=============================================== ================================================  ====================  =======================
-       Linux (x86_64)                                   Linux (arm64/aarch64)                      MacOS                 Windows (beta)
-=============================================== ================================================  ====================  =======================
-`Linux Python 3.10 (x86_64)`_                    `Linux Python 3.10 (aarch64)`_                   `MacOS Python 3.10`_  `Windows Python 3.10`_
-`Linux Python 3.9 (x86_64)`_                     `Linux Python 3.9 (aarch64)`_                    `MacOS Python 3.9`_   `Windows Python 3.9`_
-`Linux Python 3.8 (x86_64)`_                     `Linux Python 3.8 (aarch64)`_                    `MacOS Python 3.8`_   `Windows Python 3.8`_
-`Linux Python 3.7 (x86_64)`_                     `Linux Python 3.7 (aarch64)`_                    `MacOS Python 3.7`_   `Windows Python 3.7`_
-`Linux Python 3.6 (x86_64)`_                     `Linux Python 3.6 (aarch64)`_                    `MacOS Python 3.6`_
-`Linux Python 3.11 (x86_64) (EXPERIMENTAL)`_     `Linux Python 3.11 (aarch64) (EXPERIMENTAL)`_
-=============================================== ================================================  ====================  =======================
+
+.. tabbed:: Linux
+
+    =============================================== ================================================  
+           Linux (x86_64)                                   Linux (arm64/aarch64)                     
+    =============================================== ================================================  
+    `Linux Python 3.10 (x86_64)`_                    `Linux Python 3.10 (aarch64)`_                   
+    `Linux Python 3.9 (x86_64)`_                     `Linux Python 3.9 (aarch64)`_                    
+    `Linux Python 3.8 (x86_64)`_                     `Linux Python 3.8 (aarch64)`_                    
+    `Linux Python 3.7 (x86_64)`_                     `Linux Python 3.7 (aarch64)`_                    
+    `Linux Python 3.6 (x86_64)`_                     `Linux Python 3.6 (aarch64)`_                    
+    `Linux Python 3.11 (x86_64) (EXPERIMENTAL)`_     `Linux Python 3.11 (aarch64) (EXPERIMENTAL)`_
+    =============================================== ================================================  
+
+.. tabbed:: macOS
+
+    ================================  ================================
+     MacOS (x86_64)                    MacOS (arm64)
+    ================================  ================================
+    `MacOS Python 3.10 (x86_64)`_      `MacOS Python 3.10 (arm64)`_
+    `MacOS Python 3.9 (x86_64)`_       `MacOS Python 3.9 (arm64)`_
+    `MacOS Python 3.8 (x86_64)`_       `MacOS Python 3.8 (arm64)`_
+    `MacOS Python 3.7 (x86_64)`_
+    `MacOS Python 3.6 (x86_64)`_
+    ================================  ================================
+
+
+.. tabbed:: Windows (beta)
+
+    =======================
+     Windows (beta)
+    =======================
+    `Windows Python 3.10`_
+    `Windows Python 3.9`_
+    `Windows Python 3.8`_
+    `Windows Python 3.7`_
+    =======================
 
 .. note::
 
@@ -88,11 +115,17 @@ You can install the nightly Ray wheels via the following links. These daily rele
 .. _`Linux Python 3.6 (aarch64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp36-cp36m-manylinux2014_aarch64.whl
 
 
-.. _`MacOS Python 3.10`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-macosx_10_15_universal2.whl
-.. _`MacOS Python 3.9`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-macosx_10_15_x86_64.whl
-.. _`MacOS Python 3.8`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-macosx_10_15_x86_64.whl
-.. _`MacOS Python 3.7`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-macosx_10_15_intel.whl
-.. _`MacOS Python 3.6`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp36-cp36m-macosx_10_15_intel.whl
+.. _`MacOS Python 3.10 (x86_64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-macosx_10_15_universal2.whl
+.. _`MacOS Python 3.9 (x86_64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-macosx_10_15_x86_64.whl
+.. _`MacOS Python 3.8 (x86_64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-macosx_10_15_x86_64.whl
+.. _`MacOS Python 3.7 (x86_64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-macosx_10_15_intel.whl
+.. _`MacOS Python 3.6 (x86_64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp36-cp36m-macosx_10_15_intel.whl
+
+
+.. _`MacOS Python 3.10 (arm64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-macosx_11_0_arm64.whl
+.. _`MacOS Python 3.9 (arm64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-macosx_11_0_arm64.whl
+.. _`MacOS Python 3.8 (arm64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-macosx_11_0_arm64.whl
+
 
 .. _`Windows Python 3.10`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-win_amd64.whl
 .. _`Windows Python 3.9`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-win_amd64.whl

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -77,8 +77,8 @@ You can install the nightly Ray wheels via the following links. These daily rele
 
 .. tabbed:: Windows (beta)
 
-    .. list-table:: Title
-        :header-rows: 1
+    .. list-table::
+       :header-rows: 1
 
        * - Windows (beta)
        * - `Windows Python 3.10`_


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Now that we're building Mac arm64 images (#33919), we should point to them in our documentation.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
