### PR TITLE
[Serve] Add application tag into replica metrics

### DIFF
--- a/doc/source/serve/production-guide/monitoring.md
+++ b/doc/source/serve/production-guide/monitoring.md
@@ -243,32 +243,39 @@ The following metrics are exposed by Ray Serve:
      - * deployment
        * replica
        * route
+       * application
      - The number of queries that have been processed in this replica.
    * - ``serve_deployment_error_counter`` [**]
      - * deployment
        * replica
        * route
+       * application
      - The number of exceptions that have occurred in the deployment.
    * - ``serve_deployment_replica_starts`` [**]
      - * deployment
        * replica
+       * application
      - The number of times this replica has been restarted due to failure.
    * - ``serve_deployment_replica_healthy``
      - * deployment
        * replica
+       * application
      - Whether this deployment replica is healthy. 1 means healthy, 0 unhealthy.
    * - ``serve_deployment_processing_latency_ms`` [**]
      - * deployment
        * replica
        * route
+       * application
      - The latency for queries to be processed.
    * - ``serve_replica_processing_queries`` [**]
      - * deployment
        * replica
+       * application
      - The current number of queries being processed.
    * - ``serve_num_http_requests`` [*]
      - * route
        * method
+       * application
      - The number of HTTP requests processed.
    * - ``serve_num_http_error_requests`` [*]
      - * route
@@ -278,11 +285,13 @@ The following metrics are exposed by Ray Serve:
    * - ``serve_num_router_requests`` [*]
      - * deployment
        * route
+       * application
      - The number of requests processed by the router.
    * - ``serve_handle_request_counter`` [**]
      - * handle
        * deployment
        * route
+       * application
      - The number of requests processed by this ServeHandle.
    * - ``serve_deployment_queued_queries`` [*]
      - * deployment
@@ -293,9 +302,12 @@ The following metrics are exposed by Ray Serve:
        * error_code
        * method
        * route
+       * application
      - The number of non-200 HTTP responses returned by each deployment.
    * - ``serve_http_request_latency_ms`` [*]
      - * route
