### PR TITLE
[data] Add take_batch API for collecting data in the same format as iter_batches and map_batches

### DIFF
--- a/doc/source/data/api/dataset.rst
+++ b/doc/source/data/api/dataset.rst
@@ -85,6 +85,7 @@ Consuming Datasets
 
    Dataset.show
    Dataset.take
+   Dataset.take_batch
    Dataset.take_all
    Dataset.iterator
    Dataset.iter_rows

--- a/doc/source/data/api/from_other_data_libs.rst
+++ b/doc/source/data/api/from_other_data_libs.rst
@@ -26,8 +26,7 @@ For Pandas Users
    * - Pandas DataFrame API
      - Ray Datasets API
    * - df.head()
-     - :meth:`ds.show() <ray.data.Dataset.show>` or :meth:`ds.take_batch() <ray.data.Dataset.take_batch>`
-
+     - :meth:`ds.show() <ray.data.Dataset.show>`, :meth:`ds.take() <ray.data.Dataset.take>`, or :meth:`ds.take_batch() <ray.data.Dataset.take_batch>`
    * - df.dtypes
      - :meth:`ds.schema() <ray.data.Dataset.schema>`
    * - len(df) or df.shape[0]

--- a/doc/source/data/api/from_other_data_libs.rst
+++ b/doc/source/data/api/from_other_data_libs.rst
@@ -26,7 +26,8 @@ For Pandas Users
    * - Pandas DataFrame API
      - Ray Datasets API
    * - df.head()
-     - :meth:`ds.show() <ray.data.Dataset.show>` or :meth:`ds.take() <ray.data.Dataset.take>`
+     - :meth:`ds.show() <ray.data.Dataset.show>` or :meth:`ds.take_batch() <ray.data.Dataset.take_batch>`
+
    * - df.dtypes
      - :meth:`ds.schema() <ray.data.Dataset.schema>`
    * - len(df) or df.shape[0]

--- a/doc/source/data/consuming-datasets.rst
+++ b/doc/source/data/consuming-datasets.rst
@@ -14,9 +14,8 @@ Retrieving a limited set of rows
 ================================
 
 A limited set of rows can be retried from a ``Dataset`` via the
-:meth:`ds.take() <ray.data.Dataset.take>` API, along with its sibling helper APIs
-:meth:`ds.take_all() <ray.data.Dataset.take_all>`, for retrieving **all** rows, and
-:meth:`ds.show() <ray.data.Dataset.show>`, for printing a limited set of rows. These
+:meth:`ds.take_batch() <ray.data.Dataset.take_batch>` API, for retrieving a limited-size batch of rows,
+and :meth:`ds.show() <ray.data.Dataset.show>`, for printing a limited set of rows. These
 methods are convenient for quickly inspecting a subset (prefix) of rows. They have the
 benefit that, if used right after reading, they will only trigger more files to be
 read if needed to retrieve rows from that file; if inspecting a small prefix of rows,

--- a/doc/source/data/consuming-datasets.rst
+++ b/doc/source/data/consuming-datasets.rst
@@ -14,8 +14,8 @@ Retrieving a limited set of rows
 ================================
 
 A limited set of rows can be retried from a ``Dataset`` via the
-:meth:`ds.take_batch() <ray.data.Dataset.take_batch>` API, for retrieving a limited-size batch of rows,
-and :meth:`ds.show() <ray.data.Dataset.show>`, for printing a limited set of rows. These
+:meth:`ds.take() <ray.data.Dataset.take>` or :meth:`ds.take_batch() <ray.data.Dataset.take_batch>`
+APIs, and :meth:`ds.show() <ray.data.Dataset.show>`, for printing a limited set of rows. These
 methods are convenient for quickly inspecting a subset (prefix) of rows. They have the
 benefit that, if used right after reading, they will only trigger more files to be
 read if needed to retrieve rows from that file; if inspecting a small prefix of rows,

