### PR TITLE
[Data] Cooperatively exit producer threads for `iter_batches`

### DIFF
--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -1,7 +1,7 @@
 import logging
-import queue
 import threading
 from typing import Any, Callable, Iterator, List, Optional, Tuple, TypeVar, Union
+from collections import deque
 from contextlib import nullcontext
 
 import ray
@@ -230,7 +230,37 @@ def make_async_gen(
         def __init__(self, thread_index: int):
             self.thread_index = thread_index
 
-    output_queue = queue.Queue(1)
+    queue_size = 1
+    # The output queue shared across multiple threads.
+    output_queue = deque()
+    # The boolean varilable to indicate whether threads should exit.
+    threads_exit = False
+    # The semaphore for producer threads to add output batches to queue.
+    producer_semaphore = threading.Semaphore(queue_size)
+    # The semaphore for consumer thread (main thread) to get output batches from queue.
+    consumer_semaphore = threading.Semaphore(0)
+    # The mutex lock to guard access of `output_queue` and `threads_exit`.
+    mutex = threading.Lock()
+
+    # Put one item into `output_queue`. Block if queue is full.
+    # Return True if the thread should exit.
+    def put_to_queue(item: Any) -> bool:
+        producer_semaphore.acquire()
+        with mutex:
+            if threads_exit:
+                return True
+            else:
+                output_queue.append(item)
+        consumer_semaphore.release()
+        return False
+
+    # Get one item from `output_queue`. Block if queue is empty.
+    def get_from_queue() -> Any:
+        consumer_semaphore.acquire()
+        with mutex:
+            next_item = output_queue.popleft()
+        producer_semaphore.release()
+        return next_item
 
     # Because pulling from the base iterator cannot happen concurrently,
     # we must execute the expensive computation in a separate step which
@@ -238,11 +268,14 @@ def make_async_gen(
     def execute_computation(thread_index: int):
         try:
             for item in fn(thread_safe_generator):
-                output_queue.put(item, block=True)
-            output_queue.put(Sentinel(thread_index), block=True)
+                if put_to_queue(item):
+                    # Return early when it's instructed to do so.
+                    return
+            put_to_queue(Sentinel(thread_index))
         except Exception as e:
-            output_queue.put(e, block=True)
+            put_to_queue(e)
 
+    # Use separate threads to produce output batches.
     threads = [
         threading.Thread(target=execute_computation, args=(i,), daemon=True)
         for i in range(num_workers)
@@ -251,22 +284,32 @@ def make_async_gen(
     for thread in threads:
         thread.start()
 
+    # Use main thread to consume output batches.
     num_threads_finished = 0
-    while True:
-        next_item = output_queue.get(block=True)
-        if isinstance(next_item, Exception):
-            output_queue.task_done()
-            raise next_item
-        if isinstance(next_item, Sentinel):
-            output_queue.task_done()
-            logger.debug(f"Thread {next_item.thread_index} finished.")
+    try:
+        while True:
+            next_item = get_from_queue()
+            if isinstance(next_item, Exception):
+                raise next_item
+            if isinstance(next_item, Sentinel):
+                logger.debug(f"Thread {next_item.thread_index} finished.")
+                num_threads_finished += 1
+            else:
+                yield next_item
+            if num_threads_finished >= num_workers:
+                break
+    finally:
+        # Cooperatively exit all producer threads.
+        # This is to avoid these daemon threads hanging there with holding batches in
+        # memory, which can cause GRAM OOM easily. This can happen when caller breaks
+        # in the middle of iteration.
+        with mutex:
+            threads_exit = True
+        while num_threads_finished < num_workers:
+            # NOTE: After Python 3.9+, empty_semaphore.release(n) can be used to
+            # release all threads at once.
+            producer_semaphore.release()
             num_threads_finished += 1
-            threads[next_item.thread_index].join()
-        else:
-            yield next_item
-            output_queue.task_done()
-        if num_threads_finished >= num_workers:
-            break
 
 
 PREFETCHER_ACTOR_NAMESPACE = "ray.datastream"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is to fix the bug for `iter_batches` where producer daemon threads hanging there, and holding batches in memory, when caller breaks early during iteration. Example of caller like:

```py
for batch in ds.iter_batches():
  if ... :
    break
```

Change from using Python `queue.Queue`, to use a set of `Semaphore`, `Lock` and plain `deque` to allow cooperatively exit producer threads. I don't find how to achieve the same by using any classes of Python thread-safe `Queue`s, so roll my own version of producer-consumer queue here.

Also verified with user this PR fixed the GRAM OOM issue, by rerunning the workload with this PR.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Workload test on user workspace 
   - [ ] Release tests
   - [ ] This PR is not tested :(
