### PR TITLE
[core][dashboard] Make actor tasks'name default to <actor_repr>.<task_name> 

### DIFF
--- a/python/ray/experimental/state/common.py
+++ b/python/ray/experimental/state/common.py
@@ -1373,7 +1373,7 @@ def protobuf_to_task_state_dict(message: TaskEvents) -> dict:
         (task_attempt, ["task_id", "attempt_number", "job_id"]),
         (
             state_updates,
-            ["node_id", "worker_id", "task_log_info"],
+            ["node_id", "worker_id", "task_log_info", "actor_repr_name"],
         ),
     ]
     for src, keys in mappings:
@@ -1422,6 +1422,19 @@ def protobuf_to_task_state_dict(message: TaskEvents) -> dict:
                 error_info.get("error_message", "")
             )
             task_state["error_type"] = error_info.get("error_type", "")
+
+    # Parse actor task name for actor with repr name.
+    if (
+        state_updates.get("actor_repr_name")
+        and task_state["type"] == "ACTOR_TASK"
+        and task_state["name"]
+        == task_state["func_or_class_name"]  # no name option provided.
+    ):
+        # If it's an actor task with no name override, and has repr name defined
+        # for the actor, we override the name.
+        method_name = task_state["name"].split(".")[-1]
+        actor_repr_task_name = f"{state_updates['actor_repr_name']}.{method_name}"
+        task_state["name"] = actor_repr_task_name
 
     return task_state
 

--- a/python/ray/tests/test_state_api_2.py
+++ b/python/ray/tests/test_state_api_2.py
@@ -252,6 +252,67 @@ def test_actor_repr_name(shutdown_only):
     wait_for_condition(_verify_repr_name, id=a._actor_id.hex(), name="inner")
 
 
