### PR TITLE
[RLlib] Fix duplicate `setup()` in RLModules; In framework-specific RLModule sub-classes, flip inheritance order and remove c'tors.

### DIFF
--- a/rllib/algorithms/dreamerv3/tf/dreamerv3_tf_rl_module.py
+++ b/rllib/algorithms/dreamerv3/tf/dreamerv3_tf_rl_module.py
@@ -12,17 +12,13 @@ from ray.rllib.utils.nested_dict import NestedDict
 tf1, tf, _ = try_import_tf()
 
 
-class DreamerV3TfRLModule(DreamerV3RLModule, TfRLModule):
+class DreamerV3TfRLModule(TfRLModule, DreamerV3RLModule):
     """The tf-specific RLModule class for DreamerV3.
 
     Serves mainly as a thin-wrapper around the `DreamerModel` (a tf.keras.Model) class.
     """
 
     framework: str = "tf2"
-
-    def __init__(self, *args, **kwargs):
-        TfRLModule.__init__(self, *args, **kwargs)
-        DreamerV3RLModule.__init__(self, *args, **kwargs)
 
     @override(RLModule)
     def _forward_inference(self, batch: NestedDict) -> Mapping[str, Any]:

--- a/rllib/algorithms/ppo/tf/ppo_tf_rl_module.py
+++ b/rllib/algorithms/ppo/tf/ppo_tf_rl_module.py
@@ -13,12 +13,8 @@ from ray.rllib.utils.nested_dict import NestedDict
 tf1, tf, _ = try_import_tf()
 
 
-class PPOTfRLModule(PPORLModule, TfRLModule):
+class PPOTfRLModule(TfRLModule, PPORLModule):
     framework: str = "tf2"
-
-    def __init__(self, *args, **kwargs):
-        TfRLModule.__init__(self, *args, **kwargs)
-        PPORLModule.__init__(self, *args, **kwargs)
 
     @override(RLModule)
     def _forward_inference(self, batch: NestedDict) -> Mapping[str, Any]:

--- a/rllib/algorithms/ppo/torch/ppo_torch_rl_module.py
+++ b/rllib/algorithms/ppo/torch/ppo_torch_rl_module.py
@@ -13,12 +13,8 @@ from ray.rllib.utils.nested_dict import NestedDict
 torch, nn = try_import_torch()
 
 
-class PPOTorchRLModule(PPORLModule, TorchRLModule):
+class PPOTorchRLModule(TorchRLModule, PPORLModule):
     framework: str = "torch"
-
-    def __init__(self, *args, **kwargs):
-        TorchRLModule.__init__(self, *args, **kwargs)
-        PPORLModule.__init__(self, *args, **kwargs)
 
     @override(RLModule)
     def _forward_inference(self, batch: NestedDict) -> Mapping[str, Any]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Simplify framework-specific RLModule sub-classes (flip inheritance order, remove c'tor)

Currently, we are calling `RLModule.setup()` twice for the framework-specific, algo-specific RLModule sub-classes, such as `PPOTfRLModule`. For proof, change the ctor of PPOTfRLModule to:
```
    def __init__(self, *args, **kwargs):
        print("PPOTfRLModule c/tor start")
        TfRLModule.__init__(self, *args, **kwargs)
        PPORLModule.__init__(self, *args, **kwargs)
        print("PPOTfRLModule c/tor end")
```
And add another print statement to the `RLModule.setup()` method.

This results in the output (when running a PPO):
```
PPOTfRLModule c/tor start
calling setup ...
calling setup ...
PPOTfRLModule c/tor end
```

In this PR:
* For PPO(Tf|Torch)RLModule and DreamerV3TfRLModule, we flip the multi-inheritance order ([Tf|Torch]RLModule first, then `[algo]RLModule`).
* This allows us to remove the constructors entirely (b/c TfRLModule AND TorchRLModule super constructors must be called first to initialize the keras/torch base Models).
* It also avoids the RLModule `setup()` method to be called twice. We currently do that (unknowlingly) b/c our constructors have the form:
```
def __init__(self, *args, **kwargs):
    TfRLModule.__init__(self, *args, **kwargs)
    [Algo]RLModule.__init__(self, *args, **kwargs)
```
B/c we cannot user `super()` right now, this means that these two super constructors are called indiscriminatorily of the dimaond shaped inheritance pattern used here (TfRLModule is-a RLModule, but [Algo]RLModule is-also-a RLModule :( )

The changes in this PR fix this conundrum.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
