### PR TITLE
[CI][Bisect] Fix bisect due to wrong order of commit list

### DIFF
--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -90,7 +90,7 @@ def _get_commit_lists(passing_commit: str, failing_commit: str) -> List[str]:
         f"git rev-list --ancestry-path {passing_commit}..{failing_commit}",
         shell=True,
     )
-    return commit_lists.decode("utf-8").strip().split("\n")
+    return commit_lists.decode("utf-8").strip().split("\n").reverse()
 
 
 if __name__ == "__main__":

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -89,8 +89,9 @@ def _get_commit_lists(passing_commit: str, failing_commit: str) -> List[str]:
     commit_lists = subprocess.check_output(
         f"git rev-list --ancestry-path {passing_commit}..{failing_commit}",
         shell=True,
-    )
-    return commit_lists.decode("utf-8").strip().split("\n").reverse()
+    ).decode("utf-8").strip().split("\n")
+    commit_lists.reverse()
+    return commit_lists
 
 
 if __name__ == "__main__":

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -86,10 +86,15 @@ def _get_test(test_name: str) -> Test:
 
 
 def _get_commit_lists(passing_commit: str, failing_commit: str) -> List[str]:
-    commit_lists = subprocess.check_output(
-        f"git rev-list --ancestry-path {passing_commit}..{failing_commit}",
-        shell=True,
-    ).decode("utf-8").strip().split("\n")
+    commit_lists = (
+        subprocess.check_output(
+            f"git rev-list --ancestry-path {passing_commit}..{failing_commit}",
+            shell=True,
+        )
+        .decode("utf-8")
+        .strip()
+        .split("\n")
+    )
     commit_lists.reverse()
     return commit_lists
 


### PR DESCRIPTION
## Why are these changes needed?

Currently we are using `git rev-list` to get the commit lists. This command return the commits in the reverse order that we want, so reverse it before passing it to bisect.

## Related issue number

#34535

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   