### PR TITLE
[Data] Allow fusing `MapOperator` -> `Repartition` operators

### DIFF
--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -126,10 +126,15 @@ class OperatorFusionRule(Rule):
         # We currently only support fusing for the following cases:
         # - AbstractMap -> AbstractMap
         # - AbstractMap -> RandomShuffle
-        # - AbstractMap -> Repartition
+        # - AbstractMap -> Repartition (shuffle=True)
         if not isinstance(
             down_logical_op, (AbstractMap, RandomShuffle, Repartition)
         ) or not isinstance(up_logical_op, AbstractMap):
+            return False
+
+        # Do not fuse Repartition operator if shuffle is disabled
+        # (i.e. using split shuffle).
+        if isinstance(down_logical_op, Repartition) and not down_logical_op._shuffle:
             return False
 
         # Allow fusing tasks->actors if the resources are compatible (read->map), but

--- a/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
@@ -21,17 +21,10 @@ class ShuffleTaskSpec(ExchangeTaskSpec):
         random_shuffle: bool = False,
         random_seed: Optional[int] = None,
         upstream_map_fn: Optional[MapTransformFn] = None,
-        split_reduce: bool = False,
     ):
-        map_args = [upstream_map_fn, random_shuffle, random_seed]
-        reduce_args = [
-            random_shuffle,
-            random_seed,
-            upstream_map_fn if split_reduce else None,
-        ]
         super().__init__(
-            map_args=map_args,
-            reduce_args=reduce_args,
+            map_args=[upstream_map_fn, random_shuffle, random_seed],
+            reduce_args=[random_shuffle, random_seed],
         )
 
     @staticmethod
@@ -80,15 +73,15 @@ class ShuffleTaskSpec(ExchangeTaskSpec):
     def reduce(
         random_shuffle: bool,
         random_seed: Optional[int],
-        upstream_map_fn: Optional[MapTransformFn],
+        # upstream_map_fn: Optional[MapTransformFn],
         *mapper_outputs: List[Block],
         partial_reduce: bool = False,
     ) -> Tuple[Block, BlockMetadata]:
         # TODO: Support fusion with other downstream operators.
         stats = BlockExecStats.builder()
         builder = DelegatingBlockBuilder()
-        if upstream_map_fn:
-            mapper_outputs = upstream_map_fn(mapper_outputs)
+        # if upstream_map_fn:
+        #     mapper_outputs = upstream_map_fn(mapper_outputs)
         for block in mapper_outputs:
             builder.add_block(block)
         new_block = builder.build()

--- a/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
@@ -73,15 +73,12 @@ class ShuffleTaskSpec(ExchangeTaskSpec):
     def reduce(
         random_shuffle: bool,
         random_seed: Optional[int],
-        # upstream_map_fn: Optional[MapTransformFn],
         *mapper_outputs: List[Block],
         partial_reduce: bool = False,
     ) -> Tuple[Block, BlockMetadata]:
         # TODO: Support fusion with other downstream operators.
         stats = BlockExecStats.builder()
         builder = DelegatingBlockBuilder()
-        # if upstream_map_fn:
-        #     mapper_outputs = upstream_map_fn(mapper_outputs)
         for block in mapper_outputs:
             builder.add_block(block)
         new_block = builder.build()

--- a/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
@@ -21,10 +21,17 @@ class ShuffleTaskSpec(ExchangeTaskSpec):
         random_shuffle: bool = False,
         random_seed: Optional[int] = None,
         upstream_map_fn: Optional[MapTransformFn] = None,
+        split_reduce: bool = False,
     ):
+        map_args = [upstream_map_fn, random_shuffle, random_seed]
+        reduce_args = [
+            random_shuffle,
+            random_seed,
+            upstream_map_fn if split_reduce else None,
+        ]
         super().__init__(
-            map_args=[upstream_map_fn, random_shuffle, random_seed],
-            reduce_args=[random_shuffle, random_seed],
+            map_args=map_args,
+            reduce_args=reduce_args,
         )
 
     @staticmethod
@@ -73,12 +80,15 @@ class ShuffleTaskSpec(ExchangeTaskSpec):
     def reduce(
         random_shuffle: bool,
         random_seed: Optional[int],
+        upstream_map_fn: Optional[MapTransformFn],
         *mapper_outputs: List[Block],
         partial_reduce: bool = False,
     ) -> Tuple[Block, BlockMetadata]:
         # TODO: Support fusion with other downstream operators.
         stats = BlockExecStats.builder()
         builder = DelegatingBlockBuilder()
+        if upstream_map_fn:
+            mapper_outputs = upstream_map_fn(mapper_outputs)
         for block in mapper_outputs:
             builder.add_block(block)
         new_block = builder.build()

--- a/python/ray/data/_internal/planner/repartition.py
+++ b/python/ray/data/_internal/planner/repartition.py
@@ -57,16 +57,7 @@ def generate_repartition_fn(
         refs: List[RefBundle],
         ctx: TaskContext,
     ) -> Tuple[List[RefBundle], StatsDict]:
-        map_transform_fn: Optional["MapTransformFn"] = ctx.upstream_map_transform_fn
-        upstream_map_fn = None
-        if map_transform_fn:
-            upstream_map_fn = lambda block: map_transform_fn(block, ctx)  # noqa: E731
-
-        shuffle_spec = ShuffleTaskSpec(
-            random_shuffle=False,
-            upstream_map_fn=upstream_map_fn,
-            split_reduce=True,
-        )
+        shuffle_spec = ShuffleTaskSpec(random_shuffle=False)
         scheduler = SplitRepartitionTaskScheduler(shuffle_spec)
         return scheduler.execute(refs, num_outputs)
 

