### PR TITLE
[air] Store unflattened metrics in _TrackedCheckpoint

### DIFF
--- a/python/ray/air/_internal/checkpoint_manager.py
+++ b/python/ray/air/_internal/checkpoint_manager.py
@@ -379,6 +379,17 @@ class _CheckpointManager:
     def _get_checkpoint_score(
         self, checkpoint: _TrackedCheckpoint
     ) -> Tuple[bool, numbers.Number, int]:
+        """Get scoring tuple for a checkpoint, according to checkpoint strategy.
+
+        We sort checkpoints by this score. Checkpoints with a higher score are kept.
+        To achieve the desired ordering, we return a tuple of
+        (is_not_na: bool, metric: Number, checkpoint_id: int).
+
+        The first index means that checkpoints that are NaN are rated worst.
+        The second index sorts the checkpoints by metric value. The third index
+        sorts checkpoints with the same metric value by their ID - more recent
+        checkpoints are rated higher.
+        """
         checkpoint_score_attribute = (
             self._checkpoint_strategy.checkpoint_score_attribute
         )

--- a/python/ray/air/_internal/checkpoint_manager.py
+++ b/python/ray/air/_internal/checkpoint_manager.py
@@ -382,16 +382,19 @@ class _CheckpointManager:
         checkpoint_score_attribute = (
             self._checkpoint_strategy.checkpoint_score_attribute
         )
-        try:
-            checkpoint_result = unflattened_lookup(
-                checkpoint_score_attribute, checkpoint.metrics
-            )
-        except KeyError:
-            logger.error(
-                f"Result dict has no key: {checkpoint_score_attribute}. "
-                f"checkpoint_score_attr must be set to a key in the "
-                f"result dict. Valid keys are: {list(checkpoint.metrics.keys())}"
-            )
+        if checkpoint_score_attribute:
+            try:
+                checkpoint_result = unflattened_lookup(
+                    checkpoint_score_attribute, checkpoint.metrics
+                )
+            except KeyError:
+                logger.error(
+                    f"Result dict has no key: {checkpoint_score_attribute}. "
+                    f"checkpoint_score_attr must be set to a key in the "
+                    f"result dict. Valid keys are: {list(checkpoint.metrics.keys())}"
+                )
+                checkpoint_result = float("-inf")
+        else:
             checkpoint_result = float("-inf")
 
         checkpoint_score_order = self._checkpoint_strategy.checkpoint_score_order

--- a/python/ray/air/_internal/checkpoint_manager.py
+++ b/python/ray/air/_internal/checkpoint_manager.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import ray
-from ray._private.dict import unflattened_lookup, flatten_dict
+from ray._private.dict import flatten_dict
 from ray.air import Checkpoint, CheckpointConfig
 from ray.air.config import MAX
 from ray.air.constants import COPY_DIRECTORY_CHECKPOINTS_INSTEAD_OF_MOVING_ENV
@@ -383,12 +383,11 @@ class _CheckpointManager:
             self._checkpoint_strategy.checkpoint_score_attribute
         )
         if checkpoint_score_attribute:
+            flat_metrics = flatten_dict(checkpoint.metrics)
             try:
-                checkpoint_result = unflattened_lookup(
-                    checkpoint_score_attribute, checkpoint.metrics
-                )
+                checkpoint_result = flat_metrics[checkpoint_score_attribute]
             except KeyError:
-                valid_keys = list(flatten_dict(checkpoint.metrics).keys())
+                valid_keys = list(flat_metrics.keys())
                 logger.error(
                     f"Result dict has no key: {checkpoint_score_attribute}. "
                     f"checkpoint_score_attr must be set to a key in the "

--- a/python/ray/air/_internal/checkpoint_manager.py
+++ b/python/ray/air/_internal/checkpoint_manager.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import ray
-from ray._private.dict import unflattened_lookup
+from ray._private.dict import unflattened_lookup, flatten_dict
 from ray.air import Checkpoint, CheckpointConfig
 from ray.air.config import MAX
 from ray.air.constants import COPY_DIRECTORY_CHECKPOINTS_INSTEAD_OF_MOVING_ENV
@@ -388,10 +388,11 @@ class _CheckpointManager:
                     checkpoint_score_attribute, checkpoint.metrics
                 )
             except KeyError:
+                valid_keys = list(flatten_dict(checkpoint.metrics).keys())
                 logger.error(
                     f"Result dict has no key: {checkpoint_score_attribute}. "
                     f"checkpoint_score_attr must be set to a key in the "
-                    f"result dict. Valid keys are: {list(checkpoint.metrics.keys())}"
+                    f"result dict. Valid keys are: {valid_keys}"
                 )
                 checkpoint_result = float("-inf")
         else:

