### PR TITLE
[train] Fix HuggingFace -> Transformers wrapping logic

### DIFF
--- a/python/ray/train/huggingface/huggingface_checkpoint.py
+++ b/python/ray/train/huggingface/huggingface_checkpoint.py
@@ -14,7 +14,7 @@ class HuggingFaceCheckpoint(TransformersCheckpoint):
     # than __init__
     def __new__(cls: type, *args, **kwargs):
         warnings.warn(deprecation_msg, DeprecationWarning)
-        return super(HuggingFaceCheckpoint, cls).__new__(cls)
+        return super(HuggingFaceCheckpoint, cls).__new__(cls, *args, **kwargs)
 
 
 __all__ = [

--- a/python/ray/train/huggingface/huggingface_predictor.py
+++ b/python/ray/train/huggingface/huggingface_predictor.py
@@ -14,7 +14,7 @@ class HuggingFacePredictor(TransformersPredictor):
     # than __init__
     def __new__(cls: type, *args, **kwargs):
         warnings.warn(deprecation_msg, DeprecationWarning)
-        return super(HuggingFacePredictor, cls).__new__(cls)
+        return super(HuggingFacePredictor, cls).__new__(cls, *args, **kwargs)
 
 
 __all__ = [

--- a/python/ray/train/huggingface/huggingface_trainer.py
+++ b/python/ray/train/huggingface/huggingface_trainer.py
@@ -14,7 +14,7 @@ class HuggingFaceTrainer(TransformersTrainer):
     # than __init__
     def __new__(cls: type, *args, **kwargs):
         warnings.warn(deprecation_msg, DeprecationWarning)
-        return super(HuggingFaceTrainer, cls).__new__(cls)
+        return super(HuggingFaceTrainer, cls).__new__(cls, *args, **kwargs)
 
 
 __all__ = [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

This fixes an issue to make sure that constructor are properly passed through.


## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->


Follow-up to https://github.com/ray-project/ray/pull/33278.

Currently, the arguments will be dropped:
```python
TypeError: __init__() missing 1 required positional argument: 'trainer_init_per_worker'
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

Verified locally with the following script:

<details><summary>Script</summary>

```python
import ray
import pandas as pd
from transformers import (
    AutoConfig,
    AutoModelForCausalLM,
    Trainer,
    TrainingArguments,
)

from ray.air.config import ScalingConfig
from ray.train.huggingface import HuggingFaceTrainer


model_checkpoint = "hf-internal-testing/tiny-random-gpt2"
tokenizer_checkpoint = "hf-internal-testing/tiny-random-gpt2"


def train_function(train_dataset, eval_dataset=None, **config):
    # Check that train_dataset has len
    assert len(train_dataset)

    model_config = AutoConfig.from_pretrained(model_checkpoint)
    model = AutoModelForCausalLM.from_config(model_config)
    evaluation_strategy = (
        config.pop("evaluation_strategy", "epoch") if eval_dataset else "no"
    )
    training_args = TrainingArguments(
        f"{model_checkpoint}-wikitext2",
        evaluation_strategy=evaluation_strategy,
        logging_strategy=config.pop("logging_strategy", "epoch"),
        num_train_epochs=config.pop("epochs", 3),
        learning_rate=config.pop("learning_rate", 2e-5),
        weight_decay=0.01,
        disable_tqdm=True,
        no_cuda=True,
        save_strategy=config.pop("save_strategy", "no"),
        **config,
    )
    trainer = Trainer(
        model=model,
        args=training_args,
        train_dataset=train_dataset,
        eval_dataset=eval_dataset,
    )
    return trainer
  

from ray.train.tests._huggingface_data import train_data, validation_data
train_df = pd.read_json(train_data)
validation_df = pd.read_json(validation_data)

ray_train = ray.data.from_pandas(train_df)
ray_validation = ray.data.from_pandas(validation_df)
scaling_config = ScalingConfig(num_workers=1, use_gpu=False)
trainer = HuggingFaceTrainer(
    trainer_init_per_worker=train_function,
    trainer_init_config={"epochs": 4},
    scaling_config=scaling_config,
    datasets={"train": ray_train, "evaluation": ray_validation},
)
result = trainer.fit()
```

</details> 


- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
