### PR TITLE
[Serve] Unset health replica stats when replica is under STOPPING

### DIFF
--- a/python/ray/serve/tests/test_standalone3.py
+++ b/python/ray/serve/tests/test_standalone3.py
@@ -197,6 +197,11 @@ def test_http_request_number_of_retries(ray_instance, crash):
     serve.shutdown()
 
 
+@pytest.mark.parametrize(
+    "ray_instance",
+    [],
+    indirect=True,
+)
 def test_replica_health_metric(ray_instance):
     """Test replica health metrics"""
 

--- a/python/ray/serve/tests/test_standalone3.py
+++ b/python/ray/serve/tests/test_standalone3.py
@@ -380,5 +380,43 @@ assert ray.get(handle.predict.remote(1)) == 1
     )
 
 
+def test_replica_health_metric(ray_instance):
+    """Test replica health metrics"""
+
+    @serve.deployment(num_replicas=2)
+    def f():
+        return "hello"
+
+    serve.run(f.bind())
+
+    def count_live_replica_metrics():
+        resp = requests.get("http://127.0.0.1:9999").text
+        resp = resp.split("\n")
+        count = 0
+        for metrics in resp:
+            if "# HELP" in metrics or "# TYPE" in metrics:
+                continue
+            if "serve_deployment_replica_healthy" in metrics:
+                if "1.0" in metrics:
+                    count += 1
+        return count
+
+    wait_for_condition(
+        lambda: count_live_replica_metrics() == 2, timeout=60, retry_interval_ms=500
+    )
+
+    # Add more replicas
+    serve.run(f.options(num_replicas=10).bind())
+    wait_for_condition(
+        lambda: count_live_replica_metrics() == 10, timeout=60, retry_interval_ms=500
+    )
+
+    # delete the application
+    serve.delete("default_f")
+    wait_for_condition(
+        lambda: count_live_replica_metrics() == 0, timeout=60, retry_interval_ms=500
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_standalone3.py
+++ b/python/ray/serve/tests/test_standalone3.py
@@ -22,6 +22,7 @@ from ray.cluster_utils import AutoscalingCluster
 from ray.exceptions import RayActorError
 from ray.serve._private.constants import (
     SYNC_HANDLE_IN_DAG_FEATURE_FLAG_ENV_KEY,
+    SERVE_DEFAULT_APP_NAME,
 )
 from ray.serve.context import get_global_client
 from ray.tests.conftest import call_ray_stop_only  # noqa: F401
@@ -218,19 +219,19 @@ def test_replica_health_metric(ray_instance):
         return count
 
     wait_for_condition(
-        lambda: count_live_replica_metrics() == 2, timeout=60, retry_interval_ms=500
+        lambda: count_live_replica_metrics() == 2, timeout=120, retry_interval_ms=500
     )
 
     # Add more replicas
     serve.run(f.options(num_replicas=10).bind())
     wait_for_condition(
-        lambda: count_live_replica_metrics() == 10, timeout=60, retry_interval_ms=500
+        lambda: count_live_replica_metrics() == 10, timeout=120, retry_interval_ms=500
     )
 
     # delete the application
-    serve.delete("default_f")
+    serve.delete(SERVE_DEFAULT_APP_NAME)
     wait_for_condition(
-        lambda: count_live_replica_metrics() == 0, timeout=60, retry_interval_ms=500
+        lambda: count_live_replica_metrics() == 0, timeout=120, retry_interval_ms=500
     )
     serve.shutdown()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Whenever stopping a replica, set the health stats of the replica to 0.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
