### PR TITLE
[CherryPick] [ci/mac] Fix arm64 wheels builds (#34268)

### DIFF
--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -122,11 +122,19 @@ elif [[ "$platform" == "macosx" ]]; then
     # single path when it's acceptable to move up our lower
     # Python + MacOS compatibility bound.
     if [ "$(uname -m)" = "arm64" ]; then
+      CONDA_ENV_NAME="test-wheels-p$PY_MM"
+
       [ -f "$HOME/.bash_profile" ] && conda init bash
+
       source ~/.bash_profile
+
+      conda create -y -n "$CONDA_ENV_NAME"
+      conda activate "$CONDA_ENV_NAME"
+      conda remove -y python || true
       conda install -y python="${PY_MM}"
-      PYTHON_EXE="/opt/homebrew/opt/miniconda/bin/python"
-      PIP_CMD="/opt/homebrew/opt/miniconda/bin/pip"
+
+      PYTHON_EXE="/opt/homebrew/opt/miniconda/envs/${CONDA_ENV_NAME}/bin/python"
+      PIP_CMD="/opt/homebrew/opt/miniconda/envs/${CONDA_ENV_NAME}/bin/pip"
     else
       PYTHON_EXE="$MACPYTHON_PY_PREFIX/$PY_MM/bin/python$PY_MM"
       PIP_CMD="$(dirname "$PYTHON_EXE")/pip$PY_MM"


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The conda setup in test_wheels seems to fail from leftover state from previous python installs. This PR updates the test wheels script to create a new conda environment with the respective Python version which should not interfere with previous virtual envs.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
