### PR TITLE
[data] Log a warning if the batch size is misconfigured in a way that would grossly reduce parallelism for actor pool.

### DIFF
--- a/python/ray/data/datastream.py
+++ b/python/ray/data/datastream.py
@@ -605,7 +605,6 @@ class Datastream(Generic[T]):
             # Enable blocks bundling when batch_size is specified by caller.
             target_block_size = batch_size
 
-        print("BATCH SIZE", batch_size)
         if batch_format not in VALID_BATCH_FORMATS:
             raise ValueError(
                 f"The batch format must be one of {VALID_BATCH_FORMATS}, got: "

--- a/python/ray/data/datastream.py
+++ b/python/ray/data/datastream.py
@@ -605,6 +605,7 @@ class Datastream(Generic[T]):
             # Enable blocks bundling when batch_size is specified by caller.
             target_block_size = batch_size
 
+        print("BATCH SIZE", batch_size)
         if batch_format not in VALID_BATCH_FORMATS:
             raise ValueError(
                 f"The batch format must be one of {VALID_BATCH_FORMATS}, got: "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In a situation such as:

```
import ray
import time

def slow_model(x):
    time.sleep(1)
    return x

# This will try to batch 4096 elements into 1 task! resulting in no parallelism.
ds = ray.data.range(100).map_batches(
     slow_model, compute=ray.data.ActorPoolStrategy(size=4),
     batch_size=4096)
ds.show()
```

Print a warning after execution completes that the batch size is too large.