### PR TITLE
[serve] Gradio docs fixes (#32754)

### DIFF
--- a/doc/source/serve/doc_code/gradio-integration-parallel.py
+++ b/doc/source/serve/doc_code/gradio-integration-parallel.py
@@ -28,7 +28,7 @@ class TextGenerationModel:
 
 
 app1 = TextGenerationModel.bind("gpt2")
-app2 = TextGenerationModel.bind("EleutherAI/gpt-neo-125M")
+app2 = TextGenerationModel.bind("distilgpt2")
 # __doc_models_end__
 
 

--- a/doc/source/serve/doc_code/gradio-integration.py
+++ b/doc/source/serve/doc_code/gradio-integration.py
@@ -42,14 +42,14 @@ def gradio_summarizer_builder():
 
     return gr.Interface(
         fn=model,
-        inputs=[gr.inputs.Textbox(default=example_input, label="Input prompt")],
-        outputs=[gr.outputs.Textbox(label="Model output")],
+        inputs=[gr.Textbox(value=example_input, label="Input prompt")],
+        outputs=[gr.Textbox(label="Model output")],
     )
     # __doc_gradio_app_end__
 
 
 # __doc_app_begin__
-app = GradioServer.options(num_replicas=2, ray_actor_options={"num_cpus": 4}).bind(
+app = GradioServer.options(ray_actor_options={"num_cpus": 4}).bind(
     gradio_summarizer_builder
 )
 # __doc_app_end__

--- a/doc/source/serve/doc_code/gradio-original.py
+++ b/doc/source/serve/doc_code/gradio-original.py
@@ -4,7 +4,7 @@ import requests
 
 # __doc_code_begin__
 generator1 = pipeline("text-generation", model="gpt2")
-generator2 = pipeline("text-generation", model="EleutherAI/gpt-neo-125M")
+generator2 = pipeline("text-generation", model="distilgpt2")
 
 
 def model1(text):

--- a/doc/source/serve/tutorials/gradio-integration.md
+++ b/doc/source/serve/tutorials/gradio-integration.md
@@ -6,7 +6,7 @@ In this guide, we will show you how to scale up your [Gradio](https://gradio.app
 To follow this tutorial, you will need Ray Serve and Gradio. If you haven't already, install them by running:
 ```console
 $ pip install "ray[serve]"
-$ pip install gradio==3.11
+$ pip install gradio==3.19
 ```
 For this tutorial, we will use Gradio apps that run text summarization and generation models and use [HuggingFace's Pipelines](https://huggingface.co/docs/transformers/main_classes/pipelines) to access these models. **Note that you can substitute this Gradio app for any Gradio app of your own!**
 
@@ -35,7 +35,10 @@ Remember you can substitute this with your own Gradio app if you want to try sca
 ### Deploying Gradio Server
 In order to deploy your Gradio app onto Ray Serve, you need to wrap your Gradio app in a Serve [deployment](serve-key-concepts-deployment). `GradioServer` acts as that wrapper. It serves your Gradio app remotely on Ray Serve so that it can process and respond to HTTP requests. 
 
-Replicas in a deployment are copies of your program running on Ray Serve, where each replica runs on a separate Ray cluster node's worker process. More replicas scales your deployment by serving more client requests. By wrapping your application in `GradioServer`, you can increase the number of replicas of your application or increase the number of CPUs and/or GPUs available to each replica.
+By wrapping your application in `GradioServer`, you can increase the number of CPUs and/or GPUs available to the application.
+:::{note}
+Currently, there is no support for routing requests properly to multiple replicas of `GradioServer`, so we recommend only having a single replica.
+:::
 
 :::{note} 
 `GradioServer` is simply `GradioIngress` but wrapped in a Serve deployment. You can use `GradioServer` for the simple wrap-and-deploy use case, but as you will see in the next section, you can use `GradioIngress` to define your own Gradio Server for more customized use cases.
@@ -65,7 +68,7 @@ You can run multiple models in parallel with Ray Serve by utilizing the [deploym
 ### Original Approach
 Suppose you want to run the following program.
 
-1. Take two text generation models, [`gpt2`](https://huggingface.co/gpt2) and [`EleutherAI/gpt-neo-125M`](https://huggingface.co/EleutherAI/gpt-neo-125M).
+1. Take two text generation models, [`gpt2`](https://huggingface.co/gpt2) and [`distilgpt2`](https://huggingface.co/distilgpt2).
 2. Run the two models on the same input text, such that the generated text has a minimum length of 20 and maximum length of 100.
 3. Display the outputs of both models using Gradio.
 
@@ -91,7 +94,7 @@ Let's walk through a few steps to achieve parallelism. First, let's import our d
 :end-before: __doc_import_end__
 ```
 
-Then, let's wrap our `gpt2` and `EleutherAI/gpt-neo-125M` models in Serve deployments, named `TextGenerationModel`.
+Then, let's wrap our `gpt2` and `distilgpt2` models in Serve deployments, named `TextGenerationModel`.
 ```{literalinclude} ../doc_code/gradio-integration-parallel.py
 :start-after: __doc_models_begin__
 :end-before: __doc_models_end__


### PR DESCRIPTION
* The gradio example in the docs uses deprecated API, which spews deprecated warnings if a user runs it.
* I updated the gradio version in the docs from 3.11 to 3.19, as I've verified the example runs fine with the most recent gradio version.
* I switched out EleutherAI/gpt-neo-125M for distilgpt2 in the docs example because of weird errors that occur when pulling it from hugging face. (not sure why the errors are happening, it's not related to gradio or serve)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cherry pick https://github.com/ray-project/ray/pull/32754

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
