### PR TITLE
[AIR] Remove hard-deprecated and unused code

### DIFF
--- a/python/ray/train/_internal/results_preprocessors/__init__.py
+++ b/python/ray/train/_internal/results_preprocessors/__init__.py
@@ -1,8 +1,0 @@
-raise DeprecationWarning(
-    "`ray.train.callbacks.results_preprocessors` and the `ray.train.Trainer` API are "
-    "deprecated in Ray "
-    "2.0, and are replaced by Ray AI Runtime (Ray AIR). Ray AIR "
-    "(https://docs.ray.io/en/latest/ray-air/getting-started.html) "
-    "provides greater functionality and a unified API "
-    "compared to the old Ray Train API. "
-)

--- a/python/ray/train/_internal/results_preprocessors/aggregate/__init__.py
+++ b/python/ray/train/_internal/results_preprocessors/aggregate/__init__.py
@@ -1,9 +1,0 @@
-raise DeprecationWarning(
-    "`ray.train.callbacks.results_preprocessors.aggregate` and the `ray.train.Trainer` "
-    "API are "
-    "deprecated in Ray "
-    "2.0, and are replaced by Ray AI Runtime (Ray AIR). Ray AIR "
-    "(https://docs.ray.io/en/latest/ray-air/getting-started.html) "
-    "provides greater functionality and a unified API "
-    "compared to the old Ray Train API. "
-)

--- a/python/ray/train/_internal/results_preprocessors/aggregate/aggregate_fn.py
+++ b/python/ray/train/_internal/results_preprocessors/aggregate/aggregate_fn.py
@@ -1,9 +1,0 @@
-raise DeprecationWarning(
-    "`ray.train.callbacks.results_preprocessors.aggregate` and the `ray.train.Trainer` "
-    "API are "
-    "deprecated in Ray "
-    "2.0, and are replaced by Ray AI Runtime (Ray AIR). Ray AIR "
-    "(https://docs.ray.io/en/latest/ray-air/getting-started.html) "
-    "provides greater functionality and a unified API "
-    "compared to the old Ray Train API. "
-)

--- a/python/ray/train/_internal/results_preprocessors/aggregate/aggregate_preprocessor.py
+++ b/python/ray/train/_internal/results_preprocessors/aggregate/aggregate_preprocessor.py
@@ -1,9 +1,0 @@
-raise DeprecationWarning(
-    "`ray.train.callbacks.results_preprocessors.aggregate` and the `ray.train.Trainer` "
-    "API are "
-    "deprecated in Ray "
-    "2.0, and are replaced by Ray AI Runtime (Ray AIR). Ray AIR "
-    "(https://docs.ray.io/en/latest/ray-air/getting-started.html) "
-    "provides greater functionality and a unified API "
-    "compared to the old Ray Train API. "
-)

--- a/python/ray/train/_internal/results_preprocessors/aggregate/aggregate_utils.py
+++ b/python/ray/train/_internal/results_preprocessors/aggregate/aggregate_utils.py
@@ -1,9 +1,0 @@
-raise DeprecationWarning(
-    "`ray.train.callbacks.results_preprocessors.aggregate` and the `ray.train.Trainer` "
-    "API are "
-    "deprecated in Ray "
-    "2.0, and are replaced by Ray AI Runtime (Ray AIR). Ray AIR "
-    "(https://docs.ray.io/en/latest/ray-air/getting-started.html) "
-    "provides greater functionality and a unified API "
-    "compared to the old Ray Train API. "
-)

--- a/python/ray/train/_internal/results_preprocessors/index.py
+++ b/python/ray/train/_internal/results_preprocessors/index.py
@@ -1,8 +1,0 @@
-raise DeprecationWarning(
-    "`ray.train.callbacks.results_preprocessors` and the `ray.train.Trainer` API are "
-    "deprecated in Ray "
-    "2.0, and are replaced by Ray AI Runtime (Ray AIR). Ray AIR "
-    "(https://docs.ray.io/en/latest/ray-air/getting-started.html) "
-    "provides greater functionality and a unified API "
-    "compared to the old Ray Train API. "
-)

--- a/python/ray/train/_internal/results_preprocessors/keys.py
+++ b/python/ray/train/_internal/results_preprocessors/keys.py
@@ -1,8 +1,0 @@
-raise DeprecationWarning(
-    "`ray.train.callbacks.results_preprocessors` and the `ray.train.Trainer` API are "
-    "deprecated in Ray "
-    "2.0, and are replaced by Ray AI Runtime (Ray AIR). Ray AIR "
-    "(https://docs.ray.io/en/latest/ray-air/getting-started.html) "
-    "provides greater functionality and a unified API "
-    "compared to the old Ray Train API. "
-)

