### PR TITLE
Support FTP in SyncConfig

### DIFF
--- a/python/ray/air/_internal/remote_storage.py
+++ b/python/ray/air/_internal/remote_storage.py
@@ -260,8 +260,16 @@ def download_from_uri(uri: str, local_path: str, filelock: bool = True):
     try:
         if filelock:
             with TempFileLock(f"{os.path.normpath(local_path)}.lock"):
+                # if isinstance(fs, fsspec.implementations.ftp.FTPFileSystem):
+                if str(type(fs)).find("FTPFileSystem") >= 0:
+                    fs.get(bucket_path, local_path, recursive=True)
+                    return
                 _pyarrow_fs_copy_files(bucket_path, local_path, source_filesystem=fs)
         else:
+            # if isinstance(fs, fsspec.implementations.ftp.FTPFileSystem):
+            if str(type(fs)).find("FTPFileSystem") >= 0:
+                fs.get(bucket_path, local_path, recursive=True)
+                return
             _pyarrow_fs_copy_files(bucket_path, local_path, source_filesystem=fs)
     except Exception as e:
         # Clean up the directory if downloading was unsuccessful.
@@ -299,6 +307,10 @@ def upload_to_uri(
 
     if not exclude:
         _ensure_directory(bucket_path, fs=fs)
+        # if isinstance(fs, fsspec.implementations.ftp.FTPFileSystem):
+        if str(type(fs)).find("FTPFileSystem") >= 0:
+            fs.put(local_path, bucket_path, recursive=True)
+            return
         _pyarrow_fs_copy_files(local_path, bucket_path, destination_filesystem=fs)
     else:
         # Walk the filetree and upload
@@ -328,6 +340,10 @@ def _upload_to_uri_with_exclude(
             full_target_path = os.path.normpath(os.path.join(bucket_path, candidate))
 
             _ensure_directory(str(Path(full_target_path).parent), fs=fs)
+            # if isinstance(fs, fsspec.implementations.ftp.FTPFileSystem):
+            if str(type(fs)).find("FTPFileSystem") >= 0:
+                fs.put(local_path, bucket_path, recursive=True)
+                return
             _pyarrow_fs_copy_files(
                 full_source_path, full_target_path, destination_filesystem=fs
             )

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -45,7 +45,7 @@ aiohttp>=3.7
 fastapi
 gymnasium==0.26.3
 opencensus
-fsspec
+fsspec==2023.1.0
 dm_tree
 matplotlib!=3.4.3; platform_system != "Windows"
 tensorboardX>=1.9


### PR DESCRIPTION
To support FTP in SyncConfig to run training job in Ray client, for example:
                sync_config=SyncConfig(
                    upload_dir="ftp://username:password@192.168.179.15:2121/checkpoints/"
                )