### PR TITLE
[CI][Jailed] Add jailed flag for release tests

### DIFF
--- a/release/ray_release/buildkite/filter.py
+++ b/release/ray_release/buildkite/filter.py
@@ -21,6 +21,7 @@ def filter_tests(
     frequency: Frequency,
     test_attr_regex_filters: Optional[Dict[str, str]] = None,
     prefer_smoke_tests: bool = False,
+    run_jailed_tests: bool = False,
 ) -> List[Tuple[Test, bool]]:
     if test_attr_regex_filters is None:
         test_attr_regex_filters = {}
@@ -34,6 +35,8 @@ def filter_tests(
                 attr_mismatch = True
                 break
         if attr_mismatch:
+            continue
+        if not run_jailed_tests and test.get('jailed', False):
             continue
 
         test_frequency = get_frequency(test["frequency"])

--- a/release/ray_release/buildkite/filter.py
+++ b/release/ray_release/buildkite/filter.py
@@ -36,7 +36,7 @@ def filter_tests(
                 break
         if attr_mismatch:
             continue
-        if not run_jailed_tests and test.get('jailed', False):
+        if not run_jailed_tests and test.get("jailed", False):
             continue
 
         test_frequency = get_frequency(test["frequency"])

--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -21,6 +21,9 @@
 				"stable": {
 					"type": "boolean"
 				},
+				"jailed": {
+					"type": "boolean"
+				},
 				"python": {
 					"type": "string",
 					"enum": [

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -50,11 +50,13 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
     is_flag=True,
     show_default=True,
     default=False,
-    help=(
-        "Will run jailed tests."
-    ),
+    help=("Will run jailed tests."),
 )
-def main(test_collection_file: Optional[str] = None, no_clone_repo: bool = False, run_jailed_tests: bool = False):
+def main(
+    test_collection_file: Optional[str] = None,
+    no_clone_repo: bool = False,
+    run_jailed_tests: bool = False,
+):
     settings = get_pipeline_settings()
 
     repo = settings["ray_test_repo"]
@@ -76,7 +78,7 @@ def main(test_collection_file: Optional[str] = None, no_clone_repo: bool = False
         logger.info(f"Cloning test repository: {clone_cmd}")
         try:
             subprocess.check_output(clone_cmd, shell=True)
-        except Exception as e
+        except Exception as e:
             raise ReleaseTestCLIError(
                 f"Could not clone test repository " f"{repo} (branch {branch}): {e}"
             ) from e

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -45,7 +45,16 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
         "(for internal use)."
     ),
 )
-def main(test_collection_file: Optional[str] = None, no_clone_repo: bool = False):
+@click.option(
+    "--run-jailed-tests",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help=(
+        "Will run jailed tests."
+    ),
+)
+def main(test_collection_file: Optional[str] = None, no_clone_repo: bool = False, run_jailed_tests: bool = False):
     settings = get_pipeline_settings()
 
     repo = settings["ray_test_repo"]
@@ -67,7 +76,7 @@ def main(test_collection_file: Optional[str] = None, no_clone_repo: bool = False
         logger.info(f"Cloning test repository: {clone_cmd}")
         try:
             subprocess.check_output(clone_cmd, shell=True)
-        except Exception as e:
+        except Exception as e
             raise ReleaseTestCLIError(
                 f"Could not clone test repository " f"{repo} (branch {branch}): {e}"
             ) from e
@@ -132,6 +141,7 @@ def main(test_collection_file: Optional[str] = None, no_clone_repo: bool = False
         frequency=frequency,
         test_attr_regex_filters=test_attr_regex_filters,
         prefer_smoke_tests=prefer_smoke_tests,
+        run_jailed_tests=run_jailed_tests,
     )
     logger.info(f"Found {len(filtered_tests)} tests to run.")
     if len(filtered_tests) == 0:


### PR DESCRIPTION
## Why are these changes needed?
The discussion about test policy, in particular, [jailed tests](https://docs.google.com/document/d/1hV8avu2Xl16Di3zVXyFtjuhZ8OGFDWhEt7Am319bki0/edit#heading=h.tdxb82dxifm7) seem to go well. I'm adding this flag now so we can start to jail some tests. Here is the policy of jailed tests:

- Tests are jailed if the corresponding issue tasks missed it SLA
- Jailed tests are skipped/non-blocking by default on automatic master run
- Jailed tests run/block by default on release + manually triggered runs

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests - will jailed some tests and test on top of this PR

https://buildkite.com/ray-project/release-tests-pr/builds/36193 - did not run the ray-data tests which are jailed