### PR TITLE
[CI][HotFix] Revert 34499

### DIFF
--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -335,7 +335,7 @@ class AnyscaleJobManager:
             # Many of Ray components have their separated logs (e.g. dashboard,
             # gcs_server, etc.), so the interesting errors are not always in the
             # job logs. If the job has no logs, check other ray logs for error patterns.
-            if not output:
+            if "### Starting ###" not in output:
                 output = self._get_ray_error_logs()
             assert output, "No logs fetched"
             return "\n".join(output.splitlines()[-LAST_LOGS_LENGTH * 3 :])


### PR DESCRIPTION
## Why are these changes needed?

Revert 34499. Null check is not sufficient, because anyscale does return some sort of string even when there are no logs. Unfortunately, this causes all release tests to the following line of logs now:

https://buildkite.com/ray-project/release-tests-branch/builds/1595#0187a5a6-adb0-4106-b6c0-e8400c449512

`[14:52:53] Discovered 0 log files across 0 chunks.        logs_controller.py:104
`
## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- Testing Strategy
   - [X] Unit tests
   