### PR TITLE
[air/output] Fix trial status at end (more info + cut off)

### DIFF
--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -290,7 +290,8 @@ def _get_trial_table_data_per_status(
     more_info = None
     for t in trials:
         if len(trial_infos) >= max_row:
-            more_info = f"... and {str(len(trials) - max_row)} more {status} ..."
+            remaining = len(trials) - max_row
+            more_info = f"{remaining} more {status}"
             break
         trial_infos.append(_get_trial_info(t, metric_keys))
     return _PerStatusTrialTableData(trial_infos, more_info)
@@ -299,6 +300,7 @@ def _get_trial_table_data_per_status(
 def _get_trial_table_data(
     trials: List[Trial],
     metric_keys: List[str],
+    all_rows: bool = False,
 ) -> _TrialTableData:
     """Generate a table showing the current progress of tuning trials.
 
@@ -307,6 +309,7 @@ def _get_trial_table_data(
         metric_keys: Ordered list of metrics to be displayed in the table.
             Including both default and user defined.
             Will only be shown if at least one trial is having the key.
+        all_rows: Force to show all rows.
 
     Returns:
         Trial table data, including header and trial table per each status.
@@ -342,7 +345,7 @@ def _get_trial_table_data(
             t_status,
             trials_by_state[t_status],
             metric_keys=formatted_metric_columns,
-            force_max_rows=len(trials) > max_trial_num_to_show,
+            force_max_rows=not all_rows and len(trials) > max_trial_num_to_show,
         )
         if trial_data_per_status:
             trial_data.append(trial_data_per_status)
@@ -503,10 +506,10 @@ class ProgressReporter:
         if self._verbosity < self._heartbeat_threshold:
             return
         if force or time.time() - self._last_heartbeat_time > self._heartbeat_freq:
-            self._print_heartbeat(trials, *args)
+            self._print_heartbeat(trials, *args, force=force)
             self._last_heartbeat_time = time.time()
 
-    def _print_heartbeat(self, trials, *args):
+    def _print_heartbeat(self, trials, *args, force: bool = False):
         raise NotImplementedError
 
 
@@ -559,7 +562,9 @@ class TuneReporterBase(ProgressReporter):
         return f"Trial status: {result}"
 
     # TODO: Return a more structured type to share code with Jupyter flow.
-    def _get_heartbeat(self, trials, *sys_args) -> Tuple[List[str], _TrialTableData]:
+    def _get_heartbeat(
+        self, trials, *sys_args, force: bool = False
+    ) -> Tuple[List[str], _TrialTableData]:
         result = list()
         # Trial status: 1 RUNNING | 7 PENDING
         result.append(self._get_overall_trial_progress_str(trials))
@@ -580,10 +585,10 @@ class TuneReporterBase(ProgressReporter):
 
         all_metrics = list(DEFAULT_COLUMNS.keys()) + self._inferred_metric
 
-        trial_table_data = _get_trial_table_data(trials, all_metrics)
+        trial_table_data = _get_trial_table_data(trials, all_metrics, all_rows=force)
         return result, trial_table_data
 
-    def _print_heartbeat(self, trials, *sys_args):
+    def _print_heartbeat(self, trials, *sys_args, force: bool = False):
         raise NotImplementedError
 
 
@@ -624,28 +629,32 @@ class TuneTerminalReporter(TuneReporterBase):
             **kwargs,
         )
 
-    def _print_heartbeat(self, trials, *sys_args):
-        if self._verbosity < self._heartbeat_threshold:
+    def _print_heartbeat(self, trials, *sys_args, force: bool = False):
+        if self._verbosity < self._heartbeat_threshold and not force:
             return
-        heartbeat_strs, table_data = self._get_heartbeat(trials, *sys_args)
+        heartbeat_strs, table_data = self._get_heartbeat(trials, *sys_args, force=force)
+
         for s in heartbeat_strs:
             print(s)
         # now print the table using Tabulate
-        all_infos = []
+        more_infos = []
+        all_data = []
         header = table_data.header
-        table_data_list = table_data.data
-        for table in table_data_list:
-            all_infos.extend(table.trial_infos)
-            if table.more_info:
-                all_infos.append(table.more_info)
+        for sub_table in table_data.data:
+            all_data.extend(sub_table.trial_infos)
+            if sub_table.more_info:
+                more_infos.append(sub_table.more_info)
+
         print(
             tabulate(
-                all_infos,
+                all_data,
                 headers=header,
                 tablefmt=AIR_TABULATE_TABLEFMT,
                 showindex=False,
             )
         )
+        if more_infos:
+            print(", ".join(more_infos))
         print()
 
 
@@ -710,7 +719,7 @@ class TuneRichReporter(TuneReporterBase):
 
         self._live.update(table)
 
-    def _print_heartbeat(self, trials, *args):
+    def _print_heartbeat(self, trials, *args, force: bool = False):
         if not rich:
             return
         if not self._live:
@@ -719,7 +728,7 @@ class TuneRichReporter(TuneReporterBase):
                 "be called without `with_live` context manager."
             )
             return
-        heartbeat_strs, table_data = self._get_heartbeat(trials, *args)
+        heartbeat_strs, table_data = self._get_heartbeat(trials, *args, force=force)
         self._render_layout(heartbeat_strs, table_data)
 
 
@@ -727,7 +736,7 @@ class TrainReporter(ProgressReporter):
     # the minimal verbosity threshold at which heartbeat starts getting printed.
     _heartbeat_threshold = AirVerbosity.VERBOSE
 
-    def _get_heartbeat(self, trials: List[Trial]):
+    def _get_heartbeat(self, trials: List[Trial], force: bool = False):
         # Training on iteration 1. Current time: 2023-03-22 15:29:25 (running for 00:00:03.24)  # noqa
         if len(trials) == 0:
             return
@@ -744,8 +753,8 @@ class TrainReporter(ProgressReporter):
             [f"Training on iteration {iter_num}.", self._time_heartbeat_str]
         )
 
-    def _print_heartbeat(self, trials, *args):
-        print(self._get_heartbeat(trials))
+    def _print_heartbeat(self, trials, *args, force: bool = False):
+        print(self._get_heartbeat(trials, force=force))
 
 
 # These keys are blacklisted for printing out training/tuning intermediate/final result!

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -563,7 +563,7 @@ class TuneReporterBase(ProgressReporter):
 
     # TODO: Return a more structured type to share code with Jupyter flow.
     def _get_heartbeat(
-        self, trials, *sys_args, force: bool = False
+        self, trials, *sys_args, force_full_output: bool = False
     ) -> Tuple[List[str], _TrialTableData]:
         result = list()
         # Trial status: 1 RUNNING | 7 PENDING
@@ -585,7 +585,9 @@ class TuneReporterBase(ProgressReporter):
 
         all_metrics = list(DEFAULT_COLUMNS.keys()) + self._inferred_metric
 
-        trial_table_data = _get_trial_table_data(trials, all_metrics, all_rows=force)
+        trial_table_data = _get_trial_table_data(
+            trials, all_metrics, all_rows=force_full_output
+        )
         return result, trial_table_data
 
     def _print_heartbeat(self, trials, *sys_args, force: bool = False):
@@ -632,7 +634,9 @@ class TuneTerminalReporter(TuneReporterBase):
     def _print_heartbeat(self, trials, *sys_args, force: bool = False):
         if self._verbosity < self._heartbeat_threshold and not force:
             return
-        heartbeat_strs, table_data = self._get_heartbeat(trials, *sys_args, force=force)
+        heartbeat_strs, table_data = self._get_heartbeat(
+            trials, *sys_args, force_full_output=force
+        )
 
         for s in heartbeat_strs:
             print(s)
@@ -728,7 +732,9 @@ class TuneRichReporter(TuneReporterBase):
                 "be called without `with_live` context manager."
             )
             return
-        heartbeat_strs, table_data = self._get_heartbeat(trials, *args, force=force)
+        heartbeat_strs, table_data = self._get_heartbeat(
+            trials, *args, force_full_output=force
+        )
         self._render_layout(heartbeat_strs, table_data)
 
 
@@ -736,7 +742,7 @@ class TrainReporter(ProgressReporter):
     # the minimal verbosity threshold at which heartbeat starts getting printed.
     _heartbeat_threshold = AirVerbosity.VERBOSE
 
-    def _get_heartbeat(self, trials: List[Trial], force: bool = False):
+    def _get_heartbeat(self, trials: List[Trial], force_full_output: bool = False):
         # Training on iteration 1. Current time: 2023-03-22 15:29:25 (running for 00:00:03.24)  # noqa
         if len(trials) == 0:
             return
@@ -754,7 +760,7 @@ class TrainReporter(ProgressReporter):
         )
 
     def _print_heartbeat(self, trials, *args, force: bool = False):
-        print(self._get_heartbeat(trials, force=force))
+        print(self._get_heartbeat(trials, force_full_output=force))
 
 
 # These keys are blacklisted for printing out training/tuning intermediate/final result!

--- a/python/ray/tune/tests/output/test_output.py
+++ b/python/ray/tune/tests/output/test_output.py
@@ -179,9 +179,9 @@ def test_get_trial_table_data_more_than_20():
     assert len(table_data) == 3  # only the running category
     for i in range(3):
         assert len(table_data[i].trial_infos) == 5
-    assert table_data[0].more_info == "... and 5 more RUNNING ..."
-    assert table_data[1].more_info == "... and 5 more TERMINATED ..."
-    assert table_data[2].more_info == "... and 5 more PENDING ..."
+    assert table_data[0].more_info == "5 more RUNNING"
+    assert table_data[1].more_info == "5 more TERMINATED"
+    assert table_data[2].more_info == "5 more PENDING"
 
 
 def test_result_table_no_divison():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR ensures that the full trial status table is printed at the end of a Ray Tune run with the new output engine. Additionally, trial status data was previously always cut off - now we enforce that when `force= True`, all trial data is reported.

It also fixes a bug for showing the `more_info` field (how many more trials with a specific status are available).

Before:

```
╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Trial name                   status              loss     iter     total time (s)     iterations │
├──────────────────────────────────────────────────────────────────────────────────────────────────┤
│ easy_objective_d52e5_00000   TERMINATED    1.63294          20            2.12258             19 │
│ easy_objective_d52e5_00001   TERMINATED   -0.00503704       20            2.13938             19 │
│ easy_objective_d52e5_00002   TERMINATED    0.993741         20            2.12147             19 │
│ easy_objective_d52e5_00003   TERMINATED   -1.37468          20            2.12688             19 │
│ easy_objective_d52e5_00004   TERMINATED   -0.366993         20            2.12531             19 │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
55 more TERMINATED
```

After
```
╭────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Trial name                   status            loss     iter     total time (s)     iterations │
├────────────────────────────────────────────────────────────────────────────────────────────────┤
│ easy_objective_2535f_00000   TERMINATED   -8.7459         20            2.12678             19 │
│ easy_objective_2535f_00001   TERMINATED   -4.72291        20            2.13098             19 │
│ easy_objective_2535f_00002   TERMINATED    9.68591        20            2.12318             19 │
│ easy_objective_2535f_00003   TERMINATED    8.8669         20            2.13312             19 │
│ easy_objective_2535f_00004   TERMINATED   -7.76264        20            2.10994             19 │
│ easy_objective_2535f_00005   TERMINATED    9.7339         20            2.11871             19 │
│ easy_objective_2535f_00006   TERMINATED   -8.92678        20            2.12034             19 │
│ easy_objective_2535f_00007   TERMINATED   -4.14569        20            2.12235             19 │
│ easy_objective_2535f_00008   TERMINATED   -1.90578        20            2.12757             19 │
│ easy_objective_2535f_00009   TERMINATED   -9.29668        20            2.1048              19 │
│ easy_objective_2535f_00010   TERMINATED   -8.82601        20            2.11207             19 │
│ easy_objective_2535f_00011   TERMINATED    4.58302        20            2.11505             19 │
│ easy_objective_2535f_00012   TERMINATED   -3.19667        20            2.10649             19 │
│ easy_objective_2535f_00013   TERMINATED    0.276288       20            2.11077             19 │
│ easy_objective_2535f_00014   TERMINATED    3.16934        20            2.11101             19 │
│ easy_objective_2535f_00015   TERMINATED   -6.99527        20            2.11281             19 │
│ easy_objective_2535f_00016   TERMINATED    5.26072        20            2.10124             19 │
│ easy_objective_2535f_00017   TERMINATED   -1.17222        20            2.1232              19 │
│ easy_objective_2535f_00018   TERMINATED   -3.2927         20            2.103               19 │
│ easy_objective_2535f_00019   TERMINATED    8.52026        20            2.0961              19 │
│ easy_objective_2535f_00020   TERMINATED   -9.50308        20            2.11589             19 │
│ easy_objective_2535f_00021   TERMINATED    3.52898        20            2.10839             19 │
│ easy_objective_2535f_00022   TERMINATED    2.24067        20            2.10501             19 │
│ easy_objective_2535f_00023   TERMINATED   -6.59235        20            2.10195             19 │
│ easy_objective_2535f_00024   TERMINATED   -7.5678         20            2.11382             19 │
│ easy_objective_2535f_00025   TERMINATED    8.14493        20            2.10336             19 │
│ easy_objective_2535f_00026   TERMINATED    8.22056        20            2.1018              19 │
│ easy_objective_2535f_00027   TERMINATED   -7.76516        20            2.08713             19 │
│ easy_objective_2535f_00028   TERMINATED   -6.19463        20            2.10738             19 │
│ easy_objective_2535f_00029   TERMINATED   -2.16162        20            2.08866             19 │
│ easy_objective_2535f_00030   TERMINATED    6.58598        20            2.09207             19 │
│ easy_objective_2535f_00031   TERMINATED    6.69676        20            2.10172             19 │
│ easy_objective_2535f_00032   TERMINATED   -0.127672       20            2.10933             19 │
│ easy_objective_2535f_00033   TERMINATED   -9.29816        20            2.10509             19 │
│ easy_objective_2535f_00034   TERMINATED    7.68197        20            2.09605             19 │
│ easy_objective_2535f_00035   TERMINATED    6.29745        20            2.10823             19 │
│ easy_objective_2535f_00036   TERMINATED    8.52747        20            2.10674             19 │
│ easy_objective_2535f_00037   TERMINATED   -0.680396       20            2.09909             19 │
│ easy_objective_2535f_00038   TERMINATED    1.02905        20            2.11742             19 │
│ easy_objective_2535f_00039   TERMINATED   -7.29284        20            2.09985             19 │
│ easy_objective_2535f_00040   TERMINATED    0.253536       20            2.1162              19 │
│ easy_objective_2535f_00041   TERMINATED    6.71257        20            2.09051             19 │
│ easy_objective_2535f_00042   TERMINATED    3.99266        20            2.11268             19 │
│ easy_objective_2535f_00043   TERMINATED   -3.61558        20            2.1147              19 │
│ easy_objective_2535f_00044   TERMINATED    1.72299        20            2.09601             19 │
│ easy_objective_2535f_00045   TERMINATED   -5.96753        20            2.11121             19 │
│ easy_objective_2535f_00046   TERMINATED    7.91628        20            2.12614             19 │
│ easy_objective_2535f_00047   TERMINATED   -5.20284        20            2.10836             19 │
│ easy_objective_2535f_00048   TERMINATED    8.15891        20            2.10423             19 │
│ easy_objective_2535f_00049   TERMINATED    6.37054        20            2.1078              19 │
│ easy_objective_2535f_00050   TERMINATED   -8.98244        20            2.10171             19 │
│ easy_objective_2535f_00051   TERMINATED    8.82456        20            2.09652             19 │
│ easy_objective_2535f_00052   TERMINATED   -1.23827        20            2.10859             19 │
│ easy_objective_2535f_00053   TERMINATED   -6.53946        20            2.10545             19 │
│ easy_objective_2535f_00054   TERMINATED   -1.95374        20            2.10248             19 │
│ easy_objective_2535f_00055   TERMINATED   -1.79311        20            2.11117             19 │
│ easy_objective_2535f_00056   TERMINATED   -7.93258        20            2.10502             19 │
│ easy_objective_2535f_00057   TERMINATED   -1.69906        20            2.09228             19 │
│ easy_objective_2535f_00058   TERMINATED   -8.08596        20            2.1227              19 │
│ easy_objective_2535f_00059   TERMINATED    6.12904        20            2.09889             19 │
╰────────────────────────────────────────────────────────────────────────────────────────────────╯
```


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
