### PR TITLE
[doc] [data] Fix autosummary issues

### DIFF
--- a/doc/source/data/api/dataset.rst
+++ b/doc/source/data/api/dataset.rst
@@ -103,6 +103,7 @@ I/O and Conversion
    Dataset.write_csv
    Dataset.write_numpy
    Dataset.write_tfrecords
+   Dataset.write_webdataset
    Dataset.write_mongo
    Dataset.write_datasource
    Dataset.to_torch

--- a/doc/source/data/api/execution_options.rst
+++ b/doc/source/data/api/execution_options.rst
@@ -10,6 +10,7 @@ Constructor
 
 .. autosummary::
    :toctree: doc/
+   :template: autosummary/class_without_autosummary.rst
 
    ExecutionOptions
 
@@ -18,5 +19,6 @@ Resource Options
 
 .. autosummary::
    :toctree: doc/
+   :template: autosummary/class_without_autosummary.rst
 
    ExecutionResources

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4124,17 +4124,6 @@ class Datastream(Generic[T]):
         "needed and this API will be removed in a future release"
     )
     def lazy(self) -> "Datastream[T]":
-        """Enable lazy evaluation.
-
-        Datastream is lazy by default, so this is only useful for datastreams created
-        from :func:`ray.data.from_items() <ray.data.read_api.from_items>`, which is
-        eager.
-
-        The returned datastream is a lazy datastream, where all subsequent operations
-        on the stream won't be executed until the datastream is consumed
-        (e.g. ``.take()``, ``.iter_batches()``, ``.to_torch()``, ``.to_tf()``, etc.)
-        or execution is manually triggered via ``.materialize()``.
-        """
         ds = Datastream(
             self._plan, self._epoch, lazy=True, logical_plan=self._logical_plan
         )
@@ -4338,12 +4327,15 @@ class Datastream(Generic[T]):
     )
     @Deprecated(message="`dataset_format` is deprecated for streaming execution.")
     def dataset_format(self) -> BlockFormat:
+<<<<<<< Updated upstream
         """The format of the datastream's underlying data blocks. Possible values
         are: "arrow", "pandas" and "simple".
 
         This may block; if the schema is unknown, this will synchronously fetch
         the schema for the first block.
         """
+=======
+>>>>>>> Stashed changes
         context = DatasetContext.get_current()
         if context.use_streaming_executor:
             raise DeprecationWarning(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4327,15 +4327,6 @@ class Datastream(Generic[T]):
     )
     @Deprecated(message="`dataset_format` is deprecated for streaming execution.")
     def dataset_format(self) -> BlockFormat:
-<<<<<<< Updated upstream
-        """The format of the datastream's underlying data blocks. Possible values
-        are: "arrow", "pandas" and "simple".
-
-        This may block; if the schema is unknown, this will synchronously fetch
-        the schema for the first block.
-        """
-=======
->>>>>>> Stashed changes
         context = DatasetContext.get_current()
         if context.use_streaming_executor:
             raise DeprecationWarning(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. Disable autosummary for a few classes that produce duplicate object description warnings (this is a known issue from @jjyao ).
2. Add write_webdataset to toc.
3. Remove pydoc for methods deprecated and removed from toc.