### PR TITLE
[Dashboard][Bug fix] When using an nginx proxy, the front-end may misspell the URL when accessing the log. 

### DIFF
--- a/dashboard/client/src/service/log.ts
+++ b/dashboard/client/src/service/log.ts
@@ -1,17 +1,6 @@
 import { get } from "./requestHandlers";
 
 const getLogUrl = (url: string) => {
-  if (window.location.pathname !== "/" && url !== "log_index") {
-    const pathArr = window.location.pathname.split("/");
-    if (pathArr.length > 1) {
-      const idx = pathArr.findIndex((e) => e.includes(":"));
-      if (idx > -1) {
-        const afterArr = pathArr.slice(0, idx);
-        afterArr.push(url.replace(/https?:\/\//, ""));
-        url = afterArr.join("/");
-      }
-    }
-  }
   return url === "log_index" ? url : `log_proxy?url=${encodeURIComponent(url)}`;
 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In our use case, we need to access the dashboard in the online cluster through an nginx proxy from the intranet. We found that when accessing the log page under this scenario, the front-end would misspell the URL, resulting in a failure to load.


## Related issue number

Closes #34043

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
