### PR TITLE
[air] Deflake test_e2e_train_flow.py

### DIFF
--- a/python/ray/air/tests/execution/test_e2e_train_flow.py
+++ b/python/ray/air/tests/execution/test_e2e_train_flow.py
@@ -211,6 +211,7 @@ class TrainFlow:
             return
 
         self._actors_to_replace.add(tracked_actor)
+        self._ready_actors.discard(tracked_actor)
         self._actor_manager.remove_actor(tracked_actor)
 
     def run(self):

--- a/python/ray/air/tests/execution/test_e2e_train_flow.py
+++ b/python/ray/air/tests/execution/test_e2e_train_flow.py
@@ -180,7 +180,6 @@ class TrainFlow:
     def continue_training(self):
         if self._restart_training:
             self._training_iter = self._restart_training
-            self._restart_training = None
         else:
             self._training_iter += 1
 
@@ -195,6 +194,7 @@ class TrainFlow:
 
     def training_barrier_completed(self, barrier: Barrier):
         self._results.append([res for _, res in barrier.get_results()])
+        self._restart_training = None
 
         # If less than 10 epochs, continue training
         if self._training_iter < 10:
@@ -205,8 +205,7 @@ class TrainFlow:
             self._actor_manager.remove_actor(tracked_actor)
 
     def training_error(self, tracked_actor: TrackedActor, exception: Exception):
-        if not self._restart_training:
-            self._restart_training = self._training_iter
+        self._restart_training = self._training_iter
 
         if isinstance(exception, RayActorError):
             return


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test_e2e_train_flow test has been flaky. After some investigation this seems to be due to a race condition: The mock train flow would continue from the latest "checkpoint", but an actor restart could resolve before the next iteration finished. This triggers a new continuation, which increases the training iteration, leading to a mismatch.

The fix in this mock flow is to only unset the "restore" instruction after the next round of training results came in.

## Related issue number

Closes #32488

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
