### PR TITLE
[pick] [data] Rename .cache() to .materialize() (#34169)

### DIFF
--- a/doc/source/data/api/dataset.rst
+++ b/doc/source/data/api/dataset.rst
@@ -138,8 +138,7 @@ Execution
 .. autosummary::
    :toctree: doc/
 
-   Dataset.cache
-   Dataset.is_cached
+   Dataset.materialize
 
 Serialization
 -------------

--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -884,4 +884,4 @@ inspection functions like :meth:`ds.schema() <ray.data.Dataset.schema>` and
 :meth:`ds.show() <ray.data.Dataset.show>` will trigger execution of only one or some
 tasks, instead of all tasks. This allows metadata to be inspected right away. Execution
 of all read tasks can be triggered manually using the
-:meth:`ds.cache() <ray.data.Dataset.cache>` API.
+:meth:`ds.materialize() <ray.data.Dataset.materialize>` API.

--- a/doc/source/data/dataset-internals.rst
+++ b/doc/source/data/dataset-internals.rst
@@ -68,7 +68,7 @@ The Datasets execution by default is:
 
 - **Lazy**: This means that transformations on Dataset are not executed until a
   consumption operation (e.g. :meth:`ds.iter_batches() <ray.data.Dataset.iter_batches>`)
-  or :meth:`Dataset.cache() <ray.data.Dataset.cache>` is called. This creates
+  or :meth:`Dataset.materialize() <ray.data.Dataset.materialize>` is called. This creates
   opportunities for optimizing the execution plan (e.g. :ref:`stage fusion <datasets_stage_fusion>`).
 - **Pipelined**: This means that Dataset transformations will be executed in a
   streaming way, incrementally on the base data, instead of on all of the data
@@ -88,7 +88,7 @@ to stage fusion optimizations and aggressive garbage collection of intermediate 
 Dataset creation and transformation APIs are lazy, with execution only triggered via "sink"
 APIs, such as consuming (:meth:`ds.iter_batches() <ray.data.Dataset.iter_batches>`),
 writing (:meth:`ds.write_parquet() <ray.data.Dataset.write_parquet>`), or manually triggering via
-:meth:`ds.cache() <ray.data.Dataset.cache>`. There are a few
+:meth:`ds.materialize() <ray.data.Dataset.materialize>`. There are a few
 exceptions to this rule, where transformations such as :meth:`ds.union()
 <ray.data.Dataset.union>` and
 :meth:`ds.limit() <ray.data.Dataset.limit>` trigger execution; we plan to make these

--- a/doc/source/data/doc_code/creating_datasets.py
+++ b/doc/source/data/doc_code/creating_datasets.py
@@ -298,7 +298,7 @@ ds = ray.data.read_parquet(
     "example://iris.parquet",
     columns=["sepal.length", "variety"],
     filter=pa.dataset.field("sepal.length") > 5.0,
-).cache()  # Force a full read of the file.
+).materialize()  # Force a full read of the file.
 # -> Dataset(num_blocks=1, num_rows=118, schema={sepal.length: double, variety: string})
 
 ds.show(2)

--- a/doc/source/data/doc_code/tensor.py
+++ b/doc/source/data/doc_code/tensor.py
@@ -52,7 +52,7 @@ def single_col_udf(batch: pd.DataFrame) -> pd.DataFrame:
 
 
 ds.map_batches(single_col_udf)
-ds.cache()
+ds.materialize()
 # -> Dataset(num_blocks=17, num_rows=1000,
 #            schema={__value__: TensorDtype(shape=(128, 128, 3), dtype=int64)})
 # __create_pandas_end__
@@ -74,7 +74,7 @@ def multi_col_udf(batch: pd.DataFrame) -> pd.DataFrame:
 
 
 ds.map_batches(multi_col_udf)
-ds.cache()
+ds.materialize()
 # -> Dataset(num_blocks=17, num_rows=1000,
 #            schema={image: TensorDtype(shape=(128, 128, 3), dtype=int64),
 #                    embed: TensorDtype(shape=(256,), dtype=uint8)})
@@ -156,7 +156,7 @@ print(ds.schema())
 #    two: extension<arrow.py_extension_type<ArrowTensorType>>
 # __create_parquet_2_end__
 
-ds.cache()
+ds.materialize()
 shutil.rmtree(path)
 
 # __create_parquet_3_begin__
@@ -193,7 +193,7 @@ print(ds.schema())
 # -> one: int64
 #    two: extension<arrow.py_extension_type<ArrowTensorType>>
 # __create_parquet_3_end__
-ds.cache()
+ds.materialize()
 
 # __create_images_begin__
 ds = ray.data.read_images("example://image-datasets/simple")
@@ -449,7 +449,7 @@ next(ds.iter_batches(batch_format="numpy"))
 # __consume_numpy_2_end__
 
 
-ds.cache()
+ds.materialize()
 shutil.rmtree("/tmp/some_path")
 
 # __write_1_begin__
@@ -468,7 +468,7 @@ print(read_ds.schema())
 #    label: string
 # __write_1_end__
 
-read_ds.cache()
+read_ds.materialize()
 shutil.rmtree("/tmp/some_path")
 
 # __write_2_begin__

--- a/doc/source/data/examples/advanced-pipelines.rst
+++ b/doc/source/data/examples/advanced-pipelines.rst
@@ -11,7 +11,7 @@ This page covers more advanced examples for dataset pipelines.
 Pre-repeat vs post-repeat transforms
 ====================================
 
-Transformations prior to the call to ``.repeat()`` will be cached. However, note that the initial read will not be cached unless there is a subsequent transformation or ``.cache()`` call. Transformations made to the DatasetPipeline after the repeat will always be executed once for each repetition of the Dataset.
+Transformations prior to the call to ``.repeat()`` will be cached. However, note that the initial read will not be cached unless there is a subsequent transformation or ``.materialize()`` call. Transformations made to the DatasetPipeline after the repeat will always be executed once for each repetition of the Dataset.
 
 For example, in the following pipeline, the ``map(func)`` transformation only occurs once. However, the random shuffle is applied to each repetition in the pipeline. However, if we omitted the map transformation, then the pipeline would re-read from the base data on each repetition.
 
@@ -50,7 +50,7 @@ For example, in the following pipeline, the ``map(func)`` transformation only oc
 
 .. important::
 
-    Result caching only applies if there are *transformation* stages prior to the pipelining operation. If you ``repeat()`` or ``window()`` a Dataset right after the read call (e.g., ``ray.data.read_parquet(...).repeat()``), then the read will still be re-executed on each repetition. This optimization saves memory, at the cost of repeated reads from the datasource. To force result caching in all cases, use ``.cache().repeat()``.
+    Result caching only applies if there are *transformation* stages prior to the pipelining operation. If you ``repeat()`` or ``window()`` a Dataset right after the read call (e.g., ``ray.data.read_parquet(...).repeat()``), then the read will still be re-executed on each repetition. This optimization saves memory, at the cost of repeated reads from the datasource. To force result caching in all cases, use ``.materialize().repeat()``.
 
 Changing Pipeline Structure
 ===========================

--- a/doc/source/data/examples/nyc_taxi_basic_processing.ipynb
+++ b/doc/source/data/examples/nyc_taxi_basic_processing.ipynb
@@ -317,7 +317,7 @@
     }
    ],
    "source": [
-    "ds.cache().size_bytes()"
+    "ds.materialize().size_bytes()"
    ]
   },
   {
@@ -654,7 +654,7 @@
     ")\n",
     "\n",
     "# Force full execution of both of the file reads.\n",
-    "pushdown_ds = pushdown_ds.cache()\n",
+    "pushdown_ds = pushdown_ds.materialize()\n",
     "pushdown_ds"
    ]
   },

