### PR TITLE
Revert "[core] prestart worker on node startup (#33623)"

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1035,6 +1035,7 @@ class Node:
             socket_to_use=None,
             max_bytes=self.max_bytes,
             backup_count=self.backup_count,
+            start_initial_python_workers_for_first_job=self._ray_params.start_initial_python_workers_for_first_job,  # noqa: E501
             ray_debugger_external=self._ray_params.ray_debugger_external,
             env_updates=self._ray_params.env_vars,
             node_name=self._ray_params.node_name,

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -112,6 +112,8 @@ class RayParams:
             core feature flags.
         enable_object_reconstruction: Enable plasma reconstruction on
             failure.
+        start_initial_python_workers_for_first_job: If true, start
+            initial Python workers for the first job on the node.
         ray_debugger_external: If true, make the Ray debugger for a
             worker available externally to the node it is running on. This will
             bind on 0.0.0.0 instead of localhost.
@@ -166,6 +168,7 @@ class RayParams:
         runtime_env_dir_name: Optional[str] = None,
         include_log_monitor: Optional[str] = None,
         autoscaling_config: Optional[str] = None,
+        start_initial_python_workers_for_first_job=False,
         ray_debugger_external: bool = False,
         _system_config: Optional[Dict[str, str]] = None,
         enable_object_reconstruction: Optional[bool] = False,
@@ -227,6 +230,9 @@ class RayParams:
         self.tracing_startup_hook = tracing_startup_hook
         self.no_monitor = no_monitor
         self.object_ref_seed = object_ref_seed