+       * application
+
      - The end-to-end latency of HTTP requests (measured from the Serve HTTP proxy).
 ```
 [*] - only available when using HTTP calls

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -275,6 +275,7 @@ class ServeControllerClient:
                     route_prefix=deployment["route_prefix"],
                     is_driver_deployment=deployment["is_driver_deployment"],
                     docs_path=deployment["docs_path"],
+                    app_name=name,
                 )
             )
 

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -184,6 +184,7 @@ class DeploymentInfo:
         end_time_ms: Optional[int] = None,
         autoscaling_policy: Optional[AutoscalingPolicy] = None,
         is_driver_deployment: Optional[bool] = False,
+        app_name: Optional[str] = None,
     ):
         self.deployment_config = deployment_config
         self.replica_config = replica_config
@@ -200,6 +201,8 @@ class DeploymentInfo:
         self._cached_actor_def = None
 
         self.is_driver_deployment = is_driver_deployment
+
+        self.app_name = app_name
 
     def __getstate__(self) -> Dict[Any, Any]:
         clean_dict = self.__dict__.copy()
@@ -242,6 +245,7 @@ class DeploymentInfo:
             "version": proto.version if proto.version != "" else None,
             "end_time_ms": proto.end_time_ms if proto.end_time_ms != 0 else None,
             "deployer_job_id": ray.get_runtime_context().get_job_id(),
+            "app_name": proto.app_name,
         }
 
         return cls(**data)
@@ -252,6 +256,7 @@ class DeploymentInfo:
             "actor_name": self.actor_name,
             "version": self.version,
             "end_time_ms": self.end_time_ms,
+            "app_name": self.app_name,
         }
         if self.deployment_config:
             data["deployment_config"] = self.deployment_config.to_proto()

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -21,11 +21,13 @@ EndpointTag = str
 ReplicaTag = str
 NodeId = str
 Duration = float
+ApplicationName = str
 
 
 @dataclass
 class EndpointInfo:
     route: str
+    app_name: str
 
 
 # Keep in sync with ServeReplicaState in dashboard/client/src/type/serve.ts

--- a/python/ray/serve/_private/deploy_utils.py
+++ b/python/ray/serve/_private/deploy_utils.py
@@ -27,6 +27,7 @@ def get_deploy_args(
     route_prefix: Optional[str] = None,
     is_driver_deployment: Optional[str] = None,
     docs_path: Optional[str] = None,
+    app_name: Optional[str] = None,
 ) -> Dict:
     """
     Takes a deployment's configuration, and returns the arguments needed
@@ -83,6 +84,7 @@ def get_deploy_args(
         "deployer_job_id": ray.get_runtime_context().get_job_id(),
         "is_driver_deployment": is_driver_deployment,
         "docs_path": docs_path,
+        "app_name": app_name,
     }
 
     return controller_deploy_args

--- a/python/ray/serve/_private/deploy_utils.py
+++ b/python/ray/serve/_private/deploy_utils.py
@@ -95,6 +95,7 @@ def deploy_args_to_deployment_info(
     deployer_job_id: Union[str, bytes],
     previous_deployment: DeploymentInfo,
     is_driver_deployment: Optional[bool] = False,
+    app_name: Optional[str] = None,
 ) -> DeploymentInfo:
     """Takes deployment args passed to the controller after building an application and
     constructs a DeploymentInfo object.
@@ -137,6 +138,7 @@ def deploy_args_to_deployment_info(
         start_time_ms=int(time.time() * 1000),
         autoscaling_policy=autoscaling_policy,
         is_driver_deployment=is_driver_deployment,
+        app_name=app_name,
     )
 
 

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -358,6 +358,7 @@ class ActorReplicaWrapper:
                 version,
                 self._controller_name,
                 self._detached,
+                deployment_info.app_name,
             )
         # TODO(simon): unify the constructor arguments across language
         elif (

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1654,7 +1654,12 @@ class DeploymentState:
                     f"{self._name} failed health check, stopping it."
                 )
                 self.health_check_gauge.set(
-                    0, tags={"deployment": self._name, "replica": replica.replica_tag}
+                    0,
+                    tags={
+                        "deployment": self._name,
+                        "replica": replica.replica_tag,
+                        "application": self.app_name,
+                    },
                 )
                 replica.stop(graceful=False)
                 self._replicas.add(ReplicaState.STOPPING, replica)

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -259,7 +259,7 @@ class HTTPProxy:
         # Set the controller name so that serve will connect to the
         # controller instance this proxy is running in.
         ray.serve.context._set_internal_replica_context(
-            None, None, controller_name, None
+            None, None, controller_name, None, None
         )
 
         # Used only for displaying the route table.

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -398,6 +398,13 @@ class HTTPProxy:
                     "method": scope["method"].upper(),
                 }
             )
+            self.request_counter.inc(
+                tags={
+                    "route": route_path,
+                    "method": scope["method"].upper(),
+                    "application": "",
+                }
+            )
             return await self._not_found(scope, receive, send)
         self.request_counter.inc(
             tags={

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -25,7 +25,7 @@ from ray.serve._private.http_util import (
     Response,
     set_socket_reuse_port,
 )
-from ray.serve._private.common import EndpointInfo, EndpointTag
+from ray.serve._private.common import EndpointInfo, EndpointTag, ApplicationName
 from ray.serve._private.constants import (
     SERVE_LOGGER_NAME,
     SERVE_NAMESPACE,
@@ -174,7 +174,7 @@ class LongestPrefixRouter:
         # Routes sorted in order of decreasing length.
         self.sorted_routes: List[str] = list()
         # Endpoints associated with the routes.
-        self.route_info: Dict[str, EndpointTag] = dict()
+        self.route_info: Dict[str, Tuple[EndpointTag, ApplicationName]] = dict()
         # Contains a ServeHandle for each endpoint.
         self.handles: Dict[str, RayServeHandle] = dict()
 
@@ -191,7 +191,7 @@ class LongestPrefixRouter:
         route_info = {}
         for endpoint, info in endpoints.items():
             routes.append(info.route)
-            route_info[info.route] = endpoint
+            route_info[info.route] = (endpoint, info.app_name)
             if endpoint in self.handles:
                 existing_handles.remove(endpoint)
             else:
@@ -241,10 +241,10 @@ class LongestPrefixRouter:
                     matched = True
 
                 if matched:
-                    endpoint = self.route_info[route]
-                    return route, self.handles[endpoint]
+                    endpoint, app_name = self.route_info[route]
+                    return route, self.handles[endpoint], app_name
 
-        return None, None
+        return None, None, None
 
 
 class HTTPProxy:
@@ -284,10 +284,7 @@ class HTTPProxy:
         self.request_counter = metrics.Counter(
             "serve_num_http_requests",
             description="The number of HTTP requests processed.",
-            tag_keys=(
-                "route",
-                "method",
-            ),
+            tag_keys=("route", "method", "application"),
         )
 
         self.request_error_counter = metrics.Counter(
@@ -310,6 +307,7 @@ class HTTPProxy:
                 "error_code",
                 "method",
                 "route",
+                "application",
             ),
         )
         self.processing_latency_tracker = metrics.Histogram(
@@ -319,7 +317,10 @@ class HTTPProxy:
                 "(measured from the Serve HTTP proxy)."
             ),
             boundaries=DEFAULT_LATENCY_BUCKET_MS,
-            tag_keys=("route",),
+            tag_keys=(
+                "route",
+                "application",
+            ),
         )
 
     def _update_routes(self, endpoints: Dict[EndpointTag, EndpointInfo]) -> None:
@@ -364,21 +365,31 @@ class HTTPProxy:
         root_path = scope["root_path"]
         route_path = scope["path"][len(root_path) :]
 
-        self.request_counter.inc(
-            tags={"route": route_path, "method": scope["method"].upper()}
-        )
-
         if route_path == "/-/routes":
+            self.request_counter.inc(
+                tags={
+                    "route": route_path,
+                    "method": scope["method"].upper(),
+                    "application": "",
+                }
+            )
             return await starlette.responses.JSONResponse(self.route_info)(
                 scope, receive, send
             )
 
         if route_path == "/-/healthz":
+            self.request_counter.inc(
+                tags={
+                    "route": route_path,
+                    "method": scope["method"].upper(),
+                    "application": "",
+                }
+            )
             return await starlette.responses.PlainTextResponse("success")(
                 scope, receive, send
             )
 
-        route_prefix, handle = self.prefix_router.match_route(route_path)
+        route_prefix, handle, app_name = self.prefix_router.match_route(route_path)
         if route_prefix is None:
             self.request_error_counter.inc(
                 tags={
@@ -388,7 +399,13 @@ class HTTPProxy:
                 }
             )
             return await self._not_found(scope, receive, send)
-
+        self.request_counter.inc(
+            tags={
+                "route": route_path,
+                "method": scope["method"].upper(),
+                "application": app_name,
+            }
+        )
         # Modify the path and root path so that reverse lookups and redirection
         # work as expected. We do this here instead of in replicas so it can be
         # changed without restarting the replicas.
@@ -399,11 +416,15 @@ class HTTPProxy:
 
         start_time = time.time()
         ray.serve.context._serve_request_context.set(
-            ray.serve.context.RequestContext(route_path, get_random_letters(10))
+            ray.serve.context.RequestContext(
+                route_path, get_random_letters(10), app_name
+            )
         )
         status_code = await _send_request_to_handle(handle, scope, receive, send)
         latency_ms = (time.time() - start_time) * 1000.0
-        self.processing_latency_tracker.observe(latency_ms, tags={"route": route_path})
+        self.processing_latency_tracker.observe(
+            latency_ms, tags={"route": route_path, "application": app_name}
+        )
         logger.info(
             access_log_msg(
                 method=scope["method"],
@@ -426,6 +447,7 @@ class HTTPProxy:
                     "error_code": status_code,
                     "method": scope["method"].upper(),
                     "route": route_path,
+                    "application": app_name,
                 }
             )
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -290,7 +290,7 @@ class Router:
         self.num_router_requests = metrics.Counter(
             "serve_num_router_requests",
             description="The number of requests processed by the router.",
-            tag_keys=("deployment", "route"),
+            tag_keys=("deployment", "route", "application"),
         )
         self.num_router_requests.set_default_tags({"deployment": deployment_name})
 
@@ -316,7 +316,9 @@ class Router:
     ):
         """Assign a query and returns an object ref represent the result"""
 
-        self.num_router_requests.inc(tags={"route": request_meta.route})
+        self.num_router_requests.inc(
+            tags={"route": request_meta.route, "application": request_meta.app_name}
+        )
         return await self._replica_set.assign_replica(
             Query(
                 args=list(request_args),

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -40,6 +40,9 @@ class RequestMetadata:
     # HTTP route path of the request.
     route: str = ""
 
+    # Application Name
+    app_name: str = ""
+
 
 @dataclass
 class Query:
@@ -98,7 +101,7 @@ class ReplicaSet:
                 "The current number of queries to this deployment waiting"
                 " to be assigned to a replica."
             ),
-            tag_keys=("deployment", "route"),
+            tag_keys=("deployment", "route", "application"),
         )
         self.num_queued_queries_gauge.set_default_tags(
             {"deployment": self.deployment_name}
@@ -229,7 +232,11 @@ class ReplicaSet:
         """
         self.num_queued_queries += 1
         self.num_queued_queries_gauge.set(
-            self.num_queued_queries, tags={"route": query.metadata.route}
+            self.num_queued_queries,
+            tags={
+                "route": query.metadata.route,
+                "application": query.metadata.app_name,
+            },
         )
         await query.resolve_async_tasks()
         assigned_ref = self._try_assign_replica(query)
@@ -255,7 +262,11 @@ class ReplicaSet:
             assigned_ref = self._try_assign_replica(query)
         self.num_queued_queries -= 1
         self.num_queued_queries_gauge.set(
-            self.num_queued_queries, tags={"route": query.metadata.route}
+            self.num_queued_queries,
+            tags={
+                "route": query.metadata.route,
+                "application": query.metadata.app_name,
+            },
         )
         return assigned_ref
 

--- a/python/ray/serve/context.py
+++ b/python/ray/serve/context.py
@@ -31,6 +31,7 @@ class ReplicaContext:
     replica_tag: ReplicaTag
     _internal_controller_name: str
     servable_object: Callable
+    app_name: str
 
 
 @PublicAPI(stability="alpha")
@@ -73,10 +74,11 @@ def _set_internal_replica_context(
     replica_tag: ReplicaTag,
     controller_name: str,
     servable_object: Callable,
+    app_name: str,
 ):
     global _INTERNAL_REPLICA_CONTEXT
     _INTERNAL_REPLICA_CONTEXT = ReplicaContext(
-        deployment, replica_tag, controller_name, servable_object
+        deployment, replica_tag, controller_name, servable_object, app_name
     )
 
 

--- a/python/ray/serve/context.py
+++ b/python/ray/serve/context.py
@@ -148,6 +148,7 @@ def _connect() -> ServeControllerClient:
 class RequestContext:
     route: str = ""
     request_id: str = ""
+    app_name: str = ""
 
 
 _serve_request_context = contextvars.ContextVar(

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -411,7 +411,6 @@ class ServeController:
         app_name: str = None,
     ) -> bool:
         """Deploys a deployment."""
-
         if route_prefix is not None:
             assert route_prefix.startswith("/")
         if docs_path is not None:

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -408,7 +408,9 @@ class ServeController:
         deployer_job_id: Union[str, bytes],
         docs_path: Optional[str] = None,
         is_driver_deployment: Optional[bool] = False,
-        app_name: str = None,
+        # For V1 API, application name is empty string.
+        # For V2 API, it is supposed to be SERVE_DEFAULT_APP_NAME
+        app_name: str = "",
     ) -> bool:
         """Deploys a deployment."""
         if route_prefix is not None:
@@ -432,7 +434,7 @@ class ServeController:
         updating = self.deployment_state_manager.deploy(name, deployment_info)
 
         if route_prefix is not None:
-            endpoint_info = EndpointInfo(route=route_prefix)
+            endpoint_info = EndpointInfo(route=route_prefix, app_name=app_name)
             self.endpoint_state.update_endpoint(name, endpoint_info)
         else:
             self.endpoint_state.delete_endpoint(name)

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -416,7 +416,8 @@ class ServeController:
         if docs_path is not None:
             assert docs_path.startswith("/")
 
-        # For V1 API, application name is empty string.
+        # For V1 API, application name is empty string. This is only for metrics
+        # purpose.
         # For V2 API, it is supposed to be SERVE_DEFAULT_APP_NAME by default
         if app_name is None:
             app_name = ""

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -408,15 +408,18 @@ class ServeController:
         deployer_job_id: Union[str, bytes],
         docs_path: Optional[str] = None,
         is_driver_deployment: Optional[bool] = False,
-        # For V1 API, application name is empty string.
-        # For V2 API, it is supposed to be SERVE_DEFAULT_APP_NAME
-        app_name: str = "",
+        app_name: str = None,
     ) -> bool:
         """Deploys a deployment."""
         if route_prefix is not None:
             assert route_prefix.startswith("/")
         if docs_path is not None:
             assert docs_path.startswith("/")
+
+        # For V1 API, application name is empty string.
+        # For V2 API, it is supposed to be SERVE_DEFAULT_APP_NAME by default
+        if app_name is None:
+            app_name = ""
 
         deployment_info = deploy_args_to_deployment_info(
             deployment_name=name,

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -416,9 +416,8 @@ class ServeController:
         if docs_path is not None:
             assert docs_path.startswith("/")
 
-        # For V1 API, application name is empty string. This is only for metrics
-        # purpose.
-        # For V2 API, it is supposed to be SERVE_DEFAULT_APP_NAME by default
+        # app_name is None for V1 API, reset it to empty string to avoid
+        # breaking metrics.
         if app_name is None:
             app_name = ""
 

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -408,6 +408,7 @@ class ServeController:
         deployer_job_id: Union[str, bytes],
         docs_path: Optional[str] = None,
         is_driver_deployment: Optional[bool] = False,
+        app_name: str = None,
     ) -> bool:
         """Deploys a deployment."""
 
@@ -423,6 +424,7 @@ class ServeController:
             deployer_job_id=deployer_job_id,
             previous_deployment=self.deployment_state_manager.get_deployment(name),
             is_driver_deployment=is_driver_deployment,
+            app_name=app_name,
         )
 
         # TODO(architkulkarni): When a deployment is redeployed, even if

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -133,7 +133,7 @@ class RayServeHandle:
                 "The number of handle.remote() calls that have been "
                 "made on this handle."
             ),
-            tag_keys=("handle", "deployment", "route"),
+            tag_keys=("handle", "deployment", "route", "application"),
         )
         self.request_counter.set_default_tags(
             {"handle": self.handle_tag, "deployment": self.deployment_name}
@@ -236,8 +236,14 @@ class RayServeHandle:
             call_method=handle_options.method_name,
             http_arg_is_pickled=self._pickled_http_request,
             route=_request_context.route,
+            app_name=_request_context.app_name,
         )
-        self.request_counter.inc(tags={"route": _request_context.route})
+        self.request_counter.inc(
+            tags={
+                "route": _request_context.route,
+                "application": _request_context.app_name,
+            }
+        )
         coro = self.router.assign_request(request_metadata, *args, **kwargs)
         return coro
 

--- a/python/ray/serve/metrics.py
+++ b/python/ray/serve/metrics.py
@@ -47,7 +47,7 @@ def _add_serve_metric_default_tags(default_tags: Dict[str, str]):
     replica_context = context.get_internal_replica_context()
     default_tags[DEPLOYMENT_TAG] = replica_context.deployment
     default_tags[REPLICA_TAG] = replica_context.replica_tag
-    if context.get_internal_replica_context().app_name:
+    if replica_context.app_name:
         default_tags[APPLICATION_TAG] = replica_context.app_name
     return default_tags
 

--- a/python/ray/serve/metrics.py
+++ b/python/ray/serve/metrics.py
@@ -4,21 +4,33 @@ from ray.serve import context
 
 DEPLOYMENT_TAG = "deployment"
 REPLICA_TAG = "replica"
+APPLICATION_TAG = "application"
 
 
-def _add_serve_metric_tags(tag_keys: Optional[Tuple[str]] = None):
+def _add_serve_metric_tags(tag_keys: Optional[Tuple[str]] = None) -> Tuple[str]:
     """Add serve context tags to the tag_keys"""
+    if tag_keys is None:
+        tag_keys = tuple()
+
+    # If the context doesn't exist, no serve tag is added.
     if context.get_internal_replica_context() is None:
         return tag_keys
+    # Check no collision with customer tag
     if DEPLOYMENT_TAG in tag_keys:
         raise ValueError(f"'{DEPLOYMENT_TAG}' tag is reserved for Ray Serve metrics")
     if REPLICA_TAG in tag_keys:
         raise ValueError(f"'{REPLICA_TAG}' tag is reserved for Ray Serve metrics")
+    if APPLICATION_TAG in tag_keys:
+        raise ValueError(f"'{APPLICATION_TAG}' tag is reserved for Ray Serve metrics")
+
     # Get serve tag inserted:
+    ray_serve_tags = (DEPLOYMENT_TAG, REPLICA_TAG)
+    if context.get_internal_replica_context().app_name:
+        ray_serve_tags += (APPLICATION_TAG,)
     if tag_keys:
-        tag_keys = (DEPLOYMENT_TAG, REPLICA_TAG) + tag_keys
+        tag_keys = ray_serve_tags + tag_keys
     else:
-        tag_keys = (DEPLOYMENT_TAG, REPLICA_TAG)
+        tag_keys = ray_serve_tags
     return tag_keys
 
 
@@ -30,9 +42,13 @@ def _add_serve_metric_default_tags(default_tags: Dict[str, str]):
         raise ValueError(f"'{DEPLOYMENT_TAG}' tag is reserved for Ray Serve metrics")
     if REPLICA_TAG in default_tags:
         raise ValueError(f"'{REPLICA_TAG}' tag is reserved for Ray Serve metrics")
+    if APPLICATION_TAG in default_tags:
+        raise ValueError(f"'{APPLICATION_TAG}' tag is reserved for Ray Serve metrics")
     replica_context = context.get_internal_replica_context()
     default_tags[DEPLOYMENT_TAG] = replica_context.deployment
     default_tags[REPLICA_TAG] = replica_context.replica_tag
+    if context.get_internal_replica_context().app_name:
+        default_tags[APPLICATION_TAG] = replica_context.app_name
     return default_tags
 
 
@@ -40,6 +56,10 @@ class Counter(metrics.Counter):
     def __init__(
         self, name: str, description: str = "", tag_keys: Optional[Tuple[str]] = None
     ):
+        if tag_keys and not isinstance(tag_keys, tuple):
+            raise TypeError(
+                "tag_keys should be a tuple type, got: " f"{type(tag_keys)}"
+            )
         tag_keys = _add_serve_metric_tags(tag_keys)
         super().__init__(name, description, tag_keys)
         self.set_default_tags({})
@@ -52,6 +72,10 @@ class Gauge(metrics.Gauge):
     def __init__(
         self, name: str, description: str = "", tag_keys: Optional[Tuple[str]] = None
     ):
+        if tag_keys and not isinstance(tag_keys, tuple):
+            raise TypeError(
+                "tag_keys should be a tuple type, got: " f"{type(tag_keys)}"
+            )
         tag_keys = _add_serve_metric_tags(tag_keys)
         super().__init__(name, description, tag_keys)
         self.set_default_tags({})
@@ -68,6 +92,10 @@ class Histogram(metrics.Histogram):
         boundaries: List[float] = None,
         tag_keys: Optional[Tuple[str]] = None,
     ):
+        if tag_keys and not isinstance(tag_keys, tuple):
+            raise TypeError(
+                "tag_keys should be a tuple type, got: " f"{type(tag_keys)}"
+            )
         tag_keys = _add_serve_metric_tags(tag_keys)
         super().__init__(name, description, boundaries, tag_keys)
         self.set_default_tags({})

--- a/python/ray/serve/tests/test_http_prefix_matching.py
+++ b/python/ray/serve/tests/test_http_prefix_matching.py
@@ -14,87 +14,89 @@ def mock_longest_prefix_router() -> LongestPrefixRouter:
 
 def test_no_match(mock_longest_prefix_router):
     router = mock_longest_prefix_router
-    router.update_routes({"endpoint": EndpointInfo(route="/hello")})
-    route, handle = router.match_route("/nonexistent")
-    assert route is None and handle is None
+    router.update_routes({"endpoint": EndpointInfo(route="/hello", app_name="")})
+    route, handle, app_name = router.match_route("/nonexistent")
+    assert route is None and handle is None and app_name is None
 
 
 def test_default_route(mock_longest_prefix_router):
     router = mock_longest_prefix_router
-    router.update_routes({"endpoint": EndpointInfo(route="/endpoint")})
+    router.update_routes({"endpoint": EndpointInfo(route="/endpoint", app_name="")})
 
-    route, handle = router.match_route("/nonexistent")
-    assert route is None and handle is None
+    route, handle, app_name = router.match_route("/nonexistent")
+    assert route is None and handle is None and app_name is None
 
-    route, handle = router.match_route("/endpoint")
-    assert route == "/endpoint" and handle == "endpoint"
+    route, handle, app_name = router.match_route("/endpoint")
+    assert route == "/endpoint" and handle == "endpoint" and app_name == ""
 
 
 def test_trailing_slash(mock_longest_prefix_router):
     router = mock_longest_prefix_router
     router.update_routes(
         {
-            "endpoint": EndpointInfo(route="/test"),
+            "endpoint": EndpointInfo(route="/test", app_name=""),
         }
     )
 
-    route, handle = router.match_route("/test/")
+    route, handle, _ = router.match_route("/test/")
     assert route == "/test" and handle == "endpoint"
 
     router.update_routes(
         {
-            "endpoint": EndpointInfo(route="/test/"),
+            "endpoint": EndpointInfo(route="/test/", app_name=""),
         }
     )
 
-    route, handle = router.match_route("/test")
-    assert route is None and handle is None
+    route, handle, app_name = router.match_route("/test")
+    assert route is None and handle is None and app_name is None
 
 
 def test_prefix_match(mock_longest_prefix_router):
     router = mock_longest_prefix_router
     router.update_routes(
         {
-            "endpoint1": EndpointInfo(route="/test/test2"),
-            "endpoint2": EndpointInfo(route="/test"),
-            "endpoint3": EndpointInfo(route="/"),
+            "endpoint1": EndpointInfo(route="/test/test2", app_name=""),
+            "endpoint2": EndpointInfo(route="/test", app_name=""),
+            "endpoint3": EndpointInfo(route="/", app_name=""),
         }
     )
 
-    route, handle = router.match_route("/test/test2/subpath")
+    route, handle, _ = router.match_route("/test/test2/subpath")
     assert route == "/test/test2" and handle == "endpoint1"
-    route, handle = router.match_route("/test/test2/")
+    route, handle, _ = router.match_route("/test/test2/")
     assert route == "/test/test2" and handle == "endpoint1"
-    route, handle = router.match_route("/test/test2")
+    route, handle, _ = router.match_route("/test/test2")
     assert route == "/test/test2" and handle == "endpoint1"
 
-    route, handle = router.match_route("/test/subpath")
+    route, handle, _ = router.match_route("/test/subpath")
     assert route == "/test" and handle == "endpoint2"
-    route, handle = router.match_route("/test/")
+    route, handle, _ = router.match_route("/test/")
     assert route == "/test" and handle == "endpoint2"
-    route, handle = router.match_route("/test")
+    route, handle, _ = router.match_route("/test")
     assert route == "/test" and handle == "endpoint2"
 
-    route, handle = router.match_route("/test2")
+    route, handle, _ = router.match_route("/test2")
     assert route == "/" and handle == "endpoint3"
-    route, handle = router.match_route("/")
+    route, handle, _ = router.match_route("/")
     assert route == "/" and handle == "endpoint3"
 
 
 def test_update_routes(mock_longest_prefix_router):
     router = mock_longest_prefix_router
-    router.update_routes({"endpoint": EndpointInfo(route="/endpoint")})
+    router.update_routes({"endpoint": EndpointInfo(route="/endpoint", app_name="app1")})
 
-    route, handle = router.match_route("/endpoint")
-    assert route == "/endpoint" and handle == "endpoint"
+    route, handle, app_name = router.match_route("/endpoint")
+    assert route == "/endpoint" and handle == "endpoint" and app_name == "app1"
 
-    router.update_routes({"endpoint2": EndpointInfo(route="/endpoint2")})
+    router.update_routes(
+        {"endpoint2": EndpointInfo(route="/endpoint2", app_name="app2")}
+    )
 
-    route, handle = router.match_route("/endpoint")
-    assert route is None and handle is None
+    route, handle, app_name = router.match_route("/endpoint")
+    assert route is None and handle is None and app_name is None
 
-    route, handle = router.match_route("/endpoint2")
-    assert route == "/endpoint2" and handle == "endpoint2"
+    route, handle, app_name = router.match_route("/endpoint2")
+    assert route == "/endpoint2" and handle == "endpoint2" and app_name == "app2"
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_long_poll.py
+++ b/python/ray/serve/tests/test_long_poll.py
@@ -182,8 +182,8 @@ def test_listen_for_change_java(serve_instance):
     assert poll_result_1.updated_objects["key_1"].object_snapshot.decode() == "999"
     request_2 = {"keys_to_snapshot_ids": {"ROUTE_TABLE": -1}}
     endpoints: Dict[EndpointTag, EndpointInfo] = dict()
-    endpoints["deployment_name"] = EndpointInfo(route="/test/xlang/poll")
-    endpoints["deployment_name1"] = EndpointInfo(route="/test/xlang/poll1")
+    endpoints["deployment_name"] = EndpointInfo(route="/test/xlang/poll", app_name="")
+    endpoints["deployment_name1"] = EndpointInfo(route="/test/xlang/poll1", app_name="")
     ray.get(host.notify_changed.remote(LongPollNamespace.ROUTE_TABLE, endpoints))
     object_ref_2 = host.listen_for_change_java.remote(
         LongPollRequest(**request_2).SerializeToString()

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -193,6 +193,7 @@ def test_http_metrics_fields(serve_start_shutdown):
     assert len(num_requests) == 1
     assert num_requests[0]["route"] == "/fake_route"
     assert num_requests[0]["method"] == "GET"
+    assert num_requests[0]["application"] == ""
     print("serve_num_http_requests working as expected.")
 
     num_errors = get_metric_dictionaries("serve_num_http_error_requests")
@@ -215,6 +216,7 @@ def test_http_metrics_fields(serve_start_shutdown):
     assert num_deployment_errors[0]["deployment"] == "app_f"
     assert num_deployment_errors[0]["error_code"] == "500"
     assert num_deployment_errors[0]["method"] == "GET"
+    assert num_deployment_errors[0]["application"] == "app"
     print("serve_num_deployment_http_error_requests working as expected.")
 
 

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -219,6 +219,12 @@ def test_http_metrics_fields(serve_start_shutdown):
     assert num_deployment_errors[0]["application"] == "app"
     print("serve_num_deployment_http_error_requests working as expected.")
 
+    latency_metrics = get_metric_dictionaries("serve_http_request_latency_ms_sum")
+    assert len(latency_metrics) == 1
+    assert latency_metrics[0]["route"] == "/real_route"
+    assert latency_metrics[0]["application"] == "app"
+    print("serve_http_request_latency_ms working as expected.")
+
 
 def test_replica_metrics_fields(serve_start_shutdown):
     """Test replica metrics fields"""
@@ -261,6 +267,13 @@ def test_replica_metrics_fields(serve_start_shutdown):
     verify_metrics(start_metrics[1], expected_output)
 
     # Latency metrics
+    wait_for_condition(
+        lambda: len(
+            get_metric_dictionaries("serve_deployment_processing_latency_ms_count")
+        )
+        == 2,
+        timeout=20,
+    )
     for metric_name in [
         "serve_deployment_processing_latency_ms_count",
         "serve_deployment_processing_latency_ms_sum",
@@ -308,17 +321,26 @@ def test_replica_metrics_fields(serve_start_shutdown):
 
 class TestRequestContextMetrics:
     def _generate_metrics_summary(self, metrics):
-        """Generate "route" information from metrics.
+        """Generate "route", "application" information from metrics.
         Args:
             metrics: list of metrics, each item is a dictionary generated from
                 get_metric_dictionaries func.
-        Return: return a dictionary, key is deployment name, value is a set
-            including all routes.
+        Return: return a Tuple[dictionary, dictionary]
+            First dictionary: key is deployment name, value is a set
+            including all routes. string is to indicate the applicationn name.
+            Second dictionary: key is the deployment name, value is application name.
         """
-        metrics_summary = DefaultDict(set)
+        metrics_summary_route = DefaultDict(set)
+        metrics_summary_app = DefaultDict(str)
+
         for request_metrcis in metrics:
-            metrics_summary[request_metrcis["deployment"]].add(request_metrcis["route"])
-        return metrics_summary
+            metrics_summary_route[request_metrcis["deployment"]].add(
+                request_metrcis["route"]
+            )
+            metrics_summary_app[request_metrcis["deployment"]] = request_metrcis[
+                "application"
+            ]
+        return metrics_summary_route, metrics_summary_app
 
     def test_request_context_pass_for_http_proxy(self, serve_start_shutdown):
         """Test HTTP proxy passing request context"""
@@ -357,56 +379,46 @@ class TestRequestContextMetrics:
         )
 
         # Check replica qps & latency
-        qps_metrics = self._generate_metrics_summary(
+        qps_metrics_route, qps_metrics_app_name = self._generate_metrics_summary(
             get_metric_dictionaries("serve_deployment_request_counter")
         )
-        print(qps_metrics)
-        assert qps_metrics["app1_f"] == {"/app1"}
-        assert qps_metrics["app2_g"] == {"/app2"}
-        qps_metrics = self._generate_metrics_summary(
+        print(qps_metrics_route)
+        assert qps_metrics_route["app1_f"] == {"/app1"}
+        assert qps_metrics_route["app2_g"] == {"/app2"}
+        assert qps_metrics_app_name["app1_f"] == "app1"
+        assert qps_metrics_app_name["app2_g"] == "app2"
+        qps_metrics_route, qps_metrics_app_name = self._generate_metrics_summary(
             get_metric_dictionaries("serve_deployment_error_counter")
         )
-        assert qps_metrics["app3_h"] == {"/app3"}
-
-        latency_metrics = self._generate_metrics_summary(
-            get_metric_dictionaries("serve_deployment_processing_latency_ms_sum")
-        )
-        assert len(latency_metrics) == 3
-        assert latency_metrics["app1_f"] == {"/app1"}
-        assert latency_metrics["app2_g"] == {"/app2"}
-        assert latency_metrics["app3_h"] == {"/app3"}
+        assert qps_metrics_route["app3_h"] == {"/app3"}
+        assert qps_metrics_app_name["app3_h"] == "app3"
 
         # Check http proxy qps & latency
-        qps_metrics = get_metric_dictionaries("serve_num_http_requests")
-        len(qps_metrics) == 3
-        assert {metric["route"] for metric in qps_metrics} == {
-            "/app1",
-            "/app2",
-            "/app3",
-        }
+        for metric_name in [
+            "serve_num_http_requests",
+            "serve_http_request_latency_ms_sum",
+        ]:
+            metrics = get_metric_dictionaries(metric_name)
+            assert {metric["route"] for metric in metrics} == {
+                "/app1",
+                "/app2",
+                "/app3",
+            }
 
-        latency_metrics = get_metric_dictionaries("serve_http_request_latency_ms_sum")
-        assert {metric["route"] for metric in latency_metrics} == {
-            "/app1",
-            "/app2",
-            "/app3",
-        }
-
-        # Check handle qps
-        qps_metrics = self._generate_metrics_summary(
-            get_metric_dictionaries("serve_handle_request_counter")
-        )
-        assert qps_metrics["app1_f"] == {"/app1"}
-        assert qps_metrics["app2_g"] == {"/app2"}
-        assert qps_metrics["app3_h"] == {"/app3"}
-
-        # Check router qps
-        qps_metrics = self._generate_metrics_summary(
-            get_metric_dictionaries("serve_num_router_requests")
-        )
-        assert qps_metrics["app1_f"] == {"/app1"}
-        assert qps_metrics["app2_g"] == {"/app2"}
-        assert qps_metrics["app3_h"] == {"/app3"}
+        for metric_name in [
+            "serve_handle_request_counter",
+            "serve_num_router_requests",
+            "serve_deployment_processing_latency_ms_sum",
+        ]:
+            metrics_route, metrics_app_name = self._generate_metrics_summary(
+                get_metric_dictionaries("serve_handle_request_counter")
+            )
+            assert metrics_route["app1_f"] == {"/app1"}
+            assert metrics_route["app2_g"] == {"/app2"}
+            assert metrics_route["app3_h"] == {"/app3"}
+            assert metrics_app_name["app1_f"] == "app1"
+            assert metrics_app_name["app2_g"] == "app2"
+            assert metrics_app_name["app3_h"] == "app3"
 
     def test_request_context_pass_for_handle_passing(self, serve_start_shutdown):
         """Test handle passing contexts between replicas"""
@@ -453,12 +465,18 @@ class TestRequestContextMetrics:
             == 4,
             timeout=20,
         )
-        requests_metrics = self._generate_metrics_summary(
+        (
+            requests_metrics_route,
+            requests_metrics_app_name,
+        ) = self._generate_metrics_summary(
             get_metric_dictionaries("serve_deployment_request_counter")
         )
-        assert requests_metrics["app_G"] == {"/api", "/api2"}
-        assert requests_metrics["app_g1"] == {"/api"}
-        assert requests_metrics["app_g2"] == {"/api2"}
+        assert requests_metrics_route["app_G"] == {"/api", "/api2"}
+        assert requests_metrics_route["app_g1"] == {"/api"}
+        assert requests_metrics_route["app_g2"] == {"/api2"}
+        assert requests_metrics_app_name["app_G"] == "app"
+        assert requests_metrics_app_name["app_g1"] == "app"
+        assert requests_metrics_app_name["app_g2"] == "app"
 
     def test_customer_metrics_with_context(self, serve_start_shutdown):
         @serve.deployment
@@ -515,6 +533,7 @@ class TestRequestContextMetrics:
         counter_metrics[0]["my_runtime_tag"] == "100"
         counter_metrics[0]["replica"] == replica_tag
         counter_metrics[0]["deployment"] == deployment_name
+        counter_metrics[0]["application"] == "app"
 
         gauge_metrics = get_metric_dictionaries("my_gauge")
         assert len(counter_metrics) == 1
@@ -522,6 +541,7 @@ class TestRequestContextMetrics:
         gauge_metrics[0]["my_runtime_tag"] == "300"
         gauge_metrics[0]["replica"] == replica_tag
         gauge_metrics[0]["deployment"] == deployment_name
+        gauge_metrics[0]["application"] == "app"
 
         histogram_metrics = get_metric_dictionaries("my_histogram_sum")
         assert len(histogram_metrics) == 1
@@ -529,6 +549,7 @@ class TestRequestContextMetrics:
         histogram_metrics[0]["my_runtime_tag"] == "200"
         histogram_metrics[0]["replica"] == replica_tag
         histogram_metrics[0]["deployment"] == deployment_name
+        gauge_metrics[0]["application"] == "app"
 
     @pytest.mark.parametrize("use_actor", [False, True])
     def test_serve_metrics_outside_serve(self, use_actor, serve_start_shutdown):

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -170,6 +170,7 @@ message DeploymentInfo {
   string actor_name = 5;
   string version = 6;
   int64 end_time_ms = 7;
+  string app_name = 8;
 }
 
 // Wrap DeploymentInfo and route. The "" route value need to be convert to None/null.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add "application" tags into all necessary metrics.

- V1 API (.deploy()) metrics will have `application=""` tag value in all necessary metrics.
- Update all replica level metrics to use serve.util.metrics lib, so that we don't need to deal with serve context information explicitly.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
