### PR TITLE
[data] [streaming] Fix backpressure when reading directly from input datasource

### DIFF
--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -40,6 +40,9 @@ from ray.data._internal.execution.interfaces import (
 )
 from ray.data._internal.execution.util import make_callable_class_concurrent
 
+# Warn about tasks larger than this.
+TASK_SIZE_WARN_THRESHOLD_BYTES = 100000
+
 
 def execute_to_legacy_block_iterator(
     executor: Executor,
@@ -200,7 +203,7 @@ def _blocks_to_input_buffer(blocks: BlockList, owns_blocks: bool) -> PhysicalOpe
             block_meta = read_task.get_metadata()
             task_size = len(cloudpickle.dumps(read_task))
             if block_meta.size_bytes is None or task_size > block_meta.size_bytes:
-                if task_size > 100000:
+                if task_size > TASK_SIZE_WARN_THRESHOLD_BYTES:
                     print(
                         f"WARNING: the read task size ({task_size} bytes) is larger "
                         "than the reported output size of the task "

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -199,7 +199,7 @@ def _blocks_to_input_buffer(blocks: BlockList, owns_blocks: bool) -> PhysicalOpe
         def cleaned_metadata(read_task):
             block_meta = read_task.get_metadata()
             task_size = len(cloudpickle.dumps(read_task))
-            if task_size > block_meta.size_bytes:
+            if block_meta.size_bytes is None or task_size > block_meta.size_bytes:
                 if task_size > 100000:
                     print(
                         f"WARNING: the read task size ({task_size} bytes) is larger "
@@ -207,7 +207,7 @@ def _blocks_to_input_buffer(blocks: BlockList, owns_blocks: bool) -> PhysicalOpe
                         f"({block_meta.size_bytes} bytes). This may be a size "
                         "reporting bug in the datasource being read from."
                     )
-                block_meta.size_bytes = max(block_meta.size_bytes, task_size)
+                block_meta.size_bytes = task_size
             return block_meta
 
         inputs = InputDataBuffer(

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -192,6 +192,23 @@ def _blocks_to_input_buffer(blocks: BlockList, owns_blocks: bool) -> PhysicalOpe
         read_tasks = blocks._tasks
         remote_args = blocks._remote_args
         assert all(isinstance(t, ReadTask) for t in read_tasks), read_tasks
+
+        # Defensively compute the size of the block as the max size reported by the
+        # datasource and the actual read task size. This is to guard against issues
+        # with bad metadata reporting.
+        def cleaned_metadata(read_task):
+            block_meta = read_task.get_metadata()
+            task_size = len(cloudpickle.dumps(read_task))
+            if task_size > block_meta.size_bytes:
+                if task_size > 100000:
+                    print(
+                        f"WARNING: the read task size ({task_size} bytes) is larger "
+                        "than the reported output size of the task "
+                        f"({block_meta.size_bytes} bytes). This may be a size reporting "
+                        "bug in the datasource being read from.")
+                block_meta.size_bytes = max(block_meta.size_bytes, task_size)
+            return block_meta
+
         inputs = InputDataBuffer(
             [
                 RefBundle(
@@ -200,20 +217,14 @@ def _blocks_to_input_buffer(blocks: BlockList, owns_blocks: bool) -> PhysicalOpe
                             # This isn't a proper block, but it's what we are doing
                             # in the legacy code.
                             ray.put(read_task),
-                            BlockMetadata(
-                                num_rows=1,
-                                size_bytes=len(cloudpickle.dumps(read_task)),
-                                schema=None,
-                                input_files=[],
-                                exec_stats=None,
-                            ),
+                            cleaned_metadata(read_task),
                         )
                     ],
                     owns_blocks=True,
                 )
                 for read_task in read_tasks
             ]
-        )
+         )
 
         for i in inputs._input_data:
             for b in i.blocks:

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -204,8 +204,9 @@ def _blocks_to_input_buffer(blocks: BlockList, owns_blocks: bool) -> PhysicalOpe
                     print(
                         f"WARNING: the read task size ({task_size} bytes) is larger "
                         "than the reported output size of the task "
-                        f"({block_meta.size_bytes} bytes). This may be a size reporting "
-                        "bug in the datasource being read from.")
+                        f"({block_meta.size_bytes} bytes). This may be a size "
+                        "reporting bug in the datasource being read from."
+                    )
                 block_meta.size_bytes = max(block_meta.size_bytes, task_size)
             return block_meta
 
@@ -224,7 +225,7 @@ def _blocks_to_input_buffer(blocks: BlockList, owns_blocks: bool) -> PhysicalOpe
                 )
                 for read_task in read_tasks
             ]
