### PR TITLE
[Train] Fix `TorchCheckpoint` encoding directories

### DIFF
--- a/python/ray/air/checkpoint.py
+++ b/python/ray/air/checkpoint.py
@@ -348,8 +348,8 @@ class Checkpoint:
         """
         # Todo: Add support for stream in the future (to_bytes(file_like))
         data_dict = self.to_dict()
-        if "bytes_data" in data_dict:
-            return data_dict["bytes_data"]
+        if _BYTES_DATA_KEY in data_dict:
+            return data_dict[_BYTES_DATA_KEY]
         return pickle.dumps(data_dict)
 
     @classmethod

--- a/python/ray/train/torch/torch_checkpoint.py
+++ b/python/ray/train/torch/torch_checkpoint.py
@@ -7,7 +7,7 @@ import warnings
 from torch.nn import Module
 
 import ray.cloudpickle
-from ray.air.checkpoint import Checkpoint
+from ray.air.checkpoint import Checkpoint, _BYTES_DATA_KEY, _FS_CHECKPOINT_KEY
 from ray.air.constants import MODEL_KEY, PREPROCESSOR_KEY
 from ray.train.data_parallel_trainer import _load_checkpoint_dict
 from ray.air._internal.torch_utils import (
@@ -34,6 +34,13 @@ class TorchCheckpoint(Checkpoint):
     def _encode_data_dict(self, data_dict: dict) -> dict:
         """Encode data_dict using torch.save."""
 
+        # If we have _BYTES_DATA_KEY or _FS_CHECKPOINT_KEY in the data dict,
+        # that means this is a directory checkpoint which has already been
+        # converted into bytes. We don't want to double-encode it.
+        # See the definition of super().__getstate__().
+        if _BYTES_DATA_KEY in data_dict or _FS_CHECKPOINT_KEY in data_dict:
+            return data_dict
+
         for k, v in data_dict.items():
             # Only check for attribute as we want to support
             # DDP, FSDP and any future approaches
@@ -58,6 +65,7 @@ class TorchCheckpoint(Checkpoint):
         """Decode data_dict using torch_load if needed."""
         if ENCODED_DATA_KEY not in data_dict:
             return data_dict
+
         encoded_data = data_dict[ENCODED_DATA_KEY]
         _buffer = io.BytesIO(encoded_data)
         data_dict = torch.load(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes the issue where `TorchCheckpoint` would try to apply the dictionary encoding logic to directories, causing increased memory usage and exceptions for checkpoints larger than 4 GB.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
