### PR TITLE
[AIR] Cherry pick Make test_torch_predictor a medium test. #35466

### DIFF
--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -498,7 +498,7 @@ py_test(
 
 py_test(
     name = "test_torch_predictor",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_torch_predictor.py"],
     tags = ["team:ml", "exclusive", "ray_air", "gpu"],
     deps = [":train_lib", ":conftest"]


### PR DESCRIPTION
## Why are these changes needed?

Cherry-pick of https://github.com/ray-project/ray/pull/35466.
This is a zero-risk pick only to extend test time and deflake the test.