### PR TITLE
[doc] [data] Rename "Creating Datastreams" -> "Loading data", etc.

### DIFF
--- a/doc/source/data/api/datastream.rst
+++ b/doc/source/data/api/datastream.rst
@@ -77,7 +77,7 @@ Converting to Pipeline
    Datastream.repeat
    Datastream.window
 
-Consuming Datastreams
+Consuming Data
 ---------------------
 
 .. autosummary::

--- a/doc/source/data/consuming-datastreams.rst
+++ b/doc/source/data/consuming-datastreams.rst
@@ -1,7 +1,7 @@
 .. _consuming_datastreams:
 
 =====================
-Consuming Datastreams
+Consuming Data
 =====================
 
 The data underlying a ``Datastream`` can be consumed in several ways:
@@ -76,7 +76,7 @@ This is a common pattern useful for loading and sharding data between distribute
 
 .. _saving_datastreams:
 
-Saving Datastreams
+Saving Data
 ==================
 
 Datastreams can be written to local or remote storage in the desired data format.

--- a/doc/source/data/creating-datastreams.rst
+++ b/doc/source/data/creating-datastreams.rst
@@ -1,7 +1,7 @@
 .. _creating_datastreams:
 
 ====================
-Creating Datastreams
+Loading Data
 ====================
 
 :class:`Datastreams <ray.data.Datastream>` can be created from:

