### PR TITLE
[CI] fix virtualenv version to deflake linux://python/ray/tests:test_runtime_env_complicated

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -18,7 +18,7 @@ pyyaml
 aiosignal
 frozenlist
 requests
-virtualenv>=20.0.24
+virtualenv>=20.0.24, !=20.21.1
 
 # Python version-specific requirements
 dataclasses; python_version < '3.7'

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -18,7 +18,7 @@ pyyaml
 aiosignal
 frozenlist
 requests
-virtualenv>=20.0.24, !=20.21.1
+virtualenv>=20.0.24, != 20.21.1
 
 # Python version-specific requirements
 dataclasses; python_version < '3.7'

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -18,7 +18,7 @@ pyyaml
 aiosignal
 frozenlist
 requests
-virtualenv>=20.0.24, != 20.21.1
+virtualenv>=20.0.24, < 20.21.1
 
 # Python version-specific requirements
 dataclasses; python_version < '3.7'

--- a/python/setup.py
+++ b/python/setup.py
@@ -330,7 +330,7 @@ if setup_spec.type == SetupType.RAY:
         # Light weight requirement, can be replaced with "typing" once
         # we deprecate Python 3.7 (this will take a while).
         "typing_extensions; python_version < '3.8'",
-        "virtualenv >=20.0.24, != 20.21.1",  # For pip runtime env.
+        "virtualenv >=20.0.24, < 20.21.1",  # For pip runtime env.
     ]
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -330,7 +330,7 @@ if setup_spec.type == SetupType.RAY:
         # Light weight requirement, can be replaced with "typing" once
         # we deprecate Python 3.7 (this will take a while).
         "typing_extensions; python_version < '3.8'",
-        "virtualenv>=20.0.24",  # For pip runtime env.
+        "virtualenv >=20.0.24, !=20.21.1",  # For pip runtime env.
     ]
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -330,7 +330,7 @@ if setup_spec.type == SetupType.RAY:
         # Light weight requirement, can be replaced with "typing" once
         # we deprecate Python 3.7 (this will take a while).
         "typing_extensions; python_version < '3.8'",
-        "virtualenv >=20.0.24, !=20.21.1",  # For pip runtime env.
+        "virtualenv >=20.0.24, != 20.21.1",  # For pip runtime env.
     ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Looks the virtualenv has been upgraded between the success and failed test.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
