### PR TITLE
[Serve] Increase the GCS timeout

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -131,7 +131,7 @@ RAY_INTERNAL_SERVE_CONTROLLER_PIN_ON_NODE = (
 )
 
 # Timeout for GCS RPC request
-RAY_GCS_RPC_TIMEOUT_S = 3.0
+RAY_GCS_RPC_TIMEOUT_S = 15.0
 
 # Env var to control legacy sync deployment handle behavior in DAG.
 SYNC_HANDLE_IN_DAG_FEATURE_FLAG_ENV_KEY = "SERVE_DEPLOYMENT_HANDLE_IS_SYNC"

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -131,7 +131,7 @@ RAY_INTERNAL_SERVE_CONTROLLER_PIN_ON_NODE = (
 )
 
 # Timeout for GCS RPC request
-RAY_GCS_RPC_TIMEOUT_S = 15.0
+RAY_GCS_RPC_TIMEOUT_S = 30.0
 
 # Env var to control legacy sync deployment handle behavior in DAG.
 SYNC_HANDLE_IN_DAG_FEATURE_FLAG_ENV_KEY = "SERVE_DEPLOYMENT_HANDLE_IS_SYNC"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

3 seconds are too short. at a large cluster, I commonly see GCS latency increase up to 30+ seconds. 

I am using the same timeout as regular RPC timeout in general in Ray (30 seconds)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
