### PR TITLE
[RLlib] Make impala training step always return something

### DIFF
--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import platform
 import queue
@@ -1001,7 +1000,7 @@ class Impala(Algorithm):
                 learner_infos.append(learner_results)
         # Nothing new happened since last time, use the same learner stats.
         if not learner_infos:
-            final_learner_info = copy.deepcopy(self._learner_thread.learner_info)
+            final_learner_info = {}
         # Accumulate learner stats using the `LearnerInfoBuilder` utility.
         else:
             builder = LearnerInfoBuilder()


### PR DESCRIPTION
When we call `_training_step`, it is launching async requests to sampling
and learner workers. There are not necessarily results that are ready to
be returned. Here, we keep calling `_training_step` until we get results back
that way there is something to be returned every time `training_step` is
called.

This should reduce any unnecessary evaluations as well.

Signed-off-by: Avnish <avnishnarayan@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
