### PR TITLE
[ci/coverage][4] get coverage data from s3

### DIFF
--- a/.buildkite/pipeline.test.yml
+++ b/.buildkite/pipeline.test.yml
@@ -22,6 +22,7 @@
   if: build.pull_request.id != null
   instance_size: small
   commands:
+    - pip install coverage
     - python ci/pipeline/ray_release_test.py
 
 - label: ":octopus: Tune soft imports test"

--- a/.buildkite/pipeline.test.yml
+++ b/.buildkite/pipeline.test.yml
@@ -19,7 +19,11 @@
       release/...
 
 - label: ":shield: release tests"
+<<<<<<< HEAD
   if: build.pull_request.id != null
+=======
+  conditions: ["BUILDKITE_PULL_REQUEST"]
+>>>>>>> 0ccebbe38a (Add a script to run tests using coverage information)
   instance_size: small
   commands:
     - python ci/pipeline/ray_release_test.py

--- a/.buildkite/pipeline.test.yml
+++ b/.buildkite/pipeline.test.yml
@@ -22,7 +22,7 @@
   if: build.pull_request.id != null
   instance_size: small
   commands:
-    - pip install coverage
+    - pip install pytest-cov
     - python ci/pipeline/ray_release_test.py
 
 - label: ":octopus: Tune soft imports test"

--- a/.buildkite/pipeline.test.yml
+++ b/.buildkite/pipeline.test.yml
@@ -19,11 +19,7 @@
       release/...
 
 - label: ":shield: release tests"
-<<<<<<< HEAD
   if: build.pull_request.id != null
-=======
-  conditions: ["BUILDKITE_PULL_REQUEST"]
->>>>>>> 0ccebbe38a (Add a script to run tests using coverage information)
   instance_size: small
   commands:
     - python ci/pipeline/ray_release_test.py

--- a/ci/pipeline/ray_coverage.py
+++ b/ci/pipeline/ray_coverage.py
@@ -8,9 +8,9 @@ import click
 import boto3
 
 
-_COVERAGE_FILE_NAME = "ray_release.cov"
-_S3_BUCKET_NAME = "ray-test-coverage"
-_S3_BUCKET_DIR = "ci"
+COVERAGE_FILE_NAME = "ray_release.cov"
+S3_BUCKET_NAME = "ray-test-coverage"
+S3_BUCKET_DIR = "ci"
 
 
 @click.command()
