### PR TITLE
[CI][Bisect][5] Concurrent bisect

### DIFF
--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -101,7 +101,13 @@ def _trigger_test_run(test: Test, commit: str) -> None:
         commit,
         timeout=DEFAULT_WHEEL_WAIT_TIMEOUT,
     )
-    step = get_step(test, ray_wheels=ray_wheels_url)
+    step = get_step(
+        test, 
+        ray_wheels=ray_wheels_url, 
+        env = {
+            "RAY_COMMIT_OF_WHEEL": commit,
+        },
+    )
     step["label"] = f'{test["name"]}:{commit[:7]}'
     step["key"] = commit
     pipeline = subprocess.Popen(

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -129,7 +129,7 @@ def _get_test(test_name: str) -> Test:
             os.path.dirname(__file__), "..", "..", "release_tests.yaml"
         )
     )
-    return [test for test in test_collection if test.name == test_name][0]
+    return [test for test in test_collection if test['name'] == test_name][0]
 
 def _get_commit_lists(passing_commit: str, failing_commit: str) -> List[str]:
     # This command obtains all commits between inclusively

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -57,8 +57,8 @@ def _bisect(test: Test, commit_list: List[str], concurrency: int) -> str:
             f"{commit_list[0]} to {commit_list[-1]}"
         )
         idx_to_commit = {}
-        for i in range(1, concurrency + 1):
-            idx = len(commit_list) * i // (concurrency + 1)
+        for i in range(concurrency):
+            idx = len(commit_list) * (i + 1) // (concurrency + 1)
             idx_to_commit[idx] = commit_list[idx]
         outcomes = _run_test(test, set(idx_to_commit.values()))
         passing_idx = 0

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -3,7 +3,7 @@ import subprocess
 import os
 import json
 import time
-from typing import List, Dict, Set, Optional
+from typing import Dict, List, Optional, Set
 from ray_release.logger import logger
 from ray_release.buildkite.step import get_step
 from ray_release.config import (
@@ -102,9 +102,9 @@ def _trigger_test_run(test: Test, commit: str) -> None:
         timeout=DEFAULT_WHEEL_WAIT_TIMEOUT,
     )
     step = get_step(
-        test, 
-        ray_wheels=ray_wheels_url, 
-        env = {
+        test,
+        ray_wheels=ray_wheels_url,
+        env={
             "RAY_COMMIT_OF_WHEEL": commit,
         },
     )

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -123,6 +123,13 @@ def _get_test(test_name: str) -> Test:
     )
     return [test for test in test_collection if test["name"] == test_name][0]
 
+def _get_test(test_name: str) -> Test:
+    test_collection = read_and_validate_release_test_collection(
+        os.path.join(
+            os.path.dirname(__file__), "..", "..", "release_tests.yaml"
+        )
+    )
+    return [test for test in test_collection if test.name == test_name][0]
 
 def _get_commit_lists(passing_commit: str, failing_commit: str) -> List[str]:
     # This command obtains all commits between inclusively

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -125,9 +125,7 @@ def _get_test(test_name: str) -> Test:
 
 def _get_test(test_name: str) -> Test:
     test_collection = read_and_validate_release_test_collection(
-        os.path.join(
-            os.path.dirname(__file__), "..", "..", "release_tests.yaml"
-        )
+        os.path.join(os.path.dirname(__file__), "..", "..", "release_tests.yaml")
     )
     return [test for test in test_collection if test['name'] == test_name][0]
 

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -54,7 +54,7 @@ def _bisect(test: Test, commit_list: List[str], concurrency: int) -> str:
     while len(commit_list) > 2:
         logger.info(
             f"Bisecting between {len(commit_list)} commits: "
-            f"{commit_list[0]} to {commit_list[-1]}"
+            f"{commit_list[0]} to {commit_list[-1]} with concurrency {concurrency}"
         )
         idx_to_commit = {}
         for i in range(concurrency):

--- a/release/ray_release/tests/test_bisect.py
+++ b/release/ray_release/tests/test_bisect.py
@@ -15,6 +15,7 @@ def test_bisect():
         "c1": {
             "c0": "passed",
             "c1": "hard_failed",
+            "c2": "hard_failed",
         },
     }
 
@@ -27,42 +28,5 @@ def test_bisect():
             "ray_release.scripts.ray_bisect._run_test",
             side_effect=_mock_run_test,
         ):
-            assert _bisect({}, list(input.keys())) == output
-
-def test_bisect():
-    test_cases = {
-        "c3": {
-            "c0": "passed",
-            "c1": "passed",
-            "c3": "hard_failed",
-            "c4": "soft_failed",
-        },
-        "c1": {
-            "c0": "passed",
-            "c1": "hard_failed",
-        },
-    }
-
-    for output, input in test_cases.items():
-
-        def _mock_run_test(test: Test, commit: List[str]) -> Dict[str, str]:
-            return input
-
-        with mock.patch(
-            "ray_release.scripts.ray_bisect._run_test",
-            side_effect=_mock_run_test,
-        ):
-            assert _bisect({}, list(input.keys())) == output
-
-def test_bisect():
-    commit_to_test_result = {
-      'c0': True, 
-      'c1': True, 
-      'c2': True, 
-      'c3': False, 
-      'c4': False, 
-    }
-
-    def _mock_get_commit_lists(passing_commit: str, failing_commit: str) -> List[str]:
-    blamed_commit = _bisect('test', 'c0', 'c4')
-    assert blamed_commit == 'c3'
+            for concurreny in range(1, 4):
+                assert _bisect({}, list(input.keys()), concurreny) == output

