### PR TITLE
Update the default bazel installation location

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -348,8 +348,8 @@ def is_invalid_windows_platform():
     return platform == "msys" or (platform == "win32" and ver and "GCC" in ver)
 
 
-# Calls Bazel in PATH, falling back to the standard user installatation path
-# (~/.bazel/bin/bazel) if it isn't found.
+# Calls Bazel in PATH, falling back to the standard user installation path
+# (~/bin/bazel) if it isn't found.
 def bazel_invoke(invoker, cmdline, *args, **kwargs):
     home = os.path.expanduser("~")
     first_candidate = os.getenv("BAZEL_PATH", "bazel")
@@ -359,7 +359,7 @@ def bazel_invoke(invoker, cmdline, *args, **kwargs):
         if mingw_dir:
             candidates.append(mingw_dir + "/bin/bazel.exe")
     else:
-        candidates.append(os.path.join(home, ".bazel", "bin", "bazel"))
+        candidates.append(os.path.join(home, "bin", "bazel"))
     result = None
     for i, cmd in enumerate(candidates):
         try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Following the steps on the official documentation to build ray from source, it fails at `pip install -e . --verbose` in the [Building Ray on Linux & MacOS (full)](https://docs.ray.io/en/latest/ray-contribute/development.html#id6) section:
`error: [Errno 2] No such file or directory: '/home/[username]/.bazel/bin/bazel'`.

This PR updates the path to locate bazel installation to align with what's on the [bazel official website](https://bazel.build/install/ubuntu#set-environment) and the provided [bazel installation script](https://github.com/ray-project/ray/blob/4bfdacf37942c565f385b664a12c2f49d399c8b5/ci/env/install-bazel.sh#L87).

Signed-off-by: Jack Wan <omyjackwan@gmail.com>

<!-- Please give a short summary of the change and the problem this solves. -->

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] No doc changes needed.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
