### PR TITLE
Revert "[RLlib] External env is not compatible with the connectors API."

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1677,16 +1677,14 @@ sh_test(
     data = glob(["examples/serving/*.py"]),
 )
 
-# Tests with unity 3d and external envs currently don't work
-# see: https://github.com/ray-project/ray/issues/34290 for more details
-# sh_test(
-#     name = "env/tests/test_local_inference_unity3d",
-#     tags = ["team:rllib", "env"],
-#     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
-#     srcs = ["env/tests/test_policy_client_server_setup.sh"],
-#     args = ["local", "unity3d", "8850"],
-#     data = glob(["examples/serving/*.py"]),
-# )
+sh_test(
+    name = "env/tests/test_local_inference_unity3d",
+    tags = ["team:rllib", "env"],
+    size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
+    srcs = ["env/tests/test_policy_client_server_setup.sh"],
+    args = ["local", "unity3d", "8850"],
+    data = glob(["examples/serving/*.py"]),
+)
 
 py_test(
     name = "env/tests/test_multi_agent_env",
@@ -1722,16 +1720,14 @@ sh_test(
     data = glob(["examples/serving/*.py"]),
 )
 
-# Tests with unity 3d and external envs currently don't work
-# see: https://github.com/ray-project/ray/issues/34290 for more details
-# sh_test(
-#     name = "env/tests/test_remote_inference_unity3d",
-#     tags = ["team:rllib", "env", "exclusive"],
-#     size = "small",
-#     srcs = ["env/tests/test_policy_client_server_setup.sh"],
-#     args = ["remote", "unity3d", "8860"],
-#     data = glob(["examples/serving/*.py"]),
-# )
+sh_test(
+    name = "env/tests/test_remote_inference_unity3d",
+    tags = ["team:rllib", "env", "exclusive"],
+    size = "small",
+    srcs = ["env/tests/test_policy_client_server_setup.sh"],
+    args = ["remote", "unity3d", "8860"],
+    data = glob(["examples/serving/*.py"]),
+)
 
 py_test(
     name = "env/tests/test_remote_worker_envs",

--- a/rllib/env/tests/test_policy_client_server_setup.sh
+++ b/rllib/env/tests/test_policy_client_server_setup.sh
@@ -56,7 +56,7 @@ fi
 # Start server with 2 workers (will listen on ports worker_1_port and worker_2_port for client
 # connections).
 # Do not attempt to restore from checkpoint; leads to errors on travis.
-(python $basedir/$server_script --run="$trainer_cls" --num-workers=2 --no-restore --port=$worker_1_port 2>&1 | grep -v 200) &
+(python $basedir/$server_script --run=$trainer_cls --num-workers=2 --no-restore --port=$worker_1_port 2>&1 | grep -v 200) &
 server_pid=$!
 
 echo "Waiting for server to start ..."
@@ -85,32 +85,4 @@ client2_pid=$!
 sleep 2
 python $basedir/$client_script --inference-mode=$inference_mode --port=$worker_2_port "$stop_criterion"
 
-exit_if_not_running()
-{
-  local pid=$1
-
-  if ps -p "$pid"> /dev/null
-  then
-      return
-  fi
-
-  echo "$2 is not running"
-
-  wait "$pid"
-  exit_code=$?
-  echo "$2 exited with code $exit_code" 
-  return $exit_code
-}
-
-exit_if_not_running $client1_pid "client 1"
-client_1_exit_code=$?
-exit_if_not_running $client2_pid "client 2"
-client_2_exit_code=$?
-exit_if_not_running $server_pid "server"
-server_exit_code=$?
-
-if [ "$client_1_exit_code" != 0 ] || [ "$client_2_exit_code" != 0 ] || [ "$server_exit_code" != 0 ]; then
-  echo "Test failed!"
-  exit 1
-fi
 kill $server_pid $client1_pid $client2_pid || true

--- a/rllib/examples/serving/cartpole_server.py
+++ b/rllib/examples/serving/cartpole_server.py
@@ -170,11 +170,7 @@ if __name__ == "__main__":
         # Use the `PolicyServerInput` to generate experiences.
         .offline_data(input_=_input)
         # Use n worker processes to listen on different ports.
-        .rollouts(
-            num_rollout_workers=args.num_workers,
-            # Connectors are not compatible with the external env.
-            enable_connectors=False,
-        )
+        .rollouts(num_rollout_workers=args.num_workers)
         # Disable OPE, since the rollouts are coming from online clients.
         .evaluation(off_policy_estimation_methods={})
         # Set to INFO so we'll see the server's actual address:port.

--- a/rllib/examples/serving/unity3d_server.py
+++ b/rllib/examples/serving/unity3d_server.py
@@ -28,7 +28,6 @@ $ python unity3d_client.py --inference-mode=local --game [path to game binary]
 """
 
 import argparse
-import gymnasium as gym
 import os
 
 import ray
@@ -133,14 +132,6 @@ if __name__ == "__main__":
         .rollouts(
             num_rollout_workers=args.num_workers,
             rollout_fragment_length=20,
-            enable_connectors=False,
-        )
-        .environment(
-            env=None,
-            # TODO: (sven) make these settings unnecessary and get the information
-            #  about the env spaces from the client.
-            observation_space=gym.spaces.Box(float("-inf"), float("inf"), (8,)),
-            action_space=gym.spaces.Box(-1.0, 1.0, (2,)),
         )
         .training(train_batch_size=256)
         # Multi-agent setup for the given env.


### PR DESCRIPTION
Reverts ray-project/ray#33945

<img width="777" alt="Screenshot 2023-04-14 at 17 12 29" src="https://user-images.githubusercontent.com/9356806/232173043-ad07efb4-d3d3-4c49-bd8e-d9689d9ac016.png">

PR in question seems to break external env test.