--- a/release/ray_release/tests/test_bisect.py
+++ b/release/ray_release/tests/test_bisect.py
@@ -30,6 +30,31 @@ def test_bisect():
             assert _bisect({}, list(input.keys())) == output
 
 def test_bisect():
+    test_cases = {
+        "c3": {
+            "c0": "passed",
+            "c1": "passed",
+            "c3": "hard_failed",
+            "c4": "soft_failed",
+        },
+        "c1": {
+            "c0": "passed",
+            "c1": "hard_failed",
+        },
+    }
+
+    for output, input in test_cases.items():
+
+        def _mock_run_test(test: Test, commit: List[str]) -> Dict[str, str]:
+            return input
+
+        with mock.patch(
+            "ray_release.scripts.ray_bisect._run_test",
+            side_effect=_mock_run_test,
+        ):
+            assert _bisect({}, list(input.keys())) == output
+
+def test_bisect():
     commit_to_test_result = {
       'c0': True, 
       'c1': True, 
@@ -37,6 +62,7 @@ def test_bisect():
       'c3': False, 
       'c4': False, 
     }
+
     def _mock_get_commit_lists(passing_commit: str, failing_commit: str) -> List[str]:
     blamed_commit = _bisect('test', 'c0', 'c4')
     assert blamed_commit == 'c3'

--- a/release/ray_release/tests/test_bisect.py
+++ b/release/ray_release/tests/test_bisect.py
@@ -28,3 +28,15 @@ def test_bisect():
             side_effect=_mock_run_test,
         ):
             assert _bisect({}, list(input.keys())) == output
+
+def test_bisect():
+    commit_to_test_result = {
+      'c0': True, 
+      'c1': True, 
+      'c2': True, 
+      'c3': False, 
+      'c4': False, 
+    }
+    def _mock_get_commit_lists(passing_commit: str, failing_commit: str) -> List[str]:
+    blamed_commit = _bisect('test', 'c0', 'c4')
+    assert blamed_commit == 'c3'

--- a/release/ray_release/tests/test_bisect.py
+++ b/release/ray_release/tests/test_bisect.py
@@ -17,6 +17,10 @@ def test_bisect():
             "c1": "hard_failed",
             "c2": "hard_failed",
         },
+        "cc1": {
+            "cc0": "passed",
+            "cc1": "hard_failed",
+        },
     }
 
     for output, input in test_cases.items():

--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -69,7 +69,11 @@ fi
 if [ -z "${NO_CLONE}" ]; then
   TMPDIR=$(mktemp -d -t release-XXXXXXXXXX)
   echo "Cloning test repo ${RAY_TEST_REPO} branch ${RAY_TEST_BRANCH}"
-  git clone -b "${RAY_TEST_BRANCH}" "${RAY_TEST_REPO}" "${TMPDIR}"
+  if [ -n "${RAY_TEST_COMMIT}" ]; then
+    git clone -b "${RAY_TEST_BRANCH}" "${RAY_TEST_REPO}" "${TMPDIR}"
+  else
+    git clone --depth 1 -b "${RAY_TEST_BRANCH}" "${RAY_TEST_REPO}" "${TMPDIR}"
+  fi
   pushd "${TMPDIR}/release" || true
   HEAD_COMMIT=$(git rev-parse HEAD)
   echo "The cloned test repo has head commit of ${HEAD_COMMIT}"

--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -69,11 +69,7 @@ fi
 if [ -z "${NO_CLONE}" ]; then
   TMPDIR=$(mktemp -d -t release-XXXXXXXXXX)
   echo "Cloning test repo ${RAY_TEST_REPO} branch ${RAY_TEST_BRANCH}"
-  if [ -n "${RAY_TEST_COMMIT}" ]; then
-    git clone -b "${RAY_TEST_BRANCH}" "${RAY_TEST_REPO}" "${TMPDIR}"
-  else
-    git clone --depth 1 -b "${RAY_TEST_BRANCH}" "${RAY_TEST_REPO}" "${TMPDIR}"
-  fi
+  git clone -b "${RAY_TEST_BRANCH}" "${RAY_TEST_REPO}" "${TMPDIR}"
   pushd "${TMPDIR}/release" || true
   HEAD_COMMIT=$(git rev-parse HEAD)
   echo "The cloned test repo has head commit of ${HEAD_COMMIT}"


### PR DESCRIPTION
## Why are these changes needed?
This PR makes it so that, for every bisect step, we can run X test jobs in parallel. 

Speed up bisect 2, 3 times.

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests - found blame PR too https://buildkite.com/ray-project/release-tests-bisect/builds/77