### PR TITLE
[Release Test] Stop using spot instance for chaos tests

### DIFF
--- a/release/nightly_tests/chaos_test/compute_template.yaml
+++ b/release/nightly_tests/chaos_test/compute_template.yaml
@@ -15,7 +15,7 @@ worker_node_types:
      instance_type: m5.4xlarge
      min_workers: 9
      max_workers: 9
-     use_spot: true
+     use_spot: false
      resources:
       custom_resources:
         worker: 1

--- a/release/nightly_tests/chaos_test/compute_template_gce.yaml
+++ b/release/nightly_tests/chaos_test/compute_template_gce.yaml
@@ -16,7 +16,7 @@ worker_node_types:
      instance_type: n2-standard-16
      min_workers: 9
      max_workers: 9
-     use_spot: true
+     use_spot: false
      resources:
       custom_resources:
         worker: 1

--- a/release/nightly_tests/dask_on_ray/chaos_dask_on_ray_stress_compute.yaml
+++ b/release/nightly_tests/dask_on_ray/chaos_dask_on_ray_stress_compute.yaml
@@ -17,4 +17,4 @@ worker_node_types:
       instance_type: m6i.8xlarge
       min_workers: 20
       max_workers: 20
-      use_spot: true
+      use_spot: false


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Spot instances make chaos tests flaky (e.g. time out) by nature since we cannot control how many nodes will die. I think we should just rely on our own node killer for chaos tests.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
