### PR TITLE
Update development.rst to fix NVM installation issues

### DIFF
--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -116,12 +116,12 @@ You probably want some type of Python virtual environment. For example, you can 
 
 .. _python-develop:
 
-Building Ray (Python Only)
+Building Python-Only Components
 --------------------------
 
 .. note:: Unless otherwise stated, directory and file paths are relative to the project root directory.
 
-RLlib, Tune, Autoscaler, and most Python files do not require you to build and compile Ray. Follow these instructions to develop Ray's Python files locally without building Ray.
+RLlib, Tune, Autoscaler, and most Python files do not require you to build and compile Ray. Follow these instructions to develop Ray's Python files locally without building Ray. If you are interested in building Ray as a whole, please refer to the next sessions for preparation and installation in Linux, MacOS or Windows.
 
 1. Make sure you have a clone of Ray's git repository as explained above.
 
@@ -178,10 +178,12 @@ To build Ray on Ubuntu, run the following commands:
   ci/env/install-bazel.sh
 
   # Install node version manager and node 14
-  $(curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh)
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+  export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
   nvm install 14
   nvm use 14
-
+  # Please refer to https://github.com/nvm-sh/nvm#git-install for detailed instructions on NVM installation.
 
 For RHELv8 (Redhat EL 8.0-64 Minimal), run the following commands:
 

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -117,7 +117,7 @@ You probably want some type of Python virtual environment. For example, you can 
 .. _python-develop:
 
 Building Python-Only Components
---------------------------
+-------------------------------
 
 .. note:: Unless otherwise stated, directory and file paths are relative to the project root directory.
 

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -121,7 +121,7 @@ Building Python-Only Components
 
 .. note:: Unless otherwise stated, directory and file paths are relative to the project root directory.
 
-RLlib, Tune, Autoscaler, and most Python files do not require you to build and compile Ray. Follow these instructions to develop Ray's Python files locally without building Ray. If you are interested in building Ray as a whole, please refer to the next sessions for preparation and installation in Linux, MacOS or Windows.
+RLlib, Tune, Autoscaler, and most Python files do not require you to build and compile Ray. Follow these instructions to develop Ray's Python files locally without building Ray. If you are interested in building Ray as a whole, please refer to the next sessions for preparation and installation in Linux, MacOS, or Windows.
 
 1. Make sure you have a clone of Ray's git repository as explained above.
 


### PR DESCRIPTION
This PR is proposed to fix a document issue related to NVM installation when building Ray on Linux.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The original guide of NVM installation doesn't work as expected blocking the Ray build. 

<!-- Please give a short summary of the change and the problem this solves. -->
This PR proposes a fix to NVM installation issue and attaches a link to official NVM document.

## Related issue number
N/A
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
