### PR TITLE
Guard `packaging` import with fallback to `distutils`

### DIFF
--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -32,7 +32,6 @@
 
 import numbers
 import os
-from packaging.version import Version
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -56,6 +55,10 @@ except ImportError:
     # ABCIndexClass changed to ABCIndex in Pandas 1.3
     from pandas.core.dtypes.generic import ABCIndexClass as ABCIndex
 
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import LooseVersion as Version
 
 #############################################
 # Begin patching of ExtensionArrayFormatter #


### PR DESCRIPTION
When the `packaging` module is unavailable, fall back onto `distutils` as per the pattern in this PR: https://github.com/ray-project/ray/pull/28315

## Why are these changes needed?

Python versions < 3.10 will otherwise see an error on a vanilla install and import of Ray

## Related issue number

Closes issue: https://github.com/ray-project/ray/issues/34806

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
