### PR TITLE
[CI] Fix bisect index and boundary

### DIFF
--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -31,7 +31,7 @@ def main(
     test_name: str,
     passing_commit: str,
     failing_commit: str,
-    concurrency: int = 1,
+    concurrency: Optional[int] = 1,
 ) -> None:
     if concurrency <= 0:
         raise ValueError(
@@ -59,8 +59,8 @@ def _bisect(test: Test, commit_list: List[str], concurrency: int) -> str:
         idx_to_commit = {}
         for i in range(concurrency):
             idx = len(commit_list) * (i + 1) // (concurrency + 1)
-            # make sure that idx is not at the boundary, this avoids rerun bisect
-            # on the previously used revision
+            # make sure that idx is not at the boundary; this avoids rerun bisect
+            # on the previously run revision
             idx = min(max(idx, 1), len(commit_list) - 2)
             idx_to_commit[idx] = commit_list[idx]
         outcomes = _run_test(test, set(idx_to_commit.values()))

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -31,7 +31,7 @@ def main(
     test_name: str,
     passing_commit: str,
     failing_commit: str,
-    concurrency: Optional[int] = 1,
+    concurrency: int = 1,
 ) -> None:
     if concurrency <= 0:
         raise ValueError(
@@ -59,6 +59,9 @@ def _bisect(test: Test, commit_list: List[str], concurrency: int) -> str:
         idx_to_commit = {}
         for i in range(concurrency):
             idx = len(commit_list) * (i + 1) // (concurrency + 1)
+            # make sure that idx is not at the boundary, this avoids rerun bisect
+            # on the previously used revision
+            idx = min(max(idx, 1), len(commit_list) - 2)
             idx_to_commit[idx] = commit_list[idx]
         outcomes = _run_test(test, set(idx_to_commit.values()))
         passing_idx = 0


### PR DESCRIPTION
## Why are these changes needed?
Make sure that the bisect indexes are not at the boundary. This prevents situations where we bisect the same revision again (which cause buildkite to create a duplicated key, as well as wasting resources).

I have this check in some PR before but lost during rebase :(

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   