### PR TITLE
[Data] Optimize block prefetching

### DIFF
--- a/python/ray/data/_internal/block_batching/block_batching.py
+++ b/python/ray/data/_internal/block_batching/block_batching.py
@@ -194,10 +194,9 @@ def _prefetch_blocks(
     while sliding_window:
         block_ref = sliding_window.popleft()
         try:
-            next_block = next(block_ref_iter)
-            sliding_window.append(next_block)
+            sliding_window.append(next(block_ref_iter))
             with stats.iter_wait_s.timer() if stats else nullcontext():
-                prefetcher.prefetch_blocks(sliding_window)
+                prefetcher.prefetch_blocks(list(sliding_window))
         except StopIteration:
             pass
         yield block_ref

--- a/python/ray/data/_internal/block_batching/block_batching.py
+++ b/python/ray/data/_internal/block_batching/block_batching.py
@@ -197,7 +197,7 @@ def _prefetch_blocks(
             next_block = next(block_ref_iter)
             sliding_window.append(next_block)
             with stats.iter_wait_s.timer() if stats else nullcontext():
-                prefetcher.prefetch_blocks([next_block])
+                prefetcher.prefetch_blocks(sliding_window)
         except StopIteration:
             pass
         yield block_ref

--- a/python/ray/data/_internal/block_batching/block_batching.py
+++ b/python/ray/data/_internal/block_batching/block_batching.py
@@ -194,9 +194,10 @@ def _prefetch_blocks(
     while sliding_window:
         block_ref = sliding_window.popleft()
         try:
-            sliding_window.append(next(block_ref_iter))
+            next_block = next(block_ref_iter)
+            sliding_window.append(next_block)
             with stats.iter_wait_s.timer() if stats else nullcontext():
-                prefetcher.prefetch_blocks(list(sliding_window))
+                prefetcher.prefetch_blocks([next_block])
         except StopIteration:
             pass
         yield block_ref

--- a/python/ray/data/_internal/block_batching/block_batching.py
+++ b/python/ray/data/_internal/block_batching/block_batching.py
@@ -204,3 +204,4 @@ def _prefetch_blocks(
         trace_deallocation(
             block_ref, "block_batching._prefetch_blocks", free=eager_free
         )
+    prefetcher.stop()

--- a/python/ray/data/_internal/block_batching/interfaces.py
+++ b/python/ray/data/_internal/block_batching/interfaces.py
@@ -1,3 +1,5 @@
+import abc
+
 from dataclasses import dataclass
 from typing import Any, List
 
@@ -33,9 +35,14 @@ class CollatedBatch(Batch):
     data: Any
 
 
-class BlockPrefetcher:
+class BlockPrefetcher(metaclass=abc.ABCMeta):
     """Interface for prefetching blocks."""
 
+    @abc.abstractmethod
     def prefetch_blocks(self, blocks: List[ObjectRef[Block]]):
         """Prefetch the provided blocks to this node."""
-        raise NotImplementedError
+        pass
+
+    def stop(self):
+        """Stop prefetching and release resources."""
+        pass

--- a/python/ray/data/_internal/block_batching/interfaces.py
+++ b/python/ray/data/_internal/block_batching/interfaces.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, List
 
 from ray.types import ObjectRef
 from ray.data.block import Block, DataBatch
@@ -36,6 +36,6 @@ class CollatedBatch(Batch):
 class BlockPrefetcher:
     """Interface for prefetching blocks."""
 
-    def prefetch_blocks(self, blocks: ObjectRef[Block]):
+    def prefetch_blocks(self, blocks: List[ObjectRef[Block]]):
         """Prefetch the provided blocks to this node."""
         raise NotImplementedError

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -122,6 +122,7 @@ def iter_batches(
     def _async_iter_batches(
         block_refs: Iterator[Tuple[ObjectRef[Block], BlockMetadata]],
     ) -> Iterator[DataBatch]:
+
         # Step 1: Prefetch logical batches locally.
         block_refs = prefetch_batches_locally(
             block_ref_iter=block_refs,

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -274,7 +274,9 @@ def prefetch_batches_locally(
         if batch_size is None or current_window_size < num_rows_to_prefetch:
             try:
                 sliding_window.append(next(block_ref_iter))
-                prefetcher.prefetch_blocks([sliding_window[-1][0]])
+                prefetcher.prefetch_blocks(
+                    [block_ref for block_ref, _ in list(sliding_window)]
+                )
             except StopIteration:
                 pass
         yield block_ref

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -273,9 +273,8 @@ def prefetch_batches_locally(
         current_window_size -= metadata.num_rows
         if batch_size is None or current_window_size < num_rows_to_prefetch:
             try:
-                block_ref, metadata = next(block_ref_iter)
-                sliding_window.append((block_ref, metadata))
-                prefetcher.prefetch_blocks([block_ref])
+                sliding_window.append(next(block_ref_iter))
+                prefetcher.prefetch_blocks([sliding_window[-1][0]])
             except StopIteration:
                 pass
         yield block_ref

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -289,7 +289,7 @@ class WaitBlockPrefetcher(BlockPrefetcher):
         self._blocks = []
         self._condition = threading.Condition()
         self._thread = threading.Thread(
-            target=self._run, args=(self,), name="Prefetcher"
+            target=self._run, name="Prefetcher"
         )
         self._thread.start()
 

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -287,9 +287,7 @@ class WaitBlockPrefetcher(BlockPrefetcher):
     def __init__(self):
         self._blocks = []
         self._condition = threading.Condition()
-        self._thread = threading.Thread(
-            target=self._run, name="Prefetcher"
-        )
+        self._thread = threading.Thread(target=self._run, name="Prefetcher")
         self._thread.start()
 
     def _run(self):

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -1,6 +1,5 @@
 import logging
 import threading
-import time
 from typing import Any, Callable, Iterator, List, Optional, Tuple, TypeVar, Union
 from collections import deque
 from contextlib import nullcontext

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -302,10 +302,9 @@ class WaitBlockPrefetcher(BlockPrefetcher):
                         blocks_to_wait, self._blocks = self._blocks[:], []
                     else:
                         blocks_to_wait = []
+                        self._condition.wait()
                 if len(blocks_to_wait) > 0:
                     ray.wait(blocks_to_wait, num_returns=1, fetch_local=True)
-                else:
-                    self._condition.wait()
             except Exception:
                 logger.exception("Error in prefetcher thread.")
 

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -287,7 +287,11 @@ class WaitBlockPrefetcher(BlockPrefetcher):
     def __init__(self):
         self._blocks = []
         self._condition = threading.Condition()
-        self._thread = threading.Thread(target=self._run, name="Prefetcher")
+        self._thread = threading.Thread(
+            target=self._run,
+            name="Prefetcher",
+            daemon=True,
+        )
         self._thread.start()
 
     def _run(self):

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -300,12 +300,11 @@ class WaitBlockPrefetcher(BlockPrefetcher):
             try:
                 blocks_to_wait = []
                 with self._condition:
-                    if self._stopped:
-                        del self._blocks[:]
-                        return
                     if len(self._blocks) > 0:
                         blocks_to_wait, self._blocks = self._blocks[:], []
                     else:
+                        if self._stopped:
+                            return
                         blocks_to_wait = []
                         self._condition.wait()
                 if len(blocks_to_wait) > 0:

--- a/python/ray/data/tests/block_batching/test_block_batching.py
+++ b/python/ray/data/tests/block_batching/test_block_batching.py
@@ -70,10 +70,7 @@ def test_prefetch_blocks(num_blocks_to_prefetch):
             assert len(prefetcher.windows) == block_count
 
     windows = prefetcher.windows
-    # The first window should have the number of blocks to prefetch.
-    # And the rest should have 1 block.
-    assert len(windows[0]) == num_blocks_to_prefetch
-    assert all(len(window) == 1 for window in windows[1:])
+    assert all(len(window) == num_blocks_to_prefetch for window in windows)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/block_batching/test_block_batching.py
+++ b/python/ray/data/tests/block_batching/test_block_batching.py
@@ -70,7 +70,10 @@ def test_prefetch_blocks(num_blocks_to_prefetch):
             assert len(prefetcher.windows) == block_count
 
     windows = prefetcher.windows
-    assert all(len(window) == num_blocks_to_prefetch for window in windows)
+    # The first window should have the number of blocks to prefetch.
+    # And the rest should have 1 block.
+    assert len(windows[0]) == num_blocks_to_prefetch
+    assert all(len(window) == 1 for window in windows[1:])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`WaitBlockPrefetcher` will blockingly wait for the first block. When prefetch size is small, this can cause latency on the critical path. This PR moves the wait to a background thread.

## Related issue number

<!-- For example: "Closes #1234" -->
closes #35521

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
