### PR TITLE
[CI] Limit CI release test runs on one test variation at a time

### DIFF
--- a/release/air_tests/air_benchmarks/compute_gce_gpu_1.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_1.yaml
@@ -1,0 +1,27 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-32-nvidia-tesla-t4-2 # aws g3.8xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-8 # m5.2xlarge
+      max_workers: 0
+      min_workers: 0
+      use_spot: false
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            Iops: 5000
+#            Throughput: 1000
+#            VolumeSize: 1000
+#            VolumeType: gp3

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_1.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_1.yaml
@@ -1,7 +1,7 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west1
 allowed_azs: 
-    - us-west1-a
+    - us-west1-b
 
 max_workers: 0
 
@@ -16,12 +16,11 @@ worker_node_types:
       min_workers: 0
       use_spot: false
 
-#aws:
-#    BlockDeviceMappings:
-#        - DeviceName: /dev/sda1
-#          Ebs:
-#            DeleteOnTermination: true
-#            Iops: 5000
-#            Throughput: 1000
-#            VolumeSize: 1000
-#            VolumeType: gp3
+gcp_advanced_configurations_json:
+  instance_properties:
+    disks:
+      - boot: true
+        auto_delete: true
+        initialize_params:
+          disk_size_gb: 1000
+          

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
@@ -1,7 +1,7 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west1
 allowed_azs: 
-    - us-west1-a
+    - us-west1-b
 
 max_workers: 3
 

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
@@ -7,11 +7,11 @@ max_workers: 3
 
 head_node_type:
     name: head_node
-    instance_type: n1-highmem-32-nvidia-tesla-v100-4 # n1-standard-64-nvidia-tesla-t4-4 # aws g3.16xlarge
+    instance_type: n1-standard-64-nvidia-tesla-t4-4 # aws g3.16xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: n1-highmem-32-nvidia-tesla-v100-4 # n1-standard-64-nvidia-tesla-t4-4 # aws g3.16xlarge
+      instance_type: n1-standard-64-nvidia-tesla-t4-4 # aws g3.16xlarge
       max_workers: 3
       min_workers: 3
       use_spot: false

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
@@ -1,0 +1,28 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 3
+
+head_node_type:
+    name: head_node
+    instance_type: n1-highmem-32-nvidia-tesla-v100-4 # n1-standard-64-nvidia-tesla-t4-4 # aws g3.16xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n1-highmem-32-nvidia-tesla-v100-4 # n1-standard-64-nvidia-tesla-t4-4 # aws g3.16xlarge
+      max_workers: 3
+      min_workers: 3
+      use_spot: false
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 800
+#            Iops: 5000
+#            Throughput: 1000
+#            VolumeSize: 1000
+#            VolumeType: gp3

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
@@ -16,13 +16,10 @@ worker_node_types:
       min_workers: 3
       use_spot: false
 
-#aws:
-#    BlockDeviceMappings:
-#        - DeviceName: /dev/sda1
-#          Ebs:
-#            DeleteOnTermination: true
-#            VolumeSize: 800
-#            Iops: 5000
-#            Throughput: 1000
-#            VolumeSize: 1000
-#            VolumeType: gp3
+gcp_advanced_configurations_json:
+  instance_properties:
+    disks:
+      - boot: true
+        auto_delete: true
+        initialize_params:
+          disk_size_gb: 800

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_1_g4_8xl.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_1_g4_8xl.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-16-nvidia-tesla-t4-1 # aws g4dn.8xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-8 # m5.2xlarge
+      max_workers: 0
+      min_workers: 0
+      use_spot: false

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_1_g4_8xl.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_1_g4_8xl.yaml
@@ -1,7 +1,7 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west1
 allowed_azs: 
-    - us-west1-a
+    - us-west1-b
 
 max_workers: 0
 

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_4_g4_12xl.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_4_g4_12xl.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-b
+
+max_workers: 3
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-64-nvidia-tesla-t4-4 # g4dn.12xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n1-standard-64-nvidia-tesla-t4-4 # g4dn.12xlarge
+      max_workers: 3
+      min_workers: 3
+      use_spot: false

--- a/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_CPU"] | default("anyscale/ray-ml:2.3.1-py37-cpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_CPU"] | default("anyscale/ray-ml:2.3.0-py37-cpu") }}
 env_vars: {"RAY_task_oom_retries": "50", "RAY_min_memory_free_bytes": "1000000000"}
 debian_packages:
   - curl

--- a/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_CPU"] | default("anyscale/ray-ml:2.0.1-py37-cpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_CPU"] | default("anyscale/ray-ml:2.3.1-py37-cpu") }}
 env_vars: {"RAY_task_oom_retries": "50", "RAY_min_memory_free_bytes": "1000000000"}
 debian_packages:
   - curl

--- a/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_CPU"] | default("anyscale/ray-ml:2.3.0-py37-cpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_CPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
 env_vars: {"RAY_task_oom_retries": "50", "RAY_min_memory_free_bytes": "1000000000"}
 debian_packages:
   - curl

--- a/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # aws m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # m5.xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 400

--- a/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16.yaml
@@ -16,9 +16,10 @@ worker_node_types:
       max_workers: 0
       use_spot: false
 
-#aws:
-#    BlockDeviceMappings:
-#        - DeviceName: /dev/sda1
-#          Ebs:
-#            DeleteOnTermination: true
-#            VolumeSize: 400
+gcp_advanced_configurations_json:
+  instance_properties:
+    disks:
+      - boot: true
+        auto_delete: true
+        initialize_params:
+          disk_size_gb: 400

--- a/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16_worker_nodes_2.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16_worker_nodes_2.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 2
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # aws m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # m5.xlarge
+      min_workers: 2
+      max_workers: 2
+      use_spot: false

--- a/release/jobs_tests/compute_tpl_gce_4_xlarge.yaml
+++ b/release/jobs_tests/compute_tpl_gce_4_xlarge.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 4
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-4 # m5.xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # m5.xlarge
+      min_workers: 4
+      max_workers: 4
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '24'

--- a/release/jobs_tests/compute_tpl_gce_gpu_node.yaml
+++ b/release/jobs_tests/compute_tpl_gce_gpu_node.yaml
@@ -1,0 +1,22 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-16-nvidia-tesla-t4-1 # g4dn.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-16 # aws m5.4xlarge
+      min_workers: 1
+      max_workers: 1
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '24'

--- a/release/jobs_tests/compute_tpl_gce_gpu_node.yaml
+++ b/release/jobs_tests/compute_tpl_gce_gpu_node.yaml
@@ -1,7 +1,7 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west1
 allowed_azs: 
-    - us-west1-a
+    - us-west1-b
 
 head_node_type:
     name: head_node

--- a/release/jobs_tests/compute_tpl_gce_gpu_node.yaml
+++ b/release/jobs_tests/compute_tpl_gce_gpu_node.yaml
@@ -13,10 +13,3 @@ worker_node_types:
       min_workers: 1
       max_workers: 1
       use_spot: false
-
-#aws:
-#  TagSpecifications:
-#    - ResourceType: "instance"
-#      Tags:
-#        - Key: ttl-hours
-#          Value: '24'

--- a/release/jobs_tests/compute_tpl_gce_gpu_worker.yaml
+++ b/release/jobs_tests/compute_tpl_gce_gpu_worker.yaml
@@ -1,7 +1,7 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west1
 allowed_azs: 
-    - us-west1-a
+    - us-west1-b
 
 head_node_type:
     name: head_node

--- a/release/jobs_tests/compute_tpl_gce_gpu_worker.yaml
+++ b/release/jobs_tests/compute_tpl_gce_gpu_worker.yaml
@@ -13,10 +13,3 @@ worker_node_types:
       min_workers: 1
       max_workers: 1
       use_spot: false
-
-#aws:
-#  TagSpecifications:
-#    - ResourceType: "instance"
-#      Tags:
-#        - Key: ttl-hours
-#          Value: '24'

--- a/release/jobs_tests/compute_tpl_gce_gpu_worker.yaml
+++ b/release/jobs_tests/compute_tpl_gce_gpu_worker.yaml
@@ -1,0 +1,22 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # aws m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n1-standard-16-nvidia-tesla-t4-1 # g4dn.4xlarge
+      min_workers: 1
+      max_workers: 1
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '24'

--- a/release/long_running_distributed_tests/compute_tpl_gce.yaml
+++ b/release/long_running_distributed_tests/compute_tpl_gce.yaml
@@ -1,7 +1,7 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west1
 allowed_azs: 
-    - us-west1-a
+    - us-west1-b
 
 max_workers: 3
 
@@ -16,15 +16,10 @@ worker_node_types:
       max_workers: 2
       use_spot: false
 
-#aws:
-#  TagSpecifications:
-#    - ResourceType: "instance"
-#      Tags:
-#        - Key: ttl-hours
-#          Value: '48'
-#
-#  BlockDeviceMappings:
-#    - DeviceName: /dev/sda1
-#      Ebs:
-#        VolumeSize: 400
-#        DeleteOnTermination: true
+gcp_advanced_configurations_json:
+  instance_properties:
+    disks:
+      - boot: true
+        auto_delete: true
+        initialize_params:
+          disk_size_gb: 400

--- a/release/long_running_distributed_tests/compute_tpl_gce.yaml
+++ b/release/long_running_distributed_tests/compute_tpl_gce.yaml
@@ -1,0 +1,30 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 3
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-32-nvidia-tesla-t4-2 # g3.8xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n1-standard-32-nvidia-tesla-t4-2 # g3.8xlarge
+      min_workers: 2
+      max_workers: 2
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'
+#
+#  BlockDeviceMappings:
+#    - DeviceName: /dev/sda1
+#      Ebs:
+#        VolumeSize: 400
+#        DeleteOnTermination: true

--- a/release/long_running_tests/many_ppo_gce.yaml
+++ b/release/long_running_tests/many_ppo_gce.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-8 # m5.2xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'

--- a/release/long_running_tests/tpl_cpu_1_c5_gce.yaml
+++ b/release/long_running_tests/tpl_cpu_1_c5_gce.yaml
@@ -1,0 +1,30 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: c2-standard-8 # c5.2xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: c2-standard-8 # c5.2xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'
+#
+#  BlockDeviceMappings:
+#    - DeviceName: /dev/sda1
+#      Ebs:
+#        VolumeSize: 300
+#        DeleteOnTermination: true

