### PR TITLE
[CI][Bisect] Fix a bug in _run_test function

### DIFF
--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -109,7 +109,7 @@ def _sanity_check(test: Test, passing_revision: str, failing_revision: str) -> b
     )
 
 
-def _run_test(test: Test, commits: Set[str], run_per_commit: int) -> Dict[str, str]:
+def _run_test(test: Test, commits: Set[str], run_per_commit: int = 1) -> Dict[str, str]:
     logger.info(f'Running test {test["name"]} on commits {commits}')
     for commit in commits:
         _trigger_test_run(test, commit, run_per_commit)

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -104,8 +104,8 @@ def _sanity_check(test: Test, passing_revision: str, failing_revision: str) -> b
     )
     outcomes = _run_test(test, [passing_revision, failing_revision])
     return (
-        outcomes[passing_revision] == "passed"
-        and outcomes[failing_revision] != "passed"
+        outcomes[passing_revision][0] == "passed"
+        and outcomes[failing_revision][0] != "passed"
     )
 
 
@@ -140,7 +140,9 @@ def _trigger_test_run(test: Test, commit: str, run_per_commit: int) -> None:
         pipeline.stdout.close()
 
 
-def _obtain_test_result(commits: Set[str], run_per_commit: int) -> Dict[str, str]:
+def _obtain_test_result(
+    commits: Set[str], run_per_commit: int
+) -> Dict[str, Dict[str, str]]:
     outcomes = {}
     wait = 5
     total_wait = 0

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -109,7 +109,7 @@ def _sanity_check(test: Test, passing_revision: str, failing_revision: str) -> b
     )
 
 
-def _run_test(test: Test, commits: Set[str], run_per_commit: int = 1) -> Dict[str, str]:
+def _run_test(test: Test, commits: Set[str], run_per_commit: int = 1) -> Dict[str, Dict[int, str]]:
     logger.info(f'Running test {test["name"]} on commits {commits}')
     for commit in commits:
         _trigger_test_run(test, commit, run_per_commit)
@@ -142,7 +142,7 @@ def _trigger_test_run(test: Test, commit: str, run_per_commit: int) -> None:
 
 def _obtain_test_result(
     commits: Set[str], run_per_commit: int
-) -> Dict[str, Dict[str, str]]:
+) -> Dict[str, Dict[int, str]]:
     outcomes = {}
     wait = 5
     total_wait = 0

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -109,7 +109,9 @@ def _sanity_check(test: Test, passing_revision: str, failing_revision: str) -> b
     )
 
 
-def _run_test(test: Test, commits: Set[str], run_per_commit: int = 1) -> Dict[str, Dict[int, str]]:
+def _run_test(
+    test: Test, commits: Set[str], run_per_commit: int = 1
+) -> Dict[str, Dict[int, str]]:
     logger.info(f'Running test {test["name"]} on commits {commits}')
     for commit in commits:
         _trigger_test_run(test, commit, run_per_commit)

--- a/release/ray_release/tests/test_bisect.py
+++ b/release/ray_release/tests/test_bisect.py
@@ -5,13 +5,11 @@ from ray_release.config import Test
 
 
 def test_sanity_check():
-    def _mock_run_test(
-            test: Test, commit: List[str]
-        ) -> Dict[str, Dict[int, str]]:
-            return {
-                "passing_revision": {0: "passed"},
-                "failing_revision": {0: "failed"},
-            }
+    def _mock_run_test(test: Test, commit: List[str]) -> Dict[str, Dict[int, str]]:
+        return {
+            "passing_revision": {0: "passed"},
+            "failing_revision": {0: "failed"},
+        }
 
     with mock.patch(
         "ray_release.scripts.ray_bisect._run_test",

--- a/release/ray_release/tests/test_bisect.py
+++ b/release/ray_release/tests/test_bisect.py
@@ -1,7 +1,26 @@
 from unittest import mock
 from typing import List, Dict
-from ray_release.scripts.ray_bisect import _bisect, _obtain_test_result
+from ray_release.scripts.ray_bisect import _bisect, _obtain_test_result, _sanity_check
 from ray_release.config import Test
+
+
+def test_sanity_check():
+    def _mock_run_test(
+            test: Test, commit: List[str]
+        ) -> Dict[str, Dict[int, str]]:
+            return {
+                "passing_revision": {0: "passed"},
+                "failing_revision": {0: "failed"},
+            }
+
+    with mock.patch(
+        "ray_release.scripts.ray_bisect._run_test",
+        side_effect=_mock_run_test,
+    ):
+        assert _sanity_check({}, "passing_revision", "failing_revision")
+        assert not _sanity_check({}, "failing_revision", "passing_revision")
+        assert not _sanity_check({}, "passing_revision", "passing_revision")
+        assert not _sanity_check({}, "failing_revision", "failing_revision")
 
 
 def test_obtain_test_result():


### PR DESCRIPTION
## Why are these changes needed?
The run_per_commit needs a default value since the sanity_check function use it without passing that paramaters int.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- Testing Strategy
   - [X] Unit tests
   