### PR TITLE
[Doc] Fix typo in Tune restore guide

### DIFF
--- a/doc/source/tune/doc_code/fault_tolerance.py
+++ b/doc/source/tune/doc_code/fault_tolerance.py
@@ -23,7 +23,7 @@ tuner = tune.Tuner(
     trainable,
     param_space={"num_epochs": 10},
     run_config=air.RunConfig(
-        local_dir="~/ray_results", name="tune_fault_tolerance_guide"
+        storage_path="~/ray_results", name="tune_fault_tolerance_guide"
     ),
 )
 tuner.fit()
@@ -31,7 +31,7 @@ tuner.fit()
 
 # __ft_restored_run_start__
 tuner = tune.Tuner.restore(
-    path="~/ray_results/tune_fault_tolerance_guide",
+    "~/ray_results/tune_fault_tolerance_guide",
     trainable=trainable,
     resume_errored=True,
 )
@@ -40,7 +40,7 @@ tuner.fit()
 
 # __ft_restore_options_start__
 tuner = tune.Tuner.restore(
-    path="~/ray_results/tune_fault_tolerance_guide",
+    "~/ray_results/tune_fault_tolerance_guide",
     trainable=trainable,
     resume_errored=True,
     restart_errored=False,
@@ -52,9 +52,9 @@ tuner = tune.Tuner.restore(
 import os
 from ray import air, tune
 
-local_dir = "~/ray_results"
+storage_path = "~/ray_results"
 exp_name = "tune_fault_tolerance_guide"
-path = os.path.join(local_dir, exp_name)
+path = os.path.join(storage_path, exp_name)
 
 if tune.Tuner.can_restore(path):
     tuner = tune.Tuner.restore(path, trainable=trainable, resume_errored=True)
@@ -62,9 +62,7 @@ else:
     tuner = tune.Tuner(
         trainable,
         param_space={"num_epochs": 10},
-        run_config=air.RunConfig(
-            local_dir="~/ray_results", name="single_script_fit_or_restore"
-        ),
+        run_config=air.RunConfig(storage_path=storage_path, name=exp_name),
     )
 tuner.fit()
 # __ft_restore_multiplexing_end__
@@ -94,7 +92,7 @@ tuner = tune.Tuner(
     train_fn,
     # Tune over the object references!
     param_space={"model_ref": tune.grid_search(model_refs)},
-    run_config=air.RunConfig(local_dir="~/ray_results", name="restore_object_refs"),
+    run_config=air.RunConfig(storage_path="~/ray_results", name="restore_object_refs"),
 )
 tuner.fit()
 # __ft_restore_objrefs_initial_end__
@@ -125,7 +123,7 @@ tuner = tune.Tuner(
     trainable,
     param_space={"num_epochs": 10},
     run_config=air.RunConfig(
-        local_dir="~/ray_results",
+        storage_path="~/ray_results",
         name="trial_fault_tolerance",
         failure_config=air.FailureConfig(max_failures=3),
     ),

--- a/doc/source/tune/doc_code/fault_tolerance.py
+++ b/doc/source/tune/doc_code/fault_tolerance.py
@@ -67,6 +67,19 @@ else:
 tuner.fit()
 # __ft_restore_multiplexing_end__
 
+
+# Run the multiplexed logic again to make sure it goes through the restore branch.
+if tune.Tuner.can_restore(path):
+    tuner = tune.Tuner.restore(path, trainable=trainable, resume_errored=True)
+else:
+    tuner = tune.Tuner(
+        trainable,
+        param_space={"num_epochs": 10},
+        run_config=air.RunConfig(storage_path=storage_path, name=exp_name),
+    )
+assert tuner.get_results()
+
+
 # __ft_restore_objrefs_initial_start__
 import ray
 from ray import air, tune


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

[This user guide](https://docs.ray.io/en/master/tune/tutorials/tune-fault-tolerance.html) had a typo in the multiplexing/autoresume example code. This PR fixes this, and also updates these code snippets to use `storage_path` instead of `local_dir`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
