### PR TITLE
[docs] [tune] replace tune.report with session.report

### DIFF
--- a/python/ray/tune/tests/tutorial.py
+++ b/python/ray/tune/tests/tutorial.py
@@ -12,6 +12,7 @@ from torch.utils.data import DataLoader
 import torch.nn.functional as F
 
 from ray import air, tune
+from ray.air import session
 from ray.tune.schedulers import ASHAScheduler
 # __tutorial_imports_end__
 # fmt: on

--- a/python/ray/tune/tests/tutorial.py
+++ b/python/ray/tune/tests/tutorial.py
@@ -105,7 +105,7 @@ def train_mnist(config):
         acc = test(model, test_loader)
 
         # Send the current training result back to Tune
-        tune.report(mean_accuracy=acc)
+        session.report(mean_accuracy=acc)
 
         if i % 5 == 0:
             # This saves the model to the trial directory


### PR DESCRIPTION
## Why are these changes needed?

To address CSAT reported feedback that example was using an outdated API (tune.report) which is replaced with session.report.

## Related issue number

(https://github.com/ray-project/ray/issues/34434)

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
