### PR TITLE
Revert "Fix linter"

### DIFF
--- a/scripts/determine_tests_to_run.py
+++ b/scripts/determine_tests_to_run.py
@@ -7,8 +7,8 @@ import os
 import re
 import subprocess
 import sys
-import traceback
 from pprint import pformat
+import traceback
 
 
 # NOTE(simon): do not add type hint here because it's ran using python2 in CI.

--- a/scripts/py_dep_analysis_test.py
+++ b/scripts/py_dep_analysis_test.py
@@ -146,8 +146,7 @@ b = 2
 
 
 if __name__ == "__main__":
-    import sys
-
     import pytest
+    import sys
 
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Reverts ray-project/ray#34474

This is because symbolic links were replaced by copies of files. Will fix this in a followup PR.