### PR TITLE
Make test_torch_predictor a medium test.

### DIFF
--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -490,7 +490,7 @@ py_test(
 
 py_test(
     name = "test_torch_predictor",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_torch_predictor.py"],
     tags = ["team:ml", "exclusive", "ray_air", "gpu"],
     deps = [":train_lib", ":conftest"]


### PR DESCRIPTION
## Why are these changes needed?

Looking at test_torch_predictor, it is a suite of 35 test cases, and runs roughly a minute of time.
Most of the time these tests do finish fine actually. That's why it's just flaky.
Make this a medium test to de-flake it.

## Related issue number

Closes #35451

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
