### PR TITLE
[no_early_kickoff] Move virtualenv to ray["default"] dependencies

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -796,14 +796,6 @@ run_minimal_test() {
   # shellcheck disable=SC2086
   bazel test --test_output=streamed --config=ci ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_utils
 
-  # Todo: Make compatible with python 3.9/3.10
-  if [ "$1" != "3.9" ] && [ "$1" != "3.10" ]; then
-    # shellcheck disable=SC2086
-    bazel test --test_output=streamed --config=ci ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_runtime_env_complicated
-  fi
-
-  # shellcheck disable=SC2086
-  bazel test --test_output=streamed --config=ci ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_runtime_env_validation
   # shellcheck disable=SC2086
   bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_serve_ray_minimal
   # shellcheck disable=SC2086

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -794,10 +794,6 @@ run_minimal_test() {
   # shellcheck disable=SC2086
   bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_runtime_env_ray_minimal
   # shellcheck disable=SC2086
-  bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_runtime_env
-  # shellcheck disable=SC2086
-  bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_runtime_env_2
-  # shellcheck disable=SC2086
   bazel test --test_output=streamed --config=ci ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_utils
 
   # Todo: Make compatible with python 3.9/3.10

--- a/ci/env/check_minimal_install.py
+++ b/ci/env/check_minimal_install.py
@@ -18,6 +18,7 @@ DEFAULT_BLACKLIST = [
     "opencensus",
     "prometheus_client",
     "smart_open",
+    "virtualenv",
     "torch",
     "tensorflow",
     "jax",

--- a/python/ray/tests/test_runtime_env_ray_minimal.py
+++ b/python/ray/tests/test_runtime_env_ray_minimal.py
@@ -28,7 +28,7 @@ def _test_task_and_actor(capsys):
 
     def stderr_checker():
         captured = capsys.readouterr()
-        return "ray[default]" in captured.err
+        return "install virtualenv" in captured.err
 
     wait_for_condition(stderr_checker)
 
@@ -90,7 +90,7 @@ def test_ray_init(shutdown_only, capsys):
 
     def stderr_checker():
         captured = capsys.readouterr()
-        return "ray[default]" in captured.err
+        return "install virtualenv" in captured.err
 
     wait_for_condition(stderr_checker)
 
@@ -110,7 +110,7 @@ def test_ray_init(shutdown_only, capsys):
 def test_ray_client_init(call_ray_start):
     with pytest.raises(ConnectionAbortedError) as excinfo:
         ray.init("ray://localhost:25552", runtime_env={"pip": ["requests"]})
-    assert "ray[default]" in str(excinfo.value)
+    assert "install virtualenv" in str(excinfo.value)
 
 
 if __name__ == "__main__":

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -18,7 +18,6 @@ pyyaml
 aiosignal
 frozenlist
 requests
-virtualenv>=20.0.24, < 20.21.1
 
 # Python version-specific requirements
 dataclasses; python_version < '3.7'
@@ -54,6 +53,7 @@ requests
 kubernetes
 colorful
 lz4
+virtualenv>=20.0.24, < 20.21.1
 # Manually parse pandas requirement
 pandas>=1.0.5; python_version < '3.7'
 pandas>=1.3.0; python_version >= '3.7'

--- a/python/setup.py
+++ b/python/setup.py
@@ -252,6 +252,7 @@ if setup_spec.type == SetupType.RAY:
             "pydantic",
             "prometheus_client >= 0.7.1",
             "smart_open",
+            "virtualenv >=20.0.24, < 20.21.1",  # For pip runtime env.
         ],
         "serve": ["uvicorn", "requests", "starlette", "fastapi", "aiorwlock"],
         "tune": ["pandas", "tabulate", "tensorboardX>=1.9", "requests", pyarrow_dep],
@@ -330,7 +331,6 @@ if setup_spec.type == SetupType.RAY:
         # Light weight requirement, can be replaced with "typing" once
         # we deprecate Python 3.7 (this will take a while).
         "typing_extensions; python_version < '3.8'",
-        "virtualenv >=20.0.24, < 20.21.1",  # For pip runtime env.
     ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Virtualenv is needed for runtime env and runtime env is only enabled for ray["default"]
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
