### PR TITLE
[docs] sphinx design 1/n

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -308,6 +308,7 @@ build_sphinx_docs() {
     if [ "${OSTYPE}" = msys ]; then
       echo "WARNING: Documentation not built on Windows due to currently-unresolved issues"
     else
+      # TODO: revert to "make html" once "sphinx_panels" plugin is fully removed.
       FAST=True make develop
       pip install datasets==2.0.0
       RAY_MOCK_MODULES=0 RAY_DEDUP_LOGS=0 make doctest

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -308,7 +308,7 @@ build_sphinx_docs() {
     if [ "${OSTYPE}" = msys ]; then
       echo "WARNING: Documentation not built on Windows due to currently-unresolved issues"
     else
-      FAST=True make html
+      FAST=True make develop
       pip install datasets==2.0.0
       RAY_MOCK_MODULES=0 RAY_DEDUP_LOGS=0 make doctest
     fi

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -65,6 +65,7 @@ sphinxcontrib-redoc==1.6.0
 sphinx-tabs==3.4.0
 sphinx-remove-toctrees==0.0.3
 autodoc_pydantic==1.6.1
+sphinx_design==0.4.1
 
 # MyST
 myst-parser==0.15.2

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -38,7 +38,6 @@ sys.path.append(os.path.abspath("./_ext"))
 
 extensions = [
     "callouts",  # custom extension from _ext folder
-    "sphinx_panels",
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
@@ -58,6 +57,7 @@ extensions = [
     "sphinxcontrib.redoc",
     "sphinx_tabs.tabs",
     "sphinx_remove_toctrees",
+    "sphinx_panels",
     "sphinx_design",
 ]
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -58,6 +58,7 @@ extensions = [
     "sphinxcontrib.redoc",
     "sphinx_tabs.tabs",
     "sphinx_remove_toctrees",
+    "sphinx_design",
 ]
 
 # Prune deep toc-trees on demand for smaller html and faster builds.

--- a/doc/source/data/examples/index.rst
+++ b/doc/source/data/examples/index.rst
@@ -17,35 +17,52 @@ modalities and types. Here you will find a few end-to-end examples of some basic
 processing with Ray Data on tabular data, text (coming soon!), and imagery (coming
 soon!).
 
-.. panels::
-    :container: container pb-4
-    :column: col-md-4 px-2 py-2
-    :img-top-cls: pt-5 w-75 d-block mx-auto
+.. grid:: 3
+    :gutter: 2
+    :class-container: container pb-4
 
-    ---
-    :img-top: /images/taxi.png
+    .. grid-item-card::
+        :img-top: /images/taxi.png
+        :class-img-top: pt-5 w-75 d-block mx-auto
 
-    +++
-    .. link-button:: nyc_taxi_basic_processing
-        :type: ref
-        :text: Processing the NYC taxi dataset
-        :classes: btn-link btn-block stretched-link
-    ---
-    :img-top: /images/taxi.png
+        +++
+        .. button-ref:: nyc_taxi_basic_processing
+            :ref-type: ref
+            :color: primary
+            :outline:
+            :expand:
+            :click-parent:
 
-    +++
-    .. link-button:: batch_training
-        :type: ref
-        :text: Batch Training with Ray Data
-        :classes: btn-link btn-block stretched-link
-    ---
-    :img-top: /images/ocr.jpg
+            Processing the NYC taxi dataset
 
-    +++
-    .. link-button:: ocr_example
-        :type: ref
-        :text: Scaling OCR with Ray Data
-        :classes: btn-link btn-block stretched-link
+    .. grid-item-card::
+        :img-top: /images/taxi.png
+        :class-img-top: pt-5 w-75 d-block mx-auto
+
+        +++
+        .. button-ref:: batch_training
+            :ref-type: ref
+            :color: primary
+            :outline:
+            :expand:
+            :click-parent:
+
+            Batch Training with Ray Data
+
+    .. grid-item-card::
+        :img-top: /images/ocr.jpg
+        :class-img-top: pt-5 w-75 d-block mx-auto
+
+        +++
+        .. button-ref:: ocr_example
+            :ref-type: ref
+            :color: primary
+            :outline:
+            :expand:
+            :click-parent:
+
+            Scaling OCR with Ray Data
+
 
 
 Other Examples

--- a/doc/source/data/examples/index.rst
+++ b/doc/source/data/examples/index.rst
@@ -27,11 +27,10 @@ soon!).
 
         +++
         .. button-ref:: nyc_taxi_basic_processing
-            :ref-type: ref
+            :ref-type: doc
             :color: primary
             :outline:
             :expand:
-            :click-parent:
 
             Processing the NYC taxi dataset
 
@@ -41,11 +40,10 @@ soon!).
 
         +++
         .. button-ref:: batch_training
-            :ref-type: ref
+            :ref-type: doc
             :color: primary
             :outline:
             :expand:
-            :click-parent:
 
             Batch Training with Ray Data
 
@@ -55,11 +53,10 @@ soon!).
 
         +++
         .. button-ref:: ocr_example
-            :ref-type: ref
+            :ref-type: doc
             :color: primary
             :outline:
             :expand:
-            :click-parent:
 
             Scaling OCR with Ray Data
 
@@ -68,16 +65,20 @@ soon!).
 Other Examples
 --------------
 
-.. panels::
-    :container: container pb-4
-    :column: col-md-4 px-2 py-2
-    :img-top-cls: pt-5 w-75 d-block mx-auto
 
-    ---
-    :img-top: ../images/datastream-arch.svg
+.. grid:: 3
+    :gutter: 2
+    :class-container: container pb-4
 
-    +++
-    .. link-button:: random-access
-        :type: ref
-        :text: Random Data Access (Experimental)
-        :classes: btn-link btn-block stretched-link
+    .. grid-item-card::
+        :img-top: ../images/datastream-arch.svg
+        :class-img-top: pt-5 w-75 d-block mx-auto
+
+        +++
+        .. button-ref:: random-access
+            :ref-type: doc
+            :color: primary
+            :outline:
+            :expand:
+
+            Random Data Access (Experimental)

