### PR TITLE
[RLlib] More time for PPO learner tests

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1159,7 +1159,7 @@ py_test(
 py_test(
     name = "test_ppo_learner",
     tags = ["team:rllib", "algorithms_dir"],
-    size = "medium",
+    size = "large",
     srcs = ["algorithms/ppo/tests/test_ppo_learner.py"]
 )
 


### PR DESCRIPTION
## Why are these changes needed?

Because of the new KL test for the PPO learner, the whole test has because flakey because of timeouts.
This PR gives the test more time.

<img width="512" alt="Screenshot 2023-05-22 at 21 35 21" src="https://github.com/ray-project/ray/assets/9356806/fe1cb740-7ed9-47b3-a43b-57238487b315">

<img width="840" alt="Screenshot 2023-05-22 at 21 35 33" src="https://github.com/ray-project/ray/assets/9356806/1887ee2a-6ebf-45a9-89df-e885c5f6e4e3">
