### PR TITLE
[CI] Fix some core shuffle tests 

### DIFF
--- a/release/nightly_tests/dask_on_ray/1tb_sort_compute.yaml
+++ b/release/nightly_tests/dask_on_ray/1tb_sort_compute.yaml
@@ -10,13 +10,13 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m5.8xlarge
+    instance_type: m6i.8xlarge
     resources:
       cpu: 8
 
 worker_node_types:
     - name: worker_node
-      instance_type: m5.8xlarge
+      instance_type: m6i.8xlarge
       min_workers: 32
       max_workers: 32
       use_spot: false

--- a/release/nightly_tests/dask_on_ray/1tb_sort_compute.yaml
+++ b/release/nightly_tests/dask_on_ray/1tb_sort_compute.yaml
@@ -10,13 +10,13 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: i3.8xlarge
+    instance_type: m5.8xlarge
     resources:
       cpu: 8
 
 worker_node_types:
     - name: worker_node
-      instance_type: i3.8xlarge
+      instance_type: m5.8xlarge
       min_workers: 32
       max_workers: 32
       use_spot: false

--- a/release/nightly_tests/dask_on_ray/chaos_dask_on_ray_stress_compute.yaml
+++ b/release/nightly_tests/dask_on_ray/chaos_dask_on_ray_stress_compute.yaml
@@ -10,11 +10,11 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: i3.8xlarge
+    instance_type: m5.8xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: i3.8xlarge
+      instance_type: m5.8xlarge
       min_workers: 20
       max_workers: 20
       use_spot: true

--- a/release/nightly_tests/dask_on_ray/chaos_dask_on_ray_stress_compute.yaml
+++ b/release/nightly_tests/dask_on_ray/chaos_dask_on_ray_stress_compute.yaml
@@ -10,11 +10,11 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m5.8xlarge
+    instance_type: m6i.8xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: m5.8xlarge
+      instance_type: m6i.8xlarge
       min_workers: 20
       max_workers: 20
       use_spot: true

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_sort_compute_template.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_sort_compute_template.yaml
@@ -10,6 +10,6 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: i3.8xlarge
+    instance_type: m5.8xlarge
 
 worker_node_types: []

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_sort_compute_template.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_sort_compute_template.yaml
@@ -10,6 +10,6 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m5.8xlarge
+    instance_type: m6i.8xlarge
 
 worker_node_types: []

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_stress_compute.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_stress_compute.yaml
@@ -10,11 +10,11 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: i3.8xlarge
+    instance_type: m5.8xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: i3.8xlarge
+      instance_type: m5.8xlarge
       min_workers: 20
       max_workers: 20
       use_spot: false

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_stress_compute.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_stress_compute.yaml
@@ -10,11 +10,11 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m5.8xlarge
+    instance_type: m6i.8xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: m5.8xlarge
+      instance_type: m6i.8xlarge
       min_workers: 20
       max_workers: 20
       use_spot: false

--- a/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
@@ -12,16 +12,16 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: i3.8xlarge
+    instance_type: m5.8xlarge
 
 worker_node_types:
     - name: memory_node
-      instance_type: i3.8xlarge
+      instance_type: m5.8xlarge
       min_workers: 20
       max_workers: 20
       use_spot: false
     - name: gpu_node
-      instance_type: i3.8xlarge
+      instance_type: m5.8xlarge
       min_workers: 4
       max_workers: 4
       use_spot: false

--- a/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
@@ -12,16 +12,16 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m5.8xlarge
+    instance_type: m6i.8xlarge
 
 worker_node_types:
     - name: memory_node
-      instance_type: m5.8xlarge
+      instance_type: m6i.8xlarge
       min_workers: 20
       max_workers: 20
       use_spot: false
     - name: gpu_node
-      instance_type: m5.8xlarge
+      instance_type: m6i.8xlarge
       min_workers: 4
       max_workers: 4
       use_spot: false

--- a/release/nightly_tests/shuffle/shuffle_compute_autoscaling.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_autoscaling.yaml
@@ -10,11 +10,11 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: i3.4xlarge
+    instance_type: m5.4xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: i3.4xlarge
+      instance_type: m5.4xlarge
       min_workers: 0
       max_workers: 19
       use_spot: false

--- a/release/nightly_tests/shuffle/shuffle_compute_autoscaling.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_autoscaling.yaml
@@ -10,11 +10,11 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m5.4xlarge
+    instance_type: m6i.4xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: m5.4xlarge
+      instance_type: m6i.4xlarge
       min_workers: 0
       max_workers: 19
       use_spot: false

