### PR TITLE
[Runtime Env] Support expansion of certain PATH variables in env vars

### DIFF
--- a/python/ray/_private/runtime_env/context.py
+++ b/python/ray/_private/runtime_env/context.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 from ray.util.annotations import DeveloperAPI
 from ray.core.generated.common_pb2 import Language
 from ray._private.services import get_ray_jars_dir
+from ray._private.utils import update_envs
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ class RuntimeEnvContext:
         return RuntimeEnvContext(**json.loads(json_string))
 
     def exec_worker(self, passthrough_args: List[str], language: Language):
-        os.environ.update(self.env_vars)
+        update_envs(self.env_vars)
 
         if language == Language.PYTHON and sys.platform == "win32":
             executable = self.py_executable

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1893,3 +1893,25 @@ def try_import_each_module(module_names_to_import: List[str]) -> None:
             importlib.import_module(module_to_preload)
         except ImportError:
             logger.exception(f'Failed to preload the module "{module_to_preload}"')
+
+
+def update_envs(env_vars: Dict[str, str]):
+    """
+    When updating the environment variable, if there is ${X},
+    it will be replaced with the current environment variable.
+    """
+    if not env_vars:
+        return
+
+    replaceable_keys = [
+        "PATH",
+        "LD_LIBRARY_PATH",
+        "DYLD_LIBRARY_PATH",
+        "LD_PRELOAD",
+    ]
+
+    for key, value in env_vars.items():
+        if key in replaceable_keys:
+            os.environ[key] = value.replace("${" + key + "}", os.environ.get(key, ""))
+        else:
+            os.environ[key] = value

--- a/python/ray/tests/test_environ.py
+++ b/python/ray/tests/test_environ.py
@@ -1,6 +1,8 @@
 import os
 import pytest
+import unittest
 import ray
+from ray._private.utils import update_envs
 
 
 @pytest.mark.skipif("sys.platform != 'linux'")
@@ -29,6 +31,34 @@ def test_environ_file_on_linux(ray_start_10_cpus):
     actor_os_environ = ray.get(a.get_os_environ.remote())
     assert len(actor_proc_environ) > 0
     assert len(actor_os_environ) > 0
+
+
+def test_update_envs():
+    with unittest.mock.patch.dict(os.environ):
+        env_vars = {
+            "PATH": "/test/lib/path:${PATH}",
+            "LD_LIBRARY_PATH": "/test/path1:${LD_LIBRARY_PATH}:./test/path2",
+            "DYLD_LIBRARY_PATH": "${DYLD_LIBRARY_PATH}:/test/path",
+            "LD_PRELOAD": "",
+        }
+        old_path = os.environ["PATH"]
+        os.environ["LD_LIBRARY_PATH"] = "./"
+        os.environ["DYLD_LIBRARY_PATH"] = "/lib64"
+        os.environ["LD_PRELOAD"] = "/lib:/usr/local/lib"
+        update_envs(env_vars)
+        assert os.environ["PATH"] == "/test/lib/path:" + old_path
+        assert os.environ["LD_LIBRARY_PATH"] == "/test/path1:./:./test/path2"
+        assert os.environ["DYLD_LIBRARY_PATH"] == "/lib64:/test/path"
+        assert os.environ["LD_PRELOAD"] == env_vars["LD_PRELOAD"]
+
+        # Test the empty string scenario
+        os.environ["LD_LIBRARY_PATH"] = ""
+        del os.environ["DYLD_LIBRARY_PATH"]
+        del os.environ["LD_PRELOAD"]
+        update_envs(env_vars)
+        assert os.environ["LD_LIBRARY_PATH"] == "/test/path1::./test/path2"
+        assert os.environ["DYLD_LIBRARY_PATH"] == ":/test/path"
+        assert os.environ["LD_PRELOAD"] == env_vars["LD_PRELOAD"]
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_runtime_env_env_vars.py
+++ b/python/ray/tests/test_runtime_env_env_vars.py
@@ -300,6 +300,25 @@ def test_environment_variables_env_caching(shutdown_only):
     assert pid7 == pid1
 
 
+def test_appendable_environ(ray_start_regular):
+    @ray.remote
+    def get_env(key):
+        return os.environ.get(key)
+
+    custom_env = os.path.pathsep + "/usr/local/bin"
+    remote_env = ray.get(
+        get_env.options(
+            runtime_env={
+                "env_vars": {
+                    "PATH": "${PATH}" + custom_env,
+                }
+            }
+        ).remote("PATH")
+    )
+    assert remote_env.endswith(custom_env)
+    assert len(remote_env) > len(custom_env)
+
+
 if __name__ == "__main__":
     import pytest
 


### PR DESCRIPTION
## Why are these changes needed?
If the user customizes environment variables such as PATH \ LD_LIBARAY_PATH in the runtime env,
 the original PATH \ LD_LIBARAY_PATH environment variables on the ray cluster will be directly overwritten in the end. 

In C++ Worker, because we set the path of libray_api.so to LD_LIBRARY_PATH.
If the user also sets LD_LIBRARY_PATH in the runtime env, the C++ default worker cannot find libray_api.so

example:
```
1. libray_api.so in /python/site-packages/ray/cpp/lib/libray_api.so.
C++ worker origin environ LD_LIBARAY_PATH is "/python/site-packages/ray/cpp/lib/".

2. Then user set 
runtime_env={
      "env_vars": {
                        "LD_LIBARAY_PATH": "${LD_LIBARAY_PATH}:/home/admin/my_lib",
      }
 }

3. Finally, LD_LIBARAY_PATH -> "/python/site-packages/ray/cpp/lib:/home/admin/my_lib"

```

![image](https://user-images.githubusercontent.com/11072802/232666381-18c1774a-4b5b-40e0-a35f-18d3de186665.png)

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
