### PR TITLE
[Core]Fixing flakey test for redis error 'Address already in use' in macos

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1893,3 +1893,32 @@ def has_no_words(string, words):
         words: Space-separated string of words to search for
     """
     return not any(search_words(string, words))
+
+
+def find_available_port(start, end, port_num=1):
+    ports = []
+    for _ in range(port_num):
+        random_port = 0
+        with socket.socket() as s:
+            s.bind(("", 0))
+            random_port = s.getsockname()[1]
+        if random_port >= start and random_port <= end and random_port not in ports:
+            ports.append(random_port)
+            continue
+
+        for port in range(start, end + 1):
+            if port in ports:
+                continue
+            try:
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                    s.bind(("", port))
+                ports.append(port)
+                break
+            except OSError:
+                pass
+
+    if len(ports) != port_num:
+        raise RuntimeError(
+            f"Can't find {port_num} available port from {start} to {end}."
+        )
+    return ports

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -34,6 +34,7 @@ from ray._private.test_utils import (
     enable_external_redis,
     redis_replicas,
     start_redis_instance,
+    find_available_port,
 )
 from ray.cluster_utils import AutoscalingCluster, Cluster, cluster_not_supported
 
@@ -171,16 +172,7 @@ def start_redis(db_dir):
     while True:
         is_need_restart = False
         # Setup external Redis and env var for initialization.
-        redis_ports = []
-        for _ in range(redis_replicas()):
-            # max port for redis cluster
-            port = 55536
-            while port >= 55535:
-                with socket.socket() as s:
-                    s.bind(("", 0))
-                    port = s.getsockname()[1]
-            print("Picking port", port)
-            redis_ports.append(port)
+        redis_ports = find_available_port(49159, 55536, redis_replicas())
 
         processes = []
         enable_tls = "RAY_REDIS_CA_CERT" in os.environ


### PR DESCRIPTION
## Why are these changes needed?
After the merge of PR #35127, I noticed that there were still some flakey cases.
 Upon comparing the logs, I found that whenever the "bind: Address already in use" error occurred in a macOS environment, it was always when the port was below 49159. 
Therefore, I have now restricted the Redis port to the range of 49159 ~ 55535.

Macos:
![image](https://github.com/ray-project/ray/assets/11072802/89a40169-3afc-4e44-8b04-c4d466c4e8ef)

linux:
![image](https://github.com/ray-project/ray/assets/11072802/04e593ab-30e7-44ab-a029-320c2721e09e)


![image](https://github.com/ray-project/ray/assets/11072802/f2847459-33bc-401a-a531-efc724cf4225)

![image](https://github.com/ray-project/ray/assets/11072802/28b62d7b-73e8-45ea-82b5-3f47898cf105)

## Related issue number
#35127

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
