### PR TITLE
[Serve] Add status_code to http qps & latency

### DIFF
--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -320,6 +320,7 @@ class HTTPProxy:
             tag_keys=(
                 "route",
                 "application",
+                "status_code",
             ),
         )
 
@@ -437,7 +438,12 @@ class HTTPProxy:
 
         latency_ms = (time.time() - start_time) * 1000.0
         self.processing_latency_tracker.observe(
-            latency_ms, tags={"route": route_path, "application": app_name}
+            latency_ms,
+            tags={
+                "route": route_path,
+                "application": app_name,
+                "status_code": status_code,
+            },
         )
         logger.info(
             access_log_msg(

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -284,7 +284,7 @@ class HTTPProxy:
         self.request_counter = metrics.Counter(
             "serve_num_http_requests",
             description="The number of HTTP requests processed.",
-            tag_keys=("route", "method", "application"),
+            tag_keys=("route", "method", "application", "status_code"),
         )
 
         self.request_error_counter = metrics.Counter(
@@ -371,6 +371,7 @@ class HTTPProxy:
                     "route": route_path,
                     "method": scope["method"].upper(),
                     "application": "",
+                    "status_code": "200",
                 }
             )
             return await starlette.responses.JSONResponse(self.route_info)(
@@ -383,6 +384,7 @@ class HTTPProxy:
                     "route": route_path,
                     "method": scope["method"].upper(),
                     "application": "",
+                    "status_code": "200",
                 }
             )
             return await starlette.responses.PlainTextResponse("success")(
@@ -403,16 +405,11 @@ class HTTPProxy:
                     "route": route_path,
                     "method": scope["method"].upper(),
                     "application": "",
+                    "status_code": "404",
                 }
             )
             return await self._not_found(scope, receive, send)
-        self.request_counter.inc(
-            tags={
-                "route": route_path,
-                "method": scope["method"].upper(),
-                "application": app_name,
-            }
-        )
+
         # Modify the path and root path so that reverse lookups and redirection
         # work as expected. We do this here instead of in replicas so it can be
         # changed without restarting the replicas.
@@ -428,6 +425,16 @@ class HTTPProxy:
             )
         )
         status_code = await _send_request_to_handle(handle, scope, receive, send)
+
+        self.request_counter.inc(
+            tags={
+                "route": route_path,
+                "method": scope["method"].upper(),
+                "application": app_name,
+                "status_code": status_code,
+            }
+        )
+
         latency_ms = (time.time() - start_time) * 1000.0
         self.processing_latency_tracker.observe(
             latency_ms, tags={"route": route_path, "application": app_name}

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -12,6 +12,8 @@ import ray.experimental.state.api as state_api
 from fastapi import FastAPI
 from ray.serve.metrics import Counter, Histogram, Gauge
 from ray.serve._private.constants import DEFAULT_LATENCY_BUCKET_MS
+from ray.serve.drivers import DAGDriver
+from ray.serve.http_adapters import json_request
 
 
 @pytest.fixture
@@ -194,6 +196,7 @@ def test_http_metrics_fields(serve_start_shutdown):
     assert num_requests[0]["route"] == "/fake_route"
     assert num_requests[0]["method"] == "GET"
     assert num_requests[0]["application"] == ""
+    assert num_requests[0]["status_code"] == "404"
     print("serve_num_http_requests working as expected.")
 
     num_errors = get_metric_dictionaries("serve_num_http_error_requests")
@@ -223,7 +226,68 @@ def test_http_metrics_fields(serve_start_shutdown):
     assert len(latency_metrics) == 1
     assert latency_metrics[0]["route"] == "/real_route"
     assert latency_metrics[0]["application"] == "app"
+    assert latency_metrics[0]["status_code"] == "500"
     print("serve_http_request_latency_ms working as expected.")
+
+
+def test_http_redirect_metrics(serve_start_shutdown):
+    """Tests the http redirect metrics' behavior."""
+
+    def verify_metrics_with_route(metrics, expected_metrics):
+        assert len(metrics) == len(expected_metrics)
+        for metric_dict in metrics:
+            match_metric = None
+            for expected_metric in expected_metrics:
+                if expected_metric["route"] == metric_dict["route"]:
+                    match_metric = expected_metric
+                    break
+            assert match_metric is not None
+            for key in match_metric:
+                assert match_metric[key] == metric_dict[key]
+
+    @serve.deployment
+    class Model:
+        def __call__(self, *args):
+            return "123"
+
+    serve.run(
+        DAGDriver.bind(Model.bind(), http_adapter=json_request), route_prefix="/bar"
+    )
+    resp = requests.get("http://localhost:8000/bar", json=["123"])
+    assert resp.status_code == 200
+    assert resp.text == '"123"'
+
+    wait_for_condition(
+        lambda: len(get_metric_dictionaries("serve_num_http_requests")) == 2,
+        timeout=20,
+    )
+    num_http_requests = get_metric_dictionaries("serve_num_http_requests")
+    expected_output = [
+        {
+            "route": "/bar/",
+            "application": "default",
+            "method": "GET",
+            "status_code": "200",
+        },
+        {
+            "route": "/bar",
+            "application": "default",
+            "method": "GET",
+            "status_code": "307",
+        },
+    ]
+    verify_metrics_with_route(num_http_requests, expected_output)
+
+    wait_for_condition(
+        lambda: len(get_metric_dictionaries("serve_http_request_latency_ms_sum")) == 2,
+        timeout=20,
+    )
+    http_latency = get_metric_dictionaries("serve_num_http_requests")
+    expected_output = [
+        {"route": "/bar/", "application": "default", "status_code": "200"},
+        {"route": "/bar", "application": "default", "status_code": "307"},
+    ]
+    verify_metrics_with_route(http_latency, expected_output)
 
 
 def test_replica_metrics_fields(serve_start_shutdown):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add `status_code` for http qps & latency stats. 
This is to resolve "double counting" issue because of redirect request.



## Related issue number

Close #33686

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
