### PR TITLE
Preserve date and git commit prefix in tags.

### DIFF
--- a/ci/build/build-docker-images.py
+++ b/ci/build/build-docker-images.py
@@ -601,13 +601,12 @@ def push_and_tag_images(
     image_list: Optional[List[str]] = None,
     suffix: Optional[str] = None,
 ):
-
     date_tag = datetime.datetime.now().strftime("%Y-%m-%d")
     sha_tag = _get_commit_sha()
     if _release_build():
         release_name = re.search("[0-9]+\.[0-9]+\.[0-9].*", _get_branch()).group(0)
-        date_tag = release_name
-        sha_tag = release_name
+        date_tag = release_name + "." + date_tag
+        sha_tag = release_name + "." + sha_tag
 
     for image_name in image_list:
         full_image_name = f"rayproject/{image_name}"


### PR DESCRIPTION
So the release tags are not changed when adding a cherrypick, like a doc cherrypick, and there will be no need to disable container builds manually.

We will retag the ones that we eventually want to release at the last moment.

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
