### PR TITLE
[data] [streaming] Simplify progress bar reporting and integrate with Jupyter

### DIFF
--- a/doc/source/data/dataset-internals.rst
+++ b/doc/source/data/dataset-internals.rst
@@ -113,7 +113,8 @@ The following code is a hello world example which invokes the execution with
 
    # Enable verbose reporting. This can also be toggled on by setting
    # the environment variable RAY_DATA_VERBOSE_PROGRESS=1.
-   ray.data.DatasetContext.get_current().execution_options.verbose_progress = True
+   ctx = ray.data.DatasetContext.get_current()
+   ctx.execution_options.verbose_progress = True
 
    def sleep(x):
        time.sleep(0.1)
@@ -172,7 +173,7 @@ Execution options can be configured via the global DatasetContext. The options w
 
 .. code-block::
 
-   ctx = ray.data.context.DatasetContext.get_current()
+   ctx = ray.data.DatasetContext.get_current()
    ctx.execution_options.resource_limits.cpu = 10
    ctx.execution_options.resource_limits.gpu = 5
    ctx.execution_options.resource_limits.object_store_memory = 10e9

--- a/doc/source/data/dataset-internals.rst
+++ b/doc/source/data/dataset-internals.rst
@@ -104,7 +104,7 @@ Streaming Execution
 ~~~~~~~~~~~~~~~~~~~
 
 The following code is a hello world example which invokes the execution with
-:meth:`ds.iter_batches() <ray.data.Dataset.iter_batches>` consumption. We will also enable verbose progress reporting (otherwise the progress is collapsed into a single bar):
+:meth:`ds.iter_batches() <ray.data.Dataset.iter_batches>` consumption. We will also enable verbose progress reporting, which shows per-operator progress in addition to overall progress.
 
 .. code-block::
 
@@ -150,7 +150,7 @@ This line tells you how many resources are currently being used by the streaming
    MapBatches(sleep): 7 active, 2 queued, 25.64 MiB objects, 2 actors [all objects local] 3:  71%|▋| 142/
    MapBatches(sleep): 2 active, 0 queued, 7.32 MiB objects 4:  70%|██▊ | 139/200 [00:08<00:02, 23.16it/s]
 
-Lines like the above show progress for each stage. The `active` count indicates the number of running tasks for the operator. The `queued` count is the number of input blocks for the operator that are computed but are not yet submitted for execution. For operators that use actor-pool execution, the number of running actors is shown as `actors`.
+These lines are only shown when verbose progress reporting is enabled. The `active` count indicates the number of running tasks for the operator. The `queued` count is the number of input blocks for the operator that are computed but are not yet submitted for execution. For operators that use actor-pool execution, the number of running actors is shown as `actors`.
 
 .. tip::
 

--- a/doc/source/data/dataset-internals.rst
+++ b/doc/source/data/dataset-internals.rst
@@ -139,9 +139,9 @@ The next few lines will show execution progress. Here is how to interpret the ou
 
 .. code-block::
 
-   Running: 7.0/16.0 CPU, 0.0/0.0 GPU, 76.91 MiB/2.25 GiB object_store_memory
+   Running: 7.0/16.0 CPU, 0.0/0.0 GPU, 76.91 MiB/2.25 GiB object_store_memory 65%|██▊ | 130/200 [00:08<00:02, 22.52it/s]
 
-This line tells you how many resources are currently being used by the streaming executor out of the limits. The streaming executor will attempt to keep resource usage under the printed limits by throttling task executions.
+This line tells you how many resources are currently being used by the streaming executor out of the limits, as well as the number of completed output blocks. The streaming executor will attempt to keep resource usage under the printed limits by throttling task executions.
 
 .. code-block::
 
@@ -149,11 +149,8 @@ This line tells you how many resources are currently being used by the streaming
    MapBatches(sleep): 5 active, 5 queued, 18.31 MiB objects 2:  76%|██▎| 151/200 [00:08<00:02, 19.93it/s]
    MapBatches(sleep): 7 active, 2 queued, 25.64 MiB objects, 2 actors [all objects local] 3:  71%|▋| 142/
    MapBatches(sleep): 2 active, 0 queued, 7.32 MiB objects 4:  70%|██▊ | 139/200 [00:08<00:02, 23.16it/s]
-   output: 2 queued 5:  70%|█████████████████████████████▉             | 139/200 [00:08<00:02, 22.76it/s]
 
 Lines like the above show progress for each stage. The `active` count indicates the number of running tasks for the operator. The `queued` count is the number of input blocks for the operator that are computed but are not yet submitted for execution. For operators that use actor-pool execution, the number of running actors is shown as `actors`.
