### PR TITLE
[docs] ssl bug fix

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -73,4 +73,4 @@ myst-nb==0.13.1
 jupytext==1.13.6
 
 # Pin urllib to avoid downstream ssl incompatibility issues
-urllib3 >=1.26.5 < 1.27
+urllib3 < 1.27

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -71,3 +71,6 @@ myst-nb==0.13.1
 
 # Jupyter conversion
 jupytext==1.13.6
+
+# Pin urllib to avoid downstream ssl incompatibility issues
+urllib3 >=1.26.5 < 1.27


### PR DESCRIPTION
this fixes the issue noted in https://github.com/anyscale/product/issues/20320, which also causes our readthedocs builds to fail entirely. I'm choosing an explicit option here (instead of e.g. installing `boto3`) to make clear what the issue is.