### PR TITLE
[CI][Green-Ray][1] Automated retry of infra-error release tests

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -118,7 +118,7 @@ def get_step(
     step["retry"] = {
         "automatic": [
           {
-            "exit_status": BuildkiteExitCode.TRANSIENT_INFRA_ERROR,
+            "exit_status": BuildkiteExitCode.TRANSIENT_INFRA_ERROR.value,
             "limit": 2,
           }
         ]

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -15,7 +15,7 @@ from ray_release.config import (
 from ray_release.env import DEFAULT_ENVIRONMENT, load_environment
 from ray_release.template import get_test_env_var
 from ray_release.util import python_version_str, DeferredEnvVar
-from ray_release.result import BuildkiteExitCode
+from ray_release.result import ExitCode
 
 DEFAULT_ARTIFACTS_DIR_HOST = "/tmp/ray_release_test_artifacts"
 
@@ -51,6 +51,14 @@ DEFAULT_STEP_TEMPLATE: Dict[str, Any] = {
     ],
     "artifact_paths": [f"{DEFAULT_ARTIFACTS_DIR_HOST}/**/*"],
     "priority": 0,
+    "retry": {
+        "automatic": [
+            {
+                "exit_status": os.environ.get("BUILDKITE_RETRY_CODE", 79),
+                "limit": os.environ.get("BUILDKITE_MAX_RETRIES", 1),
+            }
+        ]
+    }
 }
 
 
@@ -113,16 +121,6 @@ def get_step(
     # (otherwise keep default QUEUE_DEFAULT)
     if test.get("run", {}).get("type") == "client":
         step["agents"]["queue"] = str(RELEASE_QUEUE_CLIENT)
-
-    # Auto-retry on transient infra error (according to result.BuildkiteExitCode)
-    step["retry"] = {
-        "automatic": [
-            {
-                "exit_status": BuildkiteExitCode.TRANSIENT_INFRA_ERROR.value,
-                "limit": 2,
-            }
-        ]
-    }
 
     # If a test is not stable, allow to soft fail
     stable = test.get("stable", True)

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -117,10 +117,10 @@ def get_step(
     # Auto-retry on transient infra error (according to result.BuildkiteExitCode)
     step["retry"] = {
         "automatic": [
-          {
-            "exit_status": BuildkiteExitCode.TRANSIENT_INFRA_ERROR.value,
-            "limit": 2,
-          }
+            {
+                "exit_status": BuildkiteExitCode.TRANSIENT_INFRA_ERROR.value,
+                "limit": 2,
+            }
         ]
     }
 

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -15,6 +15,7 @@ from ray_release.config import (
 from ray_release.env import DEFAULT_ENVIRONMENT, load_environment
 from ray_release.template import get_test_env_var
 from ray_release.util import python_version_str, DeferredEnvVar
+from ray_release.result import BuildkiteExitCode
 
 DEFAULT_ARTIFACTS_DIR_HOST = "/tmp/ray_release_test_artifacts"
 
@@ -112,6 +113,16 @@ def get_step(
     # (otherwise keep default QUEUE_DEFAULT)
     if test.get("run", {}).get("type") == "client":
         step["agents"]["queue"] = str(RELEASE_QUEUE_CLIENT)
+
+    # Auto-retry on transient infra error (according to result.BuildkiteExitCode)
+    step["retry"] = {
+        "automatic": [
+          {
+            "exit_status": BuildkiteExitCode.TRANSIENT_INFRA_ERROR,
+            "limit": 2,
+          }
+        ]
+    }
 
     # If a test is not stable, allow to soft fail
     stable = test.get("stable", True)

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -15,7 +15,6 @@ from ray_release.config import (
 from ray_release.env import DEFAULT_ENVIRONMENT, load_environment
 from ray_release.template import get_test_env_var
 from ray_release.util import python_version_str, DeferredEnvVar
-from ray_release.result import ExitCode
 
 DEFAULT_ARTIFACTS_DIR_HOST = "/tmp/ray_release_test_artifacts"
 
@@ -58,7 +57,7 @@ DEFAULT_STEP_TEMPLATE: Dict[str, Any] = {
                 "limit": os.environ.get("BUILDKITE_MAX_RETRIES", 1),
             }
         ]
-    }
+    },
 }
 
 

--- a/release/ray_release/command_runner/command_runner.py
+++ b/release/ray_release/command_runner/command_runner.py
@@ -119,12 +119,12 @@ class CommandRunner(abc.ABC):
             max_retries=3,
         )
 
-    def get_last_logs(self) -> str:
+    def get_last_logs(self) -> Optional[str]:
         try:
             return self.get_last_logs_ex()
         except Exception as e:
             logger.exception(f"Error fetching logs: {e}")
-            return "No logs could be retrieved."
+            return None
 
     def get_last_logs_ex(self):
         raise NotImplementedError

--- a/release/ray_release/command_runner/command_runner.py
+++ b/release/ray_release/command_runner/command_runner.py
@@ -129,7 +129,7 @@ class CommandRunner(abc.ABC):
     def get_last_logs_ex(self):
         raise NotImplementedError
 
-    def fetch_results_ex(self) -> Dict[str, Any]:
+    def fetch_results(self) -> Dict[str, Any]:
         raise NotImplementedError
 
     def fetch_metrics(self) -> Dict[str, Any]:

--- a/release/ray_release/command_runner/command_runner.py
+++ b/release/ray_release/command_runner/command_runner.py
@@ -129,7 +129,7 @@ class CommandRunner(abc.ABC):
     def get_last_logs_ex(self):
         raise NotImplementedError
 
-    def fetch_results(self) -> Dict[str, Any]:
+    def fetch_results_ex(self) -> Dict[str, Any]:
         raise NotImplementedError
 
     def fetch_metrics(self) -> Dict[str, Any]:

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -1,15 +1,13 @@
 import os
 import time
-from typing import Optional, List, Tuple
+from typing import Optional, List
 
 from ray_release.alerts.handle import handle_result, require_result
 from ray_release.anyscale_util import get_cluster_name
 from ray_release.buildkite.output import buildkite_group, buildkite_open_last
-from ray_release.cluster_manager.cluster_manager import ClusterManager
 from ray_release.cluster_manager.full import FullClusterManager
 from ray_release.cluster_manager.minimal import MinimalClusterManager
 from ray_release.command_runner.job_runner import JobRunner
-from ray_release.command_runner.command_runner import CommandRunner
 from ray_release.command_runner.anyscale_job_runner import AnyscaleJobRunner
 from ray_release.command_runner.sdk_runner import SDKRunner
 from ray_release.config import (
@@ -91,33 +89,43 @@ def _get_extra_tags_from_env() -> dict:
     return {key.lower(): os.getenv(key, "") for key in env_vars}
 
 
-def _load_test_configuration(
+def run_release_test(
     test: Test,
     anyscale_project: str,
     result: Result,
     ray_wheels_url: str,
+    reporters: Optional[List[Reporter]] = None,
     smoke_test: bool = False,
+    cluster_id: Optional[str] = None,
+    cluster_env_id: Optional[str] = None,
     no_terminate: bool = False,
-) -> Tuple[ClusterManager, CommandRunner, str]:
+) -> Result:
+    buildkite_group(":spiral_note_pad: Loading test configuration")
+
     validate_test(test)
+
     logger.info(f"Test config: {test}")
 
-    # Populate result paramaters
     result.wheels_url = ray_wheels_url
     result.stable = test.get("stable", True)
     result.smoke_test = smoke_test
+
     buildkite_url = os.getenv("BUILDKITE_BUILD_URL", "")
     buildkite_job_id = os.getenv("BUILDKITE_JOB_ID", "")
+
     if buildkite_url:
         buildkite_url += "#" + buildkite_job_id
+
     result.buildkite_url = buildkite_url
     result.buildkite_job_id = buildkite_job_id
 
-    # Setting up working directory
     working_dir = test["working_dir"]
+
+    old_wd = os.getcwd()
     new_wd = os.path.join(RELEASE_PACKAGE_DIR, working_dir)
     os.chdir(new_wd)
 
+    start_time = time.monotonic()
     run_type = test["run"].get("type", DEFAULT_RUN_TYPE)
 
     # Workaround while Anyscale Jobs don't support leaving cluster alive
@@ -152,6 +160,7 @@ def _load_test_configuration(
 
     logger.info(f"Got command runner cls: {command_runner_cls}")
     logger.info(f"Got file manager cls: {file_manager_cls}")
+
     # Extra tags to be set on resources on cloud provider's side
     extra_tags = _get_extra_tags_from_env()
     # We don't need other attributes as they can be derived from the name
@@ -175,356 +184,230 @@ def _load_test_configuration(
     except Exception as e:
         raise ReleaseTestSetupError(f"Error setting up release test: {e}") from e
 
-    return cluster_manager, command_runner, artifact_path
-
-
-def _setup_cluster_environment(
-    test: Test,
-    result: Result,
-    cluster_manager: ClusterManager,
-    ray_wheels_url: str,
-    cluster_env_id: Optional[str],
-) -> Tuple[str, int, int, int, int]:
-    setup_signal_handling()
-    # Load configs
-    cluster_env = load_test_cluster_env(test, ray_wheels_url=ray_wheels_url)
-    cluster_compute = load_test_cluster_compute(test)
-
-    if cluster_env_id:
-        try:
-            cluster_manager.cluster_env_id = cluster_env_id
-            cluster_manager.build_cluster_env()
-            cluster_manager.fetch_build_info()
-            logger.info(
-                "Using overridden cluster environment with ID "
-                f"{cluster_env_id} and build ID "
-                f"{cluster_manager.cluster_env_build_id}"
-            )
-        except Exception as e:
-            raise ClusterEnvCreateError(
-                f"Could not get existing overridden cluster environment "
-                f"{cluster_env_id}: {e}"
-            ) from e
-    else:
-        cluster_manager.set_cluster_env(cluster_env)
-
-    # Load some timeouts
-    build_timeout = int(test["run"].get("build_timeout", DEFAULT_BUILD_TIMEOUT))
-    command_timeout = int(test["run"].get("timeout", DEFAULT_COMMAND_TIMEOUT))
-    cluster_timeout = int(test["run"].get("session_timeout", DEFAULT_CLUSTER_TIMEOUT))
-
-    # Get prepare command timeout, if any
-    prepare_cmd = test["run"].get("prepare", None)
-    if prepare_cmd:
-        prepare_timeout = test["run"].get("prepare_timeout", command_timeout)
-    else:
-        prepare_timeout = 0
-
-    # Base maximum uptime on the combined command and prepare timeouts
-    command_and_prepare_timeout = command_timeout + prepare_timeout
-
-    # Use default timeout = 0 here if wait_for_nodes is empty. This is to make
-    # sure we don't inflate the maximum_uptime_minutes too much if we don't wait
-    # for nodes at all.
-    # The actual default will be otherwise loaded further down.
-    wait_timeout = int(test["run"].get("wait_for_nodes", {}).get("timeout", 0))
-
-    autosuspend_mins = test["cluster"].get("autosuspend_mins", None)
-    if autosuspend_mins:
-        cluster_manager.autosuspend_minutes = autosuspend_mins
-        autosuspend_base = autosuspend_mins
-    else:
-        cluster_manager.autosuspend_minutes = min(
-            DEFAULT_AUTOSUSPEND_MINS,
-            int(command_and_prepare_timeout / 60) + TIMEOUT_BUFFER_MINUTES,
-        )
-        # Maximum uptime should be based on the command timeout, not the
-        # DEFAULT_AUTOSUSPEND_MINS
-        autosuspend_base = (
-            int(command_and_prepare_timeout / 60) + TIMEOUT_BUFFER_MINUTES
-        )
-
-    maximum_uptime_minutes = test["cluster"].get("maximum_uptime_minutes", None)
-    if maximum_uptime_minutes:
-        cluster_manager.maximum_uptime_minutes = maximum_uptime_minutes
-    else:
-        cluster_manager.maximum_uptime_minutes = (
-            autosuspend_base + wait_timeout + TIMEOUT_BUFFER_MINUTES
-        )
-
-    # Set cluster compute here. Note that this may use timeouts provided
-    # above.
-    cluster_manager.set_cluster_compute(
-        cluster_compute,
-        extra_tags=result.extra_tags,
-    )
-
-    return prepare_cmd, prepare_timeout, build_timeout, cluster_timeout, command_timeout
-
-
-def _setup_local_environment(
-    test: Test,
-    command_runner: CommandRunner,
-    ray_wheels_url: str,
-) -> None:
-    driver_setup_script = test.get("driver_setup", None)
-    if driver_setup_script:
-        try:
-            run_bash_script(driver_setup_script)
-        except Exception as e:
-            raise LocalEnvSetupError(f"Driver setup script failed: {e}") from e
-
-    # Install local dependencies
-    command_runner.prepare_local_env(ray_wheels_url)
-
-    # Re-install anyscale package as local dependencies might have changed
-    # from local env setup
-    reinstall_anyscale_dependencies()
-
-
-def _local_environment_information(
-    result: Result,
-    cluster_manager: ClusterManager,
-    command_runner: CommandRunner,
-    build_timeout: int,
-    cluster_timeout: int,
-    no_terminate: bool,
-    cluster_id: Optional[str],
-    cluster_env_id: Optional[str],
-) -> None:
-    pip_packages = get_pip_packages()
-    pip_package_string = "\n".join(pip_packages)
-    logger.info(f"Installed python packages:\n{pip_package_string}")
-
-    if isinstance(cluster_manager, FullClusterManager):
-        if not no_terminate:
-            register_handler(
-                lambda sig, frame: cluster_manager.terminate_cluster(wait=True)
-            )
-
-    # Start cluster
-    if cluster_id:
-        buildkite_group(":rocket: Using existing cluster")
-        # Re-use existing cluster ID for development
-        cluster_manager.cluster_id = cluster_id
-        cluster_manager.cluster_name = get_cluster_name(cluster_id)
-    else:
-        buildkite_group(":gear: Building cluster environment")
-
-        if cluster_env_id:
-            cluster_manager.cluster_env_id = cluster_env_id
-
-        cluster_manager.build_configs(timeout=build_timeout)
-
-        if isinstance(cluster_manager, FullClusterManager):
-            buildkite_group(":rocket: Starting up cluster")
-            cluster_manager.start_cluster(timeout=cluster_timeout)
-        elif isinstance(command_runner, AnyscaleJobRunner):
-            command_runner.job_manager.cluster_startup_timeout = cluster_timeout
-
-    result.cluster_url = cluster_manager.get_cluster_url()
-    result.cluster_id = cluster_manager.cluster_id
-
-
-def _prepare_remote_environment(
-    test: Test,
-    command_runner: CommandRunner,
-    prepare_cmd: bool,
-    prepare_timeout: int,
-) -> None:
-    command_runner.prepare_remote_env()
-
-    wait_for_nodes = test["run"].get("wait_for_nodes", None)
-
-    if wait_for_nodes:
-        buildkite_group(":stopwatch: Waiting for nodes to come up")
-        # Overwrite wait_timeout from above to account for better default
-        wait_timeout = int(
-            wait_for_nodes.get("timeout", DEFAULT_WAIT_FOR_NODES_TIMEOUT)
-        )
-        num_nodes = test["run"]["wait_for_nodes"]["num_nodes"]
-        command_runner.wait_for_nodes(num_nodes, wait_timeout)
-
-    if prepare_cmd:
-        try:
-            command_runner.run_prepare_command(prepare_cmd, timeout=prepare_timeout)
-        except CommandError as e:
-            raise PrepareCommandError(e)
-        except CommandTimeout as e:
-            raise PrepareCommandTimeout(e)
-
-
-def _running_test_script(
-    test: Test,
-    smoke_test: bool,
-    command_runner: CommandRunner,
-    command_timeout: int,
-) -> None:
-    command = test["run"]["script"]
-    command_env = {}
-
-    if smoke_test:
-        command = f"{command} --smoke-test"
-        command_env["IS_SMOKE_TEST"] = "1"
-
-    is_long_running = test["run"].get("long_running", False)
-
-    try:
-        command_runner.run_command(
-            command,
-            env=command_env,
-            timeout=command_timeout,
-            raise_on_timeout=not is_long_running,
-        )
-    except (
-        TestCommandError,
-        PrepareCommandError,
-        TestCommandTimeout,
-        PrepareCommandTimeout,
-    ) as e:
-        raise e
-    except CommandError as e:
-        raise TestCommandError(e)
-    except CommandTimeout as e:
-        if not is_long_running:
-            # Only raise error if command is not long running
-            raise TestCommandTimeout(e)
-
-
-def _fetching_results(
-    result: Result,
-    command_runner: CommandRunner,
-    artifact_path: Optional[str],
-    smoke_test: bool,
-    start_time_unix: int,
-) -> Tuple[dict, Exception]:
-    fetch_result_exception = None
-    try:
-        command_results = command_runner.fetch_results()
-    except Exception as e:
-        logger.exception(f"Could not fetch results for test command: {e}")
-        command_results = {}
-        fetch_result_exception = e
-
-    if artifact_path:
-        try:
-            command_runner.fetch_artifact()
-        except Exception as e:
-            logger.error("Could not fetch artifact for test command")
-            logger.exception(e)
-
-    # Postprocess result:
-    if "last_update" in command_results:
-        command_results["last_update_diff"] = time.time() - command_results.get(
-            "last_update", 0.0
-        )
-
-    try:
-        # Logic duplicated in ray_release/command_runner/_anyscale_job_wrapper.py
-        # Timeout is the time the test took divided by 200
-        # (~7 minutes for a 24h test) but no less than 30s
-        # and no more than 900s
-        metrics_timeout = max(30, min((time.time() - start_time_unix) / 200, 900))
-        command_runner.save_metrics(start_time_unix, timeout=metrics_timeout)
-        metrics = command_runner.fetch_metrics()
-    except Exception as e:
-        logger.exception(f"Could not fetch metrics for test command: {e}")
-        metrics = {}
-
-    if smoke_test:
-        command_results["smoke_test"] = True
-
-    result.results = command_results
-    result.status = "finished"
-
-    return metrics, fetch_result_exception
-
-
-def run_release_test(
-    test: Test,
-    anyscale_project: str,
-    result: Result,
-    ray_wheels_url: str,
-    reporters: Optional[List[Reporter]] = None,
-    smoke_test: bool = False,
-    cluster_id: Optional[str] = None,
-    cluster_env_id: Optional[str] = None,
-    no_terminate: bool = False,
-) -> Result:
-    old_wd = os.getcwd()
-    start_time = time.monotonic()
-
-    buildkite_group(":spiral_note_pad: Loading test configuration")
-    cluster_manager, command_runner, artifact_path = _load_test_configuration(
-        test,
-        anyscale_project,
-        result,
-        ray_wheels_url,
-        smoke_test,
-        no_terminate,
-    )
-
     pipeline_exception = None
     # non critical for some tests. So separate it from the general one.
     fetch_result_exception = None
     try:
-        buildkite_group(":nut_and_bolt: Setting up cluster environment")
-        (
-            prepare_cmd,
-            prepare_timeout,
-            build_timeout,
-            cluster_timeout,
-            command_timeout,
-        ) = _setup_cluster_environment(
-            test,
-            result,
-            cluster_manager,
-            ray_wheels_url,
-            cluster_env_id,
+        setup_signal_handling()
+        # Load configs
+        cluster_env = load_test_cluster_env(test, ray_wheels_url=ray_wheels_url)
+        cluster_compute = load_test_cluster_compute(test)
+
+        if cluster_env_id:
+            try:
+                cluster_manager.cluster_env_id = cluster_env_id
+                cluster_manager.build_cluster_env()
+                cluster_manager.fetch_build_info()
+                logger.info(
+                    "Using overridden cluster environment with ID "
+                    f"{cluster_env_id} and build ID "
+                    f"{cluster_manager.cluster_env_build_id}"
+                )
+            except Exception as e:
+                raise ClusterEnvCreateError(
+                    f"Could not get existing overridden cluster environment "
+                    f"{cluster_env_id}: {e}"
+                ) from e
+        else:
+            cluster_manager.set_cluster_env(cluster_env)
+
+        # Load some timeouts
+        build_timeout = int(test["run"].get("build_timeout", DEFAULT_BUILD_TIMEOUT))
+        command_timeout = int(test["run"].get("timeout", DEFAULT_COMMAND_TIMEOUT))
+        cluster_timeout = int(
+            test["run"].get("session_timeout", DEFAULT_CLUSTER_TIMEOUT)
+        )
+
+        # Get prepare command timeout, if any
+        prepare_cmd = test["run"].get("prepare", None)
+        if prepare_cmd:
+            prepare_timeout = test["run"].get("prepare_timeout", command_timeout)
+        else:
+            prepare_timeout = 0
+
+        # Base maximum uptime on the combined command and prepare timeouts
+        command_and_prepare_timeout = command_timeout + prepare_timeout
+
+        # Use default timeout = 0 here if wait_for_nodes is empty. This is to make
+        # sure we don't inflate the maximum_uptime_minutes too much if we don't wait
+        # for nodes at all.
+        # The actual default will be otherwise loaded further down.
+        wait_timeout = int(test["run"].get("wait_for_nodes", {}).get("timeout", 0))
+
+        autosuspend_mins = test["cluster"].get("autosuspend_mins", None)
+        if autosuspend_mins:
+            cluster_manager.autosuspend_minutes = autosuspend_mins
+            autosuspend_base = autosuspend_mins
+        else:
+            cluster_manager.autosuspend_minutes = min(
+                DEFAULT_AUTOSUSPEND_MINS,
+                int(command_and_prepare_timeout / 60) + TIMEOUT_BUFFER_MINUTES,
+            )
+            # Maximum uptime should be based on the command timeout, not the
+            # DEFAULT_AUTOSUSPEND_MINS
+            autosuspend_base = (
+                int(command_and_prepare_timeout / 60) + TIMEOUT_BUFFER_MINUTES
+            )
+
+        maximum_uptime_minutes = test["cluster"].get("maximum_uptime_minutes", None)
+        if maximum_uptime_minutes:
+            cluster_manager.maximum_uptime_minutes = maximum_uptime_minutes
+        else:
+            cluster_manager.maximum_uptime_minutes = (
+                autosuspend_base + wait_timeout + TIMEOUT_BUFFER_MINUTES
+            )
+
+        # Set cluster compute here. Note that this may use timeouts provided
+        # above.
+        cluster_manager.set_cluster_compute(
+            cluster_compute,
+            extra_tags=extra_tags,
         )
 
         buildkite_group(":nut_and_bolt: Setting up local environment")
-        _setup_local_environment(test, command_runner, ray_wheels_url)
+        driver_setup_script = test.get("driver_setup", None)
+        if driver_setup_script:
+            try:
+                run_bash_script(driver_setup_script)
+            except Exception as e:
+                raise LocalEnvSetupError(f"Driver setup script failed: {e}") from e
+
+        # Install local dependencies
+        command_runner.prepare_local_env(ray_wheels_url)
+
+        # Re-install anyscale package as local dependencies might have changed
+        # from local env setup
+        reinstall_anyscale_dependencies()
 
         # Print installed pip packages
         buildkite_group(":bulb: Local environment information")
-        _local_environment_information(
-            result,
-            cluster_manager,
-            command_runner,
-            build_timeout,
-            cluster_timeout,
-            no_terminate,
-            cluster_id,
-            cluster_env_id,
-        )
+        pip_packages = get_pip_packages()
+        pip_package_string = "\n".join(pip_packages)
+        logger.info(f"Installed python packages:\n{pip_package_string}")
+
+        if isinstance(cluster_manager, FullClusterManager):
+            if not no_terminate:
+                register_handler(
+                    lambda sig, frame: cluster_manager.terminate_cluster(wait=True)
+                )
+
+        # Start cluster
+        if cluster_id:
+            buildkite_group(":rocket: Using existing cluster")
+            # Re-use existing cluster ID for development
+            cluster_manager.cluster_id = cluster_id
+            cluster_manager.cluster_name = get_cluster_name(cluster_id)
+        else:
+            buildkite_group(":gear: Building cluster environment")
+
+            if cluster_env_id:
+                cluster_manager.cluster_env_id = cluster_env_id
+
+            cluster_manager.build_configs(timeout=build_timeout)
+
+            if isinstance(cluster_manager, FullClusterManager):
+                buildkite_group(":rocket: Starting up cluster")
+                cluster_manager.start_cluster(timeout=cluster_timeout)
+            elif isinstance(command_runner, AnyscaleJobRunner):
+                command_runner.job_manager.cluster_startup_timeout = cluster_timeout
+
+        result.cluster_url = cluster_manager.get_cluster_url()
+        result.cluster_id = cluster_manager.cluster_id
 
         # Upload files
         buildkite_group(":wrench: Preparing remote environment")
-        _prepare_remote_environment(
-            test,
-            command_runner,
-            prepare_cmd,
-            prepare_timeout,
-        )
+        command_runner.prepare_remote_env()
+
+        wait_for_nodes = test["run"].get("wait_for_nodes", None)
+
+        if wait_for_nodes:
+            buildkite_group(":stopwatch: Waiting for nodes to come up")
+            # Overwrite wait_timeout from above to account for better default
+            wait_timeout = int(
+                wait_for_nodes.get("timeout", DEFAULT_WAIT_FOR_NODES_TIMEOUT)
+            )
+            num_nodes = test["run"]["wait_for_nodes"]["num_nodes"]
+            command_runner.wait_for_nodes(num_nodes, wait_timeout)
+
+        if prepare_cmd:
+            try:
+                command_runner.run_prepare_command(prepare_cmd, timeout=prepare_timeout)
+            except CommandError as e:
+                raise PrepareCommandError(e)
+            except CommandTimeout as e:
+                raise PrepareCommandTimeout(e)
 
         buildkite_group(":runner: Running test script")
+        command = test["run"]["script"]
+        command_env = {}
+
+        if smoke_test:
+            command = f"{command} --smoke-test"
+            command_env["IS_SMOKE_TEST"] = "1"
+
+        is_long_running = test["run"].get("long_running", False)
+
         start_time_unix = time.time()
-        _running_test_script(
-            test,
-            smoke_test,
-            command_runner,
-            command_timeout,
-        )
+
+        try:
+            command_runner.run_command(
+                command,
+                env=command_env,
+                timeout=command_timeout,
+                raise_on_timeout=not is_long_running,
+            )
+        except (
+            TestCommandError,
+            PrepareCommandError,
+            TestCommandTimeout,
+            PrepareCommandTimeout,
+        ) as e:
+            raise e
+        except CommandError as e:
+            raise TestCommandError(e)
+        except CommandTimeout as e:
+            if not is_long_running:
+                # Only raise error if command is not long running
+                raise TestCommandTimeout(e)
 
         buildkite_group(":floppy_disk: Fetching results")
-        metrics, fetch_result_exception = _fetching_results(
-            result,
-            command_runner,
-            artifact_path,
-            smoke_test,
-            start_time_unix,
-        )
+        try:
+            command_results = command_runner.fetch_results()
+        except Exception as e:
+            logger.exception(f"Could not fetch results for test command: {e}")
+            command_results = {}
+            fetch_result_exception = e
+
+        if artifact_path:
+            try:
+                command_runner.fetch_artifact()
+            except Exception as e:
+                logger.error("Could not fetch artifact for test command")
+                logger.exception(e)
+
+        # Postprocess result:
+        if "last_update" in command_results:
+            command_results["last_update_diff"] = time.time() - command_results.get(
+                "last_update", 0.0
+            )
+
+        try:
+            # Logic duplicated in ray_release/command_runner/_anyscale_job_wrapper.py
+            # Timeout is the time the test took divided by 200
+            # (~7 minutes for a 24h test) but no less than 30s
+            # and no more than 900s
+            metrics_timeout = max(30, min((time.time() - start_time_unix) / 200, 900))
+            command_runner.save_metrics(start_time_unix, timeout=metrics_timeout)
+            metrics = command_runner.fetch_metrics()
+        except Exception as e:
+            logger.exception(f"Could not fetch metrics for test command: {e}")
+            metrics = {}
+
+        if smoke_test:
+            command_results["smoke_test"] = True
+
+        result.results = command_results
+        result.status = "finished"
 
     except Exception as e:
         logger.exception(e)
@@ -540,11 +423,20 @@ def run_release_test(
         result.job_url = command_runner.job_manager.job_url
         result.job_id = command_runner.job_manager.job_id
 
-    result.last_logs = command_runner.get_last_logs()
+    try:
+        last_logs = command_runner.get_last_logs()
+    except Exception as e:
+        logger.exception(f"Error fetching logs: {e}")
+        last_logs = "No logs could be retrieved."
 
-    if not no_terminate:
+    result.last_logs = last_logs
+
+    if not no_terminate and isinstance(cluster_manager, FullClusterManager):
         buildkite_group(":earth_africa: Terminating cluster")
-        cluster_manager.terminate_cluster(wait=False)
+        try:
+            cluster_manager.terminate_cluster(wait=False)
+        except Exception as e:
+            logger.exception(f"Could not terminate cluster: {e}")
 
     if hasattr(command_runner, "cleanup"):
         command_runner.cleanup()
@@ -570,16 +462,20 @@ def run_release_test(
 
     if pipeline_exception:
         buildkite_group(":rotating_light: Handling errors")
-        exit_code, error_type, runtime = handle_exception(pipeline_exception)
+        exit_code, buildkite_exit_code, runtime = handle_exception(pipeline_exception)
 
         result.return_code = exit_code.value
-        result.status = error_type
+        result.status = buildkite_exit_code.name.lower
         if runtime is not None:
             result.runtime = runtime
 
     buildkite_group(":memo: Reporting results", open=True)
-    for reporter in reporters or []:
-        reporter.report_result(test, result)
+    reporters = reporters or []
+    for reporter in reporters:
+        try:
+            reporter.report_result(test, result)
+        except Exception as e:
+            logger.exception(f"Error reporting results via {type(reporter)}: {e}")
 
     if pipeline_exception:
         raise pipeline_exception

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -1,5 +1,6 @@
 import os
 import time
+import traceback
 from typing import Optional, List, Tuple
 
 from ray_release.alerts.handle import handle_result, require_result
@@ -576,6 +577,11 @@ def run_release_test(
         result.buildkite_exit_code = buildkite_exit_code.value
         if runtime is not None:
             result.runtime = runtime
+        try:
+          raise pipeline_exception
+        except:
+          if not result.last_logs:
+            result.last_logs = traceback.format_exc()
 
     buildkite_group(":memo: Reporting results", open=True)
     for reporter in reporters or []:

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -465,7 +465,7 @@ def run_release_test(
         exit_code, buildkite_exit_code, runtime = handle_exception(pipeline_exception)
 
         result.return_code = exit_code.value
-        result.status = buildkite_exit_code.name.lower
+        result.buildkite_return_code = buildkite_exit_code
         if runtime is not None:
             result.runtime = runtime
 
@@ -476,8 +476,5 @@ def run_release_test(
             reporter.report_result(test, result)
         except Exception as e:
             logger.exception(f"Error reporting results via {type(reporter)}: {e}")
-
-    if pipeline_exception:
-        raise pipeline_exception
 
     return result

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -460,7 +460,6 @@ def run_release_test(
     # non critical for some tests. So separate it from the general one.
     fetch_result_exception = None
     try:
-        raise ReleaseTestConfigError()
         buildkite_group(":spiral_note_pad: Loading test configuration")
         cluster_manager, command_runner, artifact_path = _load_test_configuration(
             test,

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -54,7 +54,6 @@ from ray_release.util import (
 type_str_to_command_runner = {
     "command": SDKRunner,
     "sdk_command": SDKRunner,
-    "job": JobRunner,
     "anyscale_job": AnyscaleJobRunner,
 }
 

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -54,6 +54,7 @@ from ray_release.util import (
 type_str_to_command_runner = {
     "command": SDKRunner,
     "sdk_command": SDKRunner,
+    "job": JobRunner,
     "anyscale_job": AnyscaleJobRunner,
 }
 

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -540,7 +540,7 @@ def run_release_test(
         result.job_url = command_runner.job_manager.job_url
         result.job_id = command_runner.job_manager.job_id
 
-    result.last_logs = command_runner.get_last_logs()
+    result.last_logs = command_runner.get_last_logs() if command_runner else None
 
     if not no_terminate and cluster_manager:
         buildkite_group(":earth_africa: Terminating cluster")

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -571,10 +571,10 @@ def run_release_test(
 
     if pipeline_exception:
         buildkite_group(":rotating_light: Handling errors")
-        exit_code, status, runtime = handle_exception(pipeline_exception)
+        exit_code, result_status, runtime = handle_exception(pipeline_exception)
 
         result.return_code = exit_code.value
-        result.status = status.value
+        result.status = result_status.value
         if runtime is not None:
             result.runtime = runtime
         try:

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -1,13 +1,15 @@
 import os
 import time
-from typing import Optional, List
+from typing import Optional, List, Tuple
 
 from ray_release.alerts.handle import handle_result, require_result
 from ray_release.anyscale_util import get_cluster_name
 from ray_release.buildkite.output import buildkite_group, buildkite_open_last
+from ray_release.cluster_manager.cluster_manager import ClusterManager
 from ray_release.cluster_manager.full import FullClusterManager
 from ray_release.cluster_manager.minimal import MinimalClusterManager
 from ray_release.command_runner.job_runner import JobRunner
+from ray_release.command_runner.command_runner import CommandRunner
 from ray_release.command_runner.anyscale_job_runner import AnyscaleJobRunner
 from ray_release.command_runner.sdk_runner import SDKRunner
 from ray_release.config import (
@@ -89,43 +91,33 @@ def _get_extra_tags_from_env() -> dict:
     return {key.lower(): os.getenv(key, "") for key in env_vars}
 
 
-def run_release_test(
+def _load_test_configuration(
     test: Test,
     anyscale_project: str,
     result: Result,
     ray_wheels_url: str,
-    reporters: Optional[List[Reporter]] = None,
     smoke_test: bool = False,
-    cluster_id: Optional[str] = None,
-    cluster_env_id: Optional[str] = None,
     no_terminate: bool = False,
-) -> Result:
-    buildkite_group(":spiral_note_pad: Loading test configuration")
-
+) -> Tuple[ClusterManager, CommandRunner, str]:
     validate_test(test)
-
     logger.info(f"Test config: {test}")
 
+    # Populate result paramaters
     result.wheels_url = ray_wheels_url
     result.stable = test.get("stable", True)
     result.smoke_test = smoke_test
-
     buildkite_url = os.getenv("BUILDKITE_BUILD_URL", "")
     buildkite_job_id = os.getenv("BUILDKITE_JOB_ID", "")
-
     if buildkite_url:
         buildkite_url += "#" + buildkite_job_id
-
     result.buildkite_url = buildkite_url
     result.buildkite_job_id = buildkite_job_id
 
+    # Setting up working directory
     working_dir = test["working_dir"]
-
-    old_wd = os.getcwd()
     new_wd = os.path.join(RELEASE_PACKAGE_DIR, working_dir)
     os.chdir(new_wd)
 
-    start_time = time.monotonic()
     run_type = test["run"].get("type", DEFAULT_RUN_TYPE)
 
     # Workaround while Anyscale Jobs don't support leaving cluster alive
@@ -160,7 +152,6 @@ def run_release_test(
 
     logger.info(f"Got command runner cls: {command_runner_cls}")
     logger.info(f"Got file manager cls: {file_manager_cls}")
-
     # Extra tags to be set on resources on cloud provider's side
     extra_tags = _get_extra_tags_from_env()
     # We don't need other attributes as they can be derived from the name
@@ -184,230 +175,354 @@ def run_release_test(
     except Exception as e:
         raise ReleaseTestSetupError(f"Error setting up release test: {e}") from e
 
+    return cluster_manager, command_runner, artifact_path
+
+
+def _setup_cluster_environment(
+    test: Test,
+    result: Result,
+    cluster_manager: ClusterManager,
+    ray_wheels_url: str,
+    cluster_env_id: Optional[str],
+) -> Tuple[str, int, int, int, int]:
+    setup_signal_handling()
+    # Load configs
+    cluster_env = load_test_cluster_env(test, ray_wheels_url=ray_wheels_url)
+    cluster_compute = load_test_cluster_compute(test)
+
+    if cluster_env_id:
+        try:
+            cluster_manager.cluster_env_id = cluster_env_id
+            cluster_manager.build_cluster_env()
+            cluster_manager.fetch_build_info()
+            logger.info(
+                "Using overridden cluster environment with ID "
+                f"{cluster_env_id} and build ID "
+                f"{cluster_manager.cluster_env_build_id}"
+            )
+        except Exception as e:
+            raise ClusterEnvCreateError(
+                f"Could not get existing overridden cluster environment "
+                f"{cluster_env_id}: {e}"
+            ) from e
+    else:
+        cluster_manager.set_cluster_env(cluster_env)
+
+    # Load some timeouts
+    build_timeout = int(test["run"].get("build_timeout", DEFAULT_BUILD_TIMEOUT))
+    command_timeout = int(test["run"].get("timeout", DEFAULT_COMMAND_TIMEOUT))
+    cluster_timeout = int(test["run"].get("session_timeout", DEFAULT_CLUSTER_TIMEOUT))
+
+    # Get prepare command timeout, if any
+    prepare_cmd = test["run"].get("prepare", None)
+    if prepare_cmd:
+        prepare_timeout = test["run"].get("prepare_timeout", command_timeout)
+    else:
+        prepare_timeout = 0
+
+    # Base maximum uptime on the combined command and prepare timeouts
+    command_and_prepare_timeout = command_timeout + prepare_timeout
+
+    # Use default timeout = 0 here if wait_for_nodes is empty. This is to make
+    # sure we don't inflate the maximum_uptime_minutes too much if we don't wait
+    # for nodes at all.
+    # The actual default will be otherwise loaded further down.
+    wait_timeout = int(test["run"].get("wait_for_nodes", {}).get("timeout", 0))
+
+    autosuspend_mins = test["cluster"].get("autosuspend_mins", None)
+    if autosuspend_mins:
+        cluster_manager.autosuspend_minutes = autosuspend_mins
+        autosuspend_base = autosuspend_mins
+    else:
+        cluster_manager.autosuspend_minutes = min(
+            DEFAULT_AUTOSUSPEND_MINS,
+            int(command_and_prepare_timeout / 60) + TIMEOUT_BUFFER_MINUTES,
+        )
+        # Maximum uptime should be based on the command timeout, not the
+        # DEFAULT_AUTOSUSPEND_MINS
+        autosuspend_base = (
+            int(command_and_prepare_timeout / 60) + TIMEOUT_BUFFER_MINUTES
+        )
+
+    maximum_uptime_minutes = test["cluster"].get("maximum_uptime_minutes", None)
+    if maximum_uptime_minutes:
+        cluster_manager.maximum_uptime_minutes = maximum_uptime_minutes
+    else:
+        cluster_manager.maximum_uptime_minutes = (
+            autosuspend_base + wait_timeout + TIMEOUT_BUFFER_MINUTES
+        )
+
+    # Set cluster compute here. Note that this may use timeouts provided
+    # above.
+    cluster_manager.set_cluster_compute(
+        cluster_compute,
+        extra_tags=result.extra_tags,
+    )
+
+    return prepare_cmd, prepare_timeout, build_timeout, cluster_timeout, command_timeout
+
+
+def _setup_local_environment(
+    test: Test,
+    command_runner: CommandRunner,
+    ray_wheels_url: str,
+) -> None:
+    driver_setup_script = test.get("driver_setup", None)
+    if driver_setup_script:
+        try:
+            run_bash_script(driver_setup_script)
+        except Exception as e:
+            raise LocalEnvSetupError(f"Driver setup script failed: {e}") from e
+
+    # Install local dependencies
+    command_runner.prepare_local_env(ray_wheels_url)
+
+    # Re-install anyscale package as local dependencies might have changed
+    # from local env setup
+    reinstall_anyscale_dependencies()
+
+
+def _local_environment_information(
+    result: Result,
+    cluster_manager: ClusterManager,
+    command_runner: CommandRunner,
+    build_timeout: int,
+    cluster_timeout: int,
+    no_terminate: bool,
+    cluster_id: Optional[str],
+    cluster_env_id: Optional[str],
+) -> None:
+    pip_packages = get_pip_packages()
+    pip_package_string = "\n".join(pip_packages)
+    logger.info(f"Installed python packages:\n{pip_package_string}")
+
+    if isinstance(cluster_manager, FullClusterManager):
+        if not no_terminate:
+            register_handler(
+                lambda sig, frame: cluster_manager.terminate_cluster(wait=True)
+            )
+
+    # Start cluster
+    if cluster_id:
+        buildkite_group(":rocket: Using existing cluster")
+        # Re-use existing cluster ID for development
+        cluster_manager.cluster_id = cluster_id
+        cluster_manager.cluster_name = get_cluster_name(cluster_id)
+    else:
+        buildkite_group(":gear: Building cluster environment")
+
+        if cluster_env_id:
+            cluster_manager.cluster_env_id = cluster_env_id
+
+        cluster_manager.build_configs(timeout=build_timeout)
+
+        if isinstance(cluster_manager, FullClusterManager):
+            buildkite_group(":rocket: Starting up cluster")
+            cluster_manager.start_cluster(timeout=cluster_timeout)
+        elif isinstance(command_runner, AnyscaleJobRunner):
+            command_runner.job_manager.cluster_startup_timeout = cluster_timeout
+
+    result.cluster_url = cluster_manager.get_cluster_url()
+    result.cluster_id = cluster_manager.cluster_id
+
+
+def _prepare_remote_environment(
+    test: Test,
+    command_runner: CommandRunner,
+    prepare_cmd: bool,
+    prepare_timeout: int,
+) -> None:
+    command_runner.prepare_remote_env()
+
+    wait_for_nodes = test["run"].get("wait_for_nodes", None)
+
+    if wait_for_nodes:
+        buildkite_group(":stopwatch: Waiting for nodes to come up")
+        # Overwrite wait_timeout from above to account for better default
+        wait_timeout = int(
+            wait_for_nodes.get("timeout", DEFAULT_WAIT_FOR_NODES_TIMEOUT)
+        )
+        num_nodes = test["run"]["wait_for_nodes"]["num_nodes"]
+        command_runner.wait_for_nodes(num_nodes, wait_timeout)
+
+    if prepare_cmd:
+        try:
+            command_runner.run_prepare_command(prepare_cmd, timeout=prepare_timeout)
+        except CommandError as e:
+            raise PrepareCommandError(e)
+        except CommandTimeout as e:
+            raise PrepareCommandTimeout(e)
+
+
+def _running_test_script(
+    test: Test,
+    smoke_test: bool,
+    command_runner: CommandRunner,
+    command_timeout: int,
+) -> None:
+    command = test["run"]["script"]
+    command_env = {}
+
+    if smoke_test:
+        command = f"{command} --smoke-test"
+        command_env["IS_SMOKE_TEST"] = "1"
+
+    is_long_running = test["run"].get("long_running", False)
+
+    try:
+        command_runner.run_command(
+            command,
+            env=command_env,
+            timeout=command_timeout,
+            raise_on_timeout=not is_long_running,
+        )
+    except (
+        TestCommandError,
+        PrepareCommandError,
+        TestCommandTimeout,
+        PrepareCommandTimeout,
+    ) as e:
+        raise e
+    except CommandError as e:
+        raise TestCommandError(e)
+    except CommandTimeout as e:
+        if not is_long_running:
+            # Only raise error if command is not long running
+            raise TestCommandTimeout(e)
+
+
+def _fetching_results(
+    result: Result,
+    command_runner: CommandRunner,
+    artifact_path: Optional[str],
+    smoke_test: bool,
+    start_time_unix: int,
+) -> Tuple[dict, Exception]:
+    fetch_result_exception = None
+    try:
+        command_results = command_runner.fetch_results()
+    except Exception as e:
+        logger.exception(f"Could not fetch results for test command: {e}")
+        command_results = {}
+        fetch_result_exception = e
+
+    if artifact_path:
+        try:
+            command_runner.fetch_artifact()
+        except Exception as e:
+            logger.error("Could not fetch artifact for test command")
+            logger.exception(e)
+
+    # Postprocess result:
+    if "last_update" in command_results:
+        command_results["last_update_diff"] = time.time() - command_results.get(
+            "last_update", 0.0
+        )
+
+    try:
+        # Logic duplicated in ray_release/command_runner/_anyscale_job_wrapper.py
+        # Timeout is the time the test took divided by 200
+        # (~7 minutes for a 24h test) but no less than 30s
+        # and no more than 900s
+        metrics_timeout = max(30, min((time.time() - start_time_unix) / 200, 900))
+        command_runner.save_metrics(start_time_unix, timeout=metrics_timeout)
+        metrics = command_runner.fetch_metrics()
+    except Exception as e:
+        logger.exception(f"Could not fetch metrics for test command: {e}")
+        metrics = {}
+
+    if smoke_test:
+        command_results["smoke_test"] = True
+
+    result.results = command_results
+    result.status = "finished"
+
+    return metrics, fetch_result_exception
+
+
+def run_release_test(
+    test: Test,
+    anyscale_project: str,
+    result: Result,
+    ray_wheels_url: str,
+    reporters: Optional[List[Reporter]] = None,
+    smoke_test: bool = False,
+    cluster_id: Optional[str] = None,
+    cluster_env_id: Optional[str] = None,
+    no_terminate: bool = False,
+) -> Result:
+    old_wd = os.getcwd()
+    start_time = time.monotonic()
     pipeline_exception = None
     # non critical for some tests. So separate it from the general one.
     fetch_result_exception = None
     try:
-        setup_signal_handling()
-        # Load configs
-        cluster_env = load_test_cluster_env(test, ray_wheels_url=ray_wheels_url)
-        cluster_compute = load_test_cluster_compute(test)
-
-        if cluster_env_id:
-            try:
-                cluster_manager.cluster_env_id = cluster_env_id
-                cluster_manager.build_cluster_env()
-                cluster_manager.fetch_build_info()
-                logger.info(
-                    "Using overridden cluster environment with ID "
-                    f"{cluster_env_id} and build ID "
-                    f"{cluster_manager.cluster_env_build_id}"
-                )
-            except Exception as e:
-                raise ClusterEnvCreateError(
-                    f"Could not get existing overridden cluster environment "
-                    f"{cluster_env_id}: {e}"
-                ) from e
-        else:
-            cluster_manager.set_cluster_env(cluster_env)
-
-        # Load some timeouts
-        build_timeout = int(test["run"].get("build_timeout", DEFAULT_BUILD_TIMEOUT))
-        command_timeout = int(test["run"].get("timeout", DEFAULT_COMMAND_TIMEOUT))
-        cluster_timeout = int(
-            test["run"].get("session_timeout", DEFAULT_CLUSTER_TIMEOUT)
+        buildkite_group(":spiral_note_pad: Loading test configuration")
+        cluster_manager, command_runner, artifact_path = _load_test_configuration(
+            test,
+            anyscale_project,
+            result,
+            ray_wheels_url,
+            smoke_test,
+            no_terminate,
         )
-
-        # Get prepare command timeout, if any
-        prepare_cmd = test["run"].get("prepare", None)
-        if prepare_cmd:
-            prepare_timeout = test["run"].get("prepare_timeout", command_timeout)
-        else:
-            prepare_timeout = 0
-
-        # Base maximum uptime on the combined command and prepare timeouts
-        command_and_prepare_timeout = command_timeout + prepare_timeout
-
-        # Use default timeout = 0 here if wait_for_nodes is empty. This is to make
-        # sure we don't inflate the maximum_uptime_minutes too much if we don't wait
-        # for nodes at all.
-        # The actual default will be otherwise loaded further down.
-        wait_timeout = int(test["run"].get("wait_for_nodes", {}).get("timeout", 0))
-
-        autosuspend_mins = test["cluster"].get("autosuspend_mins", None)
-        if autosuspend_mins:
-            cluster_manager.autosuspend_minutes = autosuspend_mins
-            autosuspend_base = autosuspend_mins
-        else:
-            cluster_manager.autosuspend_minutes = min(
-                DEFAULT_AUTOSUSPEND_MINS,
-                int(command_and_prepare_timeout / 60) + TIMEOUT_BUFFER_MINUTES,
-            )
-            # Maximum uptime should be based on the command timeout, not the
-            # DEFAULT_AUTOSUSPEND_MINS
-            autosuspend_base = (
-                int(command_and_prepare_timeout / 60) + TIMEOUT_BUFFER_MINUTES
-            )
-
-        maximum_uptime_minutes = test["cluster"].get("maximum_uptime_minutes", None)
-        if maximum_uptime_minutes:
-            cluster_manager.maximum_uptime_minutes = maximum_uptime_minutes
-        else:
-            cluster_manager.maximum_uptime_minutes = (
-                autosuspend_base + wait_timeout + TIMEOUT_BUFFER_MINUTES
-            )
-
-        # Set cluster compute here. Note that this may use timeouts provided
-        # above.
-        cluster_manager.set_cluster_compute(
-            cluster_compute,
-            extra_tags=extra_tags,
+        buildkite_group(":nut_and_bolt: Setting up cluster environment")
+        (
+            prepare_cmd,
+            prepare_timeout,
+            build_timeout,
+            cluster_timeout,
+            command_timeout,
+        ) = _setup_cluster_environment(
+            test,
+            result,
+            cluster_manager,
+            ray_wheels_url,
+            cluster_env_id,
         )
 
         buildkite_group(":nut_and_bolt: Setting up local environment")
-        driver_setup_script = test.get("driver_setup", None)
-        if driver_setup_script:
-            try:
-                run_bash_script(driver_setup_script)
-            except Exception as e:
-                raise LocalEnvSetupError(f"Driver setup script failed: {e}") from e
-
-        # Install local dependencies
-        command_runner.prepare_local_env(ray_wheels_url)
-
-        # Re-install anyscale package as local dependencies might have changed
-        # from local env setup
-        reinstall_anyscale_dependencies()
+        _setup_local_environment(test, command_runner, ray_wheels_url)
 
         # Print installed pip packages
         buildkite_group(":bulb: Local environment information")
-        pip_packages = get_pip_packages()
-        pip_package_string = "\n".join(pip_packages)
-        logger.info(f"Installed python packages:\n{pip_package_string}")
-
-        if isinstance(cluster_manager, FullClusterManager):
-            if not no_terminate:
-                register_handler(
-                    lambda sig, frame: cluster_manager.terminate_cluster(wait=True)
-                )
-
-        # Start cluster
-        if cluster_id:
-            buildkite_group(":rocket: Using existing cluster")
-            # Re-use existing cluster ID for development
-            cluster_manager.cluster_id = cluster_id
-            cluster_manager.cluster_name = get_cluster_name(cluster_id)
-        else:
-            buildkite_group(":gear: Building cluster environment")
-
-            if cluster_env_id:
-                cluster_manager.cluster_env_id = cluster_env_id
-
-            cluster_manager.build_configs(timeout=build_timeout)
-
-            if isinstance(cluster_manager, FullClusterManager):
-                buildkite_group(":rocket: Starting up cluster")
-                cluster_manager.start_cluster(timeout=cluster_timeout)
-            elif isinstance(command_runner, AnyscaleJobRunner):
-                command_runner.job_manager.cluster_startup_timeout = cluster_timeout
-
-        result.cluster_url = cluster_manager.get_cluster_url()
-        result.cluster_id = cluster_manager.cluster_id
+        _local_environment_information(
+            result,
+            cluster_manager,
+            command_runner,
+            build_timeout,
+            cluster_timeout,
+            no_terminate,
+            cluster_id,
+            cluster_env_id,
+        )
 
         # Upload files
         buildkite_group(":wrench: Preparing remote environment")
-        command_runner.prepare_remote_env()
-
-        wait_for_nodes = test["run"].get("wait_for_nodes", None)
-
-        if wait_for_nodes:
-            buildkite_group(":stopwatch: Waiting for nodes to come up")
-            # Overwrite wait_timeout from above to account for better default
-            wait_timeout = int(
-                wait_for_nodes.get("timeout", DEFAULT_WAIT_FOR_NODES_TIMEOUT)
-            )
-            num_nodes = test["run"]["wait_for_nodes"]["num_nodes"]
-            command_runner.wait_for_nodes(num_nodes, wait_timeout)
-
-        if prepare_cmd:
-            try:
-                command_runner.run_prepare_command(prepare_cmd, timeout=prepare_timeout)
-            except CommandError as e:
-                raise PrepareCommandError(e)
-            except CommandTimeout as e:
-                raise PrepareCommandTimeout(e)
+        _prepare_remote_environment(
+            test,
+            command_runner,
+            prepare_cmd,
+            prepare_timeout,
+        )
 
         buildkite_group(":runner: Running test script")
-        command = test["run"]["script"]
-        command_env = {}
-
-        if smoke_test:
-            command = f"{command} --smoke-test"
-            command_env["IS_SMOKE_TEST"] = "1"
-
-        is_long_running = test["run"].get("long_running", False)
-
         start_time_unix = time.time()
-
-        try:
-            command_runner.run_command(
-                command,
-                env=command_env,
-                timeout=command_timeout,
-                raise_on_timeout=not is_long_running,
-            )
-        except (
-            TestCommandError,
-            PrepareCommandError,
-            TestCommandTimeout,
-            PrepareCommandTimeout,
-        ) as e:
-            raise e
-        except CommandError as e:
-            raise TestCommandError(e)
-        except CommandTimeout as e:
-            if not is_long_running:
-                # Only raise error if command is not long running
-                raise TestCommandTimeout(e)
+        _running_test_script(
+            test,
+            smoke_test,
+            command_runner,
+            command_timeout,
+        )
 
         buildkite_group(":floppy_disk: Fetching results")
-        try:
-            command_results = command_runner.fetch_results()
-        except Exception as e:
-            logger.exception(f"Could not fetch results for test command: {e}")
-            command_results = {}
-            fetch_result_exception = e
-
-        if artifact_path:
-            try:
-                command_runner.fetch_artifact()
-            except Exception as e:
-                logger.error("Could not fetch artifact for test command")
-                logger.exception(e)
-
-        # Postprocess result:
-        if "last_update" in command_results:
-            command_results["last_update_diff"] = time.time() - command_results.get(
-                "last_update", 0.0
-            )
-
-        try:
-            # Logic duplicated in ray_release/command_runner/_anyscale_job_wrapper.py
-            # Timeout is the time the test took divided by 200
-            # (~7 minutes for a 24h test) but no less than 30s
-            # and no more than 900s
-            metrics_timeout = max(30, min((time.time() - start_time_unix) / 200, 900))
-            command_runner.save_metrics(start_time_unix, timeout=metrics_timeout)
-            metrics = command_runner.fetch_metrics()
-        except Exception as e:
-            logger.exception(f"Could not fetch metrics for test command: {e}")
-            metrics = {}
-
-        if smoke_test:
-            command_results["smoke_test"] = True
-
-        result.results = command_results
-        result.status = "finished"
+        metrics, fetch_result_exception = _fetching_results(
+            result,
+            command_runner,
+            artifact_path,
+            smoke_test,
+            start_time_unix,
+        )
 
     except Exception as e:
         logger.exception(e)
@@ -423,20 +538,11 @@ def run_release_test(
         result.job_url = command_runner.job_manager.job_url
         result.job_id = command_runner.job_manager.job_id
 
-    try:
-        last_logs = command_runner.get_last_logs()
-    except Exception as e:
-        logger.exception(f"Error fetching logs: {e}")
-        last_logs = "No logs could be retrieved."
+    result.last_logs = command_runner.get_last_logs()
 
-    result.last_logs = last_logs
-
-    if not no_terminate and isinstance(cluster_manager, FullClusterManager):
+    if not no_terminate:
         buildkite_group(":earth_africa: Terminating cluster")
-        try:
-            cluster_manager.terminate_cluster(wait=False)
-        except Exception as e:
-            logger.exception(f"Could not terminate cluster: {e}")
+        cluster_manager.terminate_cluster(wait=False)
 
     if hasattr(command_runner, "cleanup"):
         command_runner.cleanup()
@@ -465,16 +571,13 @@ def run_release_test(
         exit_code, buildkite_exit_code, runtime = handle_exception(pipeline_exception)
 
         result.return_code = exit_code.value
-        result.buildkite_return_code = buildkite_exit_code
+        result.status = buildkite_exit_code.name.lower()
+        result.buildkite_return_code = buildkite_exit_code.value
         if runtime is not None:
             result.runtime = runtime
 
     buildkite_group(":memo: Reporting results", open=True)
-    reporters = reporters or []
-    for reporter in reporters:
-        try:
-            reporter.report_result(test, result)
-        except Exception as e:
-            logger.exception(f"Error reporting results via {type(reporter)}: {e}")
+    for reporter in reporters or []:
+        reporter.report_result(test, result)
 
     return result

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -457,6 +457,7 @@ def run_release_test(
     # non critical for some tests. So separate it from the general one.
     fetch_result_exception = None
     try:
+        raise ReleaseTestConfigError()
         buildkite_group(":spiral_note_pad: Loading test configuration")
         cluster_manager, command_runner, artifact_path = _load_test_configuration(
             test,
@@ -523,7 +524,6 @@ def run_release_test(
             smoke_test,
             start_time_unix,
         )
-
     except Exception as e:
         logger.exception(e)
         buildkite_open_last()

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -573,7 +573,7 @@ def run_release_test(
 
         result.return_code = exit_code.value
         result.status = buildkite_exit_code.name.lower()
-        result.buildkite_return_code = buildkite_exit_code.value
+        result.buildkite_exit_code = buildkite_exit_code.value
         if runtime is not None:
             result.runtime = runtime
 

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -460,6 +460,7 @@ def run_release_test(
     # non critical for some tests. So separate it from the general one.
     fetch_result_exception = None
     try:
+        raise ReleaseTestConfigError()
         buildkite_group(":spiral_note_pad: Loading test configuration")
         cluster_manager, command_runner, artifact_path = _load_test_configuration(
             test,

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -460,6 +460,7 @@ def run_release_test(
     # non critical for some tests. So separate it from the general one.
     fetch_result_exception = None
     try:
+        raise ReleaseTestSetupError('hahahah')
         buildkite_group(":spiral_note_pad: Loading test configuration")
         cluster_manager, command_runner, artifact_path = _load_test_configuration(
             test,

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -578,10 +578,10 @@ def run_release_test(
         if runtime is not None:
             result.runtime = runtime
         try:
-          raise pipeline_exception
-        except:
-          if not result.last_logs:
-            result.last_logs = traceback.format_exc()
+            raise pipeline_exception
+        except Exception:
+            if not result.last_logs:
+                result.last_logs = traceback.format_exc()
 
     buildkite_group(":memo: Reporting results", open=True)
     for reporter in reporters or []:

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -453,6 +453,8 @@ def run_release_test(
 ) -> Result:
     old_wd = os.getcwd()
     start_time = time.monotonic()
+    command_runner = None
+    cluster_manager = None
     pipeline_exception = None
     # non critical for some tests. So separate it from the general one.
     fetch_result_exception = None
@@ -540,7 +542,7 @@ def run_release_test(
 
     result.last_logs = command_runner.get_last_logs()
 
-    if not no_terminate:
+    if not no_terminate and cluster_manager:
         buildkite_group(":earth_africa: Terminating cluster")
         cluster_manager.terminate_cluster(wait=False)
 

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -460,7 +460,6 @@ def run_release_test(
     # non critical for some tests. So separate it from the general one.
     fetch_result_exception = None
     try:
-        raise ReleaseTestSetupError('hahahah')
         buildkite_group(":spiral_note_pad: Loading test configuration")
         cluster_manager, command_runner, artifact_path = _load_test_configuration(
             test,
@@ -586,5 +585,8 @@ def run_release_test(
     buildkite_group(":memo: Reporting results", open=True)
     for reporter in reporters or []:
         reporter.report_result(test, result)
+
+    if pipeline_exception:
+        raise pipeline_exception
 
     return result

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -459,7 +459,6 @@ def run_release_test(
     # non critical for some tests. So separate it from the general one.
     fetch_result_exception = None
     try:
-        raise ReleaseTestConfigError()
         buildkite_group(":spiral_note_pad: Loading test configuration")
         cluster_manager, command_runner, artifact_path = _load_test_configuration(
             test,

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -460,7 +460,6 @@ def run_release_test(
     # non critical for some tests. So separate it from the general one.
     fetch_result_exception = None
     try:
-        raise ReleaseTestSetupError('hahahah')
         buildkite_group(":spiral_note_pad: Loading test configuration")
         cluster_manager, command_runner, artifact_path = _load_test_configuration(
             test,

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -570,11 +570,10 @@ def run_release_test(
 
     if pipeline_exception:
         buildkite_group(":rotating_light: Handling errors")
-        exit_code, buildkite_exit_code, runtime = handle_exception(pipeline_exception)
+        exit_code, status, runtime = handle_exception(pipeline_exception)
 
         result.return_code = exit_code.value
-        result.status = buildkite_exit_code.name.lower()
-        result.buildkite_exit_code = buildkite_exit_code.value
+        result.status = status.value
         if runtime is not None:
             result.runtime = runtime
         try:

--- a/release/ray_release/result.py
+++ b/release/ray_release/result.py
@@ -86,26 +86,26 @@ def handle_exception(e: Exception) -> Tuple[ExitCode, ResultStatus, Optional[int
         return ExitCode.UNKNOWN, ResultStatus.UNKNOWN, 0
     exit_code = e.exit_code
     if 1 <= exit_code.value < 10:
-        status = ResultStatus.UNKNOWN
+        result_status = ResultStatus.UNKNOWN
         runtime = None
     elif 10 <= exit_code.value < 20:
-        status = ResultStatus.INFRA_ERROR
+        result_status = ResultStatus.INFRA_ERROR
         runtime = None
     elif 30 <= exit_code.value < 40:
-        status = ResultStatus.INFRA_TIMEOUT
+        result_status = ResultStatus.INFRA_TIMEOUT
         runtime = None
     elif exit_code == ExitCode.COMMAND_TIMEOUT:
-        status = ResultStatus.TIMEOUT
+        result_status = ResultStatus.TIMEOUT
         runtime = 0
     elif 40 <= exit_code.value:
-        status = ResultStatus.ERROR
+        result_status = ResultStatus.ERROR
         runtime = 0
 
     # if this step is to be retried, mark its status as transient
-    if status in [ResultStatus.INFRA_ERROR, ResultStatus.INFRA_TIMEOUT]:
+    if result_status in [ResultStatus.INFRA_ERROR, ResultStatus.INFRA_TIMEOUT]:
         retry_count = int(os.environ.get("BUILDKITE_RETRY_COUNT", "0"))
         max_retry = int(os.environ.get("BUILDKITE_MAX_RETRIES"))
         if retry_count < max_retry:
-            status = ResultStatus.TRANSIENT_INFRA_ERROR
+            result_status = ResultStatus.TRANSIENT_INFRA_ERROR
 
-    return exit_code, status, runtime
+    return exit_code, result_status, runtime

--- a/release/ray_release/result.py
+++ b/release/ray_release/result.py
@@ -87,7 +87,7 @@ def handle_exception(e: Exception) -> Tuple[ExitCode, BuildkiteExitCode, Optiona
         error_type = BuildkiteExitCode.UNKNOWN
         runtime = None
     elif 10 <= exit_code.value < 20:
-        retry_count = os.environ.get("BUILDKITE_RETRY_COUNT", 0)
+        retry_count = int(os.environ.get("BUILDKITE_RETRY_COUNT", "0"))
         # Retry at least once of transient infra error
         if retry_count == 0:
           error_type = BuildkiteExitCode.TRANSIENT_INFRA_ERROR

--- a/release/ray_release/result.py
+++ b/release/ray_release/result.py
@@ -8,13 +8,14 @@ class ResultStatus(enum.Enum):
     """
     Overall status of the result test run
     """
-    SUCCESS = 'success'
-    UNKNOWN = 'unknown'
-    TRANSIENT_INFRA_ERROR = 'transient_infra_error'
-    INFRA_ERROR = 'infra_error'
-    INFRA_TIMEOUT = 'infra_timeout'
-    ERROR = 'error'
-    TIMEOUT = 'timeout'
+
+    SUCCESS = "success"
+    UNKNOWN = "unknown"
+    TRANSIENT_INFRA_ERROR = "transient_infra_error"
+    INFRA_ERROR = "infra_error"
+    INFRA_TIMEOUT = "infra_timeout"
+    ERROR = "error"
+    TIMEOUT = "timeout"
 
 
 @dataclass
@@ -100,11 +101,11 @@ def handle_exception(e: Exception) -> Tuple[ExitCode, ResultStatus, Optional[int
         status = ResultStatus.ERROR
         runtime = 0
 
+    # if this step is to be retried, mark its status as transient
     if status in [ResultStatus.INFRA_ERROR, ResultStatus.INFRA_TIMEOUT]:
         retry_count = int(os.environ.get("BUILDKITE_RETRY_COUNT", "0"))
         max_retry = int(os.environ.get("BUILDKITE_MAX_RETRIES"))
         if retry_count < max_retry:
-            # if this step is to be retried, mark its status as transient
             status = ResultStatus.TRANSIENT_INFRA_ERROR
 
     return exit_code, status, runtime

--- a/release/ray_release/result.py
+++ b/release/ray_release/result.py
@@ -3,18 +3,21 @@ import os
 from dataclasses import dataclass
 from typing import Optional, Dict, Tuple
 
+
 class BuildkiteExitCode(enum.Enum):
-    """ 
+    """
     Final exit code the test runner passes to buildkite-agent. This exit code is used
     to determine job policies, such as automatic retries
-    """ 
+    """
+
     SUCCESS = 0
     UNKNOWN = 1
     TRANSIENT_INFRA_ERROR = 10
     INFRA_ERROR = 11
     INFRA_TIMEOUT = 30
-    ERROR = 40 
-    TIMEOUT = 42 
+    ERROR = 40
+    TIMEOUT = 42
+
 
 @dataclass
 class Result:
@@ -77,11 +80,12 @@ class ExitCode(enum.Enum):
     COMMAND_TIMEOUT = 42
     PREPARE_ERROR = 43
 
+
 def handle_exception(e: Exception) -> Tuple[ExitCode, BuildkiteExitCode, Optional[int]]:
     from ray_release.exception import ReleaseTestError
 
     if not isinstance(e, ReleaseTestError):
-      return ExitCode.UNKNOWN, BuildkiteExitCode.UNKNOWN, 0
+        return ExitCode.UNKNOWN, BuildkiteExitCode.UNKNOWN, 0
     exit_code = e.exit_code
     if 1 <= exit_code.value < 10:
         error_type = BuildkiteExitCode.UNKNOWN
@@ -90,9 +94,9 @@ def handle_exception(e: Exception) -> Tuple[ExitCode, BuildkiteExitCode, Optiona
         retry_count = int(os.environ.get("BUILDKITE_RETRY_COUNT", "0"))
         # Retry at least once of transient infra error
         if retry_count == 0:
-          error_type = BuildkiteExitCode.TRANSIENT_INFRA_ERROR
+            error_type = BuildkiteExitCode.TRANSIENT_INFRA_ERROR
         else:
-          error_type = BuildkiteExitCode.INFRA_ERROR
+            error_type = BuildkiteExitCode.INFRA_ERROR
         runtime = None
     elif 30 <= exit_code.value < 40:
         error_type = BuildkiteExitCode.INFRA_TIMEOUT

--- a/release/ray_release/result.py
+++ b/release/ray_release/result.py
@@ -63,34 +63,39 @@ class ExitCode(enum.Enum):
     COMMAND_TIMEOUT = 42
     PREPARE_ERROR = 43
 
+class BuildkiteExitCode(enum.Enum):
+    """ 
+    Final exit code the test runner passes to buildkite-agent. This exit code is used
+    to determine job policies, such as automatic retries
+    """ 
+    SUCCESS = 0
+    UNKNOWN = 1
+    TRANSIENT_INFRA_ERROR = 10
+    INFRA_ERROR = 11
+    INFRA_TIMEOUT = 30
+    ERROR = 40 
+    TIMEOUT = 42 
 
-def handle_exception(e: Exception) -> Tuple[ExitCode, str, Optional[int]]:
+def handle_exception(e: Exception) -> Tuple[ExitCode, BuildkiteExitCode, Optional[int]]:
     from ray_release.exception import ReleaseTestError
 
-    if isinstance(e, ReleaseTestError):
-        exit_code = e.exit_code
-        # Legacy reporting
-        if 1 <= exit_code.value < 10:
-            error_type = "runtime_error"
-            runtime = None
-        elif 10 <= exit_code.value < 20:
-            error_type = "infra_error"
-            runtime = None
-        elif 30 <= exit_code.value < 40:
-            error_type = "infra_timeout"
-            runtime = None
-        elif exit_code == ExitCode.COMMAND_TIMEOUT:
-            error_type = "timeout"
-            runtime = 0
-        elif 40 <= exit_code.value < 50:
-            error_type = "error"
-            runtime = 0
-        else:
-            error_type = "error"
-            runtime = 0
-    else:
-        exit_code = ExitCode.UNKNOWN
-        error_type = "unknown error"
+    if not isinstance(e, ReleaseTestError):
+      return ExitCode.UNKNOWN, BuildkiteExitCode.UNKNOWN, 0
+    exit_code = e.exit_code
+    if 1 <= exit_code.value < 10:
+        error_type = BuildkiteExitCode.UNKNOWN
+        runtime = None
+    elif 10 <= exit_code.value < 20:
+        error_type = BuildkiteExitCode.INFRA_ERROR
+        runtime = None
+    elif 30 <= exit_code.value < 40:
+        error_type = BuildkiteExitCode.INFRA_TIMEOUT
+        runtime = None
+    elif exit_code == ExitCode.COMMAND_TIMEOUT:
+        error_type = BuildkiteExitCode.TIMEOUT
+        runtime = 0
+    elif 40 <= exit_code.value:
+        error_type = BuildkiteExitCode.ERROR
         runtime = 0
 
     return exit_code, error_type, runtime

--- a/release/ray_release/result.py
+++ b/release/ray_release/result.py
@@ -22,7 +22,7 @@ class Result:
 
     status: str = "invalid"
     return_code: int = 0
-    buildkite_return_code: int = BuildkiteExitCode.SUCCESS.value
+    buildkite_exit_code: int = BuildkiteExitCode.SUCCESS.value
     last_logs: Optional[str] = None
 
     runtime: Optional[float] = None

--- a/release/ray_release/result.py
+++ b/release/ray_release/result.py
@@ -22,13 +22,13 @@ class Result:
 
     status: str = "invalid"
     return_code: int = 0
+    buildkite_return_code: int = BuildkiteExitCode.SUCCESS.value
     last_logs: Optional[str] = None
 
     runtime: Optional[float] = None
     stable: bool = True
     smoke_test: bool = False
 
-    buildkite_return_code: BuildkiteExitCode.SUCCESS
     buildkite_url: Optional[str] = None
     wheels_url: Optional[str] = None
     cluster_url: Optional[str] = None

--- a/release/ray_release/result.py
+++ b/release/ray_release/result.py
@@ -103,8 +103,8 @@ def handle_exception(e: Exception) -> Tuple[ExitCode, ResultStatus, Optional[int
 
     # if this step is to be retried, mark its status as transient
     if result_status in [ResultStatus.INFRA_ERROR, ResultStatus.INFRA_TIMEOUT]:
-        retry_count = int(os.environ.get("BUILDKITE_RETRY_COUNT", "0"))
-        max_retry = int(os.environ.get("BUILDKITE_MAX_RETRIES"))
+        retry_count = int(os.environ.get("BUILDKITE_RETRY_COUNT", 0))
+        max_retry = int(os.environ.get("BUILDKITE_MAX_RETRIES", 1))
         if retry_count < max_retry:
             result_status = ResultStatus.TRANSIENT_INFRA_ERROR
 

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -163,7 +163,7 @@ def main(
         f"Release test pipeline for test {test['name']} completed. "
         f"Returning with exit code = {result.return_code}"
     )
-    sys.exit(result.buildkite_return_code)
+    sys.exit(result.buildkite_exit_code)
 
 
 if __name__ == "__main__":

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -163,7 +163,7 @@ def main(
         f"Release test pipeline for test {test['name']} completed. "
         f"Returning with exit code = {result.return_code}"
     )
-    sys.exit(result.buildkite_exit_code)
+    sys.exit(result.return_code)
 
 
 if __name__ == "__main__":

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -14,7 +14,7 @@ from ray_release.config import (
     read_and_validate_release_test_collection,
 )
 from ray_release.env import DEFAULT_ENVIRONMENT, load_environment, populate_os_env
-from ray_release.exception import ReleaseTestCLIError, ReleaseTestError
+from ray_release.exception import ReleaseTestCLIError
 from ray_release.glue import run_release_test
 from ray_release.logger import logger
 from ray_release.reporter.artifacts import ArtifactsReporter

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -164,6 +164,7 @@ def main(
     except ReleaseTestError as e:
         logger.exception(e)
         return_code = e.exit_code.value
+
     logger.info(
         f"Release test pipeline for test {test['name']} completed. "
         f"Returning with exit code = {return_code}"

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -148,28 +148,22 @@ def main(
     if report:
         reporters.append(DBReporter())
 
-    try:
-        result = run_release_test(
-            test,
-            anyscale_project=anyscale_project,
-            result=result,
-            ray_wheels_url=ray_wheels_url,
-            reporters=reporters,
-            smoke_test=smoke_test,
-            cluster_id=cluster_id,
-            cluster_env_id=cluster_env_id,
-            no_terminate=no_terminate,
-        )
-        return_code = result.return_code
-    except ReleaseTestError as e:
-        logger.exception(e)
-        return_code = e.exit_code.value
-
+    result = run_release_test(
+        test,
+        anyscale_project=anyscale_project,
+        result=result,
+        ray_wheels_url=ray_wheels_url,
+        reporters=reporters,
+        smoke_test=smoke_test,
+        cluster_id=cluster_id,
+        cluster_env_id=cluster_env_id,
+        no_terminate=no_terminate,
+    )
     logger.info(
         f"Release test pipeline for test {test['name']} completed. "
-        f"Returning with exit code = {return_code}"
+        f"Returning with exit code = {result.return_code}"
     )
-    sys.exit(return_code)
+    sys.exit(result.buildkite_return_code)
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_glue.py
+++ b/release/ray_release/tests/test_glue.py
@@ -621,7 +621,7 @@ class GlueTest(unittest.TestCase):
                 self._run(result)
                 self.assertTrue(any("Could not fetch results" in o for o in cm.output))
         self.assertEqual(result.return_code, ExitCode.FETCH_RESULT_ERROR.value)
-        self.assertEqual(result.status, "infra_error")
+        self.assertEqual(result.status, "transient_infra_error")
 
         # Ensure cluster was terminated, no matter what
         self.assertGreaterEqual(self.sdk.call_counter["terminate_cluster"], 1)
@@ -638,7 +638,6 @@ class GlueTest(unittest.TestCase):
             self.assertTrue(any("Error fetching logs" in o for o in cm.output))
         self.assertEqual(result.return_code, ExitCode.SUCCESS.value)
         self.assertEqual(result.status, "finished")
-        self.assertIn("No logs", result.last_logs)
 
         # Ensure cluster was terminated
         self.assertGreaterEqual(self.sdk.call_counter["terminate_cluster"], 1)

--- a/release/ray_release/tests/test_glue.py
+++ b/release/ray_release/tests/test_glue.py
@@ -24,13 +24,19 @@ from ray_release.exception import (
     ClusterEnvBuildError,
     ClusterEnvBuildTimeout,
     ClusterEnvCreateError,
+    ClusterCreationError,
     ClusterStartupError,
     ClusterStartupTimeout,
     RemoteEnvSetupError,
     CommandError,
+    PrepareCommandError,
     CommandTimeout,
+    PrepareCommandTimeout,
+    TestCommandError,
+    TestCommandTimeout,
     FetchResultError,
     LogsError,
+    ResultsAlert,
     ClusterNodesWaitTimeout,
 )
 from ray_release.file_manager.file_manager import FileManager
@@ -245,7 +251,7 @@ class GlueTest(unittest.TestCase):
 
         self.mock_alert_return = None
 
-    def _run(self, result: Result, **kwargs) -> Result:
+    def _run(self, result: Result, **kwargs):
         run_release_test(
             test=self.test,
             anyscale_project=self.anyscale_project,
@@ -261,23 +267,26 @@ class GlueTest(unittest.TestCase):
         with patch(
             "ray_release.glue.load_test_cluster_env",
             _fail_on_call(ReleaseTestConfigError),
-        ):
+        ), self.assertRaises(ReleaseTestConfigError):
             self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
         # Fails because file not found
         os.unlink(os.path.join(self.tempdir, "cluster_env.yaml"))
-        self._run(result)
+        with self.assertRaisesRegex(ReleaseTestConfigError, "Path not found"):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
         # Fails because invalid jinja template
         self.writeClusterEnv("{{ INVALID")
-        self._run(result)
+        with self.assertRaisesRegex(ReleaseTestConfigError, "yaml template"):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
         # Fails because invalid json
         self.writeClusterEnv("{'test': true, 'fail}")
-        self._run(result)
+        with self.assertRaisesRegex(ReleaseTestConfigError, "quoted scalar"):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
     def testInvalidClusterCompute(self):
@@ -286,23 +295,26 @@ class GlueTest(unittest.TestCase):
         with patch(
             "ray_release.glue.load_test_cluster_compute",
             _fail_on_call(ReleaseTestConfigError),
-        ):
+        ), self.assertRaises(ReleaseTestConfigError):
             self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
         # Fails because file not found
         os.unlink(os.path.join(self.tempdir, "cluster_compute.yaml"))
-        self._run(result)
+        with self.assertRaisesRegex(ReleaseTestConfigError, "Path not found"):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
         # Fails because invalid jinja template
         self.writeClusterCompute("{{ INVALID")
-        self._run(result)
+        with self.assertRaisesRegex(ReleaseTestConfigError, "yaml template"):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
         # Fails because invalid json
         self.writeClusterCompute("{'test': true, 'fail}")
-        self._run(result)
+        with self.assertRaisesRegex(ReleaseTestConfigError, "quoted scalar"):
+            self._run(result)
 
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
@@ -311,8 +323,9 @@ class GlueTest(unittest.TestCase):
 
         self._succeed_until("local_env")
 
-        self._run(result)
-        self.assertEqual(result.return_code, LocalEnvSetupError().exit_code.value)
+        with self.assertRaises(LocalEnvSetupError):
+            self._run(result)
+
         cluster_manager = self.instances["cluster_manager"]
 
         command_timeout = self.test["run"].get("timeout", DEFAULT_COMMAND_TIMEOUT)
@@ -349,7 +362,8 @@ class GlueTest(unittest.TestCase):
         self.command_runner_return["prepare_local_env"] = _fail_on_call(
             LocalEnvSetupError
         )
-        self._run(result)
+        with self.assertRaises(LocalEnvSetupError):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.LOCAL_ENV_SETUP_ERROR.value)
 
     def testDriverSetupFails(self):
@@ -357,7 +371,8 @@ class GlueTest(unittest.TestCase):
 
         self._succeed_until("local_env")
 
-        self._run(result)
+        with self.assertRaises(LocalEnvSetupError):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.LOCAL_ENV_SETUP_ERROR.value)
 
     def testInvalidClusterIdOverride(self):
@@ -367,14 +382,16 @@ class GlueTest(unittest.TestCase):
 
         self.sdk.returns["get_cluster_environment"] = None
 
-        self._run(result, cluster_env_id="existing")
+        with self.assertRaises(ClusterEnvCreateError):
+            self._run(result, cluster_env_id="existing")
 
         self.sdk.returns["get_cluster_environment"] = APIDict(
             result=APIDict(config_json={"overridden": True})
         )
 
-        self._run(result, cluster_env_id="existing")
-        self.assertNotEqual(result.return_code, ClusterEnvCreateError().exit_code)
+        with self.assertRaises(Exception) as cm:  # Fail somewhere else
+            self._run(result, cluster_env_id="existing")
+            self.assertNotIsInstance(cm.exception, ClusterEnvCreateError)
 
     def testBuildConfigFailsClusterCompute(self):
         result = Result()
@@ -385,14 +402,16 @@ class GlueTest(unittest.TestCase):
         self.command_runner_return["prepare_local_env"] = None
 
         # Fails because API response faulty
-        self._run(result)
+        with self.assertRaisesRegex(ClusterComputeCreateError, "Unexpected"):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_RESOURCE_ERROR.value)
 
         # Fails for random cluster compute reason
         self.cluster_manager_return["create_cluster_compute"] = _fail_on_call(
             ClusterComputeCreateError, "Known"
         )
-        self._run(result)
+        with self.assertRaisesRegex(ClusterComputeCreateError, "Known"):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_RESOURCE_ERROR.value)
 
     def testBuildConfigFailsClusterEnv(self):
@@ -400,14 +419,17 @@ class GlueTest(unittest.TestCase):
 
         self._succeed_until("cluster_compute")
 
-        self._run(result)
+        # Fails because API response faulty
+        with self.assertRaisesRegex(ClusterEnvCreateError, "Unexpected"):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_RESOURCE_ERROR.value)
 
         # Fails for random cluster env create reason
         self.cluster_manager_return["create_cluster_env"] = _fail_on_call(
             ClusterEnvCreateError, "Known"
         )
-        self._run(result)
+        with self.assertRaisesRegex(ClusterEnvCreateError, "Known"):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_RESOURCE_ERROR.value)
 
         # Now, succeed creation but fail on cluster env build
@@ -416,14 +438,16 @@ class GlueTest(unittest.TestCase):
         self.cluster_manager_return["build_cluster_env"] = _fail_on_call(
             ClusterEnvBuildError
         )
-        self._run(result)
+        with self.assertRaises(ClusterEnvBuildError):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_ENV_BUILD_ERROR.value)
 
         # Now, fail on cluster env timeout
         self.cluster_manager_return["build_cluster_env"] = _fail_on_call(
             ClusterEnvBuildTimeout
         )
-        self._run(result)
+        with self.assertRaises(ClusterEnvBuildTimeout):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_ENV_BUILD_TIMEOUT.value)
 
     def testStartClusterFails(self):
@@ -432,7 +456,8 @@ class GlueTest(unittest.TestCase):
         self._succeed_until("cluster_env")
 
         # Fails because API response faulty
-        self._run(result)
+        with self.assertRaises(ClusterCreationError):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_RESOURCE_ERROR.value)
 
         self.cluster_manager_return["cluster_id"] = "valid"
@@ -441,7 +466,8 @@ class GlueTest(unittest.TestCase):
         self.cluster_manager_return["start_cluster"] = _fail_on_call(
             ClusterStartupError
         )
-        self._run(result)
+        with self.assertRaises(ClusterStartupError):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_STARTUP_ERROR.value)
 
         # Ensure cluster was terminated
@@ -451,7 +477,8 @@ class GlueTest(unittest.TestCase):
         self.cluster_manager_return["start_cluster"] = _fail_on_call(
             ClusterStartupTimeout
         )
-        self._run(result)
+        with self.assertRaises(ClusterStartupTimeout):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_STARTUP_TIMEOUT.value)
 
         # Ensure cluster was terminated
@@ -465,7 +492,8 @@ class GlueTest(unittest.TestCase):
         self.command_runner_return["prepare_remote_env"] = _fail_on_call(
             RemoteEnvSetupError
         )
-        self._run(result)
+        with self.assertRaises(RemoteEnvSetupError):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.REMOTE_ENV_SETUP_ERROR.value)
 
         # Ensure cluster was terminated
@@ -480,7 +508,8 @@ class GlueTest(unittest.TestCase):
         self.command_runner_return["wait_for_nodes"] = _fail_on_call(
             ClusterNodesWaitTimeout
         )
-        self._run(result)
+        with self.assertRaises(ClusterNodesWaitTimeout):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_WAIT_TIMEOUT.value)
 
         # Ensure cluster was terminated
@@ -493,14 +522,16 @@ class GlueTest(unittest.TestCase):
 
         # Prepare command fails
         self.command_runner_return["run_prepare_command"] = _fail_on_call(CommandError)
-        self._run(result)
+        with self.assertRaises(PrepareCommandError):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.PREPARE_ERROR.value)
 
         # Prepare command times out
         self.command_runner_return["run_prepare_command"] = _fail_on_call(
             CommandTimeout
         )
-        self._run(result)
+        with self.assertRaises(PrepareCommandTimeout):
+            self._run(result)
         # Special case: Prepare commands are usually waiting for nodes
         # (this may change in the future!)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_WAIT_TIMEOUT.value)
@@ -515,12 +546,14 @@ class GlueTest(unittest.TestCase):
 
         # Test command fails
         self.command_runner_return["run_command"] = _fail_on_call(CommandError)
-        self._run(result)
+        with self.assertRaises(TestCommandError):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.COMMAND_ERROR.value)
 
         # Test command times out
         self.command_runner_return["run_command"] = _fail_on_call(CommandTimeout)
-        self._run(result)
+        with self.assertRaises(TestCommandTimeout):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.COMMAND_TIMEOUT.value)
 
         # Ensure cluster was terminated
@@ -533,7 +566,8 @@ class GlueTest(unittest.TestCase):
 
         # Test command times out
         self.command_runner_return["run_command"] = _fail_on_call(CommandTimeout)
-        self._run(result)
+        with self.assertRaises(TestCommandTimeout):
+            self._run(result)
         self.assertEqual(result.return_code, ExitCode.COMMAND_TIMEOUT.value)
 
         # But now set test to long running
@@ -582,11 +616,12 @@ class GlueTest(unittest.TestCase):
         self._succeed_until("test_command")
 
         self.command_runner_return["fetch_results"] = _fail_on_call(FetchResultError)
-        with self.assertLogs(logger, "ERROR") as cm:
-            self._run(result)
-            self.assertTrue(any("Could not fetch results" in o for o in cm.output))
+        with self.assertRaisesRegex(FetchResultError, "Fail"):
+            with self.assertLogs(logger, "ERROR") as cm:
+                self._run(result)
+                self.assertTrue(any("Could not fetch results" in o for o in cm.output))
         self.assertEqual(result.return_code, ExitCode.FETCH_RESULT_ERROR.value)
-        self.assertEqual(result.status, "transient_infra_error")
+        self.assertEqual(result.status, "infra_error")
 
         # Ensure cluster was terminated, no matter what
         self.assertGreaterEqual(self.sdk.call_counter["terminate_cluster"], 1)
@@ -615,7 +650,9 @@ class GlueTest(unittest.TestCase):
 
         self.mock_alert_return = "Alert raised"
 
-        self._run(result)
+        with self.assertRaises(ResultsAlert):
+            self._run(result)
+
         self.assertEqual(result.return_code, ExitCode.COMMAND_ALERT.value)
         self.assertEqual(result.status, "error")
 

--- a/release/ray_release/tests/test_glue.py
+++ b/release/ray_release/tests/test_glue.py
@@ -24,19 +24,13 @@ from ray_release.exception import (
     ClusterEnvBuildError,
     ClusterEnvBuildTimeout,
     ClusterEnvCreateError,
-    ClusterCreationError,
     ClusterStartupError,
     ClusterStartupTimeout,
     RemoteEnvSetupError,
     CommandError,
-    PrepareCommandError,
     CommandTimeout,
-    PrepareCommandTimeout,
-    TestCommandError,
-    TestCommandTimeout,
     FetchResultError,
     LogsError,
-    ResultsAlert,
     ClusterNodesWaitTimeout,
 )
 from ray_release.file_manager.file_manager import FileManager
@@ -251,7 +245,7 @@ class GlueTest(unittest.TestCase):
 
         self.mock_alert_return = None
 
-    def _run(self, result: Result, **kwargs):
+    def _run(self, result: Result, **kwargs) -> Result:
         run_release_test(
             test=self.test,
             anyscale_project=self.anyscale_project,
@@ -267,26 +261,23 @@ class GlueTest(unittest.TestCase):
         with patch(
             "ray_release.glue.load_test_cluster_env",
             _fail_on_call(ReleaseTestConfigError),
-        ), self.assertRaises(ReleaseTestConfigError):
+        ):
             self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
         # Fails because file not found
         os.unlink(os.path.join(self.tempdir, "cluster_env.yaml"))
-        with self.assertRaisesRegex(ReleaseTestConfigError, "Path not found"):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
         # Fails because invalid jinja template
         self.writeClusterEnv("{{ INVALID")
-        with self.assertRaisesRegex(ReleaseTestConfigError, "yaml template"):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
         # Fails because invalid json
         self.writeClusterEnv("{'test': true, 'fail}")
-        with self.assertRaisesRegex(ReleaseTestConfigError, "quoted scalar"):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
     def testInvalidClusterCompute(self):
@@ -295,26 +286,23 @@ class GlueTest(unittest.TestCase):
         with patch(
             "ray_release.glue.load_test_cluster_compute",
             _fail_on_call(ReleaseTestConfigError),
-        ), self.assertRaises(ReleaseTestConfigError):
+        ):
             self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
         # Fails because file not found
         os.unlink(os.path.join(self.tempdir, "cluster_compute.yaml"))
-        with self.assertRaisesRegex(ReleaseTestConfigError, "Path not found"):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
         # Fails because invalid jinja template
         self.writeClusterCompute("{{ INVALID")
-        with self.assertRaisesRegex(ReleaseTestConfigError, "yaml template"):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
         # Fails because invalid json
         self.writeClusterCompute("{'test': true, 'fail}")
-        with self.assertRaisesRegex(ReleaseTestConfigError, "quoted scalar"):
-            self._run(result)
+        self._run(result)
 
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
 
@@ -323,9 +311,8 @@ class GlueTest(unittest.TestCase):
 
         self._succeed_until("local_env")
 
-        with self.assertRaises(LocalEnvSetupError):
-            self._run(result)
-
+        self._run(result)
+        self.assertEqual(result.return_code, LocalEnvSetupError().exit_code.value)
         cluster_manager = self.instances["cluster_manager"]
 
         command_timeout = self.test["run"].get("timeout", DEFAULT_COMMAND_TIMEOUT)
@@ -362,8 +349,7 @@ class GlueTest(unittest.TestCase):
         self.command_runner_return["prepare_local_env"] = _fail_on_call(
             LocalEnvSetupError
         )
-        with self.assertRaises(LocalEnvSetupError):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.LOCAL_ENV_SETUP_ERROR.value)
 
     def testDriverSetupFails(self):
@@ -371,8 +357,7 @@ class GlueTest(unittest.TestCase):
 
         self._succeed_until("local_env")
 
-        with self.assertRaises(LocalEnvSetupError):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.LOCAL_ENV_SETUP_ERROR.value)
 
     def testInvalidClusterIdOverride(self):
@@ -382,16 +367,14 @@ class GlueTest(unittest.TestCase):
 
         self.sdk.returns["get_cluster_environment"] = None
 
-        with self.assertRaises(ClusterEnvCreateError):
-            self._run(result, cluster_env_id="existing")
+        self._run(result, cluster_env_id="existing")
 
         self.sdk.returns["get_cluster_environment"] = APIDict(
             result=APIDict(config_json={"overridden": True})
         )
 
-        with self.assertRaises(Exception) as cm:  # Fail somewhere else
-            self._run(result, cluster_env_id="existing")
-            self.assertNotIsInstance(cm.exception, ClusterEnvCreateError)
+        self._run(result, cluster_env_id="existing")
+        self.assertNotEqual(result.return_code, ClusterEnvCreateError().exit_code)
 
     def testBuildConfigFailsClusterCompute(self):
         result = Result()
@@ -402,16 +385,14 @@ class GlueTest(unittest.TestCase):
         self.command_runner_return["prepare_local_env"] = None
 
         # Fails because API response faulty
-        with self.assertRaisesRegex(ClusterComputeCreateError, "Unexpected"):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_RESOURCE_ERROR.value)
 
         # Fails for random cluster compute reason
         self.cluster_manager_return["create_cluster_compute"] = _fail_on_call(
             ClusterComputeCreateError, "Known"
         )
-        with self.assertRaisesRegex(ClusterComputeCreateError, "Known"):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_RESOURCE_ERROR.value)
 
     def testBuildConfigFailsClusterEnv(self):
@@ -419,17 +400,14 @@ class GlueTest(unittest.TestCase):
 
         self._succeed_until("cluster_compute")
 
-        # Fails because API response faulty
-        with self.assertRaisesRegex(ClusterEnvCreateError, "Unexpected"):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_RESOURCE_ERROR.value)
 
         # Fails for random cluster env create reason
         self.cluster_manager_return["create_cluster_env"] = _fail_on_call(
             ClusterEnvCreateError, "Known"
         )
-        with self.assertRaisesRegex(ClusterEnvCreateError, "Known"):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_RESOURCE_ERROR.value)
 
         # Now, succeed creation but fail on cluster env build
@@ -438,16 +416,14 @@ class GlueTest(unittest.TestCase):
         self.cluster_manager_return["build_cluster_env"] = _fail_on_call(
             ClusterEnvBuildError
         )
-        with self.assertRaises(ClusterEnvBuildError):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_ENV_BUILD_ERROR.value)
 
         # Now, fail on cluster env timeout
         self.cluster_manager_return["build_cluster_env"] = _fail_on_call(
             ClusterEnvBuildTimeout
         )
-        with self.assertRaises(ClusterEnvBuildTimeout):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_ENV_BUILD_TIMEOUT.value)
 
     def testStartClusterFails(self):
@@ -456,8 +432,7 @@ class GlueTest(unittest.TestCase):
         self._succeed_until("cluster_env")
 
         # Fails because API response faulty
-        with self.assertRaises(ClusterCreationError):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_RESOURCE_ERROR.value)
 
         self.cluster_manager_return["cluster_id"] = "valid"
@@ -466,8 +441,7 @@ class GlueTest(unittest.TestCase):
         self.cluster_manager_return["start_cluster"] = _fail_on_call(
             ClusterStartupError
         )
-        with self.assertRaises(ClusterStartupError):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_STARTUP_ERROR.value)
 
         # Ensure cluster was terminated
@@ -477,8 +451,7 @@ class GlueTest(unittest.TestCase):
         self.cluster_manager_return["start_cluster"] = _fail_on_call(
             ClusterStartupTimeout
         )
-        with self.assertRaises(ClusterStartupTimeout):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_STARTUP_TIMEOUT.value)
 
         # Ensure cluster was terminated
@@ -492,8 +465,7 @@ class GlueTest(unittest.TestCase):
         self.command_runner_return["prepare_remote_env"] = _fail_on_call(
             RemoteEnvSetupError
         )
-        with self.assertRaises(RemoteEnvSetupError):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.REMOTE_ENV_SETUP_ERROR.value)
 
         # Ensure cluster was terminated
@@ -508,8 +480,7 @@ class GlueTest(unittest.TestCase):
         self.command_runner_return["wait_for_nodes"] = _fail_on_call(
             ClusterNodesWaitTimeout
         )
-        with self.assertRaises(ClusterNodesWaitTimeout):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_WAIT_TIMEOUT.value)
 
         # Ensure cluster was terminated
@@ -522,16 +493,14 @@ class GlueTest(unittest.TestCase):
 
         # Prepare command fails
         self.command_runner_return["run_prepare_command"] = _fail_on_call(CommandError)
-        with self.assertRaises(PrepareCommandError):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.PREPARE_ERROR.value)
 
         # Prepare command times out
         self.command_runner_return["run_prepare_command"] = _fail_on_call(
             CommandTimeout
         )
-        with self.assertRaises(PrepareCommandTimeout):
-            self._run(result)
+        self._run(result)
         # Special case: Prepare commands are usually waiting for nodes
         # (this may change in the future!)
         self.assertEqual(result.return_code, ExitCode.CLUSTER_WAIT_TIMEOUT.value)
@@ -546,14 +515,12 @@ class GlueTest(unittest.TestCase):
 
         # Test command fails
         self.command_runner_return["run_command"] = _fail_on_call(CommandError)
-        with self.assertRaises(TestCommandError):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.COMMAND_ERROR.value)
 
         # Test command times out
         self.command_runner_return["run_command"] = _fail_on_call(CommandTimeout)
-        with self.assertRaises(TestCommandTimeout):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.COMMAND_TIMEOUT.value)
 
         # Ensure cluster was terminated
@@ -566,8 +533,7 @@ class GlueTest(unittest.TestCase):
 
         # Test command times out
         self.command_runner_return["run_command"] = _fail_on_call(CommandTimeout)
-        with self.assertRaises(TestCommandTimeout):
-            self._run(result)
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.COMMAND_TIMEOUT.value)
 
         # But now set test to long running
@@ -616,12 +582,11 @@ class GlueTest(unittest.TestCase):
         self._succeed_until("test_command")
 
         self.command_runner_return["fetch_results"] = _fail_on_call(FetchResultError)
-        with self.assertRaisesRegex(FetchResultError, "Fail"):
-            with self.assertLogs(logger, "ERROR") as cm:
-                self._run(result)
-                self.assertTrue(any("Could not fetch results" in o for o in cm.output))
+        with self.assertLogs(logger, "ERROR") as cm:
+            self._run(result)
+            self.assertTrue(any("Could not fetch results" in o for o in cm.output))
         self.assertEqual(result.return_code, ExitCode.FETCH_RESULT_ERROR.value)
-        self.assertEqual(result.status, "infra_error")
+        self.assertEqual(result.status, "transient_infra_error")
 
         # Ensure cluster was terminated, no matter what
         self.assertGreaterEqual(self.sdk.call_counter["terminate_cluster"], 1)
@@ -650,9 +615,7 @@ class GlueTest(unittest.TestCase):
 
         self.mock_alert_return = "Alert raised"
 
-        with self.assertRaises(ResultsAlert):
-            self._run(result)
-
+        self._run(result)
         self.assertEqual(result.return_code, ExitCode.COMMAND_ALERT.value)
         self.assertEqual(result.status, "error")
 

--- a/release/ray_release/tests/test_run_script.py
+++ b/release/ray_release/tests/test_run_script.py
@@ -94,7 +94,7 @@ def test_repeat(setup):
             ExitCode.CLUSTER_WAIT_TIMEOUT,
             ExitCode.RAY_WHEELS_TIMEOUT,
         )
-        == ExitCode.RAY_WHEELS_TIMEOUT.value
+        == 79
     )
     assert _read_state(state_file) == 3
 

--- a/release/ray_release/tests/test_run_script.py
+++ b/release/ray_release/tests/test_run_script.py
@@ -94,7 +94,7 @@ def test_repeat(setup):
             ExitCode.CLUSTER_WAIT_TIMEOUT,
             ExitCode.RAY_WHEELS_TIMEOUT,
         )
-        == 79
+        == 79  # BUILDKITE_RETRY_CODE
     )
     assert _read_state(state_file) == 3
 

--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -175,7 +175,7 @@ if [ -z "${NO_CLONE}" ]; then
   rm -rf "${TMPDIR}" || true
 fi
 
-if [ "$REASON" -eq 'infra error'] || [ "$REASON" -eq 'infra timeout']; then
+if [ "$REASON" == "infra error" ] || [ "$REASON" == "infra timeout" ]; then
   exit $BUILDKITE_RETRY_CODE
 else
   exit $EXIT_CODE

--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -30,13 +30,15 @@ RAY_TEST_SCRIPT=${RAY_TEST_SCRIPT-ray_release/scripts/run_release_test.py}
 RAY_TEST_REPO=${RAY_TEST_REPO-https://github.com/ray-project/ray.git}
 RAY_TEST_BRANCH=${RAY_TEST_BRANCH-master}
 RELEASE_RESULTS_DIR=${RELEASE_RESULTS_DIR-/tmp/artifacts}
+BUILDKITE_MAX_RETRIES=1
+BUILDKITE_RETRY_CODE=79
 
 # This is not a great idea if your OS is different to the one
 # used in the product clusters. However, we need this in CI as reloading
 # Ray within the python process does not work for protobuf changes.
 INSTALL_MATCHING_RAY=${BUILDKITE-false}
 
-export RAY_TEST_REPO RAY_TEST_BRANCH RELEASE_RESULTS_DIR
+export RAY_TEST_REPO RAY_TEST_BRANCH RELEASE_RESULTS_DIR BUILDKITE_MAX_RETRIES BUILDKITE_RETRY_CODE
 
 if [ -z "${NO_INSTALL}" ]; then
   pip install --use-deprecated=legacy-resolver -q -r requirements.txt
@@ -173,4 +175,8 @@ if [ -z "${NO_CLONE}" ]; then
   rm -rf "${TMPDIR}" || true
 fi
 
-exit $EXIT_CODE
+if [ "$REASON" -eq 'infra error'] || [ "$REASON" -eq 'infra timeout']; then
+  exit $BUILDKITE_RETRY_CODE
+else
+  exit $EXIT_CODE
+fi


### PR DESCRIPTION
## Why are these changes needed?

This might or might not be a controversial PR, so any feedback here is super welcome.

This PR is a part of my effort to make OSS release test run greener, starting with reducing infra error rates. Other work such as [this from Lonnie](https://docs.google.com/document/d/1hF7h8F19qFWFxH9WVeT8fWwVuNyUyHLTx-7LP3uxD50/edit#heading=h.i0cvl0u8jbfu) fixes systematic issues such as unstable Anyscale staging environment. This PR addresses transient issues with Anyscale that are hard to avoid in a distributed system. On a day Anyscale behaves well, transient issue seem to be around [2-3%](https://b534fd88.us1a.app.preset.io/superset/dashboard/43/?force=false&native_filters_key=MoYaGptJfGwbkF60A7RSzfoRLL_ypDf_JvNFxp2YGQ8Ls4CNgbAWEBh0WcOkOLsS), aka. 4 random failures for a test suite of 200 tests, annoying!

Concretely it will:

- First, classify an infra test run as a transient infra issue
- Instruct buildkite to automatically retry on transient issue
- If retry runs out, classify the infra test run as infra issue

Some other limitations that will be addressed in followup PRs:
- Move infra-failure retry configuration into LaunchDarkly?
- Limit auto-retry based on test cost or test runtime

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests, tests are auto-retried on infra issued ONCE - https://buildkite.com/ray-project/release-tests-pr/builds/34062
   