### PR TITLE
[CI] Fix team owner tag checking in CI script

### DIFF
--- a/ci/lint/check-bazel-team-owner.py
+++ b/ci/lint/check-bazel-team-owner.py
@@ -25,8 +25,13 @@ def perform_check(raw_xml_string: str):
     missing_owners = []
     for rule in tree.findall("rule"):
         test_name = rule.attrib["name"]
-        tags = [child.attrib["value"] for child in rule.find("list").getchildren()]
-        team_owner = [t for t in tags if t.startswith("team")]
+        tags = []
+        for lst in rule.findall("list"):
+            if lst.attrib["name"] != "tags":
+                continue
+            tags = [child.attrib["value"] for child in lst.getchildren()]
+            break
+        team_owner = [t for t in tags if t.startswith("team:")]
         if len(team_owner) == 0:
             missing_owners.append(test_name)
         owners[test_name] = team_owner


### PR DESCRIPTION
## Why are these changes needed?

- Check for all lists for with name of `tags`. It is not always the case where the first `<list>` are tags. For example, it can be `visibility`.
- Checks for prefix `team:` rather than just `team`, to be consistent with the error message.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
