### PR TITLE
[Dataset] Remove unnecessary setting of global `logging` level to `INFO` when using Ray Data

### DIFF
--- a/python/ray/data/_internal/dataset_logger.py
+++ b/python/ray/data/_internal/dataset_logger.py
@@ -43,12 +43,6 @@ class DatasetLogger:
         for writing to the Dataset log file. Not intended (nor should it be necessary)
         to call explicitly. Assumes that `ray.init()` has already been called prior
         to calling this method; otherwise raises a `ValueError`."""
-        # In the case where logger has not yet been set up in another file,
-        # initialize basic configs to set log level and format.
-        logging.basicConfig(
-            level=LOGGER_LEVEL.upper(),
-            format=LOGGER_FORMAT,
-        )
 
         # We initialize a logger using the given base `log_name`, which
         # logs to stdout. Logging with this logger to stdout is enabled by the


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When initializing Ray Data, the global logging level is set to `INFO`, which causes non-Ray `INFO` logs to be unintentionally emitted (the default level in the `logging` library is `WARNING`, which would normally ignore `INFO`-level logs). We remove an unnecessary setting of the logging level in `DatasetLogger` which resolves this issue.

I tested this PR:
(1) Without the changes in this PR, the following would fail, since the use of Ray Data would cause the global logging level to be set as described above:
```
import ray
import logging
logger = logging.getLogger()
initial_log_level = logger.level
logger.info("1")
assert logger.level == initial_log_level

ray.init()
ray.data.range(10).take()
assert logger.level == initial_log_level, (logger.level, initial_log_level)
logger.info("2")
assert logger.level == initial_log_level, (logger.level, initial_log_level)
```

With the changes in this PR, the above script passes. However, when I add this as a unit test in `test_dataset_logger.py`, the test will fail regardless of whether the global log level setting is removed. This is why I didn't add this as a unit test, but if anyone can help me debug this, I'd be happy to add it in the test file.

(2) I then verified the `ray-data.log` file as well as the stdout to confirm that the Ray Data logs were emitted, and the `logger.info()` logs were ignored.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #34298 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
