### PR TITLE
[install] fix installation instructions for ray[default]

### DIFF
--- a/dashboard/modules/serve/sdk.py
+++ b/dashboard/modules/serve/sdk.py
@@ -33,7 +33,7 @@ class ServeSubmissionClient(SubmissionClient):
         if requests is None:
             raise RuntimeError(
                 "The Serve CLI requires the ray[default] "
-                "installation: `pip install 'ray[default']``"
+                'installation: `pip install "ray[default]"`'
             )
 
         invalid_address_message = (


### PR DESCRIPTION
The current exception message for a missing dependency is
```
RuntimeError: The Serve CLI requires the ray[default] installation: `pip install 'ray[default']``
```

The quotes and backticks are incorrect

Fix the instructions
