### PR TITLE
[serve] Fix get endpoint when autoscaling config is set (#34377)

### DIFF
--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -256,12 +256,10 @@ def _deployment_info_to_schema(name: str, info: DeploymentInfo) -> DeploymentSch
     codepath)
     """
 
-    return DeploymentSchema(
+    schema = DeploymentSchema(
         name=name,
-        num_replicas=info.deployment_config.num_replicas,
         max_concurrent_queries=info.deployment_config.max_concurrent_queries,
         user_config=info.deployment_config.user_config,
-        autoscaling_config=info.deployment_config.autoscaling_config,
         graceful_shutdown_wait_loop_s=(
             info.deployment_config.graceful_shutdown_wait_loop_s
         ),
@@ -271,6 +269,13 @@ def _deployment_info_to_schema(name: str, info: DeploymentInfo) -> DeploymentSch
         ray_actor_options=info.replica_config.ray_actor_options,
         is_driver_deployment=info.is_driver_deployment,
     )
+
+    if info.deployment_config.autoscaling_config is not None:
+        schema.autoscaling_config = info.deployment_config.autoscaling_config
+    else:
+        schema.num_replicas = info.deployment_config.num_replicas
+
+    return schema
 
 
 @PublicAPI(stability="beta")


### PR DESCRIPTION
If autoscaling config is set for a deployment, we can't set the num replicas when returning the deployment details of that deployment. Otherwise, it breaks the entirety of the get metadata endpoint.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cherry pick https://github.com/ray-project/ray/pull/34377

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
