### PR TITLE
[Data] Fix actor pool scale up logic to consider min_workers

### DIFF
--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -542,6 +542,14 @@ class TestAutoscalingPolicy:
         policy = AutoscalingPolicy(config)
         assert policy.max_workers == 4
 
+    def test_should_scale_up_over_min_workers(self):
+        config = AutoscalingConfig(min_workers=1, max_workers=4)
+        policy = AutoscalingPolicy(config)
+        num_total_workers = 0
+        num_running_workers = 0
+        # Should scale up since under pool min workers.
+        assert policy.should_scale_up(num_total_workers, num_running_workers)
+
     def test_should_scale_up_over_max_workers(self):
         # Test that scale-up is blocked if the pool would go over the configured max
         # workers.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is to fix the actor pool scale up logic, to consider min_workers (minimal required number of actors).
Previously we don't consider it, so `num_total_workers == 0` could happen and lead to `ZeroDivisionError: division by zero`.

Example stack trace:

```
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/torch_iterable_dataset.py", line 18, in __iter__
    yield from it
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/dataset_iterator.py", line 570, in make_generator
    for batch in self.iter_batches(
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/dataset_iterator.py", line 156, in iter_batches
    block_iterator, stats = self._to_block_iterator()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/dataset_iterator/dataset_iterator_impl.py", line 31, in _to_block_iterator
    block_iterator, stats, executor = ds._plan.execute_to_iterator()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/plan.py", line 530, in execute_to_iterator
    block_iter = itertools.chain([next(gen)], gen)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/execution/legacy_compat.py", line 49, in execute_to_legacy_block_iterator
    for bundle in bundle_iter:
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/execution/interfaces.py", line 465, in __next__
    return self.get_next()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/execution/streaming_executor.py", line 116, in get_next
    raise item
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/execution/streaming_executor.py", line 163, in run
    while self._scheduling_loop_step(self._topology) and not self._shutdown:
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/execution/streaming_executor.py", line 217, in _scheduling_loop_step
    op = select_operator_to_run(
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/execution/streaming_executor_state.py", line 362, in select_operator_to_run
    _try_to_scale_up_cluster(topology, execution_id)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/execution/streaming_executor_state.py", line 419, in _try_to_scale_up_cluster
    per_task_resource = op.incremental_resource_usage()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/execution/operators/actor_pool_map_operator.py", line 262, in incremental_resource_usage
    if self._autoscaling_policy.should_scale_up(
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/execution/operators/actor_pool_map_operator.py", line 422, in should_scale_up
    and num_running_workers / num_total_workers
ZeroDivisionError: division by zero
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
