### PR TITLE
[RLlib] Fix self play examples with RL Modules

### DIFF
--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -135,6 +135,10 @@ class PPOConfig(PGConfig):
             # Add constructor kwargs here (if any).
         }
 
+        # enable the rl module api by default
+        self.rl_module(_enable_rl_module_api=True)
+        self.training(_enable_learner_api=True)
+
     @override(AlgorithmConfig)
     def get_default_rl_module_spec(self) -> SingleAgentRLModuleSpec:
         if self.framework_str == "torch":
@@ -294,6 +298,11 @@ class PPOConfig(PGConfig):
 
     @override(AlgorithmConfig)
     def validate(self) -> None:
+
+        # Can not use Tf with learner api.
+        if self.framework_str == "tf":
+            self.rl_module(_enable_rl_module_api=False)
+            self.training(_enable_learner_api=False)
 
         # Call super's validation method.
         super().validate()

--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -135,10 +135,6 @@ class PPOConfig(PGConfig):
             # Add constructor kwargs here (if any).
         }
 
-        # enable the rl module api by default
-        self.rl_module(_enable_rl_module_api=True)
-        self.training(_enable_learner_api=True)
-
     @override(AlgorithmConfig)
     def get_default_rl_module_spec(self) -> SingleAgentRLModuleSpec:
         if self.framework_str == "torch":
@@ -298,11 +294,6 @@ class PPOConfig(PGConfig):
 
     @override(AlgorithmConfig)
     def validate(self) -> None:
-
-        # Can not use Tf with learner api.
-        if self.framework_str == "tf":
-            self.rl_module(_enable_rl_module_api=False)
-            self.training(_enable_learner_api=False)
 
         # Call super's validation method.
         super().validate()

--- a/rllib/examples/rl_module/random_rl_module.py
+++ b/rllib/examples/rl_module/random_rl_module.py
@@ -1,12 +1,10 @@
 from typing import Mapping, Any
 from ray.rllib.core.rl_module import RLModule
+import pathlib
 import gymnasium as gym
 
 
 class RandomRLModule(RLModule):
-    def __init__(self, action_space):
-        self.action_space = action_space
-
     def _forward_inference(self, batch, **kwargs):
         # TODO (Kourosh): Implement this when we completely replace RandomPolicy.
         raise NotImplementedError
@@ -23,6 +21,12 @@ class RandomRLModule(RLModule):
         return {}
 
     def set_state(self, state_dict: Mapping[str, Any]) -> None:
+        pass
+
+    def _module_state_file_name(self) -> pathlib.Path:
+        return pathlib.Path("random_rl_module_dummy_state")
+
+    def save_state(self, path) -> None:
         pass
 
     @classmethod


### PR DESCRIPTION
## Why are these changes needed?

In order to switch on RL Modules for PPO by default, the random RL Module needs some changes.
This is because we have done some Learner migrations without making the necessary adjustments to the random RL Module for checkpointing.

Fixed test are the ones called self_play_with_open_spiel_connect_4.*