--- a/doc/source/data/key-concepts.rst
+++ b/doc/source/data/key-concepts.rst
@@ -92,7 +92,7 @@ Execution mode
 ==============
 
 Most transformations are lazy. They don't execute until you consume a dataset or call
-:meth:`Dataset.cache() <ray.data.Dataset.cache>`.
+:meth:`Dataset.materialize() <ray.data.Dataset.materialize>`.
 
 The transformations are executed in a streaming way, incrementally on the data and
 with operators processed in parallel, see :ref:`Streaming Execution <datasets_streaming_execution>`.

--- a/doc/source/data/transforming-datasets.rst
+++ b/doc/source/data/transforming-datasets.rst
@@ -473,7 +473,7 @@ aggregation has been computed.
         for x in range(10)])
 
     # Group by the A column and calculate the per-group mean for B and C columns.
-    agg_ds: ray.data.Dataset = ds.groupby("A").mean(["B", "C"]).cache()
+    agg_ds: ray.data.Dataset = ds.groupby("A").mean(["B", "C"]).materialize()
     # -> Sort Sample: 100%|███████████████████████████████████████| 10/10 [00:01<00:00,  9.04it/s]
     # -> GroupBy Map: 100%|███████████████████████████████████████| 10/10 [00:00<00:00, 23.66it/s]
     # -> GroupBy Reduce: 100%|████████████████████████████████████| 10/10 [00:00<00:00, 937.21it/s]
@@ -542,7 +542,7 @@ with calculated column means.
         return df
 
     ds = ds.map_batches(batch_standard_scaler, batch_format="pandas")
-    ds.cache()
+    ds.materialize()
     # -> Map Progress: 100%|██████████████████████████████████████| 10/10 [00:00<00:00, 144.79it/s]
     # -> Dataset(num_blocks=10, num_rows=10, schema={A: int64, B: double, C: double})
 

--- a/doc/source/ray-air/check-ingest.rst
+++ b/doc/source/ray-air/check-ingest.rst
@@ -417,7 +417,7 @@ Performance Tips
 Dataset Sharing
 ~~~~~~~~~~~~~~~
 
-When you pass Datasets to a Tuner, Datasets are executed independently per-trial. This could potentially duplicate data reads in the cluster. To share Dataset blocks between trials, call ``ds = ds.cache()`` prior to passing the Dataset to the Tuner. This ensures that the initial read operation will not be repeated per trial.
+When you pass Datasets to a Tuner, Datasets are executed independently per-trial. This could potentially duplicate data reads in the cluster. To share Dataset blocks between trials, call ``ds = ds.materialize()`` prior to passing the Dataset to the Tuner. This ensures that the initial read operation will not be repeated per trial.
 
 
 FAQ

--- a/doc/source/ray-air/examples/torch_image_example.ipynb
+++ b/doc/source/ray-air/examples/torch_image_example.ipynb
@@ -195,8 +195,8 @@
                 "    return {\"image\": images, \"label\": labels}\n",
                 "\n",
                 "\n",
-                "train_dataset = train_dataset.map_batches(convert_batch_to_numpy).cache()\n",
-                "test_dataset = test_dataset.map_batches(convert_batch_to_numpy).cache()"
+                "train_dataset = train_dataset.map_batches(convert_batch_to_numpy).materialize()\n",
+                "test_dataset = test_dataset.map_batches(convert_batch_to_numpy).materialize()"
             ]
         },
         {

--- a/doc/source/ray-air/examples/torch_incremental_learning.ipynb
+++ b/doc/source/ray-air/examples/torch_incremental_learning.ipynb
@@ -294,7 +294,7 @@
     "\n",
     "        return {\"image\": images, \"label\": labels}\n",
     "\n",
-    "    mnist_dataset = mnist_dataset.map_batches(convert_batch_to_numpy).cache()\n",
+    "    mnist_dataset = mnist_dataset.map_batches(convert_batch_to_numpy).materialize()\n",
     "    return mnist_dataset"
    ]
   },

--- a/doc/source/templates/01_batch_inference/batch_inference.ipynb
+++ b/doc/source/templates/01_batch_inference/batch_inference.ipynb
@@ -244,7 +244,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "preds = predictions.cache()\n",
+    "preds = predictions.materialize()\n",
     "preds.schema()\n"
    ]
   },

--- a/python/ray/air/util/check_ingest.py
+++ b/python/ray/air/util/check_ingest.py
@@ -67,11 +67,11 @@ class DummyTrainer(DataParallelTrainer):
         print("Starting dataset preprocessing")
         super().preprocess_datasets()
         if self.time_preprocessing_separately:
-            for dataset_name, ds in self.datasets.items():
+            for dataset_name, ds in list(self.datasets.items()):
                 start = time.perf_counter()
                 # Force execution to time preprocessing since Datasets are lazy by
                 # default.
-                ds.cache()
+                self.datasets[dataset_name] = ds.materialize()
                 print(
                     f"Preprocessed {dataset_name} in",
                     time.perf_counter() - start,

--- a/python/ray/data/_internal/pipeline_executor.py
+++ b/python/ray/data/_internal/pipeline_executor.py
@@ -19,7 +19,7 @@ def pipeline_stage(fn: Callable[[], Dataset[T]]) -> Dataset[T]:
     # Force eager evaluation of all blocks in the pipeline stage. This
     # prevents resource deadlocks due to overlapping stage execution (e.g.,
     # task -> actor stage).
-    return fn().cache()
+    return fn().materialize()
 
 
 class PipelineExecutor:

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -585,9 +585,9 @@ class ExecutionPlan:
                     preserve_order=preserve_order,
                 )
                 # TODO(ekl) we shouldn't need to set this in the future once we move
-                # to a fully lazy execution model, unless .cache() is used. The reason
-                # we need it right now is since the user may iterate over a Dataset
-                # multiple times after fully executing it once.
+                # to a fully lazy execution model, unless .materialize() is used. Th
+                # reason we need it right now is since the user may iterate over a
+                # Dataset multiple times after fully executing it once.
                 if not self._run_by_consumer:
                     blocks._owned_by_consumer = False
                 stats = executor.get_stats()

--- a/python/ray/data/tests/preprocessors/test_concatenator.py
+++ b/python/ray/data/tests/preprocessors/test_concatenator.py
@@ -28,7 +28,7 @@ class TestConcatenator:
         )
 
         with pytest.raises(ValueError, match="'b'"):
-            prep.transform(ds).cache()
+            prep.transform(ds).materialize()
 
     @pytest.mark.parametrize("exclude", ("b", ["b"]))
     def test_exclude(self, exclude):

--- a/python/ray/data/tests/preprocessors/test_encoder.py
+++ b/python/ray/data/tests/preprocessors/test_encoder.py
@@ -97,7 +97,7 @@ def test_ordinal_encoder():
 
     # Verify transform fails for null values.
     with pytest.raises(ValueError):
-        null_encoder.transform(null_ds).cache()
+        null_encoder.transform(null_ds).materialize()
     null_encoder.transform(nonnull_ds)
 
     # Verify transform_batch fails for null values.
@@ -299,7 +299,7 @@ def test_one_hot_encoder():
 
     # Verify transform fails for null values.
     with pytest.raises(ValueError):
-        null_encoder.transform(null_ds).cache()
+        null_encoder.transform(null_ds).materialize()
     null_encoder.transform(nonnull_ds)
 
     # Verify transform_batch fails for null values.
@@ -408,7 +408,7 @@ def test_multi_hot_encoder():
 
     # Verify transform fails for null values.
     with pytest.raises(ValueError):
-        null_encoder.transform(null_ds).cache()
+        null_encoder.transform(null_ds).materialize()
     null_encoder.transform(nonnull_ds)
 
     # Verify transform_batch fails for null values.
