### PR TITLE
[Data] Improve `Schema` representation

### DIFF
--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -37,7 +37,9 @@ Generating Synthetic Data
         >>> import ray
         >>> ds = ray.data.range_tensor(100 * 64 * 64, shape=(64, 64))
         >>> ds.schema()
-        Schema({'data': numpy.ndarray(shape=(64, 64), dtype=int64)})
+        Column  Type
+        ------  ----
+        data    numpy.ndarray(shape=(64, 64), dtype=int64)
         >>> ds.show(1)
         {'data': array([[0, 0, 0, ..., 0, 0, 0],
                [0, 0, 0, ..., 0, 0, 0],

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4464,11 +4464,24 @@ class Schema:
     def __eq__(self, other):
         return isinstance(other, Schema) and other.base_schema == self.base_schema
 
-    def __str__(self):
-        return f"Schema({dict(zip(self.names, self.types))})"
-
     def __repr__(self):
-        return str(self)
+        column_width = max([len(name) for name in self.names] + [len("Column")])
+        padding = 2
+
+        output = "Column"
+        output += " " * ((column_width + padding) - len("Column"))
+        output += "Type\n"
+
+        output += "-" * len("Column")
+        output += " " * ((column_width + padding) - len("Column"))
+        output += "-" * len("Type") + "\n"
+
+        for name, type in zip(self.names, self.types):
+            output += name
+            output += " " * ((column_width + padding) - len(name))
+            output += f"{type}\n"
+
+        return output
 
 
 def _get_size_bytes(block: Block) -> int:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4481,6 +4481,7 @@ class Schema:
             output += " " * ((column_width + padding) - len(name))
             output += f"{type}\n"
 
+        output = output.rstrip()
         return output
 
 

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -256,7 +256,7 @@ def test_schema_repr(ray_start_regular_shared):
         "Column  Type\n"
         "------  ----\n"
         "text    string\n"
-        "number  int64\n"
+        "number  int64"
     )
     # fmt:on
     assert repr(ds.schema()) == expected_repr
@@ -265,7 +265,7 @@ def test_schema_repr(ray_start_regular_shared):
     expected_repr = (
         "Column            Type\n"
         "------            ----\n"
-        "long_column_name  string\n"
+        "long_column_name  string"
     )
     assert repr(ds.schema()) == expected_repr
 

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -262,11 +262,13 @@ def test_schema_repr(ray_start_regular_shared):
     assert repr(ds.schema()) == expected_repr
 
     ds = ray.data.from_items([{"long_column_name": "spam"}])
+    # fmt: off
     expected_repr = (
         "Column            Type\n"
         "------            ----\n"
         "long_column_name  string"
     )
+    # fmt: on
     assert repr(ds.schema()) == expected_repr
 
 

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -249,6 +249,25 @@ def test_schema_lazy(ray_start_regular_shared):
     assert ds._plan.execute()._num_computed() == 0
 
 
+def test_schema_repr(ray_start_regular_shared):
+    ds = ray.data.from_items([{"text": "spam", "number": 0}])
+    expected_repr = (
+        "Column  Type\n"
+        "------  ----\n"
+        "text    string\n"
+        "number  int64\n"
+    )
+    assert repr(ds.schema()) == expected_repr
+
+    ds = ray.data.from_items([{"long_column_name": "spam"}])
+    expected_repr = (
+        "Column            Type\n"
+        "------            ----\n"
+        "long_column_name  string\n"
+    )
+    assert repr(ds.schema()) == expected_repr
+
+
 def test_count_lazy(ray_start_regular_shared):
     ds = ray.data.range(100, parallelism=10)
     # We do not kick off the read task by default.

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -251,12 +251,14 @@ def test_schema_lazy(ray_start_regular_shared):
 
 def test_schema_repr(ray_start_regular_shared):
     ds = ray.data.from_items([{"text": "spam", "number": 0}])
+    # fmt: off
     expected_repr = (
         "Column  Type\n"
         "------  ----\n"
         "text    string\n"
         "number  int64\n"
     )
+    # fmt:on
     assert repr(ds.schema()) == expected_repr
 
     ds = ray.data.from_items([{"long_column_name": "spam"}])

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -183,38 +183,37 @@ def test_strict_compute(ray_start_regular_shared, enable_strict_mode):
 
 
 def test_strict_schema(ray_start_regular_shared, enable_strict_mode):
-    import pyarrow
+    import pyarrow as pa
+    from ray.data.extensions.tensor_extension import ArrowTensorType
     from ray.data._internal.pandas_block import PandasBlockSchema
 
     ds = ray.data.from_items([{"x": 2}])
     schema = ds.schema()
-    assert isinstance(schema.base_schema, pyarrow.lib.Schema)
-    assert str(schema) == "Schema({'x': DataType(int64)})"
+    assert isinstance(schema.base_schema, pa.lib.Schema)
+    assert schema.names == ["x"]
+    assert schema.types == [pa.int64()]
 
     ds = ray.data.from_items([{"x": 2, "y": [1, 2]}])
     schema = ds.schema()
-    assert isinstance(schema.base_schema, pyarrow.lib.Schema)
-    assert (
-        str(schema)
-        == "Schema({'x': DataType(int64), 'y': ListType(list<item: int64>)})"
-    )
+    assert isinstance(schema.base_schema, pa.lib.Schema)
+    assert schema.names == ["x", "y"]
+    assert schema.types == [pa.int64(), pa.list_(pa.int64())]
 
     ds = ray.data.from_items([{"x": 2, "y": object(), "z": [1, 2]}])
     schema = ds.schema()
-    assert isinstance(schema.base_schema, PandasBlockSchema)
-    assert str(schema) == (
-        "Schema({'x': DataType(int64), 'y': "
-        "<class 'object'>, 'z': <class 'object'>})"
-    )
+    assert schema.names == ["x", "y", "z"]
+    assert schema.types == [pa.int64(), object, object]
 
     ds = ray.data.from_numpy(np.ones((100, 10)))
     schema = ds.schema()
-    assert isinstance(schema.base_schema, pyarrow.lib.Schema)
-    assert str(schema) == "Schema({'data': numpy.ndarray(shape=(10,), dtype=double)})"
+    assert isinstance(schema.base_schema, pa.lib.Schema)
+    assert schema.names == ["data"]
+    assert schema.types == [ArrowTensorType(shape=(10,), dtype=pa.float64())]
 
     schema = ds.map_batches(lambda x: x, batch_format="pandas").schema()
-    assert str(schema) == "Schema({'data': numpy.ndarray(shape=(10,), dtype=double)})"
     assert isinstance(schema.base_schema, PandasBlockSchema)
+    assert schema.names == ["data"]
+    assert schema.types == [ArrowTensorType(shape=(10,), dtype=pa.float64())]
 
 
 def test_use_raw_dicts(ray_start_regular_shared, enable_strict_mode):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The current representation doesn't make it clear that the keys represent column names. This can be especially confusing when your dataset contains one column (e.g., `Schema({'text': DataType(string)})`)

**Before**
```
Schema({'text': DataType(string), 'number': DataType(int64)})
```

**After**
```
Column  Type
------  ----
text    string
number  int64
```
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
