### PR TITLE
[docs] fix broken ray data imgs

### DIFF
--- a/doc/source/data/data.rst
+++ b/doc/source/data/data.rst
@@ -19,7 +19,7 @@ and is compatible with a variety of file formats, data sources, and distributed 
 
 Read on for an overview of the main use cases and operations supported by Ray Data.
 
-.. image:: images/dataset.svg
+.. image:: images/datastream.svg
 
 ..
   https://docs.google.com/drawings/d/16AwJeBNR46_TsrkOmMbGaBK7u-OPsf_V8fHjU-d2PPQ/edit
@@ -56,7 +56,7 @@ Ray Data serves as a last-mile bridge from storage or ETL pipeline outputs to di
 applications and libraries in Ray. Don't use it as a replacement for more general data
 processing systems.
 
-.. image:: images/dataset-loading-1.png
+.. image:: images/datastream-loading-1.png
    :width: 650px
    :align: center
 

--- a/doc/source/data/key-concepts.rst
+++ b/doc/source/data/key-concepts.rst
@@ -22,7 +22,7 @@ The following figure visualizes a dataset with three blocks, each holding 1000 r
 may not be computed yet. Normally, callers iterate over dataset blocks in a streaming fashion, so that not all
 blocks need to be materialized in the cluster memory at once.
 
-.. image:: images/dataset-arch.svg
+.. image:: images/datastream-arch.svg
 
 ..
   https://docs.google.com/drawings/d/1PmbDvHRfVthme9XD7EYM-LIHPXtHdOfjCbc1SCsM64k/edit
@@ -32,7 +32,7 @@ Reading Data
 
 Dataset uses Ray tasks to read data from remote storage in parallel. Each read task reads one or more files and produces an output block:
 
-.. image:: images/dataset-read.svg
+.. image:: images/datastream-read.svg
    :align: center
 
 ..
@@ -52,7 +52,7 @@ To use Actors, pass an :class:`ActorPoolStrategy` to ``compute`` in methods like
 pool of Ray actors. This allows you to cache expensive state initialization
 (e.g., model loading for GPU-based tasks).
 
-.. image:: images/dataset-map.svg
+.. image:: images/datastream-map.svg
    :align: center
 ..
   https://docs.google.com/drawings/d/12STHGV0meGWfdWyBlJMUgw7a-JcFPu9BwSOn5BjRw9k/edit
@@ -73,7 +73,7 @@ Repartition has two modes:
 * ``shuffle=False`` - performs the minimal data movement needed to equalize block sizes
 * ``shuffle=True`` - performs a full distributed shuffle
 
-.. image:: images/dataset-shuffle.svg
+.. image:: images/datastream-shuffle.svg
    :align: center
 
 ..


### PR DESCRIPTION
most images referenced on ray data master have been broken by the "datastream" renaming journey. we fix this here.