### PR TITLE
[core] Reduce self alive check from 60s to 5s.

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -154,7 +154,7 @@ prepare_docker() {
     EXPOSE 8000
     EXPOSE 10001
     RUN pip install /${wheel}[serve]
-    RUN sudo apt update && sudo apt install curl -y
+    RUN (sudo apt update || true) && sudo apt install curl -y
     " > $tmp_dir/Dockerfile
 
     pushd $tmp_dir

--- a/python/ray/tests/test_gcs_ha_e2e.py
+++ b/python/ray/tests/test_gcs_ha_e2e.py
@@ -36,6 +36,11 @@ class Container(wrappers.Container):
         port = self.ports["8000/tcp"][0]
         return HTTPConnection(f"localhost:{port}")
 
+    def print_logs(self):
+        for (name, content) in self.get_files("/tmp"):
+            print(f"===== log start:  {name} ====")
+            print(content.decode())
+
 
 gcs_network = network(driver="bridge")
 
@@ -66,7 +71,7 @@ head_node = container(
         "--node-manager-port",
         "9379",
     ],
-    volumes={ "{head_node_vol.name}": {'bind': "/tmp", 'mode': 'rw'}},
+    volumes={"{head_node_vol.name}": {"bind": "/tmp", "mode": "rw"}},
     environment={"RAY_REDIS_ADDRESS": "{redis.ips.primary}:6379"},
     wrapper_class=Container,
     ports={
@@ -88,7 +93,7 @@ worker_node = container(
         "--node-manager-port",
         "9379",
     ],
-    volumes={ "{worker_node_vol.name}": {'bind': "/tmp", 'mode': 'rw'}},
+    volumes={"{worker_node_vol.name}": {"bind": "/tmp", "mode": "rw"}},
     environment={"RAY_REDIS_ADDRESS": "{redis.ips.primary}:6379"},
     wrapper_class=Container,
     ports={

--- a/python/ray/tests/test_gcs_ha_e2e.py
+++ b/python/ray/tests/test_gcs_ha_e2e.py
@@ -3,7 +3,7 @@ import sys
 import threading
 from time import sleep
 from ray._private.test_utils import wait_for_condition
-from pytest_docker_tools import container, fetch, network
+from pytest_docker_tools import container, fetch, network, volume
 from pytest_docker_tools import wrappers
 from http.client import HTTPConnection
 
@@ -47,6 +47,9 @@ redis = container(
     command=("redis-server --save 60 1 --loglevel" " warning"),
 )
 
+head_node_vol = volume()
+worker_node_vol = volume()
+
 head_node = container(
     image="ray_ci:v1",
     name="gcs",
@@ -63,6 +66,7 @@ head_node = container(
         "--node-manager-port",
         "9379",
     ],
+    volumes={ "{head_node_vol.name}": {'bind': "/tmp", 'mode': 'rw'}},
     environment={"RAY_REDIS_ADDRESS": "{redis.ips.primary}:6379"},
     wrapper_class=Container,
     ports={
@@ -84,6 +88,7 @@ worker_node = container(
         "--node-manager-port",
         "9379",
     ],
+    volumes={ "{worker_node_vol.name}": {'bind': "/tmp", 'mode': 'rw'}},
     environment={"RAY_REDIS_ADDRESS": "{redis.ips.primary}:6379"},
     wrapper_class=Container,
     ports={

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -800,7 +800,7 @@ RAY_CONFIG(bool, kill_idle_workers_of_terminated_job, true)
 RAY_CONFIG(std::vector<std::string>, preload_python_modules, {})
 
 // By default, raylet send a self liveness check to GCS every 60s
-RAY_CONFIG(int64_t, raylet_liveness_self_check_interval_ms, 60000)
+RAY_CONFIG(int64_t, raylet_liveness_self_check_interval_ms, 5000)
 
 // Instruct the CoreWorker to kill its child processes while
 // it exits. This prevents certain classes of resource leaks

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -17,8 +17,8 @@
 #include <gtest/gtest_prod.h>
 
 #include <boost/bimap.hpp>
-#include <boost/bimap/unordered_set_of.hpp>
 #include <boost/bimap/unordered_multiset_of.hpp>
+#include <boost/bimap/unordered_set_of.hpp>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -17,6 +17,7 @@
 #include <gtest/gtest_prod.h>
 
 #include <boost/bimap.hpp>
+#include <boost/bimap/unordered_set_of.hpp>
 #include <boost/bimap/unordered_multiset_of.hpp>
 
 #include "absl/container/flat_hash_map.h"

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -17,7 +17,7 @@
 #include <gtest/gtest_prod.h>
 
 #include <boost/bimap.hpp>
-#include <boost/bimap/unordered_set_of.hpp>
+#include <boost/bimap/unordered_multiset_of.hpp>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -173,7 +173,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// A map of NodeId <-> ip:port of raylet
   using NodeIDAddrBiMap =
       boost::bimap<boost::bimaps::unordered_set_of<NodeID, std::hash<NodeID>>,
-                   boost::bimaps::unordered_set_of<std::string>>;
+                   boost::bimaps::unordered_multiset_of<std::string>>;
   NodeIDAddrBiMap node_map_;
 
   friend GcsMonitorServerTest;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -548,8 +548,8 @@ ray::Status NodeManager::RegisterGcs() {
                       << "GCS is not backed by a DB and restarted or there is data loss "
                       << "in the DB.";
                 }
-                *checking_ptr = false;
               }
+              *checking_ptr = false;
             },
             /* timeout_ms = */ 30000));
       },


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR reduce the liveness check from 60s to 5s. It also fixed a bug in the old code where if the server is restarted locally, it'll mark the current one as unhealthy incorrectly because the set is not multi set. 

One example,

- If the head node restart in-place
- when it started, it'll mark the old raylet as dead
- in the liveness check endpoint here, it'll mark the raylet as dead because they share the same ip+port.
- then the head node will exit

Node id should be used for this check in the future for simplicity but the correctness is ok, given: No two raylets can start at the same address (ip+port).


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