--- a/doc/source/ray-air/check-ingest.rst
+++ b/doc/source/ray-air/check-ingest.rst
@@ -74,57 +74,59 @@ Here are some examples of configuring Dataset ingest options and what they do:
 Enabling Streaming Ingest
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tabbed:: Bulk Ingest
+.. tab-set::
 
-    By default, AIR loads all datasets into the Ray object store at the start of training.
-    This provides the best performance if the cluster can fit the datasets
-    entirely in memory, or if the preprocessing step is expensive to run more than once.
+    .. tab-item:: Bulk Ingest
 
-    .. literalinclude:: doc_code/air_ingest.py
-        :language: python
-        :start-after: __config_4__
-        :end-before: __config_4_end__
+        By default, AIR loads all datasets into the Ray object store at the start of training.
+        This provides the best performance if the cluster can fit the datasets
+        entirely in memory, or if the preprocessing step is expensive to run more than once.
 
-    You should use bulk ingest when:
+        .. literalinclude:: doc_code/air_ingest.py
+            :language: python
+            :start-after: __config_4__
+            :end-before: __config_4_end__
 
-    * you have enough memory to fit data blocks in cluster object store; or
-    * your preprocessing transform is expensive to recompute on each epoch
+        You should use bulk ingest when:
 
-.. tabbed:: Streaming Ingest (experimental)
+        * you have enough memory to fit data blocks in cluster object store; or
+        * your preprocessing transform is expensive to recompute on each epoch
 
-    In streaming ingest mode, instead of loading the entire dataset into the
-    Ray object store at once, AIR will load a fraction of the dataset at a
-    time. This can be desirable when the dataset is very large, and caching it
-    all at once would cause expensive disk spilling. The downside is that the
-    dataset will have to be preprocessed on each epoch, which may be more
-    expensive. Preprocessing is overlapped with training computation, but
-    overall training throughput may still decrease if preprocessing is more
-    expensive than the training computation (forward pass, backward pass,
-    gradient sync).
+    .. tab-item:: Streaming Ingest (experimental)
 
-    To enable this mode, use the :py:meth:`max_object_store_memory_fraction
-    <ray.air.config.DatasetConfig>` argument. This argument defaults to -1,
-    meaning that bulk ingest should be used and the entire dataset should be
-    computed and cached before training starts.
+        In streaming ingest mode, instead of loading the entire dataset into the
+        Ray object store at once, AIR will load a fraction of the dataset at a
+        time. This can be desirable when the dataset is very large, and caching it
+        all at once would cause expensive disk spilling. The downside is that the
+        dataset will have to be preprocessed on each epoch, which may be more
+        expensive. Preprocessing is overlapped with training computation, but
+        overall training throughput may still decrease if preprocessing is more
+        expensive than the training computation (forward pass, backward pass,
+        gradient sync).
 
-    Use a float value 0 or greater to indicate the "window" size, i.e. the
-    maximum fraction of object store memory that should be used at once. A
-    reasonable value is 0.2, meaning 20% of available object store memory.
-    Larger window sizes can improve performance by increasing parallelism. A
-    window size of 1 or greater will likely result in spilling.
+        To enable this mode, use the :py:meth:`max_object_store_memory_fraction
+        <ray.air.config.DatasetConfig>` argument. This argument defaults to -1,
+        meaning that bulk ingest should be used and the entire dataset should be
+        computed and cached before training starts.
 
-    .. literalinclude:: doc_code/air_ingest.py
-        :language: python
-        :start-after: __config_5__
-        :end-before: __config_5_end__
+        Use a float value 0 or greater to indicate the "window" size, i.e. the
+        maximum fraction of object store memory that should be used at once. A
+        reasonable value is 0.2, meaning 20% of available object store memory.
+        Larger window sizes can improve performance by increasing parallelism. A
+        window size of 1 or greater will likely result in spilling.
 
-    Use streaming ingest when:
+        .. literalinclude:: doc_code/air_ingest.py
+            :language: python
+            :start-after: __config_5__
+            :end-before: __config_5_end__
 
-    * you have large datasets that don't fit into memory; and
-    * re-executing the preprocessing step on each epoch is faster than caching the preprocessed dataset on disk and reloading from disk on each epoch
+        Use streaming ingest when:
 
-    Note that this feature is experimental and the actual object store memory
-    usage may vary. Please file a `GitHub issue <https://github.com/ray-project/ray/issues>`_ if you run into problems.
+        * you have large datasets that don't fit into memory; and
+        * re-executing the preprocessing step on each epoch is faster than caching the preprocessed dataset on disk and reloading from disk on each epoch
+
+        Note that this feature is experimental and the actual object store memory
+        usage may vary. Please file a `GitHub issue <https://github.com/ray-project/ray/issues>`_ if you run into problems.
 
 .. _air-shuffle:
 
@@ -138,50 +140,52 @@ By default, AIR shuffles the assignment of data blocks (files) to dataset shards
 
 To randomize data records within a file, perform a local or global shuffle.
 
-.. tabbed:: Local Shuffling
+.. tab-set::
 
-    Local shuffling is the recommended approach for randomizing data order. To use local shuffle,
-    simply specify a non-zero ``local_shuffle_buffer_size`` as an argument to :meth:`~ray.data.DataIterator.iter_batches`.
-    The iterator will then use a local buffer of the given size to randomize record order. The
-    larger the buffer size, the more randomization will be applied, but it will also use more
-    memory.
+    .. tab-item:: Local Shuffling
 
-    See :meth:`~ray.data.DataIterator.iter_batches` for more details.
+        Local shuffling is the recommended approach for randomizing data order. To use local shuffle,
+        simply specify a non-zero ``local_shuffle_buffer_size`` as an argument to :meth:`~ray.data.DataIterator.iter_batches`.
+        The iterator will then use a local buffer of the given size to randomize record order. The
+        larger the buffer size, the more randomization will be applied, but it will also use more
+        memory.
 
