### PR TITLE
[autoscaler][observability] {pending, active, failed} metrics by node type

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -67,6 +67,7 @@ try:
 except (ImportError, ModuleNotFoundError):
 
     Sample = None
+
     def text_string_to_metric_families(*args, **kwargs):
         raise ModuleNotFoundError("`prometheus_client` not found")
 
@@ -592,11 +593,11 @@ async def async_wait_for_condition_async_predicate(
 
 @dataclass
 class MetricSamplePattern:
-    name : Optional[str] = None
+    name: Optional[str] = None
     value: Optional[str] = None
     partial_label_match: Optional[Dict[str, str]] = None
 
-    def matches(self, sample : Sample):
+    def matches(self, sample: Sample):
         if self.name is not None:
             if self.name != sample.name:
                 return False
@@ -615,8 +616,7 @@ class MetricSamplePattern:
 
 
 def get_metric_check_condition(
-        metrics_to_check: List[MetricSamplePattern],
-        export_addr: Optional[str] = None
+    metrics_to_check: List[MetricSamplePattern], export_addr: Optional[str] = None
 ):
     """A condition to check if a prometheus metrics reach a certain value.
     This is a blocking check that can be passed into a `wait_for_condition`
@@ -655,6 +655,7 @@ def get_metric_check_condition(
         return True
 
     return f
+
 
 # def get_metric_check_condition(
 #     metrics_to_check: Dict[str, Optional[float]], export_addr: Optional[str] = None

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -617,7 +617,7 @@ class MetricSamplePattern:
 
 def get_metric_check_condition(
     metrics_to_check: List[MetricSamplePattern], export_addr: Optional[str] = None
-):
+) -> Callable[[], bool]:
     """A condition to check if a prometheus metrics reach a certain value.
     This is a blocking check that can be passed into a `wait_for_condition`
     style function.
@@ -655,52 +655,6 @@ def get_metric_check_condition(
         return True
 
     return f
-
-
-# def get_metric_check_condition(
-#     metrics_to_check: Dict[str, Optional[float]], export_addr: Optional[str] = None
-# ) -> Callable[[], bool]:
-#     """A condition to check if a prometheus metrics reach a certain value.
-#     This is a blocking check that can be passed into a `wait_for_condition`
-#     style function.
-
-#     Args:
-#       metrics_to_check: A map of metric lable to values to check, to ensure
-#         that certain conditions have been reached. If a value is None, just check
-#         that the metric was emitted with any value.
-
-#     Returns:
-#       A function that returns True if all the metrics are emitted.
-#     """
-#     node_info = ray.nodes()[0]
-#     metrics_export_port = node_info["MetricsExportPort"]
-#     addr = node_info["NodeManagerAddress"]
-#     prom_addr = export_addr or f"{addr}:{metrics_export_port}"
-
-#     def f():
-#         for metric_name, metric_value in metrics_to_check.items():
-#             _, metric_names, metric_samples = fetch_prometheus([prom_addr])
-#             found_metric = False
-#             if metric_name in metric_names:
-#                 for sample in metric_samples:
-#                     if sample.name != metric_name:
-#                         continue
-
-#                     if metric_value is None:
-#                         found_metric = True
-#                     elif metric_value == sample.value:
-#                         found_metric = True
-#             if not found_metric:
-#                 print(
-#                     "Didn't find metric, all metric names: ",
-#                     metric_names,
-#                     "all values",
-#                     metric_samples,
-#                 )
-#                 return False
-#         return True
-
-#     return f
 
 
 def wait_for_stdout(strings_to_match: List[str], timeout_s: int):

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -609,7 +609,6 @@ class MetricSamplePattern:
         if self.partial_label_match is not None:
             for label, value in self.partial_label_match.items():
                 if sample.labels.get(label) != value:
-                    print("========= Didn't match ", label, value, sample)
                     return False
 
         return True
@@ -639,12 +638,8 @@ def get_metric_check_condition(
         for metric_pattern in metrics_to_check:
             _, metric_names, metric_samples = fetch_prometheus([prom_addr])
             for metric_sample in metric_samples:
-                print("checking", metric_sample)
                 if metric_pattern.matches(metric_sample):
-                    print("match")
                     break
-                else:
-                    print("didnt match")
             else:
                 print(
                     f"Didn't find {metric_pattern}",

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -367,6 +367,10 @@ class StandardAutoscaler:
             assert os.path.exists(local_path)
         logger.info("StandardAutoscaler: {}".format(self.config))
 
+    @property
+    def all_node_types(self) -> Set[str]:
+        return set(self.config["available_node_types"].values())
+
     def update(self):
         try:
             self.reset(errors_fatal=False)

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -369,7 +369,7 @@ class StandardAutoscaler:
 
     @property
     def all_node_types(self) -> Set[str]:
-        return set(self.config["available_node_types"].values())
+        return self.config["available_node_types"].keys()
 
     def update(self):
         try:

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -403,7 +403,7 @@ class Monitor:
                     self.emit_metrics(
                         load_metrics_summary,
                         autoscaler_summary,
-                        self.autoscaler.node_types,
+                        self.autoscaler.all_node_types,
                     )
                     if autoscaler_summary:
                         status["autoscaler_report"] = asdict(autoscaler_summary)
@@ -474,7 +474,7 @@ class Monitor:
                 NodeType=node_type,
             ).set(count)
 
-        for node_type, count in node_types:
+        for node_type in node_types:
             count = autoscaler_summary.active_nodes.get(node_type, 0)
             self.prom_metrics.active_nodes.labels(
                 SessionName=self.prom_metrics.session_name,

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -485,10 +485,10 @@ class Monitor:
         for _, node_type in autoscaler_summary.failed_nodes:
             failed_node_counts[node_type] += 1
 
-        # NOTE: We don't reset this metric very often, so it's possible that if
-        # nodes don't fail frequently, these values could be sticky. We can
-        # move this loop to a `for node_type in node_types: count = ...`
-        # pattern if forgetting faster is preferred.
+        # NOTE: This metric isn't reset with monitor resets. This means it will
+        # only be updated when the autoscaler' node tracker remembers failed
+        # nodes. If the node type failure is evicted from the autoscaler, the
+        # metric may not update for a while.
         for node_type, count in failed_node_counts.items():
             self.prom_metrics.recently_failed_nodes.labels(
                 SessionName=self.prom_metrics.session_name,

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -8,9 +8,9 @@ import signal
 import sys
 import time
 import traceback
+from collections import Counter
 from dataclasses import asdict
 from typing import Any, Callable, Dict, Optional, Union
-from collections import Counter
 
 import ray
 import ray._private.ray_constants as ray_constants

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -190,6 +190,7 @@ class Monitor:
             self.event_logger = None
 
         self.prom_metrics = AutoscalerPrometheusMetrics(session_name=self._session_name)
+
         if monitor_ip and prometheus_client:
             # If monitor_ip wasn't passed in, then don't attempt to start the
             # metric server to keep behavior identical to before metrics were
@@ -206,6 +207,11 @@ class Monitor:
                     registry=self.prom_metrics.registry,
                     **kwargs,
                 )
+
+                # Reset some gauges, since we don't know which labels have
+                # leaked if the autoscaler was restarted.
+                self.prom_metrics.pending_nodes.clear()
+                self.prom_metrics.active_nodes.clear()
             except Exception:
                 logger.exception(
                     "An exception occurred while starting the metrics server."
@@ -393,6 +399,9 @@ class Monitor:
                     self.autoscaler.update()
                     status["autoscaler_update_time"] = time.time() - update_start_time
                     autoscaler_summary = self.autoscaler.summary()
+                    self.emit_metrics(load_metrics_summary,
+                                      autoscaler_summary,
+                                      self.autoscaler.node_types)
                     if autoscaler_summary:
                         status["autoscaler_report"] = asdict(autoscaler_summary)
                         status[
@@ -400,27 +409,6 @@ class Monitor:
                         ] = (
                             self.autoscaler.non_terminated_nodes.non_terminated_nodes_time  # noqa: E501
                         )
-
-                        for resource_name in ["CPU", "GPU"]:
-                            _, total = load_metrics_summary.usage.get(
-                                resource_name, (0, 0)
-                            )
-                            pending = autoscaler_summary.pending_resources.get(
-                                resource_name, 0
-                            )
-                            self.prom_metrics.cluster_resources.labels(
-                                resource=resource_name,
-                                SessionName=self.prom_metrics.session_name,
-                            ).set(total)
-                            self.prom_metrics.pending_resources.labels(
-                                resource=resource_name,
-                                SessionName=self.prom_metrics.session_name,
-                            ).set(pending)
-
-                    self.prom_metrics.pending_nodes.set(
-                        len(autoscaler_summary.pending_nodes)
-                        + len(autoscaler_summary.pending_launches)
-                    )
 
                     for msg in self.event_summarizer.summary():
                         # Need to prefix each line of the message for the lines to
@@ -452,6 +440,63 @@ class Monitor:
             # Wait for a autoscaler update interval before processing the next
             # round of messages.
             time.sleep(AUTOSCALER_UPDATE_INTERVAL_S)
+
+    def emit_metrics(self, load_metrics_summary, autoscaler_summary, node_types):
+        if autoscaler_summary is None:
+            return None
+
+        for resource_name in ["CPU", "GPU"]:
+            _, total = load_metrics_summary.usage.get(
+                resource_name, (0, 0)
+            )
+            pending = autoscaler_summary.pending_resources.get(
+                resource_name, 0
+            )
+            self.prom_metrics.cluster_resources.labels(
+                resource=resource_name,
+                SessionName=self.prom_metrics.session_name,
+            ).set(total)
+            self.prom_metrics.pending_resources.labels(
+                resource=resource_name,
+                SessionName=self.prom_metrics.session_name,
+            ).set(pending)
+
+
+        pending_node_count = Counter()
+        for _, node_type, _ in autoscaler_summary.pending_nodes:
+            pending_node_count[node_type] += 1
+
+        for node_type, count in autoscaler_summary.pending_launches:
+            pending_node_count[node_type] += count
+
+        for node_type in node_types:
+            count = pending_node_count[node_type]
+            self.prom_metrics.pending_nodes.labels(
+                SessionName=self.prom_metrics.session_name,
+                NodeType=node_type,
+            ).set(count)
+
+        for node_type, count in node_types:
+            count = autoscaler_summary.active_nodes.get(node_type, 0)
+            self.prom_metrics.active_nodes.labels(
+                SessionName=self.prom_metrics.session_name,
+                NodeType=node_type,
+            ).set(count)
+
+
+        failed_node_counts = Counter()
+        for _, node_type in autoscaler_summary.failed_nodes:
+            failed_node_counts[node_type] += 1
+
+        # NOTE: We don't reset this metric very often, so it's possible that if
+        # nodes don't fail frequently, these values could be sticky. We can
+        # move this loop to a `for node_type in node_types: count = ...`
+        # pattern if forgetting faster is preferred.
+        for node_type, count in failed_node_counts.items():
+            self.prom_metrics.recently_failed_nodes.labels(
+                SessionName=self.prom_metrics.session_name,
+                NodeType=node_type,
+            ).set(count)
 
     def update_event_summary(self):
         """Report the current size of the cluster.

--- a/python/ray/autoscaler/_private/prom_metrics.py
+++ b/python/ray/autoscaler/_private/prom_metrics.py
@@ -102,15 +102,15 @@ try:
             self.pending_nodes: Gauge = Gauge(
                 "pending_nodes",
                 "Number of nodes pending to be started.",
-                labelnames=("SessionName", "NodeType"),
+                labelnames=("NodeType", "SessionName",),
                 unit="nodes",
                 namespace="autoscaler",
                 registry=self.registry,
-            ).labels(SessionName=session_name)
+            )
             self.active_nodes: Gauge = Gauge(
                 "active_nodes",
                 "Number of nodes in the cluster.",
-                labelnames=("SessionName", "NodeType"),
+                labelnames=("NodeType", "SessionName",),
                 unit="nodes",
                 namespace="autoscaler",
                 registry=self.registry,
@@ -119,7 +119,7 @@ try:
                 "recently_failed_nodes",
                 "The number of recently failed nodes. This count could reset "
                 "at undefined times.",
-                labelnames=("SessionName", "NodeType"),
+                labelnames=("NodeType", "SessionName",),
                 unit="nodes",
                 namespace="autoscaler",
                 registry=self.registry,

--- a/python/ray/autoscaler/_private/prom_metrics.py
+++ b/python/ray/autoscaler/_private/prom_metrics.py
@@ -16,6 +16,9 @@ class NullMetric:
     def labels(self, *args, **kwargs):
         return self
 
+    def clear(self):
+        pass
+
 
 try:
 
@@ -99,11 +102,29 @@ try:
             self.pending_nodes: Gauge = Gauge(
                 "pending_nodes",
                 "Number of nodes pending to be started.",
-                labelnames=("SessionName",),
+                labelnames=("SessionName", "NodeType"),
                 unit="nodes",
                 namespace="autoscaler",
                 registry=self.registry,
             ).labels(SessionName=session_name)
+            self.active_nodes: Gauge = Gauge(
+                "active_nodes",
+                "Number of nodes in the cluster.",
+                labelnames=("SessionName", "NodeType"),
+                unit="nodes",
+                namespace="autoscaler",
+                registry=self.registry,
+            )
+            self.recently_failed_nodes = Gauge(
+                "recently_failed_nodes",
+                # An implementation note (not a api guarantee), practically, this will reset whenever the autoscaler restarts.
+                "The number of recently failed nodes. This count could reset "
+                "at undefined times.",
+                labelnames=("SessionName", "NodeType"),
+                unit="nodes",
+                namespace="autoscaler",
+                registry=self.registry,
+            )
             self.started_nodes: Counter = Counter(
                 "started_nodes",
                 "Number of nodes started.",

--- a/python/ray/autoscaler/_private/prom_metrics.py
+++ b/python/ray/autoscaler/_private/prom_metrics.py
@@ -117,7 +117,6 @@ try:
             )
             self.recently_failed_nodes = Gauge(
                 "recently_failed_nodes",
-                # An implementation note (not a api guarantee), practically, this will reset whenever the autoscaler restarts.
                 "The number of recently failed nodes. This count could reset "
                 "at undefined times.",
                 labelnames=("SessionName", "NodeType"),

--- a/python/ray/autoscaler/_private/prom_metrics.py
+++ b/python/ray/autoscaler/_private/prom_metrics.py
@@ -102,7 +102,10 @@ try:
             self.pending_nodes: Gauge = Gauge(
                 "pending_nodes",
                 "Number of nodes pending to be started.",
-                labelnames=("NodeType", "SessionName",),
+                labelnames=(
+                    "NodeType",
+                    "SessionName",
+                ),
                 unit="nodes",
                 namespace="autoscaler",
                 registry=self.registry,
@@ -110,7 +113,10 @@ try:
             self.active_nodes: Gauge = Gauge(
                 "active_nodes",
                 "Number of nodes in the cluster.",
-                labelnames=("NodeType", "SessionName",),
+                labelnames=(
+                    "NodeType",
+                    "SessionName",
+                ),
                 unit="nodes",
                 namespace="autoscaler",
                 registry=self.registry,
@@ -119,7 +125,10 @@ try:
                 "recently_failed_nodes",
                 "The number of recently failed nodes. This count could reset "
                 "at undefined times.",
-                labelnames=("NodeType", "SessionName",),
+                labelnames=(
+                    "NodeType",
+                    "SessionName",
+                ),
                 unit="nodes",
                 namespace="autoscaler",
                 registry=self.registry,

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -130,8 +130,8 @@ def test_metrics(shutdown_only):
                     value=2,
                     partial_label_match={"resource": "CPU"},
                 ),
-                MetricSamplePattern(name="autoscaler_pending_resources", value=0),
-                MetricSamplePattern(name="autoscaler_pending_nodes", value=0),
+                MetricSamplePattern(name="autoscaler_pending_nodes", value=0, partial_label_match={"NodeType": "type-i"}),
+                MetricSamplePattern(name="autoscaler_pending_nodes", value=0, partial_label_match={"NodeType": "type-ii"}),
                 MetricSamplePattern(
                     name="autoscaler_active_nodes",
                     value=1,

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -6,7 +6,7 @@ import sys
 from ray._private.test_utils import (
     wait_for_condition,
     get_metric_check_condition,
-    MetricSamplePattern
+    MetricSamplePattern,
 )
 from ray.cluster_utils import AutoscalingCluster
 from ray.autoscaler.node_launch_exception import NodeLaunchException
@@ -91,15 +91,30 @@ def test_metrics(shutdown_only):
             def ping(self):
                 return True
 
-
         zero_reported_condition = get_metric_check_condition(
             [
-                MetricSamplePattern(name="autoscaler_cluster_resources", value=0, partial_label_match={"resource": "CPU"}),
+                MetricSamplePattern(
+                    name="autoscaler_cluster_resources",
+                    value=0,
+                    partial_label_match={"resource": "CPU"},
+                ),
                 MetricSamplePattern(name="autoscaler_pending_resources", value=0),
                 MetricSamplePattern(name="autoscaler_pending_nodes", value=0),
-                MetricSamplePattern(name="autoscaler_active_nodes", value=0, partial_label_match={"NodeType": "type-i"}),
-                MetricSamplePattern(name="autoscaler_active_nodes", value=0, partial_label_match={"NodeType": "type-ii"}),
-                MetricSamplePattern(name="autoscaler_active_nodes", value=1, partial_label_match={"NodeType": "ray.head.default"}),
+                MetricSamplePattern(
+                    name="autoscaler_active_nodes",
+                    value=0,
+                    partial_label_match={"NodeType": "type-i"},
+                ),
+                MetricSamplePattern(
+                    name="autoscaler_active_nodes",
+                    value=0,
+                    partial_label_match={"NodeType": "type-ii"},
+                ),
+                MetricSamplePattern(
+                    name="autoscaler_active_nodes",
+                    value=1,
+                    partial_label_match={"NodeType": "ray.head.default"},
+                ),
             ],
             export_addr=autoscaler_export_addr,
         )
@@ -110,12 +125,28 @@ def test_metrics(shutdown_only):
 
         two_cpu_no_pending_condition = get_metric_check_condition(
             [
-                MetricSamplePattern(name="autoscaler_cluster_resources", value=2, partial_label_match={"resource": "CPU"}),
+                MetricSamplePattern(
+                    name="autoscaler_cluster_resources",
+                    value=2,
+                    partial_label_match={"resource": "CPU"},
+                ),
                 MetricSamplePattern(name="autoscaler_pending_resources", value=0),
                 MetricSamplePattern(name="autoscaler_pending_nodes", value=0),
-                MetricSamplePattern(name="autoscaler_active_nodes", value=1, partial_label_match={"NodeType": "type-i"}),
-                MetricSamplePattern(name="autoscaler_active_nodes", value=1, partial_label_match={"NodeType": "type-ii"}),
-                MetricSamplePattern(name="autoscaler_active_nodes", value=1, partial_label_match={"NodeType": "ray.head.default"}),
+                MetricSamplePattern(
+                    name="autoscaler_active_nodes",
+                    value=1,
+                    partial_label_match={"NodeType": "type-i"},
+                ),
+                MetricSamplePattern(
+                    name="autoscaler_active_nodes",
+                    value=1,
+                    partial_label_match={"NodeType": "type-ii"},
+                ),
+                MetricSamplePattern(
+                    name="autoscaler_active_nodes",
+                    value=1,
+                    partial_label_match={"NodeType": "ray.head.default"},
+                ),
             ],
             export_addr=autoscaler_export_addr,
         )

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -130,8 +130,16 @@ def test_metrics(shutdown_only):
                     value=2,
                     partial_label_match={"resource": "CPU"},
                 ),
-                MetricSamplePattern(name="autoscaler_pending_nodes", value=0, partial_label_match={"NodeType": "type-i"}),
-                MetricSamplePattern(name="autoscaler_pending_nodes", value=0, partial_label_match={"NodeType": "type-ii"}),
+                MetricSamplePattern(
+                    name="autoscaler_pending_nodes",
+                    value=0,
+                    partial_label_match={"NodeType": "type-i"},
+                ),
+                MetricSamplePattern(
+                    name="autoscaler_pending_nodes",
+                    value=0,
+                    partial_label_match={"NodeType": "type-ii"},
+                ),
                 MetricSamplePattern(
                     name="autoscaler_active_nodes",
                     value=1,

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -6,6 +6,7 @@ import sys
 from ray._private.test_utils import (
     wait_for_condition,
     get_metric_check_condition,
+    MetricSamplePattern
 )
 from ray.cluster_utils import AutoscalingCluster
 from ray.autoscaler.node_launch_exception import NodeLaunchException
@@ -66,13 +67,13 @@ def test_metrics(shutdown_only):
             "type-i": {
                 "resources": {"CPU": 1},
                 "node_config": {},
-                "min_workers": 1,
+                "min_workers": 0,
                 "max_workers": 1,
             },
             "type-ii": {
                 "resources": {"CPU": 1},
                 "node_config": {},
-                "min_workers": 1,
+                "min_workers": 0,
                 "max_workers": 1,
             },
         },
@@ -90,12 +91,16 @@ def test_metrics(shutdown_only):
             def ping(self):
                 return True
 
+
         zero_reported_condition = get_metric_check_condition(
-            {
-                "autoscaler_cluster_resources": 0,
-                "autoscaler_pending_resources": 0,
-                "autoscaler_pending_nodes": 0,
-            },
+            [
+                MetricSamplePattern(name="autoscaler_cluster_resources", value=0, partial_label_match={"resource": "CPU"}),
+                MetricSamplePattern(name="autoscaler_pending_resources", value=0),
+                MetricSamplePattern(name="autoscaler_pending_nodes", value=0),
+                MetricSamplePattern(name="autoscaler_active_nodes", value=0, partial_label_match={"NodeType": "type-i"}),
+                MetricSamplePattern(name="autoscaler_active_nodes", value=0, partial_label_match={"NodeType": "type-ii"}),
+                MetricSamplePattern(name="autoscaler_active_nodes", value=1, partial_label_match={"NodeType": "ray.head.default"}),
+            ],
             export_addr=autoscaler_export_addr,
         )
         wait_for_condition(zero_reported_condition)
@@ -104,15 +109,18 @@ def test_metrics(shutdown_only):
         ray.get([actor.ping.remote() for actor in actors])
 
         two_cpu_no_pending_condition = get_metric_check_condition(
-            {
-                "autoscaler_cluster_resources": 2,
-                "autoscaler_pending_resources": 0,
-                "autoscaler_pending_nodes": 0,
-            },
+            [
+                MetricSamplePattern(name="autoscaler_cluster_resources", value=2, partial_label_match={"resource": "CPU"}),
+                MetricSamplePattern(name="autoscaler_pending_resources", value=0),
+                MetricSamplePattern(name="autoscaler_pending_nodes", value=0),
+                MetricSamplePattern(name="autoscaler_active_nodes", value=1, partial_label_match={"NodeType": "type-i"}),
+                MetricSamplePattern(name="autoscaler_active_nodes", value=1, partial_label_match={"NodeType": "type-ii"}),
+                MetricSamplePattern(name="autoscaler_active_nodes", value=1, partial_label_match={"NodeType": "ray.head.default"}),
+            ],
             export_addr=autoscaler_export_addr,
         )
         wait_for_condition(two_cpu_no_pending_condition)
-        # TODO (Alex): Ideally we'd also assert that pending_resources
+        # TODO (Alex): Ideally we'd also assert that pending increases
         # eventually became 1 or 2, but it's difficult to do that in a
         # non-racey way. (Perhaps we would need to artificially delay the fake
         # autoscaler node launch?).

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -21,6 +21,7 @@ from ray._private.test_utils import (
     object_memory_usage,
     get_metric_check_condition,
     wait_for_condition,
+    MetricSamplePattern,
 )
 
 logger = logging.getLogger(__name__)
@@ -729,11 +730,11 @@ def test_scheduling_class_depth(ray_start_regular):
     metric_name = "ray_internal_num_infeasible_scheduling_classes"
 
     # timeout=60 necessary to pass on windows debug/asan builds.
-    wait_for_condition(get_metric_check_condition({metric_name: 2}), timeout=60)
+    wait_for_condition(get_metric_check_condition([MetricSamplePattern(name=metric_name, value=2)]), timeout=60)
     start_infeasible.remote(2)
-    wait_for_condition(get_metric_check_condition({metric_name: 3}), timeout=60)
+    wait_for_condition(get_metric_check_condition([MetricSamplePattern(name=metric_name, value=3)]), timeout=60)
     start_infeasible.remote(4)
-    wait_for_condition(get_metric_check_condition({metric_name: 4}), timeout=60)
+    wait_for_condition(get_metric_check_condition([MetricSamplePattern(name=metric_name, value=4)]), timeout=60)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -730,11 +730,20 @@ def test_scheduling_class_depth(ray_start_regular):
     metric_name = "ray_internal_num_infeasible_scheduling_classes"
 
     # timeout=60 necessary to pass on windows debug/asan builds.
-    wait_for_condition(get_metric_check_condition([MetricSamplePattern(name=metric_name, value=2)]), timeout=60)
+    wait_for_condition(
+        get_metric_check_condition([MetricSamplePattern(name=metric_name, value=2)]),
+        timeout=60,
+    )
     start_infeasible.remote(2)
-    wait_for_condition(get_metric_check_condition([MetricSamplePattern(name=metric_name, value=3)]), timeout=60)
+    wait_for_condition(
+        get_metric_check_condition([MetricSamplePattern(name=metric_name, value=3)]),
+        timeout=60,
+    )
     start_infeasible.remote(4)
-    wait_for_condition(get_metric_check_condition([MetricSamplePattern(name=metric_name, value=4)]), timeout=60)
+    wait_for_condition(
+        get_metric_check_condition([MetricSamplePattern(name=metric_name, value=4)]),
+        timeout=60,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR emits metrics for pending, active, and failed nodes, similar to the information in `ray status`, directly from the autoscaler. 

This is the first half of #33550 which will allow the dashboard to use the correct metrics for cluster state instead of the mysterious and buggy metrics currently being displayed.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Related to but doesn't close #33550 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
