### PR TITLE
[CI] Fix missing team tag on test on Buildkite Requirements

### DIFF
--- a/release/BUILD
+++ b/release/BUILD
@@ -6,6 +6,9 @@ compile_pip_requirements(
     requirements_in = "requirements_buildkite.in",
     requirements_txt = "requirements_buildkite.txt",
     visibility = ["//visibility:private"],
+    tags = [
+            "team:core",
+        ],
 )
 
 test_srcs = glob(["**/*.py"])


### PR DESCRIPTION
## Why are these changes needed?

https://github.com/ray-project/ray/pull/34677 introduced a linter error.
This PR might help.

<img width="1098" alt="Screenshot 2023-04-29 at 12 00 41" src="https://user-images.githubusercontent.com/9356806/235319782-2859c086-ca89-4086-b9c8-3860a8320e76.png">
