### PR TITLE
[2.4pick][core] Improve the workflow finding Redis leader. (#34108)

### DIFF
--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -360,9 +360,7 @@ def test_redis_not_available(monkeypatch, call_ray_stop_only):
         shell=True,
         capture_output=True,
     )
-    assert (
-        "Could not establish connection to Redis localhost:12345" in p.stderr.decode()
-    )
+    assert "Could not establish connection to Redis" in p.stderr.decode()
     assert "Please check" in p.stderr.decode()
     assert "gcs_server.out for details" in p.stderr.decode()
     assert "RuntimeError: Failed to start GCS" in p.stderr.decode()

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -14,7 +14,6 @@
 
 #include "ray/gcs/redis_client.h"
 
-#include "absl/strings/str_split.h"
 #include "ray/common/ray_config.h"
 #include "ray/gcs/redis_context.h"
 
@@ -134,56 +133,7 @@ static void GetRedisShards(redisContext *context,
   freeReplyObject(reply);
 }
 
-RedisClient::RedisClient(const RedisClientOptions &options) : options_(options) {
-  instrumented_io_context io_context;
-  auto tmp_context = std::make_shared<RedisContext>(io_context);
-  RAY_CHECK_OK(tmp_context->Connect(options_.server_ip_,
-                                    options_.server_port_,
-                                    /*sharding=*/options_.enable_sharding_conn_,
-                                    /*password=*/options_.password_,
-                                    /*enable_ssl=*/options_.enable_ssl_));
-  // Firstly, we need to find the master node
-  // Replica information contains data as the following format:
-  //   # Replication
-  //   role:master
-  //   connected_slaves:0
-  //   master_failover_state:no-failover
-  //   master_replid:07a4734361f1c81d019d0a0449310e7bd76d459c
-  //   master_replid2:0000000000000000000000000000000000000000
-  //   master_repl_offset:0
-  //   second_repl_offset:-1
-  //   repl_backlog_active:0
-  //   repl_backlog_size:1048576
-  //   repl_backlog_first_byte_offset:0
-  //   repl_backlog_histlen:0
-  // Each line end with \r\n
-  auto reply = tmp_context->RunArgvSync(std::vector<std::string>{"INFO", "REPLICATION"});
-  RAY_CHECK(reply && !reply->IsNil()) << "Failed to get Redis replication info";
-  auto replication_info = reply->ReadAsString();
-  auto parts = absl::StrSplit(replication_info, "\r\n");
-
-  for (auto &part : parts) {
-    if (part.empty() || part[0] == '#') {
-      continue;
-    }
-    std::vector<std::string> kv = absl::StrSplit(part, ":");
-    RAY_CHECK(kv.size() == 2);
-    if (kv[0] == "role" && kv[1] == "master") {
-      leader_ip_ = options_.server_ip_;
-      leader_port_ = options_.server_port_;
-      break;
-    }
-
-    if (kv[0] == "master_host") {
-      leader_ip_ = kv[1];
-    }
-    if (kv[0] == "master_port") {
-      leader_port_ = std::stoi(kv[1]);
-    }
-  }
-  RAY_LOG(INFO) << "Find redis leader: " << leader_ip_ << ":" << leader_port_;
-  RAY_CHECK(!leader_ip_.empty() && leader_port_ != 0) << "Failed to get leader info";
-}
+RedisClient::RedisClient(const RedisClientOptions &options) : options_(options) {}
 
 Status RedisClient::Connect(instrumented_io_context &io_service) {
   std::vector<instrumented_io_context *> io_services;
@@ -195,15 +145,15 @@ Status RedisClient::Connect(std::vector<instrumented_io_context *> io_services) 
   RAY_CHECK(!is_connected_);
   RAY_CHECK(!io_services.empty());
 
-  if (leader_ip_.empty()) {
+  if (options_.server_ip_.empty()) {
     RAY_LOG(ERROR) << "Failed to connect, redis server address is empty.";
     return Status::Invalid("Redis server address is invalid!");
   }
 
   primary_context_ = std::make_shared<RedisContext>(*io_services[0]);
 
-  RAY_CHECK_OK(primary_context_->Connect(leader_ip_,
-                                         leader_port_,
+  RAY_CHECK_OK(primary_context_->Connect(options_.server_ip_,
+                                         options_.server_port_,
                                          /*sharding=*/options_.enable_sharding_conn_,
                                          /*password=*/options_.password_,
                                          /*enable_ssl=*/options_.enable_ssl_));
@@ -216,8 +166,8 @@ Status RedisClient::Connect(std::vector<instrumented_io_context *> io_services) 
     GetRedisShards(primary_context_->sync_context(), &addresses, &ports);
     if (addresses.empty()) {
       RAY_CHECK(ports.empty());
-      addresses.push_back(leader_ip_);
-      ports.push_back(leader_port_);
+      addresses.push_back(options_.server_ip_);
+      ports.push_back(options_.server_port_);
     }
 
     for (size_t i = 0; i < addresses.size(); ++i) {
@@ -235,8 +185,8 @@ Status RedisClient::Connect(std::vector<instrumented_io_context *> io_services) 
   } else {
     shard_contexts_.push_back(std::make_shared<RedisContext>(*io_services[0]));
     // Only async context is used in sharding context, so wen disable the other two.
-    RAY_CHECK_OK(shard_contexts_[0]->Connect(leader_ip_,
-                                             leader_port_,
+    RAY_CHECK_OK(shard_contexts_[0]->Connect(options_.server_ip_,
+                                             options_.server_port_,
                                              /*sharding=*/true,
                                              /*password=*/options_.password_,
                                              /*enable_ssl=*/options_.enable_ssl_));

--- a/src/ray/gcs/redis_client.h
+++ b/src/ray/gcs/redis_client.h
@@ -108,8 +108,6 @@ class RedisClient {
   std::unique_ptr<RedisAsioClient> asio_async_auxiliary_client_;
   // The following context writes everything to the primary shard
   std::shared_ptr<RedisContext> primary_context_;
-  std::string leader_ip_;
-  int32_t leader_port_ = 0;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -26,6 +26,7 @@ extern "C" {
 }
 
 // TODO(pcm): Integrate into the C++ tree.
+#include "absl/strings/str_split.h"
 #include "ray/common/ray_config.h"
 
 namespace {
@@ -269,7 +270,9 @@ RedisContext::RedisContext(instrumented_io_context &io_service)
       << redisSSLContextGetError(ssl_error);
 }
 
-RedisContext::~RedisContext() {
+RedisContext::~RedisContext() { Disconnect(); }
+
+void RedisContext::Disconnect() {
   if (context_) {
     redisFree(context_);
     context_ = nullptr;
@@ -278,6 +281,7 @@ RedisContext::~RedisContext() {
     redisFreeSSLContext(ssl_context_);
     ssl_context_ = nullptr;
   }
+  redis_async_context_.reset();
 }
 
 Status AuthenticateRedis(redisContext *context, const std::string &password) {
@@ -384,15 +388,92 @@ Status RedisContext::PingPort(const std::string &address, int port) {
       address, port, redisConnect, static_cast<redisContext **>(nullptr));
 }
 
+void ValidateRedisDB(RedisContext &context) {
+  auto reply = context.RunArgvSync(std::vector<std::string>{"INFO", "CLUSTER"});
+  // cluster_state:ok
+  // cluster_slots_assigned:16384
+  // cluster_slots_ok:16384
+  // cluster_slots_pfail:0
+  // cluster_size:1
+  RAY_CHECK(reply && !reply->IsNil()) << "Failed to get Redis cluster info";
+  auto cluster_info = reply->ReadAsString();
+
+  std::vector<std::string> parts = absl::StrSplit(cluster_info, "\r\n");
+  bool cluster_mode = false;
+  int cluster_size = 0;
+
+  // Check the cluster status first
+  for (const auto &part : parts) {
+    if (part.empty() || part[0] == '#') {
+      // it's a comment
+      continue;
+    }
+    std::vector<std::string> kv = absl::StrSplit(part, ":");
+    RAY_CHECK(kv.size() == 2);
+    if (kv[0] == "cluster_state") {
+      if (kv[1] == "ok") {
+        cluster_mode = true;
+      } else if (kv[1] == "fail") {
+        RAY_LOG(FATAL)
+            << "The Redis cluster is not healthy. cluster_state shows failed status: "
+            << cluster_info << "."
+            << " Please check Redis cluster used.";
+      }
+    }
+    if (kv[0] == "cluster_size") {
+      cluster_size = std::stoi(kv[1]);
+    }
+  }
+
+  if (cluster_mode) {
+    RAY_CHECK(cluster_size == 1)
+        << "Ray currently doesn't support Redis Cluster with more than one shard. ";
+  }
+}
+
+std::vector<std::string> ResolveDNS(const std::string &address, int port) {
+  using namespace boost::asio;
+  io_context ctx;
+  ip::tcp::resolver resolver(ctx);
+  ip::tcp::resolver::iterator iter = resolver.resolve(address, std::to_string(port));
+  ip::tcp::resolver::iterator end;
+  std::vector<std::string> ip_addresses;
+  while (iter != end) {
+    ip::tcp::endpoint endpoint = *iter++;
+    ip_addresses.push_back(endpoint.address().to_string());
+  }
+  return ip_addresses;
+}
+
 Status RedisContext::Connect(const std::string &address,
                              int port,
                              bool sharding,
                              const std::string &password,
                              bool enable_ssl) {
+  // Connect to the leader of the Redis cluster:
+  //   1. Resolve the ip address from domain name.
+  //      It might return multiple ip addresses
+  //   2. Connect to the first ip address.
+  //   3. Validate the Redis cluster to make sure it's configured in the way
+  //      Ray accept:
+  //        - If it's cluster mode redis, only 1 shard in the cluster.
+  //        - Make sure the cluster is healthy.
+  //   4. Send a dummy delete and check the return.
+  //      - If return OK, connection is finished.
+  //      - Otherwise, make sure it's MOVED error. And we'll get the leader
+  //        address from the error message. Re-run this function with the
+  //        right leader address.
+
   RAY_CHECK(!context_);
   RAY_CHECK(!redis_async_context_);
+  // Fetch the ip address from the address. It might return multiple
+  // addresses and only the first one will be used.
+  auto ip_addresses = ResolveDNS(address, port);
+  RAY_CHECK(!ip_addresses.empty())
+      << "Failed to resolve DNS for " << address << ":" << port;
 
-  RAY_CHECK_OK(ConnectWithRetries(address, port, redisConnect, &context_));
+  RAY_CHECK_OK(ConnectWithRetries(ip_addresses[0], port, redisConnect, &context_));
+
   if (enable_ssl) {
     RAY_CHECK(ssl_context_ != nullptr);
     RAY_CHECK(redisInitiateSSLWithContext(context_, ssl_context_) == REDIS_OK)
@@ -411,6 +492,39 @@ Status RedisContext::Connect(const std::string &address,
   RAY_CHECK_OK(AuthenticateRedis(async_context, password));
   redis_async_context_.reset(new RedisAsyncContext(async_context));
   SetDisconnectCallback(redis_async_context_.get());
+
+  // Ray has some restrictions for RedisDB. Validate it here.
+  ValidateRedisDB(*this);
+
+  // Find the true leader
+  std::vector<const char *> argv;
+  std::vector<size_t> argc;
+  std::vector<std::string> cmds = {"DEL", "DUMMY"};
+  for (const auto &arg : cmds) {
+    argv.push_back(arg.data());
+    argc.push_back(arg.size());
+  }
+
+  auto redis_reply = reinterpret_cast<redisReply *>(
+      ::redisCommandArgv(context_, cmds.size(), argv.data(), argc.data()));
+
+  if (redis_reply->type == REDIS_REPLY_ERROR) {
+    // This should be a MOVED error
+    // MOVED 14946 10.xx.xx.xx:7001
+    std::string error_msg(redis_reply->str, redis_reply->len);
+    freeReplyObject(redis_reply);
+    std::vector<std::string> parts = absl::StrSplit(error_msg, " ");
+    RAY_CHECK(parts[0] == "MOVED" && parts.size() == 3)
+        << "Setup Redis cluster failed in the dummy deletion: " << error_msg;
+    std::vector<std::string> ip_port = absl::StrSplit(parts[2], ":");
+    RAY_CHECK(ip_port.size() == 2);
+
+    Disconnect();
+    // Connect to the true leader.
+    return Connect(ip_port[0], std::stoi(ip_port[1]), sharding, password, enable_ssl);
+  } else {
+    freeReplyObject(redis_reply);
+  }
 
   return Status::OK();
 }
@@ -459,8 +573,6 @@ Status RedisContext::RunArgvAsync(const std::vector<std::string> &args,
 }
 
 void RedisContext::FreeRedisReply(void *reply) { return freeReplyObject(reply); }
-
-int RedisContext::GetRedisError(redisContext *context) { return context->err; }
 
 }  // namespace gcs
 

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -89,6 +89,9 @@ class CallbackReply {
   /// Reply data if reply_type_ is REDIS_REPLY_STRING.
   std::string string_reply_;
 
+  /// Reply data if reply_type_ is REDIS_REPLY_ERROR.
+  std::string error_reply_;
+
   /// Reply data if reply_type_ is REDIS_REPLY_ARRAY.
   /// Represent the reply of StringArray or ScanArray.
   std::vector<std::optional<std::string>> string_array_reply_;
@@ -178,6 +181,9 @@ class RedisContext {
                  const std::string &password,
                  bool enable_ssl = false);
 
+  /// Disconnect from the server.
+  void Disconnect();
+
   /// Run an arbitrary Redis command synchronously.
   ///
   /// \param args The vector of command args to pass to Redis.
@@ -203,6 +209,8 @@ class RedisContext {
   }
 
   instrumented_io_context &io_service() { return io_service_; }
+
+  std::pair<std::string, int> GetLeaderAddress();
 
  private:
   // These functions avoid problems with dependence on hiredis headers with clang-cl.


### PR DESCRIPTION
The current way of finding Redis leader sometimes giving error information. The main reason is because the ip address is not resolved.

If in the initialization stage, it connect to the master, it'll use passed in address as the leader which later might make Ray pick follower redis.

This PR fixed the issue and also uses the way redis-cli used to pick the leader. 

The PR makes the checking more strict to give better error message. New protocol as below:

- use boost to resolve the ip address from domain name.
- connect to the first ip address
- if it's cluster mode, 
  - make sure it's healthy; make sure only 1 shard
  - send a dummy write and check the return
    - if return OK, use the ip address directly
    - otherwise, use the one mentioned in the error message
- if not cluster mode, just use the ip address

Refactoring is also done in this PR. Moving connection related information to redis context

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
