### PR TITLE
[CI] Fix boto3 pip dependency

### DIFF
--- a/release/ray_release/command_runner/_anyscale_job_wrapper.py
+++ b/release/ray_release/command_runner/_anyscale_job_wrapper.py
@@ -71,7 +71,6 @@ def run_storage_cp(source: str, target: str):
     storage_service = urlparse(target).scheme
     cp_cmd_args = []
     if storage_service == "s3":
-        install_pip("awscli")
         cp_cmd_args = [
             "aws",
             "s3",


### PR DESCRIPTION
## Why are these changes needed?
Most if not all release tests currently have this error spawn in their logs:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts. 
--
  | boto3 1.26.117 requires botocore<1.30.0,>=1.29.117, but you have botocore 1.29.105 which is incompatible.
```

Example: https://buildkite.com/ray-project/release-tests-probes/builds/495#0187aacb-0f8f-440d-a7cf-5dd07b1644ac

This is because test infra re-installs awscli on anyscale, then conflicts with other previously installed packages. Good news is Anyscale already install awscli by default so we can resolve this by removing the installation. 

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
 