### PR TITLE
[Core] Fix spdlog build issue

### DIFF
--- a/bazel/BUILD.spdlog
+++ b/bazel/BUILD.spdlog
@@ -8,7 +8,6 @@ cc_library(
         "include/spdlog/*.h",
         "include/spdlog/cfg/*.h",
         "include/spdlog/details/*.h",
-        "include/spdlog/fmt/*.h",
         "include/spdlog/fmt/bundled/*.h",
         "include/spdlog/sinks/*.h",
     ]),


### PR DESCRIPTION
## Why are these changes needed?

Currently an issue with `spdlog` is preventing Ray from compiling. This PR fixes that issue.

I'm not very familiar with `spdlog`, but as I understand it `spdlog` contains a bundled (vendored in) version of the `fmt` library which it uses to write output. I noticed the bazel build file for `spdlog` included `fmt/*.h` _and_ `fmt/bundled/*.h`. I'm not sure what the difference between the two is here, but when building only using the bundled version of `fmt`, I'm able to compile successfully. I'd be grateful for someone more familiar with this part of the code base to comment (@vitsai ?)

## Related issue number

Closes #35200.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
