### PR TITLE
[CI] Fix some chaos test configurations

### DIFF
--- a/release/nightly_tests/dask_on_ray/dask_on_ray_stress_compute_gce.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_stress_compute_gce.yaml
@@ -1,14 +1,15 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-1
 allowed_azs:
-- us-west1-c
+    - us-west1-c
 
-aws:
-    BlockDeviceMappings:
-        - DeviceName: /dev/sda1
-          Ebs:
-            DeleteOnTermination: true
-            VolumeSize: 500
+gcp_advanced_configurations_json:
+  instance_properties:
+    disks:
+      - boot: true
+        auto_delete: true
+        initialize_params:
+          disk_size_gb: 500
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/dataset/pipelined_ingestion_compute_gce.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_compute_gce.yaml
@@ -5,12 +5,13 @@ allowed_azs:
 
 max_workers: 999
 
-aws:
-    BlockDeviceMappings:
-        - DeviceName: /dev/sda1
-          Ebs:
-            DeleteOnTermination: true
-            VolumeSize: 500
+gcp_advanced_configurations_json:
+  instance_properties:
+    disks:
+      - boot: true
+        auto_delete: true
+        initialize_params:
+          disk_size_gb: 500
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances_gce.yaml
+++ b/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances_gce.yaml
@@ -13,11 +13,11 @@ gcp_advanced_configurations_json:
 
 head_node_type:
     name: head_node
-    instance_type: e2-standard-16 # aws m5.4xlarge
+    instance_type: n2-standard-16 # aws m5.4xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: e2-standard-16 # aws m5.4xlarge
+      instance_type: n2-standard-16 # aws m5.4xlarge
       min_workers: 19
       max_workers: 19
       use_spot: false


### PR DESCRIPTION
## Why are these changes needed?
Some GCE chaos test configurations are using aws configs. Change them to the equivalence GCE. Also use the more powerful n2 instead of e2 machine.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Release tests
   