### PR TITLE
[core] adjust oom threshold for tune air oom test

### DIFF
--- a/release/air_tests/oom/stress_tests_tune_air_oom_app_config.yaml
+++ b/release/air_tests/oom/stress_tests_tune_air_oom_app_config.yaml
@@ -2,7 +2,7 @@ base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37
 debian_packages: []
 # Lower the threshold to trigger memory pressure.
 # TODO: turn on infinite retry by default when we switch to new policy.
-env_vars: {"RAY_memory_usage_threshold": "0.7", "RAY_task_oom_retries": "-1"}
+env_vars: {"RAY_memory_usage_threshold": "0.8", "RAY_task_oom_retries": "-1"}
 
 
 python:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix unstable release test

There appears to be infra regression the that causes excessive OOM 
Latest run that fails: https://console.anyscale-staging.com/o/anyscale-internal/projects/prj_qC3ZfndQWYYjx2cz8KWGNUL4/clusters/ses_gyf33q4nrkiu6y7sjn7atxnxmw
Same wheel that passes before: https://console.anyscale-staging.com/o/anyscale-internal/projects/prj_qC3ZfndQWYYjx2cz8KWGNUL4/clusters/ses_ehxcu5au9equjh3aly55jud8df?job-logs-tab=ray_logs_tab

passes after increasing threshold: https://console.anyscale-staging.com/o/anyscale-internal/jobs/prodjob_a3e9diftxn9p23y2vmmm9pzkqg

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/ray-project/ray/issues/34029

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