-
-The final line shows how much of the stream output has been consumed by the driver program. This value can fall behind the stream execution if your program doesn't pull data from `iter_batches()` fast enough, which may lead to execution throttling.
 
 .. tip::
 

--- a/doc/source/data/dataset-internals.rst
+++ b/doc/source/data/dataset-internals.rst
@@ -104,12 +104,16 @@ Streaming Execution
 ~~~~~~~~~~~~~~~~~~~
 
 The following code is a hello world example which invokes the execution with
-:meth:`ds.iter_batches() <ray.data.Dataset.iter_batches>` consumption:
+:meth:`ds.iter_batches() <ray.data.Dataset.iter_batches>` consumption. We will also enable verbose progress reporting (otherwise the progress is collapsed into a single bar):
 
 .. code-block::
 
    import ray
    import time
+
+   # Enable verbose reporting. This can also be toggled on by setting
+   # the environment variable RAY_DATA_VERBOSE_PROGRESS=1.
+   ray.data.DatasetContext.get_current().execution_options.verbose_progress = True
 
    def sleep(x):
        time.sleep(0.1)
@@ -134,7 +138,7 @@ The next few lines will show execution progress. Here is how to interpret the ou
 
 .. code-block::
 
-   Resource usage vs limits: 7.0/16.0 CPU, 0.0/0.0 GPU, 76.91 MiB/2.25 GiB object_store_memory
+   Running: 7.0/16.0 CPU, 0.0/0.0 GPU, 76.91 MiB/2.25 GiB object_store_memory
 
 This line tells you how many resources are currently being used by the streaming executor out of the limits. The streaming executor will attempt to keep resource usage under the printed limits by throttling task executions.
 

--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import os
 from typing import Dict, List, Optional, Iterable, Iterator, Tuple, Callable, Union
 
 import ray
@@ -216,7 +217,7 @@ class ExecutionOptions:
 
     actor_locality_enabled: bool = True
 
-    verbose_progress: bool = False
+    verbose_progress: bool = bool(int(os.environ.get("RAY_DATA_VERBOSE_PROGRESS", "0")))
 
 
 @dataclass

--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -203,6 +203,9 @@ class ExecutionOptions:
         actor_locality_enabled: Whether to enable locality-aware task dispatch to
             actors (on by default). This applies to both ActorPoolStrategy map and
             streaming_split operations.
+        verbose_progress: Whether to report progress individually per operator. By
+            default, only AllToAll operators and global progress is reported. This
+            option is useful for performance debugging, and is off by default.
     """
 
     resource_limits: ExecutionResources = ExecutionResources()

--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -205,7 +205,7 @@ class ExecutionOptions:
             streaming_split operations.
         verbose_progress: Whether to report progress individually per operator. By
             default, only AllToAll operators and global progress is reported. This
-            option is useful for performance debugging, and is off by default.
+            option is useful for performance debugging. Off by default.
     """
 
     resource_limits: ExecutionResources = ExecutionResources()

--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -207,6 +207,8 @@ class ExecutionOptions:
     # applies to both ActorPoolStrategy map and streaming_split operations.
     actor_locality_enabled: bool = True
 
+    verbose_progress: bool = False
+
 
 @dataclass
 class TaskContext:

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -86,11 +86,14 @@ class StreamingExecutor(Executor, threading.Thread):
         if not isinstance(dag, InputDataBuffer):
             logger.get_logger().info("Executing DAG %s", dag)
             logger.get_logger().info("Execution config: %s", self._options)
-            self._global_info = ProgressBar("Running", dag.num_outputs_total() or 1)
 
         # Setup the streaming DAG topology and start the runner thread.
         _validate_dag(dag, self._get_or_refresh_resource_limits())
         self._topology, _ = build_streaming_topology(dag, self._options)
+
+        if not isinstance(dag, InputDataBuffer):
+            # Note: DAG must be initialized in order to query num_outputs_total.
+            self._global_info = ProgressBar("Running", dag.num_outputs_total() or 1)
 
         self._output_node: OpState = self._topology[dag]
         self.start()

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -113,7 +113,8 @@ class StreamingExecutor(Executor, threading.Thread):
                         raise item
                     else:
                         # Otherwise return a concrete RefBundle.
