### PR TITLE
[RLlib] Check that results has learner info appo test

### DIFF
--- a/rllib/algorithms/appo/tests/tf/test_appo_learner.py
+++ b/rllib/algorithms/appo/tests/tf/test_appo_learner.py
@@ -141,7 +141,7 @@ class TestAPPOTfLearner(unittest.TestCase):
             # a asynchronous trainer and results are returned asynchronously.
             while 1:
                 results = algo.train()
-                if results:
+                if results and "info" in results and LEARNER_INFO in results["info"]:
                     break
             curr_kl_coeff = results["info"][LEARNER_INFO][DEFAULT_POLICY_ID][
                 LEARNER_STATS_KEY


### PR DESCRIPTION
The appo kl coefficient learner test is flakey because
we run training until there are some results. What can end up happening is that
training is run for so long that eval results are available but not learner results
This pr fixes this by training until there are learner results that are available
not just evaluation results.

Signed-off-by: Avnish <avnishnarayan@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