--- a/release/long_running_tests/tpl_cpu_1_gce.yaml
+++ b/release/long_running_tests/tpl_cpu_1_gce.yaml
@@ -1,0 +1,30 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-8 # m5.2xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-8 # m5.2xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'
+#
+#  BlockDeviceMappings:
+#    - DeviceName: /dev/sda1
+#      Ebs:
+#        VolumeSize: 300
+#        DeleteOnTermination: true

--- a/release/long_running_tests/tpl_cpu_1_large_gce.yaml
+++ b/release/long_running_tests/tpl_cpu_1_large_gce.yaml
@@ -1,0 +1,30 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-16 # m5.4xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'
+#
+#  BlockDeviceMappings:
+#    - DeviceName: /dev/sda1
+#      Ebs:
+#        VolumeSize: 300
+#        DeleteOnTermination: true

--- a/release/long_running_tests/tpl_cpu_3_gce.yaml
+++ b/release/long_running_tests/tpl_cpu_3_gce.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 2
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-8 # m5.2xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-8 # m5.2xlarge
+      min_workers: 2
+      max_workers: 2
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'

--- a/release/microbenchmark/tpl_64_gce.yaml
+++ b/release/microbenchmark/tpl_64_gce.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-64 # aws m5.16xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-2 # aws m5.xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false

--- a/release/nightly_tests/dataset/data_ingest_benchmark_compute_gce.yaml
+++ b/release/nightly_tests/dataset/data_ingest_benchmark_compute_gce.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 19
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # aws m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-16 # aws m5.4xlarge
+      max_workers: 19
+      min_workers: 19
+      use_spot: false

--- a/release/nightly_tests/decision_tree/autoscaling_compute_gce.yaml
+++ b/release/nightly_tests/decision_tree/autoscaling_compute_gce.yaml
@@ -1,0 +1,28 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 10
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 500
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-8 # aws m5.2xlarge
+    resources:
+      cpu: 8
+
+worker_node_types:
+   - name: worker_node
+     instance_type: n2-standard-16 # m5.4xlarge
+     min_workers: 0
+     max_workers: 10
+     use_spot: false
+     resources:
+      cpu: 16

--- a/release/nightly_tests/shuffle/100tb_shuffle_app_config_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_app_config_gce.yaml
@@ -1,6 +1,6 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
-env_vars: {"RAY_object_spilling_config": "{\"type\":\"filesystem\",\"params\":{\"directory_path\":[\"/tmp/data0\",\"/tmp/data1\"],\"buffer_size\":1_000_000}}"}
+env_vars: {"RAY_object_spilling_config": "{\"type\":\"filesystem\",\"params\":{\"directory_path\":[\"/tmp/data0\",\"/tmp/data1\"],\"buffer_size\":1000000}}"}
 
 python:
   pip_packages: []

--- a/release/nightly_tests/shuffle/100tb_shuffle_app_config_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_app_config_gce.yaml
@@ -10,9 +10,9 @@ post_build_cmds:
   - pip3 uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U ray[default]
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
-  - echo "yes N | sudo mkfs -t ext4 /dev/disk/by-id/google-anyscale-100tb || true" >> ~/.bashrc
+  - echo "yes N | sudo mkfs -t ext4 /dev/sdb || true" >> ~/.bashrc
   - echo "mkdir -p /tmp/data0" >> ~/.bashrc
   - echo "mkdir -p /tmp/data1" >> ~/.bashrc
   - echo "sudo chmod 0777 /tmp/data0" >> ~/.bashrc
   - echo "sudo chmod 0777 /tmp/data1" >> ~/.bashrc
-  - echo "sudo mount /dev/disk/by-id/google-anyscale-100tb /tmp/data1 || true" >> ~/.bashrc
+  - echo "sudo mount /dev/sdb /tmp/data1 || true" >> ~/.bashrc

--- a/release/nightly_tests/shuffle/100tb_shuffle_app_config_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_app_config_gce.yaml
@@ -1,0 +1,18 @@
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+debian_packages: []
+env_vars: {"RAY_object_spilling_config": "{\"type\":\"filesystem\",\"params\":{\"directory_path\":[\"/tmp/data0\",\"/tmp/data1\"]}}"}
+
+python:
+  pip_packages: []
+  conda_packages: []
+
+post_build_cmds:
+  - pip3 uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 install -U ray[default]
+  - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
+  - echo "yes N | sudo mkfs -t ext4 /dev/disk/by-id/google-anyscale-100tb || true" >> ~/.bashrc
+  - echo "mkdir -p /tmp/data0" >> ~/.bashrc
+  - echo "mkdir -p /tmp/data1" >> ~/.bashrc
+  - echo "sudo chmod 0777 /tmp/data0" >> ~/.bashrc
+  - echo "sudo chmod 0777 /tmp/data1" >> ~/.bashrc
+  - echo "sudo mount /dev/disk/by-id/google-anyscale-100tb /tmp/data1 || true" >> ~/.bashrc

--- a/release/nightly_tests/shuffle/100tb_shuffle_app_config_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_app_config_gce.yaml
@@ -1,6 +1,6 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 debian_packages: []
-env_vars: {"RAY_object_spilling_config": "{\"type\":\"filesystem\",\"params\":{\"directory_path\":[\"/tmp/data0\",\"/tmp/data1\"]}}"}
+env_vars: {"RAY_object_spilling_config": "{\"type\":\"filesystem\",\"params\":{\"directory_path\":[\"/tmp/data0\",\"/tmp/data1\"],\"buffer_size\":1_000_000}}"}
 
 python:
   pip_packages: []

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
@@ -1,4 +1,4 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+#cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
 aws:

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
@@ -1,4 +1,4 @@
-#cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
 aws:

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -10,7 +10,6 @@ gcp_advanced_configurations_json:
         auto_delete: true
         initialize_params:
           disk_size_gb: 2000
-          source_image: family/debian-9
       - boot: false
         auto_delete: true
         initialize_params:

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -1,0 +1,28 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 2000
+#        - DeviceName: /dev/sda2
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 2000
+
+head_node_type:
+    name: head_node
+    instance_type:  n2-standard-32 # aws m5.8xlarge
+    resources: {"cpu": 0}
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-16 # aws m5.4xlarge
+      min_workers: 99
+      max_workers: 99
+      use_spot: false
+      resources: {"cpu": 8}

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -12,6 +12,7 @@ gcp_advanced_configurations_json:
           disk_size_gb: 200
       - boot: false
         auto_delete: true
+        device_name: anyscale-100tb
         initialize_params:
           disk_size_gb: 2000
           disk_type: pd-standard

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -9,12 +9,13 @@ gcp_advanced_configurations_json:
       - boot: true
         auto_delete: true
         initialize_params:
-          disk_size_gb: 200
+          disk_size_gb: 1000
+          disk_type: pd-standard
       - boot: false
         auto_delete: true
         device_name: anyscale-100tb
         initialize_params:
-          disk_size_gb: 2000
+          disk_size_gb: 1000
           disk_type: pd-standard
 
 head_node_type:

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -14,7 +14,7 @@ gcp_advanced_configurations_json:
         auto_delete: true
         initialize_params:
           disk_size_gb: 2000
-          source_image: family/debian-9
+          source_image: projects/anyscale-bridge-cd812d38/global/images/anyscale-fast-ubuntu-ray-1677123186
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -9,12 +9,11 @@ gcp_advanced_configurations_json:
       - boot: true
         auto_delete: true
         initialize_params:
-          disk_size_gb: 1000
-          disk_type: pd-standard
+          disk_size_gb: 200
       - boot: false
         auto_delete: true
         initialize_params:
-          disk_size_gb: 1000
+          disk_size_gb: 2000
           disk_type: pd-standard
 
 head_node_type:

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -13,7 +13,6 @@ gcp_advanced_configurations_json:
           disk_type: pd-standard
       - boot: false
         auto_delete: true
-        device_name: anyscale-100tb
         initialize_params:
           disk_size_gb: 1000
           disk_type: pd-standard

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -3,16 +3,17 @@ region: us-west1
 allowed_azs: 
     - us-west1-c
 
-#aws:
-#    BlockDeviceMappings:
-#        - DeviceName: /dev/sda1
-#          Ebs:
-#            DeleteOnTermination: true
-#            VolumeSize: 2000
-#        - DeviceName: /dev/sda2
-#          Ebs:
-#            DeleteOnTermination: true
-#            VolumeSize: 2000
+gcp:
+	InstanceProperties:
+		- Disks:
+			- Boot: true
+				AutoDelete: true
+				InitializeParams:
+					- DiskSizeGb: 2000
+			- Boot: false
+				AutoDelete: true
+				InitializeParams:
+					- DiskSizeGb: 2000
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -8,10 +8,14 @@ gcp_advanced_configurations_json:
     disks:
       - boot: true
         auto_delete: true
-        disk_size_gb: 2000
+        initialize_params:
+          disk_size_gb: 2000
+          source_image: family/debian-9
       - boot: false
         auto_delete: true
-        disk_size_gb: 2000
+        initialize_params:
+          disk_size_gb: 2000
+          source_image: family/debian-9
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -10,11 +10,13 @@ gcp_advanced_configurations_json:
         auto_delete: true
         initialize_params:
           disk_size_gb: 2000
+          disk_type: pd-standard
       - boot: false
         auto_delete: true
         initialize_params:
           disk_size_gb: 2000
           source_image: projects/suse-sap-cloud/global/images/sles-12-sp5-sap-v20230116-x86-64
+          disk_type: pd-standard
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -3,16 +3,17 @@ region: us-west1
 allowed_azs: 
     - us-west1-c
 
-gcp:
-  disks:
-    - boot: true
-      autoDelete: true
-      initializeParams:
-        diskSizeGb: 2000
-    - boot: false
-      autoDelete: true
-      initializeParams:
-        diskSizeGb: 2000
+gcp_advanced_configurations_json:
+  instance_properties:
+    disks:
+      - boot: true
+        auto_delete: true
+        initialize_params:
+          disk_size_gb: 2000
+      - boot: false
+        auto_delete: true
+        initialize_params:
+          disk_size_gb: 2000
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -8,14 +8,10 @@ gcp_advanced_configurations_json:
     disks:
       - boot: true
         auto_delete: true
