### PR TITLE
[Core][Node Labels 1/n] Add --labels param in ray start command to setting node labels

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1048,6 +1048,7 @@ class Node:
             env_updates=self._ray_params.env_vars,
             node_name=self._ray_params.node_name,
             webui=self._webui_url,
+            labels=self._ray_params.labels,
         )
         assert ray_constants.PROCESS_TYPE_RAYLET not in self.all_processes
         self.all_processes[ray_constants.PROCESS_TYPE_RAYLET] = [process_info]

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -121,6 +121,7 @@ class RayParams:
         env_vars: Override environment variables for the raylet.
         session_name: The name of the session of the ray cluster.
         webui: The url of the UI.
+        labels: The key-value labels of the node.
     """
 
     def __init__(
@@ -180,6 +181,7 @@ class RayParams:
         env_vars: Optional[Dict[str, str]] = None,
         session_name: Optional[str] = None,
         webui: Optional[str] = None,
+        labels: Optional[Dict[str, str]] = None,
     ):
         self.redis_address = redis_address
         self.gcs_address = gcs_address
@@ -238,6 +240,7 @@ class RayParams:
         self.webui = webui
         self._system_config = _system_config or {}
         self._enable_object_reconstruction = enable_object_reconstruction
+        self.labels = labels
         self._check_usage()
 
         # Set the internal config options for object reconstruction.

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1391,6 +1391,7 @@ def start_raylet(
     env_updates: Optional[dict] = None,
     node_name: Optional[str] = None,
     webui: Optional[str] = None,
+    labels: Optional[dict] = None,
 ):
     """Start a raylet, which is a combined local scheduler and object manager.
 
