### PR TITLE
[ci][byod/2] compute anyscale byod for release tests

### DIFF
--- a/release/BUILD
+++ b/release/BUILD
@@ -632,6 +632,21 @@ py_test(
 )
 
 py_test(
+    name = "test_test",
+    size = "small",
+    srcs = ["ray_release/tests/test_test.py"],
+    exec_compatible_with = [":hermetic_python"],
+    tags = [
+        "release_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":ray_release",
+        bk_require("pytest"),
+    ],
+)
+
+py_test(
     name = "test_wheels",
     size = "small",
     srcs = ["ray_release/tests/test_wheels.py"],

--- a/release/microbenchmark/app_config.yaml
+++ b/release/microbenchmark/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:latest-py37") }}
 env_vars: {}
 debian_packages: []
 

--- a/release/microbenchmark/app_config.yaml
+++ b/release/microbenchmark/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:latest-py37") }}
+base_image: {{ default("anyscale/ray:latest-py37") }}
 env_vars: {}
 debian_packages: []
 

--- a/release/microbenchmark/app_config.yaml
+++ b/release/microbenchmark/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ default("anyscale/ray:latest-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
 env_vars: {}
 debian_packages: []
 

--- a/release/ray_release/alerts/default.py
+++ b/release/ray_release/alerts/default.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.result import Result
 
 

--- a/release/ray_release/alerts/handle.py
+++ b/release/ray_release/alerts/handle.py
@@ -1,4 +1,4 @@
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.exception import ReleaseTestConfigError, ResultsAlert
 from ray_release.logger import logger
 from ray_release.result import Result

--- a/release/ray_release/alerts/long_running_tests.py
+++ b/release/ray_release/alerts/long_running_tests.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.result import Result
 
 

--- a/release/ray_release/alerts/tune_tests.py
+++ b/release/ray_release/alerts/tune_tests.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.result import Result
 
 

--- a/release/ray_release/alerts/xgboost_tests.py
+++ b/release/ray_release/alerts/xgboost_tests.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.result import Result
 
 

--- a/release/ray_release/buildkite/concurrency.py
+++ b/release/ray_release/buildkite/concurrency.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from typing import Tuple, Optional, Dict
 
 from ray_release.bazel import bazel_runfile
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.template import load_test_cluster_compute
 from ray_release.logger import logger
 

--- a/release/ray_release/buildkite/filter.py
+++ b/release/ray_release/buildkite/filter.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from typing import List, Optional, Tuple, Dict, Any
 
 from ray_release.buildkite.settings import Frequency, get_frequency
-from ray_release.config import Test
+from ray_release.test import Test
 
 
 def _unflattened_lookup(lookup: Dict, flat_key: str, delimiter: str = "/") -> Any:

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -4,11 +4,13 @@ from typing import Any, Dict, Optional
 
 from ray_release.aws import RELEASE_AWS_BUCKET
 from ray_release.buildkite.concurrency import get_concurrency_group
+from ray_release.test import (
+    Test,
+    DEFAULT_PYTHON_VERSION,
+)
 from ray_release.config import (
     DEFAULT_ANYSCALE_PROJECT,
     DEFAULT_CLOUD_ID,
-    DEFAULT_PYTHON_VERSION,
-    Test,
     as_smoke_test,
     parse_python_version,
 )

--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -1,0 +1,11 @@
+from typing import List
+
+from ray_release.test import Test
+
+
+def build_anyscale_byod_images(tests: List[Test]) -> None:
+    """
+    Builds the Anyscale BYOD images for the given tests.
+    """
+    # TODO(aslonnie): Build anyscale byod images for the given ray images
+    return

--- a/release/ray_release/byod/byod.py
+++ b/release/ray_release/byod/byod.py
@@ -1,0 +1,11 @@
+from typing import List
+
+from ray_release.test import Test
+
+
+def build_anyscale_byod_images(tests: List[Test]) -> None:
+    """
+    Builds the Anyscale BYOD images for the given tests.
+    """
+    # TODO(aslonnie): Build anyscale byod images for the given ray images
+    return

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -8,6 +8,7 @@ from ray_release.aws import (
 )
 from ray_release.anyscale_util import get_project_name
 from ray_release.config import DEFAULT_AUTOSUSPEND_MINS, DEFAULT_MAXIMUM_UPTIME_MINS
+from ray_release.test import Test
 from ray_release.exception import CloudInfoError
 from ray_release.util import anyscale_cluster_url, dict_hash, get_anyscale_sdk
 from ray_release.logger import logger
@@ -19,20 +20,20 @@ if TYPE_CHECKING:
 class ClusterManager(abc.ABC):
     def __init__(
         self,
-        test_name: str,
+        test: Test,
         project_id: str,
         sdk: Optional["AnyscaleSDK"] = None,
         smoke_test: bool = False,
     ):
         self.sdk = sdk or get_anyscale_sdk()
 
-        self.test_name = test_name
+        self.test = test
         self.smoke_test = smoke_test
         self.project_id = project_id
         self.project_name = get_project_name(self.project_id, self.sdk)
 
         self.cluster_name = (
-            f"{test_name}{'-smoke-test' if smoke_test else ''}_{int(time.time())}"
+            f"{test.get_name()}{'-smoke-test' if smoke_test else ''}_{int(time.time())}"
         )
         self.cluster_id = None
 
@@ -59,11 +60,11 @@ class ClusterManager(abc.ABC):
         self.cluster_env["env_vars"]["RAY_USAGE_STATS_SOURCE"] = "nightly-tests"
         self.cluster_env["env_vars"][
             "RAY_USAGE_STATS_EXTRA_TAGS"
-        ] = f"test_name={self.test_name};smoke_test={self.smoke_test}"
+        ] = f"test_name={self.test.get_name()};smoke_test={self.smoke_test}"
 
         self.cluster_env_name = (
             f"{self.project_name}_{self.project_id[4:8]}"
-            f"__env__{self.test_name.replace('.', '_')}__"
+            f"__env__{self.test.get_name().replace('.', '_')}__"
             f"{dict_hash(self.cluster_env)}"
         )
 
@@ -89,7 +90,7 @@ class ClusterManager(abc.ABC):
 
         self.cluster_compute_name = (
             f"{self.project_name}_{self.project_id[4:8]}"
-            f"__compute__{self.test_name}__"
+            f"__compute__{self.test.get_name()}__"
             f"{dict_hash(self.cluster_compute)}"
         )
 

--- a/release/ray_release/cluster_manager/minimal.py
+++ b/release/ray_release/cluster_manager/minimal.py
@@ -24,41 +24,53 @@ class MinimalClusterManager(ClusterManager):
     def create_cluster_env(self):
         assert self.cluster_env_id is None
 
-        if self.cluster_env:
-            assert self.cluster_env_name
+        if not self.cluster_env:
+            return
+        assert self.cluster_env_name
 
-            logger.info(
-                f"Test uses a cluster env with name "
-                f"{self.cluster_env_name}. Looking up existing "
-                f"cluster envs with this name."
-            )
+        logger.info(
+            f"Test uses a cluster env with name "
+            f"{self.cluster_env_name}. Looking up existing "
+            f"cluster envs with this name."
+        )
 
-            paging_token = None
-            while not self.cluster_env_id:
-                result = self.sdk.search_cluster_environments(
-                    dict(
-                        project_id=self.project_id,
-                        name=dict(equals=self.cluster_env_name),
-                        paging=dict(count=50, paging_token=paging_token),
-                    )
+        paging_token = None
+        while not self.cluster_env_id:
+            result = self.sdk.search_cluster_environments(
+                dict(
+                    project_id=self.project_id,
+                    name=dict(equals=self.cluster_env_name),
+                    paging=dict(count=50, paging_token=paging_token),
                 )
-                paging_token = result.metadata.next_paging_token
+            )
+            paging_token = result.metadata.next_paging_token
 
-                for res in result.results:
-                    if res.name == self.cluster_env_name:
-                        self.cluster_env_id = res.id
-                        logger.info(
-                            f"Cluster env already exists with ID "
-                            f"{self.cluster_env_id}"
-                        )
-                        break
-
-                if not paging_token or self.cluster_env_id:
+            for res in result.results:
+                if res.name == self.cluster_env_name:
+                    self.cluster_env_id = res.id
+                    logger.info(
+                        f"Cluster env already exists with ID " f"{self.cluster_env_id}"
+                    )
                     break
 
-            if not self.cluster_env_id:
-                logger.info("Cluster env not found. Creating new one.")
-                try:
+            if not paging_token or self.cluster_env_id:
+                break
+
+        if not self.cluster_env_id:
+            logger.info("Cluster env not found. Creating new one.")
+            try:
+                if self.test.is_byod_cluster():
+                    result = self.sdk.create_byod_cluster_environment(
+                        dict(
+                            name=self.cluster_env_name,
+                            config_json=dict(
+                                docker_image=self.test.get_anyscale_byod_image(),
+                                ray_version="nightly",
+                                env_vars={},
+                            ),
+                        )
+                    )
+                else:
                     result = self.sdk.create_cluster_environment(
                         dict(
                             name=self.cluster_env_name,
@@ -66,16 +78,16 @@ class MinimalClusterManager(ClusterManager):
                             config_json=self.cluster_env,
                         )
                     )
-                    self.cluster_env_id = result.result.id
-                except Exception as e:
-                    logger.warning(
-                        f"Got exception when trying to create cluster "
-                        f"env: {e}. Sleeping for 10 seconds with jitter and then "
-                        f"try again..."
-                    )
-                    raise ClusterEnvCreateError("Could not create cluster env.") from e
+                self.cluster_env_id = result.result.id
+            except Exception as e:
+                logger.warning(
+                    f"Got exception when trying to create cluster "
+                    f"env: {e}. Sleeping for 10 seconds with jitter and then "
+                    f"try again..."
+                )
+                raise ClusterEnvCreateError("Could not create cluster env.") from e
 
-                logger.info(f"Cluster env created with ID {self.cluster_env_id}")
+            logger.info(f"Cluster env created with ID {self.cluster_env_id}")
 
     def build_cluster_env(self, timeout: float = 600.0):
         assert self.cluster_env_id

--- a/release/ray_release/command_runner/anyscale_job_runner.py
+++ b/release/ray_release/command_runner/anyscale_job_runner.py
@@ -63,7 +63,7 @@ class AnyscaleJobRunner(JobRunner):
         self.last_command_scd_id = None
         self.path_in_bucket = join_cloud_storage_paths(
             "working_dirs",
-            self.cluster_manager.test_name.replace(" ", "_"),
+            self.cluster_manager.test.get_name().replace(" ", "_"),
             generate_tmp_cloud_storage_path(),
         )
         # The root cloud storage bucket path. result, metric, artifact files

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -6,22 +6,15 @@ from typing import Dict, List, Optional, Tuple, Any
 
 import jsonschema
 import yaml
-from ray_release.test import Test
+from ray_release.test import (
+    Test,
+    TestDefinition,
+)
 from ray_release.anyscale_util import find_cloud_by_name
 from ray_release.bazel import bazel_runfile
 from ray_release.exception import ReleaseTestCLIError, ReleaseTestConfigError
 from ray_release.logger import logger
 from ray_release.util import DeferredEnvVar, deep_update
-
-
-class TestDefinition(dict):
-    """
-    A class represents a definition of a test, such as test name, group, etc. Comparing
-    to the test class, there are additional field, for example variations, which can be
-    used to define several variations of a test.
-    """
-
-    pass
 
 
 DEFAULT_WHEEL_WAIT_TIMEOUT = 7200  # Two hours

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -90,7 +90,7 @@ def parse_test_definition(test_definitions: List[TestDefinition]) -> List[Test]:
             test = copy.deepcopy(test_definition)
             test["name"] = f'{test["name"]}.{variation.pop("__suffix__")}'
             test = deep_update(test, variation)
-            tests.append(test)
+            tests.append(Test(test))
     return tests
 
 

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -73,7 +73,7 @@ def parse_test_definition(test_definitions: List[TestDefinition]) -> List[Test]:
     tests = []
     for test_definition in test_definitions:
         if "variations" not in test_definition:
-            tests.append(test_definition)
+            tests.append(Test(test_definition))
             continue
         variations = test_definition.pop("variations")
         _test_definition_invariant(

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -6,17 +6,12 @@ from typing import Dict, List, Optional, Tuple, Any
 
 import jsonschema
 import yaml
+from ray_release.test import Test
 from ray_release.anyscale_util import find_cloud_by_name
 from ray_release.bazel import bazel_runfile
 from ray_release.exception import ReleaseTestCLIError, ReleaseTestConfigError
 from ray_release.logger import logger
 from ray_release.util import DeferredEnvVar, deep_update
-
-
-class Test(dict):
-    """A class represents a test to run on buildkite"""
-
-    pass
 
 
 class TestDefinition(dict):
@@ -44,9 +39,6 @@ DEFAULT_CLOUD_ID = DeferredEnvVar(
 DEFAULT_ANYSCALE_PROJECT = DeferredEnvVar(
     "RELEASE_DEFAULT_PROJECT",
     "prj_FKRmeV5pA6X72aVscFALNC32",
-)
-DEFAULT_PYTHON_VERSION = tuple(
-    int(v) for v in os.environ.get("RELEASE_PY", "3.7").split(".")
 )
 
 RELEASE_PACKAGE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -4,7 +4,6 @@ import traceback
 from typing import Optional, List, Tuple
 
 from ray_release.alerts.handle import handle_result, require_result
-from ray_release.anyscale_util import get_cluster_name
 from ray_release.buildkite.output import buildkite_group, buildkite_open_last
 from ray_release.cluster_manager.cluster_manager import ClusterManager
 from ray_release.cluster_manager.full import FullClusterManager

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -4,6 +4,7 @@ import traceback
 from typing import Optional, List, Tuple
 
 from ray_release.alerts.handle import handle_result, require_result
+from ray_release.anyscale_util import get_cluster_name
 from ray_release.buildkite.output import buildkite_group, buildkite_open_last
 from ray_release.cluster_manager.cluster_manager import ClusterManager
 from ray_release.cluster_manager.full import FullClusterManager

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -127,7 +127,7 @@ def _load_test_configuration(
     # Instantiate managers and command runner
     try:
         cluster_manager = cluster_manager_cls(
-            test["name"],
+            test,
             anyscale_project,
             smoke_test=smoke_test,
         )

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -12,8 +12,8 @@ from ray_release.cluster_manager.minimal import MinimalClusterManager
 from ray_release.command_runner.job_runner import JobRunner
 from ray_release.command_runner.command_runner import CommandRunner
 from ray_release.command_runner.anyscale_job_runner import AnyscaleJobRunner
+from ray_release.test import Test
 from ray_release.config import (
-    Test,
     DEFAULT_BUILD_TIMEOUT,
     DEFAULT_CLUSTER_TIMEOUT,
     DEFAULT_COMMAND_TIMEOUT,

--- a/release/ray_release/reporter/artifacts.py
+++ b/release/ray_release/reporter/artifacts.py
@@ -2,7 +2,7 @@ import gzip
 import json
 import os
 
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.logger import logger
 from ray_release.reporter.reporter import Reporter
 from ray_release.result import Result

--- a/release/ray_release/reporter/db.py
+++ b/release/ray_release/reporter/db.py
@@ -5,7 +5,7 @@ from botocore.config import Config
 
 from ray_release.reporter.reporter import Reporter
 from ray_release.result import Result
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.logger import logger
 from ray_release.log_aggregator import LogAggregator
 

--- a/release/ray_release/reporter/log.py
+++ b/release/ray_release/reporter/log.py
@@ -1,4 +1,4 @@
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.logger import logger
 from ray_release.reporter.reporter import Reporter
 from ray_release.result import Result

--- a/release/ray_release/reporter/reporter.py
+++ b/release/ray_release/reporter/reporter.py
@@ -1,4 +1,4 @@
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.result import Result
 from ray_release.logger import logger
 

--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -87,6 +87,9 @@
 				},
 				"cloud_name": {
 					"type": "string"
+				},
+				"byod": {
+					"type": "boolean"
 				}
 			},
 			"required": [

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -153,7 +153,7 @@ def main(
             "not return any tests to run. Adjust your filters."
         )
     logger.info("Build anyscale BYOD images")
-    build_anyscale_byod_images([test for test, _ in filter_tests])
+    build_anyscale_byod_images([test for test, _ in filtered_tests])
     grouped_tests = group_tests(filtered_tests)
 
     group_str = ""

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -245,7 +245,7 @@ def _build_anyscale_byod_images(tests: List[Tuple[Test, bool]]) -> None:
     Builds the Anyscale BYOD images for the given tests.
     """
     _ = set(test.get_ray_image() for test, _ in tests)
-    # TODO(aslonnie): Build anyscale boyd images for the given ray images
+    # TODO(aslonnie): Build anyscale byod images for the given ray images
     return
 
 

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Optional
+from typing import Optional, List, Tuple
 
 import click
 
@@ -16,6 +16,7 @@ from ray_release.config import (
     DEFAULT_WHEEL_WAIT_TIMEOUT,
     parse_python_version,
 )
+from ray_release.test import Test
 from ray_release.exception import ReleaseTestCLIError, ReleaseTestConfigError
 from ray_release.logger import logger
 from ray_release.wheels import (
@@ -151,6 +152,8 @@ def main(
             "Empty test collection. The selected frequency or filter did "
             "not return any tests to run. Adjust your filters."
         )
+    logger.info("Build anyscale BYOD images")
+    _build_anyscale_byod_images(filtered_tests)
     grouped_tests = group_tests(filtered_tests)
 
     group_str = ""
@@ -235,6 +238,15 @@ def main(
 
     steps_str = json.dumps(steps)
     print(steps_str)
+
+
+def _build_anyscale_byod_images(tests: List[Tuple[Test, bool]]) -> None:
+    """
+    Builds the Anyscale BYOD images for the given tests.
+    """
+    _ = set(test.get_ray_image() for test, _ in tests)
+    # TODO(aslonnie): Build anyscale boyd images for the given ray images
+    return
 
 
 if __name__ == "__main__":

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -4,19 +4,19 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Optional, List, Tuple
+from typing import Optional
 
 import click
 
 from ray_release.buildkite.filter import filter_tests, group_tests
 from ray_release.buildkite.settings import get_pipeline_settings
 from ray_release.buildkite.step import get_step
+from ray_release.byod.build import build_anyscale_byod_images
 from ray_release.config import (
     read_and_validate_release_test_collection,
     DEFAULT_WHEEL_WAIT_TIMEOUT,
     parse_python_version,
 )
-from ray_release.test import Test
 from ray_release.exception import ReleaseTestCLIError, ReleaseTestConfigError
 from ray_release.logger import logger
 from ray_release.wheels import (
@@ -153,7 +153,7 @@ def main(
             "not return any tests to run. Adjust your filters."
         )
     logger.info("Build anyscale BYOD images")
-    _build_anyscale_byod_images(filtered_tests)
+    build_anyscale_byod_images([test for test, _ in filter_tests])
     grouped_tests = group_tests(filtered_tests)
 
     group_str = ""
@@ -238,15 +238,6 @@ def main(
 
     steps_str = json.dumps(steps)
     print(steps_str)
-
-
-def _build_anyscale_byod_images(tests: List[Tuple[Test, bool]]) -> None:
-    """
-    Builds the Anyscale BYOD images for the given tests.
-    """
-    _ = {test.get_ray_image() for test, _ in tests}
-    # TODO(aslonnie): Build anyscale byod images for the given ray images
-    return
 
 
 if __name__ == "__main__":

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -244,7 +244,7 @@ def _build_anyscale_byod_images(tests: List[Tuple[Test, bool]]) -> None:
     """
     Builds the Anyscale BYOD images for the given tests.
     """
-    _ = set(test.get_ray_image() for test, _ in tests)
+    _ = {test.get_ray_image() for test, _ in tests}
     # TODO(aslonnie): Build anyscale byod images for the given ray images
     return
 

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -11,8 +11,10 @@ from ray_release.config import (
     read_and_validate_release_test_collection,
     parse_python_version,
     DEFAULT_WHEEL_WAIT_TIMEOUT,
-    DEFAULT_PYTHON_VERSION,
+)
+from ray_release.test import (
     Test,
+    DEFAULT_PYTHON_VERSION,
 )
 from ray_release.wheels import find_and_wait_for_ray_wheels_url
 

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -6,13 +6,13 @@ from pathlib import Path
 import click
 from ray_release.aws import maybe_fetch_api_token
 from ray_release.config import (
-    DEFAULT_PYTHON_VERSION,
     DEFAULT_WHEEL_WAIT_TIMEOUT,
     as_smoke_test,
     find_test,
     parse_python_version,
     read_and_validate_release_test_collection,
 )
+from ray_release.test import DEFAULT_PYTHON_VERSION
 from ray_release.env import DEFAULT_ENVIRONMENT, load_environment, populate_os_env
 from ray_release.exception import ReleaseTestCLIError, ReleaseTestError
 from ray_release.glue import run_release_test

--- a/release/ray_release/template.py
+++ b/release/ray_release/template.py
@@ -10,9 +10,9 @@ import yaml
 from ray_release.bazel import bazel_runfile
 from ray_release.config import (
     parse_python_version,
-    DEFAULT_PYTHON_VERSION,
     get_test_cloud_id,
 )
+from ray_release.test import DEFAULT_PYTHON_VERSION
 from ray_release.exception import ReleaseTestConfigError
 from ray_release.util import python_version_str
 

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -13,7 +13,7 @@ class Test(dict):
         Returns the python version to use for this test. If not specified, use
         the default python version.
         """
-        return self.get("python", ".".join(DEFAULT_PYTHON_VERSION))
+        return self.get("python", ".".join(str(v) for v in DEFAULT_PYTHON_VERSION))
 
     def get_ray_image(self) -> str:
         """

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -21,7 +21,7 @@ class Test(dict):
         specified, use the nightly ray image.
         """
         ray_version = os.environ.get("BUILDKITE_COMMIT", "")[:6] or "nightly"
-        python_version = f"py-{self.get_python_version().replace('.',   '')}"
+        python_version = f"py{self.get_python_version().replace('.',   '')}"
         return f"rayproject/ray:{ray_version}-{python_version}"
 
     def get_anyscale_byod_image(self) -> str:

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -1,0 +1,31 @@
+import os
+
+DEFAULT_PYTHON_VERSION = tuple(
+    int(v) for v in os.environ.get("RELEASE_PY", "3.7").split(".")
+)
+
+
+class Test(dict):
+    """A class represents a test to run on buildkite"""
+
+    def get_python_version(self) -> str:
+        """
+        Returns the python version to use for this test. If not specified, use
+        the default python version.
+        """
+        return self.get("python", DEFAULT_PYTHON_VERSION)
+
+    def get_ray_image(self) -> str:
+        """
+        Returns the ray docker image to use for this test. If the commit hash is not
+        specified, use the nightly ray image.
+        """
+        ray_version = os.environ.get("BUILDKITE_COMMIT", "")[:6] or "nightly"
+        python_version = f"py-{self.get_python_version().replace('.',   '')}"
+        return f"rayproject/ray:{ray_version}-{python_version}"
+
+    def get_anyscale_byod_image(self) -> str:
+        """
+        Returns the anyscale byod image to use for this test.
+        """
+        return self.get_ray_image().replace("rayproject", "anyscale")

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -8,6 +8,15 @@ DEFAULT_PYTHON_VERSION = tuple(
 class Test(dict):
     """A class represents a test to run on buildkite"""
 
+    def is_byod_cluster(self) -> bool:
+        """
+        Returns whether this test is running on a BYOD cluster.
+        """
+        return self["cluster"].get("byod", False)
+
+    def get_name(self) -> str:
+        return self["name"]
+
     def get_python_version(self) -> str:
         """
         Returns the python version to use for this test. If not specified, use
@@ -20,7 +29,9 @@ class Test(dict):
         Returns the ray docker image to use for this test. If the commit hash is not
         specified, use the nightly ray image.
         """
-        ray_version = os.environ.get("BUILDKITE_COMMIT", "")[:6] or "nightly"
+        # TDOD(can): re-enable this test once we have a custom image
+        # ray_version = os.environ.get("BUILDKITE_COMMIT", "")[:6] or "nightly"
+        ray_version = "nightly"
         python_version = f"py{self.get_python_version().replace('.',   '')}"
         return f"rayproject/ray:{ray_version}-{python_version}"
 

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -13,7 +13,7 @@ class Test(dict):
         Returns the python version to use for this test. If not specified, use
         the default python version.
         """
-        return self.get("python", DEFAULT_PYTHON_VERSION)
+        return self.get("python", ".".join(DEFAULT_PYTHON_VERSION))
 
     def get_ray_image(self) -> str:
         """

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -29,3 +29,13 @@ class Test(dict):
         Returns the anyscale byod image to use for this test.
         """
         return self.get_ray_image().replace("rayproject", "anyscale")
+
+
+class TestDefinition(dict):
+    """
+    A class represents a definition of a test, such as test name, group, etc. Comparing
+    to the test class, there are additional field, for example variations, which can be
+    used to define several variations of a test.
+    """
+
+    pass

--- a/release/ray_release/tests/test_alerts.py
+++ b/release/ray_release/tests/test_alerts.py
@@ -9,7 +9,7 @@ from ray_release.alerts import (
     # tune_tests,
     # xgboost_tests,
 )
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.exception import ReleaseTestConfigError, ResultsAlert
 from ray_release.result import Result
 

--- a/release/ray_release/tests/test_bisect.py
+++ b/release/ray_release/tests/test_bisect.py
@@ -4,7 +4,7 @@ from unittest import mock
 from typing import List, Set, Dict
 
 from ray_release.scripts.ray_bisect import _bisect, _obtain_test_result, _sanity_check
-from ray_release.config import Test
+from ray_release.test import Test
 
 
 def test_sanity_check():

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -27,7 +27,7 @@ from ray_release.buildkite.step import (
     RELEASE_QUEUE_CLIENT,
     DOCKER_PLUGIN_KEY,
 )
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.exception import ReleaseTestConfigError
 from ray_release.wheels import (
     DEFAULT_BRANCH,

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -29,6 +29,7 @@ from ray_release.tests.utils import (
     MockSDK,
 )
 from ray_release.util import get_anyscale_sdk
+from ray_release.test import Test
 
 TEST_CLUSTER_ENV = {
     "base_image": "anyscale/ray:nightly-py37",
@@ -96,7 +97,12 @@ class MinimalSessionManagerTest(unittest.TestCase):
         self.cluster_manager = self.cls(
             project_id=UNIT_TEST_PROJECT_ID,
             sdk=self.sdk,
-            test_name=f"unit_test__{self.__class__.__name__}",
+            test=Test(
+                {
+                    "name": f"unit_test__{self.__class__.__name__}",
+                    "cluster": {},
+                }
+            ),
         )
         self.sdk.reset()
         self.sdk.returns["get_cloud"] = APIDict(result=APIDict(provider="AWS"))
@@ -106,11 +112,17 @@ class MinimalSessionManagerTest(unittest.TestCase):
         sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
         sdk.returns["get_cloud"] = APIDict(result=APIDict(provider="AWS"))
         cluster_manager = self.cls(
-            test_name="test", project_id=UNIT_TEST_PROJECT_ID, smoke_test=False, sdk=sdk
+            test=Test({"name": "test"}),
+            project_id=UNIT_TEST_PROJECT_ID,
+            smoke_test=False,
+            sdk=sdk,
         )
         self.assertRegex(cluster_manager.cluster_name, r"^test_\d+$")
         cluster_manager = self.cls(
-            test_name="test", project_id=UNIT_TEST_PROJECT_ID, smoke_test=True, sdk=sdk
+            test=Test({"name": "test"}),
+            project_id=UNIT_TEST_PROJECT_ID,
+            smoke_test=True,
+            sdk=sdk,
         )
         self.assertRegex(cluster_manager.cluster_name, r"^test-smoke-test_\d+$")
 
@@ -119,7 +131,10 @@ class MinimalSessionManagerTest(unittest.TestCase):
         sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
         sdk.returns["get_cloud"] = APIDict(result=APIDict(provider="AWS"))
         cluster_manager = self.cls(
-            test_name="test", project_id=UNIT_TEST_PROJECT_ID, smoke_test=False, sdk=sdk
+            test=Test({"name": "test"}),
+            project_id=UNIT_TEST_PROJECT_ID,
+            smoke_test=False,
+            sdk=sdk,
         )
         cluster_manager.set_cluster_env({})
         self.assertEqual(
@@ -127,7 +142,10 @@ class MinimalSessionManagerTest(unittest.TestCase):
             "test_name=test;smoke_test=False",
         )
         cluster_manager = self.cls(
-            test_name="Test", project_id=UNIT_TEST_PROJECT_ID, smoke_test=True, sdk=sdk
+            test=Test({"name": "Test"}),
+            project_id=UNIT_TEST_PROJECT_ID,
+            smoke_test=True,
+            sdk=sdk,
         )
         cluster_manager.set_cluster_env({})
         self.assertEqual(

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -3,9 +3,9 @@ import yaml
 import pytest
 
 from ray_release.bazel import bazel_runfile
+from ray_release.test import Test
 from ray_release.config import (
     read_and_validate_release_test_collection,
-    Test,
     validate_cluster_compute,
     load_schema_file,
     parse_test_definition,

--- a/release/ray_release/tests/test_glue.py
+++ b/release/ray_release/tests/test_glue.py
@@ -12,7 +12,7 @@ from ray_release.alerts.handle import result_to_handle_map
 from ray_release.cluster_manager.cluster_manager import ClusterManager
 from ray_release.cluster_manager.full import FullClusterManager
 from ray_release.command_runner.command_runner import CommandRunner
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.exception import (
     ReleaseTestConfigError,
     ClusterEnvBuildError,

--- a/release/ray_release/tests/test_template.py
+++ b/release/ray_release/tests/test_template.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
 
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.exception import ReleaseTestConfigError
 from ray_release.template import populate_cluster_env_variables, render_yaml_template
 

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -14,14 +14,16 @@ def test_get_ray_image():
     os.environ.pop("BUILDKITE_COMMIT", None)
     assert Test({"python": "3.8"}).get_ray_image() == "rayproject/ray:nightly-py38"
     os.environ["BUILDKITE_COMMIT"] = "1234567890"
-    assert Test().get_ray_image() == "rayproject/ray:123456-py37"
+    # TODO(can): re-enable this test once we have a custom image
+    # assert Test().get_ray_image() == "rayproject/ray:123456-py37"
 
 
 def test_get_anyscale_byod_image():
     os.environ.pop("BUILDKITE_COMMIT", None)
     assert Test().get_anyscale_byod_image() == "anyscale/ray:nightly-py37"
     os.environ["BUILDKITE_COMMIT"] = "1234567890"
-    assert Test().get_anyscale_byod_image() == "anyscale/ray:123456-py37"
+    # TODO(can): re-enable this test once we have a custom image
+    # assert Test().get_anyscale_byod_image() == "anyscale/ray:123456-py37"
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -1,0 +1,28 @@
+import sys
+import os
+import pytest
+
+from ray_release.test import Test
+
+
+def test_get_python_version():
+    assert Test().get_python_version() == "3.7"
+    assert Test({"python": "3.8"}).get_python_version() == "3.8"
+
+
+def test_get_ray_image():
+    os.environ.pop("BUILDKITE_COMMIT", None)
+    assert Test({"python": "3.8"}).get_ray_image() == "rayproject/ray:nightly-py38"
+    os.environ["BUILDKITE_COMMIT"] = "1234567890"
+    assert Test().get_ray_image() == "rayproject/ray:123456-py37"
+
+
+def test_get_anyscale_byod_image():
+    os.environ.pop("BUILDKITE_COMMIT", None)
+    assert Test().get_anyscale_byod_image() == "anyscale/ray:nightly-py37"
+    os.environ["BUILDKITE_COMMIT"] = "1234567890"
+    assert Test().get_anyscale_byod_image() == "anyscale/ray:123456-py37"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_wheels.py
+++ b/release/ray_release/tests/test_wheels.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from freezegun import freeze_time
 
 from ray_release.bazel import bazel_runfile
-from ray_release.config import Test
+from ray_release.test import Test
 from ray_release.template import load_test_cluster_env
 from ray_release.exception import RayWheelsNotFoundError, RayWheelsTimeoutError
 from ray_release.util import url_exists

--- a/release/ray_release/wheels.py
+++ b/release/ray_release/wheels.py
@@ -10,7 +10,8 @@ import time
 import urllib.request
 from typing import Optional, List, Tuple
 
-from ray_release.config import DEFAULT_PYTHON_VERSION, parse_python_version
+from ray_release.config import parse_python_version
+from ray_release.test import DEFAULT_PYTHON_VERSION
 from ray_release.template import set_test_env_var
 from ray_release.exception import (
     RayWheelsUnspecifiedError,

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4439,6 +4439,22 @@
         cluster_env: shuffle/shuffle_app_config.yaml
         cluster_compute: shuffle/shuffle_compute_autoscaling_gce.yaml
 
+- name: microbenchmark_byod
+  group: core-daily-test
+  team: core
+  frequency: manual
+  working_dir: microbenchmark
+
+  python: "3.7"
+
+  cluster:
+    byod: true
+    cluster_env: app_config.yaml
+    cluster_compute: tpl_64.yaml
+
+  run:
+    timeout: 1800
+    script: OMP_NUM_THREADS=64 RAY_ADDRESS=local python run_microbenchmark.py
 
 - name: microbenchmark
   group: core-daily-test


### PR DESCRIPTION
## Why are these changes needed?
**Context:** This is a series of PR that will allow OSS release tests to run on anyscale byod images. Currently, it runs against nightly anyscale which can be unreliable. Using byod image, we will be able to run them against staging or production anyscale. Proposal doc: https://docs.google.com/document/d/12WU4vpR0jHgOwceoSgPtE4B-B-6mBonnHHiCSMmMNoY/edit#

- Move Test to its own file and class
- Logic to get the correct ray and anyscale image for a test, based on its configuration (right now just python version, in the future, cpu vs. gpu, etc.)
- A holder for @aslonnie to implement logic to build anyscale custom images given a list of ray images

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests