### PR TITLE
[UI] Disable null job id jumpable

### DIFF
--- a/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
+++ b/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import fireEvent from "@testing-library/user-event";
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { useJobList } from "../../job/hook/useJobList";
@@ -65,14 +66,17 @@ describe("RecentJobsCard", () => {
     render(<RecentJobsCard />, { wrapper: MemoryRouter });
 
     await screen.findByText("01000000");
-    expect(screen.getByText("raysubmit_23456")).not.toHaveAttribute("href");
+
+    const link = screen.getByRole("link", { name: "05000000" });
+    expect(link).toHaveAttribute("href");
   });
   it("disables link when job_id is null", async () => {
     render(<RecentJobsCard />, { wrapper: MemoryRouter });
 
     await screen.findByText("01000000");
+    const jobDiv = screen.getByText("raysubmit_23456");
 
-    const link = screen.getByRole("link", { name: "04000000" });
-    expect(link).toBeInTheDocument();
+    fireEvent.click(jobDiv);
+    expect(window.location.pathname).not.toBe("/jobs/null");
   });
 });

--- a/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
+++ b/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
@@ -62,25 +62,16 @@ describe("RecentJobsCard", () => {
     expect(screen.queryByText("07000000")).toBeNull();
   });
   it("the link is active when job_id is not null", async () => {
-    const mockedUseJobList = jest.mocked(useJobList);
-    mockedUseJobList.mockReturnValue({
-      jobList: JOB_LIST,
-    } as any);
-
     render(<RecentJobsCard />, { wrapper: MemoryRouter });
 
     await screen.findByText("01000000");
     expect(screen.getByText("raysubmit_23456")).not.toHaveAttribute("href");
   });
   it("disables link when job_id is null", async () => {
-    const mockedUseJobList = jest.mocked(useJobList);
-    mockedUseJobList.mockReturnValue({
-      jobList: JOB_LIST,
-    } as any);
-
     render(<RecentJobsCard />, { wrapper: MemoryRouter });
 
     await screen.findByText("01000000");
+
     const link = screen.getByRole("link", { name: "04000000" });
     expect(link).toBeInTheDocument();
   });

--- a/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
+++ b/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import fireEvent from "@testing-library/user-event";
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { useJobList } from "../../job/hook/useJobList";

--- a/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
+++ b/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
@@ -51,6 +51,7 @@ describe("RecentJobsCard", () => {
       jobList: JOB_LIST,
     } as any);
   });
