### PR TITLE
[CI][Bisect] Check flakiness by rerun the same commits multiple times

### DIFF
--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -48,7 +48,6 @@ def main(
             f"Concurrency input need to be a positive number, received: {concurrency}"
         )
     test = _get_test(test_name)
-    """
     pre_sanity_check = _sanity_check(test, passing_commit, failing_commit)
     if not pre_sanity_check:
         logger.info(
@@ -56,7 +55,6 @@ def main(
             " an external (not a code change) factors"
         )
         return
-    """
     commit_lists = _get_commit_lists(passing_commit, failing_commit)
     blamed_commit = _bisect(test, commit_lists, concurrency, flaky_rerun)
     logger.info(f"Blamed commit found for test {test_name}: {blamed_commit}")

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -28,7 +28,7 @@ from ray_release.wheels import find_and_wait_for_ray_wheels_url
     ),
 )
 @click.option(
-    "--flaky-repeat",
+    "--flaky-rerun",
     default=1,
     type=int,
     help=(
@@ -41,7 +41,7 @@ def main(
     passing_commit: str,
     failing_commit: str,
     concurrency: int = 1,
-    flaky_repeat: int = 1,
+    flaky_rerun: int = 1,
 ) -> None:
     if concurrency <= 0:
         raise ValueError(
@@ -56,15 +56,15 @@ def main(
         )
         return
     commit_lists = _get_commit_lists(passing_commit, failing_commit)
-    blamed_commit = _bisect(test, commit_lists, concurrency, flaky_repeat)
+    blamed_commit = _bisect(test, commit_lists, concurrency, flaky_rerun)
     logger.info(f"Blamed commit found for test {test_name}: {blamed_commit}")
 
 
 def _bisect(
-    test: Test, 
-    commit_list: List[str], 
-    concurrency: int, 
-    flaky_repeat: int,
+    test: Test,
+    commit_list: List[str],
+    concurrency: int,
+    flaky_rerun: int,
 ) -> str:
     while len(commit_list) > 2:
         logger.info(
@@ -78,11 +78,13 @@ def _bisect(
             # on the previously run revision
             idx = min(max(idx, 1), len(commit_list) - 2)
             idx_to_commit[idx] = commit_list[idx]
-        outcomes = _run_test(test, set(idx_to_commit.values()), flaky_repeat)
+        outcomes = _run_test(test, set(idx_to_commit.values()), flaky_rerun)
         passing_idx = 0
         failing_idx = len(commit_list) - 1
         for idx, commit in idx_to_commit.items():
-            is_passing = all(outcome == "passed" for outcome in outcomes[commit].values())
+            is_passing = all(
+                outcome == "passed" for outcome in outcomes[commit].values()
+            )
             if is_passing and idx > passing_idx:
                 passing_idx = idx
             if not is_passing and idx < failing_idx:
@@ -107,19 +109,19 @@ def _sanity_check(test: Test, passing_revision: str, failing_revision: str) -> b
     )
 
 
-def _run_test(test: Test, commits: Set[str], flaky_repeat: int) -> Dict[str, str]:
+def _run_test(test: Test, commits: Set[str], flaky_rerun: int) -> Dict[str, str]:
     logger.info(f'Running test {test["name"]} on commits {commits}')
     for commit in commits:
-        _trigger_test_run(test, commit, flaky_repeat)
-    return _obtain_test_result(commits, flaky_repeat)
+        _trigger_test_run(test, commit, flaky_rerun)
+    return _obtain_test_result(commits, flaky_rerun)
 
 
-def _trigger_test_run(test: Test, commit: str, flaky_repeat: int) -> None:
+def _trigger_test_run(test: Test, commit: str, flaky_rerun: int) -> None:
     ray_wheels_url = find_and_wait_for_ray_wheels_url(
         commit,
         timeout=DEFAULT_WHEEL_WAIT_TIMEOUT,
     )
-    for run in range(flaky_repeat):
+    for run in range(flaky_rerun):
         step = get_step(
             test,
             ray_wheels=ray_wheels_url,
@@ -128,7 +130,7 @@ def _trigger_test_run(test: Test, commit: str, flaky_repeat: int) -> None:
             },
         )
         step["label"] = f'{test["name"]}:{commit[:7]}-{run}'
-        step["key"] = f'{commit}-{run}'
+        step["key"] = f"{commit}-{run}"
         pipeline = subprocess.Popen(
             ["echo", json.dumps({"steps": [step]})], stdout=subprocess.PIPE
         )
@@ -138,16 +140,16 @@ def _trigger_test_run(test: Test, commit: str, flaky_repeat: int) -> None:
         pipeline.stdout.close()
 
 
-def _obtain_test_result(commits: Set[str], flaky_repeat: int) -> Dict[str, str]:
+def _obtain_test_result(commits: Set[str], flaky_rerun: int) -> Dict[str, str]:
     outcomes = {}
     wait = 5
     total_wait = 0
     while True:
         logger.info(f"... waiting for test result ...({total_wait} seconds)")
         for commit in commits:
-            if commit in outcomes and len(outcomes[commit]) == flaky_repeat:
+            if commit in outcomes and len(outcomes[commit]) == flaky_rerun:
                 continue
-            for run in range(flaky_repeat):
+            for run in range(flaky_rerun):
                 outcome = subprocess.check_output(
                     [
                         "buildkite-agent",
@@ -163,7 +165,9 @@ def _obtain_test_result(commits: Set[str], flaky_repeat: int) -> Dict[str, str]:
                         outcomes[commit] = {}
                     outcomes[commit][run] = outcome
         commit_finished = len(outcomes) == len(commits)
-        flaky_repeat_finished = all(len(outcome) == flaky_repeat for outcome in outcomes.values())
+        flaky_repeat_finished = all(
+            len(outcome) == flaky_rerun for outcome in outcomes.values()
+        )
         if commit_finished and flaky_repeat_finished:
             break
         time.sleep(wait)

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -160,10 +160,11 @@ def _obtain_test_result(commits: Set[str], flaky_rerun: int) -> Dict[str, str]:
                         f"{commit}-{run}",
                     ]
                 ).decode("utf-8")
-                if outcome:
-                    if commit not in outcomes:
-                        outcomes[commit] = {}
-                    outcomes[commit][run] = outcome
+                if not outcome:
+                    continue
+                if commit not in outcomes:
+                    outcomes[commit] = {}
+                outcomes[commit][run] = outcome
         commit_finished = len(outcomes) == len(commits)
         flaky_repeat_finished = all(
             len(outcome) == flaky_rerun for outcome in outcomes.values()

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -32,7 +32,7 @@ from ray_release.wheels import find_and_wait_for_ray_wheels_url
     default=1,
     type=int,
     help=(
-        "The number of time we re-run test on the same commit, to account for test "
+        "The number of time we run test on the same commit, to account for test "
         "flakiness. Commit passes only when it passes on all runs"
     ),
 )

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -29,7 +29,7 @@ from ray_release.wheels import find_and_wait_for_ray_wheels_url
 )
 @click.option(
     "--flaky-rerun",
-    default=2,
+    default=1,
     type=int,
     help=(
         "The number of time we re-run test on the same commit, to account for test "

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -31,7 +31,7 @@ def main(
     test_name: str,
     passing_commit: str,
     failing_commit: str,
-    concurrency: int = 1,
+    concurrency: Optional[int] = 1,
 ) -> None:
     if concurrency <= 0:
         raise ValueError(

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -48,6 +48,7 @@ def main(
             f"Concurrency input need to be a positive number, received: {concurrency}"
         )
     test = _get_test(test_name)
+    """
     pre_sanity_check = _sanity_check(test, passing_commit, failing_commit)
     if not pre_sanity_check:
         logger.info(
@@ -55,6 +56,7 @@ def main(
             " an external (not a code change) factors"
         )
         return
+    """
     commit_lists = _get_commit_lists(passing_commit, failing_commit)
     blamed_commit = _bisect(test, commit_lists, concurrency, flaky_rerun)
     logger.info(f"Blamed commit found for test {test_name}: {blamed_commit}")

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -31,7 +31,7 @@ def main(
     test_name: str,
     passing_commit: str,
     failing_commit: str,
-    concurrency: Optional[int] = 1,
+    concurrency: int = 1,
 ) -> None:
     if concurrency <= 0:
         raise ValueError(

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -29,7 +29,7 @@ from ray_release.wheels import find_and_wait_for_ray_wheels_url
 )
 @click.option(
     "--flaky-rerun",
-    default=1,
+    default=2,
     type=int,
     help=(
         "The number of time we re-run test on the same commit, to account for test "

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -3,7 +3,7 @@ import subprocess
 import os
 import json
 import time
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Set
 from ray_release.logger import logger
 from ray_release.buildkite.step import get_step
 from ray_release.config import (
@@ -27,11 +27,21 @@ from ray_release.wheels import find_and_wait_for_ray_wheels_url
         "capacity, but reduce the bisect duration"
     ),
 )
+@click.option(
+    "--flaky-repeat",
+    default=1,
+    type=int,
+    help=(
+        "The number of time we re-run test on the same commit, to account for test "
+        "flakiness. Commit passes only when it passes on all runs"
+    ),
+)
 def main(
     test_name: str,
     passing_commit: str,
     failing_commit: str,
-    concurrency: Optional[int] = 1,
+    concurrency: int = 1,
+    flaky_repeat: int = 1,
 ) -> None:
     if concurrency <= 0:
         raise ValueError(
@@ -46,11 +56,16 @@ def main(
         )
         return
     commit_lists = _get_commit_lists(passing_commit, failing_commit)
-    blamed_commit = _bisect(test, commit_lists, concurrency)
+    blamed_commit = _bisect(test, commit_lists, concurrency, flaky_repeat)
     logger.info(f"Blamed commit found for test {test_name}: {blamed_commit}")
 
 
-def _bisect(test: Test, commit_list: List[str], concurrency: int) -> str:
+def _bisect(
+    test: Test, 
+    commit_list: List[str], 
+    concurrency: int, 
+    flaky_repeat: int,
+) -> str:
     while len(commit_list) > 2:
         logger.info(
             f"Bisecting between {len(commit_list)} commits: "
@@ -63,11 +78,11 @@ def _bisect(test: Test, commit_list: List[str], concurrency: int) -> str:
             # on the previously run revision
             idx = min(max(idx, 1), len(commit_list) - 2)
             idx_to_commit[idx] = commit_list[idx]
-        outcomes = _run_test(test, set(idx_to_commit.values()))
+        outcomes = _run_test(test, set(idx_to_commit.values()), flaky_repeat)
         passing_idx = 0
         failing_idx = len(commit_list) - 1
         for idx, commit in idx_to_commit.items():
-            is_passing = outcomes[commit] == "passed"
+            is_passing = all(outcome == "passed" for outcome in outcomes[commit].values())
             if is_passing and idx > passing_idx:
                 passing_idx = idx
             if not is_passing and idx < failing_idx:
@@ -92,58 +107,64 @@ def _sanity_check(test: Test, passing_revision: str, failing_revision: str) -> b
     )
 
 
-def _run_test(test: Test, commits: Set[str]) -> Dict[str, str]:
+def _run_test(test: Test, commits: Set[str], flaky_repeat: int) -> Dict[str, str]:
     logger.info(f'Running test {test["name"]} on commits {commits}')
     for commit in commits:
-        _trigger_test_run(test, commit)
-    return _obtain_test_result(commits)
+        _trigger_test_run(test, commit, flaky_repeat)
+    return _obtain_test_result(commits, flaky_repeat)
 
 
-def _trigger_test_run(test: Test, commit: str) -> None:
+def _trigger_test_run(test: Test, commit: str, flaky_repeat: int) -> None:
     ray_wheels_url = find_and_wait_for_ray_wheels_url(
         commit,
         timeout=DEFAULT_WHEEL_WAIT_TIMEOUT,
     )
-    step = get_step(
-        test,
-        ray_wheels=ray_wheels_url,
-        env={
-            "RAY_COMMIT_OF_WHEEL": commit,
-        },
-    )
-    step["label"] = f'{test["name"]}:{commit[:7]}'
-    step["key"] = commit
-    pipeline = subprocess.Popen(
-        ["echo", json.dumps({"steps": [step]})], stdout=subprocess.PIPE
-    )
-    subprocess.check_output(
-        ["buildkite-agent", "pipeline", "upload"], stdin=pipeline.stdout
-    )
-    pipeline.stdout.close()
+    for run in range(flaky_repeat):
+        step = get_step(
+            test,
+            ray_wheels=ray_wheels_url,
+            env={
+                "RAY_COMMIT_OF_WHEEL": commit,
+            },
+        )
+        step["label"] = f'{test["name"]}:{commit[:7]}-{run}'
+        step["key"] = f'{commit}-{run}'
+        pipeline = subprocess.Popen(
+            ["echo", json.dumps({"steps": [step]})], stdout=subprocess.PIPE
+        )
+        subprocess.check_output(
+            ["buildkite-agent", "pipeline", "upload"], stdin=pipeline.stdout
+        )
+        pipeline.stdout.close()
 
 
-def _obtain_test_result(buildkite_step_keys: List[str]) -> Dict[str, str]:
+def _obtain_test_result(commits: Set[str], flaky_repeat: int) -> Dict[str, str]:
     outcomes = {}
     wait = 5
     total_wait = 0
     while True:
         logger.info(f"... waiting for test result ...({total_wait} seconds)")
-        for key in buildkite_step_keys:
-            if key in outcomes:
+        for commit in commits:
+            if commit in outcomes and len(outcomes[commit]) == flaky_repeat:
                 continue
-            outcome = subprocess.check_output(
-                [
-                    "buildkite-agent",
-                    "step",
-                    "get",
-                    "outcome",
-                    "--step",
-                    key,
-                ]
-            ).decode("utf-8")
-            if outcome:
-                outcomes[key] = outcome
-        if len(outcomes) == len(buildkite_step_keys):
+            for run in range(flaky_repeat):
+                outcome = subprocess.check_output(
+                    [
+                        "buildkite-agent",
+                        "step",
+                        "get",
+                        "outcome",
+                        "--step",
+                        f"{commit}-{run}",
+                    ]
+                ).decode("utf-8")
+                if outcome:
+                    if commit not in outcomes:
+                        outcomes[commit] = {}
+                    outcomes[commit][run] = outcome
+        commit_finished = len(outcomes) == len(commits)
+        flaky_repeat_finished = all(len(outcome) == flaky_repeat for outcome in outcomes.values())
+        if commit_finished and flaky_repeat_finished:
             break
         time.sleep(wait)
         total_wait = total_wait + wait

--- a/release/ray_release/tests/test_bisect.py
+++ b/release/ray_release/tests/test_bisect.py
@@ -1,31 +1,63 @@
 from unittest import mock
 from typing import List, Dict
-from ray_release.scripts.ray_bisect import _bisect
+from ray_release.scripts.ray_bisect import _bisect, _obtain_test_result
 from ray_release.config import Test
 
+
+def test_obtain_test_result():
+    test_cases = [
+        {
+            "c0": {0: "passed"},
+        },
+        {
+            "c0": {0: "passed", 1: "passed"},
+            "c1": {0: "hard_failed", 1: "hard_failed"},
+        },
+    ]
+
+    def _mock_check_output(input: List[str]) -> str:
+        commit, run = tuple(input[-1].split("-"))
+        return bytes(test_case[commit][int(run)], 'utf-8')
+
+    for test_case in test_cases:
+        with mock.patch(
+            "subprocess.check_output",
+            side_effect=_mock_check_output,
+        ):
+            commits = set(test_case.keys())
+            flaky_rerun = len(test_case[list(commits)[0]])
+            _obtain_test_result(commits, flaky_rerun) == test_case
 
 def test_bisect():
     test_cases = {
         "c3": {
-            "c0": "passed",
-            "c1": "passed",
-            "c3": "hard_failed",
-            "c4": "soft_failed",
+            "c0": {0: "passed"},
+            "c1": {0: "passed"},
+            "c3": {0: "hard_failed"},
+            "c4": {0: "soft_failed"},
         },
         "c1": {
-            "c0": "passed",
-            "c1": "hard_failed",
-            "c2": "hard_failed",
+            "c0": {0: "passed"},
+            "c1": {0: "hard_failed"},
+            "c2": {0: "hard_failed"},
         },
         "cc1": {
-            "cc0": "passed",
-            "cc1": "hard_failed",
+            "cc0": {0: "passed"},
+            "cc1": {0: "hard_failed"},
+        },
+        "c2": {
+            "c0": {0: "passed", 1: "passed"},
+            "c2": {0: "passed", 1: "hard_failed"},
+            "c3": {0: "hard_failed", 1: "passed"},
+            "c4": {0: "soft_failed", 1: "soft_failed"},
         },
     }
 
     for output, input in test_cases.items():
 
-        def _mock_run_test(test: Test, commit: List[str]) -> Dict[str, str]:
+        def _mock_run_test(
+            test: Test, commit: List[str], flaky_rerun
+        ) -> Dict[str, str]:
             return input
 
         with mock.patch(
@@ -33,4 +65,4 @@ def test_bisect():
             side_effect=_mock_run_test,
         ):
             for concurreny in range(1, 4):
-                assert _bisect({}, list(input.keys()), concurreny) == output
+                assert _bisect({}, list(input.keys()), concurreny, 1) == output

--- a/release/ray_release/tests/test_bisect.py
+++ b/release/ray_release/tests/test_bisect.py
@@ -17,7 +17,7 @@ def test_obtain_test_result():
 
     def _mock_check_output(input: List[str]) -> str:
         commit, run = tuple(input[-1].split("-"))
-        return bytes(test_case[commit][int(run)], 'utf-8')
+        return bytes(test_case[commit][int(run)], "utf-8")
 
     for test_case in test_cases:
         with mock.patch(
@@ -27,6 +27,7 @@ def test_obtain_test_result():
             commits = set(test_case.keys())
             flaky_rerun = len(test_case[list(commits)[0]])
             _obtain_test_result(commits, flaky_rerun) == test_case
+
 
 def test_bisect():
     test_cases = {

--- a/release/ray_release/tests/test_bisect.py
+++ b/release/ray_release/tests/test_bisect.py
@@ -25,8 +25,8 @@ def test_obtain_test_result():
             side_effect=_mock_check_output,
         ):
             commits = set(test_case.keys())
-            flaky_rerun = len(test_case[list(commits)[0]])
-            _obtain_test_result(commits, flaky_rerun) == test_case
+            rerun_per_commit = len(test_case[list(commits)[0]])
+            _obtain_test_result(commits, rerun_per_commit) == test_case
 
 
 def test_bisect():
@@ -57,7 +57,7 @@ def test_bisect():
     for output, input in test_cases.items():
 
         def _mock_run_test(
-            test: Test, commit: List[str], flaky_rerun
+            test: Test, commit: List[str], rerun_per_commit
         ) -> Dict[str, str]:
             return input
 

--- a/release/ray_release/wheels.py
+++ b/release/ray_release/wheels.py
@@ -347,7 +347,7 @@ def find_ray_wheels_url(
     # Else, this is a commit
     commit = commit_or_branch
     ray_version = get_ray_version(repo_url, commit)
-    branch = os.environ.get("BUILDKITE_BRANCH", DEFAULT_BRANCH)
+    branch = 'master' # os.environ.get("BUILDKITE_BRANCH", DEFAULT_BRANCH)
     wheels_url = get_ray_wheels_url(
         repo_url, branch, commit, ray_version, python_version
     )

--- a/release/ray_release/wheels.py
+++ b/release/ray_release/wheels.py
@@ -347,7 +347,7 @@ def find_ray_wheels_url(
     # Else, this is a commit
     commit = commit_or_branch
     ray_version = get_ray_version(repo_url, commit)
-    branch = 'master' # os.environ.get("BUILDKITE_BRANCH", DEFAULT_BRANCH)
+    branch = os.environ.get("BUILDKITE_BRANCH", DEFAULT_BRANCH)
     wheels_url = get_ray_wheels_url(
         repo_url, branch, commit, ray_version, python_version
     )


### PR DESCRIPTION
## Why are these changes needed?
This PR adds a new flag, called '--run-per-commit' that allows users to run the same commit several times. The semantic of this run is that all runs have to pass for a commit to be considered as passed.

Thanks @rickyyx for requesting this feature.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests - https://buildkite.com/ray-project/release-tests-bisect/builds/103