### PR TITLE
[ci/bisect] allow sanity check to run multiple times per commit

### DIFF
--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -107,14 +107,9 @@ def _sanity_check(
         f" and failing revision: {failing_revision}"
     )
     outcomes = _run_test(test, [passing_revision, failing_revision], run_per_commit)
-    passed_on_passing_revision = all(
-        outcome == "passed" for outcome in outcomes[passing_revision].values()
-    )
-    failed_on_failing_revision = any(
-        outcome != "passed" for outcome in outcomes[failing_revision].values()
-    )
-
-    return passed_on_passing_revision and failed_on_failing_revision
+    if any(map(lambda x: x != "passed", outcomes[passing_revision].values())):
+        return False
+    return any(map(lambda x: x != "passed", outcomes[failing_revision].values()))
 
 
 def _run_test(

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -48,7 +48,9 @@ def main(
             f"Concurrency input need to be a positive number, received: {concurrency}"
         )
     test = _get_test(test_name)
-    pre_sanity_check = _sanity_check(test, passing_commit, failing_commit)
+    pre_sanity_check = _sanity_check(
+        test, passing_commit, failing_commit, run_per_commit
+    )
     if not pre_sanity_check:
         logger.info(
             "Failed pre-saniy check, the test might be flaky or fail due to"
@@ -93,7 +95,9 @@ def _bisect(
     return commit_list[-1]
 
 
-def _sanity_check(test: Test, passing_revision: str, failing_revision: str) -> bool:
+def _sanity_check(
+    test: Test, passing_revision: str, failing_revision: str, run_per_commit: int
+) -> bool:
     """
     Sanity check that the test indeed passes on the passing revision, and fails on the
     failing revision
@@ -102,15 +106,19 @@ def _sanity_check(test: Test, passing_revision: str, failing_revision: str) -> b
         f"Sanity check passing revision: {passing_revision}"
         f" and failing revision: {failing_revision}"
     )
-    outcomes = _run_test(test, [passing_revision, failing_revision])
-    return (
-        outcomes[passing_revision][0] == "passed"
-        and outcomes[failing_revision][0] != "passed"
+    outcomes = _run_test(test, [passing_revision, failing_revision], run_per_commit)
+    passed_on_passing_revision = all(
+        outcome == "passed" for outcome in outcomes[passing_revision].values()
     )
+    failed_on_failing_revision = any(
+        outcome != "passed" for outcome in outcomes[failing_revision].values()
+    )
+
+    return passed_on_passing_revision and failed_on_failing_revision
 
 
 def _run_test(
-    test: Test, commits: Set[str], run_per_commit: int = 1
+    test: Test, commits: Set[str], run_per_commit: int
 ) -> Dict[str, Dict[int, str]]:
     logger.info(f'Running test {test["name"]} on commits {commits}')
     for commit in commits:

--- a/release/ray_release/tests/test_bisect.py
+++ b/release/ray_release/tests/test_bisect.py
@@ -7,8 +7,9 @@ from ray_release.config import Test
 def test_sanity_check():
     def _mock_run_test(test: Test, commit: List[str]) -> Dict[str, Dict[int, str]]:
         return {
-            "passing_revision": {0: "passed"},
-            "failing_revision": {0: "failed"},
+            "passing_revision": {0: "passed", 1: "passed"},
+            "failing_revision": {0: "failed", 1: "failed"},
+            "flaky_revision": {0: "failed", 1: "passed"},
         }
 
     with mock.patch(
@@ -16,9 +17,11 @@ def test_sanity_check():
         side_effect=_mock_run_test,
     ):
         assert _sanity_check({}, "passing_revision", "failing_revision")
+        assert _sanity_check({}, "passing_revision", "flaky_revision")
         assert not _sanity_check({}, "failing_revision", "passing_revision")
         assert not _sanity_check({}, "passing_revision", "passing_revision")
         assert not _sanity_check({}, "failing_revision", "failing_revision")
+        assert not _sanity_check({}, "flaky_revision", "failing_revision")
 
 
 def test_obtain_test_result():

--- a/release/ray_release/tests/test_bisect.py
+++ b/release/ray_release/tests/test_bisect.py
@@ -1,11 +1,13 @@
 from unittest import mock
-from typing import List, Dict
+from typing import List, Set, Dict
 from ray_release.scripts.ray_bisect import _bisect, _obtain_test_result, _sanity_check
 from ray_release.config import Test
 
 
 def test_sanity_check():
-    def _mock_run_test(test: Test, commit: List[str]) -> Dict[str, Dict[int, str]]:
+    def _mock_run_test(
+        test: Test, commit: Set[str], run_per_commit: int
+    ) -> Dict[str, Dict[int, str]]:
         return {
             "passing_revision": {0: "passed", 1: "passed"},
             "failing_revision": {0: "failed", 1: "failed"},
@@ -16,12 +18,12 @@ def test_sanity_check():
         "ray_release.scripts.ray_bisect._run_test",
         side_effect=_mock_run_test,
     ):
-        assert _sanity_check({}, "passing_revision", "failing_revision")
-        assert _sanity_check({}, "passing_revision", "flaky_revision")
-        assert not _sanity_check({}, "failing_revision", "passing_revision")
-        assert not _sanity_check({}, "passing_revision", "passing_revision")
-        assert not _sanity_check({}, "failing_revision", "failing_revision")
-        assert not _sanity_check({}, "flaky_revision", "failing_revision")
+        assert _sanity_check({}, "passing_revision", "failing_revision", 2)
+        assert _sanity_check({}, "passing_revision", "flaky_revision", 2)
+        assert not _sanity_check({}, "failing_revision", "passing_revision", 2)
+        assert not _sanity_check({}, "passing_revision", "passing_revision", 2)
+        assert not _sanity_check({}, "failing_revision", "failing_revision", 2)
+        assert not _sanity_check({}, "flaky_revision", "failing_revision", 2)
 
 
 def test_obtain_test_result():


### PR DESCRIPTION
## Why are these changes needed?
Currently even when users specify to run multiple times per commit, sanity_check only run once per commit. To be consistent and to accommodate for flaky tests, allow sanity check to run multiple times per commit.

#auto_complete_by_autopilot

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests