### PR TITLE
Make serve http proxy more robust in high traffic.

### DIFF
--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -144,7 +144,7 @@ async def _send_request_to_handle(handle, scope, receive, send) -> str:
                 "remaining."
             )
             backoff = True
-        if backoff:
+        if backoff and HTTP_REQUEST_MAX_RETRIES != 0:
             await asyncio.sleep(backoff_time_s)
             # Be careful about the expotential backoff scaling here.
             # Assuming 10 retries, 1.5x scaling means the last retry is 38x the
@@ -511,6 +511,10 @@ Please make sure your http-host and http-port are specified correctly."""
             root_path=self.root_path,
             lifespan="off",
             access_log=False,
+            limit_concurrency=int(
+                os.environ.get("RAY_SERVE_HTTP_PROXY_LIMIT_CONCURRENCY", 0)
+            )
+            or None,
         )
         server = uvicorn.Server(config=config)
         # TODO(edoakes): we need to override install_signal_handlers here

--- a/scripts/bazel.py
+++ b/scripts/bazel.py
@@ -5,11 +5,10 @@ import errno
 import json
 import os
 import re
-import subprocess
 import stat
+import subprocess
 import sys
-
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
 
 
 def textproto_format(space, key, value, json_encoder):

--- a/scripts/bazel_sharding.py
+++ b/scripts/bazel_sharding.py
@@ -16,9 +16,6 @@
 
 # BASED ON https://github.com/philwo/bazel-utils/blob/main/sharding/sharding.py
 
-from collections import defaultdict
-from dataclasses import dataclass
-from typing import Iterable, List, Optional, Set, Tuple
 import argparse
 import os
 import re
@@ -26,6 +23,9 @@ import shlex
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Set, Tuple
 
 
 @dataclass

--- a/scripts/build-docker-images.py
+++ b/scripts/build-docker-images.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 from typing import List, Optional, Tuple
 
 import click
+
 import docker
 
 print = functools.partial(print, file=sys.stderr, flush=True)

--- a/scripts/build-docker-images.py
+++ b/scripts/build-docker-images.py
@@ -1,8 +1,8 @@
 import datetime
-import json
 import functools
 import glob
 import itertools
+import json
 import os
 import platform
 import re

--- a/scripts/determine_tests_to_run.py
+++ b/scripts/determine_tests_to_run.py
@@ -7,8 +7,8 @@ import os
 import re
 import subprocess
 import sys
-from pprint import pformat
 import traceback
+from pprint import pformat
 
 
 # NOTE(simon): do not add type hint here because it's ran using python2 in CI.

--- a/scripts/get_build_info.py
+++ b/scripts/get_build_info.py
@@ -10,9 +10,9 @@ $ python get_build_info.py
 }
 """
 
+import json
 import os
 import sys
-import json
 
 
 def gha_get_self_url():

--- a/scripts/py_dep_analysis_test.py
+++ b/scripts/py_dep_analysis_test.py
@@ -146,7 +146,8 @@ b = 2
 
 
 if __name__ == "__main__":
-    import pytest
     import sys
+
+    import pytest
 
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In low latency required high traffic environment (like 1000tps, 100ms latency, with 16 core cpu), http proxy in ray serve becomes unresponsive It returns only returning 4xx or 5xx and does not return 2xx.
In order to make ray serve robust(responsive), need to enable http proxy to drop the excessive http request as soon as possible.
This patch makes uvicorn limix concurrency configurable and drops http request as soon as possible without sleep if retry is not necessary.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