--- a/python/ray/train/_internal/results_preprocessors/preprocessor.py
+++ b/python/ray/train/_internal/results_preprocessors/preprocessor.py
@@ -1,8 +1,0 @@
-raise DeprecationWarning(
-    "`ray.train.callbacks.results_preprocessors` and the `ray.train.Trainer` API are "
-    "deprecated in Ray "
-    "2.0, and are replaced by Ray AI Runtime (Ray AIR). Ray AIR "
-    "(https://docs.ray.io/en/latest/ray-air/getting-started.html) "
-    "provides greater functionality and a unified API "
-    "compared to the old Ray Train API. "
-)

--- a/python/ray/tune/tests/test_trainable_util.py
+++ b/python/ray/tune/tests/test_trainable_util.py
@@ -74,24 +74,6 @@ class TrainableUtilTest(unittest.TestCase):
             parent = os.path.dirname(found_dir)
             TrainableUtil.find_checkpoint_dir(parent)
 
-    def testPickleCheckpoint(self):
-        for i in range(5):
-            path = os.path.join(self.checkpoint_dir, str(i))
-            with open(path, "w") as f:
-                f.write(str(i))
-
-        checkpoint_path = os.path.join(self.checkpoint_dir, "0")
-
-        data_dict = TrainableUtil.pickle_checkpoint(checkpoint_path)
-        loaded = cloudpickle.loads(data_dict)
-
-        checkpoint_name = os.path.basename(checkpoint_path)
-        self.assertEqual(loaded["checkpoint_name"], checkpoint_name)
-
-        for i in range(5):
-            path = os.path.join(self.checkpoint_dir, str(i))
-            self.assertEqual(loaded["data"][str(i)], open(path, "rb").read())
-
 
 class FlattenDictTest(unittest.TestCase):
     def test_output_type(self):

--- a/python/ray/tune/tests/test_trainable_util.py
+++ b/python/ray/tune/tests/test_trainable_util.py
@@ -10,7 +10,6 @@ from unittest.mock import patch
 
 import ray
 import ray._private.utils
-import ray.cloudpickle as cloudpickle
 from ray.tune.utils.util import wait_for_gpu
 from ray.tune.utils.util import flatten_dict, unflatten_dict, unflatten_list_dict
 from ray.tune.trainable.util import TrainableUtil

--- a/python/ray/tune/trainable/util.py
+++ b/python/ray/tune/trainable/util.py
@@ -43,27 +43,6 @@ class TrainableUtil:
             return pickle.load(f)
 
     @staticmethod
-    def pickle_checkpoint(checkpoint_path: str):
-        """Pickles checkpoint data."""
-        checkpoint_dir = TrainableUtil.find_checkpoint_dir(checkpoint_path)
-        data = {}
-        for basedir, _, file_names in os.walk(checkpoint_dir):
-            for file_name in file_names:
-                path = os.path.join(basedir, file_name)
-                with open(path, "rb") as f:
-                    data[os.path.relpath(path, checkpoint_dir)] = f.read()
-        # Use normpath so that a directory path isn't mapped to empty string.
-        name = os.path.relpath(os.path.normpath(checkpoint_path), checkpoint_dir)
-        name += os.path.sep if os.path.isdir(checkpoint_path) else ""
-        data_dict = pickle.dumps(
-            {
-                "checkpoint_name": name,
-                "data": data,
-            }
-        )
-        return data_dict
-
-    @staticmethod
     def find_checkpoint_dir(checkpoint_path):
         """Returns the directory containing the checkpoint path.
 

--- a/python/ray/tune/trainable/util.py
+++ b/python/ray/tune/trainable/util.py
@@ -18,7 +18,6 @@ from ray.air._internal.uri_utils import URI
 from ray.air.config import ScalingConfig
 from ray.tune.registry import _ParameterRegistry
 from ray.tune.utils import _detect_checkpoint_function
-from ray.util import placement_group
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This is a minor cleanup that removes some unused code in AIR:
- `ray.train._internal.results_preprocessors`. This was internal and has been hard deprecated for > 2 minor releases.
- Some utils in `TrainableUtil`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
