### PR TITLE
[serve] Shutdown http proxy state

### DIFF
--- a/python/ray/serve/_private/http_state.py
+++ b/python/ray/serve/_private/http_state.py
@@ -39,7 +39,7 @@ class HTTPProxyState:
         self._status = HTTPProxyStatus.STARTING
         self._health_check_obj_ref = None
         self._last_health_check_time: float = 0
-        self._deleting = False
+        self._shutting_down = False
 
         self._actor_details = HTTPProxyDetails(
             node_id=node_id,
@@ -77,7 +77,7 @@ class HTTPProxyState:
         self._actor_details = HTTPProxyDetails(**details_kwargs)
 
     def update(self):
-        if self._deleting:
+        if self._shutting_down:
             return
 
         if self._status == HTTPProxyStatus.STARTING:
@@ -127,7 +127,7 @@ class HTTPProxyState:
             self._last_health_check_time = time.time()
 
     def shutdown(self):
-        self._deleting = True
+        self._shutting_down = True
         ray.kill(self.actor_handle, no_restart=True)
 
 

--- a/python/ray/serve/_private/http_state.py
+++ b/python/ray/serve/_private/http_state.py
@@ -101,6 +101,7 @@ class HTTPProxyState:
             if finished:
                 try:
                     ray.get(finished[0])
+                    print("got object ref!")
                     self.set_status(HTTPProxyStatus.HEALTHY)
                 except Exception as e:
                     logger.warning(

--- a/python/ray/serve/_private/http_state.py
+++ b/python/ray/serve/_private/http_state.py
@@ -39,6 +39,7 @@ class HTTPProxyState:
         self._status = HTTPProxyStatus.STARTING
         self._health_check_obj_ref = None
         self._last_health_check_time: float = 0
+        self._deleting = False
 
         self._actor_details = HTTPProxyDetails(
             node_id=node_id,
@@ -76,6 +77,9 @@ class HTTPProxyState:
         self._actor_details = HTTPProxyDetails(**details_kwargs)
 
     def update(self):
+        if self._deleting:
+            return
+
         if self._status == HTTPProxyStatus.STARTING:
             try:
                 finished, _ = ray.wait([self._ready_obj_ref], timeout=0)
@@ -121,6 +125,10 @@ class HTTPProxyState:
             self._health_check_obj_ref = self._actor_handle.check_health.remote()
             self._last_health_check_time = time.time()
 
+    def shutdown(self):
+        self._deleting = True
+        ray.kill(self.actor_handle, no_restart=True)
+
 
 class HTTPState:
     """Manages all state for HTTP proxies in the system.
@@ -157,8 +165,8 @@ class HTTPState:
             self._start_proxies_if_needed()
 
     def shutdown(self) -> None:
-        for proxy in self.get_http_proxy_handles().values():
-            ray.kill(proxy, no_restart=True)
+        for proxy_state in self._proxy_states.values():
+            proxy_state.shutdown()
 
     def get_config(self):
         return self._config

--- a/python/ray/serve/tests/test_http_state.py
+++ b/python/ray/serve/tests/test_http_state.py
@@ -1,5 +1,6 @@
 import json
 from unittest.mock import patch
+import asyncio
 
 import pytest
 
@@ -129,6 +130,44 @@ def test_http_proxy_unhealthy():
         signal.send.remote()
         wait_for_condition(check_proxy, status=HTTPProxyStatus.HEALTHY, timeout=2)
 
+    ray.shutdown()
+
+
+def test_http_proxy_shutdown():
+    from ray.experimental.state.api import list_actors
+    ray.init()
+
+    @ray.remote(num_cpus=0)
+    class MockHTTPProxyActor:
+        async def ready(self):
+            return json.dumps(["mock_worker_id", "mock_log_file_path"])
+
+        async def check_health(self):
+            await asyncio.sleep(100)
+
+    proxy = MockHTTPProxyActor.options(lifetime="detached").remote()
+    state = HTTPProxyState(proxy, "alice", "mock_node_id", "mock_node_ip")
+    assert state.status == HTTPProxyStatus.STARTING
+
+    def check_proxy(status):
+        state.update()
+        return state.status == status
+
+    # Proxy actor is ready, so status should transition STARTING -> HEALTHY
+    wait_for_condition(check_proxy, status=HTTPProxyStatus.HEALTHY, timeout=2)
+
+    # Confirm that a new health check has been started
+    state.update()
+    assert state._health_check_obj_ref
+
+    # Shutdown the http proxy state. Wait for the http proxy actor to be killed
+    state.shutdown()
+    wait_for_condition(lambda: len(list_actors(filters=[("state", "=", "ALIVE")])) == 0)
+    
+    # Make sure that the state doesn't try to check on the status of the dead actor
+    state.update()
+    assert state.status == HTTPProxyStatus.HEALTHY
+    
     ray.shutdown()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Shutdown http proxy state so that it won't run anything in its update loop once a shutdown signal is received.

## Related issue number

Closes https://github.com/ray-project/ray/issues/35391

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
