### PR TITLE
[CI] Not upload test artifacts should be warnings

### DIFF
--- a/release/ray_release/command_runner/_anyscale_job_wrapper.py
+++ b/release/ray_release/command_runner/_anyscale_job_wrapper.py
@@ -65,7 +65,7 @@ def run_storage_cp(source: str, target: str):
         return False
 
     if not Path(source).exists():
-        logger.error(f"Couldn't upload to cloud storage: '{source}' does not exist.")
+        logger.warning(f"Couldn't upload to cloud storage: '{source}' does not exist.")
         return False
 
     storage_service = urlparse(target).scheme


### PR DESCRIPTION
## Why are these changes needed?
Some of the artifacts such as test output are not always available, and depends on the test implementation. So if the test output cannot be found, it should not be an error. Change it to warnings.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   