### PR TITLE
[ray.util.spark] Add warning if webui_url is None. optional dependencies for dashboard server might be missing. (#33521)

### DIFF
--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -115,9 +115,9 @@ class RayClusterOnSpark:
                     __import__("ray.dashboard.optional_deps")
                 except ModuleNotFoundError:
                     _logger.warning(
-                        "Dependencies to launch the optional dashboard API ",
-                        "server cannot be found. They can be installed with ",
-                        "pip install ray[default].",
+                        "Dependencies to launch the optional dashboard API "
+                        "server cannot be found. They can be installed with "
+                        "pip install ray[default]."
                     )
 
         except Exception:

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -110,6 +110,15 @@ class RayClusterOnSpark:
             webui_url = ray_ctx.address_info.get("webui_url", None)
             if webui_url:
                 self.start_hook.on_ray_dashboard_created(self.ray_dashboard_port)
+            else:
+                try:
+                    __import__("ray.dashboard.optional_deps")
+                except ModuleNotFoundError:
+                    _logger.warning(
+                        "Dependencies to launch the optional dashboard API ",
+                        "server cannot be found. They can be installed with ",
+                        "pip install ray[default].",
+                    )
 
         except Exception:
             self.shutdown()


### PR DESCRIPTION
## Why are these changes needed?

Just trying to be helpful and give distracted people like me a potential reason why the dashboard is not available.

## Related issue number

Closes #33521

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
