### PR TITLE
[RLlib] Unity3D adapter: Disable env pre-checking (agent IDs not known before connection to Unity editor).

### DIFF
--- a/rllib/env/wrappers/unity3d_env.py
+++ b/rllib/env/wrappers/unity3d_env.py
@@ -64,6 +64,9 @@ class Unity3DEnv(MultiAgentEnv):
                 Note: The game itself may contain its own episode length
                 limits, which are always obeyed (on top of this value here).
         """
+        # Skip env checking as the nature of the agent IDs depends on the game
+        # running in the connected Unity editor.
+        self._skip_env_checking = True
 
         super().__init__()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Unity3D adapter: Disable env pre-checking (agent IDs not known before connection to Unity editor).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