-    .. literalinclude:: doc_code/air_ingest.py
-        :language: python
-        :start-after: __local_shuffling_start__
-        :end-before: __local_shuffling_end__
+        See :meth:`~ray.data.DataIterator.iter_batches` for more details.
 
-    You should use local shuffling when:
+        .. literalinclude:: doc_code/air_ingest.py
+            :language: python
+            :start-after: __local_shuffling_start__
+            :end-before: __local_shuffling_end__
 
-     * a small in-memory buffer provides enough randomization; or
-     * you want the highest possible ingest performance; or
-     * your model is not overly sensitive to shuffle quality
+        You should use local shuffling when:
 
-.. tabbed:: Global Shuffling (slower)
+         * a small in-memory buffer provides enough randomization; or
+         * you want the highest possible ingest performance; or
+         * your model is not overly sensitive to shuffle quality
 
-    Global shuffling provides more uniformly random (decorrelated) samples and is carried
-    out via a distributed map-reduce operation. This higher quality shuffle can often lead
-    to more precision gain per training step, but it is also an expensive distributed
-    operation and will decrease the ingest throughput. The shuffle step is overlapped with
-    training computation, so as long as the shuffled ingest throughput matches
-    or exceeds the model training (forward pass, backward pass, gradient sync)
-    throughput, this higher-quality shuffle shouldn't slow down the overall
-    training.
+    .. tab-item:: Global Shuffling (slower)
 
-    If global shuffling *is* causing the ingest throughput to become the training
-    bottleneck, local shuffling may be a better option.
+        Global shuffling provides more uniformly random (decorrelated) samples and is carried
+        out via a distributed map-reduce operation. This higher quality shuffle can often lead
+        to more precision gain per training step, but it is also an expensive distributed
+        operation and will decrease the ingest throughput. The shuffle step is overlapped with
+        training computation, so as long as the shuffled ingest throughput matches
+        or exceeds the model training (forward pass, backward pass, gradient sync)
+        throughput, this higher-quality shuffle shouldn't slow down the overall
+        training.
 
-    .. literalinclude:: doc_code/air_ingest.py
-        :language: python
-        :start-after: __global_shuffling_start__
-        :end-before: __global_shuffling_end__
+        If global shuffling *is* causing the ingest throughput to become the training
+        bottleneck, local shuffling may be a better option.
 
-    You should use global shuffling when:
+        .. literalinclude:: doc_code/air_ingest.py
+            :language: python
+            :start-after: __global_shuffling_start__
+            :end-before: __global_shuffling_end__
 
-     * you suspect high-quality shuffles may significantly improve model quality; and
-     * absolute ingest performance is less of a concern
+        You should use global shuffling when:
+
+         * you suspect high-quality shuffles may significantly improve model quality; and
+         * absolute ingest performance is less of a concern
 
 .. _air-per-epoch-preprocessing:
 
@@ -240,43 +244,45 @@ Dataset Resources
 
 Datasets uses Ray tasks to execute data processing operations. These tasks use CPU resources in the cluster during execution, which may compete with resources needed for Training.
 
-.. tabbed:: Unreserved CPUs
+.. tab-set::
 
-    By default, Dataset tasks use cluster CPU resources for execution. This can sometimes
-    conflict with Trainer resource requests. For example, if Trainers allocate all CPU resources
-    in the cluster, then no Datasets tasks can run.
+    .. tab-item:: Unreserved CPUs
 
-    .. literalinclude:: ./doc_code/air_ingest.py
-      :language: python
-      :start-after: __resource_allocation_1_begin__
-      :end-before: __resource_allocation_1_end__
+        By default, Dataset tasks use cluster CPU resources for execution. This can sometimes
+        conflict with Trainer resource requests. For example, if Trainers allocate all CPU resources
+        in the cluster, then no Datasets tasks can run.
 
-    Unreserved CPUs work well when:
+        .. literalinclude:: ./doc_code/air_ingest.py
+          :language: python
+          :start-after: __resource_allocation_1_begin__
+          :end-before: __resource_allocation_1_end__
 
-     * you are running only one Trainer and the cluster has enough CPUs; or
-     * your Trainers are configured to use GPUs and not CPUs
+        Unreserved CPUs work well when:
 
-.. tabbed:: Using Reserved CPUs (experimental)
+         * you are running only one Trainer and the cluster has enough CPUs; or
+         * your Trainers are configured to use GPUs and not CPUs
 
-    The ``_max_cpu_fraction_per_node`` option can be used to exclude CPUs from placement
-    group scheduling. In the below example, setting this parameter to ``0.8`` enables Tune
-    trials to run smoothly without risk of deadlock by reserving 20% of node CPUs for
-    Dataset execution.
+    .. tab-item:: Using Reserved CPUs (experimental)
 
-    .. literalinclude:: ./doc_code/air_ingest.py
-      :language: python
-      :start-after: __resource_allocation_2_begin__
-      :end-before: __resource_allocation_2_end__
+        The ``_max_cpu_fraction_per_node`` option can be used to exclude CPUs from placement
+        group scheduling. In the below example, setting this parameter to ``0.8`` enables Tune
+        trials to run smoothly without risk of deadlock by reserving 20% of node CPUs for
+        Dataset execution.
 
-    You should use reserved CPUs when:
+        .. literalinclude:: ./doc_code/air_ingest.py
+          :language: python
+          :start-after: __resource_allocation_2_begin__
+          :end-before: __resource_allocation_2_end__
 
-     * you are running multiple concurrent CPU Trainers using Tune; or
-     * you want to ensure predictable Datasets performance
+        You should use reserved CPUs when:
 
-    .. warning::
+         * you are running multiple concurrent CPU Trainers using Tune; or
+         * you want to ensure predictable Datasets performance
 
