### PR TITLE
[Data] Fix `map_batches_benchmark_single_node`

### DIFF
--- a/release/nightly_tests/dataset/map_batches_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_benchmark.py
@@ -130,11 +130,12 @@ def run_map_batches_benchmark(benchmark: Benchmark):
     ).materialize()
 
     for batch_format in batch_formats:
-        for compute in ["tasks", "actors"]:
-            test_name = f"map-batches-{batch_format}-{compute}-multi-files"
-
-            if compute == "actors":
-                compute = ActorPoolStrategy(min_size=1, max_size=float("inf"))
+        for compute in [None, ActorPoolStrategy(min_size=1, max_size=float("inf"))]:
+            if compute is None:
+                compute_strategy = "tasks"
+            else:
+                compute_strategy = "actors"
+            test_name = f"map-batches-{batch_format}-{compute_strategy}-multi-files"
 
             benchmark.run(
                 test_name,

--- a/release/nightly_tests/dataset/map_batches_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_benchmark.py
@@ -132,6 +132,10 @@ def run_map_batches_benchmark(benchmark: Benchmark):
     for batch_format in batch_formats:
         for compute in ["tasks", "actors"]:
             test_name = f"map-batches-{batch_format}-{compute}-multi-files"
+
+            if compute == "actors":
+                compute = ActorPoolStrategy(min_size=1, max_size=float("inf"))
+
             benchmark.run(
                 test_name,
                 map_batches,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`map_batches` no longer supports "tasks" and "actors" as arguments to `compute`. This PR fixes the `map_batches` benchmark accordingly.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
