### PR TITLE
[Train] Fix the import path for LightningTrainer to be compatible with Pytorch Lightning 2.0.

### DIFF
--- a/python/ray/train/lightning/lightning_trainer.py
+++ b/python/ray/train/lightning/lightning_trainer.py
@@ -4,7 +4,16 @@ from inspect import isclass
 from typing import Any, Dict, Optional, Type
 import pytorch_lightning as pl
 from pytorch_lightning.plugins.environments import ClusterEnvironment
-from pytorch_lightning.callbacks.progress.base import ProgressBarBase
+
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import LooseVersion as Version
+
+if Version(pl.__version__) >= Version("2.0.0"):
+    from pytorch_lightning.callbacks.progress import ProgressBar as ProgressBarBase
+else:
+    from pytorch_lightning.callbacks.progress.base import ProgressBarBase
 
 from ray.air import session
 from ray.air.config import CheckpointConfig, DatasetConfig, RunConfig, ScalingConfig

--- a/python/ray/train/lightning/lightning_trainer.py
+++ b/python/ray/train/lightning/lightning_trainer.py
@@ -5,10 +5,7 @@ from typing import Any, Dict, Optional, Type
 import pytorch_lightning as pl
 from pytorch_lightning.plugins.environments import ClusterEnvironment
 
-try:
-    from packaging.version import Version
-except ImportError:
-    from distutils.version import LooseVersion as Version
+from packaging.version import Version
 
 if Version(pl.__version__) >= Version("2.0.0"):
     from pytorch_lightning.callbacks.progress import ProgressBar as ProgressBarBase


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Pytorch Lightning released 2.0 a few weeks ago, and they have changed the import path of `ProgressBarBase`, which could cause an import error if we do not take care of it.

Given that PTL has removed all the documentations in 1.x, and many of our users are trying out PTL 2.0, it'd be necessary to ensure compatibility with the latest PTL version in release 2.4. This PR added version check and import `ProgressBarBase` with different paths accordingly.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
