### PR TITLE
[pick] [data] [streaming] Simplify progress bar reporting and integrate with Jupyter

### DIFF
--- a/doc/source/data/dataset-internals.rst
+++ b/doc/source/data/dataset-internals.rst
@@ -104,12 +104,17 @@ Streaming Execution
 ~~~~~~~~~~~~~~~~~~~
 
 The following code is a hello world example which invokes the execution with
-:meth:`ds.iter_batches() <ray.data.Dataset.iter_batches>` consumption:
+:meth:`ds.iter_batches() <ray.data.Dataset.iter_batches>` consumption. We will also enable verbose progress reporting, which shows per-operator progress in addition to overall progress.
 
 .. code-block::
 
    import ray
    import time
+
+   # Enable verbose reporting. This can also be toggled on by setting
+   # the environment variable RAY_DATA_VERBOSE_PROGRESS=1.
+   ctx = ray.data.DatasetContext.get_current()
+   ctx.execution_options.verbose_progress = True
 
    def sleep(x):
        time.sleep(0.1)
@@ -134,9 +139,9 @@ The next few lines will show execution progress. Here is how to interpret the ou
 
 .. code-block::
 
-   Resource usage vs limits: 7.0/16.0 CPU, 0.0/0.0 GPU, 76.91 MiB/2.25 GiB object_store_memory
+   Running: 7.0/16.0 CPU, 0.0/0.0 GPU, 76.91 MiB/2.25 GiB object_store_memory 65%|██▊ | 130/200 [00:08<00:02, 22.52it/s]
 
-This line tells you how many resources are currently being used by the streaming executor out of the limits. The streaming executor will attempt to keep resource usage under the printed limits by throttling task executions.
+This line tells you how many resources are currently being used by the streaming executor out of the limits, as well as the number of completed output blocks. The streaming executor will attempt to keep resource usage under the printed limits by throttling task executions.
 
 .. code-block::
 
@@ -144,11 +149,8 @@ This line tells you how many resources are currently being used by the streaming
    MapBatches(sleep): 5 active, 5 queued, 18.31 MiB objects 2:  76%|██▎| 151/200 [00:08<00:02, 19.93it/s]
    MapBatches(sleep): 7 active, 2 queued, 25.64 MiB objects, 2 actors [all objects local] 3:  71%|▋| 142/
    MapBatches(sleep): 2 active, 0 queued, 7.32 MiB objects 4:  70%|██▊ | 139/200 [00:08<00:02, 23.16it/s]
-   output: 2 queued 5:  70%|█████████████████████████████▉             | 139/200 [00:08<00:02, 22.76it/s]
 
-Lines like the above show progress for each stage. The `active` count indicates the number of running tasks for the operator. The `queued` count is the number of input blocks for the operator that are computed but are not yet submitted for execution. For operators that use actor-pool execution, the number of running actors is shown as `actors`.
-
-The final line shows how much of the stream output has been consumed by the driver program. This value can fall behind the stream execution if your program doesn't pull data from `iter_batches()` fast enough, which may lead to execution throttling.
+These lines are only shown when verbose progress reporting is enabled. The `active` count indicates the number of running tasks for the operator. The `queued` count is the number of input blocks for the operator that are computed but are not yet submitted for execution. For operators that use actor-pool execution, the number of running actors is shown as `actors`.
 
 .. tip::
 
@@ -168,7 +170,7 @@ Execution options can be configured via the global DatasetContext. The options w
 
 .. code-block::
 
-   ctx = ray.data.context.DatasetContext.get_current()
+   ctx = ray.data.DatasetContext.get_current()
    ctx.execution_options.resource_limits.cpu = 10
    ctx.execution_options.resource_limits.gpu = 5
    ctx.execution_options.resource_limits.object_store_memory = 10e9

--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import os
 from typing import Dict, List, Optional, Iterable, Iterator, Tuple, Callable, Union
 
 import ray
@@ -188,6 +189,22 @@ class ExecutionOptions:
     """Common options for execution.
 
     Some options may not be supported on all executors (e.g., resource limits).
+
+    Attributes:
+        resource_limits: Set a soft limit on the resource usage during execution.
+            This is not supported in bulk execution mode. Autodetected by default.
+        locality_with_output: Set this to prefer running tasks on the same node as the
+            output node (node driving the execution). It can also be set to a list of
+            node ids to spread the outputs across those nodes. Off by default.
+        preserve_order: Set this to preserve the ordering between blocks processed by
+            operators under the streaming executor. The bulk executor always preserves
+            order. Off by default.
+        actor_locality_enabled: Whether to enable locality-aware task dispatch to
+            actors (on by default). This applies to both ActorPoolStrategy map and
+            streaming_split operations.
+        verbose_progress: Whether to report progress individually per operator. By
+            default, only AllToAll operators and global progress is reported. This
+            option is useful for performance debugging. Off by default.
     """
 
     # Set a soft limit on the resource usage during execution. This is not supported