@@ -511,7 +511,7 @@ def test_label_encoder():
 
     # Verify transform fails for null values.
     with pytest.raises(ValueError):
-        null_encoder.transform(null_ds).cache()
+        null_encoder.transform(null_ds).materialize()
     null_encoder.transform(nonnull_ds)
 
     # Verify transform_batch fails for null values.

--- a/python/ray/data/tests/preprocessors/test_torch.py
+++ b/python/ray/data/tests/preprocessors/test_torch.py
@@ -118,7 +118,7 @@ class TestTorchVisionPreprocessor:
         preprocessor = TorchVisionPreprocessor(columns=["image"], transform=transform)
 
         with pytest.raises(ValueError):
-            preprocessor.transform(dataset).cache()
+            preprocessor.transform(dataset).materialize()
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_bulk_executor.py
+++ b/python/ray/data/tests/test_bulk_executor.py
@@ -75,7 +75,7 @@ def test_multi_stage_execution(ray_start_10_cpus_shared, preserve_order):
 
 def test_basic_stats(ray_start_10_cpus_shared):
     executor = BulkExecutor(ExecutionOptions())
-    prev_stats = ray.data.range(10).cache()._plan.stats()
+    prev_stats = ray.data.range(10).materialize()._plan.stats()
     inputs = make_ref_bundles([[x] for x in range(20)])
     o1 = InputDataBuffer(inputs)
     o2 = MapOperator.create(

--- a/python/ray/data/tests/test_dataset_all_to_all.py
+++ b/python/ray/data/tests/test_dataset_all_to_all.py
@@ -22,7 +22,7 @@ def test_zip(ray_start_regular_shared):
     assert ds.schema() == tuple
     assert ds.take() == [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)]
     with pytest.raises(ValueError):
-        ds.zip(ray.data.range(3)).cache()
+        ds.zip(ray.data.range(3)).materialize()
 
 
 @pytest.mark.parametrize(
@@ -66,7 +66,7 @@ def test_zip_different_num_blocks_split_smallest(
         [{str(i): i for i in range(num_cols1, num_cols1 + num_cols2)}] * n,
         parallelism=num_blocks2,
     )
-    ds = ds1.zip(ds2).cache()
+    ds = ds1.zip(ds2).materialize()
     num_blocks = ds._plan._snapshot_blocks.executed_num_blocks()
     assert ds.take() == [{str(i): i for i in range(num_cols1 + num_cols2)}] * n
     if should_invert:
@@ -765,38 +765,38 @@ def test_groupby_agg_bad_on(ray_start_regular_shared):
     df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs, "C": [2 * x for x in xs]})
     # Wrong type.
     with pytest.raises(TypeError):
-        ray.data.from_pandas(df).groupby("A").mean(5).cache()
+        ray.data.from_pandas(df).groupby("A").mean(5).materialize()
     with pytest.raises(TypeError):
-        ray.data.from_pandas(df).groupby("A").mean([5]).cache()
+        ray.data.from_pandas(df).groupby("A").mean([5]).materialize()
     # Empty list.
     with pytest.raises(ValueError):
-        ray.data.from_pandas(df).groupby("A").mean([]).cache()
+        ray.data.from_pandas(df).groupby("A").mean([]).materialize()
     # Nonexistent column.
     with pytest.raises(ValueError):
-        ray.data.from_pandas(df).groupby("A").mean("D").cache()
+        ray.data.from_pandas(df).groupby("A").mean("D").materialize()
     with pytest.raises(ValueError):
-        ray.data.from_pandas(df).groupby("A").mean(["B", "D"]).cache()
+        ray.data.from_pandas(df).groupby("A").mean(["B", "D"]).materialize()
     # Columns for simple Dataset.
     with pytest.raises(ValueError):
-        ray.data.from_items(xs).groupby(lambda x: x % 3 == 0).mean("A").cache()
+        ray.data.from_items(xs).groupby(lambda x: x % 3 == 0).mean("A").materialize()
 
     # Test bad on for global aggregation
     # Wrong type.
     with pytest.raises(TypeError):
-        ray.data.from_pandas(df).mean(5).cache()
+        ray.data.from_pandas(df).mean(5).materialize()
     with pytest.raises(TypeError):
-        ray.data.from_pandas(df).mean([5]).cache()
+        ray.data.from_pandas(df).mean([5]).materialize()
     # Empty list.
     with pytest.raises(ValueError):
-        ray.data.from_pandas(df).mean([]).cache()
+        ray.data.from_pandas(df).mean([]).materialize()
     # Nonexistent column.
     with pytest.raises(ValueError):
-        ray.data.from_pandas(df).mean("D").cache()
+        ray.data.from_pandas(df).mean("D").materialize()
     with pytest.raises(ValueError):
-        ray.data.from_pandas(df).mean(["B", "D"]).cache()
+        ray.data.from_pandas(df).mean(["B", "D"]).materialize()
     # Columns for simple Dataset.
     with pytest.raises(ValueError):
-        ray.data.from_items(xs).mean("A").cache()
+        ray.data.from_items(xs).mean("A").materialize()
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
@@ -1016,7 +1016,7 @@ def test_groupby_map_groups_merging_invalid_result(ray_start_regular_shared):
 
     # The UDF returns None, which is invalid.
     with pytest.raises(TypeError):
-        grouped.map_groups(lambda x: None if x == [1] else x).cache()
+        grouped.map_groups(lambda x: None if x == [1] else x).materialize()
 
 
 @pytest.mark.parametrize("num_parts", [1, 2, 30])
@@ -1676,7 +1676,7 @@ def test_random_shuffle_with_custom_resource(ray_start_cluster):
         parallelism=2,
         ray_remote_args={"resources": {"bar": 1}},
     )
-    ds = ds.random_shuffle(resources={"bar": 1}).cache()
+    ds = ds.random_shuffle(resources={"bar": 1}).materialize()
     assert "1 nodes used" in ds.stats()
     assert "2 nodes used" not in ds.stats()
 

--- a/python/ray/data/tests/test_dataset_consumption.py
+++ b/python/ray/data/tests/test_dataset_consumption.py
@@ -164,19 +164,19 @@ def test_empty_dataset(ray_start_regular_shared):
 
     ds = ray.data.range(1)
     ds = ds.filter(lambda x: x > 1)
-    ds.cache()
+    ds = ds.materialize()
     assert str(ds) == "Dataset(num_blocks=1, num_rows=0, schema=Unknown schema)"
 
     # Test map on empty dataset.
     ds = ray.data.from_items([])
     ds = ds.map(lambda x: x)
-    ds.cache()
+    ds = ds.materialize()
     assert ds.count() == 0
 
     # Test filter on empty dataset.
     ds = ray.data.from_items([])
     ds = ds.filter(lambda: True)
-    ds.cache()
+    ds = ds.materialize()
     assert ds.count() == 0
 
 
@@ -199,7 +199,7 @@ def test_cache_dataset(ray_start_regular_shared):
 
     ds = ray.data.range(1)
     ds = ds.map(inc)
-    ds = ds.cache()
+    ds = ds.materialize()
 
     for _ in range(10):
         ds.take_all()
@@ -211,9 +211,9 @@ def test_schema(ray_start_regular_shared):
     ds = ray.data.range(10, parallelism=10)
     ds2 = ray.data.range_table(10, parallelism=10)
     ds3 = ds2.repartition(5)
-    ds3.cache()
+    ds3 = ds3.materialize()
     ds4 = ds3.map(lambda x: {"a": "hi", "b": 1.0}).limit(5).repartition(1)
