### PR TITLE
[Core] Put pg state to kv store when pg rescheduling (resubmit)

### DIFF
--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -301,6 +301,8 @@ class GlobalState:
                 return "PENDING"
             elif state == gcs_utils.PlacementGroupTableData.CREATED:
                 return "CREATED"
+            elif state == gcs_utils.PlacementGroupTableData.RESCHEDULING:
+                return "RESCHEDULING"
             else:
                 return "REMOVED"
 

--- a/python/ray/tests/test_placement_group_failover.py
+++ b/python/ray/tests/test_placement_group_failover.py
@@ -2,9 +2,7 @@ import pytest
 import sys
 import ray
 import ray.cluster_utils
-from ray._private.test_utils import (
-    get_other_nodes,
-)
+from ray._private.test_utils import get_other_nodes, wait_for_condition
 
 MB = 1024 * 1024
 
@@ -56,6 +54,73 @@ def test_placement_group_failover_when_two_nodes_die(monkeypatch, ray_start_clus
             ).remote()
             object_ref = actor.value.remote()
             ray.get(object_ref, timeout=5)
+
+
+def test_gcs_restart_when_placement_group_failover(
+    ray_start_cluster_head_with_external_redis,
+):
+    @ray.remote(num_cpus=1)
+    class Actor(object):
+        def __init__(self):
+            self.n = 0
+
+        def value(self):
+            return self.n
+
+    cluster = ray_start_cluster_head_with_external_redis
+    num_nodes = 3
+    nodes = []
+    for _ in range(num_nodes - 1):
+        nodes.append(cluster.add_node(num_cpus=1))
+
+    # Make sure the placement group is ready.
+    bundles = [{"CPU": 1, "memory": 100 * MB} for _ in range(num_nodes)]
+    placement_group = ray.util.placement_group(
+        name="name", strategy="STRICT_SPREAD", bundles=bundles
+    )
+    assert placement_group.wait(5000)
+    actors = []
+    for i in range(num_nodes):
+        actor = Actor.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=i,
+            max_restarts=-1,
+        ).remote()
+        object_ref = actor.value.remote()
+        ray.get(object_ref, timeout=5)
+        actors.append(actor)
+
+    # Simulate a node dead.
+    other_nodes = get_other_nodes(cluster, exclude_head=True)
+    cluster.remove_node(other_nodes[0])
+
+    # Make sure placement group state change to rescheduling.
+    def _check_pg_whether_be_reschedule():
+        table = ray.util.placement_group_table(placement_group)
+        return table["state"] == "RESCHEDULING"
+
+    wait_for_condition(
+        _check_pg_whether_be_reschedule, timeout=5, retry_interval_ms=1000
+    )
+
+    # Simulate gcs restart.
+    cluster.head_node.kill_gcs_server()
+    cluster.head_node.start_gcs_server()
+
+    cluster.add_node(num_cpus=1)
+    cluster.wait_for_nodes()
+
+    # Check placement gorup reschedule success after gcs server restart.
+    def _check_actor_with_pg_is_ready():
+        try:
+            for actor in actors:
+                object_ref = actor.value.remote()
+                ray.get(object_ref, timeout=5)
+            return True
+        except Exception:
+            return False
+
+    wait_for_condition(_check_actor_with_pg_is_ready, timeout=5, retry_interval_ms=1000)
 
 
 if __name__ == "__main__":

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -756,11 +756,13 @@ void GcsPlacementGroupManager::OnNodeDead(const NodeID &node_id) {
         iter->second->GetMutableStats()->set_scheduling_state(
             rpc::PlacementGroupStats::QUEUED);
         AddToPendingQueue(iter->second, 0);
+        RAY_CHECK_OK(gcs_table_storage_->PlacementGroupTable().Put(
+            iter->second->GetPlacementGroupID(),
+            iter->second->GetPlacementGroupTableData(),
+            [this](Status status) { SchedulePendingPlacementGroups(); }));
       }
     }
   }
-
-  SchedulePendingPlacementGroups();
 }
 
 void GcsPlacementGroupManager::OnNodeAdd(const NodeID &node_id) {
@@ -966,7 +968,10 @@ bool GcsPlacementGroupManager::RescheduleIfStillHasUnplacedBundles(
                       << placement_group->GetPlacementGroupID();
         placement_group->UpdateState(rpc::PlacementGroupTableData::RESCHEDULING);
         AddToPendingQueue(placement_group, 0);
-        SchedulePendingPlacementGroups();
+        RAY_CHECK_OK(gcs_table_storage_->PlacementGroupTable().Put(
+            placement_group->GetPlacementGroupID(),
+            placement_group->GetPlacementGroupTableData(),
+            [this](Status status) { SchedulePendingPlacementGroups(); }));
         return true;
       }
     }

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -462,6 +462,7 @@ TEST_F(GcsPlacementGroupManagerTest, TestReschedulingRetry) {
       placement_group->GetPlacementGroupID();
   mock_placement_group_scheduler_->bundles_on_dead_node_.push_back(0);
   gcs_placement_group_manager_->OnNodeDead(NodeID::FromRandom());
+  WaitUntilIoServiceDone();
   const auto &bundles =
       mock_placement_group_scheduler_->placement_groups_[0]->GetBundles();
   EXPECT_TRUE(NodeID::FromBinary(bundles[0]->GetMessage().node_id()).IsNil());
@@ -503,6 +504,7 @@ TEST_F(GcsPlacementGroupManagerTest, TestRescheduleWhenNodeDead) {
       placement_group->GetPlacementGroupID();
   mock_placement_group_scheduler_->bundles_on_dead_node_.push_back(0);
   gcs_placement_group_manager_->OnNodeDead(NodeID::FromRandom());
+  WaitUntilIoServiceDone();
   ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_[0]->GetPlacementGroupID(),
             placement_group->GetPlacementGroupID());
   const auto &bundles =


### PR DESCRIPTION
## Why are these changes needed?
This PR may have caused flakey failures in the test case 'test_placement_group_3', so it was rolled back. 
This is a resubmitted PR

If it is confirmed that the issue was caused by this PR, then I will make the necessary modifications to address the problem

## Related issue number

[Revert "[Core] Put pg state to kv store when pg rescheduling (#34467)" #34914](https://github.com/ray-project/ray/pull/34914)

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
