### PR TITLE
[train] Add AccelerateTrainer as valid AIR_TRAINER

### DIFF
--- a/python/ray/air/_internal/usage.py
+++ b/python/ray/air/_internal/usage.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from ray.tune.search import BasicVariantGenerator, Searcher
 
 AIR_TRAINERS = {
+    "AccelerateTrainer",
     "HorovodTrainer",
     "HuggingFaceTrainer",
     "LightGBMTrainer",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This allows `AccelerateTrainer` to be tagged properly instead of `Custom`.

<details><summary> Verified with a simple manual test. </summary>
<p>


```diff
diff --git a/python/ray/air/_internal/usage.py b/python/ray/air/_internal/usage.py
index fb9492dfd4..38705d185c 100644
--- a/python/ray/air/_internal/usage.py
+++ b/python/ray/air/_internal/usage.py
@@ -84,6 +84,7 @@ def tag_air_trainer(trainer: "BaseTrainer"):
 
     assert isinstance(trainer, BaseTrainer)
     trainer_name = _find_class_name(trainer, "ray.train", AIR_TRAINERS)
+    print(f"trainer_name: {trainer_name}")
     record_extra_usage_tag(TagKey.AIR_TRAINER, trainer_name)
```
```python
from ray.train.huggingface.accelerate import AccelerateTrainer

trainer = AccelerateTrainer(train_loop_per_worker=lambda: None)
```
```
trainer_name: AccelerateTrainer
```

</p>
</details> 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
