### PR TITLE
[Data] [strict-mode] Remove internal TableRow abstractions and instead use Dict[str, Any] as the row format

### DIFF
--- a/python/ray/data/datastream.py
+++ b/python/ray/data/datastream.py
@@ -17,6 +17,7 @@ from typing import (
     Optional,
     Tuple,
     Union,
+    Mapping,
 )
 from uuid import uuid4
 
@@ -128,7 +129,6 @@ from ray.data.datasource.file_based_datasource import (
     _wrap_arrow_serialization_workaround,
 )
 from ray.data.random_access_dataset import RandomAccessDataset
-from ray.data.row import TableRow
 from ray.types import ObjectRef
 from ray.util.annotations import DeveloperAPI, PublicAPI, Deprecated
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
@@ -3027,12 +3027,12 @@ class Datastream(Generic[T]):
         return DataIteratorImpl(self)
 
     @ConsumptionAPI
-    def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[Union[T, TableRow]]:
+    def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[Union[T, Mapping]]:
         """Return a local row iterator over the datastream.
 
-        If the datastream is a tabular datastream (Arrow/Pandas blocks), dict-like
-        mappings :py:class:`~ray.data.row.TableRow` are yielded for each row by the
-        iterator.  If the datastream is not tabular, the raw row is yielded.
+        If the datastream is a tabular datastream (Arrow/Pandas blocks), dicts
+        are yielded for each row by the iterator. If the datastream is not tabular,
+        the raw row is yielded.
 
         Examples:
             >>> import ray
@@ -4488,7 +4488,7 @@ class Datastream(Generic[T]):
             on = [on]
         return [agg_cls(on_, *args, ignore_nulls=ignore_nulls, **kwargs) for on_ in on]
 
-    def _aggregate_result(self, result: Union[Tuple, TableRow]) -> U:
+    def _aggregate_result(self, result: Union[Tuple, Mapping]) -> U:
         if result is not None and len(result) == 1:
             if isinstance(result, tuple):
                 return result[0]

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -11,12 +11,12 @@ from typing import (
     Tuple,
     Union,
     Iterator,
+    Mapping,
 )
 
 from ray.types import ObjectRef
 from ray.data.block import BlockAccessor, Block, BlockMetadata, DataBatch, T
 from ray.data.context import DataContext
-from ray.data.row import TableRow
 from ray.util.annotations import PublicAPI
 from ray.data._internal.block_batching import batch_block_refs
 from ray.data._internal.block_batching.iter_batches import iter_batches
@@ -200,12 +200,12 @@ class DataIterator(abc.ABC):
         if stats:
             stats.iter_total_s.add(time.perf_counter() - time_start)
 
-    def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[Union[T, TableRow]]:
+    def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[Union[T, Mapping]]:
         """Return a local row iterator over the datastream.
 
-        If the datastream is a tabular datastream (Arrow/Pandas blocks), dict-like
-        mappings :py:class:`~ray.data.row.TableRow` are yielded for each row by the
-        iterator. If the datastream is not tabular, the raw row is yielded.
+        If the datastream is a tabular datastream (Arrow/Pandas blocks), dicts
+        are yielded for each row by the iterator. If the datastream is not tabular,
+        the raw row is yielded.
 
         Examples:
             >>> import ray

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -171,6 +171,17 @@ def test_strict_schema(ray_start_regular_shared):
     assert isinstance(schema.base_schema, PandasBlockSchema)
 
 
+def test_use_raw_dicts(ray_start_regular_shared):
+    assert type(ray.data.range(10).take(1)[0]) is dict
+    assert type(ray.data.from_items([1]).take(1)[0]) is dict
+
+    def checker(x):
+        assert type(x) is dict
+        return x
+
+    ray.data.range(10).map(checker).show()
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?


With strict mode enabled, we always use ArrowBlock or PandasBlock for the internal data format. For row based UDF, this always outputs a TableRow. Instead of exposing our own internal TableRow abstraction, we should just return Dict[str, Any] instead

Closes https://github.com/ray-project/ray/issues/34540