@@ -41,7 +41,7 @@ def main(
     results to database (S3).
     """
     logger.info(f"Collecting coverage for test target: {test_target}")
-    coverage_file = os.path.join(artifact_dir, _COVERAGE_FILE_NAME)
+    coverage_file = os.path.join(artifact_dir, COVERAGE_FILE_NAME)
     _run_test(test_target, coverage_file)
     coverage_info = _collect_coverage(coverage_file)
     logger.info(coverage_info)
@@ -52,11 +52,11 @@ def main(
 
 def _upload_coverage_info(coverage_file: str) -> None:
     s3_file_name = (
-        f"{_S3_BUCKET_DIR}/ray-release-{date.today().strftime('%Y-%m-%d')}.cov"
+        f"{S3_BUCKET_DIR}/ray-release-{date.today().strftime('%Y-%m-%d')}.cov"
     )
     boto3.client("s3").upload_file(
         coverage_file,
-        _S3_BUCKET_NAME,
+        S3_BUCKET_NAME,
         s3_file_name,
     )
     s3_file_name = _upload_coverage_info(coverage_file)

--- a/ci/pipeline/ray_release_test.py
+++ b/ci/pipeline/ray_release_test.py
@@ -10,19 +10,13 @@ def main() -> int:
     This script determines and runs the right tests for the PR changes. To be used in
     CI and buildkite environment only.
     """
+    logger = get_logger()
     changed_files = _get_changed_files()
-=======
-    changed_files = get_changed_files()
->>>>>>> 0ccebbe38a (Add a script to run tests using coverage information):ci/test/ray_release_test.py
     logger.info(f"Changed files: {changed_files}")
     return 0
 
 
-<<<<<<< HEAD:ci/pipeline/ray_release_test.py
 def _get_changed_files() -> List[str]:
-=======
-def get_changed_files() -> List[str]:
->>>>>>> 0ccebbe38a (Add a script to run tests using coverage information):ci/test/ray_release_test.py
     """
     Get the list of changed files in the current PR.
     """

--- a/ci/pipeline/ray_release_test.py
+++ b/ci/pipeline/ray_release_test.py
@@ -11,11 +11,18 @@ def main() -> int:
     CI and buildkite environment only.
     """
     changed_files = _get_changed_files()
+=======
+    changed_files = get_changed_files()
+>>>>>>> 0ccebbe38a (Add a script to run tests using coverage information):ci/test/ray_release_test.py
     logger.info(f"Changed files: {changed_files}")
     return 0
 
 
+<<<<<<< HEAD:ci/pipeline/ray_release_test.py
 def _get_changed_files() -> List[str]:
+=======
+def get_changed_files() -> List[str]:
+>>>>>>> 0ccebbe38a (Add a script to run tests using coverage information):ci/test/ray_release_test.py
     """
     Get the list of changed files in the current PR.
     """

--- a/ci/pipeline/ray_release_test.py
+++ b/ci/pipeline/ray_release_test.py
@@ -63,7 +63,7 @@ def _get_coverage_file(artifact_dir: str) -> str:
         Bucket=S3_BUCKET_NAME,
         Prefix=f"{S3_BUCKET_DIR}/ray-release-",
     )["Contents"]
-    latest_coverage = list(file for file in sorted(files, key=_get_last_modified))[-1]
+    latest_coverage = sorted(files, key=_get_last_modified)[-1]
     coverage_file_name = os.path.join(artifact_dir, COVERAGE_FILE_NAME)
     s3.download_file(
         Bucket=S3_BUCKET_NAME,

--- a/ci/pipeline/ray_release_test.py
+++ b/ci/pipeline/ray_release_test.py
@@ -16,7 +16,7 @@ from typing import List
 @click.command()
 @click.option(
     "--artifact-dir",
-    default="/artifact-mount",
+    default="/tmp/artifacts",
     type=str,
     help=(
         "This directory is used to store artifacts, such as coverage information. "

--- a/ci/pipeline/ray_release_test.py
+++ b/ci/pipeline/ray_release_test.py
@@ -1,18 +1,29 @@
-import boto3
 import os
 import subprocess
 import sys
-import tempfile
+
+import boto3
+import click
 from ray_logger import get_logger
 from ray_coverage import (
     COVERAGE_FILE_NAME,
-    S3_BUCKET_FILEPATH,
+    S3_BUCKET_DIR,
     S3_BUCKET_NAME,
 )
 from typing import List
 
 
-def main() -> int:
+@click.command()
+@click.option(
+    "--artifact-dir",
+    default="/artifact-mount",
+    type=str,
+    help=(
+        "This directory is used to store artifacts, such as coverage information. "
+        "In buildkite CI, this is usually artifact-mount."
+    ),
+)
+def main(artifact_dir: str) -> int:
     """
     This script determines and runs the right tests for the PR changes. To be used in
     CI and buildkite environment only.
@@ -20,23 +31,26 @@ def main() -> int:
     logger = get_logger()
     changed_files = _get_changed_files()
     logger.info(f"Changed files: {changed_files}")
-    test_targets = _get_test_targets_for_changed_files(changed_files)
+    test_targets = _get_test_targets_for_changed_files(changed_files, artifact_dir)
     logger.info(test_targets)
     return 0
 
 
-def _get_test_targets_for_changed_files(changed_files: List[str]) -> str:
+def _get_test_targets_for_changed_files(
+    changed_files: List[str],
+    artifact_dir: str,
+) -> str:
     """
     Get the test target for the changed files.
     """
-    coverage_file = _get_coverage_file()
+    coverage_file = _get_coverage_file(artifact_dir)
     coverage_info = subprocess.check_output(
         ["coverage", "report", f"--data-file={coverage_file}"]
     ).decode("utf-8")
     return coverage_info
 
 
-def _get_coverage_file() -> str:
+def _get_coverage_file(artifact_dir: str) -> str:
     """
     Get the location of the test coverage file.
     """
@@ -47,12 +61,12 @@ def _get_coverage_file() -> str:
     s3 = boto3.client("s3")
     files = s3.list_objects_v2(
         Bucket=S3_BUCKET_NAME,
-        Prefix=f"{S3_BUCKET_FILEPATH}/ray-release-",
+        Prefix=f"{S3_BUCKET_DIR}/ray-release-",
     )["Contents"]
     latest_coverage = [file for file in sorted(files, key=_get_last_modified)][-1]
-    coverage_file_name = os.path.join(tempfile.gettempdir(), COVERAGE_FILE_NAME)
+    coverage_file_name = os.path.join(artifact_dir, COVERAGE_FILE_NAME)
     s3.download_file(
-        Bucket="ray-release-automation-results",
+        Bucket=S3_BUCKET_NAME,
         Key=latest_coverage["Key"],
         Filename=coverage_file_name,
     )

--- a/ci/pipeline/ray_release_test.py
+++ b/ci/pipeline/ray_release_test.py
@@ -16,7 +16,7 @@ from typing import List
 @click.command()
 @click.option(
     "--artifact-dir",
-    default="/tmp/artifacts",
+    default="/artifact-mount",
     type=str,
     help=(
         "This directory is used to store artifacts, such as coverage information. "

--- a/ci/pipeline/ray_release_test.py
+++ b/ci/pipeline/ray_release_test.py
@@ -1,7 +1,14 @@
+import boto3
 import os
 import subprocess
 import sys
-from ray_logger import logger
+import tempfile
+from ray_logger import get_logger
+from ray_coverage import (
+    COVERAGE_FILE_NAME,
+    S3_BUCKET_FILEPATH,
+    S3_BUCKET_NAME,
+)
 from typing import List
 
 
@@ -13,7 +20,43 @@ def main() -> int:
     logger = get_logger()
     changed_files = _get_changed_files()
     logger.info(f"Changed files: {changed_files}")
+    test_targets = _get_test_targets_for_changed_files(changed_files)
+    logger.info(test_targets)
     return 0
+
+
+def _get_test_targets_for_changed_files(changed_files: List[str]) -> str:
+    """
+    Get the test target for the changed files.
+    """
+    coverage_file = _get_coverage_file()
+    coverage_info = subprocess.check_output(
+        ["coverage", "report", f"--data-file={coverage_file}"]
+    ).decode("utf-8")
+    return coverage_info
+
+
+def _get_coverage_file() -> str:
+    """
+    Get the location of the test coverage file.
+    """
+
+    def _get_last_modified(file):
+        return int(file["LastModified"].strftime("%s"))
+
+    s3 = boto3.client("s3")
+    files = s3.list_objects_v2(
+        Bucket=S3_BUCKET_NAME,
+        Prefix=f"{S3_BUCKET_FILEPATH}/ray-release-",
+    )["Contents"]
+    latest_coverage = [file for file in sorted(files, key=_get_last_modified)][-1]
+    coverage_file_name = os.path.join(tempfile.gettempdir(), COVERAGE_FILE_NAME)
+    s3.download_file(
+        Bucket="ray-release-automation-results",
+        Key=latest_coverage["Key"],
+        Filename=coverage_file_name,
+    )
+    return coverage_file_name
 
 
 def _get_changed_files() -> List[str]:

--- a/ci/pipeline/ray_release_test.py
+++ b/ci/pipeline/ray_release_test.py
@@ -63,7 +63,7 @@ def _get_coverage_file(artifact_dir: str) -> str:
         Bucket=S3_BUCKET_NAME,
         Prefix=f"{S3_BUCKET_DIR}/ray-release-",
     )["Contents"]
-    latest_coverage = [file for file in sorted(files, key=_get_last_modified)][-1]
+    latest_coverage = list(file for file in sorted(files, key=_get_last_modified))[-1]
     coverage_file_name = os.path.join(artifact_dir, COVERAGE_FILE_NAME)
     s3.download_file(
         Bucket=S3_BUCKET_NAME,


### PR DESCRIPTION
## Why are these changes needed?
Download the latest coverage data from s3. Attempt to find the right test target to run based on the list of changed files, but I just print the entire coverage data out for now. Finding the right test target is a story for the next PR.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   
```
(base) can@can-Q7M1Q6FVFV ray % python ci/pipeline/ray_release_test.py         
2023-05-05 12:53:55,989:INFO:root:Changed files: ['.buildkite/pipeline.test.yml', 'ci/pipeline/ray_coverage.py', 'ci/pipeline/ray_logger.py', 'ci/pipeline/ray_release_test.py']
2023-05-05 12:53:55,998:INFO:botocore.credentials:Found credentials in environment variables.
2023-05-05 12:53:56,931:INFO:root:Name                                                          Stmts   Miss  Cover
---------------------------------------------------------------------------------
release/__init__.py                                               0      0   100%
release/ray_release/__init__.py                                   0      0   100%
release/ray_release/alerts/__init__.py                            0      0   100%
release/ray_release/alerts/default.py                             7      4    43%
release/ray_release/alerts/handle.py                             21      9    57%
release/ray_release/alerts/long_running_tests.py                 18     18     0%
release/ray_release/alerts/tune_tests.py                         44     44     0%
release/ray_release/alerts/xgboost_tests.py                      34     34     0%
release/ray_release/anyscale_util.py                             30     27    10%
release/ray_release/aws.py                                       45     34    24%
release/ray_release/buildkite/__init__.py                         0      0   100%
release/ray_release/buildkite/concurrency.py                     64     21    67%
release/ray_release/buildkite/filter.py                          45     11    76%
release/ray_release/buildkite/output.py                          13      7    46%
release/ray_release/buildkite/settings.py                       124     44    65%
release/ray_release/buildkite/step.py                            60     21    65%
release/ray_release/cluster_manager/__init__.py                   0      0   100%
release/ray_release/cluster_manager/cluster_manager.py           79     34    57%
release/ray_release/cluster_manager/full.py                      60     20    67%
release/ray_release/cluster_manager/minimal.py                  157     39    75%
release/ray_release/command_runner/__init__.py                    0      0   100%
release/ray_release/command_runner/_anyscale_job_wrapper.py     192     60    69%
release/ray_release/command_runner/_prometheus_metrics.py        76     76     0%
release/ray_release/command_runner/_wait_cluster.py              25     25     0%
release/ray_release/command_runner/anyscale_job_runner.py       150    150     0%
release/ray_release/command_runner/command_runner.py             51     41    20%
release/ray_release/command_runner/job_runner.py                 76     76     0%
release/ray_release/config.py                                   141     64    55%
release/ray_release/env.py                                       20      7    65%
release/ray_release/exception.py                                 85     85     0%
release/ray_release/file_manager/__init__.py                      0      0   100%
release/ray_release/file_manager/file_manager.py                 10      9    10%
release/ray_release/file_manager/job_file_manager.py            104     95     9%
release/ray_release/file_manager/remote_task.py                  42     42     0%
release/ray_release/glue.py                                     258     65    75%
release/ray_release/job_manager/__init__.py                       3      3     0%
release/ray_release/job_manager/anyscale_job_manager.py         182    182     0%
release/ray_release/job_manager/job_manager.py                   70     64     9%
release/ray_release/log_aggregator.py                            57     57     0%
release/ray_release/logger.py                                    11     11     0%
release/ray_release/reporter/__init__.py                          0      0   100%
release/ray_release/reporter/artifacts.py                        31     31     0%
release/ray_release/reporter/db.py                               21     21     0%
release/ray_release/reporter/log.py                              21     21     0%
release/ray_release/reporter/reporter.py                         11      7    36%
release/ray_release/result.py                                    87     62    29%
release/ray_release/scripts/__init__.py                           0      0   100%
release/ray_release/scripts/build_pipeline.py                   110    110     0%
release/ray_release/scripts/get_aws_instance_information.py      25     25     0%
release/ray_release/scripts/get_test_summary.py                  23     23     0%
release/ray_release/scripts/ray_bisect.py                        95     95     0%
release/ray_release/scripts/run_release_test.py                  61     61     0%
release/ray_release/signal_handling.py                           33     23    30%
release/ray_release/template.py                                  82      3    96%
release/ray_release/tests/__init__.py                             0      0   100%
release/ray_release/tests/_test_catch_args.py                     9      0   100%
release/ray_release/tests/_test_run_release_test_sh.py           27      0   100%
release/ray_release/tests/test_alerts.py                         18      1    94%
release/ray_release/tests/test_anyscale_job_manager.py           15     15     0%
release/ray_release/tests/test_anyscale_job_wrapper.py           55      1    98%
release/ray_release/tests/test_bisect.py                         30     30     0%
release/ray_release/tests/test_buildkite.py                     293      4    99%
release/ray_release/tests/test_cluster_manager.py               323     16    95%
release/ray_release/tests/test_config.py                         75      1    99%
release/ray_release/tests/test_env.py                            25      2    92%
release/ray_release/tests/test_glue.py                          367      7    98%
release/ray_release/tests/test_log_aggregator.py                 13     13     0%
release/ray_release/tests/test_result.py                         12     12     0%
release/ray_release/tests/test_run_script.py                     53      2    96%
release/ray_release/tests/test_template.py                       33     33     0%
release/ray_release/tests/test_wheels.py                        132      1    99%
release/ray_release/tests/utils.py                               35     16    54%
release/ray_release/util.py                                      99     71    28%
release/ray_release/wheels.py                                   205     93    55%
release/setup.py                                                  2      2     0%
---------------------------------------------------------------------------------
TOTAL                                                          4775   2281    52%
```