### PR TITLE
[CI] Deprecate sdk_runner and prod_v1 from OSS release tests

### DIFF
--- a/python/ray/autoscaler/aws/example-full.yaml
+++ b/python/ray/autoscaler/aws/example-full.yaml
@@ -45,6 +45,8 @@ provider:
     # Whether to allow node reuse. If set to False, nodes will be terminated
     # instead of stopped.
     cache_stopped_nodes: True # If not present, the default is True.
+    key_pair:
+        key_name: aws-cluster-launcher-test
 
 # How Ray will authenticate with newly launched nodes.
 auth:

--- a/python/ray/autoscaler/aws/example-minimal.yaml
+++ b/python/ray/autoscaler/aws/example-minimal.yaml
@@ -5,3 +5,5 @@ cluster_name: aws-example-minimal
 provider:
     type: aws
     region: us-west-2
+    key_pair:
+        key_name: aws-cluster-launcher-test

--- a/python/ray/autoscaler/aws/tests/aws_cluster.yaml
+++ b/python/ray/autoscaler/aws/tests/aws_cluster.yaml
@@ -9,6 +9,9 @@ provider:
     region: us-west-2
     cache_stopped_nodes: False
 
+key_pair:
+    key_name: aws-cluster-launcher-test
+
 available_node_types:
     ray.head.default:
         resources: {}

--- a/python/ray/autoscaler/aws/tests/aws_cluster.yaml
+++ b/python/ray/autoscaler/aws/tests/aws_cluster.yaml
@@ -16,4 +16,3 @@ available_node_types:
         resources: {}
         node_config:
             InstanceType: t3.large
-            IamInstanceProfile: {"Name": "ray-test-runner"}

--- a/python/ray/autoscaler/aws/tests/aws_cluster.yaml
+++ b/python/ray/autoscaler/aws/tests/aws_cluster.yaml
@@ -8,9 +8,8 @@ provider:
     type: aws
     region: us-west-2
     cache_stopped_nodes: False
-
-key_pair:
-    key_name: aws-cluster-launcher-test
+    key_pair:
+        key_name: aws-cluster-launcher-test
 
 available_node_types:
     ray.head.default:

--- a/python/ray/autoscaler/aws/tests/aws_cluster.yaml
+++ b/python/ray/autoscaler/aws/tests/aws_cluster.yaml
@@ -16,3 +16,4 @@ available_node_types:
         resources: {}
         node_config:
             InstanceType: t3.large
+            IamInstanceProfile: {"Name": "ray-test-runner"}

--- a/python/ray/autoscaler/aws/tests/aws_compute.yaml
+++ b/python/ray/autoscaler/aws/tests/aws_compute.yaml
@@ -1,4 +1,4 @@
-cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
 aws:

--- a/python/ray/autoscaler/aws/tests/aws_compute.yaml
+++ b/python/ray/autoscaler/aws/tests/aws_compute.yaml
@@ -1,4 +1,4 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
 region: us-west-2
 
 aws:

--- a/python/ray/autoscaler/aws/tests/aws_compute.yaml
+++ b/python/ray/autoscaler/aws/tests/aws_compute.yaml
@@ -2,7 +2,7 @@ cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
 aws:
-    IamInstanceProfile: {"Name": "ray-test-runner"}
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
 
 head_node_type:
     name: head_node

--- a/python/ray/autoscaler/aws/tests/aws_compute.yaml
+++ b/python/ray/autoscaler/aws/tests/aws_compute.yaml
@@ -2,7 +2,7 @@ cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
 aws:
-    IamInstanceProfile: {"Name": "anyscale-iam-role"}
+    IamInstanceProfile: {"Name": "ray-test-runner"}
 
 head_node_type:
     name: head_node

--- a/python/ray/autoscaler/aws/tests/aws_compute.yaml
+++ b/python/ray/autoscaler/aws/tests/aws_compute.yaml
@@ -2,7 +2,7 @@ cloud_id: cld_17WvYIBBkdgLwEUNcLeRAE
 region: us-west-2
 
 aws:
-    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+    IamInstanceProfile: {"Name": "anyscale-iam-role"}
 
 head_node_type:
     name: head_node

--- a/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
@@ -62,8 +62,6 @@ def download_ssh_key():
     print("======================================")
     print("Downloading ssh key...")
     # Create a Boto3 client to interact with S3