-    ds4.cache()
+    ds4 = ds4.materialize()
     assert str(ds) == "Dataset(num_blocks=10, num_rows=10, schema=<class 'int'>)"
     assert str(ds2) == "Dataset(num_blocks=10, num_rows=10, schema={value: int64})"
     assert str(ds3) == "Dataset(num_blocks=5, num_rows=10, schema={value: int64})"
@@ -288,7 +288,7 @@ def test_dataset_repr(ray_start_regular_shared):
         "   +- MapBatches(<lambda>)\n"
         "      +- Dataset(num_blocks=10, num_rows=10, schema=<class 'int'>)"
     )
-    ds.cache()
+    ds = ds.materialize()
     assert repr(ds) == "Dataset(num_blocks=10, num_rows=9, schema=<class 'int'>)"
     ds = ds.map_batches(lambda x: x)
     assert repr(ds) == (
@@ -326,7 +326,7 @@ def test_dataset_repr(ray_start_regular_shared):
 def test_limit(ray_start_regular_shared, lazy):
     ds = ray.data.range(100, parallelism=20)
     if not lazy:
-        ds = ds.cache()
+        ds = ds.materialize()
     for i in range(100):
         assert ds.limit(i).take(200) == list(range(i))
 
@@ -1397,15 +1397,15 @@ def test_read_write_local_node_ray_client(ray_start_cluster_enabled):
     # Read/write from Ray Client will result in error.
     ray.init(address)
     with pytest.raises(ValueError):
-        ds = ray.data.read_parquet("local://" + path).cache()
+        ds = ray.data.read_parquet("local://" + path).materialize()
     ds = ray.data.from_pandas(df)
     with pytest.raises(ValueError):
-        ds.write_parquet("local://" + data_path).cache()
+        ds.write_parquet("local://" + data_path).materialize()
 
 
 def test_read_warning_large_parallelism(ray_start_regular, propagate_logs, caplog):
     with caplog.at_level(logging.WARNING, logger="ray.data.read_api"):
-        ray.data.range(5000, parallelism=5000).cache()
+        ray.data.range(5000, parallelism=5000).materialize()
     assert (
         "The requested parallelism of 5000 is "
         "more than 4x the number of available CPU slots in the cluster" in caplog.text
@@ -1451,17 +1451,17 @@ def test_read_write_local_node(ray_start_cluster):
 
     local_path = "local://" + data_path
     # Plain read.
-    ds = ray.data.read_parquet(local_path).cache()
+    ds = ray.data.read_parquet(local_path).materialize()
     check_dataset_is_local(ds)
 
     # SPREAD scheduling got overridden when read local scheme.
     ds = ray.data.read_parquet(
         local_path, ray_remote_args={"scheduling_strategy": "SPREAD"}
-    ).cache()
+    ).materialize()
     check_dataset_is_local(ds)
 
     # With fusion.
-    ds = ray.data.read_parquet(local_path).map(lambda x: x).cache()
+    ds = ray.data.read_parquet(local_path).map(lambda x: x).materialize()
     check_dataset_is_local(ds)
 
     # Write back to local scheme.
@@ -1474,15 +1474,15 @@ def test_read_write_local_node(ray_start_cluster):
     with pytest.raises(ValueError):
         ds = ray.data.read_parquet(
             [local_path + "/test1.parquet", data_path + "/test2.parquet"]
-        ).cache()
+        ).materialize()
     with pytest.raises(ValueError):
         ds = ray.data.read_parquet(
             [local_path + "/test1.parquet", "example://iris.parquet"]
-        ).cache()
+        ).materialize()
     with pytest.raises(ValueError):
         ds = ray.data.read_parquet(
             ["example://iris.parquet", local_path + "/test1.parquet"]
-        ).cache()
+        ).materialize()
 
 
 @ray.remote
@@ -1588,7 +1588,7 @@ def test_polars_lazy_import(shutdown_only):
             ray.data.from_pandas(dfs)
             .map_batches(lambda t: t, batch_format="pyarrow", batch_size=None)
             .sort(key="a")
-            .cache()
+            .materialize()
         )
         assert any(ray.get([f.remote(True) for _ in range(parallelism)]))
 

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -340,7 +340,7 @@ def test_get_read_tasks(ray_start_cluster):
     head_node_id = ray.get_runtime_context().get_node_id()
 
     # Issue read so `_get_read_tasks` being executed.
-    ray.data.range(10).cache()
+    ray.data.range(10).materialize()
 
     # Verify `_get_read_tasks` being executed on same node (head node).
     def verify_get_read_tasks():

--- a/python/ray/data/tests/test_dataset_image.py
+++ b/python/ray/data/tests/test_dataset_image.py
@@ -193,7 +193,7 @@ class TestReadImages:
 
         data_size = ds.size_bytes()
         assert data_size >= 0, "estimated data size is out of expected bound"
-        data_size = ds.cache().size_bytes()
+        data_size = ds.materialize().size_bytes()
         assert data_size >= 0, "actual data size is out of expected bound"
 
         reader = _ImageDatasourceReader(
@@ -225,12 +225,12 @@ class TestReadImages:
             root = "example://image-datasets/simple"
             ds = ray.data.read_images(root, parallelism=1)
             assert ds.num_blocks() == 1
-            ds.cache()
+            ds = ds.materialize()
             # Verify dynamic block splitting taking effect to generate more blocks.
             assert ds.num_blocks() == 3
 
             # Test union of same datasets
-            union_ds = ds.union(ds, ds, ds).cache()
+            union_ds = ds.union(ds, ds, ds).materialize()
             assert union_ds.num_blocks() == 12
         finally:
             ctx.target_max_block_size = target_max_block_size

--- a/python/ray/data/tests/test_dataset_map.py
+++ b/python/ray/data/tests/test_dataset_map.py
@@ -146,7 +146,7 @@ def test_transform_failure(shutdown_only):
         return x
 
     with pytest.raises(ray.exceptions.RayTaskError):
-        ds.map(mapper).cache()
+        ds.map(mapper).materialize()
 
 
 def test_flat_map_generator(ray_start_regular_shared):
@@ -189,7 +189,7 @@ def test_drop_columns(ray_start_regular_shared, tmp_path):
         ]
         # Test dropping non-existent column
         with pytest.raises(KeyError):
-            ds.drop_columns(["dummy_col", "col1", "col2"]).cache()
+            ds.drop_columns(["dummy_col", "col1", "col2"]).materialize()
 
 
 def test_select_columns(ray_start_regular_shared):
@@ -218,12 +218,12 @@ def test_select_columns(ray_start_regular_shared):
         ]
         # Test selecting a column that is not in the dataset schema
         with pytest.raises(KeyError):
-            each_ds.select_columns(cols=["col1", "col2", "dummy_col"]).cache()
+            each_ds.select_columns(cols=["col1", "col2", "dummy_col"]).materialize()
 
     # Test simple
     ds3 = ray.data.range(10)
     with pytest.raises(ValueError):
-        ds3.select_columns(cols=[]).cache()
+        ds3.select_columns(cols=[]).materialize()
 
 
 def test_map_batches_basic(ray_start_regular_shared, tmp_path, restore_dataset_context):
