### PR TITLE
[core] Start ray syncer reconnection after a delay

### DIFF
--- a/src/ray/common/ray_syncer/ray_syncer.cc
+++ b/src/ray/common/ray_syncer/ray_syncer.cc
@@ -16,7 +16,9 @@
 
 #include <functional>
 
+#include "ray/common/asio/asio_util.h"
 #include "ray/common/ray_config.h"
+
 namespace ray {
 namespace syncer {
 
@@ -222,10 +224,14 @@ void RaySyncer::Connect(const std::string &node_id,
             [this, channel](const std::string &node_id, bool restart) {
               sync_reactors_.erase(node_id);
               if (restart) {
-                RAY_LOG_EVERY_MS(INFO, 10 * 1000)
-                    << "Connection is broken. Reconnect to node: "
-                    << NodeID::FromBinary(node_id);
-                Connect(node_id, channel);
+                execute_after(
+                    io_context_,
+                    [this, node_id, channel]() {
+                      RAY_LOG(INFO) << "Connection is broken. Reconnect to node: "
+                                    << NodeID::FromBinary(node_id);
+                      Connect(node_id, channel);
+                    },
+                    /* delay_microseconds = */ 2000);
               }
             },
             /* stub */ std::move(stub));


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previously, then a connection is broken, it'll try to do reconnection immediately. Usually when network issues happened, it's going to take a while to recover. This PR adds a 2s delay before initializing a reconnect to make the workload more reasonable.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
