### PR TITLE
[Release] Update 2.4.0 release logs

### DIFF
--- a/release/release_logs/2.4.0/benchmarks/many_actors.json
+++ b/release/release_logs/2.4.0/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-  "_dashboard_memory_usage_mb": 513.560576,
-  "_dashboard_test_success": true,
-  "_peak_memory": 3.91,
-  "_peak_process_memory": "PID\tMEM\tCOMMAND\n165\t2.02GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2388\t0.85GiB\tpython distributed/test_many_actors.py\n353\t0.37GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n41\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n670\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n38\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --ServerApp.token=agh0_CkgwRgIhAP\n2610\t0.07GiB\tray::DashboardTester.run\n2523\t0.07GiB\tray::MemoryMonitorActor.run\n280\t0.04GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.113.246:9031 --host=0.0.0.\n553\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/log_m",
-  "actors_per_second": 772.644103201044,
-  "num_actors": 10000,
-  "perf_metrics": [
-      {
-          "perf_metric_name": "actors_per_second",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 772.644103201044
-      },
-      {
-          "perf_metric_name": "dashboard_p50_latency_ms",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 34.714
-      },
-      {
-          "perf_metric_name": "dashboard_p95_latency_ms",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 2419.503
-      },
-      {
-          "perf_metric_name": "dashboard_p99_latency_ms",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 3842.061
-      }
-  ],
-  "success": "1",
-  "time": 12.942569494247437
+    "_dashboard_memory_usage_mb": 574.578688,
+    "_dashboard_test_success": true,
+    "_peak_memory": 3.84,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n165\t2.01GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2859\t0.83GiB\tpython distributed/test_many_actors.py\n338\t0.33GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n41\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n639\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n38\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --ServerApp.token= --allow-root -\n3082\t0.07GiB\tray::DashboardTester.run\n2996\t0.07GiB\tray::MemoryMonitorActor.run\n265\t0.04GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.97.64:9031 --host=0.0.0.0\n538\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/log_m",
+    "actors_per_second": 737.6387503180771,
+    "num_actors": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "actors_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 737.6387503180771
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 28.971
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 1899.861
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2901.064
+        }
+    ],
+    "success": "1",
+    "time": 13.556771516799927
 }

--- a/release/release_logs/2.4.0/benchmarks/many_nodes.json
+++ b/release/release_logs/2.4.0/benchmarks/many_nodes.json
@@ -1,38 +1,38 @@
 {
-  "_dashboard_memory_usage_mb": 186.179584,
-  "_dashboard_test_success": true,
-  "_peak_memory": 4.23,
-  "_peak_process_memory": "PID\tMEM\tCOMMAND\n277\t0.59GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1900\t0.22GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n477\t0.16GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n811\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n56\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n2221\t0.08GiB\tray::StateAPIGeneratorActor.start\n1486\t0.08GiB\tray::JobSupervisor\n46\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n2047\t0.07GiB\tray::MemoryMonitorActor.run\n2144\t0.07GiB\tray::DashboardTester.run",
-  "num_tasks": 1000,
-  "perf_metrics": [
-      {
-          "perf_metric_name": "tasks_per_second",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 216.16404352694366
-      },
-      {
-          "perf_metric_name": "used_cpus_by_deadline",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 250.0
-      },
-      {
-          "perf_metric_name": "dashboard_p50_latency_ms",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 3.915
-      },
-      {
-          "perf_metric_name": "dashboard_p95_latency_ms",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 56.099
-      },
-      {
-          "perf_metric_name": "dashboard_p99_latency_ms",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 130.237
-      }
-  ],
-  "success": "1",
-  "tasks_per_second": 216.16404352694366,
-  "time": 304.62611627578735,
-  "used_cpus": 250.0
+    "_dashboard_memory_usage_mb": 187.82208,
+    "_dashboard_test_success": true,
+    "_peak_memory": 4.05,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n277\t0.77GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1605\t0.23GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n450\t0.16GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n783\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n61\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n1925\t0.08GiB\tray::StateAPIGeneratorActor.start\n1201\t0.08GiB\tray::JobSupervisor\n52\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1753\t0.07GiB\tray::MemoryMonitorActor.run\n1863\t0.07GiB\tray::DashboardTester.run",
+    "num_tasks": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 228.0567062081301
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 250.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4.072
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 34.235
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 134.023
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 228.0567062081301,
+    "time": 304.38487434387207,
+    "used_cpus": 250.0
 }

