### PR TITLE
[ci] Exclude psutil 5.9.5 to try to fix Py310 builds

### DIFF
--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -465,7 +465,9 @@ install_pip_packages() {
     "${SCRIPT_DIR}"/install-hdfs.sh
   fi
 
-  CC=gcc pip install psutil setproctitle==1.2.2 colorama --target="${WORKSPACE_DIR}/python/ray/thirdparty_files"
+  # Python 3.10 build of psutil 5.9.5 seems to fail (minimal install test
+  # fails). Until investigated, we exclude that version.
+  CC=gcc pip install "psutil!=5.9.5" setproctitle==1.2.2 colorama --target="${WORKSPACE_DIR}/python/ray/thirdparty_files"
 }
 
 install_dependencies() {

--- a/python/setup.py
+++ b/python/setup.py
@@ -548,8 +548,8 @@ def build(build_python, build_java, build_cpp):
         # Python 3.10 build of psutil 5.9.5 seems to fail (minimal install test
         # fails). Until investigated, we exclude that version.
         pip_packages = [
-            "psutil; python_version != 3.10",
-            "psutil!=5.9.5; python_version == 3.10",
+            "psutil; python_version < 3.10",
+            "psutil!=5.9.5; python_version >= 3.10",
             "setproctitle==1.2.2",
             "colorama",
         ]

--- a/python/setup.py
+++ b/python/setup.py
@@ -545,7 +545,14 @@ def build(build_python, build_java, build_cpp):
     # that certain flags will not be passed along such as --user or sudo.
     # TODO(rkn): Fix this.
     if not os.getenv("SKIP_THIRDPARTY_INSTALL"):
-        pip_packages = ["psutil", "setproctitle==1.2.2", "colorama"]
+        # Python 3.10 build of psutil 5.9.5 seems to fail (minimal install test
+        # fails). Until investigated, we exclude that version.
+        pip_packages = [
+            "psutil; python_version != 3.10",
+            "psutil!=5.9.5; python_version == 3.10",
+            "setproctitle==1.2.2",
+            "colorama",
+        ]
         subprocess.check_call(
             [
                 sys.executable,

--- a/python/setup.py
+++ b/python/setup.py
@@ -548,8 +548,8 @@ def build(build_python, build_java, build_cpp):
         # Python 3.10 build of psutil 5.9.5 seems to fail (minimal install test
         # fails). Until investigated, we exclude that version.
         pip_packages = [
-            "psutil; python_version < 3.10",
-            "psutil!=5.9.5; python_version >= 3.10",
+            "psutil; python_version < '3.10'",
+            "psutil!=5.9.5; python_version >= '3.10'",
             "setproctitle==1.2.2",
             "colorama",
         ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
