### PR TITLE
[Core] Add bundles_to_node_id info in placement_group_table

### DIFF
--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -329,6 +329,10 @@ class GlobalState:
                 bundle.bundle_id.bundle_index: MessageToDict(bundle)["unitResources"]
                 for bundle in placement_group_info.bundles
             },
+            "bundles_to_node_id": {
+                bundle.bundle_id.bundle_index: binary_to_hex(bundle.node_id)
+                for bundle in placement_group_info.bundles
+            },
             "strategy": get_strategy(placement_group_info.strategy),
             "state": get_state(placement_group_info.state),
             "stats": {


### PR DESCRIPTION
## Why are these changes needed?
Now there is node_id information corresponding to each bundles in gcs_utils.PlacementGroupTableData. 
But there is no node_id information corresponding to bundles in ray.util.placement_group_table() interface in python.   
Now add a "bundles_to_node_id" field in the returned result of the ray.util.placement_group_table() interface

To ensure compatibility. A "bundles_to_node_id" field is added.

Python API:
```
table = ray.util.placement_group_table(placement_group)
```

```
  'bundles_to_node_id': {
      0: 'ec42972a61c566f3dbdfdcded997dad5b2c0a7236c27b2a638ca0b34', 
      1: 'a4643ba3eb792f84f58d75d05b04eb9d0f9ce0dc1925b9cf1767045c'
  }, 
```

After modification
```
{
  'placement_group_id': 'd534cc554a75b6243cf5b8cd3a4101000000',
  'name': 'name', 
  'bundles': {0: {'CPU': 2.0}, 1: {'CPU': 2.0}}, 
  'bundles_to_node_id': {0: 'ec42972a61c566f3dbdfdcded997dad5b2c0a7236c27b2a638ca0b34', 1: 'a4643ba3eb792f84f58d75d05b04eb9d0f9ce0dc1925b9cf1767045c'}, 
  'strategy': 'SPREAD', 
  'state': 'CREATED', 
  'stats': {'end_to_end_creation_latency_ms': 1.307, 'scheduling_latency_ms': 1.265, 'scheduling_attempt': 1, 'highest_retry_delay_ms': 0.0, 'scheduling_state': 'FINISHED'}
}
```

## Related issue number


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