-    print(boto3.client('sts').get_caller_identity())
-
     s3_client = boto3.client("s3", region_name="us-west-2")
 
     # Set the name of the S3 bucket and the key to download

--- a/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
@@ -66,7 +66,7 @@ def download_ssh_key():
 
     # Set the name of the S3 bucket and the key to download
     bucket_name = "aws-cluster-launcher-test"
-    key_name = "aws_cluster_launcher-test.pem"
+    key_name = "aws-cluster-launcher-test.pem"
 
     # Download the key from the S3 bucket to a local file
     local_key_path = os.path.expanduser(f"~/.ssh/{key_name}")

--- a/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
@@ -70,6 +70,8 @@ def download_ssh_key():
 
     # Download the key from the S3 bucket to a local file
     local_key_path = os.path.expanduser(f"~/.ssh/{key_name}")
+    if not os.path.exists(os.path.dirname(local_key_path)):
+        os.makedirs(os.path.dirname(local_key_path))
     s3_client.download_file(bucket_name, key_name, local_key_path)
 
     # Set permissions on the key file

--- a/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
@@ -62,6 +62,8 @@ def download_ssh_key():
     print("======================================")
     print("Downloading ssh key...")
     # Create a Boto3 client to interact with S3
+    print(boto3.client('sts').get_caller_identity())
+
     s3_client = boto3.client("s3", region_name="us-west-2")
 
     # Set the name of the S3 bucket and the key to download

--- a/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/aws/tests/aws_launch_and_verify_cluster.py
@@ -65,8 +65,8 @@ def download_ssh_key():
     s3_client = boto3.client("s3", region_name="us-west-2")
 
     # Set the name of the S3 bucket and the key to download
-    bucket_name = "oss-release-test-ssh-keys"
-    key_name = "ray-autoscaler_59_us-west-2.pem"
+    bucket_name = "aws-cluster-launcher-test"
+    key_name = "aws_cluster_launcher-test.pem"
 
     # Download the key from the S3 bucket to a local file
     local_key_path = os.path.expanduser(f"~/.ssh/{key_name}")

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5969,7 +5969,6 @@
     timeout: 28800 # 8h
     prepare: bash prepare.sh
     script: python run_gcs_ft_on_k8s.py
-    type: sdk_command
 
 - name: aws_cluster_launcher
   group: cluster-launcher-test
@@ -5989,7 +5988,6 @@
   run:
     timeout: 1200
     script: cd tests && python aws_launch_and_verify_cluster.py aws_cluster.yaml
-    type: sdk_command
 
 - name: aws_cluster_launcher_minimal
   group: cluster-launcher-test
@@ -6009,7 +6007,6 @@
   run:
     timeout: 1200
     script: cd tests && python aws_launch_and_verify_cluster.py ../example-minimal.yaml
-    type: sdk_command
 
 - name: aws_cluster_launcher_full
   group: cluster-launcher-test
@@ -6029,4 +6026,3 @@
   run:
     timeout: 1200
     script: cd tests && python aws_launch_and_verify_cluster.py ../example-full.yaml
-    type: sdk_command

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5956,8 +5956,6 @@
   working_dir: k8s_tests
 
   stable: false
-  # TODO: Migrate this test to Anyscale Jobs / staging_v2
-  env: prod_v1
 
   frequency: nightly
   team: serve
@@ -5976,9 +5974,6 @@
 
   stable: true
 
-  # TODO: Migrate this test to Anyscale Jobs / staging_v2
-  env: prod_v1
-
   frequency: nightly
   team: core
   cluster:
@@ -5995,9 +5990,6 @@
 
   stable: true
 
-  # TODO: Migrate this test to Anyscale Jobs / staging_v2
-  env: prod_v1
-
   frequency: nightly
   team: core
   cluster:
@@ -6013,9 +6005,6 @@
   working_dir: ../python/ray/autoscaler/aws/
 
   stable: true
-
-  # TODO: Migrate this test to Anyscale Jobs / staging_v2
-  env: prod_v1
 
   frequency: nightly
   team: core


### PR DESCRIPTION
## Why are these changes needed?
That time has come. There are now no remaining OSS release tests using another type runner or another anyscale stack. Everything now runs on staging v2 through anyscale job submission.

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   