### PR TITLE
[RLlib] Fix CartPole --use-lstm string in policy server test

### DIFF
--- a/rllib/env/tests/test_policy_client_server_setup.sh
+++ b/rllib/env/tests/test_policy_client_server_setup.sh
@@ -18,17 +18,20 @@ if [ "$2" == "cartpole" ]; then
   client_script=cartpole_client.py
   stop_criterion="--stop-reward=150.0"
   trainer_cls="PPO"
+  use_lstm=""
 elif [ "$2" == "cartpole_lstm" ]; then
   server_script=cartpole_server.py
   client_script=cartpole_client.py
   stop_criterion="--stop-reward=150.0"
-  trainer_cls="IMPALA --use-lstm"
+  trainer_cls="IMPALA"
+  use_lstm="--use-lstm"
 # Unity3D dummy setup.
 elif [ "$2" == "unity3d" ]; then
   server_script=unity3d_server.py
   client_script=unity3d_dummy_client.py
   stop_criterion="--num-episodes=10"
   trainer_cls="PPO"
+  use_lstm=""
 # CartPole dummy test using 2 simultaneous episodes on the client.
 # One episode has training_enabled=False (its data should NOT arrive at server).
 else
@@ -36,6 +39,7 @@ else
   client_script=dummy_client_with_two_episodes.py
   stop_criterion="--dummy-arg=dummy"  # no stop criterion: client script terminates either way
   trainer_cls="PPO"
+  use_lstm=""
 fi
 
 port=$3
@@ -56,7 +60,7 @@ fi
 # Start server with 2 workers (will listen on ports worker_1_port and worker_2_port for client
 # connections).
 # Do not attempt to restore from checkpoint; leads to errors on travis.
-(python $basedir/$server_script --run="$trainer_cls" --num-workers=2 --no-restore --port=$worker_1_port 2>&1 | grep -v 200) &
+(python $basedir/$server_script --run="$trainer_cls" --num-workers=2 $use_lstm --no-restore --port=$worker_1_port 2>&1 | grep -v 200) &
 server_pid=$!
 
 echo "Waiting for server to start ..."


### PR DESCRIPTION
## Why are these changes needed?

<img width="777" alt="Screenshot 2023-04-16 at 22 44 48" src="https://user-images.githubusercontent.com/9356806/232393404-1115663d-15f6-4156-87d2-f81cf170fa23.png">

[Avnish's PR](https://github.com/ray-project/ray/pull/33945) uncovered a bug in our IMPALA policy client server script.

This PR fixes that bug, which was that we called the _server script_ with a bad syntax for cl args.