-        ``_max_cpu_fraction_per_node`` is experimental and not currently recommended for use with
-        autoscaling clusters (scale-up will not trigger properly).
+        .. warning::
+
+            ``_max_cpu_fraction_per_node`` is experimental and not currently recommended for use with
+            autoscaling clusters (scale-up will not trigger properly).
 
 Debugging Ingest with the ``DummyTrainer``
 ------------------------------------------

--- a/doc/source/ray-air/computer-vision.rst
+++ b/doc/source/ray-air/computer-vision.rst
@@ -14,104 +14,106 @@ This guide explains how to perform common computer vision tasks like:
 Reading image data
 ------------------
 
-.. tabbed:: Raw images
+.. tab-set::
 
-    Datasets like ImageNet store files like this:
+    .. tab-item:: Raw images
 
-    .. code-block::
+        Datasets like ImageNet store files like this:
 
-        root/dog/xxx.png
-        root/dog/xxy.png
-        root/dog/[...]/xxz.png
+        .. code-block::
 
-        root/cat/123.png
-        root/cat/nsdf3.png
-        root/cat/[...]/asd932_.png
+            root/dog/xxx.png
+            root/dog/xxy.png
+            root/dog/[...]/xxz.png
 
-    To load images stored in this layout, read the raw images and include the
-    class names.
+            root/cat/123.png
+            root/cat/nsdf3.png
+            root/cat/[...]/asd932_.png
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __read_images1_start__
-        :end-before: __read_images1_stop__
-        :dedent:
+        To load images stored in this layout, read the raw images and include the
+        class names.
 
-    Then, apply a :ref:`user-defined function <transform_datastreams_writing_udfs>` to
-    encode the class names as integer targets.
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __read_images1_start__
+            :end-before: __read_images1_stop__
+            :dedent:
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __read_images2_start__
-        :end-before: __read_images2_stop__
-        :dedent:
+        Then, apply a :ref:`user-defined function <transform_datastreams_writing_udfs>` to
+        encode the class names as integer targets.
 
-    .. tip::
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __read_images2_start__
+            :end-before: __read_images2_stop__
+            :dedent:
 
-        You can also use :class:`~ray.data.preprocessors.LabelEncoder` to encode labels.
+        .. tip::
 
-.. tabbed:: NumPy
+            You can also use :class:`~ray.data.preprocessors.LabelEncoder` to encode labels.
 
-    To load NumPy arrays into a :class:`~ray.data.Datastream`, separately read the image and label arrays.
+    .. tab-item:: NumPy
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __read_numpy1_start__
-        :end-before: __read_numpy1_stop__
-        :dedent:
+        To load NumPy arrays into a :class:`~ray.data.Datastream`, separately read the image and label arrays.
 
-    Then, combine the datasets and rename the columns.
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __read_numpy1_start__
+            :end-before: __read_numpy1_stop__
+            :dedent:
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __read_numpy2_start__
-        :end-before: __read_numpy2_stop__
-        :dedent:
+        Then, combine the datasets and rename the columns.
 
-.. tabbed:: TFRecords
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __read_numpy2_start__
+            :end-before: __read_numpy2_stop__
+            :dedent:
 
-    Image datasets often contain ``tf.train.Example`` messages that look like this:
+    .. tab-item:: TFRecords
 
-    .. code-block::
+        Image datasets often contain ``tf.train.Example`` messages that look like this:
 
