### PR TITLE
Revert "[Core] Put pg state to kv store when pg rescheduling (#34467)"

### DIFF
--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -301,8 +301,6 @@ class GlobalState:
                 return "PENDING"
             elif state == gcs_utils.PlacementGroupTableData.CREATED:
                 return "CREATED"
-            elif state == gcs_utils.PlacementGroupTableData.RESCHEDULING:
-                return "RESCHEDULING"
             else:
                 return "REMOVED"
 

--- a/python/ray/tests/test_placement_group_failover.py
+++ b/python/ray/tests/test_placement_group_failover.py
@@ -2,7 +2,9 @@ import pytest
 import sys
 import ray
 import ray.cluster_utils
-from ray._private.test_utils import get_other_nodes, wait_for_condition
+from ray._private.test_utils import (
+    get_other_nodes,
+)
 
 MB = 1024 * 1024
 
@@ -54,73 +56,6 @@ def test_placement_group_failover_when_two_nodes_die(monkeypatch, ray_start_clus
             ).remote()
             object_ref = actor.value.remote()
             ray.get(object_ref, timeout=5)
-
-
-def test_gcs_restart_when_placement_group_failover(
-    ray_start_cluster_head_with_external_redis,
-):
-    @ray.remote(num_cpus=1)
-    class Actor(object):
-        def __init__(self):
-            self.n = 0
-
-        def value(self):
-            return self.n
-
-    cluster = ray_start_cluster_head_with_external_redis
-    num_nodes = 3
-    nodes = []
-    for _ in range(num_nodes - 1):
-        nodes.append(cluster.add_node(num_cpus=1))
-
-    # Make sure the placement group is ready.
-    bundles = [{"CPU": 1, "memory": 100 * MB} for _ in range(num_nodes)]
-    placement_group = ray.util.placement_group(
-        name="name", strategy="STRICT_SPREAD", bundles=bundles
-    )
-    assert placement_group.wait(5000)
-    actors = []
-    for i in range(num_nodes):
-        actor = Actor.options(
-            placement_group=placement_group,
-            placement_group_bundle_index=i,
-            max_restarts=-1,
-        ).remote()
-        object_ref = actor.value.remote()
-        ray.get(object_ref, timeout=5)
-        actors.append(actor)
-
-    # Simulate a node dead.
-    other_nodes = get_other_nodes(cluster, exclude_head=True)
-    cluster.remove_node(other_nodes[0])
-
-    # Make sure placement group state change to rescheduling.
-    def _check_pg_whether_be_reschedule():
-        table = ray.util.placement_group_table(placement_group)
-        return table["state"] == "RESCHEDULING"
-
-    wait_for_condition(
-        _check_pg_whether_be_reschedule, timeout=5, retry_interval_ms=1000
-    )
-
-    # Simulate gcs restart.
-    cluster.head_node.kill_gcs_server()
-    cluster.head_node.start_gcs_server()
-
-    cluster.add_node(num_cpus=1)
-    cluster.wait_for_nodes()
-
-    # Check placement gorup reschedule success after gcs server restart.
-    def _check_actor_with_pg_is_ready():
-        try:
-            for actor in actors:
-                object_ref = actor.value.remote()
-                ray.get(object_ref, timeout=5)
-            return True
-        except Exception:
-            return False
-
-    wait_for_condition(_check_actor_with_pg_is_ready, timeout=5, retry_interval_ms=1000)
 
 
 if __name__ == "__main__":

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -756,13 +756,11 @@ void GcsPlacementGroupManager::OnNodeDead(const NodeID &node_id) {
         iter->second->GetMutableStats()->set_scheduling_state(
             rpc::PlacementGroupStats::QUEUED);
         AddToPendingQueue(iter->second, 0);
-        RAY_CHECK_OK(gcs_table_storage_->PlacementGroupTable().Put(
-            iter->second->GetPlacementGroupID(),
-            iter->second->GetPlacementGroupTableData(),
-            [this](Status status) { SchedulePendingPlacementGroups(); }));
       }
     }
   }
+
+  SchedulePendingPlacementGroups();
 }
 
 void GcsPlacementGroupManager::OnNodeAdd(const NodeID &node_id) {
@@ -968,10 +966,7 @@ bool GcsPlacementGroupManager::RescheduleIfStillHasUnplacedBundles(
                       << placement_group->GetPlacementGroupID();
         placement_group->UpdateState(rpc::PlacementGroupTableData::RESCHEDULING);
         AddToPendingQueue(placement_group, 0);
-        RAY_CHECK_OK(gcs_table_storage_->PlacementGroupTable().Put(
-            placement_group->GetPlacementGroupID(),
-            placement_group->GetPlacementGroupTableData(),
-            [this](Status status) { SchedulePendingPlacementGroups(); }));
+        SchedulePendingPlacementGroups();
         return true;
       }
     }

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -462,7 +462,6 @@ TEST_F(GcsPlacementGroupManagerTest, TestReschedulingRetry) {
       placement_group->GetPlacementGroupID();
   mock_placement_group_scheduler_->bundles_on_dead_node_.push_back(0);
   gcs_placement_group_manager_->OnNodeDead(NodeID::FromRandom());
-  WaitUntilIoServiceDone();
   const auto &bundles =
       mock_placement_group_scheduler_->placement_groups_[0]->GetBundles();
   EXPECT_TRUE(NodeID::FromBinary(bundles[0]->GetMessage().node_id()).IsNil());
@@ -504,7 +503,6 @@ TEST_F(GcsPlacementGroupManagerTest, TestRescheduleWhenNodeDead) {
       placement_group->GetPlacementGroupID();
   mock_placement_group_scheduler_->bundles_on_dead_node_.push_back(0);
   gcs_placement_group_manager_->OnNodeDead(NodeID::FromRandom());
-  WaitUntilIoServiceDone();
   ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_[0]->GetPlacementGroupID(),
             placement_group->GetPlacementGroupID());
   const auto &bundles =


### PR DESCRIPTION
This reverts commit af018f6639f10393c030e93d9688201483c36623.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is the only pg change we made recently, so I assume it could be related. I am not 100% sure though. Let's revert and see how it goes.

<img width="962" alt="Screen Shot 2023-05-01 at 10 20 57 AM" src="https://user-images.githubusercontent.com/18510752/235495866-29b94a24-fe80-419f-a19b-aa235bc9eabc.png">

cc @larrylian 


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
