### PR TITLE
[CI] Add options for release test run to run only likely failing tests

### DIFF
--- a/release/ray_release/buildkite/filter.py
+++ b/release/ray_release/buildkite/filter.py
@@ -41,7 +41,7 @@ def filter_tests(
         test_attr_regex_filters['team'] = team
     if only_likely_failing_tests:
         coverage = _get_likely_failing_tests()
-        test_collection = [test for test in test_collection if test.name in coverage]
+        test_collection = [test for test in test_collection if test['name'] in coverage]
 
     tests_to_run = []
     for test in test_collection:

--- a/release/ray_release/buildkite/filter.py
+++ b/release/ray_release/buildkite/filter.py
@@ -21,7 +21,7 @@ def _unflattened_lookup(lookup: Dict, flat_key: str, delimiter: str = "/") -> An
 def _get_likely_failing_tests() -> List[str]:
     s3 = boto3.client('s3')
     files = s3.list_objects_v2(
-        Bucket=RELEASE_AWS_BUCKET,
+        Bucket='ray-release-automation-results',
         Prefix='continuous-release/',
     )['Contents']
     _get_last_modified = lambda obj: int(obj['LastModified'].strftime('%s'))

--- a/release/ray_release/buildkite/filter.py
+++ b/release/ray_release/buildkite/filter.py
@@ -6,8 +6,6 @@ from typing import List, Optional, Tuple, Dict, Any
 
 from ray_release.buildkite.settings import Frequency, get_frequency
 from ray_release.config import Test
-from ray_release.aws import RELEASE_AWS_BUCKET
-
 
 def _unflattened_lookup(lookup: Dict, flat_key: str, delimiter: str = "/") -> Any:
     curr = lookup
@@ -26,7 +24,7 @@ def _get_likely_failing_tests() -> List[str]:
     )['Contents']
     _get_last_modified = lambda obj: int(obj['LastModified'].strftime('%s'))
     latest_coverage = [file for file in sorted(files, key=_get_last_modified)][-1]
-    data = s3.get_object(Bucket=RELEASE_AWS_BUCKET, Key=latest_coverage['Key'])
+    data = s3.get_object(Bucket='ray-release-automation-results', Key=latest_coverage['Key'])
     return json.loads(data['Body'].read().decode('utf-8'))
 
 def filter_tests(

--- a/release/ray_release/buildkite/filter.py
+++ b/release/ray_release/buildkite/filter.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Tuple, Dict, Any
 
 from ray_release.buildkite.settings import Frequency, get_frequency
 from ray_release.config import Test
+from ray_release.aws import RELEASE_AWS_BUCKET
 
 
 def _unflattened_lookup(lookup: Dict, flat_key: str, delimiter: str = "/") -> Any:
@@ -20,12 +21,12 @@ def _unflattened_lookup(lookup: Dict, flat_key: str, delimiter: str = "/") -> An
 def _get_likely_failing_tests() -> List[str]:
     s3 = boto3.client('s3')
     files = s3.list_objects_v2(
-        Bucket='ray-test-coverage', 
+        Bucket=RELEASE_AWS_BUCKET,
         Prefix='continuous-release/',
     )['Contents']
     _get_last_modified = lambda obj: int(obj['LastModified'].strftime('%s'))
     latest_coverage = [file for file in sorted(files, key=_get_last_modified)][-1]
-    data = s3.get_object(Bucket='ray-test-coverage', Key=latest_coverage['Key'])
+    data = s3.get_object(Bucket=RELEASE_AWS_BUCKET, Key=latest_coverage['Key'])
     return json.loads(data['Body'].read().decode('utf-8'))
 
 def filter_tests(

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -36,14 +36,14 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
 )
 @click.option(
     "--only-likely-failing-tests",
-    default=False,
+    default=True,
     type=bool,
     help="Run only tests that have a higher chance to fail, which is determined based "
     "on their historical run behaviors"
 )
 @click.option(
     "--team",
-    default=None,
+    default="core",
     type=str,
     help="Run only tests that are owned by this team (core, ml, etc.)"
 )
@@ -59,8 +59,8 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
 )
 def main(
     test_collection_file: Optional[str] = None, 
-    only_likely_failing_tests: bool = False,
-    team: Optional[str] = None,
+    only_likely_failing_tests: bool = True,
+    team: Optional[str] = "core",
     no_clone_repo: bool = False,
 ):
     settings = get_pipeline_settings()

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -39,13 +39,13 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
     default=False,
     type=bool,
     help="Run only tests that have a higher chance to fail, which is determined based "
-    "on their historical run behaviors"
+    "on their historical run behaviors",
 )
 @click.option(
     "--team",
     default=None,
     type=str,
-    help="Run only tests that are owned by this team (core, ml, etc.)"
+    help="Run only tests that are owned by this team (core, ml, etc.)",
 )
 @click.option(
     "--no-clone-repo",
@@ -58,7 +58,7 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
     ),
 )
 def main(
-    test_collection_file: Optional[str] = None, 
+    test_collection_file: Optional[str] = None,
     only_likely_failing_tests: bool = True,
     team: Optional[str] = "core",
     no_clone_repo: bool = False,

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -36,14 +36,14 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
 )
 @click.option(
     "--only-likely-failing-tests",
-    default=True,
+    default=False,
     type=bool,
     help="Run only tests that have a higher chance to fail, which is determined based "
     "on their historical run behaviors"
 )
 @click.option(
     "--team",
-    default="core",
+    default=None,
     type=str,
     help="Run only tests that are owned by this team (core, ml, etc.)"
 )

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -35,6 +35,19 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
     help="File containing test configurations",
 )
 @click.option(
+    "--only-likely-failing-tests",
+    default=False,
+    type=bool,
+    help="Run only tests that have a higher chance to fail, which is determined based "
+    "on their historical run behaviors"
+)
+@click.option(
+    "--team",
+    default=None,
+    type=str,
+    help="Run only tests that are owned by this team (core, ml, etc.)"
+)
+@click.option(
     "--no-clone-repo",
     is_flag=True,
     show_default=True,
@@ -44,7 +57,12 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
         "(for internal use)."
     ),
 )
-def main(test_collection_file: Optional[str] = None, no_clone_repo: bool = False):
+def main(
+    test_collection_file: Optional[str] = None, 
+    only_likely_failing_tests: bool = False,
+    team: Optional[str] = None,
+    no_clone_repo: bool = False,
+):
     settings = get_pipeline_settings()
 
     repo = settings["ray_test_repo"]
@@ -131,6 +149,8 @@ def main(test_collection_file: Optional[str] = None, no_clone_repo: bool = False
         frequency=frequency,
         test_attr_regex_filters=test_attr_regex_filters,
         prefer_smoke_tests=prefer_smoke_tests,
+        only_likely_failing_tests=only_likely_failing_tests,
+        team=team,
     )
     logger.info(f"Found {len(filtered_tests)} tests to run.")
     if len(filtered_tests) == 0:


### PR DESCRIPTION
## Why are these changes needed?

In https://docs.google.com/document/d/1JC_dHCBkmU7dZY6CaqCFI55zRQo-zNnBeDq5BUGwdBg/edit#heading=h.kbv9vy7pjqaz, I made a proposal to using a test-behavior based coverage to run only tests that are likely to fail. At the same time, we would also want to run tests more often, so bisecting and creating issues for failing test is more prompt.

This PR add flags to build-pipeline.py to be able to run only tests that are likely to fail. Also add option to run tests that belong to a certain team.

## Related issue number

Issue #34242 

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Release tests - https://buildkite.com/ray-project/release-tests-pr/builds/34595
   