-        initialize_params:
-          disk_size_gb: 2000
-          disk_type: pd-standard
       - boot: false
         auto_delete: true
         initialize_params:
           disk_size_gb: 2000
-          source_image: projects/suse-sap-cloud/global/images/sles-12-sp5-sap-v20230116-x86-64
           disk_type: pd-standard
 
 head_node_type:

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -9,12 +9,12 @@ gcp_advanced_configurations_json:
       - boot: true
         auto_delete: true
         initialize_params:
-          disk_size_gb: 1000
+          disk_size_gb: 800
           disk_type: pd-standard
       - boot: false
         auto_delete: true
         initialize_params:
-          disk_size_gb: 1000
+          disk_size_gb: 800
           disk_type: pd-standard
 
 head_node_type:

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -9,11 +9,12 @@ gcp_advanced_configurations_json:
       - boot: true
         auto_delete: true
         initialize_params:
-          disk_size_gb: 200
+          disk_size_gb: 1000
+          disk_type: pd-standard
       - boot: false
         auto_delete: true
         initialize_params:
-          disk_size_gb: 2000
+          disk_size_gb: 1000
           disk_type: pd-standard
 
 head_node_type:

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -7,15 +7,11 @@ gcp_advanced_configurations_json:
   instance_properties:
     disks:
       - boot: true
-        type: pd-standard
         auto_delete: true
-        initialize_params:
-          disk_size_gb: 2000
+        disk_size_gb: 2000
       - boot: false
-        type: pd-standard
         auto_delete: true
-        initialize_params:
-          disk_size_gb: 2000
+        disk_size_gb: 2000
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -14,7 +14,7 @@ gcp_advanced_configurations_json:
         auto_delete: true
         initialize_params:
           disk_size_gb: 2000
-          source_image: projects/anyscale-bridge-cd812d38/global/images/anyscale-fast-ubuntu-ray-1677123186
+          source_image: projects/suse-sap-cloud/global/images/sles-12-sp5-sap-v20230116-x86-64
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -1,19 +1,18 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+#cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west1
 allowed_azs: 
     - us-west1-c
-
 gcp:
-	InstanceProperties:
-		- Disks:
-			- Boot: true
-				AutoDelete: true
-				InitializeParams:
-					- DiskSizeGb: 2000
-			- Boot: false
-				AutoDelete: true
-				InitializeParams:
-					- DiskSizeGb: 2000
+  InstanceProperties:
+    - Disks:
+    - Boot: true
+      AutoDelete: true
+      InitializeParams:
+        - DiskSizeGb: 2000
+    - Boot: false
+      AutoDelete: true
+      InitializeParams:
+        - DiskSizeGb: 2000
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -5,14 +5,14 @@ allowed_azs:
 gcp:
   InstanceProperties:
     - Disks:
-    - Boot: true
-      AutoDelete: true
-      InitializeParams:
-        - DiskSizeGb: 2000
-    - Boot: false
-      AutoDelete: true
-      InitializeParams:
-        - DiskSizeGb: 2000
+      - Boot: true
+        AutoDelete: true
+        InitializeParams:
+          - DiskSizeGb: 2000
+      - Boot: false
+        AutoDelete: true
+        InitializeParams:
+          - DiskSizeGb: 2000
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -1,4 +1,4 @@
-#cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west1
 allowed_azs: 
     - us-west1-c

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -8,6 +8,8 @@ gcp_advanced_configurations_json:
     disks:
       - boot: true
         auto_delete: true
+        initialize_params:
+          disk_size_gb: 200
       - boot: false
         auto_delete: true
         initialize_params:

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -7,10 +7,12 @@ gcp_advanced_configurations_json:
   instance_properties:
     disks:
       - boot: true
+        type: pd-standard
         auto_delete: true
         initialize_params:
           disk_size_gb: 2000
       - boot: false
+        type: pd-standard
         auto_delete: true
         initialize_params:
           disk_size_gb: 2000

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute_gce.yaml
@@ -2,17 +2,17 @@ cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west1
 allowed_azs: 
     - us-west1-c
+
 gcp:
-  InstanceProperties:
-    - Disks:
-      - Boot: true
-        AutoDelete: true
-        InitializeParams:
-          - DiskSizeGb: 2000
-      - Boot: false
-        AutoDelete: true
-        InitializeParams:
-          - DiskSizeGb: 2000
+  disks:
+    - boot: true
+      autoDelete: true
+      initializeParams:
+        diskSizeGb: 2000
+    - boot: false
+      autoDelete: true
+      initializeParams:
+        diskSizeGb: 2000
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances_gce.yaml
+++ b/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances_gce.yaml
@@ -1,0 +1,22 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 1000
+
+head_node_type:
+    name: head_node
+    instance_type: e2-standard-16 # aws m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: e2-standard-16 # aws m5.4xlarge
+      min_workers: 19
+      max_workers: 19
+      use_spot: false

--- a/release/nightly_tests/shuffle/shuffle_compute_autoscaling_gce.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_autoscaling_gce.yaml
@@ -1,0 +1,22 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 500
+
+head_node_type:
+    name: head_node
+    instance_type: n2-highmem-16 # i3.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-highmem-16 # i3.4xlarge
+      min_workers: 0
+      max_workers: 19
+      use_spot: false

--- a/release/nightly_tests/shuffle/shuffle_compute_multi_gce.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_multi_gce.yaml
@@ -1,0 +1,26 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 3
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 500
+
+head_node_type:
+    name: head_node
+    instance_type: n2-highmem-16 # i3.4xlarge
+    resources: {"object_store_memory": 21474836480}
+
+worker_node_types:
+    - name: worker_node2
+      instance_type: n2-highmem-16 # i3.4xlarge
+      min_workers: 3
+      max_workers: 3
+      use_spot: false
+      resources: {"object_store_memory": 21474836480}

--- a/release/nightly_tests/stress_tests/placement_group_tests_compute_gce.yaml
+++ b/release/nightly_tests/stress_tests/placement_group_tests_compute_gce.yaml
@@ -1,0 +1,31 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 5
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 500
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-64 # aws m4.16xlarge
+    resources:
+      cpu: 64
+
+worker_node_types:
+   - name: worker_node
+     instance_type: n2-standard-2 # aws m4.large
+     min_workers: 5
+     max_workers: 5
+     use_spot: false
+     resources:
+      cpu: 2 
+      custom_resources:
+        pg_custom: 666
+

--- a/release/ray_release/buildkite/concurrency.py
+++ b/release/ray_release/buildkite/concurrency.py
@@ -50,6 +50,7 @@ gcp_gpu_instances = {
     "n1-standard-16-nvidia-tesla-t4-1": (16, 1),
     "n1-standard-64-nvidia-tesla-t4-4": (64, 4),
     "n1-standard-32-nvidia-tesla-t4-2": (32, 2),
+    "n1-highmem-96-nvidia-tesla-v100-8": {96, 8},
 }
 
 

--- a/release/ray_release/buildkite/concurrency.py
+++ b/release/ray_release/buildkite/concurrency.py
@@ -78,6 +78,7 @@ def parse_condition(cond: int, limit: float = float("inf")) -> float:
 
 
 def get_concurrency_group(test: Test) -> Tuple[str, int]:
+    return "gce", 100
     try:
         test_cpus, test_gpus = get_test_resources(test)
     except Exception as e:

