### PR TITLE
[ci/release-tests] remove anyscale run type

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -43,11 +43,6 @@
 #
 #  # Run configuration for the test
 #  run:
-#    # Type of test. Can be [anyscale_job]
-#    # Uses either Ray jobs, anyscale jobs or anyscale SDK commands
-#    # run the actual release test.
-#    type: anyscale_job
-#
 #    # If you want to wait for nodes to be ready, you can specify this here:
 #    wait_for_nodes:
 #      # Number of nodes
@@ -930,8 +925,6 @@
 #     wait_for_nodes:
 #       num_nodes: 4
 
-#     type: anyscale_job
-
 #   alert: xgboost_tests
 
 - name: xgboost_train_moderate
@@ -1192,8 +1185,6 @@
 #     script: python workloads/train_small.py
 #     wait_for_nodes:
 #       num_nodes: 4
-
-#     type: anyscale_job
 
 #   alert: default
 
@@ -2089,7 +2080,6 @@
       run:
         timeout: 600
         script: python workloads/test_result_throughput_single_node.py
-        type: anyscale_job
 
 - name: tune_scalability_xgboost_sweep
   group: Tune scalability tests
@@ -2920,8 +2910,6 @@
 #     script: python workloads/rte_ray_client.py
 #     wait_for_nodes:
 #       num_nodes: 1
-
-#     type: anyscale_job
 
 #   alert: default
 
@@ -4874,7 +4862,6 @@
 #    wait_for_nodes:
 #      num_nodes: 251
 #
-#    type: anyscale_job
 #    file_manager: sdk
 
 - name: pg_autoscaling_regression_test

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4862,7 +4862,6 @@
 #    wait_for_nodes:
 #      num_nodes: 251
 #
-#    file_manager: sdk
 
 - name: pg_autoscaling_regression_test
   group: core-daily-test


### PR DESCRIPTION
## Why are these changes needed?
There is only one remaining run type for release tests, which is anyscale_job, so we don't need to specify these any more. Remove the instructions as well so people do not bother specify a different type

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] eyes

<div><img src="https://media3.giphy.com/media/GQI382aMVej0k/200.gif?cid=5a38a5a20t2u61gcrsyu6cmi9xwz6aerog9hlv6v8qicskef&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:156px;width:300px"/><br/>via <a href="https://giphy.com/gifs/eyes-GQI382aMVej0k">GIPHY</a></div>
