### PR TITLE
Broken link to Github python script

### DIFF
--- a/doc/source/cluster/kubernetes/examples/gpu-training-example.md
+++ b/doc/source/cluster/kubernetes/examples/gpu-training-example.md
@@ -55,7 +55,7 @@ kubectl port-forward --address 0.0.0.0 services/raycluster-head-svc 8265:8265
 pip3 install -U "ray[default]"
 
 # Download the Python script
-curl https://raw.githubusercontent.com/ray-project/ray/master/doc/source/cluster/doc_code/pytorch_training_e2e_submit.py -o pytorch_training_e2e_submit.py
+curl https://github.com/ray-project/ray/master/doc/source/cluster/doc_code/pytorch_training_e2e_submit.py -o pytorch_training_e2e_submit.py
 
 # Submit the training job to your ray cluster
 python3 pytorch_training_e2e_submit.py


### PR DESCRIPTION
## Why are these changes needed?

CSAT feedback:

"# Download the Python script curl https://raw.githubusercontent.com/ray-project/ray/master/doc/source/cluster/doc_code/pytorch_training_e2e_submit.py -o pytorch_training_e2e_submit.py URL is broken"

From Feb 1, 2023

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
