### PR TITLE
[docs] wrap autogenerated API nav items

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -96,6 +96,12 @@ div.navbar-brand-box {
     display: flex;
     flex-direction: column;
 }
+
+.bd-sidebar li {
+    position: relative;
+    word-wrap: break-word;
+}
+
 nav.bd-links {
     overflow-y: auto;
     flex: 1;


### PR DESCRIPTION
Just a tiny fix for nested nav items, noticed by @simran-2797 

old:

![wrap_overflowing_text](https://user-images.githubusercontent.com/3462566/229805414-b867d225-9293-4970-9b5d-927d437e7b71.png)

new: 

![Screenshot 2023-04-04 at 13 45 09](https://user-images.githubusercontent.com/3462566/229805445-669794f7-c14c-4a76-b02b-530363ffd145.png)
