### PR TITLE
[docs] fix build

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -58,7 +58,6 @@ sphinx-panels==0.6.0
 sphinx-version-warning==1.1.2
 sphinx-book-theme==0.3.3
 sphinx-external-toc==0.2.3
-sphinxcontrib.yt==0.2.2
 sphinx-sitemap==2.2.0
 sphinxcontrib-redoc==1.6.0
 sphinx-tabs==3.4.0

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -45,7 +45,6 @@ extensions = [
     "sphinx-jsonschema",
     "sphinxemoji.sphinxemoji",
     "sphinx_copybutton",
-    "sphinxcontrib.yt",
     "versionwarning.extension",
     "sphinx_sitemap",
     "myst_nb",

--- a/doc/source/ray-overview/use-cases.rst
+++ b/doc/source/ray-overview/use-cases.rst
@@ -576,7 +576,7 @@ The following highlights feature companies leveraging Ray's unified API to build
         :img-top: /images/ray_logo.png
         :class-img-top: pt-2 w-75 d-block mx-auto fixed-height-img
 
-        .. button-ref:: https://www.youtube.com/watch?v=_L0lsShbKaY
+        .. button-link:: https://www.youtube.com/watch?v=_L0lsShbKaY
 
             [Talk] Ray Summit Panel - ML Platform on Ray
 


### PR DESCRIPTION
currently our readthedocs.org builds are broken due to the `sphinxcontrib.yt` extension that can't be installed on their servers anymore. I don't understand the reason, but luckily it turns out we're not using the extension anymore. win win.