### PR TITLE
[air/mlflow] Flatten config and metrics before passing to mlflow

### DIFF
--- a/python/ray/air/_internal/mlflow.py
+++ b/python/ray/air/_internal/mlflow.py
@@ -4,6 +4,8 @@ from packaging import version
 from copy import deepcopy
 from typing import TYPE_CHECKING, Dict, Optional
 
+from ray._private.dict import flatten_dict
+
 if TYPE_CHECKING:
     from mlflow.entities import Run
     from mlflow.tracking import MlflowClient
@@ -262,6 +264,7 @@ class _MLflowLoggerUtil:
             params_to_log: Dictionary of parameters to log.
             run_id (Optional[str]): The ID of the run to log to.
         """
+        params_to_log = flatten_dict(params_to_log)
 
         if run_id and self._run_exists(run_id):
             client = self._get_client()
@@ -284,6 +287,7 @@ class _MLflowLoggerUtil:
             metrics_to_log: Dictionary of metrics to log.
             run_id (Optional[str]): The ID of the run to log to.
         """
+        metrics_to_log = flatten_dict(metrics_to_log)
         metrics_to_log = self._parse_dict(metrics_to_log)
 
         if run_id and self._run_exists(run_id):

--- a/python/ray/air/tests/test_integration_mlflow.py
+++ b/python/ray/air/tests/test_integration_mlflow.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from mlflow.tracking import MlflowClient
 
+from ray._private.dict import flatten_dict
 from ray.train._internal.session import init_session
 from ray.tune.trainable import wrap_function
 from ray.tune.trainable.session import _shutdown as tune_session_shutdown
@@ -367,7 +368,7 @@ class MLflowUtilTest(unittest.TestCase):
             )
 
     def test_log_params(self):
-        params = {"a": "a"}
+        params = {"a": "a", "x": {"y": "z"}}
         self.mlflow_util.setup_mlflow(
             tracking_uri=self.tracking_uri, experiment_name="new_experiment"
         )
@@ -376,21 +377,23 @@ class MLflowUtilTest(unittest.TestCase):
         self.mlflow_util.log_params(params_to_log=params, run_id=run_id)
 
         run = self.mlflow_util._mlflow.get_run(run_id=run_id)
-        assert run.data.params == params
+        assert run.data.params == flatten_dict(params)
 
         params2 = {"b": "b"}
         self.mlflow_util.start_run(set_active=True)
         self.mlflow_util.log_params(params_to_log=params2, run_id=run_id)
         run = self.mlflow_util._mlflow.get_run(run_id=run_id)
-        assert run.data.params == {
-            **params,
-            **params2,
-        }
+        assert run.data.params == flatten_dict(
+            {
+                **params,
+                **params2,
+            }
+        )
 
         self.mlflow_util.end_run()
 
     def test_log_metrics(self):
-        metrics = {"a": 1.0}
+        metrics = {"a": 1.0, "x": {"y": 2.0}}
         self.mlflow_util.setup_mlflow(
             tracking_uri=self.tracking_uri, experiment_name="new_experiment"
         )
@@ -399,15 +402,19 @@ class MLflowUtilTest(unittest.TestCase):
         self.mlflow_util.log_metrics(metrics_to_log=metrics, run_id=run_id, step=0)
 
         run = self.mlflow_util._mlflow.get_run(run_id=run_id)
-        assert run.data.metrics == metrics
+        assert run.data.metrics == flatten_dict(metrics)
 
         metrics2 = {"b": 1.0}
         self.mlflow_util.start_run(set_active=True)
         self.mlflow_util.log_metrics(metrics_to_log=metrics2, run_id=run_id, step=0)
-        assert self.mlflow_util._mlflow.get_run(run_id=run_id).data.metrics == {
-            **metrics,
-            **metrics2,
-        }
+        assert self.mlflow_util._mlflow.get_run(
+            run_id=run_id
+        ).data.metrics == flatten_dict(
+            {
+                **metrics,
+                **metrics2,
+            }
+        )
         self.mlflow_util.end_run()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Metrics and parameters are passed as-is to mlflow e.g. in the MlFlowCallback. However, mlflow can't deal with nested dicts.

Instead, we should flatten these dicts before passing them over. This leads to the desired result:


<img width="422" alt="Screenshot 2023-05-05 at 11 52 42 AM" src="https://user-images.githubusercontent.com/14904111/236439553-b8be18be-dbf9-49db-8e89-f769713dfcfa.png">
<img width="881" alt="Screenshot 2023-05-05 at 11 53 15 AM" src="https://user-images.githubusercontent.com/14904111/236439652-de7450b9-ffca-44d8-a06f-3b10d70c76b6.png">


## Related issue number

Closes #34857
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
