### PR TITLE
[Metrics] Fix shared memory is not displayed properly 

### DIFF
--- a/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
@@ -262,7 +262,7 @@ DEFAULT_GRAFANA_PANELS = [
                 legend="{{Component}}",
             ),
             Target(
-                expr="node_mem_shared_bytes{{{global_filters}}}",
+                expr="sum(ray_node_mem_shared_bytes{{{global_filters}}})",
                 legend="shared_memory",
             ),
             Target(

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -869,7 +869,7 @@ class ReporterAgent(
         if shm_used:
             node_mem_shared = Record(
                 gauge=METRICS_GAUGES["node_mem_shared_bytes"],
-                value=mem_total,
+                value=shm_used,
                 tags={"ip": ip},
             )
             records_reported.append(node_mem_shared)

--- a/dashboard/modules/reporter/tests/test_reporter.py
+++ b/dashboard/modules/reporter/tests/test_reporter.py
@@ -168,7 +168,8 @@ def test_prometheus_physical_stats_record(enable_test_module, shutdown_only):
                 "ray_node_mem_used" in metric_names,
                 "ray_node_mem_available" in metric_names,
                 "ray_node_mem_total" in metric_names,
-                "ray_component_cpu_percentage" in metric_names,
+                "ray_node_mem_total" in metric_names,
+                "ray_node_mem_shared_bytes" in metric_names,
                 "ray_component_rss_mb" in metric_names,
                 "ray_component_uss_mb" in metric_names,
                 "ray_node_disk_io_read" in metric_names,
@@ -260,6 +261,10 @@ def test_report_stats():
 
     records = agent._record_stats(STATS_TEMPLATE, cluster_stats)
     for record in records:
+        name = record.gauge.name
+        val = record.value
+        if name == "node_mem_shared_bytes":
+            assert val == STATS_TEMPLATE["shm"]
         print(record.gauge.name)
         print(record)
     assert len(records) == 33


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Looks like we incorrectly recorded shared memory, and incorrectly displayed it to the metrics graph (I forgot to append `ray_`)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