--- a/release/release_logs/2.4.0/benchmarks/many_pgs.json
+++ b/release/release_logs/2.4.0/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-  "_dashboard_memory_usage_mb": 166.48192,
-  "_dashboard_test_success": true,
-  "_peak_memory": 4.85,
-  "_peak_process_memory": "PID\tMEM\tCOMMAND\n256\t1.02GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1705\t0.4GiB\tpython distributed/test_many_pgs.py\n471\t0.15GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n803\t0.11GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n61\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n608\t0.08GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=\n1300\t0.07GiB\tray::JobSupervisor\n48\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1963\t0.07GiB\tray::DashboardTester.run\n1852\t0.07GiB\tray::MemoryMonitorActor.run",
-  "num_pgs": 1000,
-  "perf_metrics": [
-      {
-          "perf_metric_name": "pgs_per_second",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 17.929446347235622
-      },
-      {
-          "perf_metric_name": "dashboard_p50_latency_ms",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 3.307
-      },
-      {
-          "perf_metric_name": "dashboard_p95_latency_ms",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 128.925
-      },
-      {
-          "perf_metric_name": "dashboard_p99_latency_ms",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 197.038
-      }
-  ],
-  "pgs_per_second": 17.929446347235622,
-  "success": "1",
-  "time": 55.77417063713074
+    "_dashboard_memory_usage_mb": 181.796864,
+    "_dashboard_test_success": true,
+    "_peak_memory": 4.48,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n277\t1.15GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1724\t0.35GiB\tpython distributed/test_many_pgs.py\n468\t0.12GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n774\t0.11GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n595\t0.09GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=\n69\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n1318\t0.07GiB\tray::JobSupervisor\n52\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1869\t0.07GiB\tray::MemoryMonitorActor.run\n1965\t0.06GiB\tray::DashboardTester.run",
+    "num_pgs": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "pgs_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 17.321330540558634
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.244
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 134.793
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 171.365
+        }
+    ],
+    "pgs_per_second": 17.321330540558634,
+    "success": "1",
+    "time": 57.732285499572754
 }

--- a/release/release_logs/2.4.0/benchmarks/many_tasks.json
+++ b/release/release_logs/2.4.0/benchmarks/many_tasks.json
@@ -1,38 +1,38 @@
 {
-  "_dashboard_memory_usage_mb": 659.90656,
-  "_dashboard_test_success": true,
-  "_peak_memory": 4.44,
-  "_peak_process_memory": "PID\tMEM\tCOMMAND\n165\t1.99GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2232\t0.87GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n353\t0.74GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n2457\t0.1GiB\tray::DashboardTester.run\n41\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n670\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n38\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --ServerApp.token=agh0_CkYwRAIgH_\n2520\t0.07GiB\tray::StateAPIGeneratorActor.start\n2370\t0.07GiB\tray::MemoryMonitorActor.run\n280\t0.04GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.96.232:9031 --host=0.0.0.0",
-  "num_tasks": 10000,
-  "perf_metrics": [
-      {
-          "perf_metric_name": "tasks_per_second",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 324.3236630929032
-      },
-      {
-          "perf_metric_name": "used_cpus_by_deadline",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 2500.0
-      },
-      {
-          "perf_metric_name": "dashboard_p50_latency_ms",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 5.019
-      },
-      {
-          "perf_metric_name": "dashboard_p95_latency_ms",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 2788.74
-      },
-      {
-          "perf_metric_name": "dashboard_p99_latency_ms",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 3431.297
-      }
-  ],
-  "success": "1",
-  "tasks_per_second": 324.3236630929032,
-  "time": 330.83339619636536,
-  "used_cpus": 2500.0
+    "_dashboard_memory_usage_mb": 611.98336,
+    "_dashboard_test_success": true,
+    "_peak_memory": 4.61,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n165\t2.19GiB\t/home/ray/anaconda3/lib/python3.7/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2582\t0.86GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n338\t0.71GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/dashboa\n2807\t0.1GiB\tray::DashboardTester.run\n43\t0.09GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n639\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.7/site-packages/ray/dashboard/agen\n40\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --ServerApp.token= --allow-root -\n2870\t0.07GiB\tray::StateAPIGeneratorActor.start\n2720\t0.07GiB\tray::MemoryMonitorActor.run\n265\t0.04GiB\t/home/ray/anaconda3/bin/python -m ray.util.client.server --address=172.31.106.119:9031 --host=0.0.0.",
+    "num_tasks": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 296.54971037133174
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2500.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 5.024
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2713.875
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3772.233
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 296.54971037133174,
+    "time": 333.7211592197418,
+    "used_cpus": 2500.0
 }