-        features {
-            feature {
-                key: "image"
-                value {
-                    bytes_list {
-                        value: ...  # Raw image bytes
+        .. code-block::
+
+            features {
+                feature {
+                    key: "image"
+                    value {
+                        bytes_list {
+                            value: ...  # Raw image bytes
+                        }
+                    }
+                }
+                feature {
+                    key: "label"
+                    value {
+                        int64_list {
+                            value: 3
+                        }
                     }
                 }
             }
-            feature {
-                key: "label"
-                value {
-                    int64_list {
-                        value: 3
-                    }
-                }
-            }
-        }
 
-    To load examples stored in this format, read the TFRecords into a :class:`~ray.data.Datastream`.
+        To load examples stored in this format, read the TFRecords into a :class:`~ray.data.Datastream`.
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __read_tfrecords1_start__
-        :end-before: __read_tfrecords1_stop__
-        :dedent:
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __read_tfrecords1_start__
+            :end-before: __read_tfrecords1_stop__
+            :dedent:
 
-    Then, apply a :ref:`user-defined function <transform_datastreams_writing_udfs>` to
-    decode the raw image bytes.
+        Then, apply a :ref:`user-defined function <transform_datastreams_writing_udfs>` to
+        decode the raw image bytes.
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __read_tfrecords2_start__
-        :end-before: __read_tfrecords2_stop__
-        :dedent:
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __read_tfrecords2_start__
+            :end-before: __read_tfrecords2_stop__
+            :dedent:
 
-.. tabbed:: Parquet
+    .. tab-item:: Parquet
 
-    To load image data stored in Parquet files, call :func:`ray.data.read_parquet`.
+        To load image data stored in Parquet files, call :func:`ray.data.read_parquet`.
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __read_parquet_start__
-        :end-before: __read_parquet_stop__
-        :dedent:
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __read_parquet_start__
+            :end-before: __read_parquet_stop__
+            :dedent:
 
 
 For more information on creating datastreams, see :ref:`Creating Datastreams <creating_datastreams>`.
@@ -123,33 +125,35 @@ Transforming images
 To transform images, create a :class:`~ray.data.preprocessor.Preprocessor`. They're the
 standard way to preprocess data with Ray.
 
-.. tabbed:: Torch
+.. tab-set::
 
-    To apply TorchVision transforms, create a :class:`~ray.data.preprocessors.TorchVisionPreprocessor`.
+    .. tab-item:: Torch
 
-    Create two :class:`TorchVisionPreprocessors <ray.data.preprocessors.TorchVisionPreprocessor>`
-    -- one to normalize images, and another to augment images. Later, you'll pass the preprocessors to :class:`Trainers <ray.train.trainer.BaseTrainer>`,
-    :class:`Predictors <ray.train.predictor.Predictor>`, and
-    :class:`PredictorDeployments <ray.serve.air_integrations.PredictorDeployment>`.
+        To apply TorchVision transforms, create a :class:`~ray.data.preprocessors.TorchVisionPreprocessor`.
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __torch_preprocessors_start__
-        :end-before: __torch_preprocessors_stop__
-        :dedent:
+        Create two :class:`TorchVisionPreprocessors <ray.data.preprocessors.TorchVisionPreprocessor>`
+        -- one to normalize images, and another to augment images. Later, you'll pass the preprocessors to :class:`Trainers <ray.train.trainer.BaseTrainer>`,
+        :class:`Predictors <ray.train.predictor.Predictor>`, and
+        :class:`PredictorDeployments <ray.serve.air_integrations.PredictorDeployment>`.
 
-.. tabbed:: TensorFlow
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __torch_preprocessors_start__
+            :end-before: __torch_preprocessors_stop__
+            :dedent:
 
-    To apply TorchVision transforms, create a :class:`~ray.data.preprocessors.BatchMapper`.
+    .. tab-item:: TensorFlow
 
-    Create two :class:`~ray.data.preprocessors.BatchMapper` -- one to normalize images, and another to
-    augment images. Later, you'll pass the preprocessors to :class:`Trainers <ray.train.trainer.BaseTrainer>`,
-    :class:`Predictors <ray.train.predictor.Predictor>`, and
-    :class:`PredictorDeployments <ray.serve.air_integrations.PredictorDeployment>`.
+        To apply TorchVision transforms, create a :class:`~ray.data.preprocessors.BatchMapper`.
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __tensorflow_preprocessors_start__
-        :end-before: __tensorflow_preprocessors_stop__
-        :dedent:
+        Create two :class:`~ray.data.preprocessors.BatchMapper` -- one to normalize images, and another to
+        augment images. Later, you'll pass the preprocessors to :class:`Trainers <ray.train.trainer.BaseTrainer>`,
+        :class:`Predictors <ray.train.predictor.Predictor>`, and
+        :class:`PredictorDeployments <ray.serve.air_integrations.PredictorDeployment>`.
+
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __tensorflow_preprocessors_start__
+            :end-before: __tensorflow_preprocessors_stop__
+            :dedent:
 
 For more information on transforming data, see
 :ref:`Using Preprocessors <air-preprocessors>` and
@@ -160,44 +164,46 @@ Training vision models
 
 :class:`Trainers <ray.train.trainer.BaseTrainer>` let you train models in parallel.
 
-.. tabbed:: Torch
+.. tab-set::
 
-    To train a vision model, define the training loop per worker.
+    .. tab-item:: Torch
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __torch_training_loop_start__
-        :end-before: __torch_training_loop_stop__
-        :dedent:
+        To train a vision model, define the training loop per worker.
 
-    Then, create a :class:`~ray.train.torch.TorchTrainer` and call
-    :meth:`~ray.train.torch.TorchTrainer.fit`.
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __torch_training_loop_start__
+            :end-before: __torch_training_loop_stop__
+            :dedent:
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __torch_trainer_start__
-        :end-before: __torch_trainer_stop__
-        :dedent:
+        Then, create a :class:`~ray.train.torch.TorchTrainer` and call
+        :meth:`~ray.train.torch.TorchTrainer.fit`.
 
-    For more in-depth examples, read :doc:`/ray-air/examples/torch_image_example` and
-    :ref:`Using Trainers <air-trainers>`.
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __torch_trainer_start__
+            :end-before: __torch_trainer_stop__
+            :dedent:
 
-.. tabbed:: TensorFlow
+        For more in-depth examples, read :doc:`/ray-air/examples/torch_image_example` and
+        :ref:`Using Trainers <air-trainers>`.
 
-    To train a vision model, define the training loop per worker.
+    .. tab-item:: TensorFlow
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __tensorflow_training_loop_start__
-        :end-before: __tensorflow_training_loop_stop__
-        :dedent:
+        To train a vision model, define the training loop per worker.
 
-    Then, create a :class:`~ray.train.tensorflow.TensorflowTrainer` and call
-    :meth:`~ray.train.tensorflow.TensorflowTrainer.fit`.
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __tensorflow_training_loop_start__
+            :end-before: __tensorflow_training_loop_stop__
+            :dedent:
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __tensorflow_trainer_start__
-        :end-before: __tensorflow_trainer_stop__
-        :dedent:
+        Then, create a :class:`~ray.train.tensorflow.TensorflowTrainer` and call
+        :meth:`~ray.train.tensorflow.TensorflowTrainer.fit`.
 
-    For more information, read :ref:`Using Trainers <air-trainers>`.
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __tensorflow_trainer_start__
+            :end-before: __tensorflow_trainer_stop__
+            :dedent:
+
+        For more information, read :ref:`Using Trainers <air-trainers>`.
 
 Creating checkpoints
 --------------------
@@ -210,27 +216,29 @@ If you're going from training to prediction, don't create a new checkpoint.
 :class:`~ray.air.result.Result` object. Use
 :attr:`Result.checkpoint <ray.air.result.Result.checkpoint>` instead.
 
-.. tabbed:: Torch
+.. tab-set::
 
-    To create a :class:`~ray.train.torch.TorchCheckpoint`, pass a Torch model and
-    the :class:`~ray.data.preprocessor.Preprocessor` you created in `Transforming images`_
-    to :meth:`TorchCheckpoint.from_model() <ray.train.torch.TorchCheckpoint.from_model>`.
+    .. tab-item:: Torch
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __torch_checkpoint_start__
-        :end-before: __torch_checkpoint_stop__
-        :dedent:
+        To create a :class:`~ray.train.torch.TorchCheckpoint`, pass a Torch model and
+        the :class:`~ray.data.preprocessor.Preprocessor` you created in `Transforming images`_
+        to :meth:`TorchCheckpoint.from_model() <ray.train.torch.TorchCheckpoint.from_model>`.
 
-.. tabbed:: TensorFlow
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __torch_checkpoint_start__
+            :end-before: __torch_checkpoint_stop__
+            :dedent:
 
-    To create a :class:`~ray.train.tensorflow.TensorflowCheckpoint`, pass a TensorFlow model and
-    the :class:`~ray.data.preprocessor.Preprocessor` you created in `Transforming images`_
-    to :meth:`TensorflowCheckpoint.from_model() <ray.train.tensorflow.TensorflowCheckpoint.from_model>`.
+    .. tab-item:: TensorFlow
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __tensorflow_checkpoint_start__
-        :end-before: __tensorflow_checkpoint_stop__
-        :dedent:
+        To create a :class:`~ray.train.tensorflow.TensorflowCheckpoint`, pass a TensorFlow model and
+        the :class:`~ray.data.preprocessor.Preprocessor` you created in `Transforming images`_
+        to :meth:`TensorflowCheckpoint.from_model() <ray.train.tensorflow.TensorflowCheckpoint.from_model>`.
+
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __tensorflow_checkpoint_start__
+            :end-before: __tensorflow_checkpoint_stop__
+            :dedent:
 
 
 Batch predicting images
@@ -239,32 +247,34 @@ Batch predicting images
 :class:`~ray.train.batch_predictor.BatchPredictor` lets you perform inference on large
 image datasets.
 
-.. tabbed:: Torch
+.. tab-set::
 
-    To create a :class:`~ray.train.batch_predictor.BatchPredictor`, call
-    :meth:`BatchPredictor.from_checkpoint <ray.train.batch_predictor.BatchPredictor.from_checkpoint>` and pass the checkpoint
-    you created in `Creating checkpoints`_.
+    .. tab-item:: Torch
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __torch_batch_predictor_start__
-        :end-before: __torch_batch_predictor_stop__
-        :dedent:
+        To create a :class:`~ray.train.batch_predictor.BatchPredictor`, call
+        :meth:`BatchPredictor.from_checkpoint <ray.train.batch_predictor.BatchPredictor.from_checkpoint>` and pass the checkpoint
+        you created in `Creating checkpoints`_.
 
-    For more in-depth examples, read :doc:`/ray-air/examples/pytorch_resnet_batch_prediction`
-    and :ref:`Using Predictors for Inference <air-predictors>`.
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __torch_batch_predictor_start__
+            :end-before: __torch_batch_predictor_stop__
+            :dedent:
 
-.. tabbed:: TensorFlow
+        For more in-depth examples, read :doc:`/ray-air/examples/pytorch_resnet_batch_prediction`
+        and :ref:`Using Predictors for Inference <air-predictors>`.
 
-    To create a :class:`~ray.train.batch_predictor.BatchPredictor`, call
-    :meth:`BatchPredictor.from_checkpoint <ray.train.batch_predictor.BatchPredictor.from_checkpoint>` and pass the checkpoint
-    you created in `Creating checkpoints`_.
+    .. tab-item:: TensorFlow
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __tensorflow_batch_predictor_start__
-        :end-before: __tensorflow_batch_predictor_stop__
-        :dedent:
+        To create a :class:`~ray.train.batch_predictor.BatchPredictor`, call
+        :meth:`BatchPredictor.from_checkpoint <ray.train.batch_predictor.BatchPredictor.from_checkpoint>` and pass the checkpoint
+        you created in `Creating checkpoints`_.
 
-    For more information, read :ref:`Using Predictors for Inference <air-predictors>`.
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __tensorflow_batch_predictor_start__
+            :end-before: __tensorflow_batch_predictor_stop__
+            :dedent:
+
+        For more information, read :ref:`Using Predictors for Inference <air-predictors>`.
 
 Serving vision models
 ---------------------
@@ -286,44 +296,45 @@ To NumPy ndarrays like this:
     array([[1., 2.],
             [3., 4.]])
 
+.. tab-set::
 
-.. tabbed:: Torch
+    .. tab-item:: Torch
 
-    To deploy a Torch model to an endpoint, pass the checkpoint you created in `Creating checkpoints`_
-    to :meth:`PredictorDeployment.bind <ray.serve.air_integrations.PredictorDeployment.bind>` and specify
-    :func:`~ray.serve.http_adapters.json_to_ndarray` as the HTTP adapter.
+        To deploy a Torch model to an endpoint, pass the checkpoint you created in `Creating checkpoints`_
+        to :meth:`PredictorDeployment.bind <ray.serve.air_integrations.PredictorDeployment.bind>` and specify
+        :func:`~ray.serve.http_adapters.json_to_ndarray` as the HTTP adapter.
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __torch_serve_start__
-        :end-before: __torch_serve_stop__
-        :dedent:
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __torch_serve_start__
+            :end-before: __torch_serve_stop__
+            :dedent:
 
-    Then, make a request to classify an image.
+        Then, make a request to classify an image.
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __torch_online_predict_start__
-        :end-before: __torch_online_predict_stop__
-        :dedent:
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __torch_online_predict_start__
+            :end-before: __torch_online_predict_stop__
+            :dedent:
 
-    For more in-depth examples, read :doc:`/ray-air/examples/torch_image_example`
-    and :doc:`/ray-air/examples/serving_guide`.
+        For more in-depth examples, read :doc:`/ray-air/examples/torch_image_example`
+        and :doc:`/ray-air/examples/serving_guide`.
 
-.. tabbed:: TensorFlow
+    .. tab-item:: TensorFlow
 
-    To deploy a TensorFlow model to an endpoint, pass the checkpoint you created in `Creating checkpoints`_
-    to :meth:`PredictorDeployment.bind <ray.serve.air_integrations.PredictorDeployment.bind>` and specify
-    :func:`~ray.serve.http_adapters.json_to_multi_ndarray` as the HTTP adapter.
+        To deploy a TensorFlow model to an endpoint, pass the checkpoint you created in `Creating checkpoints`_
+        to :meth:`PredictorDeployment.bind <ray.serve.air_integrations.PredictorDeployment.bind>` and specify
+        :func:`~ray.serve.http_adapters.json_to_multi_ndarray` as the HTTP adapter.
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __tensorflow_serve_start__
-        :end-before: __tensorflow_serve_stop__
-        :dedent:
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __tensorflow_serve_start__
+            :end-before: __tensorflow_serve_stop__
+            :dedent:
 
-    Then, make a request to classify an image.
+        Then, make a request to classify an image.
 
-    .. literalinclude:: ./doc_code/computer_vision.py
-        :start-after: __tensorflow_online_predict_start__
-        :end-before: __tensorflow_online_predict_stop__
-        :dedent:
+        .. literalinclude:: ./doc_code/computer_vision.py
+            :start-after: __tensorflow_online_predict_start__
+            :end-before: __tensorflow_online_predict_stop__
+            :dedent:
 
-    For more information, read :doc:`/ray-air/examples/serving_guide`.
+        For more information, read :doc:`/ray-air/examples/serving_guide`.

--- a/doc/source/ray-air/getting-started.rst
+++ b/doc/source/ray-air/getting-started.rst
@@ -84,78 +84,84 @@ First, let's start by loading a dataset from storage:
 
 Then, we define a ``Preprocessor`` pipeline for our task:
 
-.. tabbed:: XGBoost
+.. tab-set::
 
-    .. literalinclude:: examples/xgboost_starter.py
-        :language: python
-        :start-after: __air_xgb_preprocess_start__
-        :end-before: __air_xgb_preprocess_end__
+    .. tab-item:: XGBoost
 
-.. tabbed:: Pytorch
+        .. literalinclude:: examples/xgboost_starter.py
+            :language: python
+            :start-after: __air_xgb_preprocess_start__
+            :end-before: __air_xgb_preprocess_end__
 
-    .. literalinclude:: examples/pytorch_tabular_starter.py
-        :language: python
-        :start-after: __air_pytorch_preprocess_start__
-        :end-before: __air_pytorch_preprocess_end__
+    .. tab-item:: Pytorch
 
-.. tabbed:: Tensorflow
+        .. literalinclude:: examples/pytorch_tabular_starter.py
+            :language: python
+            :start-after: __air_pytorch_preprocess_start__
+            :end-before: __air_pytorch_preprocess_end__
 
-    .. literalinclude:: examples/tf_tabular_starter.py
-        :language: python
-        :start-after: __air_tf_preprocess_start__
-        :end-before: __air_tf_preprocess_end__
+    .. tab-item:: Tensorflow
+
+        .. literalinclude:: examples/tf_tabular_starter.py
+            :language: python
+            :start-after: __air_tf_preprocess_start__
+            :end-before: __air_tf_preprocess_end__
 
 Training
 ~~~~~~~~
 
 Train a model with a ``Trainer`` with common ML frameworks:
 
-.. tabbed:: XGBoost
+.. tab-set::
 
-    .. literalinclude:: examples/xgboost_starter.py
-        :language: python
-        :start-after: __air_xgb_train_start__
-        :end-before: __air_xgb_train_end__
+    .. tab-item:: XGBoost
 
-.. tabbed:: Pytorch
+        .. literalinclude:: examples/xgboost_starter.py
+            :language: python
+            :start-after: __air_xgb_train_start__
+            :end-before: __air_xgb_train_end__
 
-    .. literalinclude:: examples/pytorch_tabular_starter.py
-        :language: python
-        :start-after: __air_pytorch_train_start__
-        :end-before: __air_pytorch_train_end__
+    .. tab-item:: Pytorch
 
-.. tabbed:: Tensorflow
+        .. literalinclude:: examples/pytorch_tabular_starter.py
+            :language: python
+            :start-after: __air_pytorch_train_start__
+            :end-before: __air_pytorch_train_end__
 
-    .. literalinclude:: examples/tf_tabular_starter.py
-        :language: python
-        :start-after: __air_tf_train_start__
-        :end-before: __air_tf_train_end__
+    .. tab-item:: Tensorflow
+
+        .. literalinclude:: examples/tf_tabular_starter.py
+            :language: python
+            :start-after: __air_tf_train_start__
+            :end-before: __air_tf_train_end__
 
 Hyperparameter Tuning
 ~~~~~~~~~~~~~~~~~~~~~
 
 You can specify a hyperparameter space to search over for each trainer:
 
-.. tabbed:: XGBoost
+.. tab-set::
 
-    .. literalinclude:: examples/xgboost_starter.py
-        :language: python
-        :start-after: __air_xgb_tuner_start__
-        :end-before: __air_xgb_tuner_end__
+    .. tab-item:: XGBoost
 
-.. tabbed:: Pytorch
+        .. literalinclude:: examples/xgboost_starter.py
+            :language: python
+            :start-after: __air_xgb_tuner_start__
+            :end-before: __air_xgb_tuner_end__
 
-    .. literalinclude:: examples/pytorch_tabular_starter.py
-        :language: python
-        :start-after: __air_pytorch_tuner_start__
-        :end-before: __air_pytorch_tuner_end__
+    .. tab-item:: Pytorch
 
-.. tabbed:: Tensorflow
+        .. literalinclude:: examples/pytorch_tabular_starter.py
+            :language: python
+            :start-after: __air_pytorch_tuner_start__
+            :end-before: __air_pytorch_tuner_end__
 
-    .. literalinclude:: examples/tf_tabular_starter.py
-        :language: python
-        :start-after: __air_tf_tuner_start__
-        :end-before: __air_tf_tuner_end__
+    .. tab-item:: Tensorflow
+
+        .. literalinclude:: examples/tf_tabular_starter.py
+            :language: python
+            :start-after: __air_tf_tuner_start__
+            :end-before: __air_tf_tuner_end__
 
 Then use the ``Tuner`` to run the search:
 
@@ -169,27 +175,28 @@ Batch Inference
 
 Use the trained model for scalable batch prediction with a ``BatchPredictor``.
 
-.. tabbed:: XGBoost
+.. tab-set::
 
-    .. literalinclude:: examples/xgboost_starter.py
-        :language: python
-        :start-after: __air_xgb_batchpred_start__
-        :end-before: __air_xgb_batchpred_end__
+    .. tab-item:: XGBoost
 
-.. tabbed:: Pytorch
+        .. literalinclude:: examples/xgboost_starter.py
+            :language: python
+            :start-after: __air_xgb_batchpred_start__
+            :end-before: __air_xgb_batchpred_end__
 
-    .. literalinclude:: examples/pytorch_tabular_starter.py
-        :language: python
-        :start-after: __air_pytorch_batchpred_start__
-        :end-before: __air_pytorch_batchpred_end__
+    .. tab-item:: Pytorch
 
-.. tabbed:: Tensorflow
+        .. literalinclude:: examples/pytorch_tabular_starter.py
+            :language: python
+            :start-after: __air_pytorch_batchpred_start__
+            :end-before: __air_pytorch_batchpred_end__
 
-    .. literalinclude:: examples/tf_tabular_starter.py
-        :language: python
-        :start-after: __air_tf_batchpred_start__
-        :end-before: __air_tf_batchpred_end__
+    .. tab-item:: Tensorflow
 
+        .. literalinclude:: examples/tf_tabular_starter.py
+            :language: python
+            :start-after: __air_tf_batchpred_start__
+            :end-before: __air_tf_batchpred_end__
 
 Project Status
 --------------

--- a/doc/source/ray-air/predictors.rst
+++ b/doc/source/ray-air/predictors.rst
@@ -146,34 +146,37 @@ Below, we provide examples of using common frameworks to do batch inference for 
 Tabular
 ~~~~~~~
 
-.. tabbed:: XGBoost
+.. tab-set::
 
-    .. literalinclude:: examples/xgboost_batch_prediction.py
-        :language: python
+    .. tab-item:: XGBoost
 
-.. tabbed:: Pytorch
+        .. literalinclude:: examples/xgboost_batch_prediction.py
+            :language: python
 
-    .. literalinclude:: examples/pytorch_tabular_batch_prediction.py
-        :language: python
+    .. tab-item:: Pytorch
 
-.. tabbed:: Tensorflow
+        .. literalinclude:: examples/pytorch_tabular_batch_prediction.py
+            :language: python
 
-    .. literalinclude:: examples/tf_tabular_batch_prediction.py
-        :language: python
+    .. tab-item:: Tensorflow
 
+        .. literalinclude:: examples/tf_tabular_batch_prediction.py
+            :language: python
 
 Image
 ~~~~~
 
-.. tabbed:: Pytorch
+.. tab-set::
 
-    .. literalinclude:: examples/torch_image_batch_pretrained.py
-        :language: python
+    .. tab-item:: Pytorch
+
+        .. literalinclude:: examples/torch_image_batch_pretrained.py
+            :language: python
 
 
-.. tabbed:: Tensorflow
+    .. tab-item:: Tensorflow
 
-    Coming soon!
+        Coming soon!
 
 Text
 ~~~~

--- a/doc/source/ray-air/trainers.rst
+++ b/doc/source/ray-air/trainers.rst
@@ -67,22 +67,24 @@ Read more about :ref:`Ray Train's Deep Learning Trainers <train-dl-guide>`.
 
 .. dropdown:: Code examples
 
-    .. tabbed:: Torch
+    .. tab-set::
 
-        .. literalinclude:: doc_code/torch_trainer.py
-            :language: python
+        .. tab-item:: Torch
 
-    .. tabbed:: Tensorflow
+            .. literalinclude:: doc_code/torch_trainer.py
+                :language: python
 
-        .. literalinclude:: doc_code/tf_starter.py
-            :language: python
-            :start-after: __air_tf_train_start__
-            :end-before: __air_tf_train_end__
+        .. tab-item:: Tensorflow
 
-    .. tabbed:: Horovod
+            .. literalinclude:: doc_code/tf_starter.py
+                :language: python
+                :start-after: __air_tf_train_start__
+                :end-before: __air_tf_train_end__
 
-        .. literalinclude:: doc_code/hvd_trainer.py
-            :language: python
+        .. tab-item:: Horovod
+
+            .. literalinclude:: doc_code/hvd_trainer.py
+                :language: python
 
 
 How to report metrics and checkpoints?

--- a/doc/source/ray-air/tuner.rst
+++ b/doc/source/ray-air/tuner.rst
@@ -63,19 +63,21 @@ Depending on the model and dataset, you may want to tune:
 
 The following shows some example code on how to specify the ``param_space``.
 
-.. tabbed:: XGBoost
+.. tab-set::
 
-    .. literalinclude:: doc_code/tuner.py
-        :language: python
-        :start-after: __xgboost_start__
-        :end-before: __xgboost_end__
+    .. tab-item:: XGBoost
 
-.. tabbed:: Pytorch
+        .. literalinclude:: doc_code/tuner.py
+            :language: python
+            :start-after: __xgboost_start__
+            :end-before: __xgboost_end__
 
-    .. literalinclude:: doc_code/tuner.py
-        :language: python
-        :start-after: __torch_start__
-        :end-before: __torch_end__
+    .. tab-item:: Pytorch
+
+        .. literalinclude:: doc_code/tuner.py
+            :language: python
+            :start-after: __torch_start__
+            :end-before: __torch_end__
 
 Read more about :ref:`Tune search spaces here <tune-search-space-tutorial>`.
 


### PR DESCRIPTION
First PR of many to replace the old and unmaintained `spinx-panels` by the newer plugin with LTS (by the same authors) called `sphinx-design`. Slightly different syntax, but same functionality. Stylistically slightly different, but more powerful later on. We need to take care of 3 things (the latter 2 always go together):

- replace `tabbed` by either `tabs` or `tab-set`
- replace `link-button` by `button-ref` and `button-link`
- replace `panels` by `grid`

Important: once fully removing `sphinx-panels` from dependencies, we can finally upgrade our theme and the base sphinx version to. 