### PR TITLE
[2.4pick][core] Mark raylet unhealthy if GCS can't recognize it. (#34087)

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -9,6 +9,7 @@ import ray
 from ray._private.utils import get_or_create_event_loop
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 import ray._private.gcs_utils as gcs_utils
+from ray._private import ray_constants
 from ray._private.test_utils import (
     convert_actor_state,
     generate_system_config_map,
@@ -763,6 +764,55 @@ assert ray.get(c.r.remote(10)) == 10
     # GCS should exit in this case
     print(">>> Waiting gcs server to exit", gcs_server_pid)
     wait_for_pid_to_exit(gcs_server_pid, 1000)
+
+
+@pytest.mark.parametrize(
+    "ray_start_regular_with_external_redis",
+    [
+        generate_system_config_map(
+            gcs_failover_worker_reconnect_timeout=20,
+            gcs_rpc_server_reconnect_timeout_s=60,
+            gcs_server_request_timeout_seconds=10,
+            raylet_liveness_self_check_interval_ms=3000,
+        )
+    ],
+    indirect=True,
+)
+def test_redis_data_loss_no_leak(ray_start_regular_with_external_redis):
+    @ray.remote
+    def create_actor():
+        @ray.remote
+        class A:
+            def pid(self):
+                return os.getpid()
+
+        a = A.options(lifetime="detached", name="A").remote()
+        ray.get(a.pid.remote())
+
+    ray.get(create_actor.remote())
+
+    ray._private.worker._global_node.kill_gcs_server()
+    # Delete redis
+    redis_addr = os.environ.get("RAY_REDIS_ADDRESS")
+    import redis
+
+    ip, port = redis_addr.split(":")
+    cli = redis.Redis(ip, port)
+    cli.flushall()
+    raylet_proc = ray._private.worker._global_node.all_processes[
+        ray_constants.PROCESS_TYPE_RAYLET
+    ][0].process
+
+    def check_raylet_healthy():
+        return raylet_proc.poll() is None
+
+    wait_for_condition(lambda: check_raylet_healthy())
+
+    # Start GCS
+    ray._private.worker._global_node.start_gcs_server()
+
+    # Waiting for raylet to become unhealthy
+    wait_for_condition(lambda: not check_raylet_healthy())
 
 
 if __name__ == "__main__":

--- a/python/requirements_test.txt
+++ b/python/requirements_test.txt
@@ -91,7 +91,6 @@ markdown-it-py==1.1.0
 attrs==21.4.0
 importlib-metadata==4.13.0
 
-
 # For test_basic.py::test_omp_threads_set
 threadpoolctl==3.1.0
 numexpr==2.8.4

--- a/src/mock/ray/gcs/gcs_client/accessor.h
+++ b/src/mock/ray/gcs/gcs_client/accessor.h
@@ -133,6 +133,10 @@ class MockNodeInfoAccessor : public NodeInfoAccessor {
               (const NodeID &node_id, const StatusCallback &callback),
               (override));
   MOCK_METHOD(Status,
+              AsyncCheckSelfAlive,
+              (const std::function<void(Status, bool)> &callback, int64_t timeout_ms),
+              (override));
+  MOCK_METHOD(Status,
               AsyncGetAll,
               (const MultiItemCallback<rpc::GcsNodeInfo> &callback),
               (override));

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -790,6 +790,9 @@ RAY_CONFIG(bool, kill_idle_workers_of_terminated_job, true)
 // Example: RAY_preload_python_modules=tensorflow,pytorch
 RAY_CONFIG(std::vector<std::string>, preload_python_modules, {})
 
+// By default, raylet send a self liveness check to GCS every 60s
+RAY_CONFIG(int64_t, raylet_liveness_self_check_interval_ms, 60000)
+
 // Instruct the CoreWorker to kill its child processes while
 // it exits. This prevents certain classes of resource leaks
 // that are caused by the worker processes leaking processes.

--- a/src/ray/common/ray_syncer/ray_syncer-inl.h
+++ b/src/ray/common/ray_syncer/ray_syncer-inl.h
@@ -229,7 +229,7 @@ class RaySyncerBidiReactorBase : public RaySyncerBidiReactor, public T {
       node_versions[message->message_type()] = message->version();
       message_processor_(message);
     } else {
-      RAY_LOG_EVERY_N(WARNING, 100)
+      RAY_LOG_EVERY_MS(WARNING, 1000)
           << "Drop message received from " << NodeID::FromBinary(message->node_id())
           << " because the message version " << message->version()
           << " is older than the local version " << node_versions[message->message_type()]
@@ -286,8 +286,8 @@ class RaySyncerBidiReactorBase : public RaySyncerBidiReactor, public T {
           if (ok) {
             SendNext();
           } else {
-            RAY_LOG_EVERY_N(ERROR, 100) << "Failed to send the message to: "
-                                        << NodeID::FromBinary(GetRemoteNodeID());
+            RAY_LOG_EVERY_MS(ERROR, 1000) << "Failed to send the message to: "
+                                          << NodeID::FromBinary(GetRemoteNodeID());
             Disconnect();
           }
         },
@@ -302,8 +302,8 @@ class RaySyncerBidiReactorBase : public RaySyncerBidiReactor, public T {
             ReceiveUpdate(std::move(msg));
             StartPull();
           } else {
-            RAY_LOG_EVERY_N(ERROR, 100) << "Failed to read the message from: "
-                                        << NodeID::FromBinary(GetRemoteNodeID());
+            RAY_LOG_EVERY_MS(ERROR, 1000) << "Failed to read the message from: "
+                                          << NodeID::FromBinary(GetRemoteNodeID());
             Disconnect();
           }
         },

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -470,6 +470,27 @@ Status NodeInfoAccessor::AsyncRegister(const rpc::GcsNodeInfo &node_info,
   return Status::OK();
 }
 
+Status NodeInfoAccessor::AsyncCheckSelfAlive(
+    const std::function<void(Status, bool)> &callback, int64_t timeout_ms = -1) {
+  rpc::CheckAliveRequest request;
+  auto node_addr = local_node_info_.node_manager_address() + ":" +
+                   std::to_string(local_node_info_.node_manager_port());
+  RAY_CHECK(callback != nullptr);
+  request.add_raylet_address(node_addr);
+  client_impl_->GetGcsRpcClient().CheckAlive(
+      request,
+      [callback](auto status, const auto &reply) {
+        if (status.ok()) {
+          RAY_CHECK(reply.raylet_alive().size() == 1);
+          callback(status, reply.raylet_alive()[0]);
+        } else {
+          callback(status, true);
+        }
+      },
+      timeout_ms);
+  return Status::OK();
+}
+
 Status NodeInfoAccessor::AsyncDrainNode(const NodeID &node_id,
                                         const StatusCallback &callback) {
   RAY_LOG(DEBUG) << "Draining node, node id = " << node_id;

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -305,6 +305,14 @@ class NodeInfoAccessor {
   virtual Status AsyncRegister(const rpc::GcsNodeInfo &node_info,
                                const StatusCallback &callback);
 
+  /// Send a check alive request to GCS for the liveness of some node.
+  ///
+  /// \param callback The callback function once the request is finished.
+  /// \param timeout_ms The timeout for this request.
+  /// \return Status
+  virtual Status AsyncCheckSelfAlive(const std::function<void(Status, bool)> &callback,
+                                     int64_t timeout_ms);
+
   /// Drain (remove the information of the node from the cluster) the local node from GCS
   /// asynchronously.
   ///


### PR DESCRIPTION
When GCS can't recognize the raylet, Raylet will just hang there and never exits. There is also no way to tell whether this raylet is healthy or not.

This could happen when some incorrect setup. For example, data is lost in the DB. When Raylet detect the issue, it should just exit itself or mark itself as unhealthy.

This PR will mark raylet mark itself unhealthy and the upper layer can choose what to do for this case. This is useful for Serve HA's usecase because as long as the raylet is alive, the actors will be still able to serve traffic and the upper layer can do more operations, like starting a new cluster and shutdown the current one later.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
