### PR TITLE
[Dataset] Don't trigger execution on Datastream's Jupyter repr

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4450,8 +4450,8 @@ class Datastream(Generic[T]):
             "num_blocks": self._plan.initial_num_blocks(),
             "num_rows": self._meta_count(),
         }
-
-        schema = self.schema()
+        # Show metadata if available, but don't trigger execution.
+        schema = self.schema(fetch_if_missing=False)
         if schema is None:
             schema_repr = Template("rendered_html_common.html.j2").render(
                 content="<h5>Unknown schema</h5>"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently, rendering a `Datastream` in a Jupyter notebook will trigger execution, since the Jupyter repr (`Datastream._tab_repr_`) relies on fetching the schema if not available. To align with the behavior of `Datastream.__str__` and `Datastream.__repr__` methods, we avoid forcing execution to fetch the schema if it is missing.

After the change, we do not trigger execution:
<img width="1069" alt="Screenshot at Apr 10 13-34-48" src="https://user-images.githubusercontent.com/5122851/230993977-e1ec66ba-24f8-4dc5-acce-8765ad623220.png">


## Related issue number

<!-- For example: "Closes #1234" -->
Closes #34107 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
