### PR TITLE
[Doc] Fix the title of the LightningTrainer starter example

### DIFF
--- a/doc/source/ray-more-libs/using-ray-with-pytorch-lightning.rst
+++ b/doc/source/ray-more-libs/using-ray-with-pytorch-lightning.rst
@@ -5,4 +5,4 @@ Using Ray with Pytorch Lightning
     `Ray Lightning Library <https://github.com/ray-project/ray_lightning>`_ will be deprecated in the future!
 
     In version 2.4, we introduced :class:`LightningTrainer <ray.train.lightning.LightningTrainer>`, which provides better integration with PyTorch Lightning.
-    Please refer to :ref:`Finetuning a PyTorch Lightning Image Classifier <lightning_mnist_example>` to learn how to use `LightningTrainer` for distributed model training.
+    Please refer to :ref:`Train a PyTorch Lightning Image Classifier <lightning_mnist_example>` to learn how to use `LightningTrainer` for distributed model training.

--- a/doc/source/train/examples/lightning/lightning_mnist_example.ipynb
+++ b/doc/source/train/examples/lightning/lightning_mnist_example.ipynb
@@ -1,12 +1,13 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "(lightning_mnist_example)=\n",
     "\n",
-    "# Finetuning a Pytorch Lightning Image Classifier\n",
+    "# Train a Pytorch Lightning Image Classifier\n",
     "\n",
     "This example introduces how to train a Pytorch Lightning Module using AIR {class}`LightningTrainer <ray.train.lightning.LightningTrainer>`. We will demonstrate how to train a basic neural network on the MNIST dataset with distributed data parallelism.\n"
    ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

There's a typo in the title of LightningTrainer starter example, change it from "finetune" to "train".

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