--- a/doc/source/data/consuming-datasets.rst
+++ b/doc/source/data/consuming-datasets.rst
@@ -13,7 +13,7 @@ The data underlying a ``Dataset`` can be consumed in several ways:
 Retrieving a limited set of rows
 ================================
 
-A limited set of rows can be retried from a ``Dataset`` via the
+A limited set of rows can be retrieved from a ``Dataset`` via the
 :meth:`ds.take() <ray.data.Dataset.take>` or :meth:`ds.take_batch() <ray.data.Dataset.take_batch>`
 APIs, and :meth:`ds.show() <ray.data.Dataset.show>`, for printing a limited set of rows. These
 methods are convenient for quickly inspecting a subset (prefix) of rows. They have the

--- a/doc/source/data/doc_code/consuming_datasets.py
+++ b/doc/source/data/doc_code/consuming_datasets.py
@@ -6,11 +6,18 @@ import ray
 
 ds = ray.data.range(10000)
 
-print(ds.take(5))
+# Take up to five records as a batch.
+print(ds.take_batch(5))
 # -> [0, 1, 2, 3, 4]
 
-# Warning: This will print all of the rows!
-print(ds.take_all())
+# Similar to above but coercing into Pandas format.
+print(ds.take_batch(5, batch_format="pandas"))
+# -> value
+# 0      0
+# 1      1
+# 2      2
+# 3      3
+# 4      4
 
 ds.show(5)
 # -> 0

--- a/doc/source/data/doc_code/consuming_datasets.py
+++ b/doc/source/data/doc_code/consuming_datasets.py
@@ -7,10 +7,10 @@ import ray
 ds = ray.data.range(10000)
 
 # Take up to five records as a batch.
-print(ds.take_batch(5))
+print(ds.take(5))
 # -> [0, 1, 2, 3, 4]
 
-# Similar to above but coercing into Pandas format.
+# Similar to above but returning in a batch format (like iter_batches / map_batches).
 print(ds.take_batch(5, batch_format="pandas"))
 # -> value
 # 0      0
@@ -18,6 +18,9 @@ print(ds.take_batch(5, batch_format="pandas"))
 # 2      2
 # 3      3
 # 4      4
+
+# Warning: This will print all of the rows!
+print(ds.take_all())
 
 ds.show(5)
 # -> 0

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2227,7 +2227,7 @@ class Datastream(Generic[T]):
 
     @ConsumptionAPI(pattern="Time complexity:")
     def take_batch(
-        self, batch_size: int, *, batch_format: Optional[str] = "default"
+        self, batch_size: int = 20, *, batch_format: Optional[str] = "default"
     ) -> DataBatch:
         """Return up to ``batch_size`` records from the datastream in a batch.
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2227,21 +2227,21 @@ class Datastream(Generic[T]):
 
     @ConsumptionAPI(pattern="Time complexity:")
     def take_batch(
-        self, limit: int = 20, *, batch_format: Optional[str] = "default"
+        self, batch_size: int, *, batch_format: Optional[str] = "default"
     ) -> DataBatch:
-        """Return up to ``limit`` records from the datastream in a batch.
+        """Return up to ``batch_size`` records from the datastream in a batch.
 
         Unlike take(), the records are returned in the same format as used for
         `iter_batches` and `map_batches`.
 
-        This will move up to ``limit`` records to the caller's machine; if
-        ``limit`` is very large, this can result in an OutOfMemory crash on
+        This will move up to ``batch_size`` records to the caller's machine; if
+        ``batch_size`` is very large, this can result in an OutOfMemory crash on
         the caller.
 
-        Time complexity: O(limit specified)
+        Time complexity: O(batch_size specified)
 
         Args:
-            limit: The max number of records to return.
+            batch_size: The max number of records to return.
             batch_format: Specify ``"default"`` to use the default block format
                 (promotes tables to Pandas and tensors to NumPy), ``"pandas"`` to select
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or
@@ -2255,7 +2255,7 @@ class Datastream(Generic[T]):
         """
         res = next(
             self.iter_batches(
-                batch_size=limit, prefetch_batches=0, batch_format=batch_format
+                batch_size=batch_size, prefetch_batches=0, batch_format=batch_format
             )
         )
         self._synchronize_progress_bar()

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2251,13 +2251,19 @@ class Datastream(Generic[T]):
                 formatting. The default is "default".
 
         Returns:
