### PR TITLE
[Data] fetch_local once for each object ref

### DIFF
--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -82,8 +82,11 @@ class ProgressBar:
         ref_to_result = {}
         remaining = refs
         t = threading.current_thread()
+        first = True
         while remaining:
-            done, remaining = ray.wait(remaining, fetch_local=True, timeout=0.1)
+            done, remaining = ray.wait(remaining, fetch_local=first, timeout=0.1)
+            if first:
+                first = False
             for ref, result in zip(done, ray.get(done)):
                 ref_to_result[ref] = result
             self.update(len(done))

--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -82,11 +82,15 @@ class ProgressBar:
         ref_to_result = {}
         remaining = refs
         t = threading.current_thread()
-        first = True
+        # Triggering fetch_local redundantly for the same object is slower.
+        # We only need to trigger the fetch_local once for each object,
+        # raylet will persist these fetch requests even after ray.wait returns.
+        # See https://github.com/ray-project/ray/issues/30375.
+        fetch_local = True
         while remaining:
-            done, remaining = ray.wait(remaining, fetch_local=first, timeout=0.1)
-            if first:
-                first = False
+            done, remaining = ray.wait(remaining, fetch_local=fetch_local, timeout=0.1)
+            if fetch_local:
+                fetch_local = False
             for ref, result in zip(done, ray.get(done)):
                 ref_to_result[ref] = result
             self.update(len(done))

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5714,7 +5714,7 @@
     cluster_compute: chaos_test/compute_template.yaml
 
   run:
-    timeout: 3600
+    timeout: 4200
     wait_for_nodes:
       num_nodes: 10
     prepare: python setup_chaos.py --no-start


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After #30375, ray.wait prefetches all the object refs and raylet persists those fetch requests even after ray.wait returns. As a result, for each object ref, we only need to fetch_local once. Triggering fetch_local redundantly is unnecessary and slower.

Before this PR, warm-up phase of `chaos_many_actors` takes 60 minutes and with this PR, it takes 20 minutes.

Also slightly increase the timeout of `chaos_many_actors` since we are running at the borderline. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #34719
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
