### PR TITLE
[release tests] Move aws cluster launcher tests to v2 cloud

### DIFF
--- a/python/ray/autoscaler/aws/tests/aws_compute.yaml
+++ b/python/ray/autoscaler/aws/tests/aws_compute.yaml
@@ -1,8 +1,12 @@
-cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
 aws:
-    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+    BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: true
+            VolumeSize: 1000
 
 head_node_type:
     name: head_node

--- a/python/ray/autoscaler/aws/tests/aws_compute.yaml
+++ b/python/ray/autoscaler/aws/tests/aws_compute.yaml
@@ -2,6 +2,7 @@ cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
 aws:
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:

--- a/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
@@ -16,6 +16,8 @@ import sys
 import time
 from pathlib import Path
 
+# DEBUG: print the output of pip list freeze
+subprocess.run(["pip", "list", "--format=freeze"])
 import boto3
 
 

--- a/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
@@ -85,7 +85,12 @@ def cleanup_cluster(cluster_config):
     """
     print("======================================")
     print("Cleaning up cluster...")
-    subprocess.run(["ray", "down", "-v", "-y", str(cluster_config)], check=True)
+    result = subprocess.run(
+        ["ray", "down", "-v", "-y", str(cluster_config)],
+        check=True,
+        capture_output=True,
+    )
+    print(result.stdout.decode("utf-8"))
 
 
 def run_ray_commands(cluster_config, retries):
@@ -102,7 +107,8 @@ def run_ray_commands(cluster_config, retries):
 
     print("======================================")
     print("Starting new cluster...")
-    subprocess.run(["ray", "up", "-v", "-y", str(cluster_config)], check=True)
+    result = subprocess.run(["ray", "up", "-v", "-y", str(cluster_config)], check=True)
+    print(result.stdout.decode("utf-8"))
 
     print("======================================")
     print("Verifying Ray is running...")
@@ -111,7 +117,7 @@ def run_ray_commands(cluster_config, retries):
     count = 0
     while count < retries:
         try:
-            subprocess.run(
+            result = subprocess.run(
                 [
                     "ray",
                     "exec",
@@ -120,11 +126,14 @@ def run_ray_commands(cluster_config, retries):
                     "python -c 'import ray; ray.init(\"localhost:6379\")'",
                 ],
                 check=True,
+                capture_output=True,
             )
+            print(result.stdout.decode("utf-8"))
             success = True
             break
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as e:
             count += 1
+            print(e.stdout.decode("utf-8"))
             print(f"Verification failed. Retry attempt {count} of {retries}...")
             time.sleep(5)
 

--- a/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
@@ -85,12 +85,7 @@ def cleanup_cluster(cluster_config):
     """
     print("======================================")
     print("Cleaning up cluster...")
-    result = subprocess.run(
-        ["ray", "down", "-v", "-y", str(cluster_config)],
-        check=True,
-        capture_output=True,
-    )
-    print(result.stdout.decode("utf-8"))
+    subprocess.run(["ray", "down", "-v", "-y", str(cluster_config)], check=True)
 
 
 def run_ray_commands(cluster_config, retries):
@@ -107,8 +102,7 @@ def run_ray_commands(cluster_config, retries):
 
     print("======================================")
     print("Starting new cluster...")
-    result = subprocess.run(["ray", "up", "-v", "-y", str(cluster_config)], check=True)
-    print(result.stdout.decode("utf-8"))
+    subprocess.run(["ray", "up", "-v", "-y", str(cluster_config)], check=True)
 
     print("======================================")
     print("Verifying Ray is running...")
@@ -117,7 +111,7 @@ def run_ray_commands(cluster_config, retries):
     count = 0
     while count < retries:
         try:
