### PR TITLE
[rllib] Fix rlmodule_guide tensor spec

### DIFF
--- a/doc/source/rllib/doc_code/rlmodule_guide.py
+++ b/doc/source/rllib/doc_code/rlmodule_guide.py
@@ -1,13 +1,7 @@
 # flake8: noqa
 from ray.rllib.utils.annotations import override
-
-# TODO (Kourosh): Remove this when the location of the import is fixed.
-try:
-    from ray.rllib.models.specs.typing import SpecType
-    from ray.rllib.models.specs.specs_torch import TorchTensorSpec
-except ImportError:
-    from ray.rllib.core.models.specs.typing import SpecType
-    from ray.rllib.core.models.specs.specs_torch import TorchTensorSpec
+from ray.rllib.core.models.specs.typing import SpecType
+from rllib.core.models.specs.specs_base import TensorSpec
 
 
 # __enabling-rlmodules-in-configs-begin__
@@ -267,7 +261,7 @@ class DiscreteBCTorchModule(TorchRLModule):
         # and its value is a torch.Tensor with shape (b, h) where b is the
         # batch size (determined at run-time) and h is the hidden size
         # (fixed at 10).
-        return {"obs": TorchTensorSpec("b, h", h=10)}
+        return {"obs": TensorSpec("b, h", h=10, framework="torch")}
 
 
 # __extend-spec-checking-torch-specs-end__

--- a/doc/source/rllib/doc_code/rlmodule_guide.py
+++ b/doc/source/rllib/doc_code/rlmodule_guide.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from ray.rllib.utils.annotations import override
 from ray.rllib.core.models.specs.typing import SpecType
-from rllib.core.models.specs.specs_base import TensorSpec
+from ray.rllib.core.models.specs.specs_base import TensorSpec
 
 
 # __enabling-rlmodules-in-configs-begin__


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#34493 unified the tenosr specifications in rllib, but it missed a doc test, that has been failing since. This PR updates this doc test to use the new API.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
