### PR TITLE
[Data] Update `pipelined_training_50_gb.aws` instance type

### DIFF
--- a/release/nightly_tests/dataset/pipelined_training_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_training_compute.yaml
@@ -18,7 +18,7 @@ head_node_type:
 
 worker_node_types:
     - name: memory_node
-      instance_type: i3.8xlarge
+      instance_type: m6i.16xlarge
       min_workers: 10
       max_workers: 10
       use_spot: false

--- a/release/nightly_tests/dataset/pipelined_training_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_training_compute.yaml
@@ -14,10 +14,10 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: i3.8xlarge
+    instance_type: m6i.16xlarge
 
 worker_node_types:
-    - name: memory_node 
+    - name: memory_node
       instance_type: i3.8xlarge
       min_workers: 10
       max_workers: 10


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Anyscale recently stopped supporting `i3.8xlarge` instance types. As a result, the `pipelined_training_50_gb.aws` release test -- which uses `i3.8xlarge` -- has been failing.

This PR updates the instance type to `m6i.16xlarge` (a supported instance type).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
