### PR TITLE
[RLlib] Fix Checkpointing test when using Learner API

### DIFF
--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -135,6 +135,10 @@ class PPOConfig(PGConfig):
             # Add constructor kwargs here (if any).
         }
 
+        # enable the rl module api by default
+        self.rl_module(_enable_rl_module_api=True)
+        self.training(_enable_learner_api=True)
+
     @override(AlgorithmConfig)
     def get_default_rl_module_spec(self) -> SingleAgentRLModuleSpec:
         if self.framework_str == "torch":
@@ -294,6 +298,11 @@ class PPOConfig(PGConfig):
 
     @override(AlgorithmConfig)
     def validate(self) -> None:
+
+        # Can not use Tf with learner api.
+        if self.framework_str == "tf":
+            self.rl_module(_enable_rl_module_api=False)
+            self.training(_enable_learner_api=False)
 
         # Call super's validation method.
         super().validate()

--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -135,10 +135,6 @@ class PPOConfig(PGConfig):
             # Add constructor kwargs here (if any).
         }
 
-        # enable the rl module api by default
-        self.rl_module(_enable_rl_module_api=True)
-        self.training(_enable_learner_api=True)
-
     @override(AlgorithmConfig)
     def get_default_rl_module_spec(self) -> SingleAgentRLModuleSpec:
         if self.framework_str == "torch":
@@ -298,11 +294,6 @@ class PPOConfig(PGConfig):
 
     @override(AlgorithmConfig)
     def validate(self) -> None:
-
-        # Can not use Tf with learner api.
-        if self.framework_str == "tf":
-            self.rl_module(_enable_rl_module_api=False)
-            self.training(_enable_learner_api=False)
 
         # Call super's validation method.
         super().validate()

--- a/rllib/examples/checkpoint_by_custom_criteria.py
+++ b/rllib/examples/checkpoint_by_custom_criteria.py
@@ -86,15 +86,19 @@ if __name__ == "__main__":
 
     # Get the best checkpoints from the trial, based on different metrics.
     # Checkpoint with the lowest policy loss value:
-    ckpt = results.get_best_result(
-        metric="info/learner/default_policy/learner_stats/policy_loss", mode="min"
-    ).checkpoint
+    if config._enable_learner_api:
+        policy_loss_key = "info/learner/default_policy/policy_loss"
+    else:
+        policy_loss_key = "info/learner/default_policy/learner_stats/policy_loss"
+    ckpt = results.get_best_result(metric=policy_loss_key, mode="min").checkpoint
     print("Lowest pol-loss: {}".format(ckpt))
 
     # Checkpoint with the highest value-function loss:
-    ckpt = results.get_best_result(
-        metric="info/learner/default_policy/learner_stats/vf_loss", mode="max"
-    ).checkpoint
+    if config._enable_learner_api:
+        vf_loss_key = "info/learner/default_policy/vf_loss"
+    else:
+        vf_loss_key = "info/learner/default_policy/learner_stats/vf_loss"
+    ckpt = results.get_best_result(metric=vf_loss_key, mode="max").checkpoint
     print("Highest vf-loss: {}".format(ckpt))
 
     ray.shutdown()


### PR DESCRIPTION
## Why are these changes needed?

With the Learner API, we don't use `info/learner/default_policy/learner_stats` anymore to store information about the learner but store it in `info/learner/default_policy/`.
This PR makes it so that the test picks the correct path based on whether Learner API is used.

Fixed test is checkpoint_by_custom_criteria