### PR TITLE
[data] [strict mode] Allow returning lists instead of arrays for numpy batches

### DIFF
--- a/python/ray/data/_internal/planner/map_batches.py
+++ b/python/ray/data/_internal/planner/map_batches.py
@@ -62,7 +62,7 @@ def generate_map_batches_fn(
                             f"{type(value)}. To fix this issue, convert "
                             f"the {type(value)} to a `np.ndarray`."
                         )
-                    if not isinstance(value, np.ndarray):
+                    if isinstance(value, list):
                         # Try to convert list values into an numpy array via
                         # np.array(), so users don't need to manually cast.
                         # NOTE: we don't cast generic iterables, since types like

--- a/python/ray/data/_internal/planner/map_batches.py
+++ b/python/ray/data/_internal/planner/map_batches.py
@@ -1,6 +1,6 @@
 import collections
 from types import GeneratorType
-from typing import Callable, Iterator, Optional
+from typing import Callable, Iterable, Iterator, Optional
 
 from ray.data._internal.block_batching import batch_blocks
 from ray.data._internal.execution.interfaces import TaskContext
@@ -51,8 +51,8 @@ def generate_map_batches_fn(
                 )
 
             if isinstance(batch, collections.abc.Mapping):
-                for key, value in batch.items():
-                    if not isinstance(value, np.ndarray):
+                for key, value in list(batch.items()):
+                    if not isinstance(value, (np.ndarray, Iterable)):
                         raise ValueError(
                             f"Error validating {_truncated_repr(batch)}: "
                             "The `fn` you passed to `map_batches` returned a "
@@ -62,6 +62,15 @@ def generate_map_batches_fn(
                             f"{type(value)}. To fix this issue, convert "
                             f"the {type(value)} to a `numpy.ndarray`."
                         )
+                    if not isinstance(value, np.ndarray):
+                        # Try to convert iterable values into an numpy array via
+                        # np.array(), so users don't need to manually cast.
+                        try:
+                            batch[key] = np.array(value)
+                        except Exception:
+                            raise ValueError(
+                                "Failed to convert column values to numpy array: "
+                                f"({_truncated_repr(value)}).")
 
         def process_next_batch(batch: DataBatch) -> Iterator[Block]:
             # Apply UDF.

--- a/python/ray/data/_internal/planner/map_batches.py
+++ b/python/ray/data/_internal/planner/map_batches.py
@@ -70,7 +70,8 @@ def generate_map_batches_fn(
                         except Exception:
                             raise ValueError(
                                 "Failed to convert column values to numpy array: "
-                                f"({_truncated_repr(value)}).")
+                                f"({_truncated_repr(value)})."
+                            )
 
         def process_next_batch(batch: DataBatch) -> Iterator[Block]:
             # Apply UDF.

--- a/python/ray/data/_internal/planner/map_batches.py
+++ b/python/ray/data/_internal/planner/map_batches.py
@@ -1,6 +1,6 @@
 import collections
 from types import GeneratorType
-from typing import Callable, Iterable, Iterator, Optional
+from typing import Callable, Iterator, Optional
 
 from ray.data._internal.block_batching import batch_blocks
 from ray.data._internal.execution.interfaces import TaskContext
@@ -52,19 +52,21 @@ def generate_map_batches_fn(
 
             if isinstance(batch, collections.abc.Mapping):
                 for key, value in list(batch.items()):
-                    if not isinstance(value, (np.ndarray, Iterable)):
+                    if not isinstance(value, (np.ndarray, list)):
                         raise ValueError(
                             f"Error validating {_truncated_repr(batch)}: "
                             "The `fn` you passed to `map_batches` returned a "
                             f"`dict`. `map_batches` expects all `dict` values "
-                            f"to be of type `numpy.ndarray`, but the value "
+                            f"to be `list` or `np.ndarray` type, but the value "
                             f"corresponding to key {key!r} is of type "
                             f"{type(value)}. To fix this issue, convert "
-                            f"the {type(value)} to a `numpy.ndarray`."
+                            f"the {type(value)} to a `np.ndarray`."
                         )
                     if not isinstance(value, np.ndarray):
-                        # Try to convert iterable values into an numpy array via
+                        # Try to convert list values into an numpy array via
                         # np.array(), so users don't need to manually cast.
+                        # NOTE: we don't cast generic iterables, since types like
+                        # `str` are also Iterable.
                         try:
                             batch[key] = np.array(value)
                         except Exception:

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -414,7 +414,7 @@ class BlockAccessor(Generic[T]):
                 return ArrowBlockAccessor.numpy_to_block(
                     batch, passthrough_arrow_not_implemented_errors=True
                 )
-            except pa.ArrowNotImplementedError:
+            except (pa.ArrowNotImplementedError, pa.ArrowInvalid):
                 import pandas as pd
 
                 # TODO(ekl) once we support Python objects within Arrow blocks, we

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -88,6 +88,10 @@ def test_strict_convert_map_output(ray_start_regular_shared):
     ds = ray.data.range(1).map_batches(lambda x: {"id": [0, 1, 2, 3]}).materialize()
     assert ds.take_batch()["id"].tolist() == [0, 1, 2, 3]
 
+    with pytest.raises(ValueError):
+        # Strings not converted into array.
+        ray.data.range(1).map_batches(lambda x: {"id": "string"}).materialize()
+
     class UserObj:
         def __eq__(self, other):
             return isinstance(other, UserObj)

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -84,6 +84,18 @@ def test_strict_map_output(ray_start_regular_shared):
     ds.map(lambda x: UserDict({"x": object()})).materialize()
 
 
+def test_strict_convert_map_output(ray_start_regular_shared):
+    ds = ray.data.range(1).map_batches(lambda x: {"id": [0, 1, 2, 3]}).materialize()
+    assert ds.take_batch()["id"].tolist() == [0, 1, 2, 3]
+
+    class UserObj:
+        def __eq__(self, other):
+            return isinstance(other, UserObj)
+
+    ds = ray.data.range(1).map_batches(lambda x: {"id": [0, 1, 2, UserObj()]}).materialize()
+    assert ds.take_batch()["id"].tolist() == [0, 1, 2, UserObj()]
+
+
 def test_strict_default_batch_format(ray_start_regular_shared):
     ds = ray.data.range(1)
 

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -92,7 +92,11 @@ def test_strict_convert_map_output(ray_start_regular_shared):
         def __eq__(self, other):
             return isinstance(other, UserObj)
 
-    ds = ray.data.range(1).map_batches(lambda x: {"id": [0, 1, 2, UserObj()]}).materialize()
+    ds = (
+        ray.data.range(1)
+        .map_batches(lambda x: {"id": [0, 1, 2, UserObj()]})
+        .materialize()
+    )
     assert ds.take_batch()["id"].tolist() == [0, 1, 2, UserObj()]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Allow map_batches UDFs to return `{"foo": [1, 2, 3]}` in addition to `{"foo": np.array([1, 2, 3])}` by implicitly casting lists to arrays.