### PR TITLE
[Client] Optimize chunk size

### DIFF
--- a/python/ray/tests/test_client_reconnect.py
+++ b/python/ray/tests/test_client_reconnect.py
@@ -367,17 +367,17 @@ def test_disconnects_during_large_get():
 
     @ray.remote
     def large_result():
-        # 1024x1024x128 float64 matrix (1024 MiB). With 64MiB chunk size,
+        # 1024x1024x6 float64 matrix (96 MiB). With 5MiB chunk size,
         # it will take at least 16 chunks to transfer this object. Since
         # the failure is injected every 3 chunks, this transfer can only
         # work if the chunked get request retries at the last received chunk
         # (instead of starting from the beginning each retry)
-        return np.random.random((1024, 1024, 128))
+        return np.random.random((1024, 1024, 6))
 
     with start_middleman_server(on_task_response=fail_every_three):
         started = True
         result = ray.get(large_result.remote())
-        assert result.shape == (1024, 1024, 128)
+        assert result.shape == (1024, 1024, 6)
 
 
 def test_disconnects_during_large_async_get():
@@ -398,12 +398,12 @@ def test_disconnects_during_large_async_get():
 
     @ray.remote
     def large_result():
-        # 1024x1024x128 float64 matrix (1024 MiB). With 64MiB chunk size,
+        # 1024x1024x6 float64 matrix (96 MiB). With 5MiB chunk size,
         # it will take at least 16 chunks to transfer this object. Since
         # the failure is injected every 3 chunks, this transfer can only
         # work if the chunked get request retries at the last received chunk
         # (instead of starting from the beginning each retry)
-        return np.random.random((1024, 1024, 128))
+        return np.random.random((1024, 1024, 6))
 
     with start_middleman_server(on_data_response=fail_every_three):
         started = True
@@ -412,7 +412,7 @@ def test_disconnects_during_large_async_get():
             return await large_result.remote()
 
         result = get_or_create_event_loop().run_until_complete(get_large_result())
-        assert result.shape == (1024, 1024, 128)
+        assert result.shape == (1024, 1024, 6)
 
 
 def test_disconnect_during_large_put():
@@ -433,10 +433,10 @@ def test_disconnect_during_large_put():
 
     with start_middleman_server(on_data_request=fail_halfway):
         started = True
-        objref = ray.put(np.random.random((1024, 1024, 128)))
+        objref = ray.put(np.random.random((1024, 1024, 6)))
         assert i > 8  # Check that the failure was injected
         result = ray.get(objref)
-        assert result.shape == (1024, 1024, 128)
+        assert result.shape == (1024, 1024, 6)
 
 
 def test_disconnect_during_large_schedule():
@@ -461,10 +461,10 @@ def test_disconnect_during_large_schedule():
 
     with start_middleman_server(on_data_request=fail_halfway):
         started = True
-        a = np.random.random((1024, 1024, 128))
+        a = np.random.random((1024, 1024, 6))
         result = ray.get(f.remote(a))
         assert i > 8  # Check that the failure was injected
-        assert result == (1024, 1024, 128)
+        assert result == (1024, 1024, 6)
 
 
 def test_valid_actor_state():

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -79,8 +79,8 @@ GRPC_OPTIONS = [
 
 CLIENT_SERVER_MAX_THREADS = float(os.getenv("RAY_CLIENT_SERVER_MAX_THREADS", 100))
 
-# Large objects are chunked into 64 MiB messages
-OBJECT_TRANSFER_CHUNK_SIZE = 64 * 2**20
+# Large objects are chunked into 5 MiB messages, ref PR #35025
+OBJECT_TRANSFER_CHUNK_SIZE = 5 * 2**20
 
 # Warn the user if the object being transferred is larger than 2 GiB
 OBJECT_TRANSFER_WARNING_SIZE = 2 * 2**30


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The time it takes to serialize a protobuf object is not linear by its size.

When it's necessary to transmit a large object, ray will chunk it and serialize each chunk into protobuf object. However, the default chunk size of 64MB is not optimal.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
