### PR TITLE
[autoscaler v2][1/n] introducing storage interface for instance provider

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/storage.py
+++ b/python/ray/autoscaler/v2/instance_manager/storage.py
@@ -1,0 +1,173 @@
+import copy
+from abc import ABCMeta, abstractmethod
+from collections import defaultdict
+from threading import Lock
+from typing import Dict, List, Optional, Tuple
+
+
+class Storage(metaclass=ABCMeta):
+    """Interface for a storage backend that stores the state of nodes in the cluster.
+
+    The storage is versioned, which means that each successful stage change to the
+    storage will bump the version number. The version number can be used to
+    implement optimistic concurrency control.
+
+    Each entry in the storage table is also versioned. The version number of an entry
+    is the last version number when the entry is updated.
+    """
+
+    @abstractmethod
+    def batch_update(
+        self,
+        table: str,
+        mutation: Dict[str, str] = {},
+        deletion: List[str] = [],
+        expected_storage_version: Optional[int] = None,
+    ) -> Tuple[bool, int]:
+        """Batch update the storage table. This method is atomic.
+
+        Args:
+            table: The name of the table.
+            mutation: A dictionary of key-value pairs to be updated.
+            deletion: A list of keys to be deleted.
+            expected_storage_version: The expected storage version. The
+                update will fail is the version does not match the
+                current storage version.
+
+        Returns:
+            Tuple[bool, int]: A tuple of (success, version). If the update is
+                successful, returns (True, new_version).
+                Otherwise, returns (False, current_version).
+        """
+        raise NotImplementedError("batch_update() has to be implemented")
+
+    @abstractmethod
+    def update(
+        self,
+        table: str,
+        key: str,
+        value: str,
+        expected_entry_version: Optional[int] = None,
+        insert_only: bool = False,
+    ) -> Tuple[bool, int]:
+        """Update a single entry in the storage table.
+
+        Args:
+            table: The name of the table.
+            key: The key of the entry.
+            value: The value of the entry.
+            expected_entry_version: The expected version of the entry.
+                The update will fail if the version does not match the current
+                version of the entry. insert_only (bool): If True, the update will
+                fail if the entry already exists.
+        Returns:
+            Tuple[bool, int]: A tuple of (success, version). If the update is
+                successful, returns (True, new_version). Otherwise,
+                returns (False, current_version).
+        """
+        raise NotImplementedError("update() has to be implemented")
+
+    @abstractmethod
+    def get_all(self, table: str) -> Tuple[Dict[str, Tuple[str, int]], int]:
+        raise NotImplementedError("get_all() has to be implemented")
+
+    @abstractmethod
+    def get(
+        self, table: str, keys: List[str]
+    ) -> Tuple[Dict[str, Tuple[str, int]], int]:
+        """Get a list of entries from the storage table.
+
+        Args:
+            table: The name of the table.
+            keys: A list of keys to be retrieved. If the list is empty,
+                all entries in the table will be returned.
+
+        Returns:
+            Tuple[Dict[str, Tuple[str, int]], int]: A tuple of
+                (entries, storage_version). The entries is a dictionary of
+                (key, (value, entry_version)) pairs. The entry_version is the
+                version of the entry when it was last updated. The
+                storage_version is the current storage version.
+        """
+        raise NotImplementedError("get() has to be implemented")
+
+    @abstractmethod
+    def get_version(self) -> int:
+        """Get the current storage version.
+
+        Returns:
+            int: The current storage version.
+        """
+        raise NotImplementedError("get_version() has to be implemented")
+
+
+class InMemoryStorage(Storage):
+    """An in-memory implementation of the Storage interface. This implementation
+    is not durable"""
+
+    def __init__(self):
+        self._version = 0
+        self._tables = defaultdict(dict)
+        self._lock = Lock()
+
+    def batch_update(
+        self,
+        table: str,
+        mutation: Dict[str, str] = {},
+        deletion: List[str] = [],
+        expected_version: Optional[int] = None,
+    ) -> Tuple[bool, int]:
+        with self._lock:
+            if expected_version is not None and expected_version != self._version:
+                return [False, self._version]
+            self._version += 1
+            key_value_pairs_with_version = {
+                key: (value, self._version) for key, value in mutation.items()
+            }
+            self._tables[table].update(key_value_pairs_with_version)
+            for deleted_key in deletion:
+                self._tables[table].pop(deleted_key, None)
+            return [True, self._version]
+
+    def update(
+        self,
+        table: str,
+        key: str,
+        value: str,
+        expected_entry_version: Optional[int] = None,
+        expected_storage_version: Optional[int] = None,
+        insert_only: bool = False,
+    ) -> Tuple[bool, int]:
+        with self._lock:
+            if (
+                expected_storage_version is not None
+                and expected_storage_version != self._version
+            ):
+                return [False, self._version]
+            if insert_only and key in self._tables[table]:
+                return [False, self._version]
+            _, version = self._tables[table].get(key, (None, -1))
+            if expected_entry_version is not None and expected_entry_version != version:
+                return [False, self._version]
+            self._version += 1
+            self._tables[table][key] = (value, self._version)
+            return [True, self._version]
+
+    def get_all(self, table: str) -> Tuple[Dict[str, Tuple[str, int]], int]:
+        with self._lock:
+            return (copy.deepcopy(self._tables[table]), self._version)
+
+    def get(
+        self, table: str, keys: List[str]
+    ) -> Tuple[Dict[str, Tuple[str, int]], int]:
+        if not keys:
+            return self.get_all(table)
+        with self._lock:
+            result = {}
+            for key in keys:
+                if key in self._tables.get(table, {}):
+                    result[key] = self._tables[table][key]
+            return (result, self._version)
+
+    def get_version(self) -> int:
+        return self._version

--- a/python/ray/autoscaler/v2/tests/test_storage.py
+++ b/python/ray/autoscaler/v2/tests/test_storage.py
@@ -1,4 +1,7 @@
 # coding: utf-8
+import os
+import sys
+
 import pytest  # noqa
 from ray.autoscaler.v2.instance_manager.storage import InMemoryStorage
 
@@ -10,7 +13,10 @@ def test_storage(storage):
     assert storage.get(table="test_table", keys=[]) == ({}, 0)
     assert storage.get(table="test_table", keys=["key1"]) == ({}, 0)
 
-    assert storage.batch_update(table="test_table", mutation={"key1": "value1"}) == [True, 1]
+    assert storage.batch_update(table="test_table", mutation={"key1": "value1"}) == [
+        True,
+        1,
+    ]
 
     assert storage.get_version() == 1
 
@@ -40,9 +46,20 @@ def test_storage(storage):
     )
 
     assert storage.get(table="test_table", keys=["key2", "key1"]) == (
-        {"key2": ("value3", 3)}
+        {"key2": ("value3", 3)},
         3,
     )
+
+    assert storage.update(table="test_table", key="key2", value="value5") == [True, 4]
+    assert storage.update(
+        table="test_table", key="key2", value="value5", insert_only=True
+    ) == [False, 4]
+    assert storage.update(
+        table="test_table", key="key2", value="value5", expected_entry_version=3
+    ) == [False, 4]
+    assert storage.update(
+        table="test_table", key="key2", value="value6", expected_entry_version=4
+    ) == [True, 5]
 
 
 if __name__ == "__main__":

--- a/python/ray/autoscaler/v2/tests/test_storage.py
+++ b/python/ray/autoscaler/v2/tests/test_storage.py
@@ -1,0 +1,52 @@
+# coding: utf-8
+import pytest  # noqa
+from ray.autoscaler.v2.instance_manager.storage import InMemoryStorage
+
+
+@pytest.mark.parametrize("storage", [InMemoryStorage()])
+def test_storage(storage):
+    assert storage.get_version() == 0
+    assert storage.get_all(table="test_table") == ({}, 0)
+    assert storage.get(table="test_table", keys=[]) == ({}, 0)
+    assert storage.get(table="test_table", keys=["key1"]) == ({}, 0)
+
+    assert storage.batch_update(table="test_table", mutation={"key1": "value1"}) == [True, 1]
+
+    assert storage.get_version() == 1
+
+    assert storage.get_all(table="test_table") == ({"key1": ("value1", 1)}, 1)
+    assert storage.get(table="test_table", keys=[]) == ({"key1": ("value1", 1)}, 1)
+
+    assert storage.batch_update(
+        table="test_table", mutation={"key1": "value2"}, expected_version=0
+    ) == [False, 1]
+
+    assert storage.batch_update(
+        table="test_table", mutation={"key1": "value2"}, expected_version=1
+    ) == [True, 2]
+
+    assert storage.get_all(table="test_table") == ({"key1": ("value2", 2)}, 2)
+
+    assert storage.batch_update(
+        table="test_table",
+        mutation={"key2": "value3", "key3": "value4"},
+        deletion=["key1"],
+        expected_version=2,
+    ) == [True, 3]
+
+    assert storage.get_all(table="test_table") == (
+        {"key2": ("value3", 3), "key3": ("value4", 3)},
+        3,
+    )
+
+    assert storage.get(table="test_table", keys=["key2", "key1"]) == (
+        {"key2": ("value3", 3)}
+        3,
+    )
+
+
+if __name__ == "__main__":
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

introduce a versioned storage interface for node_provider in autoscaler v2.

> Interface for a storage backend that stores the state of nodes in the cluster.
>     The storage is versioned, which means that each successful stage change to the
>     storage will bump the version number. The version number can be used to
>     implement optimistic concurrency control.
>     Each entry in the storage table is also versioned. The version number of an entry
>     is the last version number when the entry is updated.

The storage will be used to store autoscaler's scaling decisions (instance to be started), as well the instance state from the cloud provider.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
