### PR TITLE
[mac/arm64] Fix bazel install for mac arm64

### DIFF
--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -73,11 +73,14 @@ if [ "${BAZEL_CONFIG_ONLY-}" != "1" ]; then
       export PATH=$PATH:"$HOME/bin"
     fi
 
-    if [ "${architecture}" = "aarch64" ]; then
+    if [ "${architecture}" = "aarch64" ] || [ "${architecture}" = "arm64" ]; then
       # architecture is "aarch64", but the bazel tag is "arm64"
       url="https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-${platform}-arm64"
     elif [ "${architecture}" = "x86_64" ]; then
       url="https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-${platform}-amd64"
+    else
+      echo "Could not found matching bazelisk URL for platform ${platform} and architecture ${architecture}"
+      exit 1
     fi
 
     if [ "$INSTALL_USER" = "1" ]; then


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#34246 switched to using bazelisk for bazel installs, but an unbound variable error in the `install-bazel.sh` script:

```
install-bazel.sh: line 85: url: unbound variable
```

In result, bazel is not correctly installed, and the wheel build job fails.

The solution is to check for both `aarch64` and `arm64` in architecture types, which will result in the variable being set. We also raise a proper error if the URL cannot be constructed.

Lastly, it seems like bazel is occasionally found - I'm not completely where this happens, as it's on the same instance, and the previous job usually did not succeed. I'm wondering if it's manual intervention :-) Anyway, this PR should be fix the issue for now.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
