### PR TITLE
[docs] fix outdated tensor data ref

### DIFF
--- a/doc/source/data/working-with-tensors.rst
+++ b/doc/source/data/working-with-tensors.rst
@@ -103,6 +103,8 @@ Save tensor data in Parquet or Numpy files. Other formats aren't supported.
 
 For more information on saving data, read :ref:`Saving data <loading_data>`.
 
+.. _transforming_variable_tensors:
+
 Transforming variable-shape tensor data
 ---------------------------------------
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3211,8 +3211,7 @@ class Dataset:
 
         .. warning::
             If your dataset contains ragged tensors, this method errors. To prevent
-            errors, resize tensors or
-            :ref:`disable tensor extension casting <disable_tensor_extension_casting>`.
+            errors, :ref:`resize your tensors <transforming_variable_tensors>`.
 
         Examples:
             >>> import ray

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -632,8 +632,7 @@ class DataIterator(abc.ABC):
 
         .. warning::
             If your dataset contains ragged tensors, this method errors. To prevent
-            errors, resize tensors or
-            :ref:`disable tensor extension casting <disable_tensor_extension_casting>`.
+            errors, :ref:`resize your tensors <transforming_variable_tensors>`.
 
         Examples:
             >>> import ray


### PR DESCRIPTION
we referenced a section in Dataset and -iterator that doesn't exist anymore.