### PR TITLE
[Release test] Disabling empty-runtime-env tests in benchmark_worker_startup.aws

### DIFF
--- a/release/benchmark-worker-startup/benchmark_worker_startup.py
+++ b/release/benchmark-worker-startup/benchmark_worker_startup.py
@@ -172,7 +172,10 @@ def generate_test_matrix(
 
     for with_tasks in [True, False]:
         for with_gpu in [True, False]:
-            for with_runtime_env in [True, False]:
+            # Do not run without runtime env. TODO(cade) Infra team added cgroups to
+            # default runtime env, need to find some way around that if we want
+            # "pure" (non-runtime-env) measurements.
+            for with_runtime_env in [True]:
                 for import_to_try in imports_to_try:
                     for num_jobs in num_jobs_per_type.values():
 


### PR DESCRIPTION
This test uses some hackery to get a "default" (empty) runtime environment on Anyscale. This allows us to measure startup performance for non-Anyscale environments. We validate that the numbers are correct by asserting empty runtime env for these measurements. Since our infra team recently added `cgroup` to the default runtime env, the assertion now fails.

We can fix this but not a priority right now -- this PR disables the empty-runtime-env tests in this release test, so we still have metrics for the normal path.

Closes https://github.com/ray-project/ray/issues/35183