### PR TITLE
[core] Make ray able to start gcs without raylet.

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -344,8 +344,13 @@ class Node:
             return
         ray._private.utils.check_version_info(cluster_metadata)
 
+    def _should_start_raylet(self):
+        if self.head:
+            return self._ray_params.start_gcs is False
+        return True
+
     def _should_start_api_server(self):
-        if self.head and len(self._ray_params.node_services) == 0:
+        if self.head and self._ray_params.start_gcs is False:
             return True
         if self._ray_params.include_dashboard is True:
             return True
@@ -1212,6 +1217,7 @@ class Node:
             self.start_log_monitor()
         if self._ray_params.ray_client_server_port:
             self.start_ray_client_server()
+
         if self._should_start_api_server():
             if self._ray_params.include_dashboard is None:
                 # Default

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -279,6 +279,7 @@ class Node:
 
         if not connect_only and spawn_reaper and not self.kernel_fate_share:
             self.start_reaper_process()
+
         if not connect_only:
             self._ray_params.update_pre_selected_port()
 
@@ -1215,6 +1216,7 @@ class Node:
         self.start_raylet(plasma_directory, object_store_memory)
         if self._ray_params.include_log_monitor:
             self.start_log_monitor()
+
         if self._ray_params.ray_client_server_port:
             self.start_ray_client_server()
 

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -333,7 +333,7 @@ class Node:
         return True
 
     def _should_start_api_server(self):
-        if self.head and self._ray_params.start_gcs is False:
+        if self.head and not self._ray_params.start_gcs:
             return True
         if self._ray_params.include_dashboard is True:
             return True
@@ -1239,6 +1239,8 @@ class Node:
                 include_dashboard=include_dashboard,
                 raise_on_failure=raise_on_api_server_failure,
             )
+        else:
+            print("Won't start api server")
 
     def _kill_process_type(
         self,

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -180,6 +180,7 @@ class RayParams:
         env_vars: Optional[Dict[str, str]] = None,
         session_name: Optional[str] = None,
         webui: Optional[str] = None,
+        node_services: List = [],
     ):
         self.redis_address = redis_address
         self.gcs_address = gcs_address
@@ -236,6 +237,7 @@ class RayParams:
         self.env_vars = env_vars
         self.session_name = session_name
         self.webui = webui
+        self.node_services = node_services
         self._system_config = _system_config or {}
         self._enable_object_reconstruction = enable_object_reconstruction
         self._check_usage()

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -180,7 +180,7 @@ class RayParams:
         env_vars: Optional[Dict[str, str]] = None,
         session_name: Optional[str] = None,
         webui: Optional[str] = None,
-        node_services: List = [],
+        start_gcs: bool = False,
     ):
         self.redis_address = redis_address
         self.gcs_address = gcs_address
@@ -237,7 +237,7 @@ class RayParams:
         self.env_vars = env_vars
         self.session_name = session_name
         self.webui = webui
-        self.node_services = node_services
+        self.start_gcs = start_gcs
         self._system_config = _system_config or {}
         self._enable_object_reconstruction = enable_object_reconstruction
         self._check_usage()

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -397,10 +397,10 @@ def debug(address):
     help="provide this argument for the head node",
 )
 @click.option(
-    "--with-gcs",
-    is_flag=True,
+    "--start-gcs",
+    is_flag=False,
     default=False,
-    help="Start GCS on the head node",
+    help="Only start GCS on the head node",
 )
 @click.option(
     "--include-dashboard",
@@ -560,7 +560,7 @@ def start(
     num_gpus,
     resources,
     head,
-    with_gcs,
+    start_gcs,
     include_dashboard,
     dashboard_host,
     dashboard_port,
@@ -624,14 +624,10 @@ def start(
             "All the worker nodes will use the same temp_dir as a head node. "
         )
         temp_dir = None
-    if with_gcs and not head:
+    if start_gcs is True and not head:
         cli_logger.error(
-            "{} and can be be used with {}.", cf.bold("--with-gcs"), cf.bold("--head")
+            "{} and can be be used with {}.", cf.bold("--start-gcs"), cf.bold("--head")
         )
-
-    node_services = []
-    if with_gcs:
-        node_services.append(ray._private.ray_constants.PROCESS_TYPE_GCS_SERVER)
 
     redirect_output = None if not no_redirect_output else True
     ray_params = ray._private.parameter.RayParams(
@@ -669,7 +665,7 @@ def start(
         no_monitor=no_monitor,
         tracing_startup_hook=tracing_startup_hook,
         ray_debugger_external=ray_debugger_external,
-        node_services=node_services,
+        start_gcs=start_gcs,
     )
 
     if ray_constants.RAY_START_HOOK in os.environ:
@@ -677,7 +673,6 @@ def start(
 
     if head:
         # Start head node.
-
         if disable_usage_stats:
             usage_lib.set_usage_stats_enabled_via_env_var(False)
         usage_lib.show_usage_stats_prompt(cli=True)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -398,7 +398,7 @@ def debug(address):
 )
 @click.option(
     "--start-gcs",
-    is_flag=False,
+    is_flag=True,
     default=False,
     help="Only start GCS on the head node",
 )

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -626,9 +626,10 @@ def start(
         temp_dir = None
     if with_gcs and not head:
         cli_logger.error(
-            "{} and can be be used with {}.", cf.bold("--with-gcs"), cf.bold("--head"))
+            "{} and can be be used with {}.", cf.bold("--with-gcs"), cf.bold("--head")
+        )
 
-    node_services=[]
+    node_services = []
     if with_gcs:
         node_services.append(ray._private.ray_constants.PROCESS_TYPE_GCS_SERVER)
 

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -981,7 +981,7 @@ def fetch_ray_processes(pid):
     proc_names = set()
     children = psutil.Process(pid).children()
     for c in children:
-        if c.name() == "python":
+        if c.name().startswith("python"):
             cmd = c.cmdline()
             if cmd[1] == "-m":
                 if cmd[2] == "ray.util.client.server":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR enables the users able to start the GCS without Raylet. Because ray client server/dashboard has to live with raylet, this PR also enables the node able to start dashboard and ray client server in worker nodes.

This PR makes the infra managers able to start GCS in a dedicated container to protect GCS from being impacted by other workloads, like Raylet/Worker/Dashboard OOM will tigger OS OOM killer kills GCS.

Thus new flags:

- `ray start --head --start-gcs` This will only start GCS in the head node
- `ray start --address GCS_ADDR --include-dashboard --ray-client-server-port=10001` This will start raylet with dashboard and client server.

Running these two together will have the same effect like `ray start --head`



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