--- a/python/ray/data/_internal/planner/repartition.py
+++ b/python/ray/data/_internal/planner/repartition.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple, TYPE_CHECKING
 
 from ray.data._internal.execution.interfaces import (
     AllToAllTransformFn,
@@ -19,6 +19,9 @@ from ray.data._internal.planner.exchange.pull_based_shuffle_task_scheduler impor
 from ray.data._internal.stats import StatsDict
 from ray.data.context import DataContext
 
+if TYPE_CHECKING:
+    from python.ray.data._internal.execution.interfaces import MapTransformFn
+
 
 def generate_repartition_fn(
     num_outputs: int,
@@ -30,7 +33,18 @@ def generate_repartition_fn(
         refs: List[RefBundle],
         ctx: TaskContext,
     ) -> Tuple[List[RefBundle], StatsDict]:
-        shuffle_spec = ShuffleTaskSpec(random_shuffle=False)
+        # If map_transform_fn is specified (e.g. from fusing
+        # MapOperator->AllToAllOperator), we pass a map function which
+        # is applied to each block before shuffling.
+        map_transform_fn: Optional["MapTransformFn"] = ctx.upstream_map_transform_fn
+        upstream_map_fn = None
+        if map_transform_fn:
+            upstream_map_fn = lambda block: map_transform_fn(block, ctx)  # noqa: E731
+
+        shuffle_spec = ShuffleTaskSpec(
+            random_shuffle=False,
+            upstream_map_fn=upstream_map_fn,
+        )
 
         if DataContext.get_current().use_push_based_shuffle:
             scheduler = PushBasedShuffleTaskScheduler(shuffle_spec)
@@ -43,7 +57,16 @@ def generate_repartition_fn(
         refs: List[RefBundle],
         ctx: TaskContext,
     ) -> Tuple[List[RefBundle], StatsDict]:
-        shuffle_spec = ShuffleTaskSpec(random_shuffle=False)
+        map_transform_fn: Optional["MapTransformFn"] = ctx.upstream_map_transform_fn
+        upstream_map_fn = None
+        if map_transform_fn:
+            upstream_map_fn = lambda block: map_transform_fn(block, ctx)  # noqa: E731
+
+        shuffle_spec = ShuffleTaskSpec(
+            random_shuffle=False,
+            upstream_map_fn=upstream_map_fn,
+            split_reduce=True,
+        )
         scheduler = SplitRepartitionTaskScheduler(shuffle_spec)
         return scheduler.execute(refs, num_outputs)
 

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -288,11 +288,11 @@ def test_repartition_e2e(
     def _check_repartition_usage_and_stats(ds):
         _check_usage_record(["ReadRange", "Repartition"])
         ds_stats: DatastreamStats = ds._plan.stats()
-        assert ds_stats.base_name == "Repartition"
+        assert ds_stats.base_name == "DoRead->Repartition"
         if shuffle:
-            assert "RepartitionMap" in ds_stats.stages
+            assert "DoRead->RepartitionMap" in ds_stats.stages
         else:
-            assert "RepartitionSplit" in ds_stats.stages
+            assert "DoRead->RepartitionSplit" in ds_stats.stages
         assert "RepartitionReduce" in ds_stats.stages
 
     ds = ray.data.range(10000, parallelism=10).repartition(20, shuffle=shuffle)
@@ -630,7 +630,7 @@ def test_read_map_batches_operator_fusion_with_randomize_blocks_operator(
 
 
 def test_read_map_batches_operator_fusion_with_random_shuffle_operator(
-    ray_start_regular_shared, enable_optimizer
+    ray_start_regular_shared, enable_optimizer, use_push_based_shuffle
 ):
     # Note: we currently only support fusing MapOperator->AllToAllOperator.
     def fn(batch):
@@ -676,24 +676,19 @@ def test_read_map_batches_operator_fusion_with_random_shuffle_operator(
     _check_usage_record(["ReadRange", "RandomShuffle", "MapBatches"])
 
 
+@pytest.mark.parametrize("shuffle", (True, False))
 def test_read_map_batches_operator_fusion_with_repartition_operator(
-    ray_start_regular_shared, enable_optimizer
+    ray_start_regular_shared, enable_optimizer, shuffle, use_push_based_shuffle
 ):
-    # Note: We currently do not fuse MapBatches->Repartition.
-    # This test is to ensure that we don't accidentally fuse them, until
-    # we implement it later.
     def fn(batch):
         return {"id": [x + 1 for x in batch["id"]]}
 
     n = 10
     ds = ray.data.range(n)
     ds = ds.map_batches(fn, batch_size=None)
-    ds = ds.repartition(2)
+    ds = ds.repartition(2, shuffle=shuffle)
     assert set(extract_values("id", ds.take_all())) == set(range(1, n + 1))
-    # TODO(Scott): update the below assertions after we support fusion.
-    assert "DoRead->MapBatches->Repartition" not in ds.stats()
-    assert "DoRead->MapBatches" in ds.stats()
-    assert "Repartition" in ds.stats()
+    assert "DoRead->MapBatches->Repartition" in ds.stats()
     _check_usage_record(["ReadRange", "MapBatches", "Repartition"])
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As a followup to https://github.com/ray-project/ray/pull/34847, allow fusing `MapOperator` -> `Repartition` operators for the shuffle repartition case (we do not support fusing for split repartition, which only uses `ShuffleTaskSpec.reduce` and thus cannot call the upstream map function passed to `ShuffleTaskSpec.map`).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
