### PR TITLE
[Cluster launcher] Install latest Ray by default instead of nightly

### DIFF
--- a/doc/source/cluster/running-applications/job-submission/cli.rst
+++ b/doc/source/cluster/running-applications/job-submission/cli.rst
@@ -16,12 +16,6 @@ This section contains commands for :ref:`Ray Job Submission <jobs-quickstart>`.
     ``ray job submit --working_dir="." -- python script.py`` instead of ``ray job submit --working_dir="." -- "python script.py"``.
     Otherwise you may encounter the error ``/bin/sh: 1: python script.py: not found``.
 
-.. warning::
-
-   The entrypoint command must be provided last, and any arguments to `ray job submit` must be provided before the entrypoint command.
-   For example, use ``ray job submit --working_dir="." -- python script.py`` instead of ``ray job submit -- python script.py --working_dir="."``.
-   This is to support the use of ``--`` to separate arguments to `ray job submit` from arguments to the entrypoint command.
-
 .. _ray-job-status-doc:
 
 .. click:: ray.dashboard.modules.job.cli:status

--- a/doc/source/cluster/running-applications/job-submission/cli.rst
+++ b/doc/source/cluster/running-applications/job-submission/cli.rst
@@ -16,6 +16,12 @@ This section contains commands for :ref:`Ray Job Submission <jobs-quickstart>`.
     ``ray job submit --working_dir="." -- python script.py`` instead of ``ray job submit --working_dir="." -- "python script.py"``.
     Otherwise you may encounter the error ``/bin/sh: 1: python script.py: not found``.
 
+.. warning::
+
+   The entrypoint command must be provided last, and any arguments to `ray job submit` must be provided before the entrypoint command.
+   For example, use ``ray job submit --working_dir="." -- python script.py`` instead of ``ray job submit -- python script.py --working_dir="."``.
+   This is to support the use of ``--`` to separate arguments to `ray job submit` from arguments to the entrypoint command.
+
 .. _ray-job-status-doc:
 
 .. click:: ray.dashboard.modules.job.cli:status

--- a/python/ray/autoscaler/aws/defaults.yaml
+++ b/python/ray/autoscaler/aws/defaults.yaml
@@ -124,7 +124,7 @@ setup_commands:
     - >-
         (stat $HOME/anaconda3/envs/tensorflow2_p38/ &> /dev/null &&
         echo 'export PATH="$HOME/anaconda3/envs/tensorflow2_p38/bin:$PATH"' >> ~/.bashrc) || true
-    - which ray || pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl"
+    - which ray || pip install -U "ray[default]"
 
 # Custom commands that will be run on the head node after common setup.
 head_setup_commands:

--- a/python/ray/autoscaler/azure/defaults.yaml
+++ b/python/ray/autoscaler/azure/defaults.yaml
@@ -128,7 +128,7 @@ setup_commands:
     - (which conda && echo 'eval "$(conda shell.bash hook)"' >> ~/.bashrc) || true
     # - (conda activate py38_pytorch &> /dev/null && echo 'conda activate py38_pytorch' >> ~/.bashrc) || true
     - (conda activate py38_tensorflow &> /dev/null && echo 'conda activate py38_tensorflow' >> ~/.bashrc) || true
-    - which ray || pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl"
+    - which ray || pip install -U "ray[default]"
     # Consider uncommenting these if you also want to run apt-get commands during setup
     # - sudo pkill -9 apt-get || true
     # - sudo pkill -9 dpkg || true

--- a/python/ray/autoscaler/gcp/defaults.yaml
+++ b/python/ray/autoscaler/gcp/defaults.yaml
@@ -139,7 +139,7 @@ setup_commands:
     - >-
         (stat /opt/conda/bin/ &> /dev/null &&
         echo 'export PATH="/opt/conda/bin:$PATH"' >> ~/.bashrc) || true
-    - which ray || pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl"
+    - which ray || pip install -U "ray[default]"
 
 
 # Custom commands that will be run on the head node after common setup.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In the default cluster launcher configs, previously the setup commands would install the *nightly* version of Ray if Ray was not already installed. This PR changes it to the latest stable Ray version instead.

This wouldn't happen often in practice because users are likely to use a docker image with Ray preinstalled.  However, the "minimal" example YAMLs in the docs don't specify a Docker image, so people running them would end up with the nightly Ray version, which might be unstable.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #34991 
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