--- a/release/release_logs/2.4.0/microbenchmark.json
+++ b/release/release_logs/2.4.0/microbenchmark.json
@@ -1,283 +1,283 @@
 {
-  "1_1_actor_calls_async": [
-      7875.2205662523575,
-      91.32036915829057
-  ],
-  "1_1_actor_calls_concurrent": [
-      4898.403930689569,
-      18.787428785414974
-  ],
-  "1_1_actor_calls_sync": [
-      2490.1228801310986,
-      61.66895883060133
-  ],
-  "1_1_async_actor_calls_async": [
-      2893.7637668160814,
-      58.54240700476942
-  ],
-  "1_1_async_actor_calls_sync": [
-      1663.656683863718,
-      82.11634772966543
-  ],
-  "1_1_async_actor_calls_with_args_async": [
-      2053.88520928116,
-      77.88191802930348
-  ],
-  "1_n_actor_calls_async": [
-      10918.570247859934,
-      252.77023513295532
-  ],
-  "1_n_async_actor_calls_async": [
-      10007.72780551488,
-      63.167900610588546
-  ],
-  "client__1_1_actor_calls_async": [
-      1053.9221163152763,
-      16.386239593374267
-  ],
-  "client__1_1_actor_calls_concurrent": [
-      1067.680489513954,
-      12.709001083081098
-  ],
-  "client__1_1_actor_calls_sync": [
-      587.2290114221607,
-      11.254483031373043
-  ],
-  "client__get_calls": [
-      1169.0846386325316,
-      30.090440134694333
-  ],
-  "client__put_calls": [
-      953.6497274525543,
-      27.62987622516938
-  ],
-  "client__put_gigabytes": [
-      0.04453569846336401,
-      0.0005889062724214797
-  ],
-  "client__tasks_and_get_batch": [
-      0.9962426891274011,
-      0.012695780047090623
-  ],
-  "client__tasks_and_put_batch": [
-      11636.76543061424,
-      344.5895993880181
-  ],
-  "multi_client_put_calls_Plasma_Store": [
-      12782.464998678728,
-      303.0850304711337
-  ],
-  "multi_client_put_gigabytes": [
-      25.409834920338362,
-      0.9620047718388134
-  ],
-  "multi_client_tasks_async": [
-      29499.600819285548,
-      1838.097234923537
-  ],
-  "n_n_actor_calls_async": [
-      31558.549225320676,
-      675.1014999204177
-  ],
-  "n_n_actor_calls_with_arg_async": [
-      3114.287612859598,
-      43.68969356632565
-  ],
-  "n_n_async_actor_calls_async": [
-      25348.416455631697,
-      927.5572889075144
-  ],
-  "perf_metrics": [
-      {
-          "perf_metric_name": "single_client_get_calls_Plasma_Store",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 6717.39789740067
-      },
-      {
-          "perf_metric_name": "single_client_put_calls_Plasma_Store",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 6141.116222223478
-      },
-      {
-          "perf_metric_name": "multi_client_put_calls_Plasma_Store",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 12782.464998678728
-      },
-      {
-          "perf_metric_name": "single_client_put_gigabytes",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 19.77763371659089
-      },
-      {
-          "perf_metric_name": "single_client_tasks_and_get_batch",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 10.903109137328919
-      },
-      {
-          "perf_metric_name": "multi_client_put_gigabytes",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 25.409834920338362
-      },
-      {
-          "perf_metric_name": "single_client_get_object_containing_10k_refs",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 12.601815520396993
-      },
-      {
-          "perf_metric_name": "single_client_wait_1k_refs",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 6.25672193789162
-      },
-      {
-          "perf_metric_name": "single_client_tasks_sync",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 1315.6532263025485
-      },
-      {
-          "perf_metric_name": "single_client_tasks_async",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 10565.441516164923
-      },
-      {
-          "perf_metric_name": "multi_client_tasks_async",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 29499.600819285548
-      },
-      {
-          "perf_metric_name": "1_1_actor_calls_sync",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 2490.1228801310986
-      },
-      {
-          "perf_metric_name": "1_1_actor_calls_async",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 7875.2205662523575
-      },
-      {
-          "perf_metric_name": "1_1_actor_calls_concurrent",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 4898.403930689569
-      },
-      {
-          "perf_metric_name": "1_n_actor_calls_async",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 10918.570247859934
-      },
-      {
-          "perf_metric_name": "n_n_actor_calls_async",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 31558.549225320676
-      },
-      {
-          "perf_metric_name": "n_n_actor_calls_with_arg_async",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 3114.287612859598
-      },
-      {
-          "perf_metric_name": "1_1_async_actor_calls_sync",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 1663.656683863718
-      },
-      {
-          "perf_metric_name": "1_1_async_actor_calls_async",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 2893.7637668160814
-      },
-      {
-          "perf_metric_name": "1_1_async_actor_calls_with_args_async",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 2053.88520928116
-      },
-      {
-          "perf_metric_name": "1_n_async_actor_calls_async",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 10007.72780551488
-      },
-      {
-          "perf_metric_name": "n_n_async_actor_calls_async",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 25348.416455631697
-      },
-      {
-          "perf_metric_name": "placement_group_create/removal",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 1010.4619236411705
-      },
-      {
-          "perf_metric_name": "client__get_calls",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 1169.0846386325316
-      },
-      {
-          "perf_metric_name": "client__put_calls",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 953.6497274525543
-      },
-      {
-          "perf_metric_name": "client__put_gigabytes",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 0.04453569846336401
-      },
-      {
-          "perf_metric_name": "client__tasks_and_put_batch",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 11636.76543061424
-      },
-      {
-          "perf_metric_name": "client__1_1_actor_calls_sync",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 587.2290114221607
-      },
-      {
-          "perf_metric_name": "client__1_1_actor_calls_async",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 1053.9221163152763
-      },
-      {
-          "perf_metric_name": "client__1_1_actor_calls_concurrent",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 1067.680489513954
-      },
-      {
-          "perf_metric_name": "client__tasks_and_get_batch",
-          "perf_metric_type": "THROUGHPUT",
-          "perf_metric_value": 0.9962426891274011
-      }
-  ],
-  "placement_group_create/removal": [
-      1010.4619236411705,
-      10.079449349718745
-  ],
-  "single_client_get_calls_Plasma_Store": [
-      6717.39789740067,
-      383.3989162609101
-  ],
-  "single_client_get_object_containing_10k_refs": [
-      12.601815520396993,
-      0.02598969871083366
-  ],
-  "single_client_put_calls_Plasma_Store": [
-      6141.116222223478,
-      55.35476909877019
-  ],
-  "single_client_put_gigabytes": [
-      19.77763371659089,
-      4.567428080163564
-  ],
-  "single_client_tasks_and_get_batch": [
-      10.903109137328919,
-      0.578088867627798
-  ],
-  "single_client_tasks_async": [
-      10565.441516164923,
-      517.415416188027
-  ],
-  "single_client_tasks_sync": [
-      1315.6532263025485,
-      28.172086151746203
-  ],
-  "single_client_wait_1k_refs": [
-      6.25672193789162,
-      0.1697384586263945
-  ]
+    "1_1_actor_calls_async": [
+        8774.565215109124,
+        99.25145099727403
+    ],
+    "1_1_actor_calls_concurrent": [
+        5556.408295085073,
+        310.93719458837893
+    ],
+    "1_1_actor_calls_sync": [
+        2627.6907826949946,
+        17.95559542036301
+    ],
+    "1_1_async_actor_calls_async": [
+        3053.0727243465535,
+        44.040906553833615
+    ],
+    "1_1_async_actor_calls_sync": [
+        1749.332379578524,
+        36.34387252208381
+    ],
+    "1_1_async_actor_calls_with_args_async": [
+        2438.8474219503923,
+        88.20268908351537
+    ],
+    "1_n_actor_calls_async": [
+        11443.027888783963,
+        87.49946447311738
+    ],
+    "1_n_async_actor_calls_async": [
+        10589.09103935827,
+        106.34051316384893
+    ],
+    "client__1_1_actor_calls_async": [
+        1084.4466197839831,
+        33.13091505679245
+    ],
+    "client__1_1_actor_calls_concurrent": [
+        1106.1285553207586,
+        25.829782511660305
+    ],
+    "client__1_1_actor_calls_sync": [
+        569.89256256793,
+        24.8044284674939
+    ],
+    "client__get_calls": [
+        1150.072552279968,
+        36.79667266684934
+    ],
+    "client__put_calls": [
+        904.8795868787086,
+        13.073088078601502
+    ],
+    "client__put_gigabytes": [
+        0.045687216636994404,
+        0.00042081305098886794
+    ],
+    "client__tasks_and_get_batch": [
+        0.9467558674435517,
+        0.053000735219486415
+    ],
+    "client__tasks_and_put_batch": [
+        12964.98005883289,
+        319.3993930878376
+    ],
+    "multi_client_put_calls_Plasma_Store": [
+        13685.622603708454,
+        107.89607650269706
+    ],
+    "multi_client_put_gigabytes": [
+        31.944310601566972,
+        0.8025680665642678
+    ],
+    "multi_client_tasks_async": [
+        34377.35783189367,
+        2098.212516049616
+    ],
+    "n_n_actor_calls_async": [
+        34184.700321977085,
+        833.4165939251417
+    ],
+    "n_n_actor_calls_with_arg_async": [
+        3086.29057625603,
+        35.752775132663736
+    ],
+    "n_n_async_actor_calls_async": [
+        27000.281282494278,
+        1192.3434495510094
+    ],
+    "perf_metrics": [
+        {
+            "perf_metric_name": "single_client_get_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 6220.115319914286
+        },
+        {
+            "perf_metric_name": "single_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 6427.78729348863
+        },
+        {
+            "perf_metric_name": "multi_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 13685.622603708454
+        },
+        {
+            "perf_metric_name": "single_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 20.114238761619227
+        },
+        {
+            "perf_metric_name": "single_client_tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 10.621044232599615
+        },
+        {
+            "perf_metric_name": "multi_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 31.944310601566972
+        },
+        {
+            "perf_metric_name": "single_client_get_object_containing_10k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 13.4303118492593
+        },
+        {
+            "perf_metric_name": "single_client_wait_1k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5.669743175103769
+        },
+        {
+            "perf_metric_name": "single_client_tasks_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1402.5799311893395
+        },
+        {
+            "perf_metric_name": "single_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 11589.713176381527
+        },
+        {
+            "perf_metric_name": "multi_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 34377.35783189367
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2627.6907826949946
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8774.565215109124
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5556.408295085073
+        },
+        {
+            "perf_metric_name": "1_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 11443.027888783963
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 34184.700321977085
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_with_arg_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 3086.29057625603
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1749.332379578524
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 3053.0727243465535
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_with_args_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2438.8474219503923
+        },
+        {
+            "perf_metric_name": "1_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 10589.09103935827
+        },
+        {
+            "perf_metric_name": "n_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 27000.281282494278
+        },
+        {
+            "perf_metric_name": "placement_group_create/removal",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1111.4458914419295
+        },
+        {
+            "perf_metric_name": "client__get_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1150.072552279968
+        },
+        {
+            "perf_metric_name": "client__put_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 904.8795868787086
+        },
+        {
+            "perf_metric_name": "client__put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.045687216636994404
+        },
+        {
+            "perf_metric_name": "client__tasks_and_put_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 12964.98005883289
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 569.89256256793
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1084.4466197839831
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1106.1285553207586
+        },
+        {
+            "perf_metric_name": "client__tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.9467558674435517
+        }
+    ],
+    "placement_group_create/removal": [
+        1111.4458914419295,
+        36.12535104191624
+    ],
+    "single_client_get_calls_Plasma_Store": [
+        6220.115319914286,
+        224.5052300173086
+    ],
+    "single_client_get_object_containing_10k_refs": [
+        13.4303118492593,
+        0.17122469816034125
+    ],
+    "single_client_put_calls_Plasma_Store": [
+        6427.78729348863,
+        84.21488331092435
+    ],
+    "single_client_put_gigabytes": [
+        20.114238761619227,
+        6.003066360606937
+    ],
+    "single_client_tasks_and_get_batch": [
+        10.621044232599615,
+        0.7018065234293067
+    ],
+    "single_client_tasks_async": [
+        11589.713176381527,
+        69.968115451784
+    ],
+    "single_client_tasks_sync": [
+        1402.5799311893395,
+        44.22066668152743
+    ],
+    "single_client_wait_1k_refs": [
+        5.669743175103769,
+        0.16404015686449241
+    ]
 }

