### PR TITLE
[RLlib] Add missing `sampler_results` key to fetch min desired reward in RLlib release tests

### DIFF
--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -905,7 +905,8 @@ def run_learning_tests_from_yaml(
                     episode_reward_mean = np.mean(
                         [
                             t.metric_analysis[
-                                "evaluation/sampler_results/episode_reward_mean"]["max"]
+                                "evaluation/sampler_results/episode_reward_mean"
+                            ]["max"]
                             for t in trials_for_experiment
                         ]
                     )
@@ -913,7 +914,8 @@ def run_learning_tests_from_yaml(
                     episode_reward_mean = np.mean(
                         [
                             t.metric_analysis["sampler_results/episode_reward_mean"][
-                                "max"]
+                                "max"
+                            ]
                             for t in trials_for_experiment
                         ]
                     )

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -904,14 +904,16 @@ def run_learning_tests_from_yaml(
                 if check_eval:
                     episode_reward_mean = np.mean(
                         [
-                            t.metric_analysis["evaluation/episode_reward_mean"]["max"]
+                            t.metric_analysis[
+                                "evaluation/sampler_results/episode_reward_mean"]["max"]
                             for t in trials_for_experiment
                         ]
                     )
                 else:
                     episode_reward_mean = np.mean(
                         [
-                            t.metric_analysis["episode_reward_mean"]["max"]
+                            t.metric_analysis["sampler_results/episode_reward_mean"][
+                                "max"]
                             for t in trials_for_experiment
                         ]
                     )

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -786,9 +786,9 @@ def run_learning_tests_from_yaml(
 
             check_eval = should_check_eval(e)
             episode_reward_key = (
-                "episode_reward_mean"
+                "sampler_results/episode_reward_mean"
                 if not check_eval
-                else "evaluation/episode_reward_mean"
+                else "evaluation/sampler_results/episode_reward_mean"
             )
 
             # For smoke-tests, we just run for n min.


### PR DESCRIPTION
## Why are these changes needed?

RLlib release tests have not successfully grabbed the desired reward lately.
This was due to a missing `sampler_results` key that now lies in the path of the reported mean rewards.
This path in the results dict was introduced in #34526 but not added to the test util that we use to check in release tests.