### PR TITLE
[UI] [Nodes] Disable actions for dead nodes

### DIFF
--- a/dashboard/client/src/components/ActorTable.tsx
+++ b/dashboard/client/src/components/ActorTable.tsx
@@ -45,13 +45,8 @@ type StateOrder = {
 const stateOrder: StateOrder = {
   [ActorEnum.ALIVE]: 0,
   [ActorEnum.PENDING]: 1,
-<<<<<<< HEAD
   [ActorEnum.RECONSTRUCTING]: 2,
   [ActorEnum.DEAD]: 3,
-=======
-  [ActorEnum.RECONSTRUCTING]:2,
-  [ActorEnum.DEAD]: 4, 
->>>>>>> code review
 };
 //type predicate for ActorEnum
 const isActorEnum = (state: unknown): state is ActorEnum => {
@@ -59,7 +54,6 @@ const isActorEnum = (state: unknown): state is ActorEnum => {
 };
 
 // We sort the actorsList so that the "Alive" actors appear at first and "Dead" actors appear in the end.
-<<<<<<< HEAD
 export const sortActors = (actorList: Actor[]) => {
   const sortedActors = [...actorList];
   sortedActors.sort((actor1, actor2) => {
@@ -69,20 +63,12 @@ export const sortActors = (actorList: Actor[]) => {
     const actorOrder2 = isActorEnum(actor2.state)
       ? stateOrder[actor2.state]
       : 0;
-=======
-const sortActors = (actorList: Actor[]) => {
-  const sortedActors = [...actorList];
-  sortedActors.sort((actor1, actor2) => {
-    const actorOrder1 = isActorEnum(actor1.state) ? stateOrder[actor1.state] : 0;
-    const actorOrder2 =isActorEnum(actor2.state) ? stateOrder[actor2.state] : 0;
->>>>>>> code review
 
     const actorTime1 = actor1.startTime || 0;
     const actorTime2 = actor2.startTime || 0;
 
     if (actorOrder1 !== actorOrder2) {
       return actorOrder1 - actorOrder2;
-<<<<<<< HEAD
     } else {
       // When the state is equal, we sort by startTime
       // in order to provide a determined order for users no matter the backend API changes
@@ -92,14 +78,6 @@ const sortActors = (actorList: Actor[]) => {
   return sortedActors;
 };
 
-=======
-    }else {// When the state is equal, we sort by startTime, in order to provide a determined order for users no matter the backend API changes
-      return  actorTime1 - actorTime2;
-    }
-  });
-  return sortedActors;
-}
->>>>>>> code review
 const ActorTable = ({
   actors = {},
   workers = [],
@@ -120,25 +98,11 @@ const ActorTable = ({
   const [pageSize, setPageSize] = useState(10);
   const { ipLogMap } = useContext(GlobalContext);
 
-<<<<<<< HEAD
   //We get a filtered and sorted actor list to render from prop actors
   const sortedActors = useMemo(() => {
     const actorList = Object.values(actors || {}).filter(filterFunc);
     return sortActors(actorList);
   }, [actors, filterFunc]);
-=======
-
-  const actorList = Object.values(actors || {}).filter(filterFunc);
-  
-  const sortActorsCallback = useCallback(() => {
-    const sortedActors = sortActors(actorList)
-    setSortedActors(sortedActors);
-  }, [actorList]);
-
-  useEffect(() => {
-    sortActorsCallback();
-  }, [sortActorsCallback]);
->>>>>>> code review
 
   const list = sortedActors.slice((pageNo - 1) * pageSize, pageNo * pageSize);
 

--- a/dashboard/client/src/components/ActorTable.tsx
+++ b/dashboard/client/src/components/ActorTable.tsx
@@ -45,8 +45,13 @@ type StateOrder = {
 const stateOrder: StateOrder = {
   [ActorEnum.ALIVE]: 0,
   [ActorEnum.PENDING]: 1,
+<<<<<<< HEAD
   [ActorEnum.RECONSTRUCTING]: 2,
   [ActorEnum.DEAD]: 3,
+=======
+  [ActorEnum.RECONSTRUCTING]:2,
+  [ActorEnum.DEAD]: 4, 
+>>>>>>> code review
 };
 //type predicate for ActorEnum
 const isActorEnum = (state: unknown): state is ActorEnum => {
@@ -54,6 +59,7 @@ const isActorEnum = (state: unknown): state is ActorEnum => {
 };
 
 // We sort the actorsList so that the "Alive" actors appear at first and "Dead" actors appear in the end.
+<<<<<<< HEAD
 export const sortActors = (actorList: Actor[]) => {
   const sortedActors = [...actorList];
   sortedActors.sort((actor1, actor2) => {
@@ -63,12 +69,20 @@ export const sortActors = (actorList: Actor[]) => {
     const actorOrder2 = isActorEnum(actor2.state)
       ? stateOrder[actor2.state]
       : 0;
+=======
+const sortActors = (actorList: Actor[]) => {
+  const sortedActors = [...actorList];
+  sortedActors.sort((actor1, actor2) => {
+    const actorOrder1 = isActorEnum(actor1.state) ? stateOrder[actor1.state] : 0;
+    const actorOrder2 =isActorEnum(actor2.state) ? stateOrder[actor2.state] : 0;
+>>>>>>> code review
 
     const actorTime1 = actor1.startTime || 0;
     const actorTime2 = actor2.startTime || 0;
 
     if (actorOrder1 !== actorOrder2) {
       return actorOrder1 - actorOrder2;
+<<<<<<< HEAD
     } else {
       // When the state is equal, we sort by startTime
       // in order to provide a determined order for users no matter the backend API changes
@@ -78,6 +92,14 @@ export const sortActors = (actorList: Actor[]) => {
   return sortedActors;
 };
 
+=======
+    }else {// When the state is equal, we sort by startTime, in order to provide a determined order for users no matter the backend API changes
+      return  actorTime1 - actorTime2;
+    }
+  });
+  return sortedActors;
+}
+>>>>>>> code review
 const ActorTable = ({
   actors = {},
   workers = [],
@@ -98,11 +120,25 @@ const ActorTable = ({
   const [pageSize, setPageSize] = useState(10);
   const { ipLogMap } = useContext(GlobalContext);
 
+<<<<<<< HEAD
   //We get a filtered and sorted actor list to render from prop actors
   const sortedActors = useMemo(() => {
     const actorList = Object.values(actors || {}).filter(filterFunc);
     return sortActors(actorList);
   }, [actors, filterFunc]);
+=======
+
+  const actorList = Object.values(actors || {}).filter(filterFunc);
+  
+  const sortActorsCallback = useCallback(() => {
+    const sortedActors = sortActors(actorList)
+    setSortedActors(sortedActors);
+  }, [actorList]);
+
+  useEffect(() => {
+    sortActorsCallback();
+  }, [sortActorsCallback]);
+>>>>>>> code review
 
   const list = sortedActors.slice((pageNo - 1) * pageSize, pageNo * pageSize);
 

--- a/dashboard/client/src/pages/node/NodeRow.component.test.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.component.test.tsx
@@ -1,50 +1,72 @@
 import { render, screen } from "@testing-library/react";
+import { noop } from "lodash";
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { NodeDetail } from "../../type/node";
 import { CoreWorkerStats, Worker } from "../../type/worker";
 import { NodeRow, WorkerRow } from "./NodeRow";
 
+const NODE: NodeDetail = {
+  hostname: "test-hostname",
+  ip: "192.168.0.1",
+  cpu: 15,
+  mem: [100, 95, 5],
+  state: "ALIVE",
+  disk: {
+    "/": {
+      used: 20000000,
+      total: 200000000,
+      free: 180000000,
+      percent: 10,
+    },
+    "/tmp": {
+      used: 0,
+      total: 200,
+      free: 200,
+      percent: 0,
+    },
+  },
+  networkSpeed: [5, 10],
+  raylet: {
+    state: "ALIVE",
+    nodeId: "1234567890ab",
+    isHeadNode: true,
+    numWorkers: 0,
+    pid: 2345,
+    startTime: 100,
+    terminateTime: -1,
+    brpcPort: 3456,
+    nodeManagerPort: 5890,
+    objectStoreAvailableMemory: 40,
+    objectStoreUsedMemory: 10,
+  },
+  logUrl: "http://192.16.0.1/logs",
+} as NodeDetail;
+
+const WORKER: Worker = {
+  cmdline: ["echo hi"],
+  pid: 3456,
+  cpuPercent: 14,
+  memoryInfo: {
+    rss: 75,
+    vms: 0,
+    pageins: 0,
+    pfaults: 0,
+  },
+  coreWorkerStats: [
+    {
+      workerId: "worker-12345",
+    } as CoreWorkerStats,
+  ],
+} as Worker;
+
+const DEAD_NODE = { ...NODE, state: "DEAD" };
+
 describe("NodeRow", () => {
   it("renders", async () => {
-    const node: NodeDetail = {
-      hostname: "test-hostname",
-      ip: "192.168.0.1",
-      cpu: 15,
-      mem: [100, 95, 5],
-      disk: {
-        "/": {
-          used: 20000000,
-          total: 200000000,
-          free: 180000000,
-          percent: 10,
-        },
-        "/tmp": {
-          used: 0,
-          total: 200,
-          free: 200,
-          percent: 0,
-        },
-      },
-      networkSpeed: [5, 10],
-      raylet: {
-        state: "ALIVE",
-        nodeId: "1234567890ab",
-        isHeadNode: true,
-        numWorkers: 0,
-        pid: 2345,
-        startTime: 100,
-        terminateTime: -1,
-        brpcPort: 3456,
-        nodeManagerPort: 5890,
-        objectStoreAvailableMemory: 40,
-        objectStoreUsedMemory: 10,
-      },
-      logUrl: "http://192.16.0.1/logs",
-    } as NodeDetail;
     render(
       <NodeRow
-        node={node}
+        node={NODE}
         expanded
         onExpandButtonClick={() => {
           /* purposefully empty */
@@ -77,64 +99,30 @@ describe("NodeRow", () => {
     expect(screen.getByText(/5.0000B\/s/)).toBeVisible();
     expect(screen.getByText(/10.0000B\/s/)).toBeVisible();
   });
+  it("Disable actions for Dead node", async () => {
+    render(
+      <NodeRow node={DEAD_NODE} expanded={false} onExpandButtonClick={noop} />,
+      {
+        wrapper: ({ children }) => (
+          <MemoryRouter>
+            <table>
+              <tbody>{children}</tbody>
+            </table>
+          </MemoryRouter>
+        ),
+      },
+    );
+    await screen.findByText("test-hostname");
+    // Could not access logs for Dead nodes(the log is hidden)
+    expect(screen.queryByLabelText(/Log/)).not.toBeInTheDocument();
+
+    expect(screen.getByText(/3456/)).toBeVisible();
+  });
 });
 
 describe("WorkerRow", () => {
   it("renders", async () => {
-    const node: NodeDetail = {
-      hostname: "test-hostname",
-      ip: "192.168.0.1",
-      cpu: 15,
-      mem: [100, 95, 5],
-      disk: {
-        "/": {
-          used: 20000000,
-          total: 200000000,
-          free: 180000000,
-          percent: 10,
-        },
-        "/tmp": {
-          used: 0,
-          total: 200,
-          free: 200,
-          percent: 0,
-        },
-      },
-      networkSpeed: [5, 10],
-      raylet: {
-        state: "ALIVE",
-        nodeId: "1234567890ab",
-        isHeadNode: true,
-        numWorkers: 0,
-        pid: 2345,
-        startTime: 100,
-        terminateTime: -1,
-        brpcPort: 3456,
-        nodeManagerPort: 5890,
-        objectStoreAvailableMemory: 40,
-        objectStoreUsedMemory: 10,
-      },
-      logUrl: "http://192.16.0.1/logs",
-    } as NodeDetail;
-
-    const worker: Worker = {
-      cmdline: ["echo hi"],
-      pid: 3456,
-      cpuPercent: 14,
-      memoryInfo: {
-        rss: 75,
-        vms: 0,
-        pageins: 0,
-        pfaults: 0,
-      },
-      coreWorkerStats: [
-        {
-          workerId: "worker-12345",
-        } as CoreWorkerStats,
-      ],
-    } as Worker;
-
-    render(<WorkerRow node={node} worker={worker} />, {
+    render(<WorkerRow node={NODE} worker={WORKER} />, {
       wrapper: ({ children }) => (
         <MemoryRouter>
           <table>
@@ -146,6 +134,29 @@ describe("WorkerRow", () => {
 
     await screen.findByText("echo hi");
     expect(screen.getByText(/ALIVE/)).toBeVisible();
+    expect(screen.getByText(/worker-12345/)).toBeVisible();
+    expect(screen.getByText(/3456/)).toBeVisible();
+    // CPU Usage
+    expect(screen.getByText(/14%/)).toBeVisible();
+    // Memory Usage
+    expect(screen.getByText(/75\.0000B\/100\.0000B\(75\.0%\)/)).toBeVisible();
+  });
+  it("Disable CPU profiling & stacktrace for dead worker", async () => {
+    render(<WorkerRow node={DEAD_NODE} worker={WORKER} />, {
+      wrapper: ({ children }) => (
+        <MemoryRouter>
+          <table>
+            <tbody>{children}</tbody>
+          </table>
+        </MemoryRouter>
+      ),
+    });
+    await screen.findByText("echo hi");
+    // Could not access Stack Trace and CPU Flame Graph for Dead workers, but the log is still available)
+    expect(screen.getByText(/Log/)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Stack Trace/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/CPU Flame Graph/)).not.toBeInTheDocument();
+
     expect(screen.getByText(/worker-12345/)).toBeVisible();
     expect(screen.getByText(/3456/)).toBeVisible();
     // CPU Usage

--- a/dashboard/client/src/pages/node/NodeRow.component.test.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.component.test.tsx
@@ -142,28 +142,4 @@ describe("WorkerRow", () => {
     // Memory Usage
     expect(screen.getByText(/75\.0000B\/100\.0000B\(75\.0%\)/)).toBeVisible();
   });
-
-  it("Disable CPU profiling & stacktrace for dead worker", async () => {
-    render(<WorkerRow node={DEAD_NODE} worker={WORKER} />, {
-      wrapper: ({ children }) => (
-        <MemoryRouter>
-          <table>
-            <tbody>{children}</tbody>
-          </table>
-        </MemoryRouter>
-      ),
-    });
-    await screen.findByText("echo hi");
-    // Could not access Stack Trace and CPU Flame Graph for Dead workers, but the log is still available)
-    expect(screen.getByText(/Log/)).toBeInTheDocument();
-    expect(screen.queryByLabelText(/Stack Trace/)).not.toBeInTheDocument();
-    expect(screen.queryByLabelText(/CPU Flame Graph/)).not.toBeInTheDocument();
-
-    expect(screen.getByText(/worker-12345/)).toBeVisible();
-    expect(screen.getByText(/3456/)).toBeVisible();
-    // CPU Usage
-    expect(screen.getByText(/14%/)).toBeVisible();
-    // Memory Usage
-    expect(screen.getByText(/75\.0000B\/100\.0000B\(75\.0%\)/)).toBeVisible();
-  });
 });

--- a/dashboard/client/src/pages/node/NodeRow.component.test.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.component.test.tsx
@@ -99,6 +99,7 @@ describe("NodeRow", () => {
     expect(screen.getByText(/5.0000B\/s/)).toBeVisible();
     expect(screen.getByText(/10.0000B\/s/)).toBeVisible();
   });
+
   it("Disable actions for Dead node", async () => {
     render(
       <NodeRow node={DEAD_NODE} expanded={false} onExpandButtonClick={noop} />,
@@ -141,6 +142,7 @@ describe("WorkerRow", () => {
     // Memory Usage
     expect(screen.getByText(/75\.0000B\/100\.0000B\(75\.0%\)/)).toBeVisible();
   });
+
   it("Disable CPU profiling & stacktrace for dead worker", async () => {
     render(<WorkerRow node={DEAD_NODE} worker={WORKER} />, {
       wrapper: ({ children }) => (

--- a/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.tsx
@@ -205,7 +205,7 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
         <Link to={workerLogUrl} target="_blank">
           Logs
         </Link>
-        <br></br>
+        <br />
         <a
           href={`/worker/traceback?pid=${pid}&ip=${ip}&native=0`}
           target="_blank"

--- a/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.tsx
@@ -164,10 +164,9 @@ type WorkerRowProps = {
  * A single row that represents the data of a Worker
  */
 export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
-  console.log("worker: ", worker);
   const classes = rowStyles();
 
-  const { ip, mem, logUrl, state } = node;
+  const { ip, mem, logUrl } = node;
   const {
     pid,
     cpuPercent: cpu = 0,
@@ -199,33 +198,28 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
       </TableCell>
       <TableCell align="center">{pid}</TableCell>
       <TableCell>
-        {/* {state !== "DEAD" && ( */}
         <Link to={workerLogUrl} target="_blank">
           Logs
         </Link>
-        {/* )} */}
-        <br></br>
-        {state !== "DEAD" && (
-          <React.Fragment>
-            <a
-              href={`/worker/traceback?pid=${pid}&ip=${ip}&native=0`}
-              target="_blank"
-              title="Sample the current Python stack trace for this worker."
-              rel="noreferrer"
-            >
-              Stack&nbsp;Trace
-            </a>
-            <br></br>
-            <a
-              href={`/worker/cpu_profile?pid=${pid}&ip=${ip}&duration=5&native=0`}
-              target="_blank"
-              title="Profile the Python worker for 5 seconds (default) and display a CPU flame graph."
-              rel="noreferrer"
-            >
-              CPU&nbsp;Flame&nbsp;Graph
-            </a>
-          </React.Fragment>
-        )}
+        <br />
+        <a
+          href={`/worker/traceback?pid=${pid}&ip=${ip}&native=0`}
+          target="_blank"
+          title="Sample the current Python stack trace for this worker."
+          rel="noreferrer"
+        >
+          Stack&nbsp;Trace
+        </a>
+        <br />
+        <a
+          href={`/worker/cpu_profile?pid=${pid}&ip=${ip}&duration=5&native=0`}
+          target="_blank"
+          title="Profile the Python worker for 5 seconds (default) and display a CPU flame graph."
+          rel="noreferrer"
+        >
+          CPU&nbsp;Flame&nbsp;Graph
+        </a>
+        <br />
       </TableCell>
       <TableCell>
         <PercentageBar num={Number(cpu)} total={100}>

--- a/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.tsx
@@ -164,6 +164,7 @@ type WorkerRowProps = {
  * A single row that represents the data of a Worker
  */
 export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
+  console.log("worker: ", worker);
   const classes = rowStyles();
 
   const { ip, mem, logUrl, state } = node;

--- a/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.tsx
@@ -53,13 +53,17 @@ export const NodeRow = ({
     networkSpeed = [0, 0],
     raylet,
     logUrl,
-    state,
   } = node;
 
   const classes = rowStyles();
 
   const objectStoreTotalMemory =
     raylet.objectStoreAvailableMemory + raylet.objectStoreUsedMemory;
+
+  /**
+   * Why do we use raylet.state instead of node.state in the following code?
+   * Because in ray, raylet == node
+   */
 
   return (
     <TableRow>
@@ -95,7 +99,7 @@ export const NodeRow = ({
         </Box>
       </TableCell>
       <TableCell>
-        {state !== "DEAD" && (
+        {raylet.state !== "DEAD" && (
           <Link to={`/logs/${encodeURIComponent(logUrl)}`}>Log</Link>
         )}
       </TableCell>
@@ -201,7 +205,7 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
         <Link to={workerLogUrl} target="_blank">
           Logs
         </Link>
-        <br />
+        <br></br>
         <a
           href={`/worker/traceback?pid=${pid}&ip=${ip}&native=0`}
           target="_blank"

--- a/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.tsx
@@ -53,6 +53,7 @@ export const NodeRow = ({
     networkSpeed = [0, 0],
     raylet,
     logUrl,
+    state,
   } = node;
 
   const classes = rowStyles();
@@ -94,7 +95,9 @@ export const NodeRow = ({
         </Box>
       </TableCell>
       <TableCell>
-        <Link to={`/logs/${encodeURIComponent(logUrl)}`}>Log</Link>
+        {state !== "DEAD" && (
+          <Link to={`/logs/${encodeURIComponent(logUrl)}`}>Log</Link>
+        )}
       </TableCell>
       <TableCell>
         <PercentageBar num={Number(cpu)} total={100}>
@@ -163,7 +166,7 @@ type WorkerRowProps = {
 export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
   const classes = rowStyles();
 
-  const { ip, mem, logUrl } = node;
+  const { ip, mem, logUrl, state } = node;
   const {
     pid,
     cpuPercent: cpu = 0,
@@ -195,28 +198,33 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
       </TableCell>
       <TableCell align="center">{pid}</TableCell>
       <TableCell>
+        {/* {state !== "DEAD" && ( */}
         <Link to={workerLogUrl} target="_blank">
           Logs
         </Link>
-        <br />
-        <a
-          href={`/worker/traceback?pid=${pid}&ip=${ip}&native=0`}
-          target="_blank"
-          title="Sample the current Python stack trace for this worker."
-          rel="noreferrer"
-        >
-          Stack&nbsp;Trace
-        </a>
-        <br />
-        <a
-          href={`/worker/cpu_profile?pid=${pid}&ip=${ip}&duration=5&native=0`}
-          target="_blank"
-          title="Profile the Python worker for 5 seconds (default) and display a CPU flame graph."
-          rel="noreferrer"
-        >
-          CPU&nbsp;Flame&nbsp;Graph
-        </a>
-        <br />
+        {/* )} */}
+        <br></br>
+        {state !== "DEAD" && (
+          <React.Fragment>
+            <a
+              href={`/worker/traceback?pid=${pid}&ip=${ip}&native=0`}
+              target="_blank"
+              title="Sample the current Python stack trace for this worker."
+              rel="noreferrer"
+            >
+              Stack&nbsp;Trace
+            </a>
+            <br></br>
+            <a
+              href={`/worker/cpu_profile?pid=${pid}&ip=${ip}&duration=5&native=0`}
+              target="_blank"
+              title="Profile the Python worker for 5 seconds (default) and display a CPU flame graph."
+              rel="noreferrer"
+            >
+              CPU&nbsp;Flame&nbsp;Graph
+            </a>
+          </React.Fragment>
+        )}
       </TableCell>
       <TableCell>
         <PercentageBar num={Number(cpu)} total={100}>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->





## Why are these changes needed?
We are going to remove logs for dead nodes and remove Stack Trace and CPU Flame Graph for dead workers.
Otherwise, users will click the link and jump to a page without information they need.

Alive Nodes | Dead Nodes
-- | --
<img width="1627" alt="image" src="https://user-images.githubusercontent.com/125417081/233140657-d13472e7-0eea-4821-b143-d770282fc4f2.png"> |  <img width="1793" alt="image" src="https://user-images.githubusercontent.com/125417081/233222924-ae30cb2d-ef49-4d05-8ff6-435dba000f58.png">


<!-- Please give a short summary of the change and the problem this solves. -->
## Summary of Changes
1. hide logs for dead nodes in NodeRow.tsx


## Discussion and Confusion
As part of the PR, we have also come to an agreement, which I will list here for future reference.

1. There are three entities on the Cluster page: node, raylet, and worker.
2. We have a state field for node and raylet, but we do not have the state of the worker returned from the backend API.
3. In Ray, a node is equal to a raylet.

## Related issue number
fixes #32593

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
