### PR TITLE
[Docs] Remove broken link to external blogpost

### DIFF
--- a/doc/source/ray-overview/learn-more.md
+++ b/doc/source/ray-overview/learn-more.md
@@ -21,7 +21,6 @@ Please raise an issue if any of the below links are broken, or if you'd like to 
 - [How to Speed up Pandas by 4x with one line of code](https://www.kdnuggets.com/2019/11/speed-up-pandas-4x.html)
 - [Quick Tip -- Speed up Pandas using Modin](https://pythondata.com/quick-tip-speed-up-pandas-using-modin/)
 - [Ray Blog](https://medium.com/distributed-computing-with-ray)
-- [How to launch a Ray Serve API on a remote cluster (AWS)](https://jbesomi.com/ray-serve-remote-cluster)
 
 ## Talks (Videos)
 


### PR DESCRIPTION
## Why are these changes needed?

It seems like the article in question was removed.
This is also broken on 2.5.0 release branch.

<img width="1056" alt="Screenshot 2023-05-20 at 10 34 22" src="https://github.com/ray-project/ray/assets/9356806/010537cc-5630-4080-a034-ec9e7974713e">