@@ -621,13 +621,13 @@ def test_map_batches_batch_zero_copy(
     ds = ray.data.range_table(num_rows, parallelism=num_blocks).repartition(num_blocks)
     # Convert to Pandas blocks.
     ds = ds.map_batches(lambda df: df, batch_format="pandas", batch_size=None)
-    ds.cache()
+    ds = ds.materialize()
 
     # Apply UDF that mutates the batches, which should fail since the batch is
     # read-only.
     with pytest.raises(ValueError, match="tried to mutate a zero-copy read-only batch"):
         ds = ds.map_batches(mutate, batch_size=batch_size, zero_copy_batch=True)
-        ds.cache()
+        ds.materialize()
 
 
 BLOCK_BUNDLING_TEST_CASES = [
@@ -648,11 +648,11 @@ def test_map_batches_block_bundling_auto(
     assert ds.num_blocks() == num_blocks
 
     # Blocks should be bundled up to the batch size.
-    ds1 = ds.map_batches(lambda x: x, batch_size=batch_size).cache()
+    ds1 = ds.map_batches(lambda x: x, batch_size=batch_size).materialize()
     assert ds1.num_blocks() == math.ceil(num_blocks / max(batch_size // block_size, 1))
 
     # Blocks should not be bundled up when batch_size is not specified.
-    ds2 = ds.map_batches(lambda x: x).cache()
+    ds2 = ds.map_batches(lambda x: x).materialize()
     assert ds2.num_blocks() == num_blocks
 
 
@@ -678,7 +678,7 @@ def test_map_batches_block_bundling_skewed_manual(
     )
     # Confirm that we have the expected number of initial blocks.
     assert ds.num_blocks() == num_blocks
-    ds = ds.map_batches(lambda x: x, batch_size=batch_size).cache()
+    ds = ds.map_batches(lambda x: x, batch_size=batch_size).materialize()
 
     # Blocks should be bundled up to the batch size.
     assert ds.num_blocks() == expected_num_blocks
@@ -704,7 +704,7 @@ def test_map_batches_block_bundling_skewed_auto(
     )
     # Confirm that we have the expected number of initial blocks.
     assert ds.num_blocks() == num_blocks
-    ds = ds.map_batches(lambda x: x, batch_size=batch_size).cache()
+    ds = ds.map_batches(lambda x: x, batch_size=batch_size).materialize()
     curr = 0
     num_out_blocks = 0
     for block_size in block_sizes:
@@ -735,7 +735,7 @@ def test_map_with_mismatched_columns(ray_start_regular_shared):
     ds = ray.data.range(10, parallelism=1)
     error_message = "Current row has different columns compared to previous rows."
     with pytest.raises(ValueError) as e:
-        ds.map(bad_fn).cache()
+        ds.map(bad_fn).materialize()
     assert error_message in str(e.value)
     ds_map = ds.map(good_fn)
     assert ds_map.take() == [{"a": "hello1", "b": "hello2"} for _ in range(10)]
@@ -857,7 +857,7 @@ def test_actor_pool_strategy_default_num_actors(shutdown_only):
     compute_strategy = ray.data.ActorPoolStrategy()
     ray.data.range(10, parallelism=10).map_batches(
         f, batch_size=1, compute=compute_strategy
-    ).cache()
+    ).materialize()
 
     # The new execution backend is not using the ActorPoolStrategy under
     # the hood, so the expectation here applies only to the old backend.
@@ -884,7 +884,7 @@ def test_actor_pool_strategy_bundles_to_max_actors(shutdown_only):
     ds = (
         ray.data.range(10, parallelism=10)
         .map_batches(f, batch_size=None, compute=compute_strategy)
-        .cache()
+        .materialize()
     )
 
     # TODO(https://github.com/ray-project/ray/issues/31723): implement the feature
@@ -896,7 +896,7 @@ def test_actor_pool_strategy_bundles_to_max_actors(shutdown_only):
     ds = (
         ray.data.range(10, parallelism=10)
         .map_batches(f, batch_size=10, compute=compute_strategy)
-        .cache()
+        .materialize()
     )
 
     assert "1/1 blocks" in ds.stats()

--- a/python/ray/data/tests/test_dataset_parquet.py
+++ b/python/ray/data/tests/test_dataset_parquet.py
@@ -657,7 +657,7 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
         assert (
             data_size >= 6_000_000 and data_size <= 10_000_000
         ), "estimated data size is out of expected bound"
-        data_size = ds.cache().size_bytes()
+        data_size = ds.materialize().size_bytes()
         assert (
             data_size >= 7_000_000 and data_size <= 10_000_000
         ), "actual data size is out of expected bound"
@@ -685,7 +685,7 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
         assert (
             data_size >= 1_000_000 and data_size <= 2_000_000
         ), "estimated data size is out of expected bound"
-        data_size = ds.cache().size_bytes()
+        data_size = ds.materialize().size_bytes()
         assert (
             data_size >= 1_000_000 and data_size <= 2_000_000
         ), "actual data size is out of expected bound"

--- a/python/ray/data/tests/test_dataset_tensor.py
+++ b/python/ray/data/tests/test_dataset_tensor.py
@@ -287,7 +287,7 @@ def test_tensors_sort(ray_start_regular_shared):
 def test_tensors_inferred_from_map(ray_start_regular_shared):
     # Test map.
     ds = ray.data.range(10, parallelism=10).map(lambda _: np.ones((4, 4)))
-    ds.cache()
+    ds = ds.materialize()
     assert str(ds) == (
         "Dataset(\n"
         "   num_blocks=10,\n"
@@ -300,7 +300,7 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     ds = ray.data.range(16, parallelism=4).map_batches(
         lambda _: np.ones((3, 4, 4)), batch_size=2
     )
-    ds.cache()
+    ds = ds.materialize()
     assert str(ds) == (
         "Dataset(\n"
         "   num_blocks=4,\n"
@@ -313,7 +313,7 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     ds = ray.data.range(10, parallelism=10).flat_map(
         lambda _: [np.ones((4, 4)), np.ones((4, 4))]
     )
-    ds.cache()
+    ds = ds.materialize()
     assert str(ds) == (
         "Dataset(\n"
         "   num_blocks=10,\n"
@@ -326,7 +326,7 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     ds = ray.data.range(16, parallelism=4).map_batches(
         lambda _: pd.DataFrame({"a": [np.ones((4, 4))] * 3}), batch_size=2
     )
-    ds.cache()
+    ds = ds.materialize()
     assert str(ds) == (
         "Dataset(\n"
         "   num_blocks=4,\n"
@@ -339,7 +339,7 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
         lambda _: pd.DataFrame({"a": [np.ones((2, 2)), np.ones((3, 3))]}),
         batch_size=2,
     )
-    ds.cache()
+    ds = ds.materialize()
     assert str(ds) == (
         "Dataset(\n"
         "   num_blocks=4,\n"

--- a/python/ray/data/tests/test_dataset_tfrecords.py
+++ b/python/ray/data/tests/test_dataset_tfrecords.py
@@ -612,11 +612,11 @@ def test_read_with_invalid_schema(
     # which should raise a `ValueError`.
     ds.write_tfrecords(tmp_path)
     with pytest.raises(ValueError) as e:
-        ray.data.read_tfrecords(tmp_path, tf_schema=tf_schema_wrong_name).cache()
+        ray.data.read_tfrecords(tmp_path, tf_schema=tf_schema_wrong_name).materialize()
     assert "Found extra unexpected feature" in str(e.value.args[0])
 
     with pytest.raises(ValueError) as e:
-        ray.data.read_tfrecords(tmp_path, tf_schema=tf_schema_wrong_type).cache()
+        ray.data.read_tfrecords(tmp_path, tf_schema=tf_schema_wrong_type).materialize()
     assert str(e.value.args[0]) == (
         "Schema field type mismatch during read: "
         "specified type is int, but underlying type is bytes"

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -155,15 +155,15 @@ def test_dataset(
     assert ds.size_bytes() >= 0.7 * block_size * num_blocks_per_task * num_tasks
 
     map_ds = ds.map_batches(lambda x: x, compute=compute)
-    map_ds.cache()
+    map_ds = map_ds.materialize()
     assert map_ds.num_blocks() == num_tasks
     map_ds = ds.map_batches(
         lambda x: x, batch_size=num_blocks_per_task * num_tasks, compute=compute
     )
-    map_ds.cache()
+    map_ds = map_ds.materialize()
     assert map_ds.num_blocks() == 1
     map_ds = ds.map(lambda x: x, compute=compute)
-    map_ds.cache()
+    map_ds = map_ds.materialize()
     assert map_ds.num_blocks() == num_blocks_per_task * num_tasks
 
     ds_list = ds.split(5)
@@ -177,7 +177,7 @@ def test_dataset(
 
     new_ds = ds.union(ds, ds)
     assert new_ds.num_blocks() == num_tasks * 3
-    new_ds.cache()
+    new_ds = new_ds.materialize()
     assert new_ds.num_blocks() == num_blocks_per_task * num_tasks * 3
 
     new_ds = ds.random_shuffle()
@@ -187,7 +187,7 @@ def test_dataset(
     assert ds.groupby("one").count().count() == num_blocks_per_task * num_tasks
 
     new_ds = ds.zip(ds)
-    new_ds.cache()
+    new_ds = new_ds.materialize()
     assert new_ds.num_blocks() == num_blocks_per_task * num_tasks
 
     assert len(ds.take(5)) == 5
@@ -243,12 +243,12 @@ def test_filter(
     )
 
     ds = ds.filter(lambda _: True)
-    ds.cache()
+    ds = ds.materialize()
     assert ds.count() == num_blocks_per_task
     assert ds.num_blocks() == num_blocks_per_task
 
     ds = ds.filter(lambda _: False)
-    ds.cache()
+    ds = ds.materialize()
     assert ds.count() == 0
     assert ds.num_blocks() == num_blocks_per_task
 
@@ -336,7 +336,7 @@ def test_lazy_block_list(
         assert metadata.num_rows == 1
 
     # Check internal states of LazyBlockList after execution
-    ds.cache()
+    ds = ds.materialize()
     metadata = block_list.get_metadata()
 
     assert block_list._num_computed() == num_tasks

--- a/python/ray/data/tests/test_mongo_dataset.py
+++ b/python/ray/data/tests/test_mongo_dataset.py
@@ -208,7 +208,7 @@ def test_mongo_datasource(ray_start_regular_shared, start_mongo):
         database=foo_db,
         collection=foo_collection,
         schema=schema,
-    ).cache()
+    ).materialize()
     assert ds._block_num_rows() == [3, 2]
     assert str(ds) == (
         "Dataset(\n"
@@ -227,7 +227,7 @@ def test_mongo_datasource(ray_start_regular_shared, start_mongo):
         uri=mongo_url,
         database=foo_db,
         collection=foo_collection,
-    ).cache()
+    ).materialize()
     assert ds._block_num_rows() == [3, 2]
     assert str(ds) == (
         "Dataset(\n"
@@ -245,7 +245,7 @@ def test_mongo_datasource(ray_start_regular_shared, start_mongo):
         uri=mongo_url,
         database=foo_db,
         collection=foo_collection,
-    ).cache()
+    ).materialize()
     assert str(ds) == (
         "Dataset(\n"
         "   num_blocks=5,\n"

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -68,7 +68,7 @@ def test_memory_sanity(shutdown_only):
     info = ray.init(num_cpus=1, object_store_memory=500e6)
     ds = ray.data.range(10)
     ds = ds.map(lambda x: np.ones(100 * 1024 * 1024, dtype=np.uint8))
-    ds.cache()
+    ds.materialize()
     meminfo = memory_summary(info.address_info["address"], stats_only=True)
 
     # Sanity check spilling is happening as expected.
@@ -170,7 +170,7 @@ def test_memory_release_lazy(shutdown_only):
     ds = ds.map(lambda x: np.ones(100 * 1024 * 1024, dtype=np.uint8))
     ds = ds.map(lambda x: np.ones(100 * 1024 * 1024, dtype=np.uint8))
     ds = ds.map(lambda x: np.ones(100 * 1024 * 1024, dtype=np.uint8))
-    ds.cache()
+    ds.materialize()
     meminfo = memory_summary(info.address_info["address"], stats_only=True)
     assert "Spilled" not in meminfo, meminfo
 
@@ -188,7 +188,7 @@ def test_memory_release_lazy_shuffle(shutdown_only):
             # Should get fused into single stage.
             ds = ds.lazy()
             ds = ds.map(lambda x: np.ones(100 * 1024 * 1024, dtype=np.uint8))
-            ds.random_shuffle().cache()
+            ds.random_shuffle().materialize()
             meminfo = memory_summary(info.address_info["address"], stats_only=True)
             assert "Spilled" not in meminfo, meminfo
             return
@@ -224,12 +224,12 @@ def test_lazy_fanout(shutdown_only, local_path):
     ds2 = ds1.map(inc)
     ds3 = ds1.map(inc)
     # Test content.
-    assert ds2.cache().take() == [
+    assert ds2.materialize().take() == [
         {"one": 3, "two": "a"},
         {"one": 4, "two": "b"},
         {"one": 5, "two": "c"},
     ]
-    assert ds3.cache().take() == [
+    assert ds3.materialize().take() == [
         {"one": 3, "two": "a"},
         {"one": 4, "two": "b"},
         {"one": 5, "two": "c"},
@@ -254,8 +254,8 @@ def test_lazy_fanout(shutdown_only, local_path):
     ds2 = ds1.map(inc)
     ds3 = ds1.map(inc)
     # Test content.
-    assert ds2.cache().take() == list(range(2, 12))
-    assert ds3.cache().take() == list(range(2, 12))
+    assert ds2.materialize().take() == list(range(2, 12))
+    assert ds3.materialize().take() == list(range(2, 12))
     # Test that first map is executed twice.
     assert ray.get(map_counter.get.remote()) == 2 * 10 + 10 + 10
 
@@ -268,10 +268,10 @@ def test_lazy_fanout(shutdown_only, local_path):
     ds1 = ds.map(inc)
     ds2 = ds.map(inc)
     # Test content.
-    assert ds1.cache().take() == list(range(2, 12))
-    assert ds2.cache().take() == list(range(2, 12))
-    # Test that first map is executed twice, because ds1.cache()
-    # clears up the previous snapshot blocks, and ds2.cache()
+    assert ds1.materialize().take() == list(range(2, 12))
+    assert ds2.materialize().take() == list(range(2, 12))
+    # Test that first map is executed twice, because ds1.materialize()
+    # clears up the previous snapshot blocks, and ds2.materialize()
     # has to re-execute ds.map(inc) again.
     assert ray.get(map_counter.get.remote()) == 2 * 10 + 10 + 10
 
@@ -305,7 +305,7 @@ def test_stage_linking(ray_start_regular_shared):
     assert len(ds._plan._stages_before_snapshot) == 0
     _assert_has_stages(ds._plan._stages_after_snapshot, ["Map"])
     assert ds._plan._last_optimized_stages is None
-    ds = ds.cache()
+    ds = ds.materialize()
     _assert_has_stages(ds._plan._stages_before_snapshot, ["Map"])
     assert len(ds._plan._stages_after_snapshot) == 0
     _assert_has_stages(ds._plan._last_optimized_stages, ["ReadRange->Map"])
@@ -317,7 +317,7 @@ def test_optimize_reorder(ray_start_regular_shared):
     context.optimize_fuse_read_stages = True
     context.optimize_reorder_stages = True
 
-    ds = ray.data.range(10).randomize_block_order().map_batches(dummy_map).cache()
+    ds = ray.data.range(10).randomize_block_order().map_batches(dummy_map).materialize()
     expect_stages(
         ds,
         2,
@@ -329,7 +329,7 @@ def test_optimize_reorder(ray_start_regular_shared):
         .randomize_block_order()
         .repartition(10)
         .map_batches(dummy_map)
-        .cache()
+        .materialize()
     )
     expect_stages(
         ds2,

--- a/python/ray/data/tests/test_size_estimation.py
+++ b/python/ray/data/tests/test_size_estimation.py
@@ -161,7 +161,7 @@ def test_split_read_parquet(ray_start_regular_shared, tmp_path):
         ds = (
             ray.data.range(200000, parallelism=1)
             .map(lambda _: uuid.uuid4().hex)
-            .cache()
+            .materialize()
         )
         # Fully execute the operations prior to write, because with
         # parallelism=1, there is only one task; so the write operator

--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -307,7 +307,7 @@ def test_push_based_shuffle_stats(ray_start_cluster):
 
         parallelism = 100
         ds = ray.data.range(1000, parallelism=parallelism).random_shuffle()
-        ds = ds.cache()
+        ds = ds.materialize()
         assert "RandomShuffleMerge" in ds.stats()
         # Check all nodes used.
         assert "2 nodes used" in ds.stats()

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -54,7 +54,7 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
         )
     with patch.object(logger, "info") as mock_logger:
         ds = ray.data.range(1000, parallelism=10)
-        ds = ds.map_batches(dummy_map_batches).cache()
+        ds = ds.map_batches(dummy_map_batches).materialize()
 
         if enable_auto_log_stats:
             logger_args, logger_kwargs = mock_logger.call_args
@@ -86,7 +86,7 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
 """
                 )
 
-        ds = ds.map(dummy_map_batches).cache()
+        ds = ds.map(dummy_map_batches).materialize()
         if enable_auto_log_stats:
             logger_args, logger_kwargs = mock_logger.call_args
 
@@ -118,7 +118,7 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
                 )
     for batch in ds.iter_batches():
         pass
-    stats = canonicalize(ds.cache().stats())
+    stats = canonicalize(ds.materialize().stats())
 
     if context.new_execution_backend:
         if context.use_streaming_executor:
@@ -264,7 +264,7 @@ def test_dataset_stats_shuffle(ray_start_regular_shared):
     context.optimize_fuse_stages = True
     ds = ray.data.range(1000, parallelism=10)
     ds = ds.random_shuffle().repartition(1, shuffle=True)
-    stats = canonicalize(ds.cache().stats())
+    stats = canonicalize(ds.materialize().stats())
     assert (
         stats
         == """Stage N ReadRange->RandomShuffle: executed in T
@@ -309,35 +309,35 @@ Stage N Repartition: executed in T
 def test_dataset_stats_repartition(ray_start_regular_shared):
     ds = ray.data.range(1000, parallelism=10)
     ds = ds.repartition(1, shuffle=False)
-    stats = ds.cache().stats()
+    stats = ds.materialize().stats()
     assert "Repartition" in stats, stats
 
 
 def test_dataset_stats_union(ray_start_regular_shared):
     ds = ray.data.range(1000, parallelism=10)
     ds = ds.union(ds)
-    stats = ds.cache().stats()
+    stats = ds.materialize().stats()
     assert "Union" in stats, stats
 
 
 def test_dataset_stats_zip(ray_start_regular_shared):
     ds = ray.data.range(1000, parallelism=10)
     ds = ds.zip(ds)
-    stats = ds.cache().stats()
+    stats = ds.materialize().stats()
     assert "Zip" in stats, stats
 
 
 def test_dataset_stats_sort(ray_start_regular_shared):
     ds = ray.data.range(1000, parallelism=10)
     ds = ds.sort()
-    stats = ds.cache().stats()
+    stats = ds.materialize().stats()
     assert "SortMap" in stats, stats
     assert "SortReduce" in stats, stats
 
 
 def test_dataset_stats_from_items(ray_start_regular_shared):
     ds = ray.data.from_items(range(10))
-    stats = ds.cache().stats()
+    stats = ds.materialize().stats()
     assert "FromItems" in stats, stats
 
 
@@ -347,7 +347,7 @@ def test_dataset_stats_read_parquet(ray_start_regular_shared, tmp_path):
     ds = ray.data.range(1000, parallelism=10)
     ds.write_parquet(str(tmp_path))
     ds = ray.data.read_parquet(str(tmp_path)).map(lambda x: x)
-    stats = canonicalize(ds.cache().stats())
+    stats = canonicalize(ds.materialize().stats())
     if context.new_execution_backend:
         assert (
             stats
@@ -382,7 +382,7 @@ def test_dataset_split_stats(ray_start_regular_shared, tmp_path):
     dses = ds.split_at_indices([49])
     dses = [ds.map(lambda x: x + 1) for ds in dses]
     for ds_ in dses:
-        stats = canonicalize(ds_.cache().stats())
+        stats = canonicalize(ds_.materialize().stats())
 
         if context.new_execution_backend:
             assert (
@@ -470,7 +470,7 @@ def test_dataset_pipeline_stats_basic(ray_start_regular_shared, enable_auto_log_
 
     with patch.object(logger, "info") as mock_logger:
         ds = ray.data.range(1000, parallelism=10)
-        ds = ds.map_batches(dummy_map_batches).cache()
+        ds = ds.map_batches(dummy_map_batches).materialize()
 
         if enable_auto_log_stats:
             logger_args, logger_kwargs = mock_logger.call_args
@@ -702,7 +702,7 @@ def test_dataset_pipeline_cache_cases(ray_start_regular_shared):
     assert "[execution cached]" not in stats
 
     # CACHED (called cache()).
-    ds = ray.data.range(10).cache().repeat(2).map_batches(lambda x: x)
+    ds = ray.data.range(10).materialize().repeat(2).map_batches(lambda x: x)
     ds.take(999)
     stats = ds.stats()
     assert "[execution cached]" in stats

--- a/python/ray/train/tests/test_batch_predictor.py
+++ b/python/ray/train/tests/test_batch_predictor.py
@@ -114,7 +114,7 @@ def test_separate_gpu_stage(shutdown_only):
         num_gpus_per_worker=1,
         separate_gpu_stage=True,
         allow_gpu=True,
-    ).cache()
+    ).materialize()
     stats = ds.stats()
     assert "Stage 1 ReadRange->DummyPreprocessor:" in stats, stats
     assert "Stage 2 MapBatches(ScoringWrapper):" in stats, stats
@@ -125,7 +125,7 @@ def test_separate_gpu_stage(shutdown_only):
         num_gpus_per_worker=1,
         separate_gpu_stage=False,
         allow_gpu=True,
-    ).cache()
+    ).materialize()
     stats = ds.stats()
     assert "Stage 1 ReadRange:" in stats, stats
     assert "Stage 2 MapBatches(ScoringWrapper):" in stats, stats
@@ -148,7 +148,7 @@ def test_automatic_enable_gpu_from_num_gpus_per_worker(shutdown_only):
     with pytest.raises(
         ValueError, match="DummyPredictor does not support GPU prediction"
     ):
-        batch_predictor.predict(test_dataset, num_gpus_per_worker=1).cache()
+        batch_predictor.predict(test_dataset, num_gpus_per_worker=1).materialize()
 
 
 def test_batch_prediction():
@@ -158,7 +158,7 @@ def test_batch_prediction():
     )
 
     test_dataset = ray.data.range_table(4)
-    ds = batch_predictor.predict(test_dataset).cache()
+    ds = batch_predictor.predict(test_dataset).materialize()
     # Check fusion occurred.
     assert "ReadRange->DummyPreprocessor" in ds.stats(), ds.stats()
     assert ds.to_pandas().to_numpy().squeeze().tolist() == [
@@ -282,7 +282,7 @@ def test_batch_prediction_various_combination():
             predictor_cls,
         )
 
-        ds = batch_predictor.predict(input_dataset).cache()
+        ds = batch_predictor.predict(input_dataset).materialize()
         # Check no fusion needed since we're not doing a dataset read.
         assert f"Stage 1 {preprocessor.__class__.__name__}" in ds.stats(), ds.stats()
         assert ds.to_pandas().to_numpy().squeeze().tolist() == [

--- a/release/air_tests/air_benchmarks/mlperf-train/tf_utils.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/tf_utils.py
@@ -328,7 +328,7 @@ def build_tf_dataset(
     if dataset_cache:
         # Improve training / eval performance when data is in remote storage and
         # can fit into worker memory.
-        dataset = dataset.cache()
+        dataset = dataset.materialize()
 
     return process_record_dataset(
         dataset=dataset,

--- a/release/nightly_tests/dataset/aggregate_benchmark.py
+++ b/release/nightly_tests/dataset/aggregate_benchmark.py
@@ -28,7 +28,7 @@ def run_h2oai(benchmark: Benchmark):
         # Number of blocks (parallelism) should be set as number of available CPUs
         # to get best performance.
         num_blocks = int(ray.cluster_resources().get("CPU", 1))
-        input_ds = input_ds.repartition(num_blocks).cache()
+        input_ds = input_ds.repartition(num_blocks).materialize()
 
         q_list = [
             (h2oai_q1, "q1"),

--- a/release/nightly_tests/dataset/benchmark.py
+++ b/release/nightly_tests/dataset/benchmark.py
@@ -47,7 +47,7 @@ class Benchmark:
         print(f"Running case: {name}")
         start_time = time.perf_counter()
         output_ds = fn(**fn_run_args)
-        output_ds.cache()
+        output_ds.materialize()
         duration = time.perf_counter() - start_time
 
         # TODO(chengsu): Record more metrics based on dataset stats.

--- a/release/nightly_tests/dataset/inference.py
+++ b/release/nightly_tests/dataset/inference.py
@@ -86,17 +86,17 @@ ds = ray.data.read_binary_files(
     ray_remote_args={"num_cpus": 0.5},
 )
 # Do a blocking map so that we can measure the download time.
-ds = ds.map(lambda x: x).cache()
+ds = ds.map(lambda x: x).materialize()
 
 end_download_time = time.time()
 print("Preprocessing...")
-ds = ds.map(preprocess).cache()
+ds = ds.map(preprocess).materialize()
 end_preprocess_time = time.time()
 print("Inferring...")
 # NOTE: set a small batch size to avoid OOM on GRAM when doing inference.
 ds = ds.map_batches(
     infer, num_gpus=0.25, batch_size=128, batch_format="pandas", compute="actors"
-).cache()
+).materialize()
 
 end_time = time.time()
 

--- a/release/nightly_tests/dataset/iter_batches_benchmark.py
+++ b/release/nightly_tests/dataset/iter_batches_benchmark.py
@@ -54,7 +54,7 @@ def run_iter_batches_benchmark(benchmark: Benchmark):
             "s3://anonymous@air-example-data/ursa-labs-taxi-data/by_year/2018/01"
         )
         .repartition(12)
-        .cache()
+        .materialize()
     )
 
     batch_formats = ["pandas", "numpy"]
@@ -73,7 +73,7 @@ def run_iter_batches_benchmark(benchmark: Benchmark):
     for current_format in ["pyarrow", "pandas"]:
         new_ds = ds.map_batches(
             lambda ds: ds, batch_format=current_format, batch_size=None
-        ).cache()
+        ).materialize()
         for new_format in ["pyarrow", "pandas", "numpy"]:
             for batch_size in batch_sizes:
                 test_name = f"iter-batches-conversion-{current_format}-to-{new_format}-{batch_size}"  # noqa: E501
@@ -106,7 +106,7 @@ def run_iter_batches_benchmark(benchmark: Benchmark):
     new_ds = ds.repartition(512)
     new_ds = new_ds.map_batches(
         lambda ds: ds, batch_format="pandas", batch_size=None
-    ).cache()
+    ).materialize()
     for batch_size in [32 * 1024, 64 * 1024, 256 * 1024]:
         test_name = f"iter-batches-block-concat-to-batch-{batch_size}"
         benchmark.run(

--- a/release/nightly_tests/dataset/iter_tensor_batches_benchmark.py
+++ b/release/nightly_tests/dataset/iter_tensor_batches_benchmark.py
@@ -70,7 +70,7 @@ def run_iter_tensor_batches_benchmark(benchmark: Benchmark, data_size_gb: int):
         batch["__value__"] = label
         return batch
 
-    ds = ds.map_batches(add_label).cache()
+    ds = ds.map_batches(add_label).materialize()
 
     # Test iter_torch_batches() with default args.
     benchmark.run(

--- a/release/nightly_tests/dataset/map_batches_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_benchmark.py
@@ -24,7 +24,7 @@ def map_batches(
 
     ds = input_ds
     if is_eager_executed:
-        ds.cache()
+        ds.materialize()
 
     for _ in range(num_calls):
         ds = ds.map_batches(
@@ -34,7 +34,7 @@ def map_batches(
             compute=compute,
         )
         if is_eager_executed:
-            ds.cache()
+            ds.materialize()
     return ds
 
 
@@ -43,7 +43,7 @@ def run_map_batches_benchmark(benchmark: Benchmark):
         "s3://air-example-data/ursa-labs-taxi-data/by_year/2018/01"
     )
     lazy_input_ds = input_ds.lazy()
-    input_ds.cache()
+    input_ds.materialize()
 
     batch_formats = ["pandas", "numpy"]
     batch_sizes = [1024, 2048, 4096, None]
@@ -124,7 +124,7 @@ def run_map_batches_benchmark(benchmark: Benchmark):
     for current_format in ["pyarrow", "pandas"]:
         new_input_ds = input_ds.map_batches(
             lambda ds: ds, batch_format=current_format, batch_size=None
-        ).cache()
+        ).materialize()
         for new_format in ["pyarrow", "pandas", "numpy"]:
             for batch_size in batch_sizes:
                 test_name = f"map-batches-{current_format}-to-{new_format}-{batch_size}"
@@ -140,7 +140,7 @@ def run_map_batches_benchmark(benchmark: Benchmark):
     # Test reading multiple files.
     input_ds = ray.data.read_parquet(
         "s3://air-example-data/ursa-labs-taxi-data/by_year/2018"
-    ).cache()
+    ).materialize()
 
     for batch_format in batch_formats:
         for compute in ["tasks", "actors"]:

--- a/release/nightly_tests/dataset/read_parquet_benchmark.py
+++ b/release/nightly_tests/dataset/read_parquet_benchmark.py
@@ -21,7 +21,7 @@ def read_parquet(
         use_threads=use_threads,
         filter=filter,
         columns=columns,
-    ).cache()
+    ).materialize()
 
 
 def run_read_parquet_benchmark(benchmark: Benchmark):

--- a/release/nightly_tests/dataset/sort.py
+++ b/release/nightly_tests/dataset/sort.py
@@ -119,7 +119,7 @@ if __name__ == "__main__":
             ds = ds.random_shuffle()
         else:
             ds = ds.sort(key="c_0")
-        ds.cache()
+        ds.materialize()
         ds_stats = ds.stats()
     except Exception as e:
         exc = e


### PR DESCRIPTION
Based on discussion with @c21 @jjyao , as well as the new "MaterializedDatastream" class name, materialize makes more sense as an action than cache. Furthermore, we don't need an is_cached method as the new type information suffices.

## Why are these changes needed?

This picks https://github.com/ray-project/ray/pull/34169 into 2.4. We need to do this pick since this is a last minute rename of a new API in 2.4. Otherwise, we'd have to immediately deprecate the API in 2.5.