-                        self._outer._global_info.update(1)
+                        if self._outer._global_info:
+                            self._outer._global_info.update(1)
                         return item
                 except Exception:
                     self._outer.shutdown()

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -86,12 +86,11 @@ class StreamingExecutor(Executor, threading.Thread):
         if not isinstance(dag, InputDataBuffer):
             logger.get_logger().info("Executing DAG %s", dag)
             logger.get_logger().info("Execution config: %s", self._options)
+            self._global_info = ProgressBar("Running", dag.num_outputs_total() or 1)
 
         # Setup the streaming DAG topology and start the runner thread.
         _validate_dag(dag, self._get_or_refresh_resource_limits())
         self._topology, _ = build_streaming_topology(dag, self._options)
-        if not isinstance(dag, InputDataBuffer):
-            self._global_info = ProgressBar("Running", dag.num_outputs_total() or 1)
 
         self._output_node: OpState = self._topology[dag]
         self.start()

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -55,7 +55,6 @@ class StreamingExecutor(Executor, threading.Thread):
         self._initial_stats: Optional[DatasetStats] = None
         self._final_stats: Optional[DatasetStats] = None
         self._global_info: Optional[ProgressBar] = None
-        self._output_info: Optional[ProgressBar] = None
 
         self._execution_id = uuid.uuid4().hex
         self._autoscaling_state = AutoscalingState()
@@ -83,18 +82,16 @@ class StreamingExecutor(Executor, threading.Thread):
         """
         self._initial_stats = initial_stats
         self._start_time = time.perf_counter()
+
         if not isinstance(dag, InputDataBuffer):
             logger.get_logger().info("Executing DAG %s", dag)
-            self._global_info = ProgressBar("Resource usage vs limits", 1, 0)
+            logger.get_logger().info("Execution config: %s", self._options)
 
         # Setup the streaming DAG topology and start the runner thread.
         _validate_dag(dag, self._get_or_refresh_resource_limits())
-        self._topology, progress_bar_position = build_streaming_topology(
-            dag, self._options
-        )
-        self._output_info = ProgressBar(
-            "Output", dag.num_outputs_total() or 1, progress_bar_position
-        )
+        self._topology, _ = build_streaming_topology(dag, self._options)
+        if not isinstance(dag, InputDataBuffer):
+            self._global_info = ProgressBar("Running", dag.num_outputs_total() or 1)
 
         self._output_node: OpState = self._topology[dag]
         self.start()
@@ -116,7 +113,7 @@ class StreamingExecutor(Executor, threading.Thread):
                         raise item
                     else:
                         # Otherwise return a concrete RefBundle.
-                        self._outer._output_info.update(1)
+                        self._outer._global_info.update(1)
                         return item
                 except Exception:
                     self._outer.shutdown()
@@ -147,8 +144,6 @@ class StreamingExecutor(Executor, threading.Thread):
             for op, state in self._topology.items():
                 op.shutdown()
                 state.close_progress_bars()
-            if self._output_info:
-                self._output_info.close()
             # Make request for zero resources to autoscaler for this execution.
             actor = get_or_create_autoscaling_requester_actor()
             actor.request_resources.remote({}, self._execution_id)
@@ -274,18 +269,15 @@ class StreamingExecutor(Executor, threading.Thread):
     def _report_current_usage(
         self, cur_usage: TopologyResourceUsage, limits: ExecutionResources
     ) -> None:
+        resources_status = (
+            "Running: "
+            f"{cur_usage.overall.cpu}/{limits.cpu} CPU, "
+            f"{cur_usage.overall.gpu}/{limits.gpu} GPU, "
+            f"{cur_usage.overall.object_store_memory_str()}/"
+            f"{limits.object_store_memory_str()} object_store_memory"
+        )
         if self._global_info:
-            self._global_info.set_description(
-                "Resource usage vs limits: "
-                f"{cur_usage.overall.cpu}/{limits.cpu} CPU, "
-                f"{cur_usage.overall.gpu}/{limits.gpu} GPU, "
-                f"{cur_usage.overall.object_store_memory_str()}/"
-                f"{limits.object_store_memory_str()} object_store_memory"
-            )
-        if self._output_info:
-            self._output_info.set_description(
-                f"output: {len(self._output_node.outqueue)} queued"
-            )
+            self._global_info.set_description(resources_status)
 
 
 def _validate_dag(dag: PhysicalOperator, limits: ExecutionResources) -> None:

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -132,14 +132,17 @@ class OpState:
         # Only show 1:1 ops when in verbose progress mode.
         enabled = verbose_progress or is_all_to_all
         self.progress_bar = ProgressBar(
-            self.op.name,
+            "- " + self.op.name,
             self.op.num_outputs_total() or 1,
             index,
             enabled=enabled,
         )
-        num_bars = 1
-        if is_all_to_all:
-            num_bars += self.op.initialize_sub_progress_bars(index + 1)
+        if enabled:
+            num_bars = 1
+            if is_all_to_all:
+                num_bars += self.op.initialize_sub_progress_bars(index + 1)
+        else:
+            num_bars = 0
         return num_bars
 
     def close_progress_bars(self):
@@ -172,7 +175,7 @@ class OpState:
     def summary_str(self) -> str:
         queued = self.num_queued() + self.op.internal_queue_size()
         active = self.op.num_active_work_refs()
-        desc = f"{self.op.name}: {active} active, {queued} queued"
+        desc = f"- {self.op.name}: {active} active, {queued} queued"
         mem = memory_string(self.op.current_resource_usage().object_store_memory or 0)
         desc += f", {mem} objects"
         suffix = self.op.progress_str()

--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -44,9 +44,11 @@ def set_progress_bars(enabled: bool) -> bool:
 class ProgressBar:
     """Thin wrapper around tqdm to handle soft imports."""
 
-    def __init__(self, name: str, total: int, position: int = 0):
+    def __init__(
+        self, name: str, total: int, position: int = 0, enabled: bool = _enabled
+    ):
         self._desc = name
-        if not _enabled:
+        if not enabled:
             self._bar = None
         elif tqdm:
             ctx = ray.data.context.DatasetContext.get_current()

--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -245,7 +245,9 @@ class _BarManager:
         self.in_hidden_state = False
         self.num_hides = 0
         self.lock = threading.RLock()
-        self.in_notebook = ray.widgets.util.in_notebook()
+        # Avoid colorizing Jupyter output, since the tqdm bar is rendered in
+        # ipywidgets instead of in the console.
+        self.should_colorize = not ray.widgets.util.in_notebook()
 
     def process_state_update(self, state: ProgressBarState) -> None:
         """Apply the remote progress bar state update.
