### PR TITLE
[air/output] Add parameter columns to status table

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -727,12 +727,12 @@ class RunConfig:
             intermediate experiment progress. Defaults to CLIReporter if
             running in command-line, or JupyterNotebookReporter if running in
             a Jupyter notebook.
-        verbose: 0, 1, or 2. Verbosity mode.
-            0 = silent, 1 = default, 2 = verbose. Defaults to 1.
-            If the ``RAY_AIR_NEW_OUTPUT=0`` environment variable is set,
-            uses the old verbosity settings:
+        verbose: 0, 1, 2, or 3. Verbosity mode.
             0 = silent, 1 = only status updates, 2 = status and brief
-            results, 3 = status and detailed results.
+            results, 3 = status and detailed results. Defaults to 3.
+            If the ``RAY_AIR_NEW_OUTPUT=1`` environment variable is set,
+            uses the new context-aware verbosity settings:
+            0 = silent, 1 = default, 2 = verbose.
         log_to_file: Log stdout and stderr to files in
             trial directories. If this is `False` (default), no files
             are written. If `true`, outputs are written to `trialdir/stdout`

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -399,7 +399,7 @@ def _get_trial_table_data(
         for metric, formatted in zip(metric_keys, formatted_metric_columns)
     ]
 
-    param_header = [formatted for formatted in formatted_param_columns]
+    param_header = formatted_param_columns
 
     # Map to the abbreviated version if necessary.
     header = ["Trial name", "status"] + param_header + metric_header

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -25,6 +25,7 @@ import pandas as pd
 import textwrap
 import time
 
+from ray.tune.search.sample import Domain
 from ray.tune.utils.log import Verbosity
 
 try:
