### PR TITLE
unify gpu checking around gpustat

### DIFF
--- a/python/ray/tune/tests/test_trainable_util.py
+++ b/python/ray/tune/tests/test_trainable_util.py
@@ -137,18 +137,22 @@ class UnflattenDictTest(unittest.TestCase):
             unflatten_dict({"a/b": 2, "a/b/c": 3})
 
 
-class GPUUtilMock:
+class GpustatMock:
     class GPU:
         def __init__(self, id, uuid, util=None):
-            self.id = id
+            self.index = id
             self.uuid = uuid
-            self.util = [0.5, 0.0]
+            self.util = [12000, 0]
 
         @property
-        def memoryUtil(self):
+        def memory_used(self):
             if self.util:
                 return self.util.pop(0)
             return 0
+
+        @property
+        def memory_total(self):
+            return 24000
 
     def __init__(self, gpus, gpu_uuids):
         self.gpus = gpus
@@ -157,13 +161,13 @@ class GPUUtilMock:
             self.GPU(gpu, uuid) for gpu, uuid in zip(self.gpus, self.uuids)
         ]
 
-    def getGPUs(self):
+    def new_query(self):
         return self.gpu_list
 
 
 class GPUTest(unittest.TestCase):
     def setUp(self):
-        sys.modules["GPUtil"] = GPUUtilMock([0, 1], ["GPU-aaa", "GPU-bbb"])
+        sys.modules["gpustat"] = GpustatMock([0, 1], ["GPU-aaa", "GPU-bbb"])
 
     def testGPUWait1(self):
         wait_for_gpu(0, delay_s=0)
@@ -188,7 +192,7 @@ class GPUTest(unittest.TestCase):
     def testDefaultGPU(self):
         import sys
 
-        sys.modules["GPUtil"] = GPUUtilMock([0], ["GPU-aaa"])
+        sys.modules["gpustat"] = GpustatMock([0], ["GPU-aaa"])
         wait_for_gpu(delay_s=0)
 
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -38,7 +38,7 @@ scipy
 colorful
 pyyaml
 rich
-gpustat>=1.0.0
+gpustat>=1.1.0
 opentelemetry-sdk
 fastapi
 gymnasium==0.28.1

--- a/python/setup.py
+++ b/python/setup.py
@@ -247,7 +247,7 @@ if setup_spec.type == SetupType.RAY:
             "colorful",
             "py-spy >= 0.2.0",
             "requests",
-            "gpustat >= 1.0.0",  # for windows
+            "gpustat >= 1.1.0",  
             "grpcio >= 1.32.0; python_version < '3.10'",  # noqa:E501
             "grpcio >= 1.42.0; python_version >= '3.10'",  # noqa:E501
             "opencensus",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Consistently use the required gpustat to detect gpu availability. There are fall-back paths to check `/proc/driver/nvidia/gpus` on linux, which requires `root` permissions. Also update gpustat to 1.1 to get a fix for https://github.com/wookayin/gpustat/issues/142.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Toward #28064 ([this comment](https://github.com/ray-project/ray/issues/28064#issuecomment-1228453479) to fix the dashboard server checking for `/` disk usage which requires root permissions is not part of this PR, and should probably be a separate issue)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
