### PR TITLE
[data] [streaming] Improve handling of KeyboardInterrupt

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -118,7 +118,9 @@ class StreamingExecutor(Executor, threading.Thread):
                         if self._outer._global_info:
                             self._outer._global_info.update(1)
                         return item
-                except Exception:
+                # Needs to be BaseException to catch KeyboardInterrupt. Otherwise we
+                # can leave dangling progress bars by skipping shutdown.
+                except BaseException as e:
                     self._outer.shutdown()
                     raise
 

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -120,7 +120,7 @@ class StreamingExecutor(Executor, threading.Thread):
                         return item
                 # Needs to be BaseException to catch KeyboardInterrupt. Otherwise we
                 # can leave dangling progress bars by skipping shutdown.
-                except BaseException as e:
+                except BaseException:
                     self._outer.shutdown()
                     raise
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We didn't catch KeyboardInterrupt previously, which means if you Ctrl-C a stream it won't be shutdown properly. This can leave progress bars dangling in the console.