### PR TITLE
[core][state] Use `--err` flag to query stderr logs from worker/actors instead of `--suffix=err`

### DIFF
--- a/dashboard/modules/log/log_manager.py
+++ b/dashboard/modules/log/log_manager.py
@@ -120,7 +120,7 @@ class LogsManager:
         pid: Optional[str],
         get_actor_fn: Callable[[str], Dict],
         timeout: int,
-        suffix: Optional[str] = None,
+        suffix: str = "out",
     ) -> Tuple[str, str]:
         """Return the file name given all options.
 
@@ -134,11 +134,8 @@ class LogsManager:
             timeout: Timeout for the gRPC to listing logs on the node
                 specified by `node_id`.
             suffix: Log suffix if no `log_filename` is provided, when
-                resolving by other ids'.
+                resolving by other ids'. Default to "out".
         """
-        if suffix is None:
-            suffix = ""
-
         if actor_id:
             actor_data = get_actor_fn(actor_id)
             if actor_data is None:

--- a/dashboard/modules/state/state_head.py
+++ b/dashboard/modules/state/state_head.py
@@ -409,7 +409,7 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
             pid=req.query.get("pid", None),
             lines=req.query.get("lines", DEFAULT_LOG_LIMIT),
             interval=req.query.get("interval", None),
-            suffix=req.query.get("suffix", None),
+            suffix=req.query.get("suffix", "out"),
         )
 
         response = aiohttp.web.StreamResponse()

