### PR TITLE
[RLlib] Fix ARS tuned example

### DIFF
--- a/rllib/tuned_examples/ars/cartpole-ars.yaml
+++ b/rllib/tuned_examples/ars/cartpole-ars.yaml
@@ -2,8 +2,8 @@ cartpole-ars:
     env: CartPole-v1
     run: ARS
     stop:
-        sampler_results/episode_reward_mean: 1
-        timesteps_total: 1
+        sampler_results/episode_reward_mean: 150
+        timesteps_total: 1000000
     config:
         # Works for both torch and tf.
         framework: torch


### PR DESCRIPTION
## Why are these changes needed?

My previous changed the ARS tuned examples (for debugging) and I forgot to clean that up.
This does not change the validity of the actual fix the PR attempted to do.

Previous changes: https://github.com/ray-project/ray/pull/35533