@@ -206,6 +223,8 @@ class ExecutionOptions:
     # Whether to enable locality-aware task dispatch to actors (on by default). This
     # applies to both ActorPoolStrategy map and streaming_split operations.
     actor_locality_enabled: bool = True
+
+    verbose_progress: bool = bool(int(os.environ.get("RAY_DATA_VERBOSE_PROGRESS", "0")))
 
 
 @dataclass

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -51,7 +51,6 @@ class StreamingExecutor(Executor, threading.Thread):
         self._initial_stats: Optional[DatasetStats] = None
         self._final_stats: Optional[DatasetStats] = None
         self._global_info: Optional[ProgressBar] = None
-        self._output_info: Optional[ProgressBar] = None
 
         self._execution_id = uuid.uuid4().hex
         self._autoscaling_state = AutoscalingState()
@@ -79,18 +78,18 @@ class StreamingExecutor(Executor, threading.Thread):
         """
         self._initial_stats = initial_stats
         self._start_time = time.perf_counter()
+
         if not isinstance(dag, InputDataBuffer):
             logger.get_logger().info("Executing DAG %s", dag)
-            self._global_info = ProgressBar("Resource usage vs limits", 1, 0)
+            logger.get_logger().info("Execution config: %s", self._options)
 
         # Setup the streaming DAG topology and start the runner thread.
         _validate_dag(dag, self._get_or_refresh_resource_limits())
-        self._topology, progress_bar_position = build_streaming_topology(
-            dag, self._options
-        )
-        self._output_info = ProgressBar(
-            "Output", dag.num_outputs_total() or 1, progress_bar_position
-        )
+        self._topology, _ = build_streaming_topology(dag, self._options)
+
+        if not isinstance(dag, InputDataBuffer):
+            # Note: DAG must be initialized in order to query num_outputs_total.
+            self._global_info = ProgressBar("Running", dag.num_outputs_total() or 1)
 
         self._output_node: OpState = self._topology[dag]
         self.start()
@@ -112,7 +111,8 @@ class StreamingExecutor(Executor, threading.Thread):
                         raise item
                     else:
                         # Otherwise return a concrete RefBundle.
-                        self._outer._output_info.update(1)
+                        if self._outer._global_info:
+                            self._outer._global_info.update(1)
                         return item
                 except Exception:
                     self._outer.shutdown()
@@ -143,8 +143,6 @@ class StreamingExecutor(Executor, threading.Thread):
             for op, state in self._topology.items():
                 op.shutdown()
                 state.close_progress_bars()
-            if self._output_info:
-                self._output_info.close()
             # Make request for zero resources to autoscaler for this execution.
             actor = get_or_create_autoscaling_requester_actor()
             actor.request_resources.remote({}, self._execution_id)
@@ -266,18 +264,15 @@ class StreamingExecutor(Executor, threading.Thread):
     def _report_current_usage(
         self, cur_usage: TopologyResourceUsage, limits: ExecutionResources
     ) -> None:
+        resources_status = (
+            "Running: "
+            f"{cur_usage.overall.cpu}/{limits.cpu} CPU, "
+            f"{cur_usage.overall.gpu}/{limits.gpu} GPU, "
+            f"{cur_usage.overall.object_store_memory_str()}/"
+            f"{limits.object_store_memory_str()} object_store_memory"
+        )
         if self._global_info:
-            self._global_info.set_description(
-                "Resource usage vs limits: "
-                f"{cur_usage.overall.cpu}/{limits.cpu} CPU, "
-                f"{cur_usage.overall.gpu}/{limits.gpu} GPU, "
-                f"{cur_usage.overall.object_store_memory_str()}/"
-                f"{limits.object_store_memory_str()} object_store_memory"
-            )
-        if self._output_info:
-            self._output_info.set_description(
-                f"output: {len(self._output_node.outqueue)} queued"
-            )
+            self._global_info.set_description(resources_status)
 
 
 def _validate_dag(dag: PhysicalOperator, limits: ExecutionResources) -> None:

--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -44,9 +44,11 @@ def set_progress_bars(enabled: bool) -> bool:
 class ProgressBar:
     """Thin wrapper around tqdm to handle soft imports."""
 
-    def __init__(self, name: str, total: int, position: int = 0):
+    def __init__(
+        self, name: str, total: int, position: int = 0, enabled: bool = _enabled
+    ):
         self._desc = name
-        if not _enabled:
+        if not enabled:
             self._bar = None
         elif tqdm:
             ctx = ray.data.context.DatasetContext.get_current()

--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -12,7 +12,7 @@ import ray
 from ray.util.debug import log_once
 
 try:
-    import tqdm as real_tqdm
+    import tqdm.auto as real_tqdm
 except ImportError:
     real_tqdm = None
 
@@ -238,6 +238,9 @@ class _BarManager:
         self.in_hidden_state = False
         self.num_hides = 0
         self.lock = threading.RLock()
+        # Avoid colorizing Jupyter output, since the tqdm bar is rendered in
+        # ipywidgets instead of in the console.
+        self.should_colorize = not ray.widgets.util.in_notebook()
 
     def process_state_update(self, state: ProgressBarState) -> None:
         """Apply the remote progress bar state update.
