### PR TITLE
[Autoscaler] gcp parallel terminate nodes

### DIFF
--- a/python/ray/tests/gcp/test_gcp_node_provider.py
+++ b/python/ray/tests/gcp/test_gcp_node_provider.py
@@ -24,7 +24,7 @@ def test_create_node_returns_dict():
     expected_return_value = {"instance_id1": {"dict": 1}, "instance_id2": {"dict": 2}}
 
     def __init__(self, provider_config: dict, cluster_name: str):
-        self.lock = RLock()
+        self.locks: Dict[str, RLock] = {}
         self.cached_nodes: Dict[str, GCPNode] = {}
         self.resources: Dict[GCPNodeType, GCPResource] = {}
         self.resources[GCPNodeType.COMPUTE] = mock_resource
@@ -33,6 +33,56 @@ def test_create_node_returns_dict():
         node_provider = GCPNodeProvider({}, "")
         create_node_return_value = node_provider.create_node(mock_node_config, {}, 1)
     assert create_node_return_value == expected_return_value
+
+
+def test_create_node_update_locks():
+    mock_node_config = {"machineType": "n2-standard-8"}
+    mock_resource = MagicMock()
+    mock_resource.create_instances.return_value = [
+        ({"dict": 1}, "instance_id1"),
+        ({"dict": 2}, "instance_id2"),
+    ]
+    expected_node_ids_from_locks = {"instance_id1", "instance_id2"}
+
+    def __init__(self, provider_config: dict, cluster_name: str):
+        self.locks: Dict[str, RLock] = {}
+        self.cached_nodes: Dict[str, GCPNode] = {}
+        self.resources: Dict[GCPNodeType, GCPResource] = {}
+        self.resources[GCPNodeType.COMPUTE] = mock_resource
+
+    with patch.object(GCPNodeProvider, "__init__", __init__):
+        node_provider = GCPNodeProvider({}, "")
+        _ = node_provider.create_node(mock_node_config, {}, 1)
+        update_node_ids_from_locks = set(node_provider.locks.keys())
+    assert update_node_ids_from_locks == expected_node_ids_from_locks
+
+
+def test_terminate_nodes():
+    mock_node_config = {"machineType": "n2-standard-8"}
+    node_type = GCPNodeType.COMPUTE.value
+    id1, id2 = f"instance-id1-{node_type}", f"instance-id2-{node_type}"
+    terminate_node_ids = [id1, id2]
+    mock_resource = MagicMock()
+    mock_resource.create_instances.return_value = [
+        ({"dict": 1}, id1),
+        ({"dict": 2}, id2),
+    ]
+    mock_resource.delete_instance.return_value = {}
+    expected_lock_list_len = 0
+
+    def __init__(self, provider_config: dict, cluster_name: str):
+        self.locks: Dict[str, RLock] = {}
+        self.cached_nodes: Dict[str, GCPNode] = {}
+        self.resources: Dict[GCPNodeType, GCPResource] = {}
+        self.resources[GCPNodeType.COMPUTE] = mock_resource
+
+    with patch.object(GCPNodeProvider, "__init__", __init__):
+        node_provider = GCPNodeProvider({}, "")
+        node_provider.create_node(mock_node_config, {}, 1)
+        node_provider.terminate_nodes(terminate_node_ids)
+        terminated_lock_list_len = len(node_provider.locks)
+
+    assert terminated_lock_list_len == expected_lock_list_len
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`ray down` takes a lot of time when using GCPNodeProvider as stated in #26239 because GCPNodeProvider uses the serial implementation of `terminate_nodes` from parent class NodeProvider and also uses a coarse lock in its `terminate_node` which prevents executing it in a concurrent fashion (not really sure coz I'm new to this).
<!-- Please give a short summary of the change and the problem this solves. -->

- add threadpoolexecutor in GCPNodeProvider.terminate_nodes for parallelization execution of terminate_node
- use fine-grained locks which assign one RLock per node_id
- add unit_tests

_why not go with the suggestions(batch apis and non-blocking version of terminate_node) mentioned in #26239?_
As a novice, I think both solutions would break Liskov Substitute Principle, and also for those who already used terminate_node(s) would need to add await.

## Related issue number

<!-- For example: "Closes #1234" -->
#26239 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
