### PR TITLE
Update the help of language argument for api_main method

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -693,8 +693,8 @@ def api_main(program, *args):
         default="python,cpp",
         type=str,
         help="A list of languages to build native libraries. "
-        'Supported languages include "python" and "java". '
-        "If not specified, only the Python library will be built.",
+        'Supported languages include "python" "cpp" and "java". '
+        "If not specified, python and cpp library will be built.",
     )
     parsed_args = parser.parse_args(args)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The language argument support `python` `cpp` and `java`, and default is `python,cpp`. But the help message is not update, so we should correct it.

## Related issue number

Quick fixes are not required issue.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