@@ -117,6 +118,20 @@ def get_air_verbosity(
     verbose_int = min(2, verbose_int)
 
     return AirVerbosity(verbose_int)
+
+
+def _infer_params(config: Dict[str, Any]) -> List[str]:
+    params = []
+    flat_config = flatten_dict(config)
+    for key, val in flat_config.items():
+        if isinstance(val, Domain):
+            params.append(key)
+        # Grid search is a special named field. Because we flattened
+        # the whole config, we look it up per string
+        if key.endswith("/grid_search"):
+            # Truncate `/grid_search`
+            params.append(key[:-12])
+    return params
 
 
 def _get_time_str(start_time: float, current_time: float) -> Tuple[str, str]:
@@ -263,17 +278,31 @@ def _max_len(value: Any, max_len: int = 20, wrap: bool = False) -> Any:
     return result
 
 
-def _get_trial_info(trial: Trial, metric_keys: List[str]) -> List[str]:
+def _get_trial_info(
+    trial: Trial, param_keys: List[str], metric_keys: List[str]
+) -> List[str]:
     """Returns the following information about a trial:
 
     name | status | metrics...
 
     Args:
         trial: Trial to get information for.
+        param_keys: Names of parameters to include.
         metric_keys: Names of metrics to include.
     """
     result = trial.last_result
     trial_info = [str(trial), trial.status]
+
+    # params
+    trial_info.extend(
+        [
+            _max_len(
+                unflattened_lookup(param, trial.config, default=None),
+            )
+            for param in param_keys
+        ]
+    )
+    # metrics
     trial_info.extend(
         [
             _max_len(
@@ -288,6 +317,7 @@ def _get_trial_info(trial: Trial, metric_keys: List[str]) -> List[str]:
 def _get_trial_table_data_per_status(
     status: str,
     trials: List[Trial],
+    param_keys: List[str],
     metric_keys: List[str],
     force_max_rows: bool = False,
 ) -> Optional[_PerStatusTrialTableData]:
@@ -296,6 +326,7 @@ def _get_trial_table_data_per_status(
     Args:
         status: The trial status of interest.
         trials: all the trials of that status.
+        param_keys: *Ordered* list of parameters to be displayed in the table.
         metric_keys: *Ordered* list of metrics to be displayed in the table.
             Including both default and user defined.
         force_max_rows: Whether or not to enforce a max row number for this status.
@@ -316,12 +347,13 @@ def _get_trial_table_data_per_status(
             remaining = len(trials) - max_row
             more_info = f"{remaining} more {status}"
             break
-        trial_infos.append(_get_trial_info(t, metric_keys))
+        trial_infos.append(_get_trial_info(t, param_keys, metric_keys))
     return _PerStatusTrialTableData(trial_infos, more_info)
 
 
 def _get_trial_table_data(
     trials: List[Trial],
+    param_keys: List[str],
     metric_keys: List[str],
     all_rows: bool = False,
 ) -> _TrialTableData:
@@ -329,6 +361,7 @@ def _get_trial_table_data(
 
     Args:
         trials: List of trials for which progress is to be shown.
+        param_keys: Ordered list of parameters to be displayed in the table.
         metric_keys: Ordered list of metrics to be displayed in the table.
             Including both default and user defined.
             Will only be shown if at least one trial is having the key.
@@ -356,18 +389,28 @@ def _get_trial_table_data(
     formatted_metric_columns = [
         _max_len(k, max_len=max_column_length, wrap=True) for k in metric_keys
     ]
-    # Map to the abbreviated version if necessary.
-    header = ["Trial name", "status"] + [
-        DEFAULT_COLUMNS[key] if key in DEFAULT_COLUMNS else key
-        for key in formatted_metric_columns
+
+    formatted_param_columns = [
+        _max_len(k, max_len=max_column_length, wrap=True) for k in param_keys
     ]
+
+    metric_header = [
+        DEFAULT_COLUMNS[metric] if metric in DEFAULT_COLUMNS else formatted
+        for metric, formatted in zip(metric_keys, formatted_metric_columns)
+    ]
+
+    param_header = [formatted for formatted in formatted_param_columns]
+
+    # Map to the abbreviated version if necessary.
+    header = ["Trial name", "status"] + param_header + metric_header
 
     trial_data = list()
     for t_status in ORDER:
         trial_data_per_status = _get_trial_table_data_per_status(
             t_status,
             trials_by_state[t_status],
-            metric_keys=formatted_metric_columns,
+            param_keys=param_keys,
+            metric_keys=metric_keys,
             force_max_rows=not all_rows and len(trials) > max_trial_num_to_show,
         )
         if trial_data_per_status:
@@ -541,6 +584,7 @@ def _detect_reporter(
     num_samples: int,
     metric: Optional[str] = None,
     mode: Optional[str] = None,
+    config: Optional[Dict] = None,
 ):
     # TODO: Add JupyterNotebook and Ray Client case later.
     rich_enabled = bool(int(os.environ.get("RAY_AIR_RICH_LAYOUT", "0")))
@@ -548,9 +592,21 @@ def _detect_reporter(
         if rich_enabled:
             if not rich:
                 raise ImportError("Please run `pip install rich`. ")
-            reporter = TuneRichReporter(verbosity, num_samples, metric, mode)
+            reporter = TuneRichReporter(
+                verbosity,
+                num_samples=num_samples,
+                metric=metric,
+                mode=mode,
+                config=config,
+            )
         else:
-            reporter = TuneTerminalReporter(verbosity, num_samples, metric, mode)
+            reporter = TuneTerminalReporter(
+                verbosity,
+                num_samples=num_samples,
+                metric=metric,
+                mode=mode,
+                config=config,
+            )
     else:
         if rich_enabled:
             logger.warning("`RAY_AIR_RICH_LAYOUT` is only effective with Tune usecase.")
@@ -567,12 +623,14 @@ class TuneReporterBase(ProgressReporter):
         num_samples: int,
         metric: Optional[str] = None,
         mode: Optional[str] = None,
+        config: Optional[Dict] = None,
     ):
         self._num_samples = num_samples
         self._metric = metric
         self._mode = mode
         # will be populated when first result comes in.
         self._inferred_metric = None
+        self._inferred_params = _infer_params(config)
         super(TuneReporterBase, self).__init__(verbosity=verbosity)
 
     def _get_overall_trial_progress_str(self, trials):
@@ -609,7 +667,10 @@ class TuneReporterBase(ProgressReporter):
         all_metrics = list(DEFAULT_COLUMNS.keys()) + self._inferred_metric
 
         trial_table_data = _get_trial_table_data(
-            trials, all_metrics, all_rows=force_full_output
+            trials,
+            param_keys=self._inferred_params,
+            metric_keys=all_metrics,
+            all_rows=force_full_output,
         )
         return result, trial_table_data
 

--- a/python/ray/tune/tests/output/test_output.py
+++ b/python/ray/tune/tests/output/test_output.py
@@ -3,6 +3,7 @@ import sys
 
 from freezegun import freeze_time
 
+from ray import tune
 from ray.tune.experimental.output import (
     _get_time_str,
     _get_trials_by_state,
@@ -13,6 +14,7 @@ from ray.tune.experimental.output import (
     _best_trial_str,
     _get_trial_table_data,
     _get_dict_as_table_data,
+    _infer_params,
 )
 from ray.tune.experiment.trial import Trial
 
@@ -153,10 +155,11 @@ def test_get_trial_table_data_less_than_20():
         t.trial_id = str(i)
         t.set_status(Trial.RUNNING)
         t.last_result = {"episode_reward_mean": 100 + i}
+        t.config = {"param": i}
         trials.append(t)
-    table_data = _get_trial_table_data(trials, [], ["episode_reward_mean"])
+    table_data = _get_trial_table_data(trials, ["param"], ["episode_reward_mean"])
     header = table_data.header
-    assert header == ["Trial name", "status", "reward"]
+    assert header == ["Trial name", "status", "param", "reward"]
     table_data = table_data.data
     assert len(table_data) == 1  # only the running category
     assert len(table_data[0].trial_infos) == 20
@@ -172,10 +175,11 @@ def test_get_trial_table_data_more_than_20():
             t.trial_id = str(i)
             t.set_status(status)
             t.last_result = {"episode_reward_mean": 100 + i}
+            t.config = {"param": i}
             trials.append(t)
-    table_data = _get_trial_table_data(trials, [], ["episode_reward_mean"])
+    table_data = _get_trial_table_data(trials, ["param"], ["episode_reward_mean"])
     header = table_data.header
-    assert header == ["Trial name", "status", "reward"]
+    assert header == ["Trial name", "status", "param", "reward"]
     table_data = table_data.data
     assert len(table_data) == 3  # only the running category
     for i in range(3):
@@ -183,6 +187,24 @@ def test_get_trial_table_data_more_than_20():
     assert table_data[0].more_info == "5 more RUNNING"
     assert table_data[1].more_info == "5 more TERMINATED"
     assert table_data[2].more_info == "5 more PENDING"
+
+
+def test_infer_params():
+    assert _infer_params({}) == []
+    assert _infer_params({"some": "val"}) == []
+    assert _infer_params({"some": "val", "param": tune.uniform(0, 1)}) == ["param"]
+    assert _infer_params({"some": "val", "param": tune.grid_search([0, 1])}) == [
+        "param"
+    ]
+    assert sorted(
+        _infer_params(
+            {
+                "some": "val",
+                "param": tune.grid_search([0, 1]),
+                "other": tune.choice([0, 1]),
+            }
+        )
+    ) == ["other", "param"]
 
 
 def test_result_table_no_divison():

--- a/python/ray/tune/tests/output/test_output.py
+++ b/python/ray/tune/tests/output/test_output.py
@@ -135,7 +135,8 @@ def test_get_trial_info():
     t.last_result = LAST_RESULT
     assert _get_trial_info(
         t,
-        [
+        param_keys=[],
+        metric_keys=[
             "episode_reward_mean",
             "episode_reward_max",
             "episode_reward_min",

--- a/python/ray/tune/tests/output/test_output.py
+++ b/python/ray/tune/tests/output/test_output.py
@@ -154,7 +154,7 @@ def test_get_trial_table_data_less_than_20():
         t.set_status(Trial.RUNNING)
         t.last_result = {"episode_reward_mean": 100 + i}
         trials.append(t)
-    table_data = _get_trial_table_data(trials, ["episode_reward_mean"])
+    table_data = _get_trial_table_data(trials, [], ["episode_reward_mean"])
     header = table_data.header
     assert header == ["Trial name", "status", "reward"]
     table_data = table_data.data
@@ -173,7 +173,7 @@ def test_get_trial_table_data_more_than_20():
             t.set_status(status)
             t.last_result = {"episode_reward_mean": 100 + i}
             trials.append(t)
-    table_data = _get_trial_table_data(trials, ["episode_reward_mean"])
+    table_data = _get_trial_table_data(trials, [], ["episode_reward_mean"])
     header = table_data.header
     assert header == ["Trial name", "status", "reward"]
     table_data = table_data.data

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -993,7 +993,11 @@ def run(
         )
     else:
         air_progress_reporter = _detect_air_reporter(
-            air_verbosity, search_alg.total_samples, metric=metric, mode=mode
+            air_verbosity,
+            search_alg.total_samples,
+            metric=metric,
+            mode=mode,
+            config=config,
         )
 
     # rich live context manager has to be called encapsulating

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -395,11 +395,12 @@ def run(
             training workers.
         checkpoint_upload_from_workers: Whether to upload checkpoint files
             directly from distributed training workers.
-        verbose: 0, 1, or 2. Verbosity mode.
-            0 = silent, 1 = default, 2 = verbose. Defaults to 1.
-            If ``RAY_AIR_NEW_OUTPUT=0``, uses the old verbosity settings:
+        verbose: 0, 1, 2, or 3. Verbosity mode.
             0 = silent, 1 = only status updates, 2 = status and brief
-            results, 3 = status and detailed results.
+            results, 3 = status and detailed results. Defaults to 3.
+            If the ``RAY_AIR_NEW_OUTPUT=1`` environment variable is set,
+            uses the new context-aware verbosity settings:
+            0 = silent, 1 = default, 2 = verbose.
         progress_reporter: Progress reporter for reporting
             intermediate experiment progress. Defaults to CLIReporter if
             running in command-line, or JupyterNotebookReporter if running in


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, parameter columns are not printed in Ray Tune status tables. This PR re-adds this functionality for the new output engine. Parameter columns are inferred from the Ray Tune search space. They are then added to the status table data and rendered in the output.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
