### PR TITLE
[Core] Add actor_id as an attribute of RayActorError when the actor constructor fails

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -102,6 +102,7 @@ class RayTaskError(RayError):
         pid=None,
         ip=None,
         actor_repr=None,
+        actor_id=None,
     ):
         """Initialize a RayTaskError."""
         import ray
@@ -119,6 +120,7 @@ class RayTaskError(RayError):
         self.function_name = function_name
         self.traceback_str = traceback_str
         self.actor_repr = actor_repr
+        self._actor_id = actor_id
         # TODO(edoakes): should we handle non-serializable exception objects?
         self.cause = cause
         assert traceback_str is not None
@@ -183,7 +185,9 @@ class RayTaskError(RayError):
                     f"(pid={self.pid}, ip={self.ip}"
                 )
                 if self.actor_repr:
-                    traceback_line += f", repr={self.actor_repr})"
+                    traceback_line += (
+                        f", actor_id={self._actor_id}, repr={self.actor_repr})"
+                    )
                 else:
                     traceback_line += ")"
                 code_from_internal_file = False
@@ -273,6 +277,7 @@ class RayActorError(RayError):
             self.error_msg = self.base_error_msg
         elif isinstance(cause, RayTaskError):
             self._actor_init_failed = True
+            self.actor_id = cause._actor_id
             self.error_msg = (
                 "The actor died because of an error"
                 " raised in its creation task, "

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -768,8 +768,9 @@ def test_actor_creation_task_crash(ray_start_regular):
 
     # Verify an exception is thrown.
     a = Actor.remote()
-    with pytest.raises(ray.exceptions.RayActorError):
+    with pytest.raises(ray.exceptions.RayActorError) as excinfo:
         ray.get(a.f.remote())
+    assert excinfo.value.actor_id == a._actor_id.hex()
 
     # Test an actor can be restarted successfully
     # afte it dies in its constructor.

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -712,6 +712,7 @@ def test_actor_failure_per_type(ray_start_cluster):
         ray.exceptions.RayActorError, match="it was killed by `ray.kill"
     ) as exc_info:
         ray.get(a.check_alive.remote())
+    assert exc_info.value.actor_id == a._actor_id.hex()
     print(exc_info._excinfo[1])
 
     # Test actor killed because of worker failure.
@@ -723,6 +724,7 @@ def test_actor_failure_per_type(ray_start_cluster):
         match=("The actor is dead because its worker process has died"),
     ) as exc_info:
         ray.get(a.check_alive.remote())
+    assert exc_info.value.actor_id == a._actor_id.hex()
     print(exc_info._excinfo[1])
 
     # Test acator killed because of owner failure.
@@ -734,6 +736,7 @@ def test_actor_failure_per_type(ray_start_cluster):
         match="The actor is dead because its owner has died",
     ) as exc_info:
         ray.get(a.check_alive.remote())
+    assert exc_info.value.actor_id == a._actor_id.hex()
     print(exc_info._excinfo[1])
 
     # Test actor killed because the node is dead.
@@ -746,6 +749,7 @@ def test_actor_failure_per_type(ray_start_cluster):
         match="The actor is dead because its node has died.",
     ) as exc_info:
         ray.get(a.check_alive.remote())
+    assert exc_info.value.actor_id == a._actor_id.hex()
     print(exc_info._excinfo[1])
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When the actor constructor fails, RayActorError is raised and we should set the actor_id attribute so that people know which actor fails.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #29677 
Closes #28018
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
