### PR TITLE
[CI] Skip invalid python files in deps analysis

### DIFF
--- a/ci/pipeline/py_dep_analysis.py
+++ b/ci/pipeline/py_dep_analysis.py
@@ -168,6 +168,9 @@ def build_dep_graph() -> DepGraph:
                 continue
 
             full = _full_module_path(module, f)
+            if full.startswith("ray.serve.tests.test_config_files."):
+                # Skip ray serve test files; can contain invalid python code.
+                continue
 
             if full not in graph.ids:
                 graph.ids[full] = len(graph.ids)


### PR DESCRIPTION
ray serve tests contain file that are invalid python files, and can fail the parsing in the middle, making this deps analysis thing totally failing right now.

Add lines to skip those invalid python files.