### PR TITLE
[core] update ActorPool map/map_unordered to submit functions eagerly

### DIFF
--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -79,8 +79,12 @@ class ActorPool:
 
         for v in values:
             self.submit(fn, v)
-        while self.has_next():
-            yield self.get_next()
+
+        def get_generator():
+            while self.has_next():
+                yield self.get_next()
+
+        return get_generator()
 
     def map_unordered(self, fn: Callable[[Any], Any], values: List[Any]):
         """Similar to map(), but returning an unordered iterator.
@@ -116,8 +120,12 @@ class ActorPool:
 
         for v in values:
             self.submit(fn, v)
-        while self.has_next():
-            yield self.get_next_unordered()
+
+        def get_generator():
+            while self.has_next():
+                yield self.get_next_unordered()
+
+        return get_generator()
 
     def submit(self, fn, value):
         """Schedule a single task to run in the pool.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change makes it so that the rest of the code in `map` and `map_unordered` (in particular the `submit` logic) is executed eagerly. Without this change, all of the code in `map` and `map_unordered` will only be executed when the output generator is accessed (i.e. `next(results)`).
## Related issue number

<!-- For example: "Closes #1234" -->

Closes #34165

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
