### PR TITLE
[ray] pin version of urrlib3

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -36,7 +36,7 @@ typing_extensions; python_version < '3.8'
 uvicorn
 py-spy>=0.2.0
 rich
-urllib3
+urllib3<1.27
 scikit-image
 scipy
 aiohttp>=3.7

--- a/python/setup.py
+++ b/python/setup.py
@@ -256,7 +256,7 @@ if setup_spec.type == SetupType.RAY:
         ],
         "serve": ["uvicorn", "requests", "starlette", "fastapi", "aiorwlock"],
         "tune": ["pandas", "tensorboardX>=1.9", "requests", pyarrow_dep],
-        "k8s": ["kubernetes", "urllib3"],
+        "k8s": ["kubernetes", "urllib3<1.27"],
         "observability": [
             "opentelemetry-api",
             "opentelemetry-sdk",


### PR DESCRIPTION
## Why are these changes needed?
Latest version of urrlib3 (v2.0) causes compatibility issues with boto3 and request.  See the attached issues for more details. Pin to the appropriate version. 

## Related issue number

Fix https://github.com/anyscale/product/issues/20320

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy: pip install -e python/