--- a/python/ray/experimental/state/api.py
+++ b/python/ray/experimental/state/api.py
@@ -1124,7 +1124,7 @@ def get_log(
     follow: bool = False,
     tail: int = -1,
     timeout: int = DEFAULT_RPC_TIMEOUT,
-    suffix: Optional[str] = None,
+    suffix: str = "out",
     encoding: Optional[str] = "utf-8",
     errors: Optional[str] = "strict",
     _interval: Optional[float] = None,
@@ -1157,7 +1157,7 @@ def get_log(
         tail: Number of lines to get from the end of the log file. Set to -1 for getting
             the entire log.
         timeout: Max timeout for requests made when getting the logs.
-        suffix: The suffix of the log file if query by id of tasks/workers/actors.
+        suffix: The suffix of the log file if query by id of tasks/workers/actors. Default to "out".
         encoding: The encoding used to decode the content of the log file. Default is
             "utf-8". Use None to get binary data directly.
         errors: The error handling scheme to use for decoding errors. Default is

--- a/python/ray/experimental/state/common.py
+++ b/python/ray/experimental/state/common.py
@@ -298,7 +298,8 @@ class GetLogOptions:
     # Should be used only when media_type == stream.
     interval: Optional[float] = None
     # The suffix of the log file if file resolution not through filename directly.
-    suffix: Optional[str] = None
+    # Default to "out".
+    suffix: str = "out"
 
     def __post_init__(self):
         if self.pid:
@@ -329,8 +330,11 @@ class GetLogOptions:
                 "None of actor_id, task_id, pid, or filename is provided. "
                 "At least one of them is required to fetch logs."
             )
-        if self.filename and self.suffix:
-            raise ValueError("suffix should not be provided together with filename.")
+
+        if self.suffix not in ["out", "err"]:
+            raise ValueError(
+                f"Invalid suffix: {self.suffix}. Must be one of 'out' or 'err'."
+            )
 
 
 # See the ActorTableData message in gcs.proto for all potential options that

--- a/python/ray/experimental/state/state_cli.py
+++ b/python/ray/experimental/state/state_cli.py
@@ -746,13 +746,12 @@ log_node_id_option = click.option(
 )
 
 log_suffix_option = click.option(
-    "--suffix",
-    required=False,
-    default="out",
-    type=click.Choice(["out", "err"], case_sensitive=False),
+    "--err",
+    is_flag=True,
+    default=False,
     help=(
-        "The suffix of the log file that denotes the log type, where out refers "
-        "to logs from stdout, and err for logs from stderr "
+        "If supplied, querying stderr files for workers/actors, "
+        "else defaults to stdout files."
     ),
 )
 
@@ -806,7 +805,7 @@ def _print_log(
     tail: int = DEFAULT_LOG_LIMIT,
     timeout: int = DEFAULT_RPC_TIMEOUT,
     interval: Optional[float] = None,
-    suffix: Optional[str] = None,
+    suffix: str = "out",
     encoding: str = "utf-8",
     encoding_errors: str = "strict",
 ):
@@ -1042,7 +1041,7 @@ def log_actor(
     tail: int,
     interval: float,
     timeout: int,
-    suffix: str,
+    err: bool,
 ):
     """Get/List logs associated with an actor.
 
@@ -1065,7 +1064,7 @@ def log_actor(
         Get the actor err log file.
 
         ```
-        ray logs actor --id ABC --suffix err
+        ray logs actor --id ABC --err
         ```
 
     Raises:
@@ -1090,7 +1089,7 @@ def log_actor(
         follow=follow,
         interval=interval,
         timeout=timeout,
-        suffix=suffix,
+        suffix="err" if err else "out",
     )
 
 
@@ -1123,7 +1122,7 @@ def log_worker(
     tail: int,
     interval: float,
     timeout: int,
-    suffix: str,
+    err: bool,
 ):
     """Get/List logs associated with a worker process.
 
@@ -1138,7 +1137,7 @@ def log_worker(
         Get the stderr logs from a worker process.
 
         ```
-        ray logs worker --pid ABC --suffix err
+        ray logs worker --pid ABC --err
         ```
 
     Raises:
@@ -1156,5 +1155,5 @@ def log_worker(
         follow=follow,
         interval=interval,
         timeout=timeout,
-        suffix=suffix,
+        suffix="err" if err else "out",
     )

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -795,7 +795,6 @@ def test_log_get(ray_start_cluster):
     wait_for_condition(verify)
 
     def verify():
-        # Tailing with lines is not supported for binary files, thus the `tail=-1`
         runner = CliRunner()
         result = runner.invoke(
             logs_state_cli_group,

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -233,7 +233,7 @@ async def test_logs_manager_resolve_file(logs_manager):
         timeout=10,
     )
     logs_manager.list_logs.assert_awaited_with(
-        node_id.hex(), 10, glob_filter=f"*{worker_id.hex()}*"
+        node_id.hex(), 10, glob_filter=f"*{worker_id.hex()}*out"
     )
     assert log_file_name == f"worker-{worker_id.hex()}-123-123.out"
     assert n == node_id.hex()
@@ -293,7 +293,7 @@ async def test_logs_manager_resolve_file(logs_manager):
         timeout=10,
     )
     logs_manager.list_logs.assert_awaited_with(
-        node_id.hex(), 10, glob_filter=f"*{pid}*"
+        node_id.hex(), 10, glob_filter=f"*{pid}*out"
     )
     assert log_file_name == f"worker-123-123-{pid}.out"
 
@@ -330,7 +330,7 @@ async def test_logs_manager_resolve_file(logs_manager):
         timeout=10,
     )
     logs_manager.list_logs.assert_awaited_with(
-        node_id.hex(), 10, glob_filter=f"*{pid}*"
+        node_id.hex(), 10, glob_filter=f"*{pid}*out"
     )
     assert log_file_name == f"worker-123-123-{pid}.out"
 
@@ -798,11 +798,7 @@ def test_log_get(ray_start_cluster):
         runner = CliRunner()
         result = runner.invoke(
             logs_state_cli_group,
-            [
-                "actor",
-                "--id",
-                actor_id
-            ],
+            ["actor", "--id", actor_id],
         )
         assert result.exit_code == 0, result.exception
         assert ACTOR_LOG_LINE.format(dest="out") in result.output

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -794,6 +794,34 @@ def test_log_get(ray_start_cluster):
 
     wait_for_condition(verify)
 
+    def verify():
+        # Tailing with lines is not supported for binary files, thus the `tail=-1`
+        runner = CliRunner()
+        result = runner.invoke(
+            logs_state_cli_group,
+            [
+                "actor",
+                "--id",
+                actor_id
+            ],
+        )
+        assert result.exit_code == 0, result.exception
+        assert ACTOR_LOG_LINE.format(dest="out") in result.output
+
+        result = runner.invoke(
+            logs_state_cli_group,
+            [
+                "actor",
+                "--id",
+                actor_id,
+                "--err",
+            ],
+        )
+        assert result.exit_code == 0, result.exception
+        assert ACTOR_LOG_LINE.format(dest="err") in result.output
+        return True
+
+    wait_for_condition(verify)
     ##############################
     # Test binary files and encodings.
     ##############################


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
as title. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
