### PR TITLE
[core][tests] Harden flaky pytest

### DIFF
--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -657,10 +657,14 @@ def test_recursive_cancel_error_messages(shutdown_only, capsys):
             samples.append(msg)
     assert len(samples) == 10
 
-    assert (
-        f"Total Recursive cancelation success: 0, failures: {NUM_ACTORS}"
-        in total_result
-    )
+    # Usually, we expect this message to be the last. That may not always be the case.
+    found_total_msg : bool = True
+    for total_result in reversed(msgs):
+        found_total_msg = found_total_msg or (f"Total Recursive cancelation success: 0, failures:{NUM_ACTORS}" in msg)
+        if found_total_msg:
+            break
+    
+    assert(found_total_msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I suspect the flaky cancellation test is due to an expectation that the final log message assumes a particular format. This may not be the last log message, so check backwards from the last message for this string.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#34343 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
