### PR TITLE
[Doc] Fix unused config building function in lightning MNIST example.

### DIFF
--- a/doc/source/train/examples/lightning/lightning_mnist_example.ipynb
+++ b/doc/source/train/examples/lightning/lightning_mnist_example.ipynb
@@ -263,19 +263,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lightning_config = (\n",
-    "    LightningConfigBuilder()\n",
-    "    .module(MNISTClassifier, lr=1e-3, feature_dim=128)\n",
-    "    .trainer(\n",
-    "        max_epochs=10,\n",
-    "        accelerator=\"cpu\",\n",
-    "        log_every_n_steps=100,\n",
-    "        logger=CSVLogger(\"logs\"),\n",
-    "    )\n",
-    "    .fit_params(datamodule=datamodule)\n",
-    "    .checkpointing(monitor=\"val_accuracy\", mode=\"max\", save_top_k=3)\n",
-    "    .build()\n",
-    ")"
+    "lightning_config = build_lightning_config_from_existing_code()"
    ]
   },
   {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `build_lightning_config_from_existing_code()` is not called in the example, and there is a duplicated config building logic below. This PR use this function and remove the other one.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #34593 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
