### PR TITLE
[CI][Clean] Reduce retry setting for _get_logs

### DIFF
--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -286,8 +286,8 @@ class AnyscaleJobManager:
         ret = exponential_backoff_retry(
             _get_logs,
             retry_exceptions=Exception,
-            initial_retry_delay_s=30,
-            max_retries=5,
+            initial_retry_delay_s=10,
+            max_retries=3,
         )
         if ret and not self.in_progress:
             self._last_logs = ret

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -286,7 +286,7 @@ class AnyscaleJobManager:
         ret = exponential_backoff_retry(
             _get_logs,
             retry_exceptions=Exception,
-            initial_retry_delay_s=10,
+            initial_retry_delay_s=30,
             max_retries=3,
         )
         if ret and not self.in_progress:


### PR DESCRIPTION
## Why are these changes needed?

When we fail to get logs from anyscale job, the current retry setting will retry for another 15 minutes. Example: https://buildkite.com/ray-project/release-tests-pr/builds/33347#018735a2-f68f-4dc9-a1c6-4179ccaf8d54

That's a pretty long time, I think, especially for cases that there are no logs to fetch (anyscale failed to start for example).

Reduce it to retry 3 times, so around 1 minute.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests