### PR TITLE
[Test] Allow running specific python test via bazel

### DIFF
--- a/python/ray/air/tests/test_data_batch_conversion.py
+++ b/python/ray/air/tests/test_data_batch_conversion.py
@@ -296,4 +296,4 @@ def test_arrow_tensor_pandas(cast_tensor_columns):
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/autoscaler/v2/tests/test_instance_storage.py
+++ b/python/ray/autoscaler/v2/tests/test_instance_storage.py
@@ -287,4 +287,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/autoscaler/v2/tests/test_storage.py
+++ b/python/ray/autoscaler/v2/tests/test_storage.py
@@ -84,4 +84,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_batch_mapper.py
+++ b/python/ray/data/tests/preprocessors/test_batch_mapper.py
@@ -284,4 +284,4 @@ def test_batch_mapper_numpy_data_format(ds, expected_df):
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_chain.py
+++ b/python/ray/data/tests/preprocessors/test_chain.py
@@ -250,4 +250,4 @@ def test_determine_transform_to_use():
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_concatenator.py
+++ b/python/ray/data/tests/preprocessors/test_concatenator.py
@@ -66,4 +66,4 @@ class TestConcatenator:
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_discretizer.py
+++ b/python/ray/data/tests/preprocessors/test_discretizer.py
@@ -158,4 +158,4 @@ def test_custom_kbins_discretizer(
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_encoder.py
+++ b/python/ray/data/tests/preprocessors/test_encoder.py
@@ -580,4 +580,4 @@ def test_categorizer(predefined_dtypes):
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_hasher.py
+++ b/python/ray/data/tests/preprocessors/test_hasher.py
@@ -69,4 +69,4 @@ def test_hashing_vectorizer():
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_imputer.py
+++ b/python/ray/data/tests/preprocessors/test_imputer.py
@@ -117,4 +117,4 @@ def test_simple_imputer():
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_normalizer.py
+++ b/python/ray/data/tests/preprocessors/test_normalizer.py
@@ -63,4 +63,4 @@ def test_normalizer():
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_preprocessors.py
+++ b/python/ray/data/tests/preprocessors/test_preprocessors.py
@@ -430,4 +430,4 @@ def test_transform_stats_raises_deprecation_warning(create_dummy_preprocessors):
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_scaler.py
+++ b/python/ray/data/tests/preprocessors/test_scaler.py
@@ -243,4 +243,4 @@ def test_standard_scaler():
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_tokenizer.py
+++ b/python/ray/data/tests/preprocessors/test_tokenizer.py
@@ -30,4 +30,4 @@ def test_tokenizer():
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_torch.py
+++ b/python/ray/data/tests/preprocessors/test_torch.py
@@ -122,4 +122,4 @@ class TestTorchVisionPreprocessor:
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_transformer.py
+++ b/python/ray/data/tests/preprocessors/test_transformer.py
@@ -67,4 +67,4 @@ def test_power_transformer():
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_utils.py
+++ b/python/ray/data/tests/preprocessors/test_utils.py
@@ -26,4 +26,4 @@ def test_simple_hash():
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/preprocessors/test_vectorizer.py
+++ b/python/ray/data/tests/preprocessors/test_vectorizer.py
@@ -85,4 +85,4 @@ def test_count_vectorizer():
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -470,4 +470,4 @@ def test_push_based_shuffle_reduce_stage_scheduling(ray_start_cluster, pipeline)
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/serve/tests/test_runtime_env.py
+++ b/python/ray/serve/tests/test_runtime_env.py
@@ -154,4 +154,4 @@ Test.delete()
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/serve/tests/test_runtime_env_2.py
+++ b/python/ray/serve/tests/test_runtime_env_2.py
@@ -87,4 +87,4 @@ assert requests.get("http://127.0.0.1:8000/requests_version").text == "2.25.1"
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/spark/test_GPU.py
+++ b/python/ray/tests/spark/test_GPU.py
@@ -109,4 +109,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/spark/test_basic.py
+++ b/python/ray/tests/spark/test_basic.py
@@ -225,4 +225,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/spark/test_databricks_hook.py
+++ b/python/ray/tests/spark/test_databricks_hook.py
@@ -77,4 +77,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/spark/test_multicores_per_task.py
+++ b/python/ray/tests/spark/test_multicores_per_task.py
@@ -43,4 +43,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/spark/test_utils.py
+++ b/python/ray/tests/spark/test_utils.py
@@ -136,4 +136,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1226,4 +1226,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1333,4 +1333,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -941,4 +941,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_actor_group.py
+++ b/python/ray/tests/test_actor_group.py
@@ -104,4 +104,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_actor_in_container.py
+++ b/python/ray/tests/test_actor_in_container.py
@@ -76,4 +76,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_actor_lifetime.py
+++ b/python/ray/tests/test_actor_lifetime.py
@@ -87,4 +87,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_actor_out_of_order.py
+++ b/python/ray/tests/test_actor_out_of_order.py
@@ -57,4 +57,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_actor_pool.py
+++ b/python/ray/tests/test_actor_pool.py
@@ -278,4 +278,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_actor_resources.py
+++ b/python/ray/tests/test_actor_resources.py
@@ -670,4 +670,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_actor_state_metrics.py
+++ b/python/ray/tests/test_actor_state_metrics.py
@@ -287,4 +287,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -472,4 +472,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -524,4 +524,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -352,4 +352,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -293,4 +293,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_advanced_5.py
+++ b/python/ray/tests/test_advanced_5.py
@@ -233,4 +233,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_advanced_6.py
+++ b/python/ray/tests/test_advanced_6.py
@@ -249,4 +249,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_advanced_7.py
+++ b/python/ray/tests/test_advanced_7.py
@@ -269,4 +269,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_advanced_8.py
+++ b/python/ray/tests/test_advanced_8.py
@@ -694,4 +694,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -445,4 +445,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_annotations.py
+++ b/python/ray/tests/test_annotations.py
@@ -109,4 +109,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_args.py
+++ b/python/ray/tests/test_args.py
@@ -87,4 +87,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_array.py
+++ b/python/ray/tests/test_array.py
@@ -249,4 +249,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_async.py
+++ b/python/ray/tests/test_async.py
@@ -197,4 +197,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -379,4 +379,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_asyncio_cluster.py
+++ b/python/ray/tests/test_asyncio_cluster.py
@@ -37,4 +37,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -3861,4 +3861,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_autoscaler_drain_node_api.py
+++ b/python/ray/tests/test_autoscaler_drain_node_api.py
@@ -114,4 +114,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -194,4 +194,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -129,4 +129,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_autoscaler_fake_scaledown.py
+++ b/python/ray/tests/test_autoscaler_fake_scaledown.py
@@ -190,4 +190,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_autoscaler_gcp.py
+++ b/python/ray/tests/test_autoscaler_gcp.py
@@ -69,4 +69,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -633,4 +633,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_autoscaling_policy.py
+++ b/python/ray/tests/test_autoscaling_policy.py
@@ -625,4 +625,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1103,4 +1103,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -794,4 +794,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_basic_3.py
+++ b/python/ray/tests/test_basic_3.py
@@ -150,4 +150,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_basic_4.py
+++ b/python/ray/tests/test_basic_4.py
@@ -281,4 +281,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -381,4 +381,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_batch_node_provider_integration.py
+++ b/python/ray/tests/test_batch_node_provider_integration.py
@@ -175,4 +175,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_batch_node_provider_unit.py
+++ b/python/ray/tests/test_batch_node_provider_unit.py
@@ -420,4 +420,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -673,4 +673,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -252,4 +252,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -978,4 +978,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_cli_logger.py
+++ b/python/ray/tests/test_cli_logger.py
@@ -21,4 +21,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -906,4 +906,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -449,4 +449,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_client_compat.py
+++ b/python/ray/tests/test_client_compat.py
@@ -37,4 +37,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -236,4 +236,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_client_library_integration.py
+++ b/python/ray/tests/test_client_library_integration.py
@@ -72,4 +72,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_client_metadata.py
+++ b/python/ray/tests/test_client_metadata.py
@@ -51,4 +51,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_client_multi.py
+++ b/python/ray/tests/test_client_multi.py
@@ -208,4 +208,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -479,4 +479,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_client_reconnect.py
+++ b/python/ray/tests/test_client_reconnect.py
@@ -590,4 +590,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_client_references.py
+++ b/python/ray/tests/test_client_references.py
@@ -331,4 +331,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -145,4 +145,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_client_warnings.py
+++ b/python/ray/tests/test_client_warnings.py
@@ -42,4 +42,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -395,4 +395,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_component_failures.py
+++ b/python/ray/tests/test_component_failures.py
@@ -188,4 +188,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_component_failures_2.py
+++ b/python/ray/tests/test_component_failures_2.py
@@ -147,4 +147,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_component_failures_3.py
+++ b/python/ray/tests/test_component_failures_3.py
@@ -122,4 +122,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_concurrency_group.py
+++ b/python/ray/tests/test_concurrency_group.py
@@ -170,4 +170,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_coordinator_server.py
+++ b/python/ray/tests/test_coordinator_server.py
@@ -296,4 +296,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_cross_language.py
+++ b/python/ray/tests/test_cross_language.py
@@ -31,4 +31,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_dashboard.py
+++ b/python/ray/tests/test_dashboard.py
@@ -269,4 +269,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_dataclient_disconnect.py
+++ b/python/ray/tests/test_dataclient_disconnect.py
@@ -88,4 +88,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_debug_tools.py
+++ b/python/ray/tests/test_debug_tools.py
@@ -141,4 +141,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_distributed_sort.py
+++ b/python/ray/tests/test_distributed_sort.py
@@ -26,4 +26,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_environ.py
+++ b/python/ray/tests/test_environ.py
@@ -70,4 +70,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_error_ray_not_initialized.py
+++ b/python/ray/tests/test_error_ray_not_initialized.py
@@ -51,4 +51,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_exit_observability.py
+++ b/python/ray/tests/test_exit_observability.py
@@ -452,4 +452,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -664,4 +664,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_failure_2.py
+++ b/python/ray/tests/test_failure_2.py
@@ -422,4 +422,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_failure_3.py
+++ b/python/ray/tests/test_failure_3.py
@@ -456,4 +456,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -725,4 +725,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -864,4 +864,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_gcs_ha_e2e.py
+++ b/python/ray/tests/test_gcs_ha_e2e.py
@@ -283,4 +283,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_gcs_pubsub.py
+++ b/python/ray/tests/test_gcs_pubsub.py
@@ -232,4 +232,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_gcs_utils.py
+++ b/python/ray/tests/test_gcs_utils.py
@@ -291,4 +291,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_generators.py
+++ b/python/ray/tests/test_generators.py
@@ -613,4 +613,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_get_locations.py
+++ b/python/ray/tests/test_get_locations.py
@@ -136,4 +136,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_get_or_create_actor.py
+++ b/python/ray/tests/test_get_or_create_actor.py
@@ -103,4 +103,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_global_gc.py
+++ b/python/ray/tests/test_global_gc.py
@@ -222,4 +222,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_global_state.py
+++ b/python/ray/tests/test_global_state.py
@@ -451,4 +451,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_grpc_client_credentials.py
+++ b/python/ray/tests/test_grpc_client_credentials.py
@@ -61,4 +61,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_healthcheck.py
+++ b/python/ray/tests/test_healthcheck.py
@@ -73,4 +73,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_iter.py
+++ b/python/ray/tests/test_iter.py
@@ -565,4 +565,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_job.py
+++ b/python/ray/tests/test_job.py
@@ -331,4 +331,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_joblib.py
+++ b/python/ray/tests/test_joblib.py
@@ -198,4 +198,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_kill_raylet_signal_log.py
+++ b/python/ray/tests/test_kill_raylet_signal_log.py
@@ -53,4 +53,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_list_actors.py
+++ b/python/ray/tests/test_list_actors.py
@@ -59,4 +59,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_list_actors_2.py
+++ b/python/ray/tests/test_list_actors_2.py
@@ -25,4 +25,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_list_actors_3.py
+++ b/python/ray/tests/test_list_actors_3.py
@@ -55,4 +55,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_list_actors_4.py
+++ b/python/ray/tests/test_list_actors_4.py
@@ -59,4 +59,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_log_dedup.py
+++ b/python/ray/tests/test_log_dedup.py
@@ -132,4 +132,4 @@ def test_dedup_logs_allow_and_skip_regexes():
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -883,4 +883,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_memory_deadlock.py
+++ b/python/ray/tests/test_memory_deadlock.py
@@ -267,4 +267,4 @@ if __name__ == "__main__":
     pass
     # Issue #33491, timing out right now.
     # See python/ray/tests/BUILD for more details (ctrl+f test_memory_deadlock)
-    # sys.exit(pytest.main(["-sv", __file__]))
+    # sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -604,4 +604,4 @@ def test_one_actor_max_fifo_kill_previous_actor(shutdown_only):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_memory_scheduling.py
+++ b/python/ray/tests/test_memory_scheduling.py
@@ -81,4 +81,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_memstat.py
+++ b/python/ray/tests/test_memstat.py
@@ -383,4 +383,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -278,4 +278,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -778,4 +778,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_metrics_agent_2.py
+++ b/python/ray/tests/test_metrics_agent_2.py
@@ -430,4 +430,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_metrics_head.py
+++ b/python/ray/tests/test_metrics_head.py
@@ -162,4 +162,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_microbenchmarks.py
+++ b/python/ray/tests/test_microbenchmarks.py
@@ -109,4 +109,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_mini.py
+++ b/python/ray/tests/test_mini.py
@@ -69,4 +69,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_monitor.py
+++ b/python/ray/tests/test_monitor.py
@@ -55,4 +55,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -434,4 +434,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_multi_node_2.py
+++ b/python/ray/tests/test_multi_node_2.py
@@ -372,4 +372,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_multi_node_3.py
+++ b/python/ray/tests/test_multi_node_3.py
@@ -577,4 +577,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_multi_tenancy.py
+++ b/python/ray/tests/test_multi_tenancy.py
@@ -329,4 +329,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_multinode_failures.py
+++ b/python/ray/tests/test_multinode_failures.py
@@ -184,4 +184,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_multinode_failures_2.py
+++ b/python/ray/tests/test_multinode_failures_2.py
@@ -129,4 +129,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -671,4 +671,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_namespace.py
+++ b/python/ray/tests/test_namespace.py
@@ -272,4 +272,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_nested_task.py
+++ b/python/ray/tests/test_nested_task.py
@@ -180,4 +180,4 @@ def test_thread_create_task(shutdown_only):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_node_manager.py
+++ b/python/ray/tests/test_node_manager.py
@@ -306,4 +306,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_node_provider_availability_tracker.py
+++ b/python/ray/tests/test_node_provider_availability_tracker.py
@@ -214,4 +214,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_numba.py
+++ b/python/ray/tests/test_numba.py
@@ -39,4 +39,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_object_assign_owner.py
+++ b/python/ray/tests/test_object_assign_owner.py
@@ -198,4 +198,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -736,4 +736,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -578,4 +578,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_object_spilling_2.py
+++ b/python/ray/tests/test_object_spilling_2.py
@@ -454,4 +454,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_object_spilling_3.py
+++ b/python/ray/tests/test_object_spilling_3.py
@@ -369,4 +369,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_object_spilling_no_asan.py
+++ b/python/ray/tests/test_object_spilling_no_asan.py
@@ -53,4 +53,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_object_store_metrics.py
+++ b/python/ray/tests/test_object_store_metrics.py
@@ -391,4 +391,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_out_of_disk_space.py
+++ b/python/ray/tests/test_out_of_disk_space.py
@@ -257,4 +257,4 @@ def test_ood_events(shutdown_only):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -715,4 +715,4 @@ if __name__ == "__main__":
         if os.environ.get("PARALLEL_CI"):
             sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
         else:
-            sys.exit(pytest.main(["-sv", __file__]))
+            sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -617,4 +617,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_placement_group_2.py
+++ b/python/ray/tests/test_placement_group_2.py
@@ -861,4 +861,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -775,4 +775,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_placement_group_4.py
+++ b/python/ray/tests/test_placement_group_4.py
@@ -473,4 +473,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -263,4 +263,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_placement_group_metrics.py
+++ b/python/ray/tests/test_placement_group_metrics.py
@@ -67,4 +67,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_placement_group_mini_integration.py
+++ b/python/ray/tests/test_placement_group_mini_integration.py
@@ -137,4 +137,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_plasma_unlimited.py
+++ b/python/ray/tests/test_plasma_unlimited.py
@@ -332,4 +332,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_protobuf_compatibility.py
+++ b/python/ray/tests/test_protobuf_compatibility.py
@@ -32,4 +32,4 @@ def test_protobuf_compatibility(shutdown_only):
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_pydantic_serialization.py
+++ b/python/ray/tests/test_pydantic_serialization.py
@@ -188,4 +188,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -279,4 +279,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_ray_debugger.py
+++ b/python/ray/tests/test_ray_debugger.py
@@ -364,4 +364,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -242,4 +242,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -333,4 +333,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_ray_shutdown.py
+++ b/python/ray/tests/test_ray_shutdown.py
@@ -301,4 +301,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_raylet_output.py
+++ b/python/ray/tests/test_raylet_output.py
@@ -60,4 +60,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_reconstruction.py
+++ b/python/ray/tests/test_reconstruction.py
@@ -578,4 +578,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_reconstruction_2.py
+++ b/python/ray/tests/test_reconstruction_2.py
@@ -504,4 +504,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_reconstruction_stress.py
+++ b/python/ray/tests/test_reconstruction_stress.py
@@ -76,4 +76,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_reconstruction_stress_spill.py
+++ b/python/ray/tests/test_reconstruction_stress_spill.py
@@ -77,4 +77,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_redis_tls.py
+++ b/python/ray/tests/test_redis_tls.py
@@ -57,4 +57,4 @@ def test_redis_tls(setup_tls, ray_start_cluster_head):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -602,4 +602,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -804,4 +804,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -3918,4 +3918,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_resource_metrics.py
+++ b/python/ray/tests/test_resource_metrics.py
@@ -106,4 +106,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_response_cache.py
+++ b/python/ray/tests/test_response_cache.py
@@ -224,4 +224,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -344,4 +344,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -862,4 +862,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_2.py
+++ b/python/ray/tests/test_runtime_env_2.py
@@ -253,4 +253,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -1061,4 +1061,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip.py
@@ -211,4 +211,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip_2.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_2.py
@@ -73,4 +73,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip_3.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_3.py
@@ -234,4 +234,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip_4.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_4.py
@@ -129,4 +129,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip_5.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_5.py
@@ -96,4 +96,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_env_vars.py
+++ b/python/ray/tests/test_runtime_env_env_vars.py
@@ -325,4 +325,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_failure.py
+++ b/python/ray/tests/test_runtime_env_failure.py
@@ -156,4 +156,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_fork_process.py
+++ b/python/ray/tests/test_runtime_env_fork_process.py
@@ -97,4 +97,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -766,4 +766,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -631,4 +631,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_ray_minimal.py
+++ b/python/ray/tests/test_runtime_env_ray_minimal.py
@@ -105,4 +105,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_strong_type.py
+++ b/python/ray/tests/test_runtime_env_strong_type.py
@@ -67,4 +67,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -390,4 +390,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_working_dir.py
+++ b/python/ray/tests/test_runtime_env_working_dir.py
@@ -573,4 +573,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_working_dir_2.py
+++ b/python/ray/tests/test_runtime_env_working_dir_2.py
@@ -282,4 +282,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -492,4 +492,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_working_dir_4.py
+++ b/python/ray/tests/test_runtime_env_working_dir_4.py
@@ -208,4 +208,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
+++ b/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
@@ -141,4 +141,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -753,4 +753,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -741,4 +741,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_scheduling_performance.py
+++ b/python/ray/tests/test_scheduling_performance.py
@@ -108,4 +108,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -685,4 +685,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_serve_ray_minimal.py
+++ b/python/ray/tests/test_serve_ray_minimal.py
@@ -25,4 +25,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_shuffle.py
+++ b/python/ray/tests/test_shuffle.py
@@ -54,4 +54,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -3455,4 +3455,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_state_api_2.py
+++ b/python/ray/tests/test_state_api_2.py
@@ -258,4 +258,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -1397,4 +1397,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -218,4 +218,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_stress.py
+++ b/python/ray/tests/test_stress.py
@@ -106,4 +106,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_stress_failure.py
+++ b/python/ray/tests/test_stress_failure.py
@@ -359,4 +359,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_stress_sharded.py
+++ b/python/ray/tests/test_stress_sharded.py
@@ -96,4 +96,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -502,4 +502,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -857,4 +857,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -604,4 +604,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_task_metrics_reconstruction.py
+++ b/python/ray/tests/test_task_metrics_reconstruction.py
@@ -76,4 +76,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -162,4 +162,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_tensorflow.py
+++ b/python/ray/tests/test_tensorflow.py
@@ -257,4 +257,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_threaded_actor.py
+++ b/python/ray/tests/test_threaded_actor.py
@@ -297,4 +297,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_tls_auth.py
+++ b/python/ray/tests/test_tls_auth.py
@@ -158,4 +158,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_top_level_api.py
+++ b/python/ray/tests/test_top_level_api.py
@@ -110,4 +110,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_tqdm.py
+++ b/python/ray/tests/test_tqdm.py
@@ -75,4 +75,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -409,4 +409,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_tracing.py
+++ b/python/ray/tests/test_tracing.py
@@ -231,4 +231,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_typing.py
+++ b/python/ray/tests/test_typing.py
@@ -47,4 +47,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_usage_stats.py
+++ b/python/ray/tests/test_usage_stats.py
@@ -1579,4 +1579,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_utils.py
+++ b/python/ray/tests/test_utils.py
@@ -83,4 +83,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -250,4 +250,4 @@ if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:
-        sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/train/tests/test_predictor.py
+++ b/python/ray/train/tests/test_predictor.py
@@ -279,4 +279,4 @@ def test_get_and_set_preprocessor():
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/train/tests/test_torch_utils.py
+++ b/python/ray/train/tests/test_torch_utils.py
@@ -131,4 +131,4 @@ def test_contains_tensor():
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))

--- a/python/ray/train/tests/test_xgboost_predictor.py
+++ b/python/ray/train/tests/test_xgboost_predictor.py
@@ -125,4 +125,4 @@ def test_predict_no_preprocessor_no_training():
 if __name__ == "__main__":
     import sys
 
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__] + sys.argv[1:]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
One main reason why people run pytest directly is that they can specify a particular test to run via `pytest xxx.py -k test_name`. But calling pytest directly misses all the configs in `.bazelrc` and is not exactly the same as what's run in CI (i.e., via bazel) This PR adds the ability to bazel as well so people can just do `bazel test //python/ray/tests:test_basic_2 --test_arg="-k test_variable_number_of_args"`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
