### PR TITLE
[tune] Release test for durable multifile checkpoints

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1923,6 +1923,40 @@
 
   alert: tune_tests
 
+
+- name: tune_scalability_durable_multifile_checkpoints
+  group: Tune scalability tests
+  working_dir: tune_tests/scalability_tests
+
+  frequency: nightly
+  team: ml
+
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: tpl_16x2.yaml
+
+  run:
+    timeout: 900
+    script: python workloads/test_durable_multifile_checkpoints.py --bucket s3://tune-cloud-tests/scalability_durable_multifile_checkpoints
+    wait_for_nodes:
+      num_nodes: 16
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      run:
+        timeout: 900
+        script: python workloads/test_durable_multifile_checkpoints.py --bucket gs://tune-cloud-tests/scalability_durable_multifile_checkpoints
+        wait_for_nodes:
+          num_nodes: 16
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: tpl_gce_16x2.yaml
+
+  alert: tune_tests
+
 - name: tune_scalability_long_running_large_checkpoints
   group: Tune scalability tests
   working_dir: tune_tests/scalability_tests

--- a/release/tune_tests/scalability_tests/workloads/test_durable_multifile_checkpoints.py
+++ b/release/tune_tests/scalability_tests/workloads/test_durable_multifile_checkpoints.py
@@ -1,0 +1,51 @@
+"""Durable trainable with multi-file checkpoints (16 trials, checkpoint to cloud)
+
+In this run, we will start 16 trials on a cluster. The trials create 8 files a
+2 MB checkpoints every 6 seconds and should only keep 1 of these. This test
+ensures that durable checkpoints don't slow down experiment progress too much.
+
+Cluster: cluster_16x2.yaml
+
+Test owner: krfricke
+
+Acceptance criteria: Should run faster than 500 seconds.
+
+Theoretical minimum time: 300 seconds
+"""
+import argparse
+
+import ray
+
+from ray.tune.utils.release_test_util import timed_tune_run
+
+
+def main(bucket):
+    ray.init(address="auto")
+
+    num_samples = 16
+    results_per_second = 10 / 60  # 10 results per minute = 1 every 6 seconds
+    trial_length_s = 300
+
+    max_runtime = 650
+
+    timed_tune_run(
+        name="durable multi-file checkpoints",
+        num_samples=num_samples,
+        results_per_second=results_per_second,
+        trial_length_s=trial_length_s,
+        max_runtime=max_runtime,
+        checkpoint_freq_s=6,  # Once every 6 seconds (once per result)
+        checkpoint_size_b=int(2 * 1000**2),  # 2 MB
+        checkpoint_num_files=8,
+        keep_checkpoints_num=1,
+        resources_per_trial={"cpu": 2},
+        storage_path=bucket,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bucket", type=str, help="Bucket name")
+    args, _ = parser.parse_known_args()
+
+    main(args.bucket or "ray-tune-scalability-test")

--- a/release/tune_tests/scalability_tests/workloads/test_durable_multifile_checkpoints.py
+++ b/release/tune_tests/scalability_tests/workloads/test_durable_multifile_checkpoints.py
@@ -1,14 +1,14 @@
 """Durable trainable with multi-file checkpoints (16 trials, checkpoint to cloud)
 
-In this run, we will start 16 trials on a cluster. The trials create 8 files a
-2 MB checkpoints every 6 seconds and should only keep 1 of these. This test
+In this run, we will start 16 trials on a cluster. The trials create 16 files a
+1 MB checkpoints every 12 seconds and should only keep 2 of these. This test
 ensures that durable checkpoints don't slow down experiment progress too much.
 
 Cluster: cluster_16x2.yaml
 
 Test owner: krfricke
 
-Acceptance criteria: Should run faster than 500 seconds.
+Acceptance criteria: Should run faster than 750 seconds.
 
 Theoretical minimum time: 300 seconds
 """
@@ -23,10 +23,10 @@ def main(bucket):
     ray.init(address="auto")
 
     num_samples = 16
-    results_per_second = 10 / 60  # 10 results per minute = 1 every 6 seconds
+    results_per_second = 5 / 60  # 5 results per minute = 1 every 12 seconds
     trial_length_s = 300
 
-    max_runtime = 650
+    max_runtime = 750
 
     timed_tune_run(
         name="durable multi-file checkpoints",
@@ -34,9 +34,9 @@ def main(bucket):
         results_per_second=results_per_second,
         trial_length_s=trial_length_s,
         max_runtime=max_runtime,
-        checkpoint_freq_s=6,  # Once every 6 seconds (once per result)
-        checkpoint_size_b=int(2 * 1000**2),  # 2 MB
-        checkpoint_num_files=8,
+        checkpoint_freq_s=12,  # Once every 12 seconds (once per result)
+        checkpoint_size_b=int(1 * 1000**2),  # 1 MB
+        checkpoint_num_files=16,
         keep_checkpoints_num=2,
         resources_per_trial={"cpu": 2},
         storage_path=bucket,

--- a/release/tune_tests/scalability_tests/workloads/test_durable_multifile_checkpoints.py
+++ b/release/tune_tests/scalability_tests/workloads/test_durable_multifile_checkpoints.py
@@ -37,7 +37,7 @@ def main(bucket):
         checkpoint_freq_s=6,  # Once every 6 seconds (once per result)
         checkpoint_size_b=int(2 * 1000**2),  # 2 MB
         checkpoint_num_files=8,
-        keep_checkpoints_num=1,
+        keep_checkpoints_num=2,
         resources_per_trial={"cpu": 2},
         storage_path=bucket,
     )

--- a/release/tune_tests/scalability_tests/workloads/test_durable_multifile_checkpoints.py
+++ b/release/tune_tests/scalability_tests/workloads/test_durable_multifile_checkpoints.py
@@ -1,7 +1,7 @@
 """Durable trainable with multi-file checkpoints (16 trials, checkpoint to cloud)
 
 In this run, we will start 16 trials on a cluster. The trials create 16 files a
-1 MB checkpoints every 12 seconds and should only keep 2 of these. This test
+1 MB checkpoints every 12 seconds and should only keep 2 checkpoints. This test
 ensures that durable checkpoints don't slow down experiment progress too much.
 
 Cluster: cluster_16x2.yaml


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We are currently only testing single-file checkpoints. However, there have been performance regressions with multi-file checkpoints due to unthreaded uploads in pyarrow. These have since been resolved, but we should collect metrics to catch future regressions.

When comparing against a [version where the improvements have been reverted](https://github.com/ray-project/ray/pull/34861), we observe significant improvements in runtime:

```
2023-04-28 06:52:38,151	INFO tune.py:1011 -- Total run time: 362.95 seconds (337.86 seconds for the tuning loop).
```

vs.

```
2023-04-28 06:54:57,166	INFO tune.py:1011 -- Total run time: 472.55 seconds (436.54 seconds for the tuning loop).
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