--- a/release/release_logs/2.4.0/scalability/object_store.json
+++ b/release/release_logs/2.4.0/scalability/object_store.json
@@ -1,40 +1,13 @@
 {
-  "args_time": 16.78179498900002,
-  "get_time": 24.349769197,
-  "large_object_size": 107374182400,
-  "large_object_time": 34.58217635799997,
-  "num_args": 10000,
-  "num_get_args": 10000,
-  "num_queued": 1000000,
-  "num_returns": 3000,
-  "perf_metrics": [
-      {
-          "perf_metric_name": "10000_args_time",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 16.78179498900002
-      },
-      {
-          "perf_metric_name": "3000_returns_time",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 6.026168543000011
-      },
-      {
-          "perf_metric_name": "10000_get_time",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 24.349769197
-      },
-      {
-          "perf_metric_name": "1000000_queued_time",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 239.18845452300002
-      },
-      {
-          "perf_metric_name": "107374182400_large_object_time",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 34.58217635799997
-      }
-  ],
-  "queued_time": 239.18845452300002,
-  "returns_time": 6.026168543000011,
-  "success": "1"
+    "broadcast_time": 89.42807069100002,
+    "num_nodes": 50,
+    "object_size": 1073741824,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 89.42807069100002
+        }
+    ],
+    "success": "1"
 }