--- a/release/nightly_tests/shuffle/shuffle_compute_multi.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_multi.yaml
@@ -12,12 +12,12 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m5.4xlarge # i3.4xlarge
+    instance_type: m6i.4xlarge
     resources: {"object_store_memory": 21474836480}
 
 worker_node_types:
     - name: worker_node2
-      instance_type: m5.4xlarge # i3.4xlarge
+      instance_type: m6i.4xlarge
       min_workers: 3
       max_workers: 3
       use_spot: false

--- a/release/nightly_tests/shuffle/shuffle_compute_multi.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_multi.yaml
@@ -12,12 +12,12 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: i3.4xlarge
+    instance_type: m5.4xlarge # i3.4xlarge
     resources: {"object_store_memory": 21474836480}
 
 worker_node_types:
     - name: worker_node2
-      instance_type: i3.4xlarge
+      instance_type: m5.4xlarge # i3.4xlarge
       min_workers: 3
       max_workers: 3
       use_spot: false

--- a/release/nightly_tests/shuffle/shuffle_compute_single.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_single.yaml
@@ -12,7 +12,7 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m5.4xlarge
+    instance_type: m6i.4xlarge
     resources: {"object_store_memory": 21474836480}
 
 worker_node_types: []

--- a/release/nightly_tests/shuffle/shuffle_compute_single.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_single.yaml
@@ -12,7 +12,7 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: i3.4xlarge
+    instance_type: m5.4xlarge
     resources: {"object_store_memory": 21474836480}
 
 worker_node_types: []


### PR DESCRIPTION
## Why are these changes needed?
Three core shuffle release tests are failing because i3 machine is deprecated.

The i3 machine is deprecated.  Change machines type to m6i. The difference between the two type machine is that i3 uses locally SSD while m6i uses EPS through network bandwidth. EPS seems to work just fine.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   -  https://buildkite.com/ray-project/release-tests-pr/builds/36856
   - https://buildkite.com/ray-project/release-tests-pr/builds/36867 (failed tests are currently failing on master)

Performance data:


**shuffle_20gb_with_state_api.aws**
```
NEW

time = 129.80361704
--
  | success = 1
  | perf_metrics = [{'perf_metric_name': 'state_api_extra_latency_sec', 'perf_metric_value': 36.065432741999985, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'state_api_extra_latency_sec_percentage', 'perf_metric_value': 78.68508210428904, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'state_api_extra_mem', 'perf_metric_value': -0.18999999999999995, 'perf_metric_type': 'MEMORY'}]

OLD

time = 59.80607887200001
--
  | success = 1
  | perf_metrics = [{'perf_metric_name': 'state_api_extra_latency_sec', 'perf_metric_value': 27.260793666000005, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'state_api_extra_latency_sec_percentage', 'perf_metric_value': 181.9177483926357, 'perf_metric_type': 'LATENCY'}, {'perf_metric_name': 'state_api_extra_mem', 'perf_metric_value': -0.06000000000000005, 'perf_metric_type': 'MEMORY'}]
```


**shuffle_100gb.aws**
```
NEW

shuffle_time = 84.73047876358032
--
  | success = 1
  | perf_metrics = [{'perf_metric_name': 'shuffle_time', 'perf_metric_value': 84.73047876358032, 'perf_metric_type': 'LATENCY'}]

OLD

shuffle_time = 85.13335418701172
--
  | success = 1
  | perf_metrics = [{'perf_metric_name': 'shuffle_time', 'perf_metric_value': 85.13335418701172, 'perf_metric_type': 'LATENCY'}]
```

**autoscaling_shuffle_1tb_1000_partitions.aws**

```
NEW

shuffle_time = 708.3939363956451
--
  | success = 1
  | perf_metrics = [{'perf_metric_name': 'shuffle_time', 'perf_metric_value': 708.3939363956451, 'perf_metric_type': 'LATENCY'}]

OLD

shuffle_time = 742.8974359035492
--
  | success = 1
  | perf_metrics = [{'perf_metric_name': 'shuffle_time', 'perf_metric_value': 742.8974359035492, 'perf_metric_type': 'LATENCY'}]
```

**dask_on_ray_100gb_sort.aws**
```
NEW
duration = 4110.363643169403
--
  | success = 1

OLD

duration = 2549.20721244812
--
  | success = 1
```

** dask_on_ray_1tb_sort**
```
NEW
duration = 5466.110460519791
--
  | success = 1

OLD


duration = 5006.332159757614
--
  | success = 1

```

** chaos_dask_on_ray_large_scale_test_no_spilling.aws**

```
NEW
runtime: 722.30
success = 1
--
  | _peak_memory = 24.11

OLD
runtime: 1233.42
success = 1
--
  | _peak_memory = 26.56

```








   