### PR TITLE
[Data] fix CI test failing with dashboard error

### DIFF
--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -329,13 +329,8 @@ def test_read_s3_file_error(shutdown_only, s3_path):
 # tests should only be carefully reordered to retain this invariant!
 
 
-def test_get_read_tasks(ray_start_cluster):
-    ray.shutdown()
-    cluster = ray_start_cluster
-    cluster.add_node(num_cpus=4)
-    cluster.add_node(num_cpus=4)
-    cluster.wait_for_nodes()
-    ray.init(cluster.address)
+def test_get_read_tasks(shutdown_only):
+    ray.init()
 
     head_node_id = ray.get_runtime_context().get_node_id()
 
@@ -346,9 +341,7 @@ def test_get_read_tasks(ray_start_cluster):
     def verify_get_read_tasks():
         from ray.experimental.state.api import list_tasks
 
-        task_states = list_tasks(
-            address=cluster.address, filters=[("name", "=", "_get_read_tasks")]
-        )
+        task_states = list_tasks(filters=[("name", "=", "_get_read_tasks")])
         # Verify only one task being executed on same node.
         assert len(task_states) == 1
         assert task_states[0]["name"] == "_get_read_tasks"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Deflake the CI test to not specify `cluster`. The stack trace is:

```
>       raise RuntimeError(message)
E       RuntimeError: The condition wasn't met before the timeout expired. Last exception: Traceback (most recent call last):
E         File "/ray/python/ray/_private/test_utils.py", line 528, in wait_for_condition
E           if condition_predictor(**kwargs):
E         File "/root/.cache/bazel/_bazel_root/5fe90af4e7d1ed9fcf52f59e39e126f5/execroot/com_github_ray_project_ray/bazel-out/k8-opt/bin/python/ray/data/test_formats.runfiles/com_github_ray_project_ray/python/ray/data/tests/test_formats.py", line 350, in verify_get_read_tasks
E           address=cluster.address, filters=[("name", "=", "_get_read_tasks")]
E         File "/ray/python/ray/experimental/state/api.py", line 1011, in list_tasks
E           return StateApiClient(address=address).list(
E         File "/ray/python/ray/experimental/state/api.py", line 145, in __init__
E           api_server_url = get_address_for_submission_client(address)
E         File "/ray/python/ray/dashboard/utils.py", line 653, in get_address_for_submission_client
E           address = ray_address_to_api_server_url(address)
E         File "/ray/python/ray/dashboard/utils.py", line 609, in ray_address_to_api_server_url
E           num_retries=20,
E         File "/ray/python/ray/_private/utils.py", line 1433, in internal_kv_get_with_retry
E           f"Could not read '{key.decode()}' from GCS. Did GCS start successfully?"
E       ConnectionError: Could not read 'dashboard' from GCS. Did GCS start successfully?
```
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
