### PR TITLE
[air] DreamBooth example: Fix code for batch size > 1

### DIFF
--- a/python/ray/air/examples/dreambooth/dataset.py
+++ b/python/ray/air/examples/dreambooth/dataset.py
@@ -81,10 +81,23 @@ def collate(batch, device, dtype):
     # of the batch.
     # During training, a batch will be chunked into 2 sub-batches for prior
     # preserving loss calculation.
-    images = torch.squeeze(torch.stack([batch["image"], batch["image_1"]]))
+
+    # batch["image"] = image1, image2
+    # batch["image_1"] = reg1, reg2
+    # After cat, we will have [image1, reg1, image2, reg]
+
+    images = torch.cat([batch["image"], batch["image_1"]], dim=0)
     images = images.to(memory_format=torch.contiguous_format).float()
 
-    prompt_ids = torch.cat([batch["prompt_ids"], batch["prompt_ids_1"]], dim=0)
+    batch_size = len(batch["prompt_ids"])
+
+    # batch["prompt_ids"] = pr1, pr2
+    # batch["prompt_ids_1"] = rr1, rr2
+    # After stack+reshape, we will have [pr1, rr1, pr2, rr2]
+
+    prompt_ids = torch.stack(
+        [batch["prompt_ids"], batch["prompt_ids_1"]], dim=1
+    ).reshape(batch_size * 2, -1)
 
     return {
         "prompt_ids": prompt_ids.to(device),  # token ids should stay int.

--- a/release/air_examples/dreambooth/dreambooth_run.sh
+++ b/release/air_examples/dreambooth/dreambooth_run.sh
@@ -47,7 +47,8 @@ python train.py \
   --instance_images_dir=$IMAGES_OWN_DIR \
   --instance_prompt="a photo of unqtkn $CLASS_NAME" \
   --class_images_dir=$IMAGES_REG_DIR \
-  --class_prompt="a photo of a $CLASS_NAME"
+  --class_prompt="a photo of a $CLASS_NAME" \
+  --train_batch_size 2
 
 # Clear new dir
 rm -rf "$IMAGES_NEW_DIR"/*.jpg

--- a/release/air_examples/dreambooth/dreambooth_run.sh
+++ b/release/air_examples/dreambooth/dreambooth_run.sh
@@ -47,8 +47,7 @@ python train.py \
   --instance_images_dir=$IMAGES_OWN_DIR \
   --instance_prompt="a photo of unqtkn $CLASS_NAME" \
   --class_images_dir=$IMAGES_REG_DIR \
-  --class_prompt="a photo of a $CLASS_NAME" \
-  --train_batch_size 2
+  --class_prompt="a photo of a $CLASS_NAME"
 
 # Clear new dir
 rm -rf "$IMAGES_NEW_DIR"/*.jpg

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -672,6 +672,7 @@
   run:
     timeout: 1800
     script: bash dreambooth_run.sh
+    artifact_path: /tmp/artifacts/example_out.jpg
 
 
 - name: air_example_gptj_deepspeed_fine_tuning


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The DreamBooth finetuning example currently throws an error when batch size > 1, even when the GPU memory is large enough. This is because the training batches are currently not created correctly.

This PR fixes the batch format and includes in-line comments to explain the new behavior.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