@@ -258,20 +261,26 @@ class _BarManager:
             if state["pid"] == self.pid:
                 prefix = ""
             else:
-                prefix = "{}{}(pid={}){} ".format(
-                    colorama.Style.DIM,
-                    colorama.Fore.CYAN,
-                    state.get("pid"),
-                    colorama.Style.RESET_ALL,
-                )
+                prefix = "(pid={}) ".format(state.get("pid"))
+                if self.should_colorize:
+                    prefix = "{}{}{}{}".format(
+                        colorama.Style.DIM,
+                        colorama.Fore.CYAN,
+                        prefix,
+                        colorama.Style.RESET_ALL,
+                    )
         else:
-            prefix = "{}{}(pid={}, ip={}){} ".format(
-                colorama.Style.DIM,
-                colorama.Fore.CYAN,
+            prefix = "(pid={}, ip={}) ".format(
                 state.get("pid"),
                 state.get("ip"),
-                colorama.Style.RESET_ALL,
             )
+            if self.should_colorize:
+                prefix = "{}{}{}{}".format(
+                    colorama.Style.DIM,
+                    colorama.Fore.CYAN,
+                    prefix,
+                    colorama.Style.RESET_ALL,
+                )
         state["desc"] = prefix + state["desc"]
         process = self._get_or_allocate_bar_group(state)
         if process.has_bar(state["uuid"]):

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -22,6 +22,7 @@ try:
 except ImportError:
     rich = None
 
+import ray
 from ray._private.dict import unflattened_lookup
 from ray.air._internal.checkpoint_manager import _TrackedCheckpoint
 from ray.tune.callback import Callback
@@ -81,11 +82,7 @@ class AirVerbosity(IntEnum):
     VERBOSE = 2
 
 
-try:
-    class_name = get_ipython().__class__.__name__
-    IS_NOTEBOOK = True if "Terminal" not in class_name else False
-except NameError:
-    IS_NOTEBOOK = False
+IS_NOTEBOOK = ray.widgets.util.in_notebook()
 
 
 def get_air_verbosity() -> Optional[AirVerbosity]:

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -58,12 +58,7 @@ except ImportError:
         "'pip install ray[rllib]'."
     )
 
-try:
-    class_name = get_ipython().__class__.__name__
-    IS_NOTEBOOK = True if "Terminal" not in class_name else False
-except NameError:
-    IS_NOTEBOOK = False
-
+IS_NOTEBOOK = ray.widgets.util.in_notebook()
 
 SKIP_RESULTS_IN_REPORT = {"config", TRIAL_ID, EXPERIMENT_TAG, DONE}
 

--- a/python/ray/widgets/util.py
+++ b/python/ray/widgets/util.py
@@ -186,3 +186,14 @@ def fallback_if_colab(func: F) -> Callable[[F], F]:
             return None
 
     return wrapped
+
+
+@DeveloperAPI
+def in_notebook() -> bool:
+    """Return whether we are in a Jupyter notebook."""
+    try:
+        class_name = get_ipython().__class__.__name__
+        is_notebook = True if "Terminal" not in class_name else False
+    except NameError:
+        is_notebook = False
+    return is_notebook


### PR DESCRIPTION
Currently, we render verbose progress bars by default. This is both probably too verbose in many cases, and breaks Jupyter as multi-line progress bars are not well supported.

This PR changes the output to a single progress bar by default, gated by a verbose_progress option. In addition, it changes tqdm_ray to use the jupyter integrated tqdm when possible, to also support UI rendering of both single and verbose progress reporting.

## Why are these changes needed?

This picks https://github.com/ray-project/ray/pull/34150 into 2.4.0, which resolves a critical Jupyter UX issue with data streaming.