### PR TITLE
[Data] Fix mutable dataclass attribute

### DIFF
--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 from typing import Dict, List, Optional, Iterable, Iterator, Tuple, Callable, Union
 
@@ -209,7 +209,7 @@ class ExecutionOptions:
             option is useful for performance debugging. Off by default.
     """
 
-    resource_limits: ExecutionResources = ExecutionResources()
+    resource_limits: ExecutionResources = field(default_factory=ExecutionResources)
 
     locality_with_output: Union[bool, List[NodeIdStr]] = False
 


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes an instance where a mutable attribute is used as a dataclass member, which causes an exception. See [this part of the docs](https://docs.python.org/3/library/dataclasses.html#mutable-default-values) for more information.

## Related issue number

Possibly addresses #31225.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
