### PR TITLE
fix sample error in TorchBinaryAutoregressiveDistribution

### DIFF
--- a/rllib/examples/models/autoregressive_action_dist.py
+++ b/rllib/examples/models/autoregressive_action_dist.py
@@ -115,7 +115,7 @@ class TorchBinaryAutoregressiveDistribution(TorchDistributionWrapper):
         )
 
     def sampled_action_logp(self):
-        return torch.exp(self._action_logp)
+        return self._action_logp
 
     def entropy(self):
         a1_dist = self._a1_distribution()


### PR DESCRIPTION
In torch version of BinaryAutoregressiveDistribution, the log_prob of the sample action is wrong. Fixed in this commit.