### PR TITLE
[Data] Fix nightly test import of pipelined_training.py

### DIFF
--- a/release/nightly_tests/dataset/pipelined_training.py
+++ b/release/nightly_tests/dataset/pipelined_training.py
@@ -14,7 +14,7 @@ from horovod.ray import RayExecutor
 
 from ray_shuffling_data_loader.data_generation import DATA_SPEC
 from ray_shuffling_data_loader.embedding_model import MyModel, annotation, huber_loss
-from ray.data.datastream_pipeline import DatasetPipeline
+from ray.data import DatasetPipeline
 
 # Training settings
 parser = argparse.ArgumentParser(description="Dataset ingestion Example")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The nightly test is failing ([link](https://buildkite.com/ray-project/release-tests-branch/builds/1596#0187a5e6-2b7a-4941-b4c3-2c3f2a246e8e)), with error:

```
Traceback (most recent call last):
  File "pipelined_training.py", line 17, in <module>
    from ray.data.datastream_pipeline import DatasetPipeline
ModuleNotFoundError: No module named 'ray.data.datastream_pipeline'
```

This PR is to fix the import.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