--- a/python/ray/air/tests/test_checkpoint_manager.py
+++ b/python/ray/air/tests/test_checkpoint_manager.py
@@ -97,38 +97,31 @@ def test_keep_best_checkpoints():
     ] == [1, 0]
 
 
-def test_nested_get_checkpoint_score():
+@pytest.mark.parametrize(
+    "metrics",
+    [
+        {"nested": {"sub": {"attr": 5}}},
+        {"nested": {"sub/attr": 5}},
+        {"nested/sub": {"attr": 5}},
+        {"nested/sub/attr": 5},
+    ],
+)
+def test_nested_get_checkpoint_score(metrics):
     cpm = _CheckpointManager(
         checkpoint_strategy=CheckpointConfig(
             num_to_keep=2,
-            checkpoint_score_attribute="nested/attr",
+            checkpoint_score_attribute="nested/sub/attr",
             checkpoint_score_order="max",
         )
     )
 
-    # Nested metric
     assert cpm._get_checkpoint_score(
         _TrackedCheckpoint(
             dir_or_data=None,
-            metrics={
-                "foo": 2.0,
-                "nested": {"attr": 5},
-            },
+            metrics=metrics,
             storage_mode=CheckpointStorage.MEMORY,
         )
-    ) == (True, 5.0, None)
-
-    # Non-nested metric containing `/`
-    assert cpm._get_checkpoint_score(
-        _TrackedCheckpoint(
-            dir_or_data=None,
-            metrics={
-                "foo": 2.0,
-                "nested/attr": 6,
-            },
-            storage_mode=CheckpointStorage.MEMORY,
-        )
-    ) == (True, 6.0, None)
+    ) == (True, 5.0, None), metrics
 
 
 if __name__ == "__main__":

--- a/python/ray/air/tests/test_checkpoint_manager.py
+++ b/python/ray/air/tests/test_checkpoint_manager.py
@@ -97,6 +97,40 @@ def test_keep_best_checkpoints():
     ] == [1, 0]
 
 
+def test_nested_get_checkpoint_score():
+    cpm = _CheckpointManager(
+        checkpoint_strategy=CheckpointConfig(
+            num_to_keep=2,
+            checkpoint_score_attribute="nested/attr",
+            checkpoint_score_order="max",
+        )
+    )
+
+    # Nested metric
+    assert cpm._get_checkpoint_score(
+        _TrackedCheckpoint(
+            dir_or_data=None,
+            metrics={
+                "foo": 2.0,
+                "nested": {"attr": 5},
+            },
+            storage_mode=CheckpointStorage.MEMORY,
+        )
+    ) == (True, 5.0, None)
+
+    # Non-nested metric containing `/`
+    assert cpm._get_checkpoint_score(
+        _TrackedCheckpoint(
+            dir_or_data=None,
+            metrics={
+                "foo": 2.0,
+                "nested/attr": 6,
+            },
+            storage_mode=CheckpointStorage.MEMORY,
+        )
+    ) == (True, 6.0, None)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -16,7 +16,6 @@ from typing import Any, Dict, Optional, Sequence, Union, Callable, List, Tuple
 import uuid
 
 import ray
-from ray._private.dict import unflatten_dict
 from ray.air import CheckpointConfig
 from ray.air._internal.uri_utils import URI
 from ray.air._internal.checkpoint_manager import _TrackedCheckpoint, CheckpointStorage
@@ -994,7 +993,7 @@ class Trial:
     def on_restore(self):
         """Handles restoration completion."""
         assert self.is_restoring
-        self.last_result = unflatten_dict(self.restoring_from.metrics)
+        self.last_result = self.restoring_from.metrics
         self.last_result.setdefault("config", self.config)
         self.restoring_from = None
         self.num_restore_failures = 0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We currently store metrics associated with a tracked AIR checkpoint in flattened format. This was done so we can specify nested keys in e.g. `checkpoint_score_attr`, which determines which checkpoints to keep.

However, we also rely on these stored metrics to restore the `trial.last_result` property when restoring from a checkpoint. Since #35000, we unflatten the dict there to resolve issues where we relied on the original structure in `trial.last_result`.

This again leads to issues with metrics in e.g. pytorch lightning, where some metrics are reported with a `/` (our default flatten separator). Or in a nutshell, `dict != unflatten(flatten(dict))` when the separator can be contained in the dict keys.

Some users may prefer to report with `/`, since it shows up nicely as nested metrics in wandb.

The proper resolution here is to not flatten the metrics at all. Instead, we should use `unflattened_lookup` to lookup the `checkpoint_score_attr` from the original metrics dict. 

This PR updates the `_TrackedCheckpoint` to retain the unflattened metrics.

## Related issue number

Closes #35187

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
