### PR TITLE
[serve] Fix `app_builder` doc code test (#35456)

### DIFF
--- a/doc/source/serve/doc_code/app_builder.py
+++ b/doc/source/serve/doc_code/app_builder.py
@@ -23,6 +23,8 @@ def app_builder(args: Dict[str, str]) -> Application:
 
 # __end_untyped_builder__
 
+import requests
+
 serve.run(app_builder({"message": "Hello bar"}))
 resp = requests.get("http://localhost:8000")
 assert resp.text == "Hello bar"


### PR DESCRIPTION
Cherry-picks #35456

Missing import.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
