### PR TITLE
[core] Graceful handling of returning bundles when node is removed (#34726)

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -691,6 +691,14 @@ bool GcsPlacementGroupScheduler::TryReleasingBundleResources(
   const auto &bundle_spec = bundle.second;
   std::vector<scheduling::ResourceID> bundle_resource_ids;
   absl::flat_hash_map<std::string, FixedPoint> wildcard_resources;
+
+  if (!cluster_resource_manager.HasNode(node_id)) {
+    // If the node is dead, we do not need to release the bundle resources.
+    // The bundle resources will be released when the node is removed by
+    // the cluster resource manager.
+    return true;
+  }
+
   // Subtract wildcard resources and delete bundle resources.
   for (const auto &entry : bundle_spec->GetFormattedResources()) {
     auto resource_id = scheduling::ResourceID(entry.first);
@@ -848,8 +856,8 @@ const std::shared_ptr<BundleLocations> &LeaseStatusTracker::GetPreparedBundleLoc
   return preparing_bundle_locations_;
 }
 
-const std::shared_ptr<BundleLocations>
-    &LeaseStatusTracker::GetUnCommittedBundleLocations() const {
+const std::shared_ptr<BundleLocations> &
+LeaseStatusTracker::GetUnCommittedBundleLocations() const {
   return uncommitted_bundle_locations_;
 }
 
@@ -862,8 +870,8 @@ const std::shared_ptr<BundleLocations> &LeaseStatusTracker::GetBundleLocations()
   return bundle_locations_;
 }
 
-const std::vector<std::shared_ptr<const BundleSpecification>>
-    &LeaseStatusTracker::GetBundlesToSchedule() const {
+const std::vector<std::shared_ptr<const BundleSpecification>> &
+LeaseStatusTracker::GetBundlesToSchedule() const {
   return bundles_to_schedule_;
 }
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -856,8 +856,8 @@ const std::shared_ptr<BundleLocations> &LeaseStatusTracker::GetPreparedBundleLoc
   return preparing_bundle_locations_;
 }
 
-const std::shared_ptr<BundleLocations> &
-LeaseStatusTracker::GetUnCommittedBundleLocations() const {
+const std::shared_ptr<BundleLocations>
+    &LeaseStatusTracker::GetUnCommittedBundleLocations() const {
   return uncommitted_bundle_locations_;
 }
 
@@ -870,8 +870,8 @@ const std::shared_ptr<BundleLocations> &LeaseStatusTracker::GetBundleLocations()
   return bundle_locations_;
 }
 
-const std::vector<std::shared_ptr<const BundleSpecification>> &
-LeaseStatusTracker::GetBundlesToSchedule() const {
+const std::vector<std::shared_ptr<const BundleSpecification>>
+    &LeaseStatusTracker::GetBundlesToSchedule() const {
   return bundles_to_schedule_;
 }
 

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -124,6 +124,11 @@ class ClusterResourceManager {
   bool UpdateNodeNormalTaskResources(scheduling::NodeID node_id,
                                      const rpc::ResourcesData &resource_data);
 
+  /// Return if the node is tracked.
+  bool HasNode(const scheduling::NodeID &node_id) const {
+    return nodes_.count(node_id) > 0;
+  }
+
   void DebugString(std::stringstream &buffer) const;
 
   BundleLocationIndex &GetBundleLocationIndex();


### PR DESCRIPTION
Cherry picks #34726

When a node is dead, we did a series of clean up for the node. There was failure like this where a node was already removed from the internal data structures (i.e. ClusterResourceManager.nodes_) when trying to clean up bundles from the node.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
