### PR TITLE
[RLlib] Fix missing action distribution error in policy files

### DIFF
--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -135,6 +135,10 @@ class PPOConfig(PGConfig):
             # Add constructor kwargs here (if any).
         }
 
+        # enable the rl module api by default
+        self.rl_module(_enable_rl_module_api=True)
+        self.training(_enable_learner_api=True)
+
     @override(AlgorithmConfig)
     def get_default_rl_module_spec(self) -> SingleAgentRLModuleSpec:
         if self.framework_str == "torch":
@@ -294,6 +298,11 @@ class PPOConfig(PGConfig):
 
     @override(AlgorithmConfig)
     def validate(self) -> None:
+
+        # Can not use Tf with learner api.
+        if self.framework_str == "tf":
+            self.rl_module(_enable_rl_module_api=False)
+            self.training(_enable_learner_api=False)
 
         # Call super's validation method.
         super().validate()

--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -135,10 +135,6 @@ class PPOConfig(PGConfig):
             # Add constructor kwargs here (if any).
         }
 
-        # enable the rl module api by default
-        self.rl_module(_enable_rl_module_api=True)
-        self.training(_enable_learner_api=True)
-
     @override(AlgorithmConfig)
     def get_default_rl_module_spec(self) -> SingleAgentRLModuleSpec:
         if self.framework_str == "torch":
@@ -298,11 +294,6 @@ class PPOConfig(PGConfig):
 
     @override(AlgorithmConfig)
     def validate(self) -> None:
-
-        # Can not use Tf with learner api.
-        if self.framework_str == "tf":
-            self.rl_module(_enable_rl_module_api=False)
-            self.training(_enable_learner_api=False)
 
         # Call super's validation method.
         super().validate()

--- a/rllib/policy/eager_tf_policy_v2.py
+++ b/rllib/policy/eager_tf_policy_v2.py
@@ -613,9 +613,16 @@ class EagerTFPolicyV2(Policy):
                             "True."
                         )
 
-                action_dist = action_dist_cls.from_logits(
-                    output[SampleBatch.ACTION_DIST_INPUTS]
-                )
+                action_dist_inputs = output.get(SampleBatch.ACTION_DIST_INPUTS, None)
+                if action_dist_inputs is None:
+                    raise ValueError(
+                        "The RLModules must provide inputs to create the action "
+                        "distribution. These should be part of the output of the "
+                        "appropriate forward method under the key "
+                        "SampleBatch.ACTION_DIST_INPUTS."
+                    )
+
+                action_dist = action_dist_cls.from_logits(action_dist_inputs)
             else:
                 dist_inputs, _ = self.model(input_batch, state_batches, seq_lens)
                 action_dist = self.dist_class(dist_inputs, self.model)

--- a/rllib/policy/torch_policy_v2.py
+++ b/rllib/policy/torch_policy_v2.py
@@ -622,20 +622,26 @@ class TorchPolicyV2(Policy):
                 if self.config.get("_enable_rl_module_api", False):
                     if in_training:
                         output = self.model.forward_train(input_dict)
+                        action_dist_cls = self.model.get_train_action_dist_cls()
+                        if action_dist_cls is None:
+                            raise ValueError(
+                                "The RLModules must provide an appropriate action "
+                                "distribution class for training if is_eval_mode is "
+                                "False."
+                            )
                     else:
-                        self.model.eval()
                         output = self.model.forward_exploration(input_dict)
+                        action_dist_cls = self.model.get_exploration_action_dist_cls()
+                        if action_dist_cls is None:
+                            raise ValueError(
+                                "The RLModules must provide an appropriate action "
+                                "distribution class for exploration if is_eval_mode is "
+                                "True."
+                            )
 
-                    action_dist = output.get(SampleBatch.ACTION_DIST)
-
-                    if action_dist is None:
-                        raise ValueError(
-                            "The model output must contain the key "
-                            "`SampleBatch.ACTION_DIST` when using the RL module API."
-                            "Make sure if is_eval_mode is True the forward_exploration "
-                            "returns this key, and if it is False the forward_train "
-                            "returns this key."
-                        )
+                    action_dist = action_dist_cls.from_logits(
+                        output[SampleBatch.ACTION_DIST_INPUTS]
+                    )
                 else:
                     dist_class = self.dist_class
                     dist_inputs, _ = self.model(input_dict, state_batches, seq_lens)

--- a/rllib/policy/torch_policy_v2.py
+++ b/rllib/policy/torch_policy_v2.py
@@ -639,9 +639,18 @@ class TorchPolicyV2(Policy):
                                 "True."
                             )
 
-                    action_dist = action_dist_cls.from_logits(
-                        output[SampleBatch.ACTION_DIST_INPUTS]
+                    action_dist_inputs = output.get(
+                        SampleBatch.ACTION_DIST_INPUTS, None
                     )
+                    if action_dist_inputs is None:
+                        raise ValueError(
+                            "The RLModules must provide inputs to create the action "
+                            "distribution. These should be part of the output of the "
+                            "appropriate forward method under the key "
+                            "SampleBatch.ACTION_DIST_INPUTS."
+                        )
+
+                    action_dist = action_dist_cls.from_logits(action_dist_inputs)
                 else:
                     dist_class = self.dist_class
                     dist_inputs, _ = self.model(input_dict, state_batches, seq_lens)


### PR DESCRIPTION
## Why are these changes needed?

Since we moves action distributions out of forward methods, we missed a small part of that move:
The TorchPolicyV2 and The EagerTFPolicyV2.
This PR fixes that. Therefore, it fixes test_compute_log_likelihoods test.

Affected test was test_compute_log_likelihoods