-            result = subprocess.run(
+            subprocess.run(
                 [
                     "ray",
                     "exec",
@@ -126,14 +120,11 @@ def run_ray_commands(cluster_config, retries):
                     "python -c 'import ray; ray.init(\"localhost:6379\")'",
                 ],
                 check=True,
-                capture_output=True,
             )
-            print(result.stdout.decode("utf-8"))
             success = True
             break
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             count += 1
-            print(e.stdout.decode("utf-8"))
             print(f"Verification failed. Retry attempt {count} of {retries}...")
             time.sleep(5)
 

--- a/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
@@ -16,8 +16,6 @@ import sys
 import time
 from pathlib import Path
 
-# DEBUG: print the output of pip list freeze
-subprocess.run(["pip", "list", "--format=freeze"])
 import boto3
 
 
@@ -67,14 +65,15 @@ def download_ssh_key():
     s3_client = boto3.client("s3", region_name="us-west-2")
 
     # Set the name of the S3 bucket and the key to download
-    bucket_name = "oss-release-test-ssh-keys"
-    key_name = "ray-autoscaler_59_us-west-2.pem"
+    bucket_name = "anyscale-staging-data-cld-kvedzwag2qa8i5bjxuevf5i7"
+    key_name = "oss-release-test-ssh-keys/ray-autoscaler_59_us-west-2.pem"
 
     # Download the key from the S3 bucket to a local file
-    local_key_path = os.path.expanduser(f"~/.ssh/{key_name}")
+    local_filename = os.path.basename(key_name)
+    local_key_path = os.path.expanduser(f"~/.ssh/{local_filename}")
     s3_client.download_file(bucket_name, key_name, local_key_path)
 
-    # Set permissions on the key file
+    # Set permissions on the key file to 400 (read-only for owner)
     os.chmod(local_key_path, 0o400)
 
 

--- a/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
@@ -61,6 +61,7 @@ def download_ssh_key():
     """Download the ssh key from the S3 bucket to the local machine."""
     print("======================================")
     print("Downloading ssh key...")
+
     # Create a Boto3 client to interact with S3
     s3_client = boto3.client("s3", region_name="us-west-2")
 
@@ -68,9 +69,15 @@ def download_ssh_key():
     bucket_name = "anyscale-staging-data-cld-kvedzwag2qa8i5bjxuevf5i7"
     key_name = "oss-release-test-ssh-keys/ray-autoscaler_59_us-west-2.pem"
 
-    # Download the key from the S3 bucket to a local file
+    # Determine the local file path for the downloaded key
     local_filename = os.path.basename(key_name)
-    local_key_path = os.path.expanduser(f"~/.ssh/{local_filename}")
+    local_key_dir = os.path.expanduser("~/.ssh")
+    local_key_path = os.path.join(local_key_dir, local_filename)
+
+    # Create the local_key_dir if it doesn't exist
+    os.makedirs(local_key_dir, exist_ok=True)
+
+    # Download the key from the S3 bucket to the local_key_path
     s3_client.download_file(bucket_name, key_name, local_key_path)
 
     # Set permissions on the key file to 400 (read-only for owner)

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4344,9 +4344,6 @@
 
   stable: true
 
-  # TODO: Migrate this test to Anyscale Jobs / staging_v2
-  env: prod_v1
-
   frequency: nightly
   team: core
   cluster:
@@ -4363,9 +4360,6 @@
   working_dir: ../python/ray/autoscaler/aws/
 
   stable: true
-
-  # TODO: Migrate this test to Anyscale Jobs / staging_v2
-  env: prod_v1
 
   frequency: nightly
   team: core

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4353,7 +4353,6 @@
   run:
     timeout: 1200
     script: cd tests && python aws_launch_and_verify_cluster.py aws_cluster.yaml
-    type: sdk_command
 
 - name: aws_cluster_launcher_minimal
   group: cluster-launcher-test
@@ -4370,4 +4369,3 @@
   run:
     timeout: 1200
     script: cd tests && python aws_launch_and_verify_cluster.py ../example-minimal.yaml
-    type: sdk_command


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Moves the AWS cluster launcher tests from the V1 cloud to the V2 cloud and the Anyscale job runner (in other words, using the defaults used for all release tests).  To do this, we move the ssh key to a bucket accessible from the V2 cloud.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
