### PR TITLE
Fix DDPG Device Error

### DIFF
--- a/rllib/utils/exploration/ornstein_uhlenbeck_noise.py
+++ b/rllib/utils/exploration/ornstein_uhlenbeck_noise.py
@@ -197,6 +197,7 @@ class OrnsteinUhlenbeckNoise(GaussianNoise):
                 gaussian_sample = scale * torch.normal(
                     mean=torch.zeros(self.ou_state.size()), std=1.0
                 ).to(self.device)
+                self.ou_state = self.ou_state.to(self.device)
                 ou_new = (
                     self.ou_theta * -self.ou_state + self.ou_sigma * gaussian_sample
                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Change: 
Add `self.ou_state = self.ou_state.to(self.device)` inside function `_get_torch_exploration_action()` to ensure the device of tensor `self.ou_state aligns` with `gaussian_sample`.

Original Problem: 
If a DDPG algorithm trained on gpu is restored from history checkpoints to perform a policy (e.g. call by agent.compute_single_action()) the error: "Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!" will occur, indicating that there is a mismatch between the devices of the tensors being used in the computation.

This change fixed the device mismatch.

## Related issue number

Haven't yet reported it as an issue, but it is easy to reproduce. Make sure to train the DDPG algorithm on gpu.
For reproduction, you may want to use the code in git@github.com:Annivia/ROB498_Project.git

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
