### PR TITLE
[CI] Limit CI release test runs on one test variation at a time

### DIFF
--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -35,6 +35,7 @@ DEFAULT_CLUSTER_TIMEOUT = 1800
 DEFAULT_AUTOSUSPEND_MINS = 120
 DEFAULT_MAXIMUM_UPTIME_MINS = 3200
 DEFAULT_WAIT_FOR_NODES_TIMEOUT = 3000
+DEFAULT_ALLOWED_TEST_VARIATION = "aws"
 
 DEFAULT_CLOUD_ID = DeferredEnvVar(
     "RELEASE_DEFAULT_CLOUD_ID",
@@ -96,6 +97,12 @@ def parse_test_definition(test_definitions: List[TestDefinition]) -> List[Test]:
                 "__suffix__" in variation,
                 "missing __suffix__ field in a variation",
             )
+            allowed_variation = os.environ.get(
+                "ANYSCALE_ALLOWED_TEST_VARIATION",
+                DEFAULT_ALLOWED_TEST_VARIATION,
+            )
+            if variation["__suffix__"] != allowed_variation:
+                continue
             test = copy.deepcopy(test_definition)
             test["name"] = f'{test["name"]}.{variation.pop("__suffix__")}'
             test.update(variation)


### PR DESCRIPTION
## Why are these changes needed?

We have legitimate concern costs when it come to running all release tests on GCE and AWS (currently it takes 120K a month to run release tests on AWS). 

This added feature make it so that we can only run on test variation type at the same time. By default, it will run only AWS tests. We can use this feature to on-demand run GCE tests.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests -  python -m pytest ray_release/tests/test_config.py