--- a/release/release_logs/2.4.0/scalability/single_node.json
+++ b/release/release_logs/2.4.0/scalability/single_node.json
@@ -1,40 +1,40 @@
 {
-  "args_time": 16.78179498900002,
-  "get_time": 24.349769197,
-  "large_object_size": 107374182400,
-  "large_object_time": 34.58217635799997,
-  "num_args": 10000,
-  "num_get_args": 10000,
-  "num_queued": 1000000,
-  "num_returns": 3000,
-  "perf_metrics": [
-      {
-          "perf_metric_name": "10000_args_time",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 16.78179498900002
-      },
-      {
-          "perf_metric_name": "3000_returns_time",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 6.026168543000011
-      },
-      {
-          "perf_metric_name": "10000_get_time",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 24.349769197
-      },
-      {
-          "perf_metric_name": "1000000_queued_time",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 239.18845452300002
-      },
-      {
-          "perf_metric_name": "107374182400_large_object_time",
-          "perf_metric_type": "LATENCY",
-          "perf_metric_value": 34.58217635799997
-      }
-  ],
-  "queued_time": 239.18845452300002,
-  "returns_time": 6.026168543000011,
-  "success": "1"
+    "args_time": 17.054044035999993,
+    "get_time": 24.36676771400002,
+    "large_object_size": 107374182400,
+    "large_object_time": 34.06999374499998,
+    "num_args": 10000,
+    "num_get_args": 10000,
+    "num_queued": 1000000,
+    "num_returns": 3000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "10000_args_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 17.054044035999993
+        },
+        {
+            "perf_metric_name": "3000_returns_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 6.002825282000003
+        },
+        {
+            "perf_metric_name": "10000_get_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 24.36676771400002
+        },
+        {
+            "perf_metric_name": "1000000_queued_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 175.74473816900002
+        },
+        {
+            "perf_metric_name": "107374182400_large_object_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 34.06999374499998
+        }
+    ],
+    "queued_time": 175.74473816900002,
+    "returns_time": 6.002825282000003,
+    "success": "1"
 }

