### PR TITLE
[Core] Shorten the membership checking time to 5 seconds.

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -267,7 +267,7 @@ RAY_CONFIG(int64_t, fetch_warn_timeout_milliseconds, 60000)
 /// object directory.
 RAY_CONFIG(int64_t, fetch_fail_timeout_milliseconds, 600000)
 
-/// Temporary workaround for https://github.com/ray-project/ray/pull/16402.
+/// Temporary workaround for https://gitsb.com/ray-project/ray/pull/16402.
 RAY_CONFIG(bool, yield_plasma_lock_workaround, true)
 
 // Whether to inline object status in serialized references.
@@ -799,8 +799,8 @@ RAY_CONFIG(bool, kill_idle_workers_of_terminated_job, true)
 // Example: RAY_preload_python_modules=tensorflow,pytorch
 RAY_CONFIG(std::vector<std::string>, preload_python_modules, {})
 
-// By default, raylet send a self liveness check to GCS every 60s
-RAY_CONFIG(int64_t, raylet_liveness_self_check_interval_ms, 60000)
+// By default, raylet send a self liveness check to GCS every 5s
+RAY_CONFIG(int64_t, raylet_liveness_self_check_interval_ms, 5000)
 
 // Instruct the CoreWorker to kill its child processes while
 // it exits. This prevents certain classes of resource leaks

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -267,7 +267,7 @@ RAY_CONFIG(int64_t, fetch_warn_timeout_milliseconds, 60000)
 /// object directory.
 RAY_CONFIG(int64_t, fetch_fail_timeout_milliseconds, 600000)
 
-/// Temporary workaround for https://gitsb.com/ray-project/ray/pull/16402.
+/// Temporary workaround for https://github.com/ray-project/ray/pull/16402.
 RAY_CONFIG(bool, yield_plasma_lock_workaround, true)
 
 // Whether to inline object status in serialized references.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

60 seconds are too long in case the GCS is restarted. This can unblock the problem when the GCS is restarted, raylets won't be killed. We will discuss the fundamental fix and follow up with it. 

## Related issue number

Address https://github.com/ray-project/ray/issues/34763 short term

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
