### PR TITLE
[docs] fix link to data/data.html

### DIFF
--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -133,7 +133,7 @@ dataset_transformed = preprocessor.fit_transform(dataset=dataset)
             </code></pre>
               <div class="row" style="padding:16px;">
                 <div class="col-6">
-                  <a href="https://docs.ray.io/en/latest/data/datastream.html" target="_blank">Learn more </a> | <a href="https://docs.ray.io/en/latest/data/api/api.html" target="_blank"> API references</a>
+                  <a href="https://docs.ray.io/en/latest/data/data.html" target="_blank">Learn more </a> | <a href="https://docs.ray.io/en/latest/data/api/api.html" target="_blank"> API references</a>
                 </div>
                 <div class="col-6" style="display: flex; justify-content: flex-end;">
                     <a href="https://colab.research.google.com/github/ray-project/ray/blob/master/doc/source/data/examples/nyc_taxi_basic_processing.ipynb" target="_blank" style="color:black;">


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/34512  changed the link to `data/datastream.html`, which doesn't exist.

## Why are these changes needed?

Link was broken unintentionally. 

## Related issue number
(https://github.com/ray-project/ray/pull/34512)

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