--- a/release/release_logs/2.4.0/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.4.0/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 2.4128899502754213,
-    "max_iteration_time": 11.154391050338745,
-    "min_iteration_time": 0.2948293685913086,
+    "avg_iteration_time": 2.0598055481910706,
+    "max_iteration_time": 15.883565187454224,
+    "min_iteration_time": 0.14446020126342773,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.4128899502754213
+            "perf_metric_value": 2.0598055481910706
         }
     ],
     "success": 1,
-    "total_time": 241.28934574127197
+    "total_time": 205.98083114624023
 }

--- a/release/release_logs/2.4.0/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.4.0/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 14.71593689918518
+            "perf_metric_value": 12.432663917541504
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.45582284927368
+            "perf_metric_value": 22.303217387199403
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 59.12007422447205
+            "perf_metric_value": 58.13721342086792
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.639009952545166
+            "perf_metric_value": 4.9506330490112305
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2746.616822242737
+            "perf_metric_value": 2541.1457979679108
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.8324665945841853
+            "perf_metric_value": 0.653147785580004
         }
     ],
-    "stage_0_time": 14.71593689918518,
-    "stage_1_avg_iteration_time": 23.45582284927368,
-    "stage_1_max_iteration_time": 24.144246339797974,
-    "stage_1_min_iteration_time": 22.638681411743164,
-    "stage_1_time": 234.5583221912384,
-    "stage_2_avg_iteration_time": 59.12007422447205,
-    "stage_2_max_iteration_time": 60.01493453979492,
-    "stage_2_min_iteration_time": 57.3223192691803,
-    "stage_2_time": 295.60199069976807,
-    "stage_3_creation_time": 5.639009952545166,
-    "stage_3_time": 2746.616822242737,
-    "stage_4_spread": 0.8324665945841853,
+    "stage_0_time": 12.432663917541504,
+    "stage_1_avg_iteration_time": 22.303217387199403,
+    "stage_1_max_iteration_time": 23.565119743347168,
+    "stage_1_min_iteration_time": 21.196225881576538,
+    "stage_1_time": 223.03227972984314,
+    "stage_2_avg_iteration_time": 58.13721342086792,
+    "stage_2_max_iteration_time": 58.608288526535034,
+    "stage_2_min_iteration_time": 57.48827838897705,
+    "stage_2_time": 290.6870460510254,
+    "stage_3_creation_time": 4.9506330490112305,
+    "stage_3_time": 2541.1457979679108,
+    "stage_4_spread": 0.653147785580004,
     "success": 1
 }

