### PR TITLE
[CI] Fix air_example_gptj_deepspeed_fine_tuning.aws by pinning deepspeed version < 0.9

### DIFF
--- a/release/air_examples/gptj_deepspeed_finetuning/gptj_deepspeed_env.yaml
+++ b/release/air_examples/gptj_deepspeed_finetuning/gptj_deepspeed_env.yaml
@@ -10,7 +10,7 @@ python:
     - "accelerate>=0.16.0"
     - "transformers>=4.26.0"
     - "torch>=1.12.0"
-    - "deepspeed"
+    - "deepspeed<=0.9.0"
     - myst-parser==0.15.2
     - myst-nb==0.13.1
     - jupytext==1.13.6


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
