### PR TITLE
[CI][release 2.5.0] Fix ml_user_ray_lightning_user_test_(master|latest).aws release test

### DIFF
--- a/release/ml_user_tests/ray-lightning/app_config.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config.yaml
@@ -17,4 +17,5 @@ post_build_cmds:
   - pip3 install --force-reinstall torch==1.11.0
   - pip3 install --force-reinstall torchvision==0.12.0
   - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 install "urllib3<1.27" --ignore-installed
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/ml_user_tests/ray-lightning/app_config_master.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config_master.yaml
@@ -20,4 +20,5 @@ post_build_cmds:
   - pip3 install --force-reinstall torch==1.11.0
   - pip3 install --force-reinstall torchvision==0.12.0
   - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 install "urllib3<1.27" --ignore-installed
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The release tests failed due to the incompatible urllib3 version. Pin urllib < 1.27 to fix the ml_user_ray_lightning_user_test_(master|latest).aws release test.

Passed release test: https://buildkite.com/ray-project/release-tests-pr/builds/38990#_

## Related issue number

<!-- For example: "Closes #1234" -->

Close #35437

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
