### PR TITLE
[CI] Make it visible on UI if we are running a jailed test

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -121,13 +121,16 @@ def get_step(
     if test.get("run", {}).get("type") == "client":
         step["agents"]["queue"] = str(RELEASE_QUEUE_CLIENT)
 
-    # If a test is not stable, allow to soft fail
+    # If a test is not stable or jailed, allow to soft fail
     stable = test.get("stable", True)
-    if not stable:
+    jailed = test.get("jailed", True)
+    full_label = ""
+    if not stable or jailed:
         step["soft_fail"] = True
-        full_label = "[unstable] "
-    else:
-        full_label = ""
+    if not stable:
+        full_label += "[unstable]"
+    if jailed:
+        full_label += "[jailed]"
 
     full_label += test["name"]
     if smoke_test:

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -123,9 +123,9 @@ def get_step(
 
     # If a test is not stable or jailed, allow to soft fail
     stable = test.get("stable", True)
-    jailed = test.get("jailed", True)
+    jailed = test.get("jailed", False)
     full_label = ""
-    if not stable or jailed:
+    if jailed or not stable:
         step["soft_fail"] = True
     if not stable:
         full_label += "[unstable]"

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -121,7 +121,7 @@ def get_step(
     if test.get("run", {}).get("type") == "client":
         step["agents"]["queue"] = str(RELEASE_QUEUE_CLIENT)
 
-    # If a test is not stable or jailed, allow to soft fail
+    # If a test is jailed or not stable, allow to soft fail
     stable = test.get("stable", True)
     jailed = test.get("jailed", False)
     full_label = ""


### PR DESCRIPTION
## Why are these changes needed?
Put the word "jailed" on the test title when running it. Also mark "jailed" test as soft_failed (show up as a different kind of red) so that it behaves similarly to a unstable test right now.


- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests