### PR TITLE
Revert "[CI] Fix shellcheck lint (#34488)"

### DIFF
--- a/rllib/env/tests/test_policy_client_server_setup.sh
+++ b/rllib/env/tests/test_policy_client_server_setup.sh
@@ -60,6 +60,7 @@ fi
 # Start server with 2 workers (will listen on ports worker_1_port and worker_2_port for client
 # connections).
 # Do not attempt to restore from checkpoint; leads to errors on travis.
+# shellcheck disable=SC2046
 (python $basedir/$server_script --run="$trainer_cls" --num-workers=2 $use_lstm --no-restore --port=$worker_1_port 2>&1 | grep -v 200) &
 server_pid=$!
 

--- a/rllib/env/tests/test_policy_client_server_setup.sh
+++ b/rllib/env/tests/test_policy_client_server_setup.sh
@@ -60,7 +60,7 @@ fi
 # Start server with 2 workers (will listen on ports worker_1_port and worker_2_port for client
 # connections).
 # Do not attempt to restore from checkpoint; leads to errors on travis.
-(python $basedir/$server_script --run="$trainer_cls" --num-workers=2 "$use_lstm" --no-restore --port=$worker_1_port 2>&1 | grep -v 200) &
+(python $basedir/$server_script --run="$trainer_cls" --num-workers=2 $use_lstm --no-restore --port=$worker_1_port 2>&1 | grep -v 200) &
 server_pid=$!
 
 echo "Waiting for server to start ..."

--- a/rllib/env/tests/test_policy_client_server_setup.sh
+++ b/rllib/env/tests/test_policy_client_server_setup.sh
@@ -60,7 +60,7 @@ fi
 # Start server with 2 workers (will listen on ports worker_1_port and worker_2_port for client
 # connections).
 # Do not attempt to restore from checkpoint; leads to errors on travis.
-# shellcheck disable=SC2046
+# shellcheck disable=SC2086
 (python $basedir/$server_script --run="$trainer_cls" --num-workers=2 $use_lstm --no-restore --port=$worker_1_port 2>&1 | grep -v 200) &
 server_pid=$!
 


### PR DESCRIPTION
This reverts commit 90ae25cd5df3e546c1f38f39cfbd542e6544cdcb.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The shellcheck fix broke the shellscript when `$use_lstm` is empty

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
