### PR TITLE
[RLlib] Change broken doc name: MultiAgentRLModule.build->MultiAgentRLModule.setup

### DIFF
--- a/doc/source/rllib/package_ref/rl_modules.rst
+++ b/doc/source/rllib/package_ref/rl_modules.rst
@@ -114,7 +114,7 @@ Constructor
     :toctree: doc/
 
     MultiAgentRLModule
-    MultiAgentRLModule.build
+    MultiAgentRLModule.setup
     MultiAgentRLModule.as_multi_agent
 
 Modifying the underlying RL modules


### PR DESCRIPTION
Signed-off-by: Avnish <avnishnarayan@gmail.com>

fix in the title. We had a autogenerated doc that was broken because the name of a function changed.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