-            A batch of up to ``limit`` records from the datastream.
+            A batch of up to ``batch_size`` records from the datastream.
+
+        Raises:
+            ValueError if the datastream is empty.
         """
-        res = next(
-            self.iter_batches(
-                batch_size=batch_size, prefetch_batches=0, batch_format=batch_format
+        try:
+            res = next(
+                self.iter_batches(
+                    batch_size=batch_size, prefetch_batches=0, batch_format=batch_format
+                )
             )
-        )
+        except StopIteration:
+            raise ValueError("The datastream is empty.")
         self._synchronize_progress_bar()
         return res
 

--- a/python/ray/data/tests/test_dataset_consumption.py
+++ b/python/ray/data/tests/test_dataset_consumption.py
@@ -472,6 +472,19 @@ def test_from_items_parallelism_truncated(ray_start_regular_shared):
     assert ds.num_blocks() == n
 
 
+def test_take_batch(ray_start_regular_shared):
+    ds = ray.data.range(10, parallelism=2)
+    assert ds.take_batch(3) == [0, 1, 2]
+    assert ds.take_batch(6) == [0, 1, 2, 3, 4, 5]
+    assert isinstance(ds.take_batch(3, batch_format="pandas"), pd.DataFrame)
+    assert isinstance(ds.take_batch(3, batch_format="numpy"), np.ndarray)
+
+    ds = ray.data.range_tensor(10, parallelism=2)
+    assert np.all(ds.take_batch(3) == np.array([[0], [1], [2]]))
+    assert isinstance(ds.take_batch(3, batch_format="pandas"), pd.DataFrame)
+    assert isinstance(ds.take_batch(3, batch_format="numpy"), np.ndarray)
+
+
 def test_take_all(ray_start_regular_shared):
     assert ray.data.range(5).take_all() == [0, 1, 2, 3, 4]
 

--- a/python/ray/data/tests/test_dataset_consumption.py
+++ b/python/ray/data/tests/test_dataset_consumption.py
@@ -476,6 +476,7 @@ def test_take_batch(ray_start_regular_shared):
     ds = ray.data.range(10, parallelism=2)
     assert ds.take_batch(3) == [0, 1, 2]
     assert ds.take_batch(6) == [0, 1, 2, 3, 4, 5]
+    assert ds.take_batch(100) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     assert isinstance(ds.take_batch(3, batch_format="pandas"), pd.DataFrame)
     assert isinstance(ds.take_batch(3, batch_format="numpy"), np.ndarray)
 

--- a/python/ray/data/tests/test_dataset_consumption.py
+++ b/python/ray/data/tests/test_dataset_consumption.py
@@ -484,6 +484,9 @@ def test_take_batch(ray_start_regular_shared):
     assert isinstance(ds.take_batch(3, batch_format="pandas"), pd.DataFrame)
     assert isinstance(ds.take_batch(3, batch_format="numpy"), np.ndarray)
 
+    with pytest.raises(ValueError):
+        ray.data.range(0).take_batch()
+
 
 def test_take_all(ray_start_regular_shared):
     assert ray.data.range(5).take_all() == [0, 1, 2, 3, 4]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There isn't any convenient way to take just a single batch today, which is confusing. Introduce `ds.take_batch(n, batch_format="default")`, which returns a batch of `n` records as `next(ds.iter_batches(batch_size=n, batch_format="default"))` would.

TODO:
- [x] Update docs

Closes https://github.com/ray-project/ray/issues/34116