@@ -267,9 +269,7 @@ class _BarManager:
                 prefix = ""
             else:
                 prefix = "(pid={}) ".format(state.get("pid"))
-                # Avoid colorizing Jupyter output, since the tqdm bar is rendered in
-                # ipywidgets instead of in the console.
-                if not self.in_jupyter:
+                if self.should_colorize:
                     prefix = "{}{}{}{}".format(
                         colorama.Style.DIM,
                         colorama.Fore.CYAN,
@@ -281,7 +281,7 @@ class _BarManager:
                 state.get("pid"),
                 state.get("ip"),
             )
-            if not self.in_jupyter:
+            if self.should_colorize:
                 prefix = "{}{}{}{}".format(
                     colorama.Style.DIM,
                     colorama.Fore.CYAN,

--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -26,6 +26,9 @@ ProgressBarState = Dict[str, Any]
 # Magic token used to identify Ray TQDM log lines.
 RAY_TQDM_MAGIC = "__ray_tqdm_magic_token__"
 
+# Whether we are in Jupyter.
+IN_JUPYTER = ray.widgets.util.in_notebook()
+
 # Global manager singleton.
 _manager: Optional["_BarManager"] = None
 _print = builtins.print
@@ -265,20 +268,26 @@ class _BarManager:
             if state["pid"] == self.pid:
                 prefix = ""
             else:
-                prefix = "{}{}(pid={}){} ".format(
-                    colorama.Style.DIM,
-                    colorama.Fore.CYAN,
-                    state.get("pid"),
-                    colorama.Style.RESET_ALL,
-                )
+                prefix = "(pid={}) ".format(state.get("pid"))
+                if not IN_JUPYTER:
+                    prefix = "{}{}{}{}".format(
+                        colorama.Style.DIM,
+                        colorama.Fore.CYAN,
+                        prefix,
+                        colorama.Style.RESET_ALL,
+                    )
         else:
-            prefix = "{}{}(pid={}, ip={}){} ".format(
-                colorama.Style.DIM,
-                colorama.Fore.CYAN,
+            prefix = "(pid={}, ip={}) ".format(
                 state.get("pid"),
                 state.get("ip"),
-                colorama.Style.RESET_ALL,
             )
+            if not IN_JUPYTER:
+                prefix = "{}{}{}{}".format(
+                    colorama.Style.DIM,
+                    colorama.Fore.CYAN,
+                    prefix,
+                    colorama.Style.RESET_ALL,
+                )
         state["desc"] = prefix + state["desc"]
         process = self._get_or_allocate_bar_group(state)
         if process.has_bar(state["uuid"]):

--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -14,7 +14,7 @@ from ray._private.ray_constants import env_bool
 from ray.util.debug import log_once
 
 try:
-    import tqdm as real_tqdm
+    import tqdm.auto as real_tqdm
 except ImportError:
     real_tqdm = None
 

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -22,6 +22,7 @@ try:
 except ImportError:
     rich = None
 
+import ray
 from ray._private.dict import unflattened_lookup
 from ray.air._internal.checkpoint_manager import _TrackedCheckpoint
 from ray.tune.callback import Callback
@@ -81,11 +82,7 @@ class AirVerbosity(IntEnum):
     VERBOSE = 2
 
 
-try:
-    class_name = get_ipython().__class__.__name__
-    IS_NOTEBOOK = True if "Terminal" not in class_name else False
-except NameError:
-    IS_NOTEBOOK = False
+IS_NOTEBOOK = ray.util.widgets.in_notebook()
 
 
 def get_air_verbosity() -> Optional[AirVerbosity]:

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -82,7 +82,7 @@ class AirVerbosity(IntEnum):
     VERBOSE = 2
 
 
-IS_NOTEBOOK = ray.util.widgets.in_notebook()
+IS_NOTEBOOK = ray.widgets.util.in_notebook()
 
 
 def get_air_verbosity() -> Optional[AirVerbosity]:

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -58,12 +58,7 @@ except ImportError:
         "'pip install ray[rllib]'."
     )
 
-try:
-    class_name = get_ipython().__class__.__name__
-    IS_NOTEBOOK = True if "Terminal" not in class_name else False
-except NameError:
-    IS_NOTEBOOK = False
-
+IS_NOTEBOOK = ray.util.widgets.in_notebook()
 
 SKIP_RESULTS_IN_REPORT = {"config", TRIAL_ID, EXPERIMENT_TAG, DONE}
 

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -58,7 +58,7 @@ except ImportError:
         "'pip install ray[rllib]'."
     )
 
