### PR TITLE
[Draft] [Core] Deflake test_placement_group_3

### DIFF
--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -497,7 +497,11 @@ def test_actor_scheduling_not_block_with_placement_group(ray_start_cluster):
             for _, pg in ray.util.placement_group_table().items()
             if pg["state"] == "CREATED"
         ]
-        return len(created_pgs) == expected_created_num
+        print(created_pgs)
+        print(expected_created_num)
+        assert len(created_pgs) == expected_created_num
+        return True
+        #return len(created_pgs) == expected_created_num
 
     wait_for_condition(is_pg_created_number_correct, timeout=3)
     wait_for_condition(is_actor_created_number_correct, timeout=30, retry_interval_ms=0)


### PR DESCRIPTION
* Not sure what the cause is, printing out more info to see

The test should do the following:
* Create Ray cluster with CPU=1
* Create 1000 CPU=1 pg's
* Schedule one CPU=1 actor on each pg
* Assert that only one pg is "created"
* Assert that only one actor has been scheduled

What actually happens:
* Ray cluster has one node with CPU=1
* 64 PG's are created
* 64 actors are scheduled