### PR TITLE
[Doc] Fix error in "Writing code snippets"

### DIFF
--- a/doc/source/ray-contribute/writing-code-snippets.rst
+++ b/doc/source/ray-contribute/writing-code-snippets.rst
@@ -280,7 +280,7 @@ If your output is nondeterministic and you want to display a sample output, add
         0.969461416250246
 
 If your output is hard to test and you don't want to display a sample output, add
-`:options: +SKIP` and `:hide:`. ::
+`:options: +ELLIPSIS` and `:hide:`. ::
 
     .. testcode::
 
@@ -288,9 +288,9 @@ If your output is hard to test and you don't want to display a sample output, ad
 
     .. testoutput::
         :hide:
-        :options: +SKIP
+        :options: +ELLIPSIS
 
-        ...  # Add ellipsis. Otherwise, Sphinx can't parse the block.
+        ...
 
 --------------------
 How to test examples


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The "Writing code snippet" guide contains an error. To ignore outputs from a code snippet, the guide suggests using `+SKIP`. However, this causes CI to not test the code. This PR revises the guide to suggest `+ELLIPSIS` instead.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
