### PR TITLE
[core] Fix test_advanced_9 for windows (#34074)

### DIFF
--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -363,7 +363,8 @@ def test_redis_not_available(monkeypatch, call_ray_stop_only):
     assert (
         "Could not establish connection to Redis localhost:12345" in p.stderr.decode()
     )
-    assert "Please check /tmp/ray/session" in p.stderr.decode()
+    assert "Please check" in p.stderr.decode()
+    assert "gcs_server.out for details" in p.stderr.decode()
     assert "RuntimeError: Failed to start GCS" in p.stderr.decode()
 
 


### PR DESCRIPTION
Windows uses a different path which make the test broken. This PR fixes this issue by checking a different string.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
