### PR TITLE
[ci][byod/1] clean up local environment setup for release tests

### DIFF
--- a/release/microbenchmark/app_config.yaml
+++ b/release/microbenchmark/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:latest-py37") }}
 env_vars: {}
 debian_packages: []
 

--- a/release/microbenchmark/app_config.yaml
+++ b/release/microbenchmark/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:latest-py37") }}
+base_image: {{ default("anyscale/ray:latest-py37") }}
 env_vars: {}
 debian_packages: []
 

--- a/release/microbenchmark/app_config.yaml
+++ b/release/microbenchmark/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ default("anyscale/ray:latest-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 env_vars: {}
 debian_packages: []
 

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -4,7 +4,6 @@ import traceback
 from typing import Optional, List, Tuple
 
 from ray_release.alerts.handle import handle_result, require_result
-from ray_release.anyscale_util import get_cluster_name
 from ray_release.buildkite.output import buildkite_group, buildkite_open_last
 from ray_release.cluster_manager.cluster_manager import ClusterManager
 from ray_release.cluster_manager.full import FullClusterManager
@@ -31,7 +30,6 @@ from ray_release.exception import (
     PrepareCommandTimeout,
     TestCommandError,
     TestCommandTimeout,
-    LocalEnvSetupError,
     ClusterEnvCreateError,
 )
 from ray_release.file_manager.job_file_manager import JobFileManager
@@ -41,12 +39,6 @@ from ray_release.result import Result, handle_exception
 from ray_release.signal_handling import (
     setup_signal_handling,
     reset_signal_handling,
-    register_handler,
-)
-from ray_release.util import (
-    run_bash_script,
-    get_pip_packages,
-    reinstall_anyscale_dependencies,
 )
 
 type_str_to_command_runner = {
@@ -233,70 +225,6 @@ def _setup_cluster_environment(
     return prepare_cmd, prepare_timeout, build_timeout, cluster_timeout, command_timeout
 
 
-def _setup_local_environment(
-    test: Test,
-    command_runner: CommandRunner,
-    ray_wheels_url: str,
-) -> None:
-    driver_setup_script = test.get("driver_setup", None)
-    if driver_setup_script:
-        try:
-            run_bash_script(driver_setup_script)
-        except Exception as e:
-            raise LocalEnvSetupError(f"Driver setup script failed: {e}") from e
-
-    # Install local dependencies
-    command_runner.prepare_local_env(ray_wheels_url)
-
-    # Re-install anyscale package as local dependencies might have changed
-    # from local env setup
-    reinstall_anyscale_dependencies()
-
-
-def _local_environment_information(
-    result: Result,
-    cluster_manager: ClusterManager,
-    command_runner: CommandRunner,
-    build_timeout: int,
-    cluster_timeout: int,
-    no_terminate: bool,
-    cluster_id: Optional[str],
-    cluster_env_id: Optional[str],
-) -> None:
-    pip_packages = get_pip_packages()
-    pip_package_string = "\n".join(pip_packages)
-    logger.info(f"Installed python packages:\n{pip_package_string}")
-
-    if isinstance(cluster_manager, FullClusterManager):
-        if not no_terminate:
-            register_handler(
-                lambda sig, frame: cluster_manager.terminate_cluster(wait=True)
-            )
-
-    # Start cluster
-    if cluster_id:
-        buildkite_group(":rocket: Using existing cluster")
-        # Re-use existing cluster ID for development
-        cluster_manager.cluster_id = cluster_id
-        cluster_manager.cluster_name = get_cluster_name(cluster_id)
-    else:
-        buildkite_group(":gear: Building cluster environment")
-
-        if cluster_env_id:
-            cluster_manager.cluster_env_id = cluster_env_id
-
-        cluster_manager.build_configs(timeout=build_timeout)
-
-        if isinstance(cluster_manager, FullClusterManager):
-            buildkite_group(":rocket: Starting up cluster")
-            cluster_manager.start_cluster(timeout=cluster_timeout)
-        elif isinstance(command_runner, AnyscaleJobRunner):
-            command_runner.job_manager.cluster_startup_timeout = cluster_timeout
-
-    result.cluster_url = cluster_manager.get_cluster_url()
-    result.cluster_id = cluster_manager.cluster_id
-
-
 def _prepare_remote_environment(
     test: Test,
     command_runner: CommandRunner,
@@ -451,22 +379,6 @@ def run_release_test(
             result,
             cluster_manager,
             ray_wheels_url,
-            cluster_env_id,
-        )
-
-        buildkite_group(":nut_and_bolt: Setting up local environment")
-        _setup_local_environment(test, command_runner, ray_wheels_url)
-
-        # Print installed pip packages
-        buildkite_group(":bulb: Local environment information")
-        _local_environment_information(
-            result,
-            cluster_manager,
-            command_runner,
-            build_timeout,
-            cluster_timeout,
-            no_terminate,
-            cluster_id,
             cluster_env_id,
         )
 

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -20,7 +20,6 @@ from ray_release.config import (
     DEFAULT_WAIT_FOR_NODES_TIMEOUT,
     RELEASE_PACKAGE_DIR,
     DEFAULT_AUTOSUSPEND_MINS,
-    validate_test,
 )
 from ray_release.template import load_test_cluster_env, load_test_cluster_compute
 from ray_release.exception import (
@@ -83,7 +82,6 @@ def _load_test_configuration(
     smoke_test: bool = False,
     no_terminate: bool = False,
 ) -> Tuple[ClusterManager, CommandRunner, str]:
-    validate_test(test)
     logger.info(f"Test config: {test}")
 
     # Populate result paramaters

--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -45,9 +45,6 @@
 				"team": {
 					"type": "string"
 				},
-				"driver_setup": {
-					"type": "string"
-				},
 				"cluster": {
 					"$ref": "#/definitions/Cluster"
 				},
@@ -165,9 +162,6 @@
 					"type": "string"
 				},
 				"env": {
-					"type": "string"
-				},
-				"driver_setup": {
 					"type": "string"
 				},
 				"cluster": {

--- a/release/ray_release/tests/test_glue.py
+++ b/release/ray_release/tests/test_glue.py
@@ -12,15 +12,9 @@ from ray_release.alerts.handle import result_to_handle_map
 from ray_release.cluster_manager.cluster_manager import ClusterManager
 from ray_release.cluster_manager.full import FullClusterManager
 from ray_release.command_runner.command_runner import CommandRunner
-from ray_release.config import (
-    Test,
-    DEFAULT_COMMAND_TIMEOUT,
-    DEFAULT_WAIT_FOR_NODES_TIMEOUT,
-)
+from ray_release.config import Test
 from ray_release.exception import (
     ReleaseTestConfigError,
-    LocalEnvSetupError,
-    ClusterComputeCreateError,
     ClusterEnvBuildError,
     ClusterEnvBuildTimeout,
     ClusterEnvCreateError,
@@ -44,7 +38,6 @@ from ray_release.glue import (
     run_release_test,
     type_str_to_command_runner,
     command_runner_to_cluster_manager,
-    TIMEOUT_BUFFER_MINUTES,
 )
 from ray_release.logger import logger
 from ray_release.reporter.reporter import Reporter
@@ -73,8 +66,6 @@ class MockReturn:
         return object.__getattribute__(self, item)
 
 
-@patch("ray_release.glue.reinstall_anyscale_dependencies", lambda: None)
-@patch("ray_release.glue.get_pip_packages", lambda: ["pip-packages"])
 class GlueTest(unittest.TestCase):
     def writeClusterEnv(self, content: str):
         with open(os.path.join(self.tempdir, "cluster_env.yaml"), "wt") as fp:
@@ -174,7 +165,6 @@ class GlueTest(unittest.TestCase):
                 cluster_env="cluster_env.yaml", cluster_compute="cluster_compute.yaml"
             ),
             alert="unit_test_alerter",
-            driver_setup="driver_fail.sh",
         )
         self.anyscale_project = "prj_unit12345678"
         self.ray_wheels_url = "http://mock.wheels/"
@@ -184,16 +174,6 @@ class GlueTest(unittest.TestCase):
 
     def _succeed_until(self, until: str):
         # These commands should succeed
-        self.command_runner_return["prepare_local_env"] = None
-
-        if until == "local_env":
-            return
-
-        self.test["driver_setup"] = "driver_succeed.sh"
-
-        if until == "driver_setup":
-            return
-
         self.cluster_manager_return["cluster_compute_id"] = "valid"
         self.cluster_manager_return["create_cluster_compute"] = None
 
@@ -315,102 +295,6 @@ class GlueTest(unittest.TestCase):
             self._run(result)
 
         self.assertEqual(result.return_code, ExitCode.CONFIG_ERROR.value)
-
-    def testAutomaticClusterEnvVariables(self):
-        result = Result()
-
-        self._succeed_until("local_env")
-
-        with self.assertRaises(LocalEnvSetupError):
-            self._run(result)
-
-        cluster_manager = self.instances["cluster_manager"]
-
-        command_timeout = self.test["run"].get("timeout", DEFAULT_COMMAND_TIMEOUT)
-        prepare_cmd = self.test["run"].get("prepare", None)
-        if prepare_cmd:
-            prepare_timeout = self.test["run"].get("prepare_timeout", command_timeout)
-        else:
-            prepare_timeout = 0
-        command_and_prepare_timeout = command_timeout + prepare_timeout
-
-        wait_timeout = self.test["run"]["wait_for_nodes"].get(
-            "timeout", DEFAULT_WAIT_FOR_NODES_TIMEOUT
-        )
-
-        expected_idle_termination_minutes = int(
-            command_and_prepare_timeout / 60 + TIMEOUT_BUFFER_MINUTES
-        )
-        expected_maximum_uptime_minutes = int(
-            expected_idle_termination_minutes + wait_timeout + TIMEOUT_BUFFER_MINUTES
-        )
-
-        self.assertEqual(
-            cluster_manager.cluster_compute["idle_termination_minutes"],
-            expected_idle_termination_minutes,
-        )
-        self.assertEqual(
-            cluster_manager.cluster_compute["maximum_uptime_minutes"],
-            expected_maximum_uptime_minutes,
-        )
-
-    def testInvalidPrepareLocalEnv(self):
-        result = Result()
-
-        self.command_runner_return["prepare_local_env"] = _fail_on_call(
-            LocalEnvSetupError
-        )
-        with self.assertRaises(LocalEnvSetupError):
-            self._run(result)
-        self.assertEqual(result.return_code, ExitCode.LOCAL_ENV_SETUP_ERROR.value)
-
-    def testDriverSetupFails(self):
-        result = Result()
-
-        self._succeed_until("local_env")
-
-        with self.assertRaises(LocalEnvSetupError):
-            self._run(result)
-        self.assertEqual(result.return_code, ExitCode.LOCAL_ENV_SETUP_ERROR.value)
-
-    def testInvalidClusterIdOverride(self):
-        result = Result()
-
-        self._succeed_until("driver_setup")
-
-        self.sdk.returns["get_cluster_environment"] = None
-
-        with self.assertRaises(ClusterEnvCreateError):
-            self._run(result, cluster_env_id="existing")
-
-        self.sdk.returns["get_cluster_environment"] = APIDict(
-            result=APIDict(config_json={"overridden": True})
-        )
-
-        with self.assertRaises(Exception) as cm:  # Fail somewhere else
-            self._run(result, cluster_env_id="existing")
-            self.assertNotIsInstance(cm.exception, ClusterEnvCreateError)
-
-    def testBuildConfigFailsClusterCompute(self):
-        result = Result()
-
-        self._succeed_until("driver_setup")
-
-        # These commands should succeed
-        self.command_runner_return["prepare_local_env"] = None
-
-        # Fails because API response faulty
-        with self.assertRaisesRegex(ClusterComputeCreateError, "Unexpected"):
-            self._run(result)
-        self.assertEqual(result.return_code, ExitCode.CLUSTER_RESOURCE_ERROR.value)
-
-        # Fails for random cluster compute reason
-        self.cluster_manager_return["create_cluster_compute"] = _fail_on_call(
-            ClusterComputeCreateError, "Known"
-        )
-        with self.assertRaisesRegex(ClusterComputeCreateError, "Known"):
-            self._run(result)
-        self.assertEqual(result.return_code, ExitCode.CLUSTER_RESOURCE_ERROR.value)
 
     def testBuildConfigFailsClusterEnv(self):
         result = Result()

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -22,10 +22,6 @@
 #  # on. This must be a string!
 #  python: "3.7"
 #
-#  # Optional location of a bash setup script to run on the driver
-#  # when setting up the local environment. Relative to working_dir
-#  driver_setup: setup_driver.sh
-#
 #  # Cluster information
 #  cluster:
 #    # Location of cluster env, relative to working_dir
@@ -1474,7 +1470,6 @@
     cluster_env: horovod/app_config.yaml
     cluster_compute: horovod/compute_tpl_aws.yaml
 
-  driver_setup: horovod/driver_setup_latest.sh
   run:
     timeout: 1200
     script: python horovod/horovod_user_test.py
@@ -1503,7 +1498,6 @@
     cluster_env: horovod/app_config_master.yaml
     cluster_compute: horovod/compute_tpl_aws.yaml
 
-  driver_setup: horovod/driver_setup_master.sh
   run:
     timeout: 1200
     script: python horovod/horovod_user_test.py
@@ -1532,7 +1526,6 @@
     cluster_env: train/app_config.yaml
     cluster_compute: train/compute_tpl_aws.yaml
 
-  driver_setup: train/driver_setup.sh
   run:
     timeout: 36000
     script: python train/train_tensorflow_mnist_test.py
@@ -1561,7 +1554,6 @@
     cluster_env: train/app_config.yaml
     cluster_compute: train/compute_tpl_aws.yaml
 
-  driver_setup: train/driver_setup.sh
   run:
     timeout: 36000
     script: python train/train_torch_linear_test.py
@@ -1646,7 +1638,6 @@
     cluster_env: ray-lightning/app_config.yaml
     cluster_compute: ray-lightning/compute_tpl_aws.yaml
 
-  driver_setup: ray-lightning/driver_setup.sh
   run:
     timeout: 1200
     script: python ray-lightning/ray_lightning_user_test.py
@@ -1675,7 +1666,6 @@
     cluster_env: ray-lightning/app_config_master.yaml
     cluster_compute: ray-lightning/compute_tpl_aws.yaml
 
-  driver_setup: ray-lightning/driver_setup.sh
   run:
     timeout: 1200
     script: python ray-lightning/ray_lightning_user_test.py
@@ -1704,7 +1694,6 @@
     cluster_env: ../rllib_tests/app_config.yaml
     cluster_compute: tune_rllib/compute_tpl_aws.yaml
 
-  driver_setup: tune_rllib/driver_setup.sh
   run:
     timeout: 2000
     script: python tune_rllib/run_connect_tests.py


### PR DESCRIPTION
## Why are these changes needed?
All release tests are using remote execution via anyscale at this point. Remove code path for local environment setup. In particular, the driver_setup is used to install packages on buildkite host, which is no longer neccessary/used.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests