### PR TITLE
[RLlib] Deflake gym API tests

### DIFF
--- a/rllib/tests/backward_compat/test_gym_env_apis.py
+++ b/rllib/tests/backward_compat/test_gym_env_apis.py
@@ -131,7 +131,9 @@ class TestGymEnvAPIs(unittest.TestCase):
             (
                 PPOConfig()
                 .environment(env=GymnasiumOldAPI, auto_wrap_old_gym_envs=False)
-                .rollouts(num_envs_per_worker=2, num_rollout_workers=2)
+                # Forces the error to be raised on the local worker so that it is not
+                # swallowed by a RayActorError and speeds the test up.
+                .rollouts(num_rollout_workers=0)
                 .build()
             )
 
@@ -159,7 +161,9 @@ class TestGymEnvAPIs(unittest.TestCase):
             (
                 PPOConfig()
                 .environment(GymnasiumNewAPIButOldSpaces, auto_wrap_old_gym_envs=True)
-                .rollouts(num_envs_per_worker=2, num_rollout_workers=2)
+                # Forces the error to be raised on the local worker so that it is not
+                # swallowed by a RayActorError and speeds the test up.
+                .rollouts(num_rollout_workers=0)
                 .build()
             )
 
@@ -179,7 +183,9 @@ class TestGymEnvAPIs(unittest.TestCase):
                     GymnasiumNewAPIButThrowsErrorOnReset,
                     auto_wrap_old_gym_envs=True,
                 )
-                .rollouts(num_envs_per_worker=1, num_rollout_workers=0)
+                # Forces the error to be raised on the local worker so that it is not
+                # swallowed by a RayActorError and speeds the test up.
+                .rollouts(num_rollout_workers=0)
                 .build()
             )
 
@@ -198,7 +204,8 @@ class TestGymEnvAPIs(unittest.TestCase):
         algo = (
             PPOConfig()
             .environment("test", auto_wrap_old_gym_envs=False)
-            .rollouts(num_envs_per_worker=2, num_rollout_workers=2)
+            # Speeds the test up.
+            .rollouts(num_rollout_workers=0)
             .build()
         )
         algo.train()
@@ -211,7 +218,9 @@ class TestGymEnvAPIs(unittest.TestCase):
             (
                 PPOConfig()
                 .environment(env=OldGymEnv, auto_wrap_old_gym_envs=True)
-                .rollouts(num_envs_per_worker=2, num_rollout_workers=2)
+                # Forces the error to be raised on the local worker so that it is not
+                # swallowed by a RayActorError and speeds the test up.
+                .rollouts(num_rollout_workers=0)
                 .build()
             )
 
@@ -231,6 +240,9 @@ class TestGymEnvAPIs(unittest.TestCase):
                     MultiAgentGymnasiumOldAPI,
                     auto_wrap_old_gym_envs=False,
                 )
+                # Forces the error to be raised on the local worker so that it is not
+                # swallowed by a RayActorError and speeds the test up.
+                .rollouts(num_rollout_workers=0)
                 .build()
             )
 
@@ -250,6 +262,8 @@ class TestGymEnvAPIs(unittest.TestCase):
                 auto_wrap_old_gym_envs=True,
                 disable_env_checking=True,
             )
+            # Speeds the test up.
+            .rollouts(num_rollout_workers=0)
             .build()
         )
         algo.train()
@@ -270,6 +284,8 @@ class TestGymEnvAPIs(unittest.TestCase):
             .environment(
                 "test", auto_wrap_old_gym_envs=False, disable_env_checking=True
             )
+            # Speeds the test up.
+            .rollouts(num_rollout_workers=0)
             .build()
         )
         algo.train()


### PR DESCRIPTION
## Why are these changes needed?

This PR makes an attempt at deflaking our gym API tests.
If you look at the runs of these tests, it comes as a surprise that they are failing.
Most of them check if an error is raised with a regex to check for the content of the error message.
But failed runs I found do include the content.

My theory is that the flakeyness comes from us having to get lucky with where/when the error is raised.
In the tests, we have rolloutworkers managed by a worker set.
This might cause some non-determinism in when/where the error is raised and so sometimes it will 
be raised as a RayActorError (reraised [here](https://sourcegraph.com/github.com/ray-project/ray/-/blob/rllib/evaluation/worker_set.py?L197)).

I think it's worth a try to make these changes to see if that gets rid of the non-determinism.
As a side effect, it makes the tests a little quicker.

<img width="1535" alt="Screenshot 2023-05-22 at 21 57 59" src="https://github.com/ray-project/ray/assets/9356806/7394087a-f528-4c40-95f2-07db04d52139">
