### PR TITLE
[core] Change log error to log info when node disconnect and got detected by ray syncer.

### DIFF
--- a/src/ray/common/ray_syncer/ray_syncer-inl.h
+++ b/src/ray/common/ray_syncer/ray_syncer-inl.h
@@ -289,8 +289,8 @@ class RaySyncerBidiReactorBase : public RaySyncerBidiReactor, public T {
           if (ok) {
             SendNext();
           } else {
-            RAY_LOG_EVERY_MS(ERROR, 1000) << "Failed to send the message to: "
-                                          << NodeID::FromBinary(GetRemoteNodeID());
+            RAY_LOG_EVERY_MS(INFO, 1000) << "Failed to send the message to: "
+                                         << NodeID::FromBinary(GetRemoteNodeID());
             Disconnect();
           }
         },
@@ -305,8 +305,8 @@ class RaySyncerBidiReactorBase : public RaySyncerBidiReactor, public T {
             ReceiveUpdate(std::move(msg));
             StartPull();
           } else {
-            RAY_LOG_EVERY_MS(ERROR, 1000) << "Failed to read the message from: "
-                                          << NodeID::FromBinary(GetRemoteNodeID());
+            RAY_LOG_EVERY_MS(INFO, 1000) << "Failed to read the message from: "
+                                         << NodeID::FromBinary(GetRemoteNodeID());
             Disconnect();
           }
         },


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Logging an error will be pushed to the driver and it's annoying since it's actually not an error and will be handled by ray internally.
This PR changes it to log info for usability.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
