### PR TITLE
[CI] Simpler test variation

### DIFF
--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -98,7 +98,7 @@ def parse_test_definition(test_definitions: List[TestDefinition]) -> List[Test]:
             )
             test = copy.deepcopy(test_definition)
             test["name"] = f'{test["name"]}.{variation.pop("__suffix__")}'
-            test.update(variation)
+            test = deep_update(test, variation)
             tests.append(test)
     return tests
 

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -65,7 +65,6 @@ def test_parse_test_definition():
             - __suffix__: aws
             - __suffix__: gce
               cluster:
-                cluster_env: env_gce.yaml
                 cluster_compute: compute_gce.yaml
     """
     )
@@ -79,6 +78,7 @@ def test_parse_test_definition():
     assert not validate_test(gce_test, schema)
     assert aws_test["name"] == "sample_test.aws"
     assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
+    assert gce_test["cluster"]["cluster_env"] == "env.yaml"
     invalid_test_definition = test_definitions[0]
     # Intentionally make the test definition invalid by create an empty 'variations'
     # field. Check that the parser throws exception at runtime

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4567,6 +4567,14 @@
     wait_for_nodes:
       num_nodes: 2
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: inference_gce.yaml
 
 - name: shuffle_data_loader
   group: data-tests
@@ -4582,6 +4590,15 @@
     timeout: 1800
     script: python dataset_shuffle_data_loader.py
 
+  # TODO: Port s3://shuffling-data-loader-benchmarks/ to GCS.
+  # variations:
+  #   - __suffix__: aws
+  #   - __suffix__: gce
+  #     env: gce
+  #     frequency: manual
+  #     cluster:
+  #       cluster_env: shuffle_app_config.yaml
+  #       cluster_compute: shuffle_compute_gce.yaml
 
 - name: parquet_metadata_resolution
   group: data-tests
@@ -4598,6 +4615,15 @@
     timeout: 100
     script: python parquet_metadata_resolution.py --num-files 915
 
+  # TODO: Port s3://shuffling-data-loader-benchmarks/ to GCS.
+  # variations:
+  #   - __suffix__: aws
+  #   - __suffix__: gce
+  #     env: gce
+  #     frequency: manual
+  #     cluster:
+  #       cluster_env: app_config.yaml
+  #       cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: dataset_random_access
   group: data-tests
@@ -4616,6 +4642,14 @@
     wait_for_nodes:
       num_nodes: 15
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: pipelined_training_app.yaml
+        cluster_compute: pipelined_training_compute_gce.yaml
 
 - name: pipelined_data_ingest_benchmark_1tb
   group: data-tests
@@ -4681,6 +4715,14 @@
     timeout: 1800
     script: python aggregate_benchmark.py
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: read_parquet_benchmark_single_node
   group: data-tests
@@ -4697,6 +4739,14 @@
     timeout: 400
     script: python read_parquet_benchmark.py
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: read_images_benchmark_single_node
   group: data-tests
@@ -4712,6 +4762,14 @@
     timeout: 1800
     script: python read_images_benchmark.py
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: read_tfrecords_benchmark_single_node
   group: data-tests
@@ -4728,6 +4786,14 @@
     timeout: 1800
     script: python read_tfrecords_benchmark.py
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: read_tfrecords_benchmark_app.yaml
+        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: map_batches_benchmark_single_node
   group: data-tests
@@ -4744,6 +4810,14 @@
     timeout: 2400
     script: python map_batches_benchmark.py
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: iter_tensor_batches_benchmark_single_node
   group: data-tests
@@ -4760,6 +4834,15 @@
     timeout: 2400
     script: python iter_tensor_batches_benchmark.py
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: single_node_benchmark_compute_gce.yaml
+
 - name: iter_tensor_batches_benchmark_multi_node
   group: data-tests
   working_dir: nightly_tests/dataset
@@ -4774,6 +4857,15 @@
     # Expect the benchmark to finish around 30 minutes.
     timeout: 2400
     script: python iter_tensor_batches_benchmark.py --data-size-gb=10
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: iter_batches_benchmark_single_node
   group: data-tests
@@ -4790,6 +4882,14 @@
     timeout: 1080
     script: python iter_batches_benchmark.py
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: pipelined_training_50_gb
   group: data-tests
@@ -4807,6 +4907,14 @@
     wait_for_nodes:
       num_nodes: 15
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: pipelined_training_app.yaml
+        cluster_compute: pipelined_training_compute_gce.yaml
 
 - name: pipelined_ingestion_1500_gb
   group: data-tests
@@ -4826,6 +4934,14 @@
     wait_for_nodes:
       num_nodes: 21
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: pipelined_training_app.yaml
+        cluster_compute: pipelined_training_compute_gce.yaml
 
 - name: dataset_shuffle_random_shuffle_1tb
   group: data-tests
@@ -4843,6 +4959,15 @@
     wait_for_nodes:
       num_nodes: 20
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: shuffle/shuffle_app_config.yaml
+        cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
+
 - name: dataset_shuffle_sort_1tb
   group: data-tests
   working_dir: nightly_tests
@@ -4859,6 +4984,15 @@
     wait_for_nodes:
       num_nodes: 20
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: shuffle/shuffle_app_config.yaml
+        cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
+
 - name: dataset_shuffle_push_based_random_shuffle_1tb
   group: data-tests
   working_dir: nightly_tests
@@ -4871,7 +5005,7 @@
 
   run:
     timeout: 7200
-    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
+    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
 
@@ -4883,7 +5017,6 @@
       cluster:
         cluster_env: shuffle/shuffle_app_config.yaml
         cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
-
 
 - name: dataset_shuffle_push_based_sort_1tb
   group: data-tests
@@ -4897,9 +5030,18 @@
 
   run:
     timeout: 7200
-    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9
+    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9
     wait_for_nodes:
       num_nodes: 20
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: shuffle/shuffle_app_config.yaml
+        cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
 
 - name: dataset_shuffle_push_based_random_shuffle_100tb
   group: data-tests
@@ -4913,7 +5055,7 @@
 
   run:
     timeout: 28800
-    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=100000 --partition-size=1e9 --shuffle
+    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=100000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 100
 
@@ -4927,7 +5069,7 @@
         cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
       run:
         timeout: 28800
-        script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=40000 --partition-size=1e9 --shuffle
+        script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=40000 --partition-size=1e9 --shuffle
         wait_for_nodes:
           num_nodes: 100
 
@@ -5060,7 +5202,7 @@
   run:
     timeout: 7200
     prepare: ' python setup_chaos.py --node-kill-interval 1200 --max-nodes-to-kill 3'
-    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9
+    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9
     wait_for_nodes:
       num_nodes: 20
 
@@ -5117,7 +5259,7 @@
   run:
     timeout: 7200
     prepare: ' python setup_chaos.py --node-kill-interval 600 --max-nodes-to-kill 2'
-    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
+    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1460,7 +1460,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_gce_4x8.yaml
 
   alert: tune_tests
@@ -4568,14 +4567,6 @@
     wait_for_nodes:
       num_nodes: 2
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: inference_gce.yaml
 
 - name: shuffle_data_loader
   group: data-tests
@@ -4591,15 +4582,6 @@
     timeout: 1800
     script: python dataset_shuffle_data_loader.py
 
-  # TODO: Port s3://shuffling-data-loader-benchmarks/ to GCS.
-  # variations:
-  #   - __suffix__: aws
-  #   - __suffix__: gce
-  #     env: gce
-  #     frequency: manual
-  #     cluster:
-  #       cluster_env: shuffle_app_config.yaml
-  #       cluster_compute: shuffle_compute_gce.yaml
 
 - name: parquet_metadata_resolution
   group: data-tests
@@ -4616,15 +4598,6 @@
     timeout: 100
     script: python parquet_metadata_resolution.py --num-files 915
 
-  # TODO: Port s3://shuffling-data-loader-benchmarks/ to GCS.
-  # variations:
-  #   - __suffix__: aws
-  #   - __suffix__: gce
-  #     env: gce
-  #     frequency: manual
-  #     cluster:
-  #       cluster_env: app_config.yaml
-  #       cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: dataset_random_access
   group: data-tests
@@ -4643,14 +4616,6 @@
     wait_for_nodes:
       num_nodes: 15
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: pipelined_training_app.yaml
-        cluster_compute: pipelined_training_compute_gce.yaml
 
 - name: pipelined_data_ingest_benchmark_1tb
   group: data-tests
@@ -4716,14 +4681,6 @@
     timeout: 1800
     script: python aggregate_benchmark.py
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: read_parquet_benchmark_single_node
   group: data-tests
@@ -4740,14 +4697,6 @@
     timeout: 400
     script: python read_parquet_benchmark.py
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: read_images_benchmark_single_node
   group: data-tests
@@ -4763,14 +4712,6 @@
     timeout: 1800
     script: python read_images_benchmark.py
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: read_tfrecords_benchmark_single_node
   group: data-tests
@@ -4787,14 +4728,6 @@
     timeout: 1800
     script: python read_tfrecords_benchmark.py
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: read_tfrecords_benchmark_app.yaml
-        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: map_batches_benchmark_single_node
   group: data-tests
@@ -4811,14 +4744,6 @@
     timeout: 2400
     script: python map_batches_benchmark.py
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: iter_tensor_batches_benchmark_single_node
   group: data-tests
@@ -4835,15 +4760,6 @@
     timeout: 2400
     script: python iter_tensor_batches_benchmark.py
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: single_node_benchmark_compute_gce.yaml
-
 - name: iter_tensor_batches_benchmark_multi_node
   group: data-tests
   working_dir: nightly_tests/dataset
@@ -4858,15 +4774,6 @@
     # Expect the benchmark to finish around 30 minutes.
     timeout: 2400
     script: python iter_tensor_batches_benchmark.py --data-size-gb=10
-
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: iter_batches_benchmark_single_node
   group: data-tests
@@ -4883,14 +4790,6 @@
     timeout: 1080
     script: python iter_batches_benchmark.py
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: app_config.yaml
-        cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: pipelined_training_50_gb
   group: data-tests
@@ -4908,14 +4807,6 @@
     wait_for_nodes:
       num_nodes: 15
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: pipelined_training_app.yaml
-        cluster_compute: pipelined_training_compute_gce.yaml
 
 - name: pipelined_ingestion_1500_gb
   group: data-tests
@@ -4935,14 +4826,6 @@
     wait_for_nodes:
       num_nodes: 21
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: pipelined_training_app.yaml
-        cluster_compute: pipelined_training_compute_gce.yaml
 
 - name: dataset_shuffle_random_shuffle_1tb
   group: data-tests
@@ -4960,15 +4843,6 @@
     wait_for_nodes:
       num_nodes: 20
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: shuffle/shuffle_app_config.yaml
-        cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
-
 - name: dataset_shuffle_sort_1tb
   group: data-tests
   working_dir: nightly_tests
@@ -4985,15 +4859,6 @@
     wait_for_nodes:
       num_nodes: 20
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: shuffle/shuffle_app_config.yaml
-        cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
-
 - name: dataset_shuffle_push_based_random_shuffle_1tb
   group: data-tests
   working_dir: nightly_tests
@@ -5006,7 +4871,7 @@
 
   run:
     timeout: 7200
-    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
+    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
 
@@ -5018,6 +4883,7 @@
       cluster:
         cluster_env: shuffle/shuffle_app_config.yaml
         cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
+
 
 - name: dataset_shuffle_push_based_sort_1tb
   group: data-tests
@@ -5031,18 +4897,9 @@
 
   run:
     timeout: 7200
-    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9
+    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9
     wait_for_nodes:
       num_nodes: 20
-
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_env: shuffle/shuffle_app_config.yaml
-        cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
 
 - name: dataset_shuffle_push_based_random_shuffle_100tb
   group: data-tests
@@ -5056,7 +4913,7 @@
 
   run:
     timeout: 28800
-    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=100000 --partition-size=1e9 --shuffle
+    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=100000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 100
 
@@ -5070,7 +4927,7 @@
         cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
       run:
         timeout: 28800
-        script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=40000 --partition-size=1e9 --shuffle
+        script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=40000 --partition-size=1e9 --shuffle
         wait_for_nodes:
           num_nodes: 100
 
@@ -5203,7 +5060,7 @@
   run:
     timeout: 7200
     prepare: ' python setup_chaos.py --node-kill-interval 1200 --max-nodes-to-kill 3'
-    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9
+    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9
     wait_for_nodes:
       num_nodes: 20
 
@@ -5260,7 +5117,7 @@
   run:
     timeout: 7200
     prepare: ' python setup_chaos.py --node-kill-interval 600 --max-nodes-to-kill 2'
-    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
+    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3967,8 +3967,9 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: stress_tests/state_api_app_config.yaml
         cluster_compute: stress_tests/stress_tests_compute_large_gce.yaml
+      smoke_test:
+        frequency: manual
 
 
 - name: shuffle_20gb_with_state_api
@@ -4032,6 +4033,8 @@
       cluster:
         cluster_env: stress_tests/stress_tests_app_config.yaml
         cluster_compute: stress_tests/stress_tests_compute_gce.yaml
+      smoke_test:
+        frequency: manual
 
 - name: stress_test_dead_actors
   group: core-daily-test
@@ -4071,6 +4074,8 @@
       cluster:
         cluster_env: stress_tests/stress_tests_app_config.yaml
         cluster_compute: stress_tests/stress_tests_compute_gce.yaml
+      smoke_test:
+        frequency: manual
 
 # The full test is not stable, so run the smoke test only.
 # See https://github.com/ray-project/ray/issues/23244.


### PR DESCRIPTION
## Why are these changes needed?
Currently when declaring test variation, you need to copy-pasta duplicated information, such as `cluster_env`. That's bad. This PR use deep_copy so you do not to re-declare information in variations.

Update one test to remove duplicated cluster_env. Folks are changing this file so I'll avoid a mass refactor at this point.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests