### PR TITLE
[autoscaler v2][3/n] introducing instance storage

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2883,6 +2883,7 @@ filegroup(
         "//src/ray/protobuf:event_py_proto",
         "//src/ray/protobuf:gcs_py_proto",
         "//src/ray/protobuf:gcs_service_py_proto",
+        "//src/ray/protobuf:instance_manager_py_proto",
         "//src/ray/protobuf:job_agent_py_proto",
         "//src/ray/protobuf:monitor_py_proto",
         "//src/ray/protobuf:node_manager_py_proto",

--- a/python/ray/autoscaler/v2/BUILD
+++ b/python/ray/autoscaler/v2/BUILD
@@ -6,6 +6,14 @@
 load("//bazel:python.bzl", "py_test_module_list")
 
 py_test(
+    name = "test_instance_storage",
+    size = "small",
+    srcs = ["tests/test_instance_storage.py"],
+    tags = ["team:core"],
+    deps = ["//:ray_lib",],
+)
+
+py_test(
     name = "test_storage",
     size = "small",
     srcs = ["tests/test_storage.py"],

--- a/python/ray/autoscaler/v2/instance_manager/instance_storage.py
+++ b/python/ray/autoscaler/v2/instance_manager/instance_storage.py
@@ -1,0 +1,198 @@
+import logging
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Set, Tuple
+
+from ray.autoscaler.v2.instance_manager.storage import Storage, StoreStatus
+from ray.core.generated.instance_manager_pb2 import Instance
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class InstanceUpdateEvent:
+    """Notifies the status change of an instance."""
+
+    instance_id: str
+    new_status: int
+
+
+class InstanceUpdatedSuscriber(metaclass=ABCMeta):
+    """Subscribers to instance status changes."""
+
+    @abstractmethod
+    def notify(self, events: List[InstanceUpdateEvent]) -> None:
+        pass
+
+
+class InstanceStorage(object):
+    """Instance storage stores the states of instances in the storage. It also
+    allows users to subscribe to instance status changes to trigger reconciliation
+    with cloud provider."""
+
+    def __init__(
+        self,
+        cluster_id: str,
+        storage: Storage,
+        status_change_subscriber: Optional[InstanceUpdatedSuscriber] = None,
+    ) -> None:
+        super().__init__()
+        self._storage = storage
+        self._cluster_id = cluster_id
+        self._table_name = f"instance_table@{cluster_id}"
+        self._status_change_subscriber = status_change_subscriber
+
+    def batch_upsert_instances(
+        self,
+        updates: List[Instance],
+        expected_storage_version: Optional[int] = None,
+    ) -> StoreStatus:
+        """Upsert instances into the storage. If the instance already exists,
+        it will be updated. Otherwise, it will be inserted. If the
+        expected_storage_version is specified, the update will fail if the
+        current storage version does not match the expected version.
+
+        Note the version of the upserted instances will be set to the current
+        storage version.
+
+        Args:
+            updates: A list of instances to be upserted.
+            expected_storage_version: The expected storage version.
+
+        Returns:
+            StoreStatus: A tuple of (success, storage_version).
+        """
+        mutations = {}
+        version = self._storage.get_version()
+        # handle version mismatch
+        if expected_storage_version and expected_storage_version != version:
+            return StoreStatus(False, version)
+
+        for instance in updates:
+            # the instance version is set to 0, it will be
+            # populated by the storage entry's verion on read
+            instance.version = 0
+            mutations[instance.instance_id] = instance.SerializeToString()
+
+        result, version = self._storage.batch_update(
+            self._table_name, mutations, {}, expected_storage_version
+        )
+
+        if result and self._status_change_subscriber:
+            self._status_change_subscriber.notify(
+                [
+                    InstanceUpdateEvent(
+                        instance_id=instance.instance_id,
+                        new_status=instance.status,
+                    )
+                    for instance in updates
+                ],
+            )
+
+        return StoreStatus(result, version)
+
+    def upsert_instance(
+        self,
+        instance: Instance,
+        expected_instance_version: Optional[int] = None,
+        expected_storage_verison: Optional[int] = None,
+    ) -> StoreStatus:
+        """Upsert an instance in the storage.
+        If the expected_instance_version is specified, the update will fail
+        if the current instance version does not match the expected version.
+        Similarly, if the expected_storage_version is
+        specified, the update will fail if the current storage version does not
+        match the expected version.
+
+        Note the version of the upserted instances will be set to the current
+        storage version.
+
+        Args:
+            instance: The instance to be updated.
+            expected_instance_version: The expected instance version.
+            expected_storage_version: The expected storage version.
+
+        Returns:
+            StoreStatus: A tuple of (success, storage_version).
+        """
+        # the instance version is set to 0, it will be
+        # populated by the storage entry's verion on read
+        instance.version = 0
+        result, version = self._storage.update(
+            self._table_name,
+            key=instance.instance_id,
+            value=instance.SerializeToString(),
+            expected_entry_version=expected_instance_version,
+            expected_storage_version=expected_storage_verison,
+            insert_only=False,
+        )
+
+        if result and self._status_change_subscriber:
+            self._status_change_subscriber.notify(
+                [
+                    InstanceUpdateEvent(
+                        instance_id=instance.instance_id,
+                        new_status=instance.status,
+                    )
+                ],
+            )
+
+        return StoreStatus(result, version)
+
+    def get_instances(
+        self, instance_ids: List[str] = [], status_filter: Set[int] = {}
+    ) -> Tuple[Dict[str, Instance], int]:
+        """Get instances from the storage.
+
+        Args:
+            instance_ids: A list of instance ids to be retrieved. If empty, all
+                instances will be retrieved.
+
+        Returns:
+            Tuple[Dict[str, Instance], int]: A tuple of (instances, version).
+                The instances is a dictionary of (instance_id, instance) pairs.
+        """
+        pairs, version = self._storage.get(self._table_name, instance_ids)
+        instances = {}
+        for instance_id, (instance_data, entry_version) in pairs.items():
+            instance = Instance()
+            instance.ParseFromString(instance_data)
+            instance.version = entry_version
+            if status_filter and instance.status not in status_filter:
+                continue
+            instances[instance_id] = instance
+        return instances, version
+
+    def batch_delete_instances(
+        self, instance_ids: List[str], expected_storage_version: Optional[int] = None
+    ) -> StoreStatus:
+        """Delete instances from the storage. If the expected_version is
+        specified, the update will fail if the current storage version does not
+        match the expected version.
+
+        Args:
+            to_delete: A list of instances to be deleted.
+            expected_version: The expected storage version.
+
+        Returns:
+            StoreStatus: A tuple of (success, storage_version).
+        """
+        version = self._storage.get_version()
+        if expected_storage_version and expected_storage_version != version:
+            return StoreStatus(False, version)
+
+        result = self._storage.batch_update(
+            self._table_name, {}, instance_ids, expected_storage_version
+        )
+
+        if result[0] and self._status_change_subscriber:
+            self._status_change_subscriber.notify(
+                [
+                    InstanceUpdateEvent(
+                        instance_id=instance_id,
+                        new_status=Instance.GARAGE_COLLECTED,
+                    )
+                    for instance_id in instance_ids
+                ],
+            )
+        return result

--- a/python/ray/autoscaler/v2/instance_manager/instance_storage.py
+++ b/python/ray/autoscaler/v2/instance_manager/instance_storage.py
@@ -25,7 +25,7 @@ class InstanceUpdatedSuscriber(metaclass=ABCMeta):
         pass
 
 
-class InstanceStorage(object):
+class InstanceStorage:
     """Instance storage stores the states of instances in the storage. It also
     allows users to subscribe to instance status changes to trigger reconciliation
     with cloud provider."""
@@ -36,7 +36,6 @@ class InstanceStorage(object):
         storage: Storage,
         status_change_subscriber: Optional[InstanceUpdatedSuscriber] = None,
     ) -> None:
-        super().__init__()
         self._storage = storage
         self._cluster_id = cluster_id
         self._table_name = f"instance_table@{cluster_id}"
@@ -140,7 +139,7 @@ class InstanceStorage(object):
         return StoreStatus(result, version)
 
     def get_instances(
-        self, instance_ids: List[str] = [], status_filter: Set[int] = {}
+        self, instance_ids: List[str] = None, status_filter: Set[int] = None
     ) -> Tuple[Dict[str, Instance], int]:
         """Get instances from the storage.
 
@@ -152,6 +151,8 @@ class InstanceStorage(object):
             Tuple[Dict[str, Instance], int]: A tuple of (instances, version).
                 The instances is a dictionary of (instance_id, instance) pairs.
         """
+        instance_ids = instance_ids or []
+        status_filter = status_filter or set()
         pairs, version = self._storage.get(self._table_name, instance_ids)
         instances = {}
         for instance_id, (instance_data, entry_version) in pairs.items():

--- a/python/ray/autoscaler/v2/tests/test_instance_storage.py
+++ b/python/ray/autoscaler/v2/tests/test_instance_storage.py
@@ -1,0 +1,289 @@
+# coding: utf-8
+import copy
+import os
+import sys
+
+import pytest  # noqa
+from ray.autoscaler.v2.instance_manager.instance_storage import (
+    InstanceStorage,
+    InstanceUpdatedSuscriber,
+    InstanceUpdateEvent,
+)
+from ray.autoscaler.v2.instance_manager.storage import InMemoryStorage
+from ray.core.generated.instance_manager_pb2 import Instance
+
+
+class DummySubscriber(InstanceUpdatedSuscriber):
+    def __init__(self):
+        self.events = []
+
+    def notify(self, events):
+        self.events.extend(events)
+
+
+def create_instance(
+    instance_id, status=Instance.INSTANCE_STATUS_UNSPECIFIED, version=0
+):
+    return Instance(instance_id=instance_id, status=status, version=version)
+
+
+def test_upsert():
+    subscriber = DummySubscriber()
+
+    storage = InstanceStorage(
+        cluster_id="test_cluster",
+        storage=InMemoryStorage(),
+        status_change_subscriber=subscriber,
+    )
+    instance1 = create_instance("instance1")
+    instance2 = create_instance("instance2")
+    instance3 = create_instance("instance3")
+
+    assert (True, 1) == storage.batch_upsert_instances(
+        [instance1, instance2],
+        expected_storage_version=None,
+    )
+
+    assert subscriber.events == [
+        InstanceUpdateEvent("instance1", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance2", Instance.INSTANCE_STATUS_UNSPECIFIED),
+    ]
+
+    instance1.version = 1
+    instance2.version = 1
+    entries, storage_version = storage.get_instances()
+
+    assert storage_version == 1
+    assert entries == {
+        "instance1": instance1,
+        "instance2": instance2,
+    }
+
+    assert (False, 1) == storage.batch_upsert_instances(
+        [create_instance("instance1"), create_instance("instance2")],
+        expected_storage_version=0,
+    )
+
+    assert subscriber.events == [
+        InstanceUpdateEvent("instance1", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance2", Instance.INSTANCE_STATUS_UNSPECIFIED),
+    ]
+
+    instance2.status = Instance.IDLE
+    assert (True, 2) == storage.batch_upsert_instances(
+        [instance3, instance2],
+        expected_storage_version=1,
+    )
+
+    instance1.version = 1
+    instance2.version = 2
+    instance3.version = 2
+    entries, storage_version = storage.get_instances()
+
+    assert storage_version == 2
+    assert entries == {
+        "instance1": instance1,
+        "instance2": instance2,
+        "instance3": instance3,
+    }
+
+    assert subscriber.events == [
+        InstanceUpdateEvent("instance1", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance2", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance3", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance2", Instance.IDLE),
+    ]
+
+
+def test_update():
+    subscriber = DummySubscriber()
+
+    storage = InstanceStorage(
+        cluster_id="test_cluster",
+        storage=InMemoryStorage(),
+        status_change_subscriber=subscriber,
+    )
+    instance1 = create_instance("instance1")
+    instance2 = create_instance("instance2")
+
+    assert (True, 1) == storage.upsert_instance(instance=instance1)
+    assert subscriber.events == [
+        InstanceUpdateEvent("instance1", Instance.INSTANCE_STATUS_UNSPECIFIED),
+    ]
+    assert (True, 2) == storage.upsert_instance(instance=instance2)
+
+    assert subscriber.events == [
+        InstanceUpdateEvent("instance1", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance2", Instance.INSTANCE_STATUS_UNSPECIFIED),
+    ]
+
+    assert (
+        {
+            "instance1": create_instance("instance1", version=1),
+            "instance2": create_instance("instance2", version=2),
+        },
+        2,
+    ) == storage.get_instances()
+
+    # failed because instance version is not correct
+    assert (False, 2) == storage.upsert_instance(
+        instance=instance1,
+        expected_instance_version=0,
+    )
+
+    # failed because storage version is not correct
+    assert (False, 2) == storage.upsert_instance(
+        instance=instance1,
+        expected_storage_verison=0,
+    )
+
+    assert subscriber.events == [
+        InstanceUpdateEvent("instance1", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance2", Instance.INSTANCE_STATUS_UNSPECIFIED),
+    ]
+
+    assert (True, 3) == storage.upsert_instance(
+        instance=instance2,
+        expected_storage_verison=2,
+    )
+
+    assert (
+        {
+            "instance1": create_instance("instance1", version=1),
+            "instance2": create_instance("instance2", version=3),
+        },
+        3,
+    ) == storage.get_instances()
+
+    assert subscriber.events == [
+        InstanceUpdateEvent("instance1", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance2", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance2", Instance.INSTANCE_STATUS_UNSPECIFIED),
+    ]
+
+    assert (True, 4) == storage.upsert_instance(
+        instance=instance1,
+        expected_instance_version=1,
+    )
+
+    assert (
+        {
+            "instance1": create_instance("instance1", version=4),
+            "instance2": create_instance("instance2", version=3),
+        },
+        4,
+    ) == storage.get_instances()
+
+    assert subscriber.events == [
+        InstanceUpdateEvent("instance1", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance2", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance2", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance1", Instance.INSTANCE_STATUS_UNSPECIFIED),
+    ]
+
+
+def test_delete():
+    subscriber = DummySubscriber()
+
+    storage = InstanceStorage(
+        cluster_id="test_cluster",
+        storage=InMemoryStorage(),
+        status_change_subscriber=subscriber,
+    )
+    instance1 = create_instance("instance1")
+    instance2 = create_instance("instance2")
+    instance3 = create_instance("instance3")
+
+    assert (True, 1) == storage.batch_upsert_instances(
+        [instance1, instance2, instance3],
+        expected_storage_version=None,
+    )
+
+    assert (False, 1) == storage.batch_delete_instances(
+        instance_ids=["instance1"], expected_storage_version=0
+    )
+    assert (True, 2) == storage.batch_delete_instances(instance_ids=["instance1"])
+
+    assert subscriber.events == [
+        InstanceUpdateEvent("instance1", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance2", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance3", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance1", Instance.GARAGE_COLLECTED),
+    ]
+
+    assert (
+        {
+            "instance2": create_instance("instance2", version=1),
+            "instance3": create_instance("instance3", version=1),
+        },
+        2,
+    ) == storage.get_instances()
+
+    assert (True, 3) == storage.batch_delete_instances(
+        instance_ids=["instance2"], expected_storage_version=2
+    )
+
+    assert (
+        {
+            "instance3": create_instance("instance3", version=1),
+        },
+        3,
+    ) == storage.get_instances()
+
+    assert subscriber.events == [
+        InstanceUpdateEvent("instance1", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance2", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance3", Instance.INSTANCE_STATUS_UNSPECIFIED),
+        InstanceUpdateEvent("instance1", Instance.GARAGE_COLLECTED),
+        InstanceUpdateEvent("instance2", Instance.GARAGE_COLLECTED),
+    ]
+
+
+def test_get_instances():
+    storage = InstanceStorage(
+        cluster_id="test_cluster",
+        storage=InMemoryStorage(),
+    )
+    instance1 = create_instance("instance1", version=1)
+    instance2 = create_instance("instance2", status=Instance.RUNNING, version=1)
+    instance3 = create_instance("instance3", status=Instance.IDLE, version=1)
+
+    assert (True, 1) == storage.batch_upsert_instances(
+        [copy.deepcopy(instance1), copy.deepcopy(instance2), copy.deepcopy(instance3)],
+        expected_storage_version=None,
+    )
+
+    assert (
+        {
+            "instance1": instance1,
+            "instance2": instance2,
+            "instance3": instance3,
+        },
+        1,
+    ) == storage.get_instances()
+
+    assert (
+        {
+            "instance1": instance1,
+            "instance2": instance2,
+        },
+        1,
+    ) == storage.get_instances(instance_ids=["instance1", "instance2"])
+
+    assert ({"instance2": instance2}, 1) == storage.get_instances(
+        instance_ids=["instance1", "instance2"], status_filter={Instance.RUNNING}
+    )
+
+    assert (
+        {
+            "instance2": instance2,
+        },
+        1,
+    ) == storage.get_instances(status_filter={Instance.RUNNING})
+
+
+if __name__ == "__main__":
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/autoscaler/v2/tests/test_instance_storage.py
+++ b/python/ray/autoscaler/v2/tests/test_instance_storage.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import pytest  # noqa
+
 from ray.autoscaler.v2.instance_manager.instance_storage import (
     InstanceStorage,
     InstanceUpdatedSuscriber,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

this is the stack of PRs to introduce new node_provider for autoscaler v2.

Stack of PRs
#34976
#34977
#34979  <- this PR 
#34983
#34985

This PR introduces instance storage, which is a wrapper around the storage that allows us to store and update the state of instances; it also allows users to subscribe to instance state change, which enables the followup reconciler to reconcile the instance state with cloud provider.



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
