### PR TITLE
[data] feat: add performant way to read large tfrecord datasets

### DIFF
--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -14,7 +14,6 @@ import struct
 
 from ray.util.annotations import PublicAPI
 from ray.data._internal.util import _check_import
-from ray.data.datastream import Datastream
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 
@@ -25,6 +24,7 @@ if TYPE_CHECKING:
     import tensorflow as tf
     import pandas as pd
     from tensorflow_metadata.proto.v0 import schema_pb2
+    from ray.data import Datastream
 
 
 logger = logging.getLogger(__name__)

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -14,7 +14,7 @@ import struct
 
 from ray.util.annotations import PublicAPI
 from ray.data._internal.util import _check_import
-from ray.data import Dataset
+from ray.data.datastream import Datastream
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 
@@ -57,14 +57,14 @@ class TFRecordDatasource(FileBasedDatasource):
         except ModuleNotFoundError:
             if platform.processor() == "arm":
                 logger.warning(
-                    "This function depends on tfx-bsl which is currently not supported on "
-                    "devices with Apple silicon (e.g. M1) and requires an environment with "
-                    "x86 CPU architecture."
+                    "This function depends on tfx-bsl which is currently not supported"
+                    " on devices with Apple silicon (e.g. M1) and requires an"
+                    " environment with x86 CPU architecture."
                 )
             else:
                 logger.warning(
-                    "To use TFRecordDatasource with large datasets, please install tfx-bsl package with "
-                    "`pip install tfx_bsl --no-dependencies`."
+                    "To use TFRecordDatasource with large datasets, please install"
+                    " tfx-bsl package with pip install tfx_bsl --no-dependencies`."
                 )
             logger.info("Falling back to slower strategy for reading tf.records.")
             yield from self._fallback_read(f, path, **reader_args)
@@ -140,6 +140,9 @@ class TFRecordDatasource(FileBasedDatasource):
 
 
 def _get_full_file_path(file_system: "pyarrow.fs.FileSystem", path: str) -> str:
+    from pyarrow.fs import LocalFileSystem
+    from gcsfs import GCSFileSystem
+
     if isinstance(file_system, GCSFileSystem):
         return f"gs://{path}"
     if isinstance(file_system, LocalFileSystem):
@@ -452,7 +455,7 @@ def _read_records(
             raise RuntimeError(error_message) from e
 
 
-def unwrap_single_value_columns(dataset: Dataset):
+def unwrap_single_value_columns(dataset: Datastream):
     list_sizes = dataset.aggregate(_MaxListSize(dataset.schema().names))
 
     return dataset.map_batches(

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -12,10 +12,9 @@ from typing import (
 )
 import struct
 
-import numpy as np
-
 from ray.util.annotations import PublicAPI
 from ray.data._internal.util import _check_import
+from ray.data import Dataset
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 
@@ -24,6 +23,7 @@ from ray.data.aggregate import AggregateFn
 if TYPE_CHECKING:
     import pyarrow
     import tensorflow as tf
+    import pandas as pd
     from tensorflow_metadata.proto.v0 import schema_pb2
 
 
@@ -452,7 +452,7 @@ def _read_records(
             raise RuntimeError(error_message) from e
 
 
-def unwrap_single_value_columns(dataset: ray.data.Dataset):
+def unwrap_single_value_columns(dataset: Dataset):
     list_sizes = dataset.aggregate(_MaxListSize(dataset.schema().names))
 
     return dataset.map_batches(
@@ -462,7 +462,7 @@ def unwrap_single_value_columns(dataset: ray.data.Dataset):
     )
 
 
-def _unwrap_single_value_lists(batch: pd.DataFrame, col_lengths: Dict[str, int]):
+def _unwrap_single_value_lists(batch: "pd.DataFrame", col_lengths: Dict[str, int]):
     for col in col_lengths:
         if col_lengths[col] == 1:
             batch[col] = batch[col].str[0]
@@ -541,6 +541,7 @@ def _write_record(
 def _masked_crc(data: bytes) -> bytes:
     """CRC checksum."""
     import crc32c
+    import numpy as np
 
     mask = 0xA282EAD8
     crc = crc32c.crc32(data)

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1269,17 +1269,17 @@ def read_tfrecords(
         fast_read = True
     except ModuleNotFoundError:
         if platform.processor() == "arm":
-            logger.get_logger().warning(
+            logger.warning(
                 "This function depends on tfx-bsl which is currently not supported"
                 " on devices with Apple silicon (e.g. M1) and requires an"
                 " environment with x86 CPU architecture."
             )
         else:
-            logger.get_logger().warning(
+            logger.warning(
                 "To use TFRecordDatasource with large datasets, please install"
                 " tfx-bsl package with pip install tfx_bsl --no-dependencies`."
             )
-        logger.get_logger().info(
+        logger.info(
             "Falling back to slower strategy for reading tf.records. This"
             "reading strategy should be avoided when reading large datasets."
         )

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -16,7 +16,7 @@ from typing import (
 import numpy as np
 
 import ray
-from python.ray.data.datasource.tfrecords_datasource import unwrap_single_value_columns
+from ray.data.datasource.tfrecords_datasource import unwrap_single_value_columns
 from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
 from ray.data._internal.block_list import BlockList
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
@@ -1257,7 +1257,7 @@ def read_tfrecords(
     Raises:
         ValueError: If a file contains a message that isn't a ``tf.train.Example``.
     """  # noqa: E501
-    dataset = read_datasource(
+    ds = read_datasource(
         TFRecordDatasource(filesystem=filesystem),
         parallelism=parallelism,
         paths=paths,
@@ -1270,9 +1270,9 @@ def read_tfrecords(
     )
 
     if schema_inference and not tf_schema:
-        return unwrap_single_value_columns(dataset)
+        return unwrap_single_value_columns(ds)
 
-    return dataset
+    return ds
 
 
 @PublicAPI(stability="alpha")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The main motivation for this PR is that `ray.data.read_tfrcords` yields suboptimal performance when reading large datasets.
This PR adds a default "fast" route for reading tf.records that relies on `tfx-bsl` decoder. This approach also infers the schema when no `tf_schema` is provided by doing a pass of the data to determine the cardinality of the feature lists.

## Related issue number

<!-- For example: "Closes #1234" -->
Relates to https://github.com/ray-project/ray/pull/33611

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
