### PR TITLE
[can/test-policy] jail 4 core tests that have been failing for weeks

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -701,6 +701,7 @@
   working_dir: air_tests/air_benchmarks/mlperf-train
 
   stable: false
+  jailed: true
 
   frequency: nightly
   team: core
@@ -727,6 +728,7 @@
   working_dir: air_tests/air_benchmarks/mlperf-train
 
   stable: false
+  jailed: true
 
   frequency: nightly
   team: core
@@ -753,6 +755,7 @@
   working_dir: air_tests/air_benchmarks/mlperf-train
 
   stable: false
+  jailed: true
 
   frequency: nightly
   team: core
@@ -4799,7 +4802,9 @@
 - name: tune_air_oom
   group: core-daily-test
   working_dir: air_tests
+
   stable: false
+  jailed: true
 
   frequency: nightly
   team: core


### PR DESCRIPTION
## Why are these changes needed?
Jail the following 4 tests:

- ray-data-bulk-ingest-file-size-benchmark
- ray-data-bulk-ingest-heterogeneity-benchmark
- ray-data-bulk-ingest-out-of-core-benchmark
- tune_air_oom

Should not be a surprise I think since they have been ignored during 2.4 release and prior. Context regarding [release policy](https://docs.google.com/document/d/1hV8avu2Xl16Di3zVXyFtjuhZ8OGFDWhEt7Am319bki0/edit).

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Release tests