### PR TITLE
[data] Fix bugs in handling of nested ndarrays (and other complex object types)

### DIFF
--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -673,9 +673,7 @@ class ArrowVariableShapedTensorArray(
         #    underlying scalar data type.
         #  - shape: a variable-sized list array containing the shapes of each tensor
         #    element.
-        if isinstance(arr, Iterable):
-            arr = list(arr)
-        elif not isinstance(arr, (list, tuple)):
+        if not isinstance(arr, (list, tuple, np.ndarray)):
             raise ValueError(
                 "ArrowVariableShapedTensorArray can only be constructed from an "
                 f"ndarray or a list/tuple of ndarrays, but got: {type(arr)}"
@@ -716,13 +714,6 @@ class ArrowVariableShapedTensorArray(
         else:
             np_data_buffer = np.concatenate(raveled)
         dtype = np_data_buffer.dtype
-        if dtype.type is np.object_:
-            types_and_shapes = [(f"dtype={a.dtype}", f"shape={a.shape}") for a in arr]
-            raise ValueError(
-                "ArrowVariableShapedTensorArray only supports heterogeneous-shaped "
-                "tensor collections, not arbitrarily nested ragged tensors. Got "
-                f"arrays: {types_and_shapes}"
-            )
         pa_dtype = pa.from_numpy_dtype(dtype)
         if pa.types.is_string(pa_dtype):
             if dtype.byteorder == ">" or (

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -158,7 +158,6 @@ class ArrowBlockAccessor(TableBlockAccessor):
     @staticmethod
     def numpy_to_block(
         batch: Union[np.ndarray, Dict[str, np.ndarray], Dict[str, list]],
-        passthrough_arrow_not_implemented_errors: bool = False,
     ) -> "pyarrow.Table":
         import pyarrow as pa
 
@@ -180,17 +179,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
             col = convert_udf_returns_to_numpy(col)
             # Use Arrow's native *List types for 1-dimensional ndarrays.
             if col.dtype.type is np.object_ or col.ndim > 1:
-                try:
-                    col = ArrowTensorArray.from_numpy(col)
-                except pa.ArrowNotImplementedError as e:
-                    if passthrough_arrow_not_implemented_errors:
-                        raise e
-                    raise ValueError(
-                        "Failed to convert multi-dimensional ndarray of dtype "
-                        f"{col.dtype} to our tensor extension since this dtype is not "
-                        "supported by Arrow. If encountering this due to string data, "
-                        'cast the ndarray to a string dtype, e.g. a.astype("U").'
-                    ) from e
+                col = ArrowTensorArray.from_numpy(col)
             new_batch[col_name] = col
         return pa.Table.from_pydict(new_batch)
 

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -59,15 +59,18 @@ def convert_udf_returns_to_numpy(udf_return_col: Any) -> Any:
             if all(is_valid_udf_return(e) for e in udf_return_col):
                 udf_return_col = [np.array(e) for e in udf_return_col]
             shapes = set()
-            if all(isinstance(e, np.ndarray) for e in udf_return_col):
-                for e in udf_return_col:
-                    shapes.add(e.shape)
+            for e in udf_return_col:
+                if isinstance(e, np.ndarray):
+                    shapes.add((e.dtype, e.shape))
+                else:
+                    shapes.add(type(e))
             if len(shapes) > 1:
                 # This util works around some limitations of np.array(dtype=object).
                 udf_return_col = create_ragged_ndarray(udf_return_col)
             else:
                 udf_return_col = np.array(udf_return_col)
         except Exception as e:
+            raise
             raise ValueError(
                 "Failed to convert column values to numpy array: "
                 f"({_truncated_repr(udf_return_col)}): {e}."

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -70,7 +70,6 @@ def convert_udf_returns_to_numpy(udf_return_col: Any) -> Any:
             else:
                 udf_return_col = np.array(udf_return_col)
         except Exception as e:
-            raise
             raise ValueError(
                 "Failed to convert column values to numpy array: "
                 f"({_truncated_repr(udf_return_col)}): {e}."

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -433,10 +433,8 @@ class BlockAccessor:
             import pyarrow as pa
 
             try:
-                return ArrowBlockAccessor.numpy_to_block(
-                    batch, passthrough_arrow_not_implemented_errors=True
-                )
-            except (pa.ArrowNotImplementedError, pa.ArrowInvalid):
+                return ArrowBlockAccessor.numpy_to_block(batch)
+            except (pa.ArrowNotImplementedError, pa.ArrowInvalid, pa.ArrowTypeError):
                 import pandas as pd
 
                 # TODO(ekl) once we support Python objects within Arrow blocks, we


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There were a couple bugs in our handling of complex ndarrays:
- We weren't consistently falling back to PandasBlock for object dtypes. This was due to raising different exception types, some of which were not caught at the upper layer. This PR simplifies our exception handling path, removing legacy code.
- We weren't calling create_ragged_ndarray for certain return types due to a bug in the shape mismatch detection code.

## Related issue number

Closes https://github.com/ray-project/ray/issues/35340