### PR TITLE
[RLlib] Move 8gpus 96cpus rllib GCE release test to n1/t4 nodes

### DIFF
--- a/release/rllib_tests/8gpus_96cpus_gce.yaml
+++ b/release/rllib_tests/8gpus_96cpus_gce.yaml
@@ -3,13 +3,18 @@ region: us-west1
 allowed_azs:
     - us-west1-b
 
-max_workers: 0
+max_workers: 1
 
 head_node_type:
     name: head_node
-    instance_type: n1-highmem-96-nvidia-tesla-v100-8 # g4dn.metal
+    instance_type: n1-standard-64-nvidia-tesla-t4-4
 
-worker_node_types: []
+worker_node_types:
+    - name: worker_node
+      instance_type: n1-standard-32-nvidia-tesla-t4-4
+      min_workers: 1
+      max_workers: 1
+      use_spot: false
 
 gcp_advanced_configurations_json:
   instance_properties:


### PR DESCRIPTION
## Why are these changes needed?

The RLlib release tests we are currently running on GCE experience a throughput regression.
As seen with other tests, this might be mitigated by running them on n1/t4 nodes.
Since these are not available in a 96cpu/8gpu configuration, we attempt to split them between two nodes (64/4, 32/4).