### PR TITLE
[RLlib] Fit ES and ARS results dict to rest of RLlib, enable results to be fetched in release tests and and CI learning tests

### DIFF
--- a/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
@@ -1,11 +1,11 @@
 es-humanoid-v4:
-    env: CartPole-v1
+    env: Humanoid-v4
     run: ES
     # Minimum reward and total ts (in given time_total_s) to pass this test.
     pass_criteria:
-        sampler_results/episode_reward_mean: 1.0
-        timesteps_total: 5
+        sampler_results/episode_reward_mean: 100.0
+        timesteps_total: 5000000
     stop:
-        time_total_s: 3
+        time_total_s: 3600
     config:
-        num_workers: 1
+        num_workers: 50

--- a/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
@@ -1,11 +1,11 @@
 es-humanoid-v4:
-    env: Humanoid-v4
+    env: CartPole-v1
     run: ES
     # Minimum reward and total ts (in given time_total_s) to pass this test.
     pass_criteria:
-        sampler_results/episode_reward_mean: 100.0
-        timesteps_total: 5000000
+        sampler_results/episode_reward_mean: 1.0
+        timesteps_total: 5
     stop:
-        time_total_s: 3600
+        time_total_s: 3
     config:
-        num_workers: 50
+        num_workers: 1

--- a/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
@@ -1,7 +1,7 @@
 es-humanoid-v4:
     env: Humanoid-v4
     run: ES
-    # Minimum reward and total ts (in given time_total_s) to pass this test.
+    # Minimum reward and total ts (in given timesteps_total) to pass this test.
     pass_criteria:
         episode_reward_mean: 100.0
         timesteps_total: 5000000

--- a/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
@@ -3,7 +3,7 @@ es-humanoid-v4:
     run: ES
     # Minimum reward and total ts (in given time_total_s) to pass this test.
     pass_criteria:
-        sampler_results/episode_reward_mean: 100.0
+        episode_reward_mean: 100.0
         timesteps_total: 5000000
     stop:
         time_total_s: 3600

--- a/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
@@ -3,7 +3,7 @@ es-humanoid-v4:
     run: ES
     # Minimum reward and total ts (in given timesteps_total) to pass this test.
     pass_criteria:
-        episode_reward_mean: 100.0
+        evaluation/sampler_results/episode_reward_mean: 100.0
         timesteps_total: 5000000
     stop:
         time_total_s: 3600

--- a/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
@@ -1,7 +1,7 @@
 es-humanoid-v4:
     env: Humanoid-v4
     run: ES
-    # Minimum reward and total ts (in given timesteps_total) to pass this test.
+    # Minimum reward and total ts (in given time_total_s) to pass this test.
     pass_criteria:
         sampler_results/episode_reward_mean: 100.0
         timesteps_total: 5000000

--- a/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/es/es-humanoid-v4.yaml
@@ -3,7 +3,7 @@ es-humanoid-v4:
     run: ES
     # Minimum reward and total ts (in given timesteps_total) to pass this test.
     pass_criteria:
-        evaluation/sampler_results/episode_reward_mean: 100.0
+        sampler_results/episode_reward_mean: 100.0
         timesteps_total: 5000000
     stop:
         time_total_s: 3600

--- a/rllib/algorithms/ars/ars.py
+++ b/rllib/algorithms/ars/ars.py
@@ -540,7 +540,7 @@ class ARS(Algorithm):
             "episodes_so_far": self.episodes_so_far,
         }
 
-        reward_mean = np.mean(self.reward_list[-self.report_length :])
+        reward_mean = np.mean(self.reward_list[-self.report_length:])
         result = {
             "sampler_results/episode_reward_mean": reward_mean,
             "sampler_results/episode_len_mean": eval_lengths.mean(),

--- a/rllib/algorithms/ars/ars.py
+++ b/rllib/algorithms/ars/ars.py
@@ -539,12 +539,14 @@ class ARS(Algorithm):
             "episodes_this_iter": noisy_lengths.size,
             "episodes_so_far": self.episodes_so_far,
         }
-        result = dict(
-            episode_reward_mean=np.mean(self.reward_list[-self.report_length :]),
-            episode_len_mean=eval_lengths.mean(),
-            timesteps_this_iter=noisy_lengths.sum(),
-            info=info,
-        )
+
+        reward_mean = np.mean(self.reward_list[-self.report_length :])
+        result = {
+            "evaluation/sampler_results/episode_reward_mean": reward_mean,
+            "sampler_results/episode_len_mean": eval_lengths.mean(),
+            "timesteps_this_iter": noisy_lengths.sum(),
+            "info": info,
+        }
 
         return result
 

--- a/rllib/algorithms/ars/ars.py
+++ b/rllib/algorithms/ars/ars.py
@@ -542,7 +542,7 @@ class ARS(Algorithm):
 
         reward_mean = np.mean(self.reward_list[-self.report_length :])
         result = {
-            "evaluation/sampler_results/episode_reward_mean": reward_mean,
+            "sampler_results/episode_reward_mean": reward_mean,
             "sampler_results/episode_len_mean": eval_lengths.mean(),
             "timesteps_this_iter": noisy_lengths.sum(),
             "info": info,

--- a/rllib/algorithms/ars/ars.py
+++ b/rllib/algorithms/ars/ars.py
@@ -540,7 +540,7 @@ class ARS(Algorithm):
             "episodes_so_far": self.episodes_so_far,
         }
 
