### PR TITLE
[Docs] [runtime_env] Add instructions on using `.netrc` for remote URIs

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -683,7 +683,7 @@ Here is a list of different use cases and corresponding URLs:
     runtime_env = {"working_dir": ("https://github.com"
                                    "/[username]/[repository]/archive/[commit hash].zip")}
 
-- Example: Retrieve package from a private GitHub repository using a Personal Access Token. **Warning: this is not a best practice**. See :ref:`this document <runtime-env-auth>` to learn how to authenticate private dependencies safely.
+- Example: Retrieve package from a private GitHub repository using a Personal Access Token **during development**. **For production** see :ref:`this document <runtime-env-auth>` to learn how to authenticate private dependencies safely.
 
 .. testcode::
 

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -683,7 +683,7 @@ Here is a list of different use cases and corresponding URLs:
     runtime_env = {"working_dir": ("https://github.com"
                                    "/[username]/[repository]/archive/[commit hash].zip")}
 
-- Example: Retrieve package from a private GitHub repository using a Personal Access Token
+- Example: Retrieve package from a private GitHub repository using a Personal Access Token. **Warning: this is not a best practice**. See :ref:`this document <runtime-env-auth>` to learn how to authenticate private dependencies safely.
 
 .. testcode::
 

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -68,7 +68,9 @@ Add the `netrc` file to your VM container's home directory, so Ray can access th
 [KubeRay](https://ray-project.github.io/kuberay/) can also obtain credentials from a `netrc` file for remote URIs. Supply your `netrc` file using a Kubernetes secret and a Kubernetes volume with these steps:
 
 1\. Launch your Kubernetes cluster.
+
 2\. Create the `netrc` file locally in your home directory.
+
 3\. Store the `netrc` file's contents as a Kubernetes secret on your cluster:
 
 ```bash

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -63,7 +63,7 @@ You can add your `netrc` file to your VM container's home directory, so Ray can 
 
 ## Running on KubeRay: Secrets with netrc
 
-KubeRay can also obtain credentials from a `netrc` file for remote URIs. You can supply your `netrc` file using a Kubernetes secret and a Kubernetes volume with these steps:
+[KubeRay](https://ray-project.github.io/kuberay/) can also obtain credentials from a `netrc` file for remote URIs. You can supply your `netrc` file using a Kubernetes secret and a Kubernetes volume with these steps:
 
 1. Launch your Kubernetes cluster.
 2. Create your `netrc` file locally in your home directory.

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -32,7 +32,7 @@ runtime_env = {"working_dir": (
 In this example, `personal_access_token` is a secret credential that authenticates this URI. While Ray can successfully access your dependencies using authenticated URIs, **you should not include secret credentials in your URIs** for two reasons:
 
 1. Ray may log the URIs used in your `runtime_env`, which means the Ray logs could contain your credentials.
-2. Ray stores your remote dependency package in a local directory, and it uses a parsed version of the remote URI– including your credential– as the directory's name.
+2. Ray stores your remote dependency package in a local directory, and it uses a parsed version of the remote URI–including your credential–as the directory's name.
 
 In short, your remote URI is not treated as a secret, so it should not contain secret info. Instead you should use a `netrc` file.
 

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -9,7 +9,7 @@ This section helps you:
 
 ## Authenticating Remote URIs
 
-You can add dependencies to your `runtime_env` with [remote URIs](remote-uris). This is straightfoward for files hosted publicly, since you can simply paste the public URI into your `runtime_env`:
+You can add dependencies to your `runtime_env` with [remote URIs](remote-uris). This is straightforward for files hosted publicly, because you simply paste the public URI into your `runtime_env`:
 
 ```python
 runtime_env = {"working_dir": (

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -34,7 +34,7 @@ In this example, `personal_access_token` is a secret credential that authenticat
 1. Ray may log the URIs used in your `runtime_env`, which means the Ray logs could contain your credentials.
 2. Ray stores your remote dependency package in a local directory, and it uses a parsed version of the remote URI–including your credential–as the directory's name.
 
-In short, your remote URI is not treated as a secret, so it should not contain secret info. Instead you should use a `netrc` file.
+In short, your remote URI is not treated as a secret, so it should not contain secret info. Instead, use a `netrc` file.
 
 ## Running on VMs: the netrc File
 

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -41,7 +41,7 @@ In short, your remote URI is not treated as a secret, so it should not contain s
 The [.netrc file](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html) contains credentials that Ray uses to automatically log into remote servers. You can set your credentials in this file instead of in the remote URI:
 
 ```bash
-# ~/.netrc
+# "$HOME/.netrc"
 
 machine github.com
 login username
@@ -51,7 +51,7 @@ password personal_access_token
 The `.netrc` file requires owner read/write access, so make sure to run the `chmod` command after creating the file:
 
 ```bash
-chmod 600 ~/.netrc
+chmod 600 "$HOME/.netrc"
 ```
 
 You can add your `.netrc` file to your VM container's home directory, so Ray can access your `runtime_env`'s private remote URI, even when they don't contain credentials.
@@ -65,7 +65,7 @@ KubeRay can also obtain credentials from a `.netrc` file for remote URIs. You ca
 3. Store your `.netrc` file's contents as a Kubernetes secret on your cluster:
 
 ```bash
-kubectl create secret generic netrc-secret --from-file=.netrc=~/.netrc
+kubectl create secret generic netrc-secret --from-file=.netrc="$HOME/.netrc"
 ```
 
 4. Expose the secret to your KubeRay application using a mounted volume, and update the `NETRC` environment variable to point to the `.netrc` file. You can include the following YAML in your KubeRay config.

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -38,7 +38,7 @@ In short, your remote URI is not treated as a secret, so it should not contain s
 
 ## Running on VMs: the netrc File
 
-The [netrc file](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html) contains credentials that Ray uses to automatically log into remote servers. You can set your credentials in this file instead of in the remote URI:
+The [netrc file](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html) contains credentials that Ray uses to automatically log into remote servers. Set your credentials in this file instead of in the remote URI:
 
 ```bash
 # "$HOME/.netrc"

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -52,7 +52,7 @@ In this example, the `machine github.com` line specifies that any access to `git
 
 :::{note}
 On Unix, name the `netrc` file as `.netrc`. On Windows, name the
-file, `_netrc`.
+file as `_netrc`.
 :::
 
 The `netrc` file requires owner read/write access, so make sure to run the `chmod` command after creating the file:
@@ -61,7 +61,7 @@ The `netrc` file requires owner read/write access, so make sure to run the `chmo
 chmod 600 "$HOME/.netrc"
 ```
 
-Add the `netrc` file to your VM container's home directory, so Ray can access the `runtime_env`'s private remote URI, even when they don't contain credentials.
+Add the `netrc` file to your VM container's home directory, so Ray can access the `runtime_env`'s private remote URIs, even when they don't contain credentials.
 
 ## Running on KubeRay: Secrets with netrc
 

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -48,6 +48,8 @@ login username
 password personal_access_token
 ```
 
+In this example, the `machine github.com` line specifies that any access to `github.com` should be authenticated using the provided `login` and `password`.
+
 :::{note}
 On Unix, the `netrc` file should be named `.netrc`. On Windows, the
 file should be named `_netrc`.

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -1,0 +1,113 @@
+(runtime-env-auth)=
+# Authenticating Remote URIs in your runtime_env
+
+This section helps you:
+
+* Avoid leaking remote URI credentials in your `runtime_env`
+* provide credentials safely in KubeRay
+* understand best practices when authenticating your remote URI
+
+## Authenticating Remote URIs
+
+You can add dependencies to your `runtime_env` with [remote URIs](remote-uris). This is straightfoward for files hosted publicly, since you can simply paste the public URI into your `runtime_env`:
+
+```python
+runtime_env = {"working_dir": (
+        "https://github.com/"
+        "username/repo/archive/refs/heads/master.zip"
+    )
+}
+```
+
+However, dependencies hosted privately, in a private GitHub repo for example, require authentication. One common way to authenticate is to insert credentials into the URI itself:
+
+```python
+runtime_env = {"working_dir": (
+        "https://username:personal_access_token@github.com/"
+        "username/repo/archive/refs/heads/master.zip"
+    )
+}
+```
+
+In this example, `personal_access_token` is a secret credential that authenticates this URI. While Ray can successfully access your dependencies using authenticated URIs, **you should not include secret credentials in your URIs** for two reasons:
+
+1. Ray may log the URIs used in your `runtime_env`, which means the Ray logs could contain your credentials.
+2. Ray stores your remote dependency package in a local directory, and it uses a parsed version of the remote URI– including your credential– as the directory's name.
+
+In short, your remote URI is not treated as a secret, so it should not contain secret info. Instead you should use a `.netrc` file.
+
+## Running on VMs: the .netrc File
+
+The [.netrc file](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html) contains credentials that Ray uses to automatically log into remote servers. You can set your credentials in this file instead of in the remote URI:
+
+```bash
+# ~/.netrc
+
+machine github.com
+login username
+password personal_access_token
+```
+
+The `.netrc` file requires owner read/write access, so make sure to run the `chmod` command after creating the file:
+
+```bash
+chmod 600 ~/.netrc
+```
+
+You can add your `.netrc` file to your VM container's home directory, so Ray can access your `runtime_env`'s private remote URI, even when they don't contain credentials.
+
+## Running on KubeRay: Secrets with .netrc
+
+KubeRay can also obtain credentials from a `.netrc` file for remote URIs. You can supply your `.netrc` file using a Kubernetes secret and a Kubernetes volume with these steps:
+
+1. Launch your Kubernetes cluster.
+2. Create your `.netrc` file locally in your home directory.
+3. Store your `.netrc` file's contents as a Kubernetes secret on your cluster:
+
+```bash
+kubectl create secret generic netrc-secret --from-file=.netrc=~/.netrc
+```
+
+4. Expose the secret to your KubeRay application using a mounted volume, and update the `NETRC` environment variable to point to the `.netrc` file. You can include the following YAML in your KubeRay config.
+
+```yaml
+headGroupSpec:
+    ...
+    containers:
+        - name: ...
+          image: rayproject/ray:latest
+          ...
+          volumeMounts:
+            - mountPath: "/home/ray/netrcvolume/"
+              name: netrc-kuberay
+              readOnly: true
+          env:
+            - name: NETRC
+              value: "/home/ray/netrcvolume/.netrc"
+    volumes:
+        - name: netrc-kuberay
+          secret:
+            secretName: netrc-secret
+
+workerGroupSpecs:
+    ...
+    containers:
+        - name: ...
+          image: rayproject/ray:latest
+          ...
+          volumeMounts:
+            - mountPath: "/home/ray/netrcvolume/"
+              name: netrc-kuberay
+              readOnly: true
+          env:
+            - name: NETRC
+              value: "/home/ray/netrcvolume/.netrc"
+    volumes:
+        - name: netrc-kuberay
+          secret:
+            secretName: netrc-secret
+```
+
+5. Apply your KubeRay config.
+
+Your KubeRay application can use the `.netrc` file to access private remote URIs, even when they don't contain credentials.

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -51,7 +51,7 @@ password personal_access_token
 In this example, the `machine github.com` line specifies that any access to `github.com` should be authenticated using the provided `login` and `password`.
 
 :::{note}
-On Unix, the `netrc` file should be named `.netrc`. On Windows, the
+On Unix, name the `netrc` file as `.netrc`. On Windows, name the
 file should be named `_netrc`.
 :::
 

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -1,5 +1,5 @@
 (runtime-env-auth)=
-# Authenticating Remote URIs in your runtime_env
+# Authenticating Remote URIs in runtime_env
 
 This section helps you:
 

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -52,7 +52,7 @@ In this example, the `machine github.com` line specifies that any access to `git
 
 :::{note}
 On Unix, name the `netrc` file as `.netrc`. On Windows, name the
-file should be named `_netrc`.
+file, `_netrc`.
 :::
 
 The `netrc` file requires owner read/write access, so make sure to run the `chmod` command after creating the file:

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -65,7 +65,7 @@ Add the `netrc` file to your VM container's home directory, so Ray can access th
 
 ## Running on KubeRay: Secrets with netrc
 
-[KubeRay](https://ray-project.github.io/kuberay/) can also obtain credentials from a `netrc` file for remote URIs. You can supply your `netrc` file using a Kubernetes secret and a Kubernetes volume with these steps:
+[KubeRay](https://ray-project.github.io/kuberay/) can also obtain credentials from a `netrc` file for remote URIs. Supply your `netrc` file using a Kubernetes secret and a Kubernetes volume with these steps:
 
 1\. Launch your Kubernetes cluster.
 2\. Create your `netrc` file locally in your home directory.

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -61,7 +61,7 @@ The `netrc` file requires owner read/write access, so make sure to run the `chmo
 chmod 600 "$HOME/.netrc"
 ```
 
-You can add your `netrc` file to your VM container's home directory, so Ray can access your `runtime_env`'s private remote URI, even when they don't contain credentials.
+Add the `netrc` file to your VM container's home directory, so Ray can access the `runtime_env`'s private remote URI, even when they don't contain credentials.
 
 ## Running on KubeRay: Secrets with netrc
 

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -67,15 +67,15 @@ You can add your `netrc` file to your VM container's home directory, so Ray can 
 
 [KubeRay](https://ray-project.github.io/kuberay/) can also obtain credentials from a `netrc` file for remote URIs. You can supply your `netrc` file using a Kubernetes secret and a Kubernetes volume with these steps:
 
-1. Launch your Kubernetes cluster.
-2. Create your `netrc` file locally in your home directory.
-3. Store your `netrc` file's contents as a Kubernetes secret on your cluster:
+1\. Launch your Kubernetes cluster.
+2\. Create your `netrc` file locally in your home directory.
+3\. Store your `netrc` file's contents as a Kubernetes secret on your cluster:
 
 ```bash
 kubectl create secret generic netrc-secret --from-file=.netrc="$HOME/.netrc"
 ```
 
-4. Expose the secret to your KubeRay application using a mounted volume, and update the `NETRC` environment variable to point to the `netrc` file. You can include the following YAML in your KubeRay config.
+4\. Expose the secret to your KubeRay application using a mounted volume, and update the `NETRC` environment variable to point to the `netrc` file. You can include the following YAML in your KubeRay config.
 
 ```yaml
 headGroupSpec:
@@ -115,6 +115,6 @@ workerGroupSpecs:
             secretName: netrc-secret
 ```
 
-5. Apply your KubeRay config.
+5\. Apply your KubeRay config.
 
 Your KubeRay application can use the `netrc` file to access private remote URIs, even when they don't contain credentials.

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -68,7 +68,7 @@ Add the `netrc` file to your VM container's home directory, so Ray can access th
 [KubeRay](https://ray-project.github.io/kuberay/) can also obtain credentials from a `netrc` file for remote URIs. Supply your `netrc` file using a Kubernetes secret and a Kubernetes volume with these steps:
 
 1\. Launch your Kubernetes cluster.
-2\. Create your `netrc` file locally in your home directory.
+2\. Create the `netrc` file locally in your home directory.
 3\. Store your `netrc` file's contents as a Kubernetes secret on your cluster:
 
 ```bash

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -34,11 +34,11 @@ In this example, `personal_access_token` is a secret credential that authenticat
 1. Ray may log the URIs used in your `runtime_env`, which means the Ray logs could contain your credentials.
 2. Ray stores your remote dependency package in a local directory, and it uses a parsed version of the remote URI– including your credential– as the directory's name.
 
-In short, your remote URI is not treated as a secret, so it should not contain secret info. Instead you should use a `.netrc` file.
+In short, your remote URI is not treated as a secret, so it should not contain secret info. Instead you should use a `netrc` file.
 
-## Running on VMs: the .netrc File
+## Running on VMs: the netrc File
 
-The [.netrc file](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html) contains credentials that Ray uses to automatically log into remote servers. You can set your credentials in this file instead of in the remote URI:
+The [netrc file](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html) contains credentials that Ray uses to automatically log into remote servers. You can set your credentials in this file instead of in the remote URI:
 
 ```bash
 # "$HOME/.netrc"
@@ -48,27 +48,32 @@ login username
 password personal_access_token
 ```
 
-The `.netrc` file requires owner read/write access, so make sure to run the `chmod` command after creating the file:
+:::{note}
+On Unix, the `netrc` file should be named `.netrc`. On Windows, the
+file should be named `_netrc`.
+:::
+
+The `netrc` file requires owner read/write access, so make sure to run the `chmod` command after creating the file:
 
 ```bash
 chmod 600 "$HOME/.netrc"
 ```
 
-You can add your `.netrc` file to your VM container's home directory, so Ray can access your `runtime_env`'s private remote URI, even when they don't contain credentials.
+You can add your `netrc` file to your VM container's home directory, so Ray can access your `runtime_env`'s private remote URI, even when they don't contain credentials.
 
-## Running on KubeRay: Secrets with .netrc
+## Running on KubeRay: Secrets with netrc
 
-KubeRay can also obtain credentials from a `.netrc` file for remote URIs. You can supply your `.netrc` file using a Kubernetes secret and a Kubernetes volume with these steps:
+KubeRay can also obtain credentials from a `netrc` file for remote URIs. You can supply your `netrc` file using a Kubernetes secret and a Kubernetes volume with these steps:
 
 1. Launch your Kubernetes cluster.
-2. Create your `.netrc` file locally in your home directory.
-3. Store your `.netrc` file's contents as a Kubernetes secret on your cluster:
+2. Create your `netrc` file locally in your home directory.
+3. Store your `netrc` file's contents as a Kubernetes secret on your cluster:
 
 ```bash
 kubectl create secret generic netrc-secret --from-file=.netrc="$HOME/.netrc"
 ```
 
-4. Expose the secret to your KubeRay application using a mounted volume, and update the `NETRC` environment variable to point to the `.netrc` file. You can include the following YAML in your KubeRay config.
+4. Expose the secret to your KubeRay application using a mounted volume, and update the `NETRC` environment variable to point to the `netrc` file. You can include the following YAML in your KubeRay config.
 
 ```yaml
 headGroupSpec:
@@ -110,4 +115,4 @@ workerGroupSpecs:
 
 5. Apply your KubeRay config.
 
-Your KubeRay application can use the `.netrc` file to access private remote URIs, even when they don't contain credentials.
+Your KubeRay application can use the `netrc` file to access private remote URIs, even when they don't contain credentials.

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -5,7 +5,7 @@ This section helps you:
 
 * Avoid leaking remote URI credentials in your `runtime_env`
 * Provide credentials safely in KubeRay
-* understand best practices when authenticating your remote URI
+* Understand best practices for authenticating your remote URI
 
 ## Authenticating Remote URIs
 

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -4,7 +4,7 @@
 This section helps you:
 
 * Avoid leaking remote URI credentials in your `runtime_env`
-* provide credentials safely in KubeRay
+* Provide credentials safely in KubeRay
 * understand best practices when authenticating your remote URI
 
 ## Authenticating Remote URIs

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -69,7 +69,7 @@ Add the `netrc` file to your VM container's home directory, so Ray can access th
 
 1\. Launch your Kubernetes cluster.
 2\. Create the `netrc` file locally in your home directory.
-3\. Store your `netrc` file's contents as a Kubernetes secret on your cluster:
+3\. Store the `netrc` file's contents as a Kubernetes secret on your cluster:
 
 ```bash
 kubectl create secret generic netrc-secret --from-file=.netrc="$HOME/.netrc"

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -75,7 +75,7 @@ Add the `netrc` file to your VM container's home directory, so Ray can access th
 kubectl create secret generic netrc-secret --from-file=.netrc="$HOME/.netrc"
 ```
 
-4\. Expose the secret to your KubeRay application using a mounted volume, and update the `NETRC` environment variable to point to the `netrc` file. You can include the following YAML in your KubeRay config.
+4\. Expose the secret to your KubeRay application using a mounted volume, and update the `NETRC` environment variable to point to the `netrc` file. Include the following YAML in your KubeRay config.
 
 ```yaml
 headGroupSpec:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Users can provide dependencies via a remote URI in their `runtime_env`. To access private dependencies, users must include authentication information with their request. Commonly, this is done by including credentials in the URI itself. However, this pattern can be insecure since Ray may log the URI or use it to name temporary directories. Instead, users should supply their credentials using a `.netrc` file.

This change adds documentation explaining how to use a `.netrc` file on VMs or KubeRay. Thanks to @Xalag and @Martin4R for the discussion in #28253. Some of the examples have been adapted from that issue.

* `netrc` documentation link: https://anyscale-ray--35578.com.readthedocs.build/en/35578/ray-core/runtime_env_auth.html
* `runtime_env` URL templates link: https://anyscale-ray--35578.com.readthedocs.build/en/35578/ray-core/handling-dependencies.html#option-2-manually-create-url-slower-to-implement-but-recommended-for-production-environments

## Related issue number

<!-- For example: "Closes #1234" -->

See #28253

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - I manually tested these steps on my laptop and a GKE Kubernetes cluster.
