### PR TITLE
[Doc] Add missing links for LightningTrainer and HuggingfaceTrainer

### DIFF
--- a/doc/source/train/key-concepts.rst
+++ b/doc/source/train/key-concepts.rst
@@ -35,8 +35,6 @@ There are three categories of built-in Trainers:
     - :class:`TorchTrainer <ray.train.torch.TorchTrainer>`
     - :class:`TensorflowTrainer <ray.train.tensorflow.TensorflowTrainer>`
     - :class:`HorovodTrainer <ray.train.horovod.HorovodTrainer>`
-    - :class:`LightningTrainer <ray.train.lightning.LightningTrainer>`
-    - :class:`HuggingFaceTrainer <ray.train.huggingface.HuggingFaceTrainer>`
 
     For these trainers, you usually define your own training function that loads the model
     and executes single-worker training steps. Refer to the following guides for more details:
@@ -63,6 +61,7 @@ There are three categories of built-in Trainers:
 
     Some trainers don't fit into the other two categories, such as:
 
+    - :class:`LightningTrainer <ray.train.lightning.LightningTrainer>` for PyTorch Lightning
     - :class:`HuggingFaceTrainer <ray.train.huggingface.HuggingFaceTrainer>` for NLP
     - :class:`RLTrainer <ray.train.rl.RLTrainer>` for reinforcement learning
     - :class:`SklearnTrainer <ray.train.sklearn.sklearn_trainer.SklearnTrainer>` for (non-distributed) training of sklearn models.

--- a/doc/source/train/key-concepts.rst
+++ b/doc/source/train/key-concepts.rst
@@ -35,6 +35,8 @@ There are three categories of built-in Trainers:
     - :class:`TorchTrainer <ray.train.torch.TorchTrainer>`
     - :class:`TensorflowTrainer <ray.train.tensorflow.TensorflowTrainer>`
     - :class:`HorovodTrainer <ray.train.horovod.HorovodTrainer>`
+    - :class:`LightningTrainer <ray.train.lightning.LightningTrainer>`
+    - :class:`HuggingFaceTrainer <ray.train.huggingface.HuggingFaceTrainer>`
 
     For these trainers, you usually define your own training function that loads the model
     and executes single-worker training steps. Refer to the following guides for more details:

--- a/doc/source/train/train.rst
+++ b/doc/source/train/train.rst
@@ -105,6 +105,9 @@ classes that ship out of the box with Train:
     * - :class:`LightGBMTrainer <ray.train.lightgbm.LightGBMTrainer>`
       - :class:`LightGBMCheckpoint <ray.train.lightgbm.LightGBMCheckpoint>`
       - :class:`LightGBMPredictor <ray.train.lightgbm.LightGBMPredictor>`
+    * - :class:`LightningTrainer <ray.train.lightning.LightningTrainer>`
+      - :class:`LightningCheckpoint <ray.train.lightning.LightningCheckpoint>`
+      - :class:`LightningPredictor <ray.train.lightning.LightningPredictor>`
     * - :class:`SklearnTrainer <ray.train.sklearn.SklearnTrainer>`
       - :class:`SklearnCheckpoint <ray.train.sklearn.SklearnCheckpoint>`
       - :class:`SklearnPredictor <ray.train.sklearn.SklearnPredictor>`


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In Release 2.4 docs, the links to LightningTrainer and HuggingfaceTrainer are missing in the [Trainer Catalog](https://docs.ray.io/en/releases-2.4.0/train/train.html#training-framework-catalog) and [Key Concepts](https://docs.ray.io/en/releases-2.4.0/train/key-concepts.html#deep-learning-tree-based-and-other-trainers) pages. Those trainers are important features for release 2.4 and it's necessary to add these links for visibility.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
