### PR TITLE
Replace deprecated usage of get_runtime_context().node_id

### DIFF
--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -588,7 +588,7 @@ def test_pull_bundle_deadlock(ray_start_cluster):
 
     @ray.remote(num_cpus=0)
     def get_node_id():
-        return ray.get_runtime_context().node_id
+        return ray.get_runtime_context().get_node_id()
 
     worker_node_1_id = ray.get(
         get_node_id.options(resources={"worker_node_1": 0.1}).remote()

--- a/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
+++ b/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
@@ -97,7 +97,7 @@ def test_multi_node(start_cluster, option: str, source: str):
             import test_module
 
             test_module.one()
-            return ray.get_runtime_context().node_id
+            return ray.get_runtime_context().get_node_id()
 
     num_cpus = int(ray.available_resources()["CPU"])
     actors = [A.remote() for _ in range(num_cpus)]

--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -568,7 +568,7 @@ def test_demand_report_for_node_affinity_scheduling_strategy(
     @ray.remote(num_cpus=1)
     def f(sleep_s):
         time.sleep(sleep_s)
-        return ray.get_runtime_context().node_id
+        return ray.get_runtime_context().get_node_id()
 
     worker_node_id = ray.get(f.remote(0))
 
@@ -713,13 +713,13 @@ def test_data_locality_spilled_objects(
     def f():
         return (
             np.zeros(50 * 1024 * 1024, dtype=np.uint8),
-            ray.runtime_context.get_runtime_context().node_id,
+            ray.runtime_context.get_runtime_context().get_node_id(),
         )
 
     @ray.remote
     def check_locality(x):
         _, node_id = x
-        assert node_id == ray.runtime_context.get_runtime_context().node_id
+        assert node_id == ray.runtime_context.get_runtime_context().get_node_id()
 
     # Check locality works when dependent task is already submitted by the time
     # the upstream task finishes.

--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -211,7 +211,7 @@ def test_spillback(ray_start_cluster):
 
     @ray.remote
     def get_node_id():
-        return ray.get_runtime_context().node_id
+        return ray.get_runtime_context().get_node_id()
 
     @ray.remote
     def func(i, counter):
@@ -220,7 +220,7 @@ def test_spillback(ray_start_cluster):
             while True:
                 time.sleep(1)
         else:
-            return ray.get_runtime_context().node_id
+            return ray.get_runtime_context().get_node_id()
 
     refs = [func.remote(i, counter) for i in range(2)]
 

--- a/python/ray/workflow/tests/test_error_handling.py
+++ b/python/ray/workflow/tests/test_error_handling.py
@@ -165,7 +165,7 @@ def test_disable_auto_lineage_reconstruction(ray_start_cluster, tmp_path):
 
     @ray.remote
     def get_node_id():
-        return ray.get_runtime_context().node_id
+        return ray.get_runtime_context().get_node_id()
 
     lock_path = str(tmp_path / "lock")
 

--- a/release/jobs_tests/workloads/jobs_check_cuda_available.py
+++ b/release/jobs_tests/workloads/jobs_check_cuda_available.py
@@ -37,7 +37,7 @@ NUM_NODES = 2
 
 @ray.remote(num_cpus=1, scheduling_strategy="SPREAD")
 def get_node_id():
-    return ray.get_runtime_context().node_id
+    return ray.get_runtime_context().get_node_id()
 
 
 node_ids = set(ray.get([get_node_id.remote() for _ in range(100)]))

--- a/release/jobs_tests/workloads/jobs_remote_multi_node.py
+++ b/release/jobs_tests/workloads/jobs_remote_multi_node.py
@@ -23,7 +23,7 @@ NUM_NODES = 5
 
 @ray.remote(num_cpus=1)
 def get_node_id():
-    return ray.get_runtime_context().node_id
+    return ray.get_runtime_context().get_node_id()
 
 
 # Allow one fewer node in case a node fails to come up.

--- a/release/nightly_tests/stress_tests/test_state_api_scale.py
+++ b/release/nightly_tests/stress_tests/test_state_api_scale.py
@@ -262,7 +262,7 @@ def test_large_log_file(log_file_size_byte: int):
                 log_file_size_byte -= n
 
             sys.stdout.flush()
-            return ctx.hexdigest(), ray.get_runtime_context().node_id.hex()
+            return ctx.hexdigest(), ray.get_runtime_context().get_node_id()
 
     actor = LogActor.remote()
     expected_hash, node_id = ray.get(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
get_runtime_context().node_id is deprecated, use get_runtime_context().get_node_id() instead.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
