### PR TITLE
[train] Fix HuggingFace -> Transformers wrapping logic 2

### DIFF
--- a/python/ray/train/huggingface/huggingface_checkpoint.py
+++ b/python/ray/train/huggingface/huggingface_checkpoint.py
@@ -14,7 +14,7 @@ class HuggingFaceCheckpoint(TransformersCheckpoint):
     # than __init__
     def __new__(cls: type, *args, **kwargs):
         warnings.warn(deprecation_msg, DeprecationWarning)
-        return super(HuggingFaceCheckpoint, cls).__new__(cls, *args, **kwargs)
+        return super(HuggingFaceCheckpoint, cls).__new__(cls)
 
 
 __all__ = [

--- a/python/ray/train/huggingface/huggingface_predictor.py
+++ b/python/ray/train/huggingface/huggingface_predictor.py
@@ -14,7 +14,7 @@ class HuggingFacePredictor(TransformersPredictor):
     # than __init__
     def __new__(cls: type, *args, **kwargs):
         warnings.warn(deprecation_msg, DeprecationWarning)
-        return super(HuggingFacePredictor, cls).__new__(cls, *args, **kwargs)
+        return super(HuggingFacePredictor, cls).__new__(cls)
 
 
 __all__ = [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->


#35276 was added to properly pass arguments. However, it causes `HuggingFacePredictor` and `HuggingFaceCheckpoint` to break.

**This was an oversight on how `__new__` works.** Originally, I thought the arguments needed to always pass through. However, this was only specific to `HuggingFaceTrainer` _because_ `BaseTrainer` overrides `__new__`:

https://github.com/ray-project/ray/blob/a44b00d0114a9a5ede6318d20fb35fe3df01c3c2/python/ray/train/base_trainer.py#L381-L390

`HuggingFacePredictor` and `HuggingFaceCheckpoint` pass through to `object`'s `__new__`, which does not take in any additional arguments.


## Related issue number

<!-- For example: "Closes #1234" -->


Closes #35282

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
