### PR TITLE
[air/output] Use flat metrics in results report, use Trainable._progress_metrics

### DIFF
--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -424,9 +424,9 @@ AIR_TABULATE_TABLEFMT = TableFormat(
 def _print_dict_as_table(
     data: Dict,
     header: Optional[str] = None,
-    include: Optional[Collection] = None,
-    exclude: Optional[Collection] = None,
-    division: Optional[Collection] = None,
+    include: Optional[Collection[str]] = None,
+    exclude: Optional[Collection[str]] = None,
+    division: Optional[Collection[str]] = None,
 ):
     table_data = _get_dict_as_table_data(
         data=data, include=include, exclude=exclude, upper_keys=division
@@ -759,7 +759,7 @@ BLACKLISTED_KEYS = {
 class AirResultCallbackWrapper(Callback):
     # This is only to bypass the issue that by the time default callbacks
     # are added, there is no information on `num_samples` yet.
-    def __init__(self, verbosity: AirVerbosity, metrics: Tuple = ()):
+    def __init__(self, verbosity: AirVerbosity, metrics: Collection[str] = ()):
         self._verbosity = verbosity
         self._callback = None
         self._metrics = metrics
@@ -796,7 +796,7 @@ class AirResultProgressCallback(Callback):
     _intermediate_result_verbosity = None
     _addressing_tmpl = None
 
-    def __init__(self, verbosity: AirVerbosity, metrics: Tuple = ()):
+    def __init__(self, verbosity: AirVerbosity, metrics: Collection[str] = ()):
         self._verbosity = verbosity
         self._start_time = time.time()
         self._trial_last_printed_results = {}

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional, Tuple, Any, TYPE_CHECKING, Collection
+from typing import Any, Collection, Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING
 
 import contextlib
 import collections
@@ -22,7 +22,7 @@ except ImportError:
     rich = None
 
 import ray
-from ray._private.dict import unflattened_lookup
+from ray._private.dict import unflattened_lookup, flatten_dict
 from ray._private.thirdparty.tabulate.tabulate import (
     tabulate,
     TableFormat,
@@ -360,36 +360,36 @@ def _best_trial_str(
     )
 
 
-def _render_table_item(key: str, item: Any, prefix: str = ""):
+def _render_table_item(
+    key: str, item: Any, prefix: str = ""
+) -> Iterable[Tuple[str, str]]:
     key = prefix + key
     if isinstance(item, float):
         # tabulate does not work well with mixed-type columns, so we format
         # numbers ourselves.
         yield key, f"{item:.5f}".rstrip("0")
-    elif isinstance(item, list):
-        yield key, None
-        for sv in item:
-            yield from _render_table_item("", sv, prefix=prefix + "-")
-    elif isinstance(item, Dict):
-        yield key, None
-        for sk, sv in item.items():
-            yield from _render_table_item(str(sk), sv, prefix=prefix + "/")
     else:
-        yield key, item
+        yield key, _max_len(item, 20)
 
 
 def _get_dict_as_table_data(
     data: Dict,
+    include: Optional[Collection] = None,
     exclude: Optional[Collection] = None,
     upper_keys: Optional[Collection] = None,
 ):
+    include = include or set()
     exclude = exclude or set()
     upper_keys = upper_keys or set()
 
     upper = []
     lower = []
 
-    for key, value in sorted(data.items()):
+    flattened = flatten_dict(data)
+
+    for key, value in sorted(flattened.items()):
+        if include and key not in include:
+            continue
         if key in exclude:
             continue
 
@@ -423,11 +423,12 @@ AIR_TABULATE_TABLEFMT = TableFormat(
 def _print_dict_as_table(
     data: Dict,
     header: Optional[str] = None,
+    include: Optional[Collection] = None,
     exclude: Optional[Collection] = None,
     division: Optional[Collection] = None,
 ):
     table_data = _get_dict_as_table_data(
-        data=data, exclude=exclude, upper_keys=division
+        data=data, include=include, exclude=exclude, upper_keys=division
     )
 
     headers = [header, ""] if header else []
@@ -701,9 +702,10 @@ BLACKLISTED_KEYS = {
 class AirResultCallbackWrapper(Callback):
     # This is only to bypass the issue that by the time default callbacks
     # are added, there is no information on `num_samples` yet.
-    def __init__(self, verbosity):
+    def __init__(self, verbosity: AirVerbosity, metrics: Tuple = ()):
         self._verbosity = verbosity
         self._callback = None
+        self._metrics = metrics
 
     def setup(
         self,
@@ -713,9 +715,9 @@ class AirResultCallbackWrapper(Callback):
         **info,
     ):
         self._callback = (
-            TuneResultProgressCallback(self._verbosity)
+            TuneResultProgressCallback(self._verbosity, metrics=self._metrics)
             if total_num_samples > 1
-            else TrainResultProgressCallback(self._verbosity)
+            else TrainResultProgressCallback(self._verbosity, metrics=self._metrics)
         )
 
     # everything ELSE is just passing through..
@@ -737,10 +739,11 @@ class AirResultProgressCallback(Callback):
     _intermediate_result_verbosity = None
     _addressing_tmpl = None
 
-    def __init__(self, verbosity):
+    def __init__(self, verbosity: AirVerbosity, metrics: Tuple = ()):
         self._verbosity = verbosity
         self._start_time = time.time()
         self._trial_last_printed_results = {}
+        self._metrics = metrics
 
     def _print_result(self, trial, result: Optional[Dict] = None, force: bool = False):
         """Only print result if a different result has been reported, or force=True"""
@@ -753,6 +756,7 @@ class AirResultProgressCallback(Callback):
             _print_dict_as_table(
                 result,
                 header=f"{self._addressing_tmpl.format(trial)} result",
+                include=self._metrics,
                 exclude=BLACKLISTED_KEYS,
                 division=AUTO_RESULT_KEYS,
             )

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -9,7 +9,7 @@ import sys
 import textwrap
 import time
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Collection, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -1517,7 +1517,7 @@ def _detect_reporter(**kwargs) -> TuneReporterBase:
 
 def _detect_progress_metrics(
     trainable: Optional[Union["Trainable", Callable]]
-) -> Optional[Tuple]:
+) -> Optional[Collection[str]]:
     """Detect progress metrics to report."""
     if not trainable:
         return None

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -1517,7 +1517,7 @@ def _detect_reporter(**kwargs) -> TuneReporterBase:
 
 def _detect_progress_metrics(
     trainable: Optional[Union["Trainable", Callable]]
-) -> Optional[List[str]]:
+) -> Optional[Tuple]:
     """Detect progress metrics to report."""
     if not trainable:
         return None

--- a/python/ray/tune/tests/output/test_output.py
+++ b/python/ray/tune/tests/output/test_output.py
@@ -185,10 +185,8 @@ def test_result_table_no_divison():
         ["c", 5],
         ["x", "19.12312"],
         ["y", 20],
-        ["z", None],
-        ["/m", 4],
-        ["/n", None],
-        ["//o", "p"],
+        ["z/m", 4],
+        ["z/n/o", "p"],
     ]
 
 
@@ -204,16 +202,14 @@ def test_result_table_divison():
             "z": {"m": 4, "n": {"o": "p"}},
         },
         exclude={"ignore"},
-        upper_keys={"x", "y", "z"},
+        upper_keys={"x", "y", "z", "z/m", "z/n/o"},
     )
 
     assert data == [
         ["x", "19.12312"],
         ["y", 20],
-        ["z", None],
-        ["/m", 4],
-        ["/n", None],
-        ["//o", "p"],
+        ["z/m", 4],
+        ["z/n/o", "p"],
         ["a", 8],
         ["b", 6],
         ["c", 5],

--- a/python/ray/tune/utils/callback.py
+++ b/python/ray/tune/utils/callback.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import List, Optional, Type, Union, TYPE_CHECKING
+from typing import List, Optional, Tuple, Type, Union, TYPE_CHECKING
 
 from ray.tune.callback import Callback, CallbackList
 
@@ -45,7 +45,7 @@ def _create_default_callbacks(
     sync_config: SyncConfig,
     air_verbosity: Optional["AirVerbosity"] = None,
     metric: Optional[str] = None,
-    progress_metrics: Optional[List[str]] = None,
+    progress_metrics: Optional[Tuple] = None,
 ):
     """Create default callbacks for `Tuner.fit()`.
 
@@ -93,7 +93,9 @@ def _create_default_callbacks(
     if air_verbosity is not None:  # new flow
         from ray.tune.experimental.output import AirResultCallbackWrapper
 
-        callbacks.append(AirResultCallbackWrapper(air_verbosity))
+        callbacks.append(
+            AirResultCallbackWrapper(air_verbosity, metrics=progress_metrics)
+        )
     elif not has_trial_progress_callback:  # old flow
         trial_progress_callback = TrialProgressCallback(
             metric=metric, progress_metrics=progress_metrics

--- a/python/ray/tune/utils/callback.py
+++ b/python/ray/tune/utils/callback.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import List, Optional, Tuple, Type, Union, TYPE_CHECKING
+from typing import Collection, List, Optional, Type, Union, TYPE_CHECKING
 
 from ray.tune.callback import Callback, CallbackList
 
@@ -45,7 +45,7 @@ def _create_default_callbacks(
     sync_config: SyncConfig,
     air_verbosity: Optional["AirVerbosity"] = None,
     metric: Optional[str] = None,
-    progress_metrics: Optional[Tuple] = None,
+    progress_metrics: Optional[Collection[str]] = None,
 ):
     """Create default callbacks for `Tuner.fit()`.
 

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -214,9 +214,9 @@ class Algorithm(Trainable):
         "num_env_steps_sampled",
         "num_env_steps_trained",
         "episodes_total",
-        "episode_len_mean",
-        "episode_reward_mean",
-        "evaluation/episode_reward_mean",
+        "sampler_results/episode_len_mean",
+        "sampler_results/episode_reward_mean",
+        "evaluation/sampler_results/episode_reward_mean",
     )
 
     @staticmethod

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -210,12 +210,14 @@ class Algorithm(Trainable):
     # List of keys that are always fully overridden if present in any dict or sub-dict
     _override_all_key_list = ["off_policy_estimation_methods", "policies"]
 
-    _progress_metrics = [
-        "sampler_results/episode_reward_mean",
-        "evaluation/sampler_results/episode_reward_mean",
+    _progress_metrics = (
         "num_env_steps_sampled",
         "num_env_steps_trained",
-    ]
+        "episodes_total",
+        "episode_len_mean",
+        "episode_reward_mean",
+        "evaluation/episode_reward_mean",
+    )
 
     @staticmethod
     def from_checkpoint(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We already have a `Trainable._progress_metrics` property that can be used to define default metrics to be displayed in the results table.

With this PR, we port this functionality to the new output. For rllib, an example output can look like this:

```
Trial PPO_CartPole-v1_cdf47_00000 finished iteration 4 at 2023-05-04 11:03:06 (running for 00:00:21.57).
╭─────────────────────────────────────────────────────╮
│ Trial PPO_CartPole-v1_cdf47_00000 result            │
├─────────────────────────────────────────────────────┤
│ episodes_total                                  423 │
│ num_env_steps_sampled                         28000 │
│ num_env_steps_trained                         28000 │
│ sampler_results/episode_len_mean             153.15 │
│ sampler_results/episode_reward_mean          153.15 │
╰─────────────────────────────────────────────────────╯
```

In order to make the implementation simpler, and also to increase readability, we move from the "short-flat" output to a full flattened output, where the full config path is displayed in the results and config tables. E.g.

```
...
model/use_lstm                                                      False │
│ model/vf_share_layers                                               False │
│ model/zero_mean                                                      True │
│ multiagent/count_steps_by                                       env_steps │
│ multiagent/observation_fn                                                 │
│ multiagent/policies/default_policy                   ...None, None, None) │
│ multiagent/policies_to_train                                              │
...
```



## Related issue number

Closes #34919

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
