### PR TITLE
[CI] Fix iter_tensor_batches_benchmark_multi_node cluster compute

### DIFF
--- a/release/nightly_tests/dataset/multi_node_benchmark_compute_gce.yaml
+++ b/release/nightly_tests/dataset/multi_node_benchmark_compute_gce.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs:
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-16 # m5.4xlarge
+      max_workers: 3
+      min_workers: 3
+      use_spot: false

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5102,7 +5102,7 @@
       frequency: manual
       cluster:
         cluster_env: app_config.yaml
-        cluster_compute: single_node_benchmark_compute_gce.yaml
+        cluster_compute: multi_node_benchmark_compute_gce.yaml
 
 - name: iter_batches_benchmark_single_node
   group: data-tests


### PR DESCRIPTION
## Why are these changes needed?
iter_tensor_batches_benchmark_multi_node.gce is currently failing, likely because they use a wrong compute config (use 1 instead of 3 workers)

## Related issue number

Closes issue #34532 

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Release tests