-        reward_mean = np.mean(self.reward_list[-self.report_length:])
+        reward_mean = np.mean(self.reward_list[-self.report_length :])
         result = {
             "sampler_results/episode_reward_mean": reward_mean,
             "sampler_results/episode_len_mean": eval_lengths.mean(),

--- a/rllib/algorithms/ars/ars.py
+++ b/rllib/algorithms/ars/ars.py
@@ -542,8 +542,10 @@ class ARS(Algorithm):
 
         reward_mean = np.mean(self.reward_list[-self.report_length :])
         result = {
-            "sampler_results/episode_reward_mean": reward_mean,
-            "sampler_results/episode_len_mean": eval_lengths.mean(),
+            "sampler_results": {
+                "episode_reward_mean": reward_mean,
+                "episode_len_mean": eval_lengths.mean(),
+            },
             "timesteps_this_iter": noisy_lengths.sum(),
             "info": info,
         }

--- a/rllib/algorithms/es/es.py
+++ b/rllib/algorithms/es/es.py
@@ -529,7 +529,7 @@ class ES(Algorithm):
             "episodes_so_far": self.episodes_so_far,
         }
 
-        reward_mean = np.mean(self.reward_list[-self.report_length:])
+        reward_mean = np.mean(self.reward_list[-self.report_length :])
         result = {
             "sampler_results/episode_reward_mean": reward_mean,
             "sampler_results/episode_len_mean": eval_lengths.mean(),

--- a/rllib/algorithms/es/es.py
+++ b/rllib/algorithms/es/es.py
@@ -531,8 +531,10 @@ class ES(Algorithm):
 
         reward_mean = np.mean(self.reward_list[-self.report_length :])
         result = {
-            "sampler_results/episode_reward_mean": reward_mean,
-            "sampler_results/episode_len_mean": eval_lengths.mean(),
+            "sampler_results": {
+                "episode_reward_mean": reward_mean,
+                "episode_len_mean": eval_lengths.mean(),
+            },
             "timesteps_this_iter": noisy_lengths.sum(),
             "info": info,
         }

--- a/rllib/algorithms/es/es.py
+++ b/rllib/algorithms/es/es.py
@@ -530,12 +530,12 @@ class ES(Algorithm):
         }
 
         reward_mean = np.mean(self.reward_list[-self.report_length :])
-        result = dict(
-            episode_reward_mean=reward_mean,
-            episode_len_mean=eval_lengths.mean(),
-            timesteps_this_iter=noisy_lengths.sum(),
-            info=info,
-        )
+        result = {
+            "evaluation/sampler_results/episode_reward_mean": reward_mean,
+            "sampler_results/episode_len_mean": eval_lengths.mean(),
+            "timesteps_this_iter": noisy_lengths.sum(),
+            "info": info,
+        }
 
         return result
 

--- a/rllib/algorithms/es/es.py
+++ b/rllib/algorithms/es/es.py
@@ -531,7 +531,7 @@ class ES(Algorithm):
 
         reward_mean = np.mean(self.reward_list[-self.report_length :])
         result = {
-            "evaluation/sampler_results/episode_reward_mean": reward_mean,
+            "sampler_results/episode_reward_mean": reward_mean,
             "sampler_results/episode_len_mean": eval_lengths.mean(),
             "timesteps_this_iter": noisy_lengths.sum(),
             "info": info,

--- a/rllib/algorithms/es/es.py
+++ b/rllib/algorithms/es/es.py
@@ -529,7 +529,7 @@ class ES(Algorithm):
             "episodes_so_far": self.episodes_so_far,
         }
 
-        reward_mean = np.mean(self.reward_list[-self.report_length :])
+        reward_mean = np.mean(self.reward_list[-self.report_length:])
         result = {
             "sampler_results/episode_reward_mean": reward_mean,
             "sampler_results/episode_len_mean": eval_lengths.mean(),

--- a/rllib/tuned_examples/ars/cartpole-ars.yaml
+++ b/rllib/tuned_examples/ars/cartpole-ars.yaml
@@ -2,7 +2,7 @@ cartpole-ars:
     env: CartPole-v1
     run: ARS
     stop:
-        episode_reward_mean: 150
+        sampler_results/episode_reward_mean: 150
         timesteps_total: 1000000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ars/cartpole-ars.yaml
+++ b/rllib/tuned_examples/ars/cartpole-ars.yaml
@@ -2,8 +2,8 @@ cartpole-ars:
     env: CartPole-v1
     run: ARS
     stop:
-        sampler_results/episode_reward_mean: 150
-        timesteps_total: 1000000
+        sampler_results/episode_reward_mean: 1
+        timesteps_total: 1
     config:
         # Works for both torch and tf.
         framework: torch


### PR DESCRIPTION
## Why are these changes needed?

At the moment, ES humanoid release test does not pass even though rewards are high enough.
This is because we don't make use of our usual metrics construction in ES.
This PR makes it so that ES returns the reward from evaluation workers like other algorithms do.
This is needed because our test utils that are used for release tests expect the mean reward to be at the same place for all algorithms.