### PR TITLE
[Serve] [Dashboard] Omit `colorama` characters in Serve RayTaskError message

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -18,6 +18,9 @@ from ray.util.annotations import DeveloperAPI, PublicAPI
 
 import setproctitle
 
+TRACEBACK_COLOR = colorama.Fore.CYAN
+END_COLOR = colorama.Fore.RESET
+
 
 @PublicAPI
 class RayError(Exception):
@@ -186,9 +189,9 @@ class RayTaskError(RayError):
             if line.startswith("Traceback "):
                 if colorize:
                     traceback_line = (
-                        f"{colorama.Fore.CYAN}"
+                        f"{TRACEBACK_COLOR}"
                         f"{self.proctitle}()"
-                        f"{colorama.Fore.RESET} "
+                        f"{END_COLOR} "
                         f"(pid={self.pid}, ip={self.ip}"
                     )
                 else:

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -162,8 +162,14 @@ class RayTaskError(RayError):
 
         return cls(self.cause)
 
-    def __str__(self):
-        """Format a RayTaskError as a string."""
+    def get_formatted_traceback(self, colorize=True):
+        """Reformats the traceback string nicely.
+
+        Args:
+            colorize: Whether to insert colorama characters that colorize the
+                traceback.
+        """
+
         lines = self.traceback_str.strip().split("\n")
         out = []
         code_from_internal_file = False
@@ -178,12 +184,17 @@ class RayTaskError(RayError):
         for i, line in enumerate(lines):
             # Convert traceback to the readable information.
             if line.startswith("Traceback "):
-                traceback_line = (
-                    f"{colorama.Fore.CYAN}"
-                    f"{self.proctitle}()"
-                    f"{colorama.Fore.RESET} "
-                    f"(pid={self.pid}, ip={self.ip}"
-                )
+                if colorize:
+                    traceback_line = (
+                        f"{colorama.Fore.CYAN}"
+                        f"{self.proctitle}()"
+                        f"{colorama.Fore.RESET} "
+                        f"(pid={self.pid}, ip={self.ip}"
+                    )
+                else:
+                    traceback_line = (
+                        f"{self.proctitle}()" f"(pid={self.pid}, ip={self.ip}"
+                    )
                 if self.actor_repr:
                     traceback_line += (
                         f", actor_id={self._actor_id}, repr={self.actor_repr})"
@@ -226,6 +237,10 @@ class RayTaskError(RayError):
             else:
                 out.append(line)
         return "\n".join(out)
+
+    def __str__(self):
+        """Format a RayTaskError as a string."""
+        return self.get_formatted_traceback()
 
 
 @PublicAPI

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -207,7 +207,10 @@ class ApplicationState:
                     # here because the full details of the error is not displayed
                     # properly with traceback.format_exc(). RayTaskError has its own
                     # custom __str__ function.
-                    self._app_msg = f"Deploying app '{self._name}' failed:\n{str(e)}"
+                    self._app_msg = (
+                        f"Deploying app '{self._name}' failed:"
+                        f"\n{e.get_formatted_traceback(colorize=False)}"
+                    )
                     logger.warning(self._app_msg)
                     return
                 except RuntimeEnvSetupError:

--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -401,6 +401,39 @@ def test_serialization_error_message(shutdown_only):
     )
 
 
+def test_ray_task_error_traceback_no_colorize():
+    """Check that RayTaskError doesn't use colorize when its disabled."""
+
+    # colorama should not be used when colorize is disabled
+    ray.exceptions.colorama = None
+    RayTaskError = ray.exceptions.RayTaskError
+
+    print(ray.exceptions.colorama)
+
+    err = RayTaskError(
+        function_name="test_func",
+        traceback_str="""Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+ZeroDivisionError: division by zero
+""",
+        cause=ZeroDivisionError,
+        proctitle="test proctitle",
+        pid=122,
+        ip="1.1.1.1",
+        actor_repr="test_actor_repr",
+        actor_id=11,
+    )
+
+    err.get_formatted_traceback(colorize=False)
+
+    with pytest.raises(AttributeError):
+        err.get_formatted_traceback(colorize=True)
+
+    # __str__ should return colored traceback
+    with pytest.raises(AttributeError):
+        str(err)
+
+
 if __name__ == "__main__":
     import pytest
     import os


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When Serve fails to deploy a deployment graph inside its `deploy_serve_application` task, it stores the traceback of the error. If the error is a `RayTaskError`, the traceback contains `colorama` characters that get inserted into the string. On the dashboard, these characters appear as-is rather than coloring the string.

This change removes the `colorama` characters from this traceback.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #35678

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds a unit test to `test_traceback.py` to ensure that `RayTaskError` doesn't use `colorama` when `colorize` is disabled.
