### PR TITLE
[Train] Allow local datasets in `HuggingFaceTrainer`

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -417,12 +417,13 @@ class DatasetConfig:
 
     @staticmethod
     def validated(
-        config: Dict[str, "DatasetConfig"], datasets: Dict[str, "Dataset"]
+        config: Dict[str, "DatasetConfig"], datasets: Optional[Dict[str, "Dataset"]]
     ) -> Dict[str, "DatasetConfig"]:
         """Validate the given config and datasets are usable.
 
         Returns dict of validated configs with defaults filled out.
         """
+        datasets = datasets or {}
         has_wildcard = WILDCARD_KEY in config
         fittable = set()
         result = {k: v.fill_defaults() for k, v in config.items()}

--- a/python/ray/train/huggingface/_huggingface_utils.py
+++ b/python/ray/train/huggingface/_huggingface_utils.py
@@ -98,7 +98,10 @@ def process_datasets(
     eval_dataset: DataIterator,
 ) -> Tuple["IterableDataset", "IterableDataset"]:
     """Convert Ray train and validation to HF IterableDatasets."""
-    train_torch_dataset = process_dataset_for_hf(train_dataset)
+    if train_dataset:
+        train_torch_dataset = process_dataset_for_hf(train_dataset)
+    else:
+        train_torch_dataset = None
 
     if eval_dataset:
         eval_torch_dataset = process_dataset_for_hf(eval_dataset)

--- a/python/ray/train/huggingface/huggingface_trainer.py
+++ b/python/ray/train/huggingface/huggingface_trainer.py
@@ -93,9 +93,9 @@ main/en/main_classes/trainer#transformers.TrainingArguments>`__.
     All the other datasets will not be split.
 
     You can also provide ``datasets.Dataset`` object or other dataset objects
-    allowed by ``transformers.Trainer`` directly in the training function, without
-    specifying the ``datasets`` dict. It is recommended to initialize those
-    objects in the function, as otherwise they will be serialized and passed
+    allowed by ``transformers.Trainer`` directly in the ``trainer_init_per_worker``
+    function, without specifying the ``datasets`` dict. It is recommended to initialize
+    those objects inside the function, as otherwise they will be serialized and passed
     to the function, which may lead to long runtime and memory issues with large
     amounts of data.
 

--- a/python/ray/train/huggingface/huggingface_trainer.py
+++ b/python/ray/train/huggingface/huggingface_trainer.py
@@ -76,8 +76,10 @@ class HuggingFaceTrainer(TorchTrainer):
     DDP. These actors already have the necessary torch process group already
     configured for distributed PyTorch training. If you have PyTorch >= 1.12.0
     installed, you can also run FSDP training by specifying the ``fsdp`` argument
-    in ``TrainingArguments``. For more information on configuring FSDP,
-    refer to `Hugging Face documentation <https://huggingface.co/docs/transformers/\
+    in ``TrainingArguments``. DeepSpeed is
+    also supported - see :doc:`/ray-air/examples/gptj_deepspeed_fine_tuning`.
+    For more information on configuring FSDP or DeepSpeed, refer to `Hugging Face
+    documentation <https://huggingface.co/docs/transformers/\
 main/en/main_classes/trainer#transformers.TrainingArguments>`__.
 
     The training function ran on every Actor will first run the
@@ -89,6 +91,13 @@ main/en/main_classes/trainer#transformers.TrainingArguments>`__.
     the "train" key), then it will be split into multiple dataset
     shards, with each Actor training on a single shard.
     All the other datasets will not be split.
+
+    You can also provide ``datasets.Dataset`` object or other dataset objects
+    allowed by ``transformers.Trainer`` directly in the training function, without
+    specifying the ``datasets`` dict. It is recommended to initialize those
+    objects in the function, as otherwise they will be serialized and passed
+    to the function, which may lead to long runtime and memory issues with large
+    amounts of data.
 
     Please note that if you use a custom ``transformers.Trainer`` subclass,
     the ``get_train_dataloader`` method will be wrapped around to disable
@@ -202,14 +211,6 @@ main/en/main_classes/trainer#transformers.TrainingArguments>`__.
             and config as kwargs. The Torch Datasets are automatically
             created by converting the Ray Datasets internally before
             they are passed into the function.
-        datasets: Any Ray Datasets to use for training. Use
-            the key "train" to denote which dataset is the training
-            dataset and (optionally) key "evaluation" to denote the evaluation
-            dataset. Can only contain a training dataset
-            and up to one extra dataset to be used for evaluation.
-            If a ``preprocessor`` is provided and has not already been fit,
-            it will be fit on the training dataset. All datasets will be
-            transformed by the ``preprocessor`` if one is provided.
         trainer_init_config: Configurations to pass into
             ``trainer_init_per_worker`` as kwargs.
         torch_config: Configuration for setting up the PyTorch backend. If set to
@@ -218,6 +219,14 @@ main/en/main_classes/trainer#transformers.TrainingArguments>`__.
         scaling_config: Configuration for how to scale data parallel training.
         dataset_config: Configuration for dataset ingest.
         run_config: Configuration for the execution of the training run.
+        datasets: Any Ray Datasets to use for training. Use
+            the key "train" to denote which dataset is the training
+            dataset and key "evaluation" to denote the evaluation
+            dataset. Can only contain a training dataset
+            and up to one extra dataset to be used for evaluation.
+            If a ``preprocessor`` is provided and has not already been fit,
+            it will be fit on the training dataset. All datasets will be
+            transformed by the ``preprocessor`` if one is provided.
         preprocessor: A ray.data.Preprocessor to preprocess the
             provided datasets.
         resume_from_checkpoint: A checkpoint to resume training from.
@@ -225,7 +234,7 @@ main/en/main_classes/trainer#transformers.TrainingArguments>`__.
 
     _dataset_config = {
         # training dataset should be split by us
-        "train": DatasetConfig(fit=True, split=True, required=True),
+        "train": DatasetConfig(fit=True, split=True),
         # do not split eval dataset, as HF has a system to parallelize
         # evaluation across workers, and it requires each worker
         # to have the full eval dataset
@@ -235,15 +244,16 @@ main/en/main_classes/trainer#transformers.TrainingArguments>`__.
     def __init__(
         self,
         trainer_init_per_worker: Callable[
-            [TorchDataset, Optional[TorchDataset], Any], transformers.trainer.Trainer
+            [Optional[TorchDataset], Optional[TorchDataset], Any],
+            transformers.trainer.Trainer,
         ],
         *,
-        datasets: Dict[str, GenDataset],
         trainer_init_config: Optional[Dict] = None,
         torch_config: Optional[TorchConfig] = None,
         scaling_config: Optional[ScalingConfig] = None,
         dataset_config: Optional[Dict[str, DatasetConfig]] = None,
         run_config: Optional[RunConfig] = None,
+        datasets: Optional[Dict[str, GenDataset]] = None,
         preprocessor: Optional["Preprocessor"] = None,
         resume_from_checkpoint: Optional[Checkpoint] = None,
     ):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Loosens restrictions in `HuggingFaceTrainer` to make the `datasets` argument optional and thus allow Hugging Face Datasets to be used directly.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/34476#event-9027131192

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
