### PR TITLE
[Release tests] Moving Ray Data bulk ingest test ownership team to Data

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -699,7 +699,7 @@
   jailed: true
 
   frequency: nightly
-  team: core
+  team: data
   cluster:
     cluster_env: app_config_oom.yaml
     cluster_compute: compute_cpu_16.yaml
@@ -726,7 +726,7 @@
   jailed: true
 
   frequency: nightly
-  team: core
+  team: data
   cluster:
     cluster_env: app_config_oom.yaml
     cluster_compute: compute_cpu_16.yaml
@@ -753,7 +753,7 @@
   jailed: true
 
   frequency: nightly
-  team: core
+  team: data
   cluster:
     cluster_env: app_config_oom.yaml
     cluster_compute: compute_cpu_16_worker_nodes_2.yaml


### PR DESCRIPTION
The tests are currently jailed but we will keep them as reference implementations of the MLPerf benchmark (up to @c21 to delete or keep around).