### PR TITLE
[serve][nit] Fix formatting & verbiage for `serve shutdown`

### DIFF
--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -204,13 +204,11 @@ def deploy(config_file_name: str, address: str):
         # Error deploying application
         raise
 
-    cli_logger.newline()
     cli_logger.success(
-        "\nSent deploy request successfully!\n "
-        "* Use `serve status` to check deployments' statuses.\n "
-        "* Use `serve config` to see the current config(s).\n"
+        "\nSent deploy request successfully.\n "
+        "* Use `serve status` to check applications' statuses.\n "
+        "* Use `serve config` to see the current application config(s).\n"
     )
-    cli_logger.newline()
 
 
 @cli.command(
@@ -580,7 +578,9 @@ def shutdown(address: str, yes: bool):
 
     ServeSubmissionClient(address).delete_application()
 
-    cli_logger.success("Sent shutdown request; applications will be deleted asynchronously.")
+    cli_logger.success(
+        "Sent shutdown request; applications will be deleted asynchronously."
+    )
 
 
 @cli.command(

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -572,17 +572,15 @@ def status(address: str, name: Optional[str]):
 def shutdown(address: str, yes: bool):
     if not yes:
         click.confirm(
-            f"\nThis will shutdown the Serve application at address "
-            f'"{address}" and delete all deployments there. Do you '
+            f"This will shut down Serve on the cluster at address "
+            f'"{address}" and delete all applications there. Do you '
             "want to continue?",
             abort=True,
         )
 
     ServeSubmissionClient(address).delete_application()
 
-    cli_logger.newline()
-    cli_logger.success("\nSent delete request successfully!\n")
-    cli_logger.newline()
+    cli_logger.success("Sent shutdown request; applications will be deleted asynchronously.")
 
 
 @cli.command(

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -66,7 +66,7 @@ def test_deploy(ray_start_stop):
         os.path.dirname(__file__), "test_config_files", "arithmetic.yaml"
     )
 
-    success_message_fragment = b"Sent deploy request successfully!"
+    success_message_fragment = b"Sent deploy request successfully."
 
     # Ensure the CLI is idempotent
     num_iterations = 2
@@ -136,7 +136,7 @@ def test_deploy_with_http_options(ray_start_stop):
     f2 = os.path.join(
         os.path.dirname(__file__), "test_config_files", "basic_graph.yaml"
     )
-    success_message_fragment = b"Sent deploy request successfully!"
+    success_message_fragment = b"Sent deploy request successfully."
 
     with open(f1, "r") as config_file:
         config = yaml.safe_load(config_file)
@@ -183,7 +183,7 @@ def test_deploy_multi_app(ray_start_stop):
         os.path.dirname(__file__), "test_config_files", "pizza_world.yaml"
     )
 
-    success_message_fragment = b"Sent deploy request successfully!"
+    success_message_fragment = b"Sent deploy request successfully."
 
     # Ensure the CLI is idempotent
     num_iterations = 2
@@ -368,7 +368,7 @@ def test_config(ray_start_stop):
     config_file_name = os.path.join(
         os.path.dirname(__file__), "test_config_files", "basic_graph.yaml"
     )
-    success_message_fragment = b"Sent deploy request successfully!"
+    success_message_fragment = b"Sent deploy request successfully."
 
     with open(config_file_name, "r") as config_file:
         config = yaml.safe_load(config_file)
@@ -1030,7 +1030,7 @@ def test_idempotence_after_controller_death(ray_start_stop, use_command: bool):
     config_file_name = os.path.join(
         os.path.dirname(__file__), "test_config_files", "basic_graph.yaml"
     )
-    success_message_fragment = b"Sent deploy request successfully!"
+    success_message_fragment = b"Sent deploy request successfully."
     deploy_response = subprocess.check_output(["serve", "deploy", config_file_name])
     assert success_message_fragment in deploy_response
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes unnecessary spaces & cleans up wording.

Before:
```
(ray) eoakes@Edwards-MacBook-Pro-2 serve % serve shutdown

This will shutdown the Serve application at address "http://localhost:52365" and delete all deployments there. Do you want to continue? [y/N]: y
2023-04-19 12:46:12,078 SUCC scripts.py:584 --
Sent delete request successfully!

```

After:
```
(ray) eoakes@Edwards-MacBook-Pro-2 serve % serve shutdown
This will shut down Serve on the cluster at address "http://localhost:52365" and delete all applications there. Do you want to continue? [y/N]: y
2023-04-19 12:45:52,050 SUCC scripts.py:583 -- Sent shutdown request; applications will be deleted asynchronously.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
