### PR TITLE
[Train] Enable progress bar in LightningTrainer

### DIFF
--- a/python/ray/train/lightning/lightning_trainer.py
+++ b/python/ray/train/lightning/lightning_trainer.py
@@ -1,15 +1,9 @@
 import os
+import pytorch_lightning as pl
+
 from inspect import isclass
 from typing import Any, Dict, Optional, Type
-import pytorch_lightning as pl
 from pytorch_lightning.plugins.environments import ClusterEnvironment
-
-from packaging.version import Version
-
-if Version(pl.__version__) >= Version("2.0.0"):
-    from pytorch_lightning.callbacks.progress import ProgressBar as ProgressBarBase
-else:
-    from pytorch_lightning.callbacks.progress.base import ProgressBarBase
 
 from ray.air import session
 from ray.air.config import CheckpointConfig, DatasetConfig, RunConfig, ScalingConfig
@@ -509,13 +503,6 @@ def _lightning_train_loop_per_worker(config):
     lightning_module = module_class(**module_init_config)
 
     # Prepare Lightning Trainer
-    # Disable the Lightning progress bar to avoid corrupted AIR outputs,
-    # unless users provide a customized progress bar callback.
-    trainer_config["enable_progress_bar"] = any(
-        isinstance(callback, ProgressBarBase)
-        for callback in trainer_config.get("callbacks", [])
-    )
-
     # Setup trainer's parallel devices
     if trainer_config.get("accelerator", None) == "gpu":
         current_device = get_worker_root_device()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Previously, AIR output was under development and enabling the progress bar would corrupt it. We disabled the progress bar by default as a temporary solution. 

Given that the progress bar works with AIR output now, it is time to re-enable it for users to better track the their experiment progress.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
