### PR TITLE
[ci/docker] Fix arm64 docker image builds by downgrading miniconda

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -29,6 +29,10 @@ RUN apt-get update -y \
 USER $RAY_UID
 ENV HOME=/home/ray
 
+# Todo (krfricke): Move to latest miniconda version once we stop building
+# images for Python 3.7.
+# https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${HOSTTYPE}.sh
+
 RUN sudo apt-get update -y && sudo apt-get upgrade -y \
     && sudo apt-get install -y \
         git \
@@ -44,7 +48,8 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
         openssh-client \
         gnupg; fi) \
     && wget \
-        --quiet "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${HOSTTYPE}.sh" \
+    https://repo.anaconda.com/miniconda/Miniconda3-py37_23.1.0-1-Linux-x86_64.sh
+        --quiet "https://repo.anaconda.com/miniconda/Miniconda3-py37_23.1.0-1-${HOSTTYPE}.sh" \
         -O /tmp/miniconda.sh \
     && /bin/bash /tmp/miniconda.sh -b -u -p $HOME/anaconda3 \
     && $HOME/anaconda3/bin/conda init \ 

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -48,7 +48,7 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
         openssh-client \
         gnupg; fi) \
     && wget \
-        --quiet "https://repo.anaconda.com/miniconda/Miniconda3-py37_23.1.0-1-${HOSTTYPE}.sh" \
+        --quiet "https://repo.anaconda.com/miniconda/Miniconda3-py37_23.1.0-1-Linux-${HOSTTYPE}.sh" \
         -O /tmp/miniconda.sh \
     && /bin/bash /tmp/miniconda.sh -b -u -p $HOME/anaconda3 \
     && $HOME/anaconda3/bin/conda init \ 

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -48,7 +48,6 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
         openssh-client \
         gnupg; fi) \
     && wget \
-    https://repo.anaconda.com/miniconda/Miniconda3-py37_23.1.0-1-Linux-x86_64.sh
         --quiet "https://repo.anaconda.com/miniconda/Miniconda3-py37_23.1.0-1-${HOSTTYPE}.sh" \
         -O /tmp/miniconda.sh \
     && /bin/bash /tmp/miniconda.sh -b -u -p $HOME/anaconda3 \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The latest release of miniconda ships with Python 3.8 as the base python. Trying to downgrade to Python 3.7 runs into unresolvable issues. Thus we pin miniconda until we stop building images for Python 3.7 (presumably once Python 3.7 is EOL, i.e. in ~2 months).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