+
   it("renders", async () => {
     render(<RecentJobsCard />, { wrapper: MemoryRouter });
 
@@ -62,6 +63,7 @@ describe("RecentJobsCard", () => {
     expect(screen.getByText("06000000")).toBeVisible();
     expect(screen.queryByText("07000000")).toBeNull();
   });
+
   it("the link is active when job_id is not null", async () => {
     render(<RecentJobsCard />, { wrapper: MemoryRouter });
 
@@ -70,13 +72,11 @@ describe("RecentJobsCard", () => {
     const link = screen.getByRole("link", { name: "05000000" });
     expect(link).toHaveAttribute("href");
   });
+
   it("disables link when job_id is null", async () => {
     render(<RecentJobsCard />, { wrapper: MemoryRouter });
 
     await screen.findByText("01000000");
-    const jobDiv = screen.getByText("raysubmit_23456");
-
-    fireEvent.click(jobDiv);
-    expect(window.location.pathname).not.toBe("/jobs/null");
+    expect(screen.queryByRole("link", { name: "raysubmit_23456" })).toBeNull();
   });
 });

--- a/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
+++ b/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
@@ -4,50 +4,50 @@ import { MemoryRouter } from "react-router-dom";
 import { useJobList } from "../../job/hook/useJobList";
 import { RecentJobsCard } from "./RecentJobsCard";
 
-jest.mock("../../job/hook/useJobList");
+const JOB_LIST = [
+  {
+    job_id: "01000000",
+    submission_id: "raysubmit_12345",
+    status: "SUCCEEDED",
+  },
+  {
+    job_id: "02000000",
+    submission_id: null,
+    status: "FAILED",
+  },
+  {
+    job_id: null,
+    submission_id: "raysubmit_23456",
+    status: "STOPPED",
+  },
+  {
+    job_id: "04000000",
+    submission_id: "raysubmit_34567",
+    status: "SUCCEEDED",
+  },
+  {
+    job_id: "05000000",
+    submission_id: "raysubmit_45678",
+    status: "RUNNING",
+  },
+  {
+    job_id: "06000000",
+    submission_id: "raysubmit_56789",
+    status: "RUNNING",
+  },
+  {
+    job_id: "07000000",
+    submission_id: "raysubmit_67890",
+    status: "RUNNING",
+  },
+];
 
+jest.mock("../../job/hook/useJobList");
 describe("RecentJobsCard", () => {
   it("renders", async () => {
     const mockedUseJobList = jest.mocked(useJobList);
-
     mockedUseJobList.mockReturnValue({
-      jobList: [
-        {
-          job_id: "01000000",
-          submission_id: "raysubmit_12345",
-          status: "SUCCEEDED",
-        },
-        {
-          job_id: "02000000",
-          submission_id: null,
-          status: "FAILED",
-        },
-        {
-          job_id: null,
-          submission_id: "raysubmit_23456",
-          status: "STOPPED",
-        },
-        {
-          job_id: "04000000",
-          submission_id: "raysubmit_34567",
-          status: "SUCCEEDED",
-        },
-        {
-          job_id: "05000000",
-          submission_id: "raysubmit_45678",
-          status: "RUNNING",
-        },
-        {
-          job_id: "06000000",
-          submission_id: "raysubmit_56789",
-          status: "RUNNING",
-        },
-        {
-          job_id: "07000000",
-          submission_id: "raysubmit_67890",
-          status: "RUNNING",
-        },
-      ],
+      jobList: JOB_LIST,
     } as any);
 
     render(<RecentJobsCard />, { wrapper: MemoryRouter });
@@ -60,4 +60,39 @@ describe("RecentJobsCard", () => {
     expect(screen.getByText("06000000")).toBeVisible();
     expect(screen.queryByText("07000000")).toBeNull();
   });
+  it("the link is active when job_id is not null", async () => {
+    const mockedUseJobList = jest.mocked(useJobList);
+    mockedUseJobList.mockReturnValue({
+      jobList: JOB_LIST,
+    } as any);
+
+    render(<RecentJobsCard />, { wrapper: MemoryRouter });
+
+    await screen.findByText("01000000");
+    expect(screen.getByText("raysubmit_23456")).not.toHaveAttribute("href");
+  });
+  it("disables link when job_id is null", async () => {
+    const mockedUseJobList = jest.mocked(useJobList);
+    mockedUseJobList.mockReturnValue({
+      jobList: JOB_LIST,
+    } as any);
+
+    render(<RecentJobsCard />, { wrapper: MemoryRouter });
+
+    await screen.findByText("01000000");
+    expect(screen.getByText("04000000")).toHaveAttribute("href");
+  });
 });
+
+// it("renders link if job id is not null", () => {
+//   const { getByRole } = render(<RecentJobListItem job={job} />);
+//   expect(getByRole("link")).toBeInTheDocument();
+// });
+// it("do not render the link if job id is null", () => {
+//   job = {
+//     ...job,
+//   }
+//   mockedUseJobList
+//   const { getByRole } = render(<RecentJobListItem job={job} />);
+//   expect(getByRole("link")).toBeInTheDocument();
+// });

--- a/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
+++ b/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
@@ -83,16 +83,3 @@ describe("RecentJobsCard", () => {
     expect(screen.getByText("04000000")).toHaveAttribute("href");
   });
 });
-
-// it("renders link if job id is not null", () => {
-//   const { getByRole } = render(<RecentJobListItem job={job} />);
-//   expect(getByRole("link")).toBeInTheDocument();
-// });
-// it("do not render the link if job id is null", () => {
-//   job = {
-//     ...job,
-//   }
-//   mockedUseJobList
-//   const { getByRole } = render(<RecentJobListItem job={job} />);
-//   expect(getByRole("link")).toBeInTheDocument();
-// });

--- a/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
+++ b/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
@@ -41,15 +41,16 @@ const JOB_LIST = [
     status: "RUNNING",
   },
 ];
+const mockedUseJobList = jest.mocked(useJobList);
 
 jest.mock("../../job/hook/useJobList");
 describe("RecentJobsCard", () => {
-  it("renders", async () => {
-    const mockedUseJobList = jest.mocked(useJobList);
+  beforeEach(() => {
     mockedUseJobList.mockReturnValue({
       jobList: JOB_LIST,
     } as any);
-
+  });
+  it("renders", async () => {
     render(<RecentJobsCard />, { wrapper: MemoryRouter });
 
     await screen.findByText("01000000");
@@ -80,6 +81,7 @@ describe("RecentJobsCard", () => {
     render(<RecentJobsCard />, { wrapper: MemoryRouter });
 
     await screen.findByText("01000000");
-    expect(screen.getByText("04000000")).toHaveAttribute("href");
+    const link = screen.getByRole("link", { name: "04000000" });
+    expect(link).toBeInTheDocument();
   });
 });

--- a/dashboard/client/src/pages/overview/cards/RecentJobsCard.tsx
+++ b/dashboard/client/src/pages/overview/cards/RecentJobsCard.tsx
@@ -40,49 +40,8 @@ type RecentJobsCardProps = {
 export const RecentJobsCard = ({ className }: RecentJobsCardProps) => {
   const classes = useStyles();
 
-  let { jobList } = useJobList();
-  jobList = [
-    {
-      job_id: "01000000",
-      submission_id: "raysubmit_12345",
-      status: "SUCCEEDED",
-    },
-    {
-      job_id: "02000000",
-      submission_id: null,
-      status: "FAILED",
-    },
-    {
-      job_id: null,
-      submission_id: "raysubmit_23456",
-      status: "STOPPED",
-    },
-    {
-      job_id: "04000000",
-      submission_id: "raysubmit_34567",
-      status: "SUCCEEDED",
-    },
-    {
-      job_id: "05000000",
-      submission_id: "raysubmit_45678",
-      status: "RUNNING",
-    },
-    {
-      job_id: "06000000",
-      submission_id: "raysubmit_56789",
-      status: "RUNNING",
-    },
-    {
-      job_id: "07000000",
-      submission_id: "raysubmit_67890",
-      status: "RUNNING",
-    },
-    {
-      job_id: null,
-      submission_id: "raysubmit_67900",
-      status: "FAILED",
-    },
-  ] as any;
+  const { jobList } = useJobList();
+
   const sortedJobs = _.orderBy(jobList, ["startTime"], ["desc"]).slice(0, 6);
 
   return (

--- a/dashboard/client/src/pages/overview/cards/RecentJobsCard.tsx
+++ b/dashboard/client/src/pages/overview/cards/RecentJobsCard.tsx
@@ -1,5 +1,4 @@
 import { createStyles, makeStyles, Typography } from "@material-ui/core";
-import { AnyListenerPredicate } from "@reduxjs/toolkit";
 import classNames from "classnames";
 import _ from "lodash";
 import React from "react";

--- a/dashboard/client/src/pages/overview/cards/RecentJobsCard.tsx
+++ b/dashboard/client/src/pages/overview/cards/RecentJobsCard.tsx
@@ -1,4 +1,5 @@
 import { createStyles, makeStyles, Typography } from "@material-ui/core";
+import { AnyListenerPredicate } from "@reduxjs/toolkit";
 import classNames from "classnames";
 import _ from "lodash";
 import React from "react";
@@ -39,7 +40,49 @@ type RecentJobsCardProps = {
 export const RecentJobsCard = ({ className }: RecentJobsCardProps) => {
   const classes = useStyles();
 
-  const { jobList } = useJobList();
+  let { jobList } = useJobList();
+  jobList = [
+    {
+      job_id: "01000000",
+      submission_id: "raysubmit_12345",
+      status: "SUCCEEDED",
+    },
+    {
+      job_id: "02000000",
+      submission_id: null,
+      status: "FAILED",
+    },
+    {
+      job_id: null,
+      submission_id: "raysubmit_23456",
+      status: "STOPPED",
+    },
+    {
+      job_id: "04000000",
+      submission_id: "raysubmit_34567",
+      status: "SUCCEEDED",
+    },
+    {
+      job_id: "05000000",
+      submission_id: "raysubmit_45678",
+      status: "RUNNING",
+    },
+    {
+      job_id: "06000000",
+      submission_id: "raysubmit_56789",
+      status: "RUNNING",
+    },
+    {
+      job_id: "07000000",
+      submission_id: "raysubmit_67890",
+      status: "RUNNING",
+    },
+    {
+      job_id: null,
+      submission_id: "raysubmit_67900",
+      status: "FAILED",
+    },
+  ] as any;
   const sortedJobs = _.orderBy(jobList, ["startTime"], ["desc"]).slice(0, 6);
 
   return (
@@ -145,23 +188,32 @@ const RecentJobListItem = ({ job, className }: RecentJobListItemProps) => {
         );
     }
   })();
+  const cardContent = (
+    <React.Fragment>
+      {icon}
+      <div className={classes.textContainer}>
+        <Typography className={classes.title} variant="body2">
+          {job.job_id ?? job.submission_id}
+        </Typography>
+        <Typography
+          className={classes.entrypoint}
+          title={job.entrypoint}
+          variant="caption"
+        >
+          {job.entrypoint}
+        </Typography>
+      </div>
+    </React.Fragment>
+  );
   return (
     <div className={className}>
-      <Link className={classes.root} to={`/jobs/${job.job_id}`}>
-        {icon}
-        <div className={classes.textContainer}>
-          <Typography className={classes.title} variant="body2">
-            {job.job_id ?? job.submission_id}
-          </Typography>
-          <Typography
-            className={classes.entrypoint}
-            title={job.entrypoint}
-            variant="caption"
-          >
-            {job.entrypoint}
-          </Typography>
-        </div>
-      </Link>
+      {job.job_id !== null && job.job_id !== "" ? (
+        <Link className={classes.root} to={`/jobs/${job.job_id}`}>
+          {cardContent}
+        </Link>
+      ) : (
+        <div className={classes.root}>{cardContent}</div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
## Why are these changes needed?

We would make ray submit job not clickable for job without a job id. Otherwise, we will navigate the users to a page `/jobs/null `where no job info is shown, making our customer confuse

## Summary of changes
1. Disabled jumpable for null job_id
2. unit test for both job_id and null job_id

![image](https://user-images.githubusercontent.com/125417081/231865622-03e2ef20-7f38-4f27-89cc-8ad7a3487bf3.png)
See the picture above, raysubmit_23456 is not clickable because the job_id is null

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
