### PR TITLE
[Core] Add support for resource limiting flags for bazel build

### DIFF
--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -75,7 +75,7 @@ Every time you want to update your local version you can pull the changes from t
 Prepare the Python environment
 ------------------------------
 
-You probably want some type of Python virtual environment. For example, you can use Anaconda's ``conda``. 
+You probably want some type of Python virtual environment. For example, you can use Anaconda's ``conda``.
 
 .. tab-set::
 
@@ -343,9 +343,9 @@ You can tweak the build with the following environment variables (when running `
   python packages
 - ``RAY_DEBUG_BUILD``: Can be set to ``debug``, ``asan``, or ``tsan``. Any
   other value will be ignored
-- ``BAZEL_LIMIT_CPUS``: If set, it must be an integers. This will be fed to the
-  ``--local_cpu_resources`` argument for the call to Bazel, which will limit the
-  number of CPUs used during Bazel steps.
+- ``BAZEL_ARGS``: If set, pass a space-separated set of arguments to Bazel. This can be useful
+  for restricting resource usage during builds, for example. See https://bazel.build/docs/user-manual
+  for more information about valid arguments.
 - ``IS_AUTOMATED_BUILD``: Used in CI to tweak the build for the CI machines
 - ``SRC_DIR``: Can be set to the root of the source checkout, defaults to
   ``None`` which is ``cwd()``


### PR DESCRIPTION
## Why are these changes needed?

This PR adds support for a few Bazel build flags that limit resource consumption, allowing users with limited system resources to build Ray without locking up their system.

## Related issue number

Closes #34669.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