--- a/release/release_logs/2.4.0/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.4.0/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9266749219217597,
-    "avg_pg_remove_time_ms": 0.9992335435431319,
+    "avg_pg_create_time_ms": 0.8416926516519441,
+    "avg_pg_remove_time_ms": 0.8426233363353036,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9266749219217597
+            "perf_metric_value": 0.8416926516519441
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9992335435431319
+            "perf_metric_value": 0.8426233363353036
         }
     ],
     "success": 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
```
REGRESSION 11.77%: multi_client_put_gigabytes (THROUGHPUT) regresses from 36.20768872444627 to 31.944310601566972 (11.77%) in 2.4.0/microbenchmark.json
REGRESSION 8.76%: actors_per_second (THROUGHPUT) regresses from 808.4407587905971 to 737.6387503180771 (8.76%) in 2.4.0/benchmarks/many_actors.json
REGRESSION 3.41%: client__get_calls (THROUGHPUT) regresses from 1190.7189254696584 to 1150.072552279968 (3.41%) in 2.4.0/microbenchmark.json
REGRESSION 2.21%: pgs_per_second (THROUGHPUT) regresses from 17.712835160069687 to 17.321330540558634 (2.21%) in 2.4.0/benchmarks/many_pgs.json
REGRESSION 1.34%: single_client_put_gigabytes (THROUGHPUT) regresses from 20.38683304648347 to 20.114238761619227 (1.34%) in 2.4.0/microbenchmark.json
REGRESSION 8983.16%: stage_3_creation_time (LATENCY) regresses from 0.054503440856933594 to 4.9506330490112305 (8983.16%) in 2.4.0/stress_tests/stress_test_many_tasks.json
REGRESSION 996.59%: dashboard_p95_latency_ms (LATENCY) regresses from 12.292 to 134.793 (996.59%) in 2.4.0/benchmarks/many_pgs.json
REGRESSION 358.31%: dashboard_p95_latency_ms (LATENCY) regresses from 592.153 to 2713.875 (358.31%) in 2.4.0/benchmarks/many_tasks.json
REGRESSION 198.77%: dashboard_p99_latency_ms (LATENCY) regresses from 1262.576 to 3772.233 (198.77%) in 2.4.0/benchmarks/many_tasks.json
REGRESSION 23.88%: dashboard_p50_latency_ms (LATENCY) regresses from 3.287 to 4.072 (23.88%) in 2.4.0/benchmarks/many_nodes.json
REGRESSION 20.45%: dashboard_p50_latency_ms (LATENCY) regresses from 4.171 to 5.024 (20.45%) in 2.4.0/benchmarks/many_tasks.json
REGRESSION 10.30%: dashboard_p95_latency_ms (LATENCY) regresses from 1722.469 to 1899.861 (10.30%) in 2.4.0/benchmarks/many_actors.json
REGRESSION 8.31%: stage_0_time (LATENCY) regresses from 11.479018211364746 to 12.432663917541504 (8.31%) in 2.4.0/stress_tests/stress_test_many_tasks.json
REGRESSION 7.71%: dashboard_p99_latency_ms (LATENCY) regresses from 2693.468 to 2901.064 (7.71%) in 2.4.0/benchmarks/many_actors.json
REGRESSION 3.71%: 10000_args_time (LATENCY) regresses from 16.44382056200004 to 17.054044035999993 (3.71%) in 2.4.0/scalability/single_node.json
REGRESSION 3.31%: dashboard_p50_latency_ms (LATENCY) regresses from 3.14 to 3.244 (3.31%) in 2.4.0/benchmarks/many_pgs.json
REGRESSION 2.21%: 3000_returns_time (LATENCY) regresses from 5.873062359000016 to 6.002825282000003 (2.21%) in 2.4.0/scalability/single_node.json
REGRESSION 0.83%: avg_pg_remove_time_ms (LATENCY) regresses from 0.8356835120128541 to 0.8426233363353036 (0.83%) in 2.4.0/stress_tests/stress_test_placement_group.json
REGRESSION 0.27%: dashboard_p99_latency_ms (LATENCY) regresses from 133.659 to 134.023 (0.27%) in 2.4.0/benchmarks/many_nodes.json
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