-IS_NOTEBOOK = ray.util.widgets.in_notebook()
+IS_NOTEBOOK = ray.widgets.util.in_notebook()
 
 SKIP_RESULTS_IN_REPORT = {"config", TRIAL_ID, EXPERIMENT_TAG, DONE}
 

--- a/python/ray/widgets/util.py
+++ b/python/ray/widgets/util.py
@@ -186,3 +186,13 @@ def fallback_if_colab(func: F) -> Callable[[F], F]:
             return None
 
     return wrapped
+
+
+def in_notebook() -> bool:
+    """Return whether we are in a Jupyter notebook."""
+    try:
+        class_name = get_ipython().__class__.__name__
+        is_notebook = True if "Terminal" not in class_name else False
+    except NameError:
+        is_notebook = False
+    return is_notebook

--- a/python/ray/widgets/util.py
+++ b/python/ray/widgets/util.py
@@ -188,6 +188,7 @@ def fallback_if_colab(func: F) -> Callable[[F], F]:
     return wrapped
 
 
+@DeveloperAPI
 def in_notebook() -> bool:
     """Return whether we are in a Jupyter notebook."""
     try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, we render verbose progress bars by default. This is both probably too verbose in many cases, and breaks Jupyter as multi-line progress bars are not well supported.

This PR changes the output to a single progress bar by default, gated by a verbose_progress option. In addition, it changes tqdm_ray to use the jupyter integrated tqdm when possible, to also support UI rendering of both single and verbose progress reporting.

Before:
![Screenshot from 2023-04-07 13-28-33](https://user-images.githubusercontent.com/14922/230676870-c07dc77e-36ef-4a3f-bbed-a3ab999743f7.png)

After:

![Screenshot from 2023-04-07 13-29-35](https://user-images.githubusercontent.com/14922/230676882-47080116-acc8-4e0e-b7f1-f439cdf9b9db.png)

Verbose:
![Screenshot from 2023-04-07 13-47-29](https://user-images.githubusercontent.com/14922/230676895-073867b7-6db1-490a-a5b7-baece699cea2.png)


## Related issue number

Closes https://github.com/ray-project/ray/issues/34089
Closes https://github.com/ray-project/ray/issues/34066