### PR TITLE
[Release test] [Cluster launcher] Add release test for aws `example-full.yaml`

### DIFF
--- a/python/ray/autoscaler/aws/example-full.yaml
+++ b/python/ray/autoscaler/aws/example-full.yaml
@@ -79,7 +79,7 @@ available_node_types:
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
                   Ebs:
-                      VolumeSize: 140GB
+                      VolumeSize: 140
             # Additional options in the boto docs.
     ray.worker.default:
         # The minimum number of worker nodes of this type to launch.

--- a/python/ray/autoscaler/aws/example-full.yaml
+++ b/python/ray/autoscaler/aws/example-full.yaml
@@ -169,7 +169,7 @@ worker_setup_commands: []
 # Command to start ray on the head node. You don't need to change this.
 head_start_ray_commands:
     - ray stop
-    - ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml
+    - ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml --dashboard-host=0.0.0.0
 
 # Command to start ray on worker nodes. You don't need to change this.
 worker_start_ray_commands:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4812,3 +4812,23 @@
     timeout: 1200
     script: cd tests && python aws_launch_and_verify_cluster.py ../example-minimal.yaml
     type: sdk_command
+
+- name: aws_cluster_launcher_full
+  group: cluster-launcher-test
+  working_dir: ../python/ray/autoscaler/aws/
+
+  stable: true
+
+  # TODO: Migrate this test to Anyscale Jobs / staging_v2
+  env: prod_v1
+
+  frequency: nightly
+  team: core
+  cluster:
+    cluster_env: tests/aws_config.yaml
+    cluster_compute: tests/aws_compute.yaml
+
+  run:
+    timeout: 1200
+    script: cd tests && python aws_launch_and_verify_cluster.py ../example-full.yaml
+    type: sdk_command


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Adds a release test for `example-full.yaml` on AWS.

Starts the cluster with `ray up`, runs a simple Ray driver script, and calls `ray down`.

Also fixes a bug in this YAML file where we were using a string instead of an int for a VolumeSize.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