-         )
+        )
 
         for i in inputs._input_data:
             for b in i.blocks:

--- a/python/ray/data/tests/test_streaming_backpressure_edge_case.py
+++ b/python/ray/data/tests/test_streaming_backpressure_edge_case.py
@@ -36,7 +36,9 @@ def test_input_backpressure_e2e(restore_data_context, shutdown_only):
         def prepare_read(self, parallelism, n):
             def range_(i):
                 ray.get(self.counter.increment.remote())
-                return [pd.DataFrame({"data": np.ones((n // parallelism * 1024 * 1024,))})]
+                return [
+                    pd.DataFrame({"data": np.ones((n // parallelism * 1024 * 1024,))})
+                ]
 
             sz = (n // parallelism) * 1024 * 1024 * 8
             print("Block size", sz)

--- a/python/ray/data/tests/test_streaming_backpressure_edge_case.py
+++ b/python/ray/data/tests/test_streaming_backpressure_edge_case.py
@@ -1,12 +1,76 @@
 import pytest
 import time
+import pandas as pd
 import numpy as np
 
 import ray
 from ray._private.internal_api import memory_summary
+from ray.data.datasource import Datasource, ReadTask
+from ray.data.block import BlockMetadata
+from ray.data.tests.conftest import *  # noqa
+from ray.tests.conftest import *  # noqa
 
 
-def test_streaming_backpressure_e2e():
+def test_input_backpressure_e2e(restore_data_context, shutdown_only):
+
+    # Tests that backpressure applies even when reading directly from the input
+    # datasource. This relies on datasource metadata size estimation.
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            self.count = 0
+
+        def increment(self):
+            self.count += 1
+
+        def get(self):
+            return self.count
+
+        def reset(self):
+            self.count = 0
+
+    class CountingRangeDatasource(Datasource):
+        def __init__(self):
+            self.counter = Counter.remote()
+
+        def prepare_read(self, parallelism, n):
+            def range_(i):
+                ray.get(self.counter.increment.remote())
+                return [pd.DataFrame({"data": np.ones((n // parallelism * 1024 * 1024,))})]
+
+            sz = (n // parallelism) * 1024 * 1024 * 8
+            print("Block size", sz)
+
+            return [
+                ReadTask(
+                    lambda i=i: range_(i),
+                    BlockMetadata(
+                        num_rows=n // parallelism,
+                        size_bytes=sz,
+                        schema=None,
+                        input_files=None,
+                        exec_stats=None,
+                    ),
+                )
+                for i in range(parallelism)
+            ]
+
+    source = CountingRangeDatasource()
+    ctx = ray.data.DataContext.get_current()
+    ctx.execution_options.resource_limits.object_store_memory = 10e6
+
+    # 10GiB dataset.
+    ds = ray.data.read_datasource(source, n=10000, parallelism=1000)
+    it = ds.iter_batches(batch_size=None, prefetch_batches=0)
+    next(it)
+    time.sleep(3)
+    launched = ray.get(source.counter.get.remote())
+
+    # If backpressure is broken we'll launch 15+.
+    assert launched < 5, launched
+
+
+def test_streaming_backpressure_e2e(restore_data_context):
 
     # This test case is particularly challenging since there is a large input->output
     # increase in data size: https://github.com/ray-project/ray/issues/34041
@@ -21,7 +85,7 @@ def test_streaming_backpressure_e2e():
             return np.random.randn(1, 20, 1024, 1024)
 
     ctx = ray.init(object_store_memory=4e9)
-    ds = ray.data.range_tensor(20, shape=(3, 1024, 1024), parallelism=20)
+    ds = ray.data.range_tensor(20, shape=(3, 1024, 1024), parallelism=1000)
 
     pipe = ds.map_batches(
         TestFast,

--- a/python/ray/data/tests/test_streaming_backpressure_edge_case.py
+++ b/python/ray/data/tests/test_streaming_backpressure_edge_case.py
@@ -87,7 +87,7 @@ def test_streaming_backpressure_e2e(restore_data_context):
             return np.random.randn(1, 20, 1024, 1024)
 
     ctx = ray.init(object_store_memory=4e9)
-    ds = ray.data.range_tensor(20, shape=(3, 1024, 1024), parallelism=1000)
+    ds = ray.data.range_tensor(20, shape=(3, 1024, 1024), parallelism=20)
 
     pipe = ds.map_batches(
         TestFast,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The size_bytes of the input metadata was not properly included from read tasks. This meant we can easily launch too many tasks and go over the memory limit on reads of this type.

This bug only happens on code of the form:

`ds.read_datasource().iter_batches()`.

But it doesn't happen if there are any intermediate transformations, which hits a different code path that has correct metadata propagation.