+def test_actor_task_with_repr_name():
+    @ray.remote
+    class ReprActor:
+        def __init__(self, x) -> None:
+            self.x = x
+
+        def __repr__(self) -> str:
+            return self.x
+
+        def f(self):
+            pass
+
+    a = ReprActor.remote(x="repr-name-a")
+    ray.get(a.f.remote())
+
+    def verify():
+        tasks = list_tasks(detail=True, filters=[("type", "=", "ACTOR_TASK")])
+        assert len(tasks) == 1, tasks
+        assert tasks[0].name == "repr-name-a.f"
+        assert tasks[0].func_or_class_name == "ReprActor.f"
+        return True
+
+    wait_for_condition(verify)
+
+    b = ReprActor.remote(x="repr-name-b")
+    ray.get(b.f.options(name="custom-name").remote())
+
+    def verify():
+        tasks = list_tasks(
+            detail=True,
+            filters=[("actor_id", "=", b._actor_id.hex()), ("type", "=", "ACTOR_TASK")],
+        )
+        assert len(tasks) == 1, tasks
+        assert tasks[0].name == "custom-name"
+        assert tasks[0].func_or_class_name == "ReprActor.f"
+        return True
+
+    wait_for_condition(verify)
+
+    @ray.remote
+    class Actor:
+        def f(self):
+            pass
+
+    c = Actor.remote()
+    ray.get(c.f.remote())
+
+    def verify():
+        tasks = list_tasks(
+            detail=True,
+            filters=[("actor_id", "=", c._actor_id.hex()), ("type", "=", "ACTOR_TASK")],
+        )
+
+        assert len(tasks) == 1, tasks
+        assert tasks[0].name == "Actor.f"
+        assert tasks[0].func_or_class_name == "Actor.f"
+        return True
+
+    wait_for_condition(verify)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2562,11 +2562,25 @@ Status CoreWorker::ExecuteTask(
 
   // Modify the worker's per function counters.
   std::string func_name = task_spec.FunctionDescriptor()->CallString();
+  std::string actor_repr_name = "";
+  {
+    absl::MutexLock lock(&mutex_);
+    actor_repr_name = actor_repr_name_;
+  }
   if (!options_.is_local_mode) {
     task_counter_.MovePendingToRunning(func_name, task_spec.IsRetry());
 
-    task_manager_->RecordTaskStatusEvent(
-        task_spec.AttemptNumber(), task_spec, rpc::TaskStatus::RUNNING);
+    if (task_spec.IsActorTask() && !actor_repr_name.empty()) {
+      task_manager_->RecordTaskStatusEvent(
+          task_spec.AttemptNumber(),
+          task_spec,
+          rpc::TaskStatus::RUNNING,
+          /* include_task_info */ false,
+          worker::TaskStatusEvent::TaskStateUpdate(actor_repr_name));
+    } else {
+      task_manager_->RecordTaskStatusEvent(
+          task_spec.AttemptNumber(), task_spec, rpc::TaskStatus::RUNNING);
+    }
 
     worker_context_.SetCurrentTask(task_spec);
     SetCurrentTaskId(task_spec.TaskId(), task_spec.AttemptNumber(), task_spec.GetName());
@@ -3845,6 +3859,9 @@ void CoreWorker::SetActorTitle(const std::string &title) {
 void CoreWorker::SetActorReprName(const std::string &repr_name) {
   RAY_CHECK(direct_task_receiver_ != nullptr);
   direct_task_receiver_->SetActorReprName(repr_name);
+
+  absl::MutexLock lock(&mutex_);
+  actor_repr_name_ = repr_name;
 }
 
 rpc::JobConfig CoreWorker::GetJobConfig() const {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1562,6 +1562,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// Actor title that consists of class name, args, kwargs for actor construction.
   std::string actor_title_ GUARDED_BY(mutex_);
 
+  /// Actor repr name if overrides by the user, empty string if not.
+  std::string actor_repr_name_ GUARDED_BY(mutex_) = "";
+
   /// Number of tasks that have been pushed to the actor but not executed.
   std::atomic<int64_t> task_queue_length_;
 

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -95,6 +95,10 @@ bool TaskStatusEvent::ToRpcTaskEventsOrDrop(rpc::TaskEvents *rpc_task_events) {
         state_update_->task_log_info_.value());
   }
 
+  if (!state_update_->actor_repr_name_.empty()) {
+    dst_state_update->set_actor_repr_name(state_update_->actor_repr_name_);
+  }
+
   return false;
 }
 

--- a/src/ray/core_worker/task_event_buffer.h
+++ b/src/ray/core_worker/task_event_buffer.h
@@ -90,6 +90,9 @@ class TaskStatusEvent : public TaskEvent {
     TaskStateUpdate(const rpc::TaskLogInfo &task_log_info)
         : task_log_info_(task_log_info) {}
 
+    TaskStateUpdate(const std::string &actor_repr_name)
+        : actor_repr_name_(actor_repr_name) {}
+
    private:
     friend class TaskStatusEvent;
 
@@ -101,6 +104,8 @@ class TaskStatusEvent : public TaskEvent {
     const absl::optional<rpc::RayErrorInfo> error_info_ = absl::nullopt;
     /// Task log info.
     const absl::optional<rpc::TaskLogInfo> task_log_info_ = absl::nullopt;
+    /// Actor task repr name.
+    const std::string actor_repr_name_ = "";
   };
 
   explicit TaskStatusEvent(

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -240,6 +240,8 @@ message TaskStateUpdate {
   optional RayErrorInfo error_info = 9;
   // Task logs info.
   optional TaskLogInfo task_log_info = 10;
+  // Actor task repr name.
+  optional string actor_repr_name = 11;
 }
 
 // Represents events and state changes from a single task run.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
We updated the dashboard to show actor's name with actor repr, and we should do the same for actor tasks. 

Caveat: 
- `Actor.__init__` is currently not showing up as `repr_name.__init__` because during creation task initialization, we haven't initialized the actor states yet, so the `repr` func should not yet be called.  There's workaround (i.e we could modify the init task name later at rendering, but chose not implement in this PR), but would be rather hacky. The major issue is that `repr` info for an actor is only available on the executor, and on the submitter (or encoded in actor handle). Given the feature is only for dashboard, I feel this the intrusive change in this PR is better. 
- Eventually, with `group_name` options currently planned as an API to unify assigning names to anonymous actors/tasks, we should 
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/34012

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
