### PR TITLE
moved dqn target inference in a torch.no_grad() context block.

### DIFF
--- a/rllib/algorithms/dqn/dqn_torch_policy.py
+++ b/rllib/algorithms/dqn/dqn_torch_policy.py
@@ -286,7 +286,6 @@ def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> Tensor
             is_training=True,
         )
 
-
     # Q scores for actions which we know were selected in the given state.
     one_hot_selection = F.one_hot(
         train_batch[SampleBatch.ACTIONS].long(), policy.action_space.n

--- a/rllib/algorithms/dqn/dqn_torch_policy.py
+++ b/rllib/algorithms/dqn/dqn_torch_policy.py
@@ -286,6 +286,7 @@ def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> Tensor
             is_training=True,
         )
 
+
     # Q scores for actions which we know were selected in the given state.
     one_hot_selection = F.one_hot(
         train_batch[SampleBatch.ACTIONS].long(), policy.action_space.n


### PR DESCRIPTION
## Why are these changes needed?

The computation of the q_values on the [target network](https://github.com/ray-project/ray/blob/master/rllib/algorithms/dqn/dqn_torch_policy.py#L280) is not wrapped within a "torch.no_grad()" block which is inefficient when it comes to gpu memory allocation. 