### PR TITLE
[tests] fix lint and dependency issues in tests

### DIFF
--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -392,6 +392,7 @@ install_pip_packages() {
   if [ "${INSTALL_TIMESERIES_LIBS-}" = 1 ]; then
     requirements_packages+=("statsforecast==1.5.0")
     requirements_packages+=("prophet==1.1.1")
+    requirements_packages+=("holidays==0.24") # holidays 0.25 causes `import prophet` to fail.
   fi
 
   # Data processing test dependencies.

--- a/release/nightly_tests/dataset/data_ingest_benchmark.py
+++ b/release/nightly_tests/dataset/data_ingest_benchmark.py
@@ -170,10 +170,7 @@ def run_ingest_bulk(dataset_size_gb, num_workers):
     ]
     ds = ds.map_batches(lambda df: df * 2, batch_format="pandas")
     splits = ds.split(num_workers, equal=True, locality_hints=consumers)
-    future = [
-        consumers[i].consume.remote(s)
-        for i, s in enumerate(splits)
-    ]
+    future = [consumers[i].consume.remote(s) for i, s in enumerate(splits)]
     ray.get(future)
 
     # Example ballpark number for transformation (5s):
@@ -203,10 +200,7 @@ def run_ingest_dataset_pipeline(dataset_size_gb, num_workers):
         .map_batches(lambda df: df * 2, batch_format="pandas")
     )
     splits = p.split(num_workers, equal=True, locality_hints=consumers)
-    future = [
-        consumers[i].consume.remote(s)
-        for i, s in enumerate(splits)
-    ]
+    future = [consumers[i].consume.remote(s) for i, s in enumerate(splits)]
     ray.get(future)
 
     # Example ballpark numbers:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes two issues

<img width="550" alt="image" src="https://github.com/ray-project/ray/assets/3967392/ceb3bd62-3e7f-4a19-a2c6-277039a9192a">


### `lint`

Re-ran `./scripts/format.sh` to fix the minor lint issue introduced in https://github.com/ray-project/ray/pull/34986.


### `batch_forecasting`

This test started failing with the following error:

```
Traceback (most recent call last):
--
  | File "/tmp/tmpuibbf2l5", line 93, in <module>
  | import prophet
  | File "/opt/miniconda/lib/python3.7/site-packages/prophet/__init__.py", line 7, in <module>
  | from prophet.forecaster import Prophet
  | File "/opt/miniconda/lib/python3.7/site-packages/prophet/forecaster.py", line 18, in <module>
  | from prophet.make_holidays import get_holiday_names, make_holidays_df
  | File "/opt/miniconda/lib/python3.7/site-packages/prophet/make_holidays.py", line 14, in <module>
  | import prophet.hdays as hdays_part2
  | File "/opt/miniconda/lib/python3.7/site-packages/prophet/hdays.py", line 683, in <module>
  | class TU(Turkey):
  | File "/opt/miniconda/lib/python3.7/site-packages/holidays/registry.py", line 178, in __init__
  | super().__init__(*args, **kwargs)
  | TypeError: object.__init__() takes exactly one argument (the instance to initialize)
```

This seems to be related to today's release of [`holidays==0.25`](https://pypi.org/project/holidays/0.25/). As this code is directly part of `prophet`, fixing this by pinning `holidays`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
