### PR TITLE
[CI] Remove hash when computing log signature

### DIFF
--- a/release/ray_release/log_aggregator.py
+++ b/release/ray_release/log_aggregator.py
@@ -23,7 +23,10 @@ class LogAggregator:
         """
         massaged_trace = []
         for line in stack_trace:
-            line = re.sub(r"\d", "", line.strip())
+            # remove any hashes that are more than 10 characters
+            line = re.sub(r"[a-z0-9]{10,}", "", line.strip())
+            # remove any numbers
+            line = re.sub(r"\d", "", line)
             if line == "Traceback (most recent call last):":
                 continue
             file_line = re.search(r'File "(.*)", (.*)', line)

--- a/release/ray_release/tests/test_log_aggregator.py
+++ b/release/ray_release/tests/test_log_aggregator.py
@@ -24,10 +24,11 @@ def test_compute_signature():
             [
                 "Traceback (most recent call last):",
                 '   File "/tmp/something", line 584',
+                '   File "/tmp/another", deedeebeeaacfa-abc'
                 "Exception: yaya45",
             ]
         )
-        == "somethingline Exception: yaya"
+        == "somethingline -abcException: yaya"
     )
 
 

--- a/release/ray_release/tests/test_log_aggregator.py
+++ b/release/ray_release/tests/test_log_aggregator.py
@@ -28,7 +28,7 @@ def test_compute_signature():
                 "Exception: yaya45",
             ]
         )
-        == "somethingline -abcException: yaya"
+        == "somethingline another-abcException: yaya"
     )
 
 

--- a/release/ray_release/tests/test_log_aggregator.py
+++ b/release/ray_release/tests/test_log_aggregator.py
@@ -24,8 +24,7 @@ def test_compute_signature():
             [
                 "Traceback (most recent call last):",
                 '   File "/tmp/something", line 584',
-                '   File "/tmp/another", deedeebeeaacfa-abc'
-                "Exception: yaya45",
+                '   File "/tmp/another", deedeebeeaacfa-abc' "Exception: yaya45",
             ]
         )
         == "somethingline another-abcException: yaya"


### PR DESCRIPTION
## Why are these changes needed?
Remove random string of character and number that lasts longer than 10 characters in the signature. They are often hashes that change from logs to logs.

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   