--- a/doc/source/data/examples/nyc_taxi_basic_processing.ipynb
+++ b/doc/source/data/examples/nyc_taxi_basic_processing.ipynb
@@ -591,7 +591,7 @@
    "id": "0ade2a72",
    "metadata": {},
    "source": [
-    "See {ref}`Transforming Datastreams <transforming_datastreams>` for more information on how we can process our data with Ray Data."
+    "See {ref}`Transforming Data <transforming_datastreams>` for more information on how we can process our data with Ray Data."
    ]
   },
   {

--- a/doc/source/data/getting-started.rst
+++ b/doc/source/data/getting-started.rst
@@ -47,7 +47,7 @@ Ray reads from any `filesystem supported by Arrow
 
 
 To learn more about creating datastreams, read
-:ref:`Creating datastreams <creating_datastreams>`.
+:ref:`Loading data <creating_datastreams>`.
 
 Transform the datastream
 ------------------------
@@ -83,7 +83,7 @@ transform datastreams. Ray executes transformations in parallel for performance.
 
 
 To learn more about transforming datastreams, read
-:ref:`Transforming datastreams <transforming_datastreams>`.
+:ref:`Transforming data <transforming_datastreams>`.
 
 Consume the datastream
 ----------------------
@@ -140,7 +140,7 @@ Pass datastreams to Ray tasks or actors, and access records with methods like
 
 
 To learn more about consuming datastreams, read
-:ref:`Consuming datastreams <consuming_datastreams>`.
+:ref:`Consuming data <consuming_datastreams>`.
 
 Save the datastream
 -------------------
@@ -162,7 +162,7 @@ or remote filesystems.
     ['..._000000.parquet']
 
 
-To learn more about saving datastream contents, read :ref:`Saving datastreams <saving_datastreams>`.
+To learn more about saving datastream contents, read :ref:`Saving data <saving_datastreams>`.
 
 Next Steps
 ----------

--- a/doc/source/data/key-concepts.rst
+++ b/doc/source/data/key-concepts.rst
@@ -39,7 +39,7 @@ Datastream uses Ray tasks to read data from remote storage in parallel. Each rea
 
 You can manually specify the number of read tasks, but the final parallelism is always capped by the number of files in the underlying datastream.
 
-For an in-depth guide on creating datastreams, read :ref:`Creating Datastreams <creating_datastreams>`.
+For an in-depth guide on creating datastreams, read :ref:`Loading Data <creating_datastreams>`.
 
 Transforming Data
 =================
@@ -56,7 +56,7 @@ pool of Ray actors. This allows you to cache expensive state initialization
 ..
   https://docs.google.com/drawings/d/12STHGV0meGWfdWyBlJMUgw7a-JcFPu9BwSOn5BjRw9k/edit
 
-For an in-depth guide on transforming datastreams, read :ref:`Transforming Datastreams <transforming_datastreams>`.
+For an in-depth guide on transforming datastreams, read :ref:`Transforming Data <transforming_datastreams>`.
 
 Shuffling Data
 ==============

--- a/doc/source/data/transforming-datastreams.rst
+++ b/doc/source/data/transforming-datastreams.rst
@@ -1,7 +1,7 @@
 .. _transforming_datastreams:
 
 ========================
-Transforming Datastreams
+Transforming Data
 ========================
 
 Datastreams transformations take in datastreams and produce new datastreams. For example, *map_batches*

--- a/doc/source/ray-air/computer-vision.rst
+++ b/doc/source/ray-air/computer-vision.rst
@@ -116,7 +116,7 @@ Reading image data
             :dedent:
 
 
-For more information on creating datastreams, see :ref:`Creating Datastreams <creating_datastreams>`.
+For more information on creating datastreams, see :ref:`Loading Data <creating_datastreams>`.
 
 
 Transforming images
@@ -157,7 +157,7 @@ standard way to preprocess data with Ray.
 
 For more information on transforming data, see
 :ref:`Using Preprocessors <air-preprocessors>` and
-:ref:`Transforming Datastreams <transforming_datastreams>`.
+:ref:`Transforming Data <transforming_datastreams>`.
 
 Training vision models
 ----------------------

--- a/doc/source/ray-overview/getting-started.md
+++ b/doc/source/ray-overview/getting-started.md
@@ -139,7 +139,7 @@ Use the trained model for batch prediction with a ``BatchPredictor``.
 Ray has a rich ecosystem of libraries and frameworks built on top of it. 
 Simply click on the dropdowns below to see examples of our most popular libraries.
 
-`````{dropdown} <img src="images/ray_svg_logo.svg" alt="ray" width="50px"> Data: Creating and Transforming Data
+`````{dropdown} <img src="images/ray_svg_logo.svg" alt="ray" width="50px"> Data: Distributed ML Preprocessing
 :animate: fade-in-slide-down
 
 Ray Data is the standard way to load and exchange data in Ray libraries and applications.

--- a/doc/source/ray-overview/getting-started.md
+++ b/doc/source/ray-overview/getting-started.md
@@ -139,7 +139,7 @@ Use the trained model for batch prediction with a ``BatchPredictor``.
 Ray has a rich ecosystem of libraries and frameworks built on top of it. 
 Simply click on the dropdowns below to see examples of our most popular libraries.
 
-`````{dropdown} <img src="images/ray_svg_logo.svg" alt="ray" width="50px"> Data: Creating and Transforming Datastreams
+`````{dropdown} <img src="images/ray_svg_logo.svg" alt="ray" width="50px"> Data: Creating and Transforming Data
 :animate: fade-in-slide-down
 
 Ray Data is the standard way to load and exchange data in Ray libraries and applications.

--- a/doc/source/ray-overview/getting-started.md
+++ b/doc/source/ray-overview/getting-started.md
@@ -139,7 +139,7 @@ Use the trained model for batch prediction with a ``BatchPredictor``.
 Ray has a rich ecosystem of libraries and frameworks built on top of it. 
 Simply click on the dropdowns below to see examples of our most popular libraries.
 
-`````{dropdown} <img src="images/ray_svg_logo.svg" alt="ray" width="50px"> Data: Creating and Transforming Data
+`````{dropdown} <img src="images/ray_svg_logo.svg" alt="ray" width="50px"> Data: Loading and Transforming Data
 :animate: fade-in-slide-down
 
 Ray Data is the standard way to load and exchange data in Ray libraries and applications.


### PR DESCRIPTION
New users shouldn't need to know about the internal concept name.