### PR TITLE
[CI] Fix stable_diffusion_batch_prediction by switching to strict_mode

### DIFF
--- a/doc/source/ray-air/examples/stablediffusion_batch_prediction.ipynb
+++ b/doc/source/ray-air/examples/stablediffusion_batch_prediction.ipynb
@@ -121,12 +121,14 @@
     "\n",
     "    def __call__(self, batch: pd.DataFrame) -> pd.DataFrame:\n",
     "        import torch\n",
+    "        import numpy as np\n",
     "\n",
     "        # Set a different seed for every image in batch\n",
     "        self.pipe.generator = [\n",
     "            torch.Generator(device=\"cuda\").manual_seed(i) for i in range(len(batch))\n",
     "        ]\n",
-    "        return self.pipe(list(batch[\"prompt\"])).images"
+    "        images = self.pipe(list(batch[\"prompt\"])).images\n",
+    "        return {\"image\": np.array(images, dtype=object)}"
    ]
   },
   {
@@ -164,7 +166,7 @@
     "    batch_format=\"pandas\",\n",
     "    num_gpus=1,\n",
     ")\n",
-    "images = preds.take_all()"
+    "results = preds.take_all()"
    ]
   },
   {
@@ -193,7 +195,7 @@
     }
    ],
    "source": [
-    "images[0]"
+    "results[0][\"images\"]"
    ]
   },
   {
@@ -214,7 +216,7 @@
     }
    ],
    "source": [
-    "images[1]"
+    "results[1][\"images\"]"
    ]
   },
   {

--- a/doc/source/ray-air/examples/stablediffusion_batch_prediction.ipynb
+++ b/doc/source/ray-air/examples/stablediffusion_batch_prediction.ipynb
@@ -128,7 +128,7 @@
     "            torch.Generator(device=\"cuda\").manual_seed(i) for i in range(len(batch))\n",
     "        ]\n",
     "        images = self.pipe(list(batch[\"prompt\"])).images\n",
-    "        return {\"image\": np.array(images, dtype=object)}"
+    "        return {\"images\": np.array(images, dtype=object)}"
    ]
   },
   {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fix this failed air example due to the recent "strict_mode" change in Ray Data.

Previously, we could return a list in the batch mapper function, but now we must return a dictionary.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
