### PR TITLE
[RLlib] Fit ES and ARS results dict to rest of RLlib, enable results to be fetched in release tests and and CI learning tests 

### DIFF
--- a/rllib/algorithms/ars/ars.py
+++ b/rllib/algorithms/ars/ars.py
@@ -539,12 +539,16 @@ class ARS(Algorithm):
             "episodes_this_iter": noisy_lengths.size,
             "episodes_so_far": self.episodes_so_far,
         }
-        result = dict(
-            episode_reward_mean=np.mean(self.reward_list[-self.report_length :]),
-            episode_len_mean=eval_lengths.mean(),
-            timesteps_this_iter=noisy_lengths.sum(),
-            info=info,
-        )
+
+        reward_mean = np.mean(self.reward_list[-self.report_length :])
+        result = {
+            "sampler_results": {
+                "episode_reward_mean": reward_mean,
+                "episode_len_mean": eval_lengths.mean(),
+            },
+            "timesteps_this_iter": noisy_lengths.sum(),
+            "info": info,
+        }
 
         return result
 

--- a/rllib/algorithms/es/es.py
+++ b/rllib/algorithms/es/es.py
@@ -530,12 +530,14 @@ class ES(Algorithm):
         }
 
         reward_mean = np.mean(self.reward_list[-self.report_length :])
-        result = dict(
-            episode_reward_mean=reward_mean,
-            episode_len_mean=eval_lengths.mean(),
-            timesteps_this_iter=noisy_lengths.sum(),
-            info=info,
-        )
+        result = {
+            "sampler_results": {
+                "episode_reward_mean": reward_mean,
+                "episode_len_mean": eval_lengths.mean(),
+            },
+            "timesteps_this_iter": noisy_lengths.sum(),
+            "info": info,
+        }
 
         return result
 

--- a/rllib/tuned_examples/ars/cartpole-ars.yaml
+++ b/rllib/tuned_examples/ars/cartpole-ars.yaml
@@ -2,8 +2,8 @@ cartpole-ars:
     env: CartPole-v1
     run: ARS
     stop:
-        episode_reward_mean: 150
-        timesteps_total: 1000000
+        sampler_results/episode_reward_mean: 1
+        timesteps_total: 1
     config:
         # Works for both torch and tf.
         framework: torch

--- a/rllib/tuned_examples/ars/cartpole-ars.yaml
+++ b/rllib/tuned_examples/ars/cartpole-ars.yaml
@@ -2,8 +2,8 @@ cartpole-ars:
     env: CartPole-v1
     run: ARS
     stop:
-        sampler_results/episode_reward_mean: 1
-        timesteps_total: 1
+        sampler_results/episode_reward_mean: 150
+        timesteps_total: 1000000
     config:
         # Works for both torch and tf.
         framework: torch


### PR DESCRIPTION
## Why are these changes needed?

At the moment, ES humanoid release test does not pass even though rewards are high enough.
This is because we don't make use of our usual metrics construction in ES.
This PR makes it so that ES returns the reward from evaluation workers like other algorithms do.
This is needed because our test utils that are used for release tests expect the mean reward to be at the same place for all algorithms.

Picks https://github.com/ray-project/ray/pull/35533

