### PR TITLE
[core] Sending ReportWorkerFailure after the process died.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1454,6 +1454,18 @@ cc_test(
 )
 
 cc_test(
+    name = "asio_retry_runner_test",
+    size = "small",
+    srcs = ["src/ray/common/test/asio_retry_runner_test.cc"],
+    copts = COPTS,
+    tags = ["team:core"],
+    deps = [
+        "ray_common",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "ray_config_test",
     size = "small",
     srcs = ["src/ray/common/test/ray_config_test.cc"],

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -238,8 +238,10 @@ def test_controller_recover_initializing_actor(serve_instance):
     _, controller1_pid = get_actor_info(SERVE_CONTROLLER_NAME)
     ray.kill(serve.context._global_client._controller, no_restart=False)
     # wait for controller is alive again
-    wait_for_condition(get_actor_info, name=SERVE_CONTROLLER_NAME)
-    assert controller1_pid != get_actor_info(SERVE_CONTROLLER_NAME)[1]
+    wait_for_condition(
+        lambda: get_actor_info(SERVE_CONTROLLER_NAME) is not None
+        and get_actor_info(SERVE_CONTROLLER_NAME)[1] != controller1_pid
+    )
 
     # Let the actor proceed initialization
     ray.get(signal.send.remote())

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1087,7 +1087,7 @@ def test_actor_timestamps(ray_start_regular):
         lapsed = end_time - start_time
 
         assert end_time > start_time > 0, f"Start: {start_time}, End: {end_time}"
-        assert 1500 < lapsed < 2500, f"Start: {start_time}, End: {end_time}"
+        assert 1500 < lapsed < 3500, f"Start: {start_time}, End: {end_time}"
 
     def restarted():
         actor = Foo.options(max_restarts=1, max_task_retries=-1).remote()
@@ -1098,7 +1098,9 @@ def test_actor_timestamps(ray_start_regular):
         actor.kill_self.remote()
         time.sleep(1)
         actor.kill_self.remote()
-        time.sleep(1)
+        wait_for_condition(
+            lambda: ray._private.state.actors()[actor_id]["EndTime"] != 0
+        )
         state_after_ending = ray._private.state.actors()[actor_id]
 
         assert state_after_starting["StartTime"] == state_after_ending["StartTime"]
@@ -1108,7 +1110,7 @@ def test_actor_timestamps(ray_start_regular):
         lapsed = end_time - start_time
 
         assert end_time > start_time > 0, f"Start: {start_time}, End: {end_time}"
-        assert 1500 < lapsed < 2500, f"Start: {start_time}, End: {end_time}"
+        assert 1500 < lapsed < 4000, f"Start: {start_time}, End: {end_time}"
 
     graceful_exit()
     not_graceful_exit()

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1076,8 +1076,8 @@ def test_actor_timestamps(ray_start_regular):
         time.sleep(1)
         actor.kill_self.remote()
         time.sleep(1)
+        wait_for_condition(lambda: ray._private.state.actors()[actor_id]["EndTime"] != 0)
         state_after_ending = ray._private.state.actors()[actor_id]
-
         assert state_after_starting["StartTime"] == state_after_ending["StartTime"]
 
         start_time = state_after_ending["StartTime"]
@@ -1085,7 +1085,7 @@ def test_actor_timestamps(ray_start_regular):
         lapsed = end_time - start_time
 
         assert end_time > start_time > 0, f"Start: {start_time}, End: {end_time}"
-        assert 500 < lapsed < 1500, f"Start: {start_time}, End: {end_time}"
+        assert 1500 < lapsed < 2500, f"Start: {start_time}, End: {end_time}"
 
     def restarted():
         actor = Foo.options(max_restarts=1, max_task_retries=-1).remote()

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1076,7 +1076,9 @@ def test_actor_timestamps(ray_start_regular):
         time.sleep(1)
         actor.kill_self.remote()
         time.sleep(1)
-        wait_for_condition(lambda: ray._private.state.actors()[actor_id]["EndTime"] != 0)
+        wait_for_condition(
+            lambda: ray._private.state.actors()[actor_id]["EndTime"] != 0
+        )
         state_after_ending = ray._private.state.actors()[actor_id]
         assert state_after_starting["StartTime"] == state_after_ending["StartTime"]
 

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -735,7 +735,10 @@ def test_actor_failure_per_type(ray_start_cluster):
     ray.kill(owner)
     with pytest.raises(
         ray.exceptions.RayActorError,
-        match="The actor is dead because its owner has died",
+        # TODO(iycheng): re-enable the match after fixing the
+        # race condition.
+        # https://github.com/ray-project/ray/pull/34883
+        # match="The actor is dead because its owner has died",
     ) as exc_info:
         ray.get(a.check_alive.remote())
     assert exc_info.value.actor_id == a._actor_id.hex()

--- a/python/ray/tests/test_failure_3.py
+++ b/python/ray/tests/test_failure_3.py
@@ -366,6 +366,9 @@ def test_no_worker_child_process_leaks(ray_start_cluster, tmp_path):
     processes.
     """
 
+    ray_start_cluster.add_node()
+    ray_start_cluster.wait_for_nodes()
+
     output_file_path = tmp_path / "leaked_pids.json"
     driver_script = f"""
 import ray
@@ -374,7 +377,7 @@ import multiprocessing
 import shutil
 import time
 import os
-
+ray.init("{ray_start_cluster.address}")
 @ray.remote
 class Actor:
     def create_leaked_child_process(self, num_to_leak):

--- a/python/ray/tests/test_usage_stats.py
+++ b/python/ray/tests/test_usage_stats.py
@@ -251,7 +251,7 @@ def test_worker_crash_increment_stats():
 
         assert "worker_crash_system_error" in result
         assert result["worker_crash_system_error"] == "2"
-
+        print(result)
         assert "worker_crash_oom" in result
         assert result["worker_crash_oom"] == "1"
 

--- a/python/ray/tests/test_usage_stats.py
+++ b/python/ray/tests/test_usage_stats.py
@@ -247,11 +247,17 @@ def test_worker_crash_increment_stats():
             timeout=4,
         )
 
+        wait_for_condition(
+            lambda: "worker_crash_oom"
+            in ray_usage_lib.get_extra_usage_tags_to_report(gcs_client),
+            timeout=4,
+        )
+
         result = ray_usage_lib.get_extra_usage_tags_to_report(gcs_client)
 
         assert "worker_crash_system_error" in result
         assert result["worker_crash_system_error"] == "2"
-        print(result)
+
         assert "worker_crash_oom" in result
         assert result["worker_crash_oom"] == "1"
 

--- a/src/ray/common/asio/asio_util.h
+++ b/src/ray/common/asio/asio_util.h
@@ -36,7 +36,7 @@ std::shared_ptr<boost::asio::deadline_timer> execute_after(
   return timer;
 }
 
-pename Fn, typename Ex, typename Duration,
+typename Fn, typename Ex, typename Duration,
     typename CompletionToken =
         boost::asio::use_future_t<> >
         auto async_retry_until(Ex &&e,

--- a/src/ray/common/asio/asio_util.h
+++ b/src/ray/common/asio/asio_util.h
@@ -36,36 +36,43 @@ std::shared_ptr<boost::asio::deadline_timer> execute_after(
   return timer;
 }
 
-pename Fn, typename Ex, typename Duration, typename CompletionToken = boost::asio::use_future_t<>>
-    auto async_retry_until(Ex&& e, Fn &&fn, std::optional<int64_t> retry_num, Duration delay_duration, CompletionToken &&token = CompletionToken()) {
+pename Fn, typename Ex, typename Duration,
+    typename CompletionToken =
+        boost::asio::use_future_t<> >
+        auto async_retry_until(Ex &&e,
+                               Fn &&fn,
+                               std::optional<int64_t> retry_num,
+                               Duration delay_duration,
+                               CompletionToken &&token = CompletionToken()) {
   auto delay_timer = std::make_unique<boost::asio::deadline_timer>(e);
   auto delay = boost::posix_time::microseconds(
       std::chrono::duration_cast<std::chrono::microseconds>(delay_duration).count());
   return boost::asio::async_compose<CompletionToken, void(bool)>(
-    [
-      retry_num = retry_num,
-      delay_timer = std::move(delay_timer),
-      delay = delay,
-      coro = boost::asio::coroutine(),
-      fn = std::forward<Fn>(fn)
-    ] (auto& self, const boost::system::error_code& error = {}) mutable {
-      reenter (coro) {
-        while (true) {
-          if(fn()) {
-            self.complete(true);
-            return;
-          } else {
-            if(retry_num) {
-              --*retry_num;
-              if(*retry_num < 0) {
-                self.complete(false);
-                return;
+      [retry_num = retry_num,
+       delay_timer = std::move(delay_timer),
+       delay = delay,
+       coro = boost::asio::coroutine(),
+       fn = std::forward<Fn>(fn)](auto &self,
+                                  const boost::system::error_code &error = {}) mutable {
+        reenter(coro) {
+          while (true) {
+            if (fn()) {
+              self.complete(true);
+              return;
+            } else {
+              if (retry_num) {
+                --*retry_num;
+                if (*retry_num < 0) {
+                  self.complete(false);
+                  return;
+                }
               }
+              delay_timer->expires_from_now(boost::posix_time::milliseconds(delay));
+              yield delay_timer->async_wait(std::move(self));
             }
-            delay_timer->expires_from_now(boost::posix_time::milliseconds(delay));
-            yield delay_timer->async_wait(std::move(self));
           }
         }
-      }
-    }, token, e);
+      },
+      token,
+      e);
 }

--- a/src/ray/common/asio/asio_util.h
+++ b/src/ray/common/asio/asio_util.h
@@ -21,7 +21,7 @@
 
 template <typename Duration>
 std::shared_ptr<boost::asio::deadline_timer> execute_after(
-    instrumented_io_context &io_context,
+    boost::asio::io_context &io_context,
     std::function<void()> fn,
     Duration delay_duration) {
   auto timer = std::make_shared<boost::asio::deadline_timer>(io_context);

--- a/src/ray/common/asio/asio_util.h
+++ b/src/ray/common/asio/asio_util.h
@@ -38,15 +38,35 @@ std::shared_ptr<boost::asio::deadline_timer> execute_after(
   return timer;
 }
 
+// This function is used to retry a function until it returns true or the
+// retry_num is exhausted. The function will be called immediately and then
+// after delay_duration for each retry.
+//
+// \param e The executor to run the retry loop on. It has to be an io_executor
+// from boost::asio
+// \param predicate The function to retry. It should accept no arguments and
+// return bool.
+// \param retry_num The number of times to retry. If it's nullopt, it'll retry
+// forever until predicate returns true.
+// \param duration The duration to wait between retries. It needs to be
+// std::chrono::Duration.
+// \param token The completion token to use. It can be either a callback or
+// other completion tokens accepted by boost::asio.
+//
+// \return The completion token return type. For example, if the completion
+// token is a callback, it'll return void. If the completion token is
+// boost::asio::use_future_t it'll return future<bool>.
 template <typename Fn,
-          typename Ex,
+          typename AsioIOExecutor,
           typename Duration,
           typename CompletionToken = boost::asio::use_future_t<> >
-auto async_retry_until(Ex &&e,
-                       Fn &&fn,
+auto async_retry_until(AsioIOExecutor &&e,
+                       Fn &&predicate,
                        std::optional<int64_t> retry_num,
                        Duration delay_duration,
                        CompletionToken &&token = CompletionToken()) {
+  static_assert(std::is_assignable_v<std::function<bool()>, Fn>,
+                "predicate must should accept no arguments and return bool");
   auto delay_timer = std::make_unique<boost::asio::deadline_timer>(e);
   auto delay = boost::posix_time::microseconds(
       std::chrono::duration_cast<std::chrono::microseconds>(delay_duration).count());
@@ -55,11 +75,15 @@ auto async_retry_until(Ex &&e,
        delay_timer = std::move(delay_timer),
        delay = delay,
        coro = boost::asio::coroutine(),
-       fn = std::forward<Fn>(fn)](auto &self,
-                                  const boost::system::error_code &error = {}) mutable {
+       predicate = std::forward<Fn>(predicate)](
+          auto &self, const boost::system::error_code &error = {}) mutable {
         reenter(coro) {
           while (true) {
-            if (fn()) {
+            if (error) {
+              self.complete(false);
+              return;
+            }
+            if (predicate()) {
               self.complete(true);
               return;
             } else {

--- a/src/ray/common/test/asio_retry_runner_test.cc
+++ b/src/ray/common/test/asio_retry_runner_test.cc
@@ -45,12 +45,16 @@ TEST_F(RetryRunnerTest, Basic) {
     return count == 3;
   };
   // Retry 1 time, wait 5ms between retries.
-  ASSERT_FALSE(ray::async_retry(io_context.get_executor(), fn, 1, 5ms, boost::asio::use_future).get());
+  ASSERT_FALSE(
+      ray::async_retry(io_context.get_executor(), fn, 1, 5ms, boost::asio::use_future)
+          .get());
   ASSERT_EQ(2, count);
 
   count = 0;
   // Retry 2 times, wait 5ms between retries.
-  ASSERT_TRUE(ray::async_retry(io_context.get_executor(), fn, 2, 5ms, boost::asio::use_future).get());
+  ASSERT_TRUE(
+      ray::async_retry(io_context.get_executor(), fn, 2, 5ms, boost::asio::use_future)
+          .get());
   ASSERT_EQ(3, count);
 
   count = 0;

--- a/src/ray/common/test/asio_retry_runner_test.cc
+++ b/src/ray/common/test/asio_retry_runner_test.cc
@@ -1,0 +1,65 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "gtest/gtest.h"
+#include "ray/common/asio/asio_util.h"
+
+using namespace std::chrono_literals;
+
+class RetryRunnerTest : public ::testing::Test {
+ public:
+  RetryRunnerTest() {}
+  void SetUp() override {
+    t = std::make_unique<std::thread>([this]() {
+      boost::asio::executor_work_guard<instrumented_io_context::executor_type> work_guard(
+          io_context.get_executor());
+      io_context.run();
+    });
+  }
+  void TearDown() override {
+    io_context.stop();
+    t->join();
+  }
+
+  instrumented_io_context io_context;
+  std::unique_ptr<std::thread> t;
+};
+
+TEST_F(RetryRunnerTest, Basic) {
+  int count = 0;
+  auto fn = [&count]() mutable {
+    count++;
+    return count == 3;
+  };
+  // Retry 1 time, wait 5ms between retries.
+  ASSERT_FALSE(ray::async_retry(io_context.get_executor(), fn, 1, 5ms, boost::asio::use_future).get());
+  ASSERT_EQ(2, count);
+
+  count = 0;
+  // Retry 2 times, wait 5ms between retries.
+  ASSERT_TRUE(ray::async_retry(io_context.get_executor(), fn, 2, 5ms, boost::asio::use_future).get());
+  ASSERT_EQ(3, count);
+
+  count = 0;
+  // Test default completion token works
+  ASSERT_TRUE(ray::async_retry(io_context.get_executor(), fn, 2, 5ms).get());
+  ASSERT_EQ(3, count);
+
+  count = 0;
+  // Test default completion token works
+  ASSERT_TRUE(ray::async_retry(io_context.get_executor(), fn, -1, 5ms).get());
+  ASSERT_EQ(3, count);
+}

--- a/src/ray/common/test/asio_retry_runner_test.cc
+++ b/src/ray/common/test/asio_retry_runner_test.cc
@@ -64,6 +64,6 @@ TEST_F(RetryRunnerTest, Basic) {
 
   count = 0;
   // Test default completion token works
-  ASSERT_TRUE(async_retry_until(io_context.get_executor(), fn, -1, 5ms).get());
+  ASSERT_TRUE(async_retry_until(io_context.get_executor(), fn, std::nullopt, 5ms).get());
   ASSERT_EQ(3, count);
 }

--- a/src/ray/common/test/asio_retry_runner_test.cc
+++ b/src/ray/common/test/asio_retry_runner_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <optional>
 #include <string>
 
 #include "gtest/gtest.h"
@@ -66,4 +67,9 @@ TEST_F(RetryRunnerTest, Basic) {
   // Test default completion token works
   ASSERT_TRUE(async_retry_until(io_context.get_executor(), fn, std::nullopt, 5ms).get());
   ASSERT_EQ(3, count);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1565,12 +1565,15 @@ void NodeManager::DisconnectClient(const std::shared_ptr<ClientConnection> &clie
   client->Close();
   auto proc = worker->GetProcess();
 
-  async_retry_until(io_service_.get_executor(), [proc](){
-    return proc.IsAlive() == false;
-  }, std::nullopt, 100ms, [this]() {
-    RAY_CHECK_OK(
-        gcs_client_->Workers().AsyncReportWorkerFailure(worker_failure_data_ptr, nullptr));
-  });
+  async_retry_until(
+      io_service_.get_executor(),
+      [proc]() { return proc.IsAlive() == false; },
+      std::nullopt,
+      100ms,
+      [this]() {
+        RAY_CHECK_OK(gcs_client_->Workers().AsyncReportWorkerFailure(
+            worker_failure_data_ptr, nullptr));
+      });
 
   // TODO(rkn): Tell the object manager that this client has disconnected so
   // that it can clean up the wait requests for this client. Currently I think

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -39,6 +39,8 @@
 #include "ray/util/sample.h"
 #include "ray/util/util.h"
 
+using namespace std::chrono_literals;
+
 namespace {
 
 #define RAY_CHECK_ENUM(x, y) \
@@ -1570,7 +1572,8 @@ void NodeManager::DisconnectClient(const std::shared_ptr<ClientConnection> &clie
       [proc]() { return proc.IsAlive() == false; },
       std::nullopt,
       100ms,
-      [this]() {
+      [this, worker_failure_data_ptr](bool ret) {
+        RAY_CHECK(ret);
         RAY_CHECK_OK(gcs_client_->Workers().AsyncReportWorkerFailure(
             worker_failure_data_ptr, nullptr));
       });

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1487,9 +1487,6 @@ void NodeManager::DisconnectClient(const std::shared_ptr<ClientConnection> &clie
                                    disconnect_detail,
                                    worker->GetProcess().GetId(),
                                    creation_task_exception);
-  RAY_CHECK_OK(
-      gcs_client_->Workers().AsyncReportWorkerFailure(worker_failure_data_ptr, nullptr));
-
   if (is_worker) {
     const ActorID &actor_id = worker->GetActorId();
     const TaskID &task_id = worker->GetAssignedTaskId();
@@ -1566,6 +1563,14 @@ void NodeManager::DisconnectClient(const std::shared_ptr<ClientConnection> &clie
   cluster_task_manager_->CancelTaskForOwner(worker->GetAssignedTaskId());
 
   client->Close();
+  auto proc = worker->GetProcess();
+
+  async_retry_until(io_service_.get_executor(), [proc](){
+    return proc.IsAlive() == false;
+  }, std::nullopt, 100ms, [this]() {
+    RAY_CHECK_OK(
+        gcs_client_->Workers().AsyncReportWorkerFailure(worker_failure_data_ptr, nullptr));
+  });
 
   // TODO(rkn): Tell the object manager that this client has disconnected so
   // that it can clean up the wait requests for this client. Currently I think

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -635,7 +635,7 @@ bool IsProcessAlive(pid_t pid) {
   }
   // If it's a child, check whether it's zombie
   int ret = waitpid(pid, nullptr, WNOHANG);
-  if(ret == pid) {
+  if (ret == pid) {
     return false;
   }
   return true;

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -629,8 +629,12 @@ bool IsProcessAlive(pid_t pid) {
   }
   return false;
 #else
-  int stat;
-  if (pid == waitpid(pid, &stat, WNOHANG)) {
+  if (kill(pid, 0) == -1 && errno == ESRCH) {
+    return false;
+  }
+  // If it's a child, check whether it's zombie
+  int ret = waitpid(pid, nullptr, WNOHANG);
+  if(ret == pid) {
     return false;
   }
   return true;

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -629,7 +629,8 @@ bool IsProcessAlive(pid_t pid) {
   }
   return false;
 #else
-  if (kill(pid, 0) == -1 && errno == ESRCH) {
+  int stat;
+  if (pid == waitpid(pid, &stat, WNOHANG)) {
     return false;
   }
   return true;

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -634,8 +634,12 @@ bool IsProcessAlive(pid_t pid) {
     return false;
   }
   // If it's a child, check whether it's zombie
-  int ret = waitpid(pid, nullptr, WNOHANG);
+  int status = 0;
+  int ret = waitpid(pid, &status, WNOHANG);
   if (ret == pid) {
+    if (WIFEXITED(status)) {
+      RAY_LOG(DEBUG) << "Child exited with status: " << WEXITSTATUS(status);
+    }
     return false;
   }
   return true;

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -629,6 +629,7 @@ bool IsProcessAlive(pid_t pid) {
   }
   return false;
 #else
+  // Check pid is alive or not
   if (kill(pid, 0) == -1 && errno == ESRCH) {
     return false;
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This fix is not fixing from the root https://github.com/ray-project/ray/pull/35247

And in many_nodes_actor_tests_v2, the file descriptor error still shows. 

This fix tries to monitor the process's liveness in some way.  It also introduce a new util function which will retry the failed function until certain number.

Some tests are disabled due to the race condition in detecting node failures which will be fixed later.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/34635
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
