### PR TITLE
[core] Deflake gcs_client_test.cc

### DIFF
--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -513,11 +513,7 @@ TEST_P(GcsClientTest, TestActorInfo) {
   ActorID actor_id = ActorID::FromBinary(actor_table_data->actor_id());
 
   // Subscribe to any update operations of an actor.
-  std::atomic<int> actor_update_count(0);
-  auto on_subscribe = [&actor_update_count](const ActorID &actor_id,
-                                            const gcs::ActorTableData &data) {
-    ++actor_update_count;
-  };
+  auto on_subscribe = [](const ActorID &actor_id, const gcs::ActorTableData &data) {};
   ASSERT_TRUE(SubscribeActor(actor_id, on_subscribe));
 
   // Register an actor to GCS.


### PR DESCRIPTION
* Hypothesis is that on_subscribe callback is invoked after test finishes; the reference to the stack-allocated atomic counter is no longer valid, causing asan failure.
* I don't understand the intention of this test. The counter is actually unused. Should I re-add it on-heap and then assert a correct value? Couldn't determine from `git blame` the intention.