--- a/release/ray_release/buildkite/concurrency.py
+++ b/release/ray_release/buildkite/concurrency.py
@@ -18,8 +18,12 @@ Condition = namedtuple(
 
 aws_gpu_cpu_to_concurrency_groups = [
     Condition(min_gpu=9, max_gpu=-1, min_cpu=0, max_cpu=-1, group="large-gpu", limit=4),
-    Condition(min_gpu=1, max_gpu=9, min_cpu=0, max_cpu=-128, group="small-gpu", limit=8),
-    Condition(min_gpu=0, max_gpu=0, min_cpu=1025, max_cpu=-1, group="enormous", limit=1),
+    Condition(
+        min_gpu=1, max_gpu=9, min_cpu=0, max_cpu=-128, group="small-gpu", limit=8
+    ),
+    Condition(
+        min_gpu=0, max_gpu=0, min_cpu=1025, max_cpu=-1, group="enormous", limit=1
+    ),
     Condition(min_gpu=0, max_gpu=0, min_cpu=513, max_cpu=1024, group="large", limit=8),
     Condition(min_gpu=0, max_gpu=0, min_cpu=129, max_cpu=512, group="medium", limit=6),
     Condition(min_gpu=0, max_gpu=0, min_cpu=0, max_cpu=32, group="tiny", limit=32),
@@ -32,11 +36,19 @@ gce_gpu_cpu_to_concurrent_groups = [
     Condition(min_gpu=4, max_gpu=-1, min_cpu=0, max_cpu=-1, group="gpu-gce", limit=1),
     Condition(min_gpu=2, max_gpu=-1, min_cpu=0, max_cpu=-1, group="gpu-gce", limit=3),
     Condition(min_gpu=1, max_gpu=-1, min_cpu=0, max_cpu=-1, group="gpu-gce", limit=4),
-    Condition(min_gpu=0, max_gpu=0, min_cpu=1025, max_cpu=-1, group="enormous-gce", limit=1),
-    Condition(min_gpu=0, max_gpu=0, min_cpu=513, max_cpu=1024, group="large-gce", limit=8),
-    Condition(min_gpu=0, max_gpu=0, min_cpu=129, max_cpu=512, group="medium-gce", limit=6),
+    Condition(
+        min_gpu=0, max_gpu=0, min_cpu=1025, max_cpu=-1, group="enormous-gce", limit=1
+    ),
+    Condition(
+        min_gpu=0, max_gpu=0, min_cpu=513, max_cpu=1024, group="large-gce", limit=8
+    ),
+    Condition(
+        min_gpu=0, max_gpu=0, min_cpu=129, max_cpu=512, group="medium-gce", limit=6
+    ),
     Condition(min_gpu=0, max_gpu=0, min_cpu=0, max_cpu=32, group="tiny-gce", limit=32),
-    Condition(min_gpu=0, max_gpu=0, min_cpu=0, max_cpu=128, group="small-gce", limit=16),
+    Condition(
+        min_gpu=0, max_gpu=0, min_cpu=0, max_cpu=128, group="small-gce", limit=16
+    ),
 ]
 
 
@@ -84,10 +96,10 @@ def parse_condition(cond: int, limit: float = float("inf")) -> float:
 
 
 def get_concurrency_group(test: Test) -> Tuple[str, int]:
-    if get_cloud_environment() == 'gs':
-      concurrent_group = aws_gpu_cpu_to_concurrency_groups
+    if get_cloud_environment() == "gs":
+        concurrent_group = aws_gpu_cpu_to_concurrency_groups
     else:
-      concurrent_group = gce_gpu_cpu_to_concurrent_groups
+        concurrent_group = gce_gpu_cpu_to_concurrent_groups
     default_concurrent = concurrent_group[-1]
     try:
         test_cpus, test_gpus = get_test_resources(test)

--- a/release/ray_release/buildkite/concurrency.py
+++ b/release/ray_release/buildkite/concurrency.py
@@ -6,35 +6,37 @@ from typing import Tuple, Optional, Dict
 from ray_release.config import Test, RELEASE_PACKAGE_DIR
 from ray_release.template import load_test_cluster_compute
 from ray_release.logger import logger
+from ray_release.util import get_cloud_environment
 
 # Keep 10% for the buffer.
 limit = int(15784 * 0.9)
 
 
-CONCURRENY_GROUPS = {
-    "tiny": 32,  # <= 1k vCPU
-    "small": 16,  # <= 2k vCPU
-    "medium": 6,  # <= 3k vCPU
-    "large": 8,  # <= 8k vCPU
-    "enormous": 1,  # <= 4k vCPU (?)
-    "small-gpu": 8,
-    "large-gpu": 4,
-}
-
-
 Condition = namedtuple(
-    "Condition", ["min_gpu", "max_gpu", "min_cpu", "max_cpu", "group"]
+    "Condition", ["min_gpu", "max_gpu", "min_cpu", "max_cpu", "group", "limit"]
 )
 
-gpu_cpu_to_concurrency_groups = [
-    Condition(min_gpu=9, max_gpu=-1, min_cpu=0, max_cpu=-1, group="large-gpu"),
-    Condition(min_gpu=1, max_gpu=9, min_cpu=0, max_cpu=-128, group="small-gpu"),
-    Condition(min_gpu=0, max_gpu=0, min_cpu=1025, max_cpu=-1, group="enormous"),
-    Condition(min_gpu=0, max_gpu=0, min_cpu=513, max_cpu=1024, group="large"),
-    Condition(min_gpu=0, max_gpu=0, min_cpu=129, max_cpu=512, group="medium"),
-    Condition(min_gpu=0, max_gpu=0, min_cpu=0, max_cpu=32, group="tiny"),
+aws_gpu_cpu_to_concurrency_groups = [
+    Condition(min_gpu=9, max_gpu=-1, min_cpu=0, max_cpu=-1, group="large-gpu", limit=4),
+    Condition(min_gpu=1, max_gpu=9, min_cpu=0, max_cpu=-128, group="small-gpu", limit=8),
+    Condition(min_gpu=0, max_gpu=0, min_cpu=1025, max_cpu=-1, group="enormous", limit=1),
+    Condition(min_gpu=0, max_gpu=0, min_cpu=513, max_cpu=1024, group="large", limit=8),
+    Condition(min_gpu=0, max_gpu=0, min_cpu=129, max_cpu=512, group="medium", limit=6),
+    Condition(min_gpu=0, max_gpu=0, min_cpu=0, max_cpu=32, group="tiny", limit=32),
     # Make sure "small" is the last in the list, because it is the fallback.
-    Condition(min_gpu=0, max_gpu=0, min_cpu=0, max_cpu=128, group="small"),
+    Condition(min_gpu=0, max_gpu=0, min_cpu=0, max_cpu=128, group="small", limit=16),
+]
+
+gce_gpu_cpu_to_concurrent_groups = [
+    Condition(min_gpu=8, max_gpu=-1, min_cpu=0, max_cpu=-1, group="gpu-gce", limit=1),
+    Condition(min_gpu=4, max_gpu=-1, min_cpu=0, max_cpu=-1, group="gpu-gce", limit=1),
+    Condition(min_gpu=2, max_gpu=-1, min_cpu=0, max_cpu=-1, group="gpu-gce", limit=3),
+    Condition(min_gpu=1, max_gpu=-1, min_cpu=0, max_cpu=-1, group="gpu-gce", limit=4),
+    Condition(min_gpu=0, max_gpu=0, min_cpu=1025, max_cpu=-1, group="enormous-gce", limit=1),
+    Condition(min_gpu=0, max_gpu=0, min_cpu=513, max_cpu=1024, group="large-gce", limit=8),
+    Condition(min_gpu=0, max_gpu=0, min_cpu=129, max_cpu=512, group="medium-gce", limit=6),
+    Condition(min_gpu=0, max_gpu=0, min_cpu=0, max_cpu=32, group="tiny-gce", limit=32),
+    Condition(min_gpu=0, max_gpu=0, min_cpu=0, max_cpu=128, group="small-gce", limit=16),
 ]
 
 
@@ -45,6 +47,9 @@ gcp_gpu_instances = {
     "a2-highgpu-4g": (48, 4),
     "a2-highgpu-8g": (96, 8),
     "a2-megagpu-16g": (96, 16),
+    "n1-standard-16-nvidia-tesla-t4-1": (16, 1),
+    "n1-standard-64-nvidia-tesla-t4-4": (64, 4),
+    "n1-standard-32-nvidia-tesla-t4-2": (32, 2),
 }
 
 
@@ -78,29 +83,32 @@ def parse_condition(cond: int, limit: float = float("inf")) -> float:
 
 
 def get_concurrency_group(test: Test) -> Tuple[str, int]:
-    return "gce", 100
+    if get_cloud_environment() == 'gs':
+      concurrent_group = aws_gpu_cpu_to_concurrency_groups
+    else:
+      concurrent_group = gce_gpu_cpu_to_concurrent_groups
+    default_concurrent = concurrent_group[-1]
     try:
         test_cpus, test_gpus = get_test_resources(test)
     except Exception as e:
         logger.warning(f"Couldn't get test resources for test {test['name']}: {e}")
-        return "small", CONCURRENY_GROUPS["small"]
+        return default_concurrent.group, default_concurrent.limit
 
-    for condition in gpu_cpu_to_concurrency_groups:
+    for condition in concurrent_group:
         min_gpu = parse_condition(condition.min_gpu, float("-inf"))
         max_gpu = parse_condition(condition.max_gpu, float("inf"))
         min_cpu = parse_condition(condition.min_cpu, float("-inf"))
         max_cpu = parse_condition(condition.max_cpu, float("inf"))
 
         if min_cpu <= test_cpus <= max_cpu and min_gpu <= test_gpus <= max_gpu:
-            group = condition.group
-            return group, CONCURRENY_GROUPS[group]
+            return condition.group, condition.limit
 
     # Return default
     logger.warning(
         f"Could not find concurrency group for test {test['name']} "
         f"based on used resources."
     )
-    return "small", CONCURRENY_GROUPS["small"]
+    return default_concurrent.group, default_concurrent.limit
 
 
 def get_test_resources(test: Test) -> Tuple[int, int]:

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -41,7 +41,6 @@ DEFAULT_STEP_TEMPLATE: Dict[str, Any] = {
                 "image": "rayproject/ray",
                 "propagate-environment": True,
                 "volumes": [
-                    "/dev/disk/by-id:/dev/disk/by-id",
                     "/var/lib/buildkite/builds:/var/lib/buildkite/builds",
                     "/usr/local/bin/buildkite-agent:/usr/local/bin/buildkite-agent",
                     f"{DEFAULT_ARTIFACTS_DIR_HOST}:{DEFAULT_ARTIFACTS_DIR_HOST}",

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -3,7 +3,7 @@ import os
 from typing import Any, Dict, Optional
 
 from ray_release.aws import RELEASE_AWS_BUCKET
-from ray_release.buildkite.concurrency import CONCURRENY_GROUPS, get_concurrency_group
+from ray_release.buildkite.concurrency import get_concurrency_group
 from ray_release.config import (
     DEFAULT_ANYSCALE_PROJECT,
     DEFAULT_CLOUD_ID,
@@ -98,19 +98,11 @@ def get_step(
     branch = get_test_env_var("RAY_BRANCH")
     label = commit[:7] if commit else branch
 
-    concurrency_group = test.get("concurrency_group", None)
-    if concurrency_group:
-        if concurrency_group not in CONCURRENY_GROUPS:
-            raise ReleaseTestConfigError(
-                f"Unknown concurrency group: {concurrency_group}"
-            )
-        concurrency_limit = CONCURRENY_GROUPS[concurrency_group]
+    if smoke_test:
+      concurrency_test = as_smoke_test(test)
     else:
-        if smoke_test:
-            concurrency_test = as_smoke_test(test)
-        else:
-            concurrency_test = test
-        concurrency_group, concurrency_limit = get_concurrency_group(concurrency_test)
+      concurrency_test = test
+    concurrency_group, concurrency_limit = get_concurrency_group(concurrency_test)
 
     step["concurrency_group"] = concurrency_group
     step["concurrency"] = concurrency_limit

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -13,7 +13,6 @@ from ray_release.config import (
     parse_python_version,
 )
 from ray_release.env import DEFAULT_ENVIRONMENT, load_environment
-from ray_release.exception import ReleaseTestConfigError
 from ray_release.template import get_test_env_var
 from ray_release.util import python_version_str, DeferredEnvVar
 
@@ -99,9 +98,9 @@ def get_step(
     label = commit[:7] if commit else branch
 
     if smoke_test:
-      concurrency_test = as_smoke_test(test)
+        concurrency_test = as_smoke_test(test)
     else:
-      concurrency_test = test
+        concurrency_test = test
     concurrency_group, concurrency_limit = get_concurrency_group(concurrency_test)
 
     step["concurrency_group"] = concurrency_group

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -41,6 +41,7 @@ DEFAULT_STEP_TEMPLATE: Dict[str, Any] = {
                 "image": "rayproject/ray",
                 "propagate-environment": True,
                 "volumes": [
+                    "/dev/disk/by-id:/dev/disk/by-id",
                     "/var/lib/buildkite/builds:/var/lib/buildkite/builds",
                     "/usr/local/bin/buildkite-agent:/usr/local/bin/buildkite-agent",
                     f"{DEFAULT_ARTIFACTS_DIR_HOST}:{DEFAULT_ARTIFACTS_DIR_HOST}",

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -35,7 +35,7 @@ DEFAULT_CLUSTER_TIMEOUT = 1800
 DEFAULT_AUTOSUSPEND_MINS = 120
 DEFAULT_MAXIMUM_UPTIME_MINS = 3200
 DEFAULT_WAIT_FOR_NODES_TIMEOUT = 3000
-DEFAULT_ALLOWED_TEST_VARIATION = 'aws'
+DEFAULT_ALLOWED_TEST_VARIATION = "aws"
 
 DEFAULT_CLOUD_ID = DeferredEnvVar(
     "RELEASE_DEFAULT_CLOUD_ID",
@@ -92,7 +92,7 @@ def parse_test_definition(test_definitions: List[TestDefinition]) -> List[Test]:
             "variations field cannot be empty in a test definition",
         )
         allowed_variation = os.environ.get(
-            "ANYSCALE_ALLOWED_TEST_VARIATION", 
+            "ANYSCALE_ALLOWED_TEST_VARIATION",
             DEFAULT_ALLOWED_TEST_VARIATION,
         )
         for variation in variations:
@@ -101,7 +101,7 @@ def parse_test_definition(test_definitions: List[TestDefinition]) -> List[Test]:
                 "__suffix__" in variation,
                 "missing __suffix__ field in a variation",
             )
-            if variation['__suffix__'] != allowed_variation:
+            if variation["__suffix__"] != allowed_variation:
                 continue
             test = copy.deepcopy(test_definition)
             test["name"] = f'{test["name"]}.{variation.pop("__suffix__")}'

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -35,6 +35,7 @@ DEFAULT_CLUSTER_TIMEOUT = 1800
 DEFAULT_AUTOSUSPEND_MINS = 120
 DEFAULT_MAXIMUM_UPTIME_MINS = 3200
 DEFAULT_WAIT_FOR_NODES_TIMEOUT = 3000
+DEFAULT_ALLOWED_TEST_VARIATION = 'aws'
 
 DEFAULT_CLOUD_ID = DeferredEnvVar(
     "RELEASE_DEFAULT_CLOUD_ID",
@@ -90,12 +91,18 @@ def parse_test_definition(test_definitions: List[TestDefinition]) -> List[Test]:
             variations,
             "variations field cannot be empty in a test definition",
         )
+        allowed_variation = os.environ.get(
+            "ANYSCALE_ALLOWED_TEST_VARIATION", 
+            DEFAULT_ALLOWED_TEST_VARIATION,
+        )
         for variation in variations:
             _test_definition_invariant(
                 test_definition,
                 "__suffix__" in variation,
                 "missing __suffix__ field in a variation",
             )
+            if variation['__suffix__'] != allowed_variation:
+                continue
             test = copy.deepcopy(test_definition)
             test["name"] = f'{test["name"]}.{variation.pop("__suffix__")}'
             test.update(variation)

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -286,8 +286,8 @@ class AnyscaleJobManager:
         ret = exponential_backoff_retry(
             _get_logs,
             retry_exceptions=Exception,
-            initial_retry_delay_s=30,
-            max_retries=5,
+            initial_retry_delay_s=10,
+            max_retries=3,
         )
         if ret and not self.in_progress:
             self._last_logs = ret

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -287,7 +287,7 @@ class AnyscaleJobManager:
             _get_logs,
             retry_exceptions=Exception,
             initial_retry_delay_s=30,
-            max_retries=3,
+            max_retries=5,
         )
         if ret and not self.in_progress:
             self._last_logs = ret

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -286,7 +286,7 @@ class AnyscaleJobManager:
         ret = exponential_backoff_retry(
             _get_logs,
             retry_exceptions=Exception,
-            initial_retry_delay_s=10,
+            initial_retry_delay_s=30,
             max_retries=3,
         )
         if ret and not self.in_progress:

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -10,7 +10,6 @@ import yaml
 from ray_release.buildkite.concurrency import (
     get_test_resources_from_cluster_compute,
     get_concurrency_group,
-    CONCURRENY_GROUPS,
 )
 from ray_release.buildkite.filter import filter_tests, group_tests
 from ray_release.buildkite.settings import (
@@ -614,9 +613,8 @@ class BuildkiteSettingsTest(unittest.TestCase):
                 "ray_release.buildkite.concurrency.get_test_resources",
                 _return((cpu, gpu)),
             ):
-                group_name, limit = get_concurrency_group(test)
+                group_name, _ = get_concurrency_group(test)
                 self.assertEqual(group_name, group)
-                self.assertEqual(limit, CONCURRENY_GROUPS[group_name])
 
         test_concurrency(12800, 9, "large-gpu")
         test_concurrency(12800, 8, "small-gpu")

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import yaml
+import copy
 import pytest
 
 from ray_release.config import (
@@ -70,10 +71,16 @@ def test_definition_parser():
     assert not validate_test(gce_test, schema)
     assert aws_test["name"] == "sample_test.aws"
     assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
+    invalid_test_definition = test_definitions[0]
+    invalid_test_definition['variations'] = []
     with pytest.raises(ReleaseTestConfigError):
-        test_definitions[0]['variations'] = []
-        parse_test_definition(test_definitions)
-
+        parse_test_definition([invalid_test_definition])
+    invalid_test_definition['variations'] = [
+        {'__suffix__': 'aws'},
+        {}
+    ]
+    with pytest.raises(ReleaseTestConfigError):
+        parse_test_definition([invalid_test_definition])
 
 def test_parse_test_definition():
     """

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -74,7 +74,7 @@ def test_parse_test_definition():
     # Check that parsing returns one test for aws variation. Check
     # that the test is valid and the field is populdated correctly
     with mock.patch.dict(os.environ, {"ANYSCALE_ALLOWED_TEST_VARIATION": "aws"}):
-      tests = parse_test_definition(copy.deepcopy(test_definitions))
+        tests = parse_test_definition(copy.deepcopy(test_definitions))
     test = tests[0]
     schema = load_schema_file()
     assert len(tests) == 1
@@ -84,7 +84,7 @@ def test_parse_test_definition():
     # Check that parsing returns one test for gce variation. Check
     # that the test is valid and the field is populdated correctly
     with mock.patch.dict(os.environ, {"ANYSCALE_ALLOWED_TEST_VARIATION": "gce"}):
-      tests = parse_test_definition(copy.deepcopy(test_definitions))
+        tests = parse_test_definition(copy.deepcopy(test_definitions))
     test = tests[0]
     schema = load_schema_file()
     assert len(tests) == 1

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import yaml
-import copy
 import pytest
 
 from ray_release.config import (
@@ -44,7 +43,12 @@ VALID_TEST = Test(
     }
 )
 
-def test_definition_parser():
+"""
+Unit test for the ray_release.config.parse_test_definition function. In particular,
+we check that the code correctly parse a test definition that have the 'variations' 
+field.
+"""
+def test_parse_test_definition():
     test_definitions = yaml.safe_load('''
         - name: sample_test
           working_dir: sample_dir
@@ -63,6 +67,8 @@ def test_definition_parser():
                 cluster_env: env_gce.yaml
                 cluster_compute: compute_gce.yaml
     ''')
+    # Check that parsing returns two tests, one for each variation (aws and gce). Check
+    # that both tests are valid, and their fields are populated correctly
     tests = parse_test_definition(test_definitions)
     aws_test = tests[0]
     gce_test = tests[1]
@@ -72,9 +78,13 @@ def test_definition_parser():
     assert aws_test["name"] == "sample_test.aws"
     assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
     invalid_test_definition = test_definitions[0]
+    # Intentionally make the test definition invalid by create an empty 'variations'
+    # field. Check that the parser throws exception at runtime
     invalid_test_definition['variations'] = []
     with pytest.raises(ReleaseTestConfigError):
         parse_test_definition([invalid_test_definition])
+    # Intentionally make the test definition invalid by making one 'variation' entry
+    # missing the __suffix__ entry. Check that the parser throws exception at runtime
     invalid_test_definition['variations'] = [
         {'__suffix__': 'aws'},
         {}

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -6,6 +6,7 @@ import pytest
 from ray_release.config import (
     read_and_validate_release_test_collection,
     Test,
+    TestDefinition,
     validate_cluster_compute,
     load_schema_file,
     parse_test_definition,
@@ -41,6 +42,37 @@ VALID_TEST = Test(
         "alert": "default",
     }
 )
+
+def test_definition_parser():
+    test_definitions = yaml.safe_load('''
+        - name: sample_test
+          working_dir: sample_dir
+          frequency: nightly
+          team: sample
+          cluster:
+            cluster_env: env.yaml
+            cluster_compute: compute.yaml
+          run:
+            timeout: 100
+            script: python script.py
+          variations:
+            - __suffix__: aws
+            - __suffix__: gce
+              cluster:
+                cluster_env: env_gce.yaml
+                cluster_compute: compute_gce.yaml
+    ''')
+    tests = parse_test_definition(test_definitions)
+    aws_test = tests[0]
+    gce_test = tests[1]
+    schema = load_schema_file()
+    assert not validate_test(aws_test, schema)
+    assert not validate_test(gce_test, schema)
+    assert aws_test["name"] == "sample_test.aws"
+    assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
+    with pytest.raises(ReleaseTestConfigError):
+        test_definitions[0]['variations'] = []
+        parse_test_definition(test_definitions)
 
 
 def test_parse_test_definition():

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -6,7 +6,6 @@ import pytest
 from ray_release.config import (
     read_and_validate_release_test_collection,
     Test,
-    TestDefinition,
     validate_cluster_compute,
     load_schema_file,
     parse_test_definition,
@@ -43,102 +42,6 @@ VALID_TEST = Test(
     }
 )
 
-"""
-Unit test for the ray_release.config.parse_test_definition function. In particular,
-we check that the code correctly parse a test definition that have the 'variations' 
-field.
-"""
-def test_parse_test_definition():
-    test_definitions = yaml.safe_load('''
-        - name: sample_test
-          working_dir: sample_dir
-          frequency: nightly
-          team: sample
-          cluster:
-            cluster_env: env.yaml
-            cluster_compute: compute.yaml
-          run:
-            timeout: 100
-            script: python script.py
-          variations:
-            - __suffix__: aws
-            - __suffix__: gce
-              cluster:
-                cluster_env: env_gce.yaml
-                cluster_compute: compute_gce.yaml
-    ''')
-    # Check that parsing returns two tests, one for each variation (aws and gce). Check
-    # that both tests are valid, and their fields are populated correctly
-    tests = parse_test_definition(test_definitions)
-    aws_test = tests[0]
-    gce_test = tests[1]
-    schema = load_schema_file()
-    assert not validate_test(aws_test, schema)
-    assert not validate_test(gce_test, schema)
-    assert aws_test["name"] == "sample_test.aws"
-    assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
-    invalid_test_definition = test_definitions[0]
-    # Intentionally make the test definition invalid by create an empty 'variations'
-    # field. Check that the parser throws exception at runtime
-    invalid_test_definition['variations'] = []
-    with pytest.raises(ReleaseTestConfigError):
-        parse_test_definition([invalid_test_definition])
-    # Intentionally make the test definition invalid by making one 'variation' entry
-    # missing the __suffix__ entry. Check that the parser throws exception at runtime
-    invalid_test_definition['variations'] = [
-        {'__suffix__': 'aws'},
-        {}
-    ]
-    with pytest.raises(ReleaseTestConfigError):
-        parse_test_definition([invalid_test_definition])
-
-def test_parse_test_definition():
-    """
-    Unit test for the ray_release.config.parse_test_definition function. In particular,
-    we check that the code correctly parse a test definition that have the 'variations'
-    field.
-    """
-    test_definitions = yaml.safe_load(
-        """
-        - name: sample_test
-          working_dir: sample_dir
-          frequency: nightly
-          team: sample
-          cluster:
-            cluster_env: env.yaml
-            cluster_compute: compute.yaml
-          run:
-            timeout: 100
-            script: python script.py
-          variations:
-            - __suffix__: aws
-            - __suffix__: gce
-              cluster:
-                cluster_env: env_gce.yaml
-                cluster_compute: compute_gce.yaml
-    """
-    )
-    # Check that parsing returns two tests, one for each variation (aws and gce). Check
-    # that both tests are valid, and their fields are populated correctly
-    tests = parse_test_definition(test_definitions)
-    aws_test = tests[0]
-    gce_test = tests[1]
-    schema = load_schema_file()
-    assert not validate_test(aws_test, schema)
-    assert not validate_test(gce_test, schema)
-    assert aws_test["name"] == "sample_test.aws"
-    assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
-    invalid_test_definition = test_definitions[0]
-    # Intentionally make the test definition invalid by create an empty 'variations'
-    # field. Check that the parser throws exception at runtime
-    invalid_test_definition["variations"] = []
-    with pytest.raises(ReleaseTestConfigError):
-        parse_test_definition([invalid_test_definition])
-    # Intentionally make the test definition invalid by making one 'variation' entry
-    # missing the __suffix__ entry. Check that the parser throws exception at runtime
-    invalid_test_definition["variations"] = [{"__suffix__": "aws"}, {}]
-    with pytest.raises(ReleaseTestConfigError):
-        parse_test_definition([invalid_test_definition])
 
 def test_parse_test_definition():
     """

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import yaml
+from unittest import mock
+import copy
 import pytest
 
 from ray_release.config import (
@@ -69,19 +71,29 @@ def test_parse_test_definition():
                 cluster_compute: compute_gce.yaml
     """
     )
-    # Check that parsing returns two tests, one for each variation (aws and gce). Check
-    # that both tests are valid, and their fields are populated correctly
-    tests = parse_test_definition(test_definitions)
-    aws_test = tests[0]
-    gce_test = tests[1]
+    # Check that parsing returns one test for aws variation. Check
+    # that the test is valid and the field is populdated correctly
+    with mock.patch.dict(os.environ, {"ANYSCALE_ALLOWED_TEST_VARIATION": "aws"}):
+      tests = parse_test_definition(copy.deepcopy(test_definitions))
+    test = tests[0]
     schema = load_schema_file()
-    assert not validate_test(aws_test, schema)
-    assert not validate_test(gce_test, schema)
-    assert aws_test["name"] == "sample_test.aws"
-    assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
-    invalid_test_definition = test_definitions[0]
+    assert len(tests) == 1
+    assert not validate_test(test, schema)
+    assert test["name"] == "sample_test.aws"
+    assert test["cluster"]["cluster_compute"] == "compute.yaml"
+    # Check that parsing returns one test for gce variation. Check
+    # that the test is valid and the field is populdated correctly
+    with mock.patch.dict(os.environ, {"ANYSCALE_ALLOWED_TEST_VARIATION": "gce"}):
+      tests = parse_test_definition(copy.deepcopy(test_definitions))
+    test = tests[0]
+    schema = load_schema_file()
+    assert len(tests) == 1
+    assert not validate_test(test, schema)
+    assert test["name"] == "sample_test.gce"
+    assert test["cluster"]["cluster_compute"] == "compute_gce.yaml"
     # Intentionally make the test definition invalid by create an empty 'variations'
     # field. Check that the parser throws exception at runtime
+    invalid_test_definition = test_definitions[0]
     invalid_test_definition["variations"] = []
     with pytest.raises(ReleaseTestConfigError):
         parse_test_definition([invalid_test_definition])

--- a/release/ray_release/util.py
+++ b/release/ray_release/util.py
@@ -26,10 +26,10 @@ class DeferredEnvVar:
 
 ANYSCALE_HOST = DeferredEnvVar("ANYSCALE_HOST", "https://console.anyscale.com")
 
+
 def get_cloud_environment() -> str:
-  return os.environ.get(
-    "ANYSCALE_CLOUD_STORAGE_PROVIDER", "s3"
-  )
+    return os.environ.get("ANYSCALE_CLOUD_STORAGE_PROVIDER", "s3")
+
 
 def deep_update(d, u) -> Dict:
     for k, v in u.items():

--- a/release/ray_release/util.py
+++ b/release/ray_release/util.py
@@ -26,6 +26,10 @@ class DeferredEnvVar:
 
 ANYSCALE_HOST = DeferredEnvVar("ANYSCALE_HOST", "https://console.anyscale.com")
 
+def get_cloud_environment() -> str:
+  return os.environ.get(
+    "ANYSCALE_CLOUD_STORAGE_PROVIDER", "s3"
+  )
 
 def deep_update(d, u) -> Dict:
     for k, v in u.items():

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -563,6 +563,15 @@
     timeout: 3600
     script: bash file_size_benchmark.sh
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      stable: false
+      cluster:
+        cluster_env: app_config_oom.yaml
+        cluster_compute: compute_gce_cpu_16.yaml
+
 # Test dataset larger than object store memory.
 - name: ray-data-bulk-ingest-out-of-core-benchmark
   group: AIR tests
@@ -579,6 +588,15 @@
   run:
     timeout: 3600
     script: bash out_of_core_benchmark.sh
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      stable: false
+      cluster:
+        cluster_env: app_config_oom.yaml
+        cluster_compute: compute_gce_cpu_16.yaml
 
 # Test additional CPU nodes for preprocessing.
 - name: ray-data-bulk-ingest-heterogeneity-benchmark
@@ -599,6 +617,15 @@
 
     timeout: 1800
     script: bash heterogeneity_benchmark.sh 2
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      stable: false
+      cluster:
+        cluster_env: app_config_oom.yaml
+        cluster_compute: compute_gce_cpu_16_worker_nodes_2.yam
 
 
 #######################
@@ -4162,6 +4189,15 @@
     wait_for_nodes:
       num_nodes: 20
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      stable: false
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: data_ingest_benchmark_compute_gce.yaml
+
 - name: streaming_data_ingest_benchmark_1tb
   group: data-tests
   working_dir: nightly_tests/dataset
@@ -4441,6 +4477,7 @@
     - __suffix__: aws
     - __suffix__: gce
       env: gce
+      stable: false
       cluster:
         cluster_env: shuffle/100tb_shuffle_app_config.yaml
         cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4488,14 +4488,14 @@
     wait_for_nodes:
       num_nodes: 100
 
-#  variations:
-#    - __suffix__: aws
-#    - __suffix__: gce
-#      env: gce
-#      stable: false
-#      cluster:
-#        cluster_env: shuffle/100tb_shuffle_app_config_gce.yaml
-#        cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      stable: false
+      cluster:
+        cluster_env: shuffle/100tb_shuffle_app_config_gce.yaml
+        cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
 
 ##################
 # Core Chaos tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4413,14 +4413,6 @@
     wait_for_nodes:
       num_nodes: 100
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: shuffle/100tb_shuffle_app_config.yaml
-        cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
-
 ##################
 # Core Chaos tests
 ##################

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3182,7 +3182,6 @@
     timeout: 18000
     script: python learning_tests/run.py --yaml-sub-dir=ppo/torch --framework=torch
 
-
   alert: default
 
 - name: rllib_learning_tests_sac_tf

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4496,6 +4496,11 @@
       cluster:
         cluster_env: shuffle/100tb_shuffle_app_config_gce.yaml
         cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
+      run:
+        timeout: 28800
+        script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=50000 --partition-size=1e9 --shuffle
+        wait_for_nodes:
+          num_nodes: 100
 
 ##################
 # Core Chaos tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1570,7 +1570,7 @@
 
   variations:
     - __suffix__: aws
-    - name: smoke-test
+    - __suffix__: smoke-test
       frequency: nightly
       cluster:
         cluster_env: app_config.yaml

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3283,14 +3283,6 @@
 
   alert: default
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: 8gpus_96cpus_gce.yaml 
-
 - name: rllib_multi_gpu_with_lstm_learning_tests
   group: RLlib tests
   working_dir: rllib_tests
@@ -3309,14 +3301,6 @@
 
   alert: default
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: 8gpus_96cpus_gce.yaml 
-
 - name: rllib_multi_gpu_with_attention_learning_tests
   group: RLlib tests
   working_dir: rllib_tests
@@ -3334,14 +3318,6 @@
 
 
   alert: default
-
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: 8gpus_96cpus_gce.yaml 
 
 - name: rllib_stress_tests
   group: RLlib tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -284,6 +284,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_gce_gpu_1_g4_8xl.yaml
+
 
 - name: air_benchmark_torch_batch_prediction_gpu_4x4_100gb
   group: AIR tests
@@ -306,6 +314,15 @@
         num_nodes: 4
 
   alert: default
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_gce_gpu_4_g4_12xl.yaml
+
 
 
 - name: air_benchmark_torch_mnist_cpu_4x4
@@ -492,6 +509,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_gce_gpu_1.yaml
+
 
 - name: air_benchmark_pytorch_training_e2e_gpu_4x4_100gb
   group: AIR tests
@@ -513,8 +538,15 @@
     wait_for_nodes:
       num_nodes: 4
 
-
   alert: default
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_gce_gpu_16.yaml
 
 # Test tiny, medium, and huge input files.
 - name: ray-data-bulk-ingest-file-size-benchmark
@@ -1474,6 +1506,14 @@
 
   alert: tune_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_gce_1x16.yaml
+
 - name: tune_scalability_durable_trainable
   group: Tune scalability tests
   working_dir: tune_tests/scalability_tests
@@ -1518,6 +1558,14 @@
 
   alert: tune_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_gce_1x32_hd.yaml
+
 - name: tune_scalability_network_overhead
   group: Tune scalability tests
   working_dir: tune_tests/scalability_tests
@@ -1536,19 +1584,26 @@
     wait_for_nodes:
       num_nodes: 100
 
-  smoke_test:
-    frequency: nightly
-
-    cluster:
-      cluster_compute: tpl_20x2.yaml
-
-    run:
-      timeout: 500
-      prepare_timeout: 600
-      wait_for_nodes:
-        num_nodes: 20
-
   alert: tune_tests
+
+  variations:
+    - __suffix__: aws
+    - name: smoke-test
+      frequency: nightly
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_20x2.yaml
+      run:
+        timeout: 500
+        prepare_timeout: 600
+        script: python workloads/test_network_overhead.py
+        wait_for_nodes:
+          num_nodes: 20
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_gce_100x2.yaml
 
 - name: tune_scalability_result_throughput_cluster
   group: Tune scalability tests
@@ -1570,6 +1625,14 @@
 
   alert: tune_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_gce_16x64.yaml
+
 - name: tune_scalability_result_throughput_single_node
   group: Tune scalability tests
   working_dir: tune_tests/scalability_tests
@@ -1586,6 +1649,18 @@
     script: python workloads/test_result_throughput_single_node.py
 
   alert: tune_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_gce_1x96.yaml
+      run:
+        timeout: 600
+        script: python workloads/test_result_throughput_single_node.py
+        type: anyscale_job
 
 - name: tune_scalability_xgboost_sweep
   group: Tune scalability tests
@@ -1607,6 +1682,14 @@
 
 
   alert: tune_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config_data.yaml
+        cluster_compute: tpl_gce_16x64.yaml
 
 
 ############################
@@ -1682,6 +1765,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
+
 - name: long_running_apex
   group: Long running tests
   working_dir: long_running_tests
@@ -1708,6 +1799,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: ../rllib_tests/app_config.yaml
+        cluster_compute: tpl_cpu_3_gce.yaml
+
 - name: long_running_impala
   group: Long running tests
   working_dir: long_running_tests
@@ -1730,6 +1829,14 @@
       timeout: 3600
 
   alert: long_running_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: ../rllib_tests/app_config.yaml
+        cluster_compute: tpl_cpu_1_large_gce.yaml
 
 - name: long_running_many_actor_tasks
   group: Long running tests
@@ -1754,6 +1861,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
+
 - name: long_running_many_drivers
   group: Long running tests
   working_dir: long_running_tests
@@ -1776,6 +1891,14 @@
       timeout: 3600
 
   alert: long_running_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_many_ppo
   group: Long running tests
@@ -1805,6 +1928,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: ../rllib_tests/app_config.yaml
+        cluster_compute: many_ppo_gce.yaml
+
 - name: long_running_many_tasks
   group: Long running tests
   working_dir: long_running_tests
@@ -1827,6 +1958,14 @@
       timeout: 3600
 
   alert: long_running_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_many_tasks_serialized_ids
   group: Long running tests
@@ -1851,6 +1990,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
+
 - name: long_running_node_failures
   group: Long running tests
   working_dir: long_running_tests
@@ -1873,6 +2020,14 @@
       timeout: 3600
 
   alert: long_running_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_pbt
   group: Long running tests
@@ -1897,6 +2052,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: ../rllib_tests/app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
+
 - name: long_running_serve
   group: Long running tests
   working_dir: long_running_tests
@@ -1919,6 +2082,14 @@
       timeout: 3600
 
   alert: long_running_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_serve_failure
   group: Long running tests
@@ -1948,6 +2119,19 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_c5_gce.yaml
+      run:
+        timeout: 86400
+        script: python workloads/serve_failure.py
+        long_running: true
+        type: anyscale_job
+
 - name: long_running_many_jobs
   group: Long running tests
   working_dir: long_running_tests
@@ -1973,6 +2157,14 @@
 
   alert: long_running_tests
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_cpu_1_gce.yaml
+
 - name: long_running_distributed_pytorch_pbt_failure
   group: Long running tests
   working_dir: long_running_distributed_tests
@@ -1994,6 +2186,14 @@
       timeout: 3600
 
   alert: long_running_tests
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_tpl_gce.yaml
 
 ########################
 # Jobs tests
@@ -2019,6 +2219,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_tpl_gce_4_xlarge.yaml
+
 - name: jobs_basic_remote_working_dir
   group: Jobs tests
   working_dir: jobs_tests
@@ -2039,6 +2247,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_tpl_gce_4_xlarge.yaml
+
 - name: jobs_remote_multi_node
   group: Jobs tests
   team: serve
@@ -2052,6 +2268,14 @@
     script: python workloads/jobs_remote_multi_node.py
     wait_for_nodes:
       num_nodes: 4
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_tpl_gce_4_xlarge.yaml
 
 - name: jobs_check_cuda_available
   group: Jobs tests
@@ -2067,6 +2291,14 @@
     wait_for_nodes:
       num_nodes: 2
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_tpl_gce_gpu_node.yaml
+
 - name: jobs_specify_num_gpus
   group: Jobs tests
   team: serve
@@ -2081,6 +2313,13 @@
     wait_for_nodes:
       num_nodes: 2
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_tpl_gce_gpu_worker.yaml
 
 ########################
 # Runtime env tests
@@ -2105,6 +2344,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: rte_gce_small.yaml
+
 - name: runtime_env_wheel_urls
   group: Runtime env tests
   working_dir: runtime_env_tests
@@ -2124,6 +2371,14 @@
 
 
   alert: default
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: rte_gce_minimal.yaml
 
 # It seems like the consensus is that this should be tested in CI, and not in a nightly test.
 
@@ -3046,6 +3301,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: 8gpus_96cpus_gce.yaml 
+
 - name: rllib_multi_gpu_with_lstm_learning_tests
   group: RLlib tests
   working_dir: rllib_tests
@@ -3064,6 +3327,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: 8gpus_96cpus_gce.yaml 
+
 - name: rllib_multi_gpu_with_attention_learning_tests
   group: RLlib tests
   working_dir: rllib_tests
@@ -3081,6 +3352,14 @@
 
 
   alert: default
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: 8gpus_96cpus_gce.yaml 
 
 - name: rllib_stress_tests
   group: RLlib tests
@@ -3110,6 +3389,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: 4gpus_544_cpus_gce.yaml 
+
 ########################
 # Core Nightly Tests
 ########################
@@ -3130,6 +3417,14 @@
     wait_for_nodes:
       num_nodes: 4
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: shuffle/shuffle_app_config.yaml
+        cluster_compute: shuffle/shuffle_compute_multi_gce.yaml
+
 
 - name: stress_test_placement_group
   group: core-multi-test
@@ -3145,6 +3440,14 @@
     timeout: 7200
     script: python stress_tests/test_placement_group.py
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: stress_tests/stress_tests_app_config.yaml
+        cluster_compute: stress_tests/placement_group_tests_compute_gce.yaml
+
 - name: decision_tree_autoscaling_20_runs
   group: core-multi-test
   working_dir: nightly_tests
@@ -3158,6 +3461,14 @@
   run:
     timeout: 9600
     script: python decision_tree/cart_with_tree.py --concurrency=20
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: decision_tree/decision_tree_app_config.yaml
+        cluster_compute: decision_tree/autoscaling_compute_gce.yaml
 
 - name: autoscaling_shuffle_1tb_1000_partitions
   group: core-multi-test
@@ -3173,6 +3484,14 @@
     timeout: 4000
     script: python shuffle/shuffle_test.py --num-partitions=1000 --partition-size=1e9
       --no-streaming
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: shuffle/shuffle_app_config.yaml
+        cluster_compute: shuffle/shuffle_compute_autoscaling_gce.yaml
 
 
 - name: microbenchmark
@@ -3190,6 +3509,14 @@
   run:
     timeout: 1800
     script: OMP_NUM_THREADS=64 RAY_ADDRESS=local python run_microbenchmark.py
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_64_gce.yaml
 
 
 - name: microbenchmark_staging
@@ -3866,6 +4193,13 @@
     wait_for_nodes:
       num_nodes: 20
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: data_ingest_benchmark_compute_gce.yaml
 
 - name: streaming_data_ingest_benchmark_1tb
   group: data-tests
@@ -3883,6 +4217,13 @@
     wait_for_nodes:
       num_nodes: 20
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: data_ingest_benchmark_compute_gce.yaml
 
 - name: aggregate_benchmark
   group: data-tests
@@ -4094,6 +4435,15 @@
     wait_for_nodes:
       num_nodes: 20
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: shuffle/shuffle_app_config.yaml
+        cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
+
+
 - name: dataset_shuffle_push_based_sort_1tb
   group: data-tests
   working_dir: nightly_tests
@@ -4125,6 +4475,14 @@
     script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=100000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 100
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: shuffle/100tb_shuffle_app_config.yaml
+        cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
 
 ##################
 # Core Chaos tests
@@ -4298,6 +4656,14 @@
     script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml
+        cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
 
 #####################
 # Observability tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4494,7 +4494,7 @@
       env: gce
       stable: false
       cluster:
-        cluster_env: shuffle/100tb_shuffle_app_config.yaml
+        cluster_env: shuffle/100tb_shuffle_app_config_gce.yaml
         cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
 
 ##################

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -210,7 +210,6 @@
     wait_for_nodes:
       num_nodes: 4
 
-
   alert: default
 
 - name: air_benchmark_torch_mnist_gpu_4x4

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -315,6 +315,13 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_gce_gpu_4_g4_12xl.yaml
+
 - name: air_benchmark_torch_mnist_cpu_4x4
   group: AIR tests
   working_dir: air_tests/air_benchmarks

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4413,6 +4413,14 @@
     wait_for_nodes:
       num_nodes: 100
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: shuffle/100tb_shuffle_app_config.yaml
+        cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
+
 ##################
 # Core Chaos tests
 ##################

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4488,14 +4488,14 @@
     wait_for_nodes:
       num_nodes: 100
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      stable: false
-      cluster:
-        cluster_env: shuffle/100tb_shuffle_app_config_gce.yaml
-        cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
+#  variations:
+#    - __suffix__: aws
+#    - __suffix__: gce
+#      env: gce
+#      stable: false
+#      cluster:
+#        cluster_env: shuffle/100tb_shuffle_app_config_gce.yaml
+#        cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
 
 ##################
 # Core Chaos tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4497,7 +4497,7 @@
         cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
       run:
         timeout: 28800
-        script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=50000 --partition-size=1e9 --shuffle
+        script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=40000 --partition-size=1e9 --shuffle
         wait_for_nodes:
           num_nodes: 100
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -538,6 +538,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: compute_gce_gpu_16.yaml
+
 # Test tiny, medium, and huge input files.
 - name: ray-data-bulk-ingest-file-size-benchmark
   group: AIR tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4344,8 +4344,6 @@
     timeout: 2400
     script: python iter_tensor_batches_benchmark.py --data-size-gb=10
 
-
-
 - name: iter_batches_benchmark_single_node
   group: data-tests
   working_dir: nightly_tests/dataset

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -625,7 +625,7 @@
       stable: false
       cluster:
         cluster_env: app_config_oom.yaml
-        cluster_compute: compute_gce_cpu_16_worker_nodes_2.yam
+        cluster_compute: compute_gce_cpu_16_worker_nodes_2.yaml
 
 
 #######################

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -530,14 +530,6 @@
 
   alert: default
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: compute_gce_gpu_16.yaml
-
 # Test tiny, medium, and huge input files.
 - name: ray-data-bulk-ingest-file-size-benchmark
   group: AIR tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2101,19 +2101,6 @@
 
   alert: long_running_tests
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: tpl_cpu_1_c5_gce.yaml
-      run:
-        timeout: 86400
-        script: python workloads/serve_failure.py
-        long_running: true
-        type: anyscale_job
-
 - name: long_running_many_jobs
   group: Long running tests
   working_dir: long_running_tests
@@ -4150,14 +4137,6 @@
     script: python data_ingest_benchmark.py --dataset-size-gb=1000 --num-workers=20 --streaming
     wait_for_nodes:
       num_nodes: 20
-
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: data_ingest_benchmark_compute_gce.yaml
 
 - name: streaming_data_ingest_benchmark_1tb
   group: data-tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -315,16 +315,6 @@
 
   alert: default
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: compute_gce_gpu_4_g4_12xl.yaml
-
-
-
 - name: air_benchmark_torch_mnist_cpu_4x4
   group: AIR tests
   working_dir: air_tests/air_benchmarks

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3338,6 +3338,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: 8gpus_96cpus_gce.yaml
+
 - name: rllib_multi_gpu_with_attention_learning_tests
   group: RLlib tests
   working_dir: rllib_tests
@@ -3355,6 +3363,14 @@
 
 
   alert: default
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: 8gpus_96cpus_gce.yaml
 
 - name: rllib_stress_tests
   group: RLlib tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -318,6 +318,7 @@
   variations:
     - __suffix__: aws
     - __suffix__: gce
+      env: gce
       cluster:
         cluster_env: app_config.yaml
         cluster_compute: compute_gce_gpu_4_g4_12xl.yaml
@@ -3276,6 +3277,14 @@
     script: python multi_gpu_learning_tests/run.py
 
   alert: default
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: 8gpus_96cpus_gce.yaml
 
 - name: rllib_multi_gpu_with_lstm_learning_tests
   group: RLlib tests

--- a/release/rllib_tests/4gpus_544_cpus_gce.yaml
+++ b/release/rllib_tests/4gpus_544_cpus_gce.yaml
@@ -1,7 +1,7 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west1
 allowed_azs: 
-    - us-west1-a
+    - us-west1-b
 
 max_workers: 5
 
@@ -16,9 +16,10 @@ worker_node_types:
       max_workers: 5
       use_spot: false
 
-#aws:
-#    BlockDeviceMappings:
-#        - DeviceName: /dev/sda1
-#          Ebs:
-#            DeleteOnTermination: true
-#            VolumeSize: 500
+gcp_advanced_configurations_json:
+  instance_properties:
+    disks:
+      - boot: true
+        auto_delete: true
+        initialize_params:
+          disk_size_gb: 500

--- a/release/rllib_tests/4gpus_544_cpus_gce.yaml
+++ b/release/rllib_tests/4gpus_544_cpus_gce.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 5
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-64-nvidia-tesla-t4-4 # g3.16xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-96 # m5.24xlarge
+      min_workers: 5
+      max_workers: 5
+      use_spot: false
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 500

--- a/release/rllib_tests/8gpus_96cpus_gce.yaml
+++ b/release/rllib_tests/8gpus_96cpus_gce.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n1-highmem-96-nvidia-tesla-v100-8 # g4dn.metal
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # m5.xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 500

--- a/release/rllib_tests/8gpus_96cpus_gce.yaml
+++ b/release/rllib_tests/8gpus_96cpus_gce.yaml
@@ -7,7 +7,7 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: a2-highgpu-8g # n1-highmem-96-nvidia-tesla-v100-8 # g4dn.metal
+    instance_type: n1-highmem-96-nvidia-tesla-v100-8 # g4dn.metal
 
 worker_node_types:
     - name: worker_node
@@ -16,9 +16,10 @@ worker_node_types:
       max_workers: 0
       use_spot: false
 
-#aws:
-#    BlockDeviceMappings:
-#        - DeviceName: /dev/sda1
-#          Ebs:
-#            DeleteOnTermination: true
-#            VolumeSize: 500
+gcp_advanced_configurations_json:
+  instance_properties:
+    disks:
+      - boot: true
+        auto_delete: true
+        initialize_params:
+          disk_size_gb: 500

--- a/release/rllib_tests/8gpus_96cpus_gce.yaml
+++ b/release/rllib_tests/8gpus_96cpus_gce.yaml
@@ -1,13 +1,13 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west1
 allowed_azs: 
-    - us-west1-a
+    - us-west1-b
 
 max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: n1-highmem-96-nvidia-tesla-v100-8 # g4dn.metal
+    instance_type: a2-highgpu-8g # n1-highmem-96-nvidia-tesla-v100-8 # g4dn.metal
 
 worker_node_types:
     - name: worker_node

--- a/release/runtime_env_tests/rte_gce_minimal.yaml
+++ b/release/runtime_env_tests/rte_gce_minimal.yaml
@@ -1,0 +1,18 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-4 # aws m5.xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # aws m5.xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+

--- a/release/runtime_env_tests/rte_gce_small.yaml
+++ b/release/runtime_env_tests/rte_gce_small.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 3
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-4 # aws m5.xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # aws m5.xlarge
+      min_workers: 3
+      max_workers: 3
+      use_spot: false

--- a/release/tune_tests/scalability_tests/tpl_gce_100x2.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_100x2.yaml
@@ -1,0 +1,17 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 99
+
+head_node_type:
+    name: head_node
+    instance_type: n2d-standard-16
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2d-standard-2
+      min_workers: 99
+      max_workers: 99
+      use_spot: true

--- a/release/tune_tests/scalability_tests/tpl_gce_16x2.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_16x2.yaml
@@ -1,0 +1,17 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 15
+
+head_node_type:
+    name: head_node
+    instance_type: n2d-standard-2
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2d-standard-2
+      min_workers: 15
+      max_workers: 15
+      use_spot: false

--- a/release/tune_tests/scalability_tests/tpl_gce_16x64.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_16x64.yaml
@@ -1,0 +1,17 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 15
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-64 # n2d-standard-64
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-64 # n2d-standard-64
+      min_workers: 15
+      max_workers: 15
+      use_spot: false

--- a/release/tune_tests/scalability_tests/tpl_gce_1x16.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_1x16.yaml
@@ -1,0 +1,17 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # n2d-standard-16
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # n2d-standard-4
+      min_workers: 0
+      max_workers: 0
+      use_spot: false

--- a/release/tune_tests/scalability_tests/tpl_gce_1x32_hd.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_1x32_hd.yaml
@@ -1,0 +1,24 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2d-standard-16
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2d-standard-32
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '48'

--- a/release/tune_tests/scalability_tests/tpl_gce_1x96.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_1x96.yaml
@@ -1,0 +1,17 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2d-standard-96
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2d-standard-4
+      min_workers: 0
+      max_workers: 0
+      use_spot: false

--- a/release/tune_tests/scalability_tests/tpl_gce_20x2.yaml
+++ b/release/tune_tests/scalability_tests/tpl_gce_20x2.yaml
@@ -1,0 +1,17 @@
+cloud_id: cld_tPsS3nQz8p5cautbyWgEdr4y
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 19
+
+head_node_type:
+    name: head_node
+    instance_type: n2d-standard-2
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2d-standard-2
+      min_workers: 19
+      max_workers: 19
+      use_spot: true


### PR DESCRIPTION
## Why are these changes needed?

We have legitimate concern costs when it come to running all release tests on GCE and AWS (currently it takes 120K a month to run release tests on AWS). 

This added feature make it so that we can only run on test variation type at the same time. By default, it will run only AWS tests. We can use this feature to on-demand run GCE tests.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests -  python -m pytest ray_release/tests/test_config.py