### PR TITLE
Run bisect with the correct python version

### DIFF
--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -9,7 +9,9 @@ from ray_release.logger import logger
 from ray_release.buildkite.step import get_step
 from ray_release.config import (
     read_and_validate_release_test_collection,
+    parse_python_version,
     DEFAULT_WHEEL_WAIT_TIMEOUT,
+    DEFAULT_PYTHON_VERSION,
     Test,
 )
 from ray_release.wheels import find_and_wait_for_ray_wheels_url
@@ -123,9 +125,12 @@ def _run_test(
 
 
 def _trigger_test_run(test: Test, commit: str, run_per_commit: int) -> None:
+    python_version = DEFAULT_PYTHON_VERSION
+    if "python" in test:
+        python_version = parse_python_version(test["python"])
+
     ray_wheels_url = find_and_wait_for_ray_wheels_url(
-        commit,
-        timeout=DEFAULT_WHEEL_WAIT_TIMEOUT,
+        commit, timeout=DEFAULT_WHEEL_WAIT_TIMEOUT, python_version=python_version
     )
     for run in range(run_per_commit):
         step = get_step(


### PR DESCRIPTION
## Why are these changes needed?
Currently because we do not specify the python version, bisect defaults to 3.7. Some tests want to run with a specific python version, so read the python version from the test configuration for those cases.

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests - https://buildkite.com/ray-project/release-tests-bisect/builds/129
   