@@ -1443,7 +1444,7 @@ def start_raylet(
         ray_debugger_external: True if the Ray debugger should be made
             available externally to this node.
         env_updates: Environment variable overrides.
-
+        labels: The key-value labels of the node.
     Returns:
         ProcessInfo for the process that was started.
     """
@@ -1554,6 +1555,10 @@ def start_raylet(
     if max_worker_port is None:
         max_worker_port = 0
 
+    labels_json_str = ""
+    if labels:
+        labels_json_str = json.dumps(labels)
+
     agent_command = [
         *_build_python_executable_command_memory_profileable(
             ray_constants.PROCESS_TYPE_DASHBOARD_AGENT, session_dir
@@ -1617,6 +1622,7 @@ def start_raylet(
         f"--ray-debugger-external={1 if ray_debugger_external else 0}",
         f"--gcs-address={gcs_address}",
         f"--session-name={session_name}",
+        f"--labels={labels_json_str}",
     ]
 
     if is_head_node:

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1896,3 +1896,30 @@ def update_envs(env_vars: Dict[str, str]):
             os.environ[key] = value.replace("${" + key + "}", os.environ.get(key, ""))
         else:
             os.environ[key] = value
+
+
+def parse_node_labels_json(
+    labels_json: str, cli_logger, cf, command_arg="--labels"
+) -> Dict[str, str]:
+    try:
+        labels = json.loads(labels_json)
+        if not isinstance(labels, dict):
+            raise ValueError(
+                "The format after deserialization is not a key-value pair map"
+            )
+        for key, value in labels.items():
+            if not isinstance(key, str):
+                raise ValueError("The key is not string type.")
+            if not isinstance(value, str):
+                raise ValueError(f'The value of the "{key}" is not string type')
+    except Exception as e:
+        cli_logger.error(
+            "`{}` is not a valid JSON string, detail error:{}",
+            cf.bold(command_arg),
+            str(e),
+        )
+        cli_logger.abort(
+            "Valid values look like this: `{}`",
+            cf.bold(f'{command_arg}=\'{{"gpu_type": "A100", ' '"region": "us"}}\''),
+        )
+    return labels

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -400,6 +400,10 @@ cdef extern from "ray/gcs/pubsub/gcs_pub_sub.h" nogil:
 cdef extern from "ray/gcs/pubsub/gcs_pub_sub.h" namespace "ray::gcs" nogil:
     c_vector[c_string] PythonGetLogBatchLines(const CLogBatch& log_batch)
 
+cdef extern from "ray/gcs/gcs_client/gcs_client.h" namespace "ray::gcs" nogil:
+    unordered_map[c_string, c_string] PythonGetNodeLabels(
+        const CGcsNodeInfo& node_info)
+
 cdef extern from "src/ray/protobuf/gcs.pb.h" nogil:
     cdef enum CChannelType "ray::rpc::ChannelType":
         RAY_ERROR_INFO_CHANNEL "ray::rpc::ChannelType::RAY_ERROR_INFO_CHANNEL",

--- a/python/ray/includes/global_state_accessor.pxi
+++ b/python/ray/includes/global_state_accessor.pxi
@@ -1,7 +1,8 @@
 from ray.includes.common cimport (
     CGcsClientOptions,
     CGcsNodeState,
-    PythonGetResourcesTotal
+    PythonGetResourcesTotal,
+    PythonGetNodeLabels
 )
 
 from ray.includes.unique_ids cimport (
@@ -83,6 +84,9 @@ cdef class GlobalStateAccessor:
                 if node_info["Alive"]
                 else {}
             )
+            c_labels = PythonGetNodeLabels(c_node_info)
+            node_info["Labels"] = \
+                {key.decode(): value.decode() for key, value in c_labels}
             results.append(node_info)
         return results
 

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -205,6 +205,7 @@ py_test_module_list(
     "test_unhandled_error.py",
     "test_utils.py",
     "test_widgets.py",
+    "test_node_labels.py",
   ],
   size = "small",
   tags = ["exclusive", "small_size_python_tests", "team:core"],

--- a/python/ray/tests/test_node_labels.py
+++ b/python/ray/tests/test_node_labels.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import pytest
+
+import ray
+
+
+@pytest.mark.parametrize(
+    "call_ray_start",
+    ['ray start --head --labels={"gpu_type":"A100","region":"us"}'],
+    indirect=True,
+)
+def test_ray_start_set_node_labels(call_ray_start):
+    ray.init(address=call_ray_start)
+    assert ray.nodes()[0]["Labels"] == {"gpu_type": "A100", "region": "us"}
+
+
+@pytest.mark.parametrize(
+    "call_ray_start",
+    [
+        "ray start --head --labels={}",
+    ],
+    indirect=True,
+)
+def test_ray_start_set_empty_node_labels(call_ray_start):
+    ray.init(address=call_ray_start)
+    assert ray.nodes()[0]["Labels"] == {}
+
+
+if __name__ == "__main__":
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -402,5 +402,11 @@ std::unordered_map<std::string, double> PythonGetResourcesTotal(
                                                  node_info.resources_total().end());
 }
 
+std::unordered_map<std::string, std::string> PythonGetNodeLabels(
+    const rpc::GcsNodeInfo &node_info) {
+  return std::unordered_map<std::string, std::string>(node_info.labels().begin(),
+                                                      node_info.labels().end());
+}
+
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -234,6 +234,9 @@ class RAY_EXPORT PythonGcsClient {
 std::unordered_map<std::string, double> PythonGetResourcesTotal(
     const rpc::GcsNodeInfo &node_info);
 
+std::unordered_map<std::string, std::string> PythonGetNodeLabels(
+    const rpc::GcsNodeInfo &node_info);
+
 }  // namespace gcs
 
 }  // namespace ray

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -331,6 +331,8 @@ message GcsNodeInfo {
   uint64 end_time_ms = 24;
   // If this is a head node.
   bool is_head_node = 25;
+  // The key-value labels of this node.
+  map<string, string> labels = 26;
 }
 
 // Please keep this in sync with the definition of JobInfo in

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -110,6 +110,8 @@ struct NodeManagerConfig {
   int max_io_workers;
   // The minimum object size that can be spilled by each spill operation.
   int64_t min_spilling_size;
+  // The key-value labels of this node.
+  absl::flat_hash_map<std::string, std::string> labels;
 };
 
 class NodeManager : public rpc::NodeManagerServiceHandler,

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -97,6 +97,8 @@ Raylet::Raylet(instrumented_io_context &main_service,
   // Read from env
   auto instance_id = std::getenv(kNodeCloudInstanceIdEnv);
   self_node_info_.set_instance_id(instance_id ? instance_id : "");
+  self_node_info_.mutable_labels()->insert(node_manager_config.labels.begin(),
+                                           node_manager_config.labels.end());
 }
 
 Raylet::~Raylet() {}


### PR DESCRIPTION
## Why are these changes needed?
1. Add --labels param in ray start command-line to setting node labels
```
ray start --head --labels='{"gpu_type": "A100", "region": "us"}'
```

2. Add a new field "Labels" to the ray.nodes() API to getting the labels of each node.
```
ray.nodes()[0]["Labels"] == {"gpu_type": "A100", "region": "us"}
```

3. Add a basic test case  
python/ray/tests/test_node_labels.py  
Other exceptional scenarios and boundary scenarios testing will be added later by new PR.

## Related issue number
Enhancing node affinity scheduling feature through node labels #34894
> (P1)Finalize the command-line API(ray start) for setting node labels.  

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