+        self.start_initial_python_workers_for_first_job = (
+            start_initial_python_workers_for_first_job
+        )
         self.ray_debugger_external = ray_debugger_external
         self.env_vars = env_vars
         self.session_name = session_name

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1373,6 +1373,7 @@ def start_raylet(
     huge_pages: bool = False,
     fate_share: Optional[bool] = None,
     socket_to_use: Optional[int] = None,
+    start_initial_python_workers_for_first_job: bool = False,
     max_bytes: int = 0,
     backup_count: int = 0,
     ray_debugger_external: bool = False,
@@ -1609,9 +1610,12 @@ def start_raylet(
 
     if worker_port_list is not None:
         command.append(f"--worker_port_list={worker_port_list}")
-    command.append(
-        "--num_prestart_python_workers={}".format(int(resource_spec.num_cpus))
-    )
+    if start_initial_python_workers_for_first_job:
+        command.append(
+            "--num_initial_python_workers_for_first_job={}".format(
+                resource_spec.num_cpus
+            )
+        )
     command.append("--agent_command={}".format(subprocess.list2cmdline(agent_command)))
     if huge_pages:
         command.append("--huge_pages")

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1501,6 +1501,15 @@ def init(
             plasma_store_socket_name=None,
             temp_dir=_temp_dir,
             storage=storage,
+            # We need to disable it if runtime env is not set.
+            # Uploading happens after core worker is created. And we should
+            # prevent default worker being created before uploading.
+            # TODO (yic): Have a separate connection to gcs client when
+            # removal redis is done. The uploading should happen before this
+            # one.
+            start_initial_python_workers_for_first_job=(
+                job_config is None or job_config.runtime_env is None
+            ),
             _system_config=_system_config,
             enable_object_reconstruction=_enable_object_reconstruction,
             metrics_export_port=_metrics_export_port,

--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -295,21 +295,18 @@ def test_gcs_connection_no_leak(ray_start_cluster):
     # Kill the actor
     del a
 
-    # TODO(clarng):remove this once prestart works with actors.
-    # ray_start_cluster defaults to one cpu, which prestarts one worker.
-    FD_PER_WORKER = 2
     # Make sure the # of fds opened by the GCS dropped.
-    wait_for_condition(lambda: get_gcs_num_of_connections() + FD_PER_WORKER == curr_fds)
+    wait_for_condition(lambda: get_gcs_num_of_connections() == curr_fds)
 
     n = cluster.add_node(wait=True)
 
     # Make sure the # of fds opened by the GCS increased.
-    wait_for_condition(lambda: get_gcs_num_of_connections() + FD_PER_WORKER > curr_fds)
+    wait_for_condition(lambda: get_gcs_num_of_connections() > curr_fds)
 
     cluster.remove_node(n)
 
     # Make sure the # of fds opened by the GCS dropped.
-    wait_for_condition(lambda: get_gcs_num_of_connections() + FD_PER_WORKER == curr_fds)
+    wait_for_condition(lambda: get_gcs_num_of_connections() == curr_fds)
 
 
 @pytest.mark.parametrize(

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -9,12 +9,13 @@ import pytest
 import ray
 import ray.client_builder as client_builder
 import ray.util.client.server.server as ray_client_server
+from ray.experimental.state.api import list_workers
 from ray._private.test_utils import (
     run_string_as_driver,
     run_string_as_driver_nonblocking,
     wait_for_condition,
 )
-from ray.experimental.state.api import list_workers
+import time
 
 
 @pytest.mark.parametrize(
@@ -431,18 +432,32 @@ def test_client_deprecation_warn():
     ],
     indirect=True,
 )
-def test_task_use_prestarted_worker(call_ray_start):
+def test_worker_processes(call_ray_start):
+    """
+    Test that no workers are spawned until a remote function is called.
+    """
     ray.init("ray://localhost:50056")
 
-    assert len(list_workers(filters=[("worker_type", "!=", "DRIVER")])) == 2
+    # Check for 10 seconds that no workers spawned after connecting
+    for _ in range(10):
+        workers = list_workers()
+        non_driver_workers = [w for w in workers if w.get("worker_type") != "DRIVER"]
+        assert len(non_driver_workers) == 0, workers
+        time.sleep(1)
 
     @ray.remote(num_cpus=2)
     def f():
         return 42
 
     assert ray.get(f.remote()) == 42
+    time.sleep(3)
 
-    assert len(list_workers(filters=[("worker_type", "!=", "DRIVER")])) == 2
+    # 2 worker processes should have spawned to accommodate the remote func
+    for _ in range(10):
+        workers = list_workers()
+        non_driver_workers = [w for w in workers if w.get("worker_type") != "DRIVER"]
+        assert len(non_driver_workers) == 2, workers
+        time.sleep(1)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -514,7 +514,6 @@ def test_worker_start_timeout(monkeypatch, ray_start_cluster):
             "InternalKVGcsService.grpc_server.InternalKVGet=2000000:2000000",
         )
         m.setenv("RAY_worker_register_timeout_seconds", "1")
-        m.setenv("RAY_prestart_worker_first_driver", "false")
         cluster = ray_start_cluster
         cluster.add_node(num_cpus=4, object_store_memory=1e9)
         script = """

--- a/python/ray/tests/test_node_manager.py
+++ b/python/ray/tests/test_node_manager.py
@@ -1,5 +1,4 @@
 import ray
-from ray.experimental.state.api import list_workers
 from ray._private.test_utils import (
     get_load_metrics_report,
     run_string_as_driver,
@@ -11,8 +10,6 @@ import pytest
 import os
 from ray.experimental.state.api import list_objects
 import subprocess
-from ray._private.utils import get_num_cpus
-import time
 
 
 # This tests the queue transitions for infeasible tasks. This has been an issue
@@ -256,44 +253,6 @@ ds.map(leak_repro, max_retries=0)
         return len(objects) == 0
 
     wait_for_condition(no_object_leaks, timeout=10, retry_interval_ms=1000)
-
-
-@pytest.mark.parametrize(
-    "call_ray_start",
-    ["""ray start --head --system-config={"enable_worker_prestart":true}"""],
-    indirect=True,
-)
-def test_worker_prestart_on_node_manager_start(call_ray_start, shutdown_only):
-    def num_idle_workers(count):
-        result = subprocess.check_output(
-            "ps aux | grep ray::IDLE | grep -v grep",
-            shell=True,
-        )
-        return len(result.splitlines()) == count
-
-    wait_for_condition(num_idle_workers, count=get_num_cpus())
-
-    with ray.init():
-        for _ in range(5):
-            workers = list_workers(filters=[("worker_type", "=", "WORKER")])
-            assert len(workers) == get_num_cpus(), workers
-            time.sleep(1)
-
-
-@pytest.mark.parametrize(
-    "call_ray_start",
-    ["""ray start --head"""],
-    indirect=True,
-)
-def test_jobs_prestart_worker_once(call_ray_start, shutdown_only):
-    with ray.init():
-        workers = list_workers(filters=[("worker_type", "=", "WORKER")])
-        assert len(workers) == get_num_cpus(), workers
-    with ray.init():
-        for _ in range(5):
-            workers = list_workers(filters=[("worker_type", "=", "WORKER")])
-            assert len(workers) == get_num_cpus(), workers
-            time.sleep(1)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_runtime_env_working_dir_4.py
+++ b/python/ray/tests/test_runtime_env_working_dir_4.py
@@ -95,8 +95,6 @@ def test_default_large_cache(start_cluster, option: str, source: str):
                 # this delay will make worker start slow and time out
                 "testing_asio_delay_us": "InternalKVGcsService.grpc_server"
                 ".InternalKVGet=2000000:2000000",
-                # don't prestart worker as it is expected to fail
-                "prestart_worker_first_driver": False,
                 "worker_register_timeout_seconds": 0.5,
             },
         },
@@ -107,8 +105,6 @@ def test_default_large_cache(start_cluster, option: str, source: str):
                 # this delay will make worker start slow and time out
                 "testing_asio_delay_us": "InternalKVGcsService.grpc_server"
                 ".InternalKVGet=2000000:2000000",
-                # don't prestart worker as it is expected to fail
-                "prestart_worker_first_driver": False,
                 "worker_register_timeout_seconds": 0.5,
             },
         },

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -1591,11 +1591,8 @@ async def test_state_data_source_client_limit_gcs_source(ray_start_cluster):
     """
     result = await client.get_all_worker_info(limit=2)
     assert len(result.worker_table_data) == 2
-    # Driver + 3 workers for actors + 2 prestarted task-only workers
-    # TODO(clarng): prestart worker on worker lease request doesn't
-    # work, otherwise it should have created the 2 prestarted task-only
-    # workers prior to https://github.com/ray-project/ray/pull/33623
-    assert result.total == 6
+    # Driver + 3 workers for actors.
+    assert result.total == 4
 
 
 @pytest.mark.asyncio

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -519,11 +519,7 @@ RAY_CONFIG(int64_t, max_resource_shapes_per_load_report, 100)
 RAY_CONFIG(int64_t, gcs_server_request_timeout_seconds, 60)
 
 /// Whether to enable worker prestarting: https://github.com/ray-project/ray/issues/12052
-RAY_CONFIG(bool, enable_worker_prestart, false)
-
-/// Whether to enable worker prestarting on first driver
-/// TODO(clarng): reconcile with enable_worker_prestart
-RAY_CONFIG(bool, prestart_worker_first_driver, true)
+RAY_CONFIG(bool, enable_worker_prestart, true)
 
 /// The interval of periodic idle worker killing. Value of 0 means worker capping is
 /// disabled.

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -42,9 +42,9 @@ DEFINE_int32(max_worker_port,
 DEFINE_string(worker_port_list,
               "",
               "An explicit list of ports that workers' gRPC servers will bind on.");
-DEFINE_int32(num_prestart_python_workers,
+DEFINE_int32(num_initial_python_workers_for_first_job,
              0,
-             "Number of prestarted default Python workers on raylet startup.");
+             "Number of initial Python workers for the first job.");
 DEFINE_int32(maximum_startup_concurrency, 1, "Maximum startup concurrency.");
 DEFINE_string(static_resource_list, "", "The static resource list of this node.");
 DEFINE_string(python_worker_command, "", "Python worker command.");
@@ -96,8 +96,8 @@ int main(int argc, char *argv[]) {
   const int min_worker_port = static_cast<int>(FLAGS_min_worker_port);
   const int max_worker_port = static_cast<int>(FLAGS_max_worker_port);
   const std::string worker_port_list = FLAGS_worker_port_list;
-  const int num_prestart_python_workers =
-      static_cast<int>(FLAGS_num_prestart_python_workers);
+  const int num_initial_python_workers_for_first_job =
+      static_cast<int>(FLAGS_num_initial_python_workers_for_first_job);
   const int maximum_startup_concurrency =
       static_cast<int>(FLAGS_maximum_startup_concurrency);
   const std::string static_resource_list = FLAGS_static_resource_list;
@@ -177,7 +177,8 @@ int main(int argc, char *argv[]) {
         auto soft_limit_config = RayConfig::instance().num_workers_soft_limit();
         node_manager_config.num_workers_soft_limit =
             soft_limit_config >= 0 ? soft_limit_config : num_cpus;
-        node_manager_config.num_prestart_python_workers = num_prestart_python_workers;
+        node_manager_config.num_initial_python_workers_for_first_job =
+            num_initial_python_workers_for_first_job;
         node_manager_config.maximum_startup_concurrency = maximum_startup_concurrency;
         node_manager_config.min_worker_port = min_worker_port;
         node_manager_config.max_worker_port = max_worker_port;

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -77,8 +77,8 @@ struct NodeManagerConfig {
   std::vector<int> worker_ports;
   /// The soft limit of the number of workers.
   int num_workers_soft_limit;
-  /// Number of initial Python workers to start when raylet starts.
-  int num_prestart_python_workers;
+  /// Number of initial Python workers for the first job.
+  int num_initial_python_workers_for_first_job;
   /// The maximum number of workers that can be started concurrently by a
   /// worker pool.
   int maximum_startup_concurrency;

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -118,16 +118,15 @@ class WorkerInterface {
  protected:
   virtual void SetStartupToken(StartupToken startup_token) = 0;
 
-  FRIEND_TEST(WorkerPoolDriverRegisteredTest, PopWorkerMultiTenancy);
-  FRIEND_TEST(WorkerPoolDriverRegisteredTest, TestWorkerCapping);
-  FRIEND_TEST(WorkerPoolDriverRegisteredTest,
-              TestWorkerCappingLaterNWorkersNotOwningObjects);
-  FRIEND_TEST(WorkerPoolDriverRegisteredTest, TestJobFinishedForceKillIdleWorker);
-  FRIEND_TEST(WorkerPoolDriverRegisteredTest,
+  FRIEND_TEST(WorkerPoolTest, PopWorkerMultiTenancy);
+  FRIEND_TEST(WorkerPoolTest, TestWorkerCapping);
+  FRIEND_TEST(WorkerPoolTest, TestWorkerCappingLaterNWorkersNotOwningObjects);
+  FRIEND_TEST(WorkerPoolTest, TestJobFinishedForceKillIdleWorker);
+  FRIEND_TEST(WorkerPoolTest,
               WorkerFromAliveJobDoesNotBlockWorkerFromDeadJobFromGettingKilled);
-  FRIEND_TEST(WorkerPoolDriverRegisteredTest, TestWorkerCappingWithExitDelay);
-  FRIEND_TEST(WorkerPoolDriverRegisteredTest, MaximumStartupConcurrency);
-  FRIEND_TEST(WorkerPoolDriverRegisteredTest, HandleWorkerRegistration);
+  FRIEND_TEST(WorkerPoolTest, TestWorkerCappingWithExitDelay);
+  FRIEND_TEST(WorkerPoolTest, MaximumStartupConcurrency);
+  FRIEND_TEST(WorkerPoolTest, HandleWorkerRegistration);
 };
 
 /// Worker class encapsulates the implementation details of a worker. A worker

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -72,7 +72,7 @@ WorkerPool::WorkerPool(instrumented_io_context &io_service,
                        const NodeID node_id,
                        const std::string node_address,
                        int num_workers_soft_limit,
-                       int num_prestarted_python_workers,
+                       int num_initial_python_workers_for_first_job,
                        int maximum_startup_concurrency,
                        int min_worker_port,
                        int max_worker_port,
@@ -94,9 +94,9 @@ WorkerPool::WorkerPool(instrumented_io_context &io_service,
       starting_worker_timeout_callback_(starting_worker_timeout_callback),
       ray_debugger_external(ray_debugger_external),
       first_job_registered_python_worker_count_(0),
-      first_job_driver_wait_num_python_workers_(
-          std::min(num_prestarted_python_workers, maximum_startup_concurrency)),
-      num_prestart_python_workers(num_prestarted_python_workers),
+      first_job_driver_wait_num_python_workers_(std::min(
+          num_initial_python_workers_for_first_job, maximum_startup_concurrency)),
+      num_initial_python_workers_for_first_job_(num_initial_python_workers_for_first_job),
       periodical_runner_(io_service),
       get_time_(get_time) {
   RAY_CHECK(maximum_startup_concurrency > 0);
@@ -138,6 +138,12 @@ WorkerPool::WorkerPool(instrumented_io_context &io_service,
       free_ports_->push(port);
     }
   }
+  if (RayConfig::instance().kill_idle_workers_interval_ms() > 0) {
+    periodical_runner_.RunFnPeriodically(
+        [this] { TryKillingIdleWorkers(); },
+        RayConfig::instance().kill_idle_workers_interval_ms(),
+        "RayletWorkerPool.deadline_timer.kill_idle_workers");
+  }
 }
 
 WorkerPool::~WorkerPool() {
@@ -151,19 +157,6 @@ WorkerPool::~WorkerPool() {
   for (Process proc : procs_to_kill) {
     proc.Kill();
     // NOTE: Avoid calling Wait() here. It fails with ECHILD, as SIGCHLD is disabled.
-  }
-}
-
-void WorkerPool::Start() {
-  if (RayConfig::instance().kill_idle_workers_interval_ms() > 0) {
-    periodical_runner_.RunFnPeriodically(
-        [this] { TryKillingIdleWorkers(); },
-        RayConfig::instance().kill_idle_workers_interval_ms(),
-        "RayletWorkerPool.deadline_timer.kill_idle_workers");
-  }
-
-  if (RayConfig::instance().enable_worker_prestart()) {
-    PrestartDefaultCpuWorkers(Language::PYTHON, num_prestart_python_workers);
   }
 }
 
@@ -459,10 +452,9 @@ std::tuple<Process, StartupToken> WorkerPool::StartWorkerProcess(
   // Here we consider both task workers and I/O workers.
   if (starting_workers >= maximum_startup_concurrency_) {
     // Workers have been started, but not registered. Force start disabled -- returning.
-    RAY_LOG(DEBUG) << "Worker not started, exceeding maximum_startup_concurrency("
-                   << maximum_startup_concurrency_ << "), " << starting_workers
+    RAY_LOG(DEBUG) << "Worker not started, " << starting_workers
                    << " workers of language type " << static_cast<int>(language)
-                   << " being started and pending registration";
+                   << " pending registration";
     *status = PopWorkerStatus::TooManyStartingWorkerProcesses;
     process_failed_rate_limited_++;
     return {Process(), (StartupToken)-1};
@@ -798,21 +790,6 @@ void WorkerPool::OnWorkerStarted(const std::shared_ptr<WorkerInterface> &worker)
   }
 }
 
-void WorkerPool::ExecuteOnPrestartWorkersStarted(std::function<void()> callback) {
-  bool prestart = RayConfig::instance().prestart_worker_first_driver() ||
-                  RayConfig::instance().enable_worker_prestart();
-  if (first_job_registered_ ||
-      first_job_registered_python_worker_count_ >=  // Don't wait if prestart is completed
-          first_job_driver_wait_num_python_workers_ ||
-      !prestart) {  // Don't wait if prestart is disabled
-    callback();
-    return;
-  }
-  first_job_registered_ = true;
-  RAY_CHECK(!first_job_send_register_client_reply_to_driver_);
-  first_job_send_register_client_reply_to_driver_ = std::move(callback);
-}
-
 Status WorkerPool::RegisterDriver(const std::shared_ptr<WorkerInterface> &driver,
                                   const rpc::JobConfig &job_config,
                                   std::function<void(Status, int)> send_reply_callback) {
@@ -829,23 +806,31 @@ Status WorkerPool::RegisterDriver(const std::shared_ptr<WorkerInterface> &driver
   const auto job_id = driver->GetAssignedJobId();
   HandleJobStarted(job_id, job_config);
 
-  if (driver->GetLanguage() == Language::JAVA) {
-    send_reply_callback(Status::OK(), port);
-  } else {
-    if (!first_job_registered_ && RayConfig::instance().prestart_worker_first_driver() &&
-        !RayConfig::instance().enable_worker_prestart()) {
-      RAY_LOG(DEBUG) << "PrestartDefaultCpuWorkers " << num_prestart_python_workers;
-      PrestartDefaultCpuWorkers(Language::PYTHON, num_prestart_python_workers);
+  // This is a workaround to start initial workers on this node if and only if Raylet is
+  // started by a Python driver and the job config is not set in `ray.init(...)`.
+  // Invoke the `send_reply_callback` later to only finish driver
+  // registration after all initial workers are registered to Raylet.
+  bool delay_callback = false;
+  // If this is the first job.
+  if (first_job_.IsNil()) {
+    first_job_ = job_id;
+    // If the number of Python workers we need to wait is positive.
+    if (num_initial_python_workers_for_first_job_ > 0) {
+      delay_callback = true;
+      PrestartDefaultCpuWorkers(Language::PYTHON,
+                                num_initial_python_workers_for_first_job_);
     }
-
-    // Invoke the `send_reply_callback` later to only finish driver
-    // registration after all prestarted workers are registered to Raylet.
-    // NOTE(clarng): prestart is only for python workers.
-    ExecuteOnPrestartWorkersStarted(
-        [send_reply_callback = std::move(send_reply_callback), port]() {
-          send_reply_callback(Status::OK(), port);
-        });
   }
+
+  if (delay_callback) {
+    RAY_CHECK(!first_job_send_register_client_reply_to_driver_);
+    first_job_send_register_client_reply_to_driver_ = [send_reply_callback, port]() {
+      send_reply_callback(Status::OK(), port);
+    };
+  } else {
+    send_reply_callback(Status::OK(), port);
+  }
+
   return Status::OK();
 }
 

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -164,8 +164,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// \param node_id The id of the current node.
   /// \param node_address The address of the current node.
   /// \param num_workers_soft_limit The soft limit of the number of workers.
-  /// \param num_prestarted_python_workers The number of prestarted Python
-  /// workers.
+  /// \param num_initial_python_workers_for_first_job The number of initial Python
+  /// workers for the first job.
   /// \param maximum_startup_concurrency The maximum number of worker processes
   /// that can be started in parallel (typically this should be set to the number of CPU
   /// resources on the machine).
@@ -188,7 +188,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
              const NodeID node_id,
              const std::string node_address,
              int num_workers_soft_limit,
-             int num_prestarted_python_workers,
+             int num_initial_python_workers_for_first_job,
              int maximum_startup_concurrency,
              int min_worker_port,
              int max_worker_port,
@@ -202,9 +202,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
 
   /// Destructor responsible for freeing a set of workers owned by this class.
   virtual ~WorkerPool();
-
-  /// Start the worker pool. Could only be called once.
-  void Start();
 
   /// Set the node manager port.
   /// \param node_manager_port The port Raylet uses for listening to incoming connections.
@@ -705,8 +702,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
       const std::string &serialized_runtime_env_context,
       const WorkerPool::State &state) const;
 
-  void ExecuteOnPrestartWorkersStarted(std::function<void()> callback);
-
   /// For Process class for managing subprocesses (e.g. reaping zombies).
   instrumented_io_context *io_service_;
   /// Node ID of the current node.
@@ -731,8 +726,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// If 1, expose Ray debuggers started by the workers externally (to this node).
   int ray_debugger_external;
 
-  /// If the first job has already been registered.
-  bool first_job_registered_ = false;
+  /// The Job ID of the firstly received job.
+  JobID first_job_;
 
   /// The callback to send RegisterClientReply to the driver of the first job.
   std::function<void()> first_job_send_register_client_reply_to_driver_;
@@ -744,8 +739,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// receives RegisterClientReply.
   int first_job_driver_wait_num_python_workers_;
 
-  /// The number of prestarted default Python workers.
-  const int num_prestart_python_workers;
+  /// The number of initial Python workers for the first job.
+  int num_initial_python_workers_for_first_job_;
 
   /// This map tracks the latest infos of unfinished jobs.
   absl::flat_hash_map<JobID, rpc::JobConfig> all_jobs_;
@@ -777,7 +772,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   int64_t process_failed_runtime_env_setup_failed_ = 0;
 
   friend class WorkerPoolTest;
-  friend class WorkerPoolDriverRegisteredTest;
 };
 
 }  // namespace raylet


### PR DESCRIPTION
This reverts commit f3bd6c0009a7ae53488148b51457c8d6ebee6f97.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Seems like it fails the windows test 

<img width="602" alt="Screen Shot 2023-04-12 at 1 12 23 AM" src="https://user-images.githubusercontent.com/18510752/231395039-fbf6b260-f889-40a5-9795-8ed23756f54c.png">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
