### PR TITLE
[core] Fix flickering progress bar due to overriden prints to StringIO

### DIFF
--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -3,6 +3,7 @@ import copy
 import json
 import logging
 import os
+import sys
 import threading
 import uuid
 from typing import Any, Dict, Iterable, Optional
@@ -37,6 +38,11 @@ def safe_print(*args, **kwargs):
     By default, the builtin print will be patched to this function when tqdm_ray is
     used. To disable this, set RAY_TQDM_PATCH_PRINT=0.
     """
+
+    # Ignore prints to StringIO objects, etc.
+    if kwargs.get("file") not in [sys.stdout, sys.stderr]:
+        return _print(*args, **kwargs)
+
     try:
         instance().hide_bars()
         _print(*args, **kwargs)

--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -40,7 +40,7 @@ def safe_print(*args, **kwargs):
     """
 
     # Ignore prints to StringIO objects, etc.
-    if kwargs.get("file") not in [sys.stdout, sys.stderr]:
+    if kwargs.get("file") not in [sys.stdout, sys.stderr, None]:
         return _print(*args, **kwargs)
 
     try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some modules are using print() to string buffers, which we unnecessarily intercept and hide/unhide our tqdm bars for. This causes flickering in the progress bar.