### PR TITLE
[air] pin deepspeed version for now to unblock ci.

### DIFF
--- a/python/requirements/ml/requirements_train.txt
+++ b/python/requirements/ml/requirements_train.txt
@@ -20,6 +20,7 @@ transformers==4.19.1; python_version > '3.6'
 # If changing the version here, also change it in AccelerateTrainer docstring
 accelerate==0.5.1; python_version <= '3.6'
 accelerate==0.17.1; python_version > '3.6'
+# Tracking issue: https://github.com/ray-project/ray/issues/34399
 deepspeed==0.8.3; python_version > '3.6'
 datasets==2.0.0
 sentencepiece==0.1.96

--- a/python/requirements/ml/requirements_train.txt
+++ b/python/requirements/ml/requirements_train.txt
@@ -20,6 +20,6 @@ transformers==4.19.1; python_version > '3.6'
 # If changing the version here, also change it in AccelerateTrainer docstring
 accelerate==0.5.1; python_version <= '3.6'
 accelerate==0.17.1; python_version > '3.6'
-deepspeed; python_version > '3.6'
+deepspeed==0.8.3; python_version > '3.6'
 datasets==2.0.0
 sentencepiece==0.1.96


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Deepspeed had a new release yesterday that broke our CI.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#34399

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
