### PR TITLE
[Data] Improve state initialization for `ActorPoolMapOperator`

### DIFF
--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -260,22 +260,20 @@ def _stage_to_operator(stage: Stage, input_op: PhysicalOperator) -> PhysicalOper
                 fn_ = stage.fn
 
                 def fn(item: Any) -> Any:
-                    # Wrapper providing cached instantiation of stateful callable class
-                    # UDFs.
+                    assert ray.data._cached_fn is not None
+                    assert ray.data._cached_cls == fn_
+                    return ray.data._cached_fn(item)
+
+                def init_fn():
                     if ray.data._cached_fn is None:
                         ray.data._cached_cls = fn_
                         ray.data._cached_fn = fn_(
                             *fn_constructor_args, **fn_constructor_kwargs
                         )
-                    else:
-                        # A worker is destroyed when its actor is killed, so we
-                        # shouldn't have any worker reuse across different UDF
-                        # applications (i.e. different map operators).
-                        assert ray.data._cached_cls == fn_
-                    return ray.data._cached_fn(item)
 
             else:
                 fn = stage.fn
+                init_fn = None
             fn_args = (fn,)
         else:
             fn_args = ()
@@ -288,6 +286,7 @@ def _stage_to_operator(stage: Stage, input_op: PhysicalOperator) -> PhysicalOper
 
         return MapOperator.create(
             do_map,
+            init_fn,
             input_op,
             name=stage.name,
             compute_strategy=compute,

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -277,6 +277,7 @@ def _stage_to_operator(stage: Stage, input_op: PhysicalOperator) -> PhysicalOper
             fn_args = (fn,)
         else:
             fn_args = ()
+            init_fn = None
         if stage.fn_args:
             fn_args += stage.fn_args
         fn_kwargs = stage.fn_kwargs or {}

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -287,8 +287,8 @@ def _stage_to_operator(stage: Stage, input_op: PhysicalOperator) -> PhysicalOper
 
         return MapOperator.create(
             do_map,
-            init_fn,
             input_op,
+            init_fn,
             name=stage.name,
             compute_strategy=compute,
             min_rows_per_bundle=stage.target_block_size,

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -243,6 +243,9 @@ def _stage_to_operator(stage: Stage, input_op: PhysicalOperator) -> PhysicalOper
     if isinstance(stage, OneToOneStage):
         compute = get_compute(stage.compute)
 
+        def _empty_init():
+            pass
+
         block_fn = stage.block_fn
         if stage.fn:
             if isinstance(stage.fn, CallableClass):
@@ -273,11 +276,11 @@ def _stage_to_operator(stage: Stage, input_op: PhysicalOperator) -> PhysicalOper
 
             else:
                 fn = stage.fn
-                init_fn = None
+                init_fn = _empty_init
             fn_args = (fn,)
         else:
             fn_args = ()
-            init_fn = None
+            init_fn = _empty_init
         if stage.fn_args:
             fn_args += stage.fn_args
         fn_kwargs = stage.fn_kwargs or {}
@@ -287,8 +290,8 @@ def _stage_to_operator(stage: Stage, input_op: PhysicalOperator) -> PhysicalOper
 
         return MapOperator.create(
             do_map,
-            input_op,
             init_fn,
+            input_op,
             name=stage.name,
             compute_strategy=compute,
             min_rows_per_bundle=stage.target_block_size,

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -243,9 +243,6 @@ def _stage_to_operator(stage: Stage, input_op: PhysicalOperator) -> PhysicalOper
     if isinstance(stage, OneToOneStage):
         compute = get_compute(stage.compute)
 
-        def _empty_init():
-            pass
-
         block_fn = stage.block_fn
         if stage.fn:
             if isinstance(stage.fn, CallableClass):
@@ -276,11 +273,11 @@ def _stage_to_operator(stage: Stage, input_op: PhysicalOperator) -> PhysicalOper
 
             else:
                 fn = stage.fn
-                init_fn = _empty_init
+                init_fn = None
             fn_args = (fn,)
         else:
             fn_args = ()
-            init_fn = _empty_init
+            init_fn = None
         if stage.fn_args:
             fn_args += stage.fn_args
         fn_kwargs = stage.fn_kwargs or {}
@@ -290,8 +287,8 @@ def _stage_to_operator(stage: Stage, input_op: PhysicalOperator) -> PhysicalOper
 
         return MapOperator.create(
             do_map,
-            init_fn,
             input_op,
+            init_fn=init_fn,
             name=stage.name,
             compute_strategy=compute,
             min_rows_per_bundle=stage.target_block_size,

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -306,6 +306,7 @@ class _MapWorker:
         DatasetContext._set_current(ctx)
         self.src_fn_name: str = src_fn_name
 
+        # Initialize state for this actor.
         init_fn()
 
     def get_location(self) -> NodeIdStr:

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -37,7 +37,7 @@ class ActorPoolMapOperator(MapOperator):
     def __init__(
         self,
         transform_fn: Callable[[Iterator[Block]], Iterator[Block]],
-        init_fn: _CallableClassProtocol,
+        init_fn: Callable[[], None],
         input_op: PhysicalOperator,
         autoscaling_policy: "AutoscalingPolicy",
         name: str = "ActorPoolMap",

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -71,8 +71,8 @@ class MapOperator(PhysicalOperator, ABC):
     def create(
         cls,
         transform_fn: MapTransformFn,
-        init_fn: Optional[_CallableClassProtocol],
         input_op: PhysicalOperator,
+        init_fn: Optional[_CallableClassProtocol] = None,
         name: str = "Map",
         # TODO(ekl): slim down ComputeStrategy to only specify the compute
         # config and not contain implementation code.
@@ -89,8 +89,8 @@ class MapOperator(PhysicalOperator, ABC):
 
         Args:
             transform_fn: The function to apply to each ref bundle input.
-            init_fn: The callable class to instantiate if using ActorPoolMapOperator.
             input_op: Operator generating input data for this op.
+            init_fn: The callable class to instantiate if using ActorPoolMapOperator.
             name: The name of this operator.
             compute_strategy: Customize the compute strategy for this op.
             min_rows_per_bundle: The number of rows to gather per batch passed to the

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -5,7 +5,13 @@ import itertools
 from typing import List, Iterator, Any, Dict, Optional, Union
 
 import ray
-from ray.data.block import Block, BlockAccessor, BlockMetadata, BlockExecStats
+from ray.data.block import (
+    Block,
+    BlockAccessor,
+    BlockMetadata,
+    BlockExecStats,
+    _CallableClassProtocol,
+)
 from ray.data._internal.compute import (
     ComputeStrategy,
     TaskPoolStrategy,
@@ -65,6 +71,7 @@ class MapOperator(PhysicalOperator, ABC):
     def create(
         cls,
         transform_fn: MapTransformFn,
+        init_fn: Optional[_CallableClassProtocol],
         input_op: PhysicalOperator,
         name: str = "Map",
         # TODO(ekl): slim down ComputeStrategy to only specify the compute
@@ -82,6 +89,7 @@ class MapOperator(PhysicalOperator, ABC):
 
         Args:
             transform_fn: The function to apply to each ref bundle input.
+            init_fn: The callable class to instantiate if using ActorPoolMapOperator.
             input_op: Operator generating input data for this op.
             name: The name of this operator.
             compute_strategy: Customize the compute strategy for this op.
@@ -119,6 +127,7 @@ class MapOperator(PhysicalOperator, ABC):
             autoscaling_policy = AutoscalingPolicy(autoscaling_config)
             return ActorPoolMapOperator(
                 transform_fn,
+                init_fn,
                 input_op,
                 autoscaling_policy=autoscaling_policy,
                 name=name,

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -70,8 +70,8 @@ class MapOperator(PhysicalOperator, ABC):
     def create(
         cls,
         transform_fn: MapTransformFn,
-        input_op: PhysicalOperator,
         init_fn: Callable[[], None],
+        input_op: PhysicalOperator,
         name: str = "Map",
         # TODO(ekl): slim down ComputeStrategy to only specify the compute
         # config and not contain implementation code.

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -70,8 +70,8 @@ class MapOperator(PhysicalOperator, ABC):
     def create(
         cls,
         transform_fn: MapTransformFn,
-        init_fn: Callable[[], None],
         input_op: PhysicalOperator,
+        init_fn: Optional[Callable[[], None]] = None,
         name: str = "Map",
         # TODO(ekl): slim down ComputeStrategy to only specify the compute
         # config and not contain implementation code.
@@ -124,6 +124,12 @@ class MapOperator(PhysicalOperator, ABC):
                 compute_strategy
             )
             autoscaling_policy = AutoscalingPolicy(autoscaling_config)
+
+            if init_fn is None:
+
+                def init_fn():
+                    pass
+
             return ActorPoolMapOperator(
                 transform_fn,
                 init_fn,

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import copy
 from dataclasses import dataclass
 import itertools
-from typing import List, Iterator, Any, Dict, Optional, Union
+from typing import Callable, List, Iterator, Any, Dict, Optional, Union
 
 import ray
 from ray.data.block import (
@@ -10,7 +10,6 @@ from ray.data.block import (
     BlockAccessor,
     BlockMetadata,
     BlockExecStats,
-    _CallableClassProtocol,
 )
 from ray.data._internal.compute import (
     ComputeStrategy,
@@ -72,7 +71,7 @@ class MapOperator(PhysicalOperator, ABC):
         cls,
         transform_fn: MapTransformFn,
         input_op: PhysicalOperator,
-        init_fn: Optional[_CallableClassProtocol] = None,
+        init_fn: Callable[[], None],
         name: str = "Map",
         # TODO(ekl): slim down ComputeStrategy to only specify the compute
         # config and not contain implementation code.

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -73,11 +73,7 @@ def _plan_udf_map_op(
 
     else:
         fn = op._fn
-
-        def _empty_init():
-            pass
-
-        init_fn = _empty_init
+        init_fn = None
     fn_args = (fn,)
     if op._fn_args:
         fn_args += op._fn_args
@@ -88,8 +84,8 @@ def _plan_udf_map_op(
 
     return MapOperator.create(
         do_map,
-        init_fn,
         input_physical_dag,
+        init_fn=init_fn,
         name=op.name,
         compute_strategy=compute,
         min_rows_per_bundle=op._target_block_size,

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -84,8 +84,8 @@ def _plan_udf_map_op(
 
     return MapOperator.create(
         do_map,
-        init_fn,
         input_physical_dag,
+        init_fn,
         name=op.name,
         compute_strategy=compute,
         min_rows_per_bundle=op._target_block_size,

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -73,7 +73,11 @@ def _plan_udf_map_op(
 
     else:
         fn = op._fn
-        init_fn = None
+
+        def _empty_init():
+            pass
+
+        init_fn = _empty_init
     fn_args = (fn,)
     if op._fn_args:
         fn_args += op._fn_args
@@ -84,8 +88,8 @@ def _plan_udf_map_op(
 
     return MapOperator.create(
         do_map,
-        input_physical_dag,
         init_fn,
+        input_physical_dag,
         name=op.name,
         compute_strategy=compute,
         min_rows_per_bundle=op._target_block_size,

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -510,6 +510,33 @@ def test_map_operator_shutdown(shutdown_only, use_actors):
     wait_for_condition(lambda: (ray.available_resources().get("GPU", 0) == 1.0))
 
 
+def test_actor_pool_map_operator_init(ray_start_regular_shared):
+    """Tests that ActorPoolMapOperator runs init_fn on start."""
+
+    from ray.exceptions import RayActorError
+
+    def _sleep(block_iter: Iterable[Block]) -> Iterable[Block]:
+        time.sleep(999)
+
+    def _fail():
+        raise ValueError("init_failed")
+
+    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(10)]))
+    compute_strategy = ActorPoolStrategy(min_size=1)
+
+    op = MapOperator.create(
+        _sleep,
+        input_op=input_op,
+        init_fn=_fail,
+        name="TestMapper",
+        compute_strategy=compute_strategy,
+    )
+
+    with pytest.raises(RayActorError) as e:
+        op.start(ExecutionOptions())
+        assert "init_failed" in e.error_msg
+
+
 @pytest.mark.parametrize(
     "compute,expected",
     [

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -532,9 +532,8 @@ def test_actor_pool_map_operator_init(ray_start_regular_shared):
         compute_strategy=compute_strategy,
     )
 
-    with pytest.raises(RayActorError) as e:
+    with pytest.raises(RayActorError, match=r"init_failed"):
         op.start(ExecutionOptions())
-        assert "init_failed" in e.error_msg
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

`ActorPoolMapOperator` takes in a Callable class which initializes some state to be reused for every batch.

In the current implementation, this state is initialized on the first batch, rather than during actor init.

In this PR, we separate the state initialization and actually call it during Actor init. This allows state to be initialized for fixed size actor pools, even when tasks are not ready to be dispatched for better pipelining. It also supports using multithreaded actors, so state gets initialized once per actor instead of once per thread.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
