### PR TITLE
[ci] External code tracker: Ignore if file is not found

### DIFF
--- a/.github/workflows/external-code-affected.yml
+++ b/.github/workflows/external-code-affected.yml
@@ -63,9 +63,17 @@ jobs:
             comment.user.login === 'github-actions[bot]' && comment.body.startsWith(commentHeader)
           );
           
+          let externCodeFileContent;
+          let trackedFilesToURIs;
+          
           // Read and parse external_code.txt file
-          let externCodeFileContent = fs.readFileSync(externalCodeFile, "utf8");
-          let trackedFilesToURIs = parseTrackedFilesToURIs(externCodeFileContent);
+          try {
+            externCodeFileContent = fs.readFileSync(externalCodeFile, "utf8");
+            trackedFilesToURIs = parseTrackedFilesToURIs(externCodeFileContent);
+          } catch (error) {
+            console.error("An error occurred reading the external code file:", error);
+            trackedFilesToURIs = {};
+          }
           
           console.log("trackedFileToURIs");
           console.log(trackedFilesToURIs);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When master is not merged, a file not found error can come up. This update to the script will prevent that from happening by catching errors and setting default values for the variables.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
