### PR TITLE
During GCS restarts, grpc based resource broadcaster should only add ALIVE nodes during initialization

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_resource_report_poller.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_report_poller.cc
@@ -39,7 +39,9 @@ GcsResourceReportPoller::~GcsResourceReportPoller() { Stop(); }
 
 void GcsResourceReportPoller::Initialize(const GcsInitData &gcs_init_data) {
   for (const auto &pair : gcs_init_data.Nodes()) {
-    HandleNodeAdded(pair.second);
+    if (pair.second.state() == rpc::GcsNodeInfo::ALIVE) {
+      HandleNodeAdded(pair.second);
+    }
   }
 }
 

--- a/src/ray/gcs/gcs_server/grpc_based_resource_broadcaster.cc
+++ b/src/ray/gcs/gcs_server/grpc_based_resource_broadcaster.cc
@@ -36,7 +36,9 @@ GrpcBasedResourceBroadcaster::~GrpcBasedResourceBroadcaster() {}
 
 void GrpcBasedResourceBroadcaster::Initialize(const GcsInitData &gcs_init_data) {
   for (const auto &pair : gcs_init_data.Nodes()) {
-    HandleNodeAdded(pair.second);
+    if (pair.second.state() == rpc::GcsNodeInfo::ALIVE) {
+      HandleNodeAdded(pair.second);
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
During GCS restarts, grpc based resource broadcaster should only add ALIVE nodes during initialization. Otherwise it will keep broadcasting messages to dead nodes after restart.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
