### PR TITLE
[release] fix tune_scalability_network_overhead by adding `--smoke-test`

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1506,7 +1506,7 @@
       run:
         timeout: 500
         prepare_timeout: 600
-        script: python workloads/test_network_overhead.py
+        script: python workloads/test_network_overhead.py --smoke-test
         wait_for_nodes:
           num_nodes: 20
     - __suffix__: gce


### PR DESCRIPTION
The current script is not running smoke version and yet the timeout is checked against smoke test criteria, hence giving timeout error.

See https://console.anyscale-staging.com/o/anyscale-internal/jobs/prodjob_m2gwmh5wvs9pmrnhb6g8hx69v3

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
