### PR TITLE
[Dataset] Reset row count when filtering on Dataset reading from Parquet

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -278,6 +278,11 @@ class _ParquetDatasourceReader(Reader):
                 pieces=pieces,
                 prefetched_metadata=metadata,
             )
+            # If there is a filter operation, reset the calculated row count,
+            # since the resulting row count is unknown.
+            if self._reader_args.get("filter") is not None:
+                meta.num_rows = None
+
             if meta.size_bytes is not None:
                 meta.size_bytes = int(meta.size_bytes * self._encoding_ratio)
             block_udf, reader_args, columns, schema = (
@@ -411,7 +416,6 @@ def _read_pieces(
 def _fetch_metadata_serialization_wrapper(
     pieces: _SerializedPiece,
 ) -> List["pyarrow.parquet.FileMetaData"]:
-
     pieces: List[
         "pyarrow._dataset.ParquetFileFragment"
     ] = _deserialize_pieces_with_retry(pieces)

--- a/python/ray/data/tests/test_dataset_parquet.py
+++ b/python/ray/data/tests/test_dataset_parquet.py
@@ -53,7 +53,6 @@ def check_num_computed(ds, expected, streaming_expected) -> None:
 def test_parquet_deserialize_pieces_with_retry(
     ray_start_regular_shared, fs, data_path, monkeypatch
 ):
-
     setup_data_path = _unwrap_protocol(data_path)
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     table = pa.Table.from_pandas(df1)
@@ -500,6 +499,7 @@ def test_parquet_read_partitioned_with_filter(ray_start_regular_shared, tmp_path
     values = [[s["one"], s["two"]] for s in ds.take()]
     check_num_computed(ds, 1, 0)
     assert sorted(values) == [[1, "a"], [1, "a"]]
+    assert ds.count() == 2
 
     # 2 partitions, 1 empty partition, 2 block/read tasks, 1 empty block
 
@@ -510,6 +510,7 @@ def test_parquet_read_partitioned_with_filter(ray_start_regular_shared, tmp_path
     values = [[s["one"], s["two"]] for s in ds.take()]
     check_num_computed(ds, 2, 0)
     assert sorted(values) == [[1, "a"], [1, "a"]]
+    assert ds.count() == 2
 
 
 def test_parquet_read_partitioned_explicit(ray_start_regular_shared, tmp_path):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previously, if we filter on a Dataset which read from a Parquet datasource, the row count on the resulting Dataset is the same as the unfiltered Dataset (see #33766 and modified test for example). This PR fixes the bug and gets the correct row count after applying the filter.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #33766 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
