### PR TITLE
[RLlib] Fix _fake model to support testing with RL Modules and torch

### DIFF
--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -135,6 +135,10 @@ class PPOConfig(PGConfig):
             # Add constructor kwargs here (if any).
         }
 
+        # enable the rl module api by default
+        self.rl_module(_enable_rl_module_api=True)
+        self.training(_enable_learner_api=True)
+
     @override(AlgorithmConfig)
     def get_default_rl_module_spec(self) -> SingleAgentRLModuleSpec:
         if self.framework_str == "torch":
@@ -294,6 +298,11 @@ class PPOConfig(PGConfig):
 
     @override(AlgorithmConfig)
     def validate(self) -> None:
+
+        # Can not use Tf with learner api.
+        if self.framework_str == "tf":
+            self.rl_module(_enable_rl_module_api=False)
+            self.training(_enable_learner_api=False)
 
         # Call super's validation method.
         super().validate()

--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -135,10 +135,6 @@ class PPOConfig(PGConfig):
             # Add constructor kwargs here (if any).
         }
 
-        # enable the rl module api by default
-        self.rl_module(_enable_rl_module_api=True)
-        self.training(_enable_learner_api=True)
-
     @override(AlgorithmConfig)
     def get_default_rl_module_spec(self) -> SingleAgentRLModuleSpec:
         if self.framework_str == "torch":
@@ -298,11 +294,6 @@ class PPOConfig(PGConfig):
 
     @override(AlgorithmConfig)
     def validate(self) -> None:
-
-        # Can not use Tf with learner api.
-        if self.framework_str == "tf":
-            self.rl_module(_enable_rl_module_api=False)
-            self.training(_enable_learner_api=False)
 
         # Call super's validation method.
         super().validate()

--- a/rllib/examples/policy/episode_env_aware_policy.py
+++ b/rllib/examples/policy/episode_env_aware_policy.py
@@ -42,6 +42,12 @@ class EpisodeEnvAwareLSTMPolicy(RandomPolicy):
                         space=state_space
                     )
 
+            def compile(self, *args, **kwargs):
+                """Dummy method for compatibility with TorchRLModule.
+
+                This is hit when RolloutWorker tries to compile TorchRLModule."""
+                pass
+
         self.model = _fake_model(self.state_space, self.action_space)
 
         self.view_requirements = dict(
@@ -132,6 +138,12 @@ class EpisodeEnvAwareAttentionPolicy(RandomPolicy):
                         space=state_space, used_for_compute_actions=False
                     ),
                 }
+
+            def compile(self, *args, **kwargs):
+                """Dummy method for compatibility with TorchRLModule.
+
+                This is hit when RolloutWorker tries to compile TorchRLModule."""
+                pass
 
             # We need to provide at least an initial state if we want agent collector
             # to build episodes with state_in_ and state_out_


### PR DESCRIPTION
## Why are these changes needed?

Since the TorchRLModule has a method `compile()` and the test_trajectory_view_api tests still use the random policies in question, their fake models need to act as dummy torch RL Modules here.

Fixed test is test_trajectory_view_api