### PR TITLE
[Streaming Generator] Fix a reference leak when a stream is deleted with out of order writes.

### DIFF
--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -120,6 +120,11 @@ class ObjectRefStream {
   /// \param[in] The last item index that means the end of stream.
   void MarkEndOfStream(int64_t item_index);
 
+  /// Get all the ObjectIDs that are not read yet via TryReadNextItem.
+  ///
+  /// \return A list of object IDs that are not read yet.
+  std::vector<ObjectID> GetItemsUnconsumed() const;
+
  private:
   const ObjectID generator_id_;
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, when we delete the `ObjectRefStream`, we have the following logics.
- Keeps reading the next references 
- If it reaches EoF, finish reading it.
- If there's no next index, finish reading it.
- Since all these unconsumed objects have a local reference we call `RemoveLocalReferences` to remove references.

This doesn't work well when the items are written in out of order, For example, see the following example.

Write (index 1) -> Delete -> Write (index 0). In this case, Delete thinks there's no references in the stream because it checks index 0 and found there's no references. It stops reading the stream. This works when the ordering of write is ensured, but not when it is not.

This PR fixes the issue by instead reading all unconsumed references via `GetItemsUnconsumed` API. This API will return every references that are not read yet. 

When the references are written out of order,

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
