### PR TITLE
[Cherry pick][2/N] Streaming Generator.  Support core worker APIs + cython generat…

### DIFF
--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -99,6 +99,9 @@ cdef extern from "ray/common/status.h" namespace "ray" nogil:
         @staticmethod
         CRayStatus NotFound()
 
+        @staticmethod
+        CRayStatus ObjectRefStreamEoF()
+
         c_bool ok()
         c_bool IsOutOfMemory()
         c_bool IsKeyError()
@@ -118,6 +121,7 @@ cdef extern from "ray/common/status.h" namespace "ray" nogil:
         c_bool IsObjectUnknownOwner()
         c_bool IsRpcError()
         c_bool IsOutOfResource()
+        c_bool IsObjectRefStreamEoF()
 
         c_string ToString()
         c_string CodeAsString()

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -147,6 +147,11 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             const CObjectID& return_id,
             shared_ptr[CRayObject] *return_object,
             const CObjectID& generator_id)
+        void DelObjectRefStream(const CObjectID &generator_id)
+        void CreateObjectRefStream(const CObjectID &generator_id)
+        CRayStatus TryReadObjectRefStream(
+            const CObjectID &generator_id,
+            CObjectReference *object_ref_out)
         CObjectID AllocateDynamicReturnId()
 
         CJobID GetCurrentJobId()

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -46,6 +46,7 @@ py_test_module_list(
     "test_gcs_fault_tolerance.py",
     "test_gcs_utils.py",
     "test_generators.py",
+    "test_streaming_generator.py",
     "test_metrics_agent.py",
     "test_metrics_head.py",
     "test_component_failures_2.py",

--- a/python/ray/tests/test_streaming_generator.py
+++ b/python/ray/tests/test_streaming_generator.py
@@ -1,0 +1,143 @@
+import pytest
+import sys
+import time
+
+from unittest.mock import patch, Mock
+
+import ray
+from ray._raylet import StreamingObjectRefGenerator, ObjectRefStreamEoFError
+from ray.cloudpickle import dumps
+from ray.exceptions import WorkerCrashedError
+
+
+class MockedWorker:
+    def __init__(self, mocked_core_worker):
+        self.core_worker = mocked_core_worker
+
+    def reset_core_worker(self):
+        """Emulate the case ray.shutdown is called
+        and the core_worker instance is GC'ed.
+        """
+        self.core_worker = None
+
+
+@pytest.fixture
+def mocked_worker():
+    mocked_core_worker = Mock()
+    mocked_core_worker.try_read_next_object_ref_stream.return_value = None
+    mocked_core_worker.delete_object_ref_stream.return_value = None
+    mocked_core_worker.create_object_ref_stream.return_value = None
+    worker = MockedWorker(mocked_core_worker)
+    yield worker
+
+
+def test_streaming_object_ref_generator_basic_unit(mocked_worker):
+    """
+    Verify the basic case:
+    create a generator -> read values -> nothing more to read -> delete.
+    """
+    with patch("ray.wait") as mocked_ray_wait:
+        c = mocked_worker.core_worker
+        generator_ref = ray.ObjectRef.from_random()
+        generator = StreamingObjectRefGenerator(generator_ref, mocked_worker)
+        c.try_read_next_object_ref_stream.return_value = ray.ObjectRef.nil()
+        c.create_object_ref_stream.assert_called()
+
+        # Test when there's no new ref, it returns a nil.
+        mocked_ray_wait.return_value = [], [generator_ref]
+        ref = generator._next(timeout_s=0)
+        assert ref.is_nil()
+
+        # When the new ref is available, next should return it.
+        for _ in range(3):
+            new_ref = ray.ObjectRef.from_random()
+            c.try_read_next_object_ref_stream.return_value = new_ref
+            ref = generator._next(timeout_s=0)
+            assert new_ref == ref
+
+        # When try_read_next_object_ref_stream raises a
+        # ObjectRefStreamEoFError, it should raise a stop iteration.
+        c.try_read_next_object_ref_stream.side_effect = ObjectRefStreamEoFError(
+            ""
+        )  # noqa
+        with pytest.raises(StopIteration):
+            ref = generator._next(timeout_s=0)
+
+        # Make sure we cannot serialize the generator.
+        with pytest.raises(TypeError):
+            dumps(generator)
+
+        del generator
+        c.delete_object_ref_stream.assert_called()
+
+
+def test_streaming_object_ref_generator_task_failed_unit(mocked_worker):
+    """
+    Verify when a task is failed by a system error,
+    the generator ref is returned.
+    """
+    with patch("ray.get") as mocked_ray_get:
+        with patch("ray.wait") as mocked_ray_wait:
+            c = mocked_worker.core_worker
+            generator_ref = ray.ObjectRef.from_random()
+            generator = StreamingObjectRefGenerator(generator_ref, mocked_worker)
+
+            # Simulate the worker failure happens.
+            mocked_ray_wait.return_value = [generator_ref], []
+            mocked_ray_get.side_effect = WorkerCrashedError()
+
+            c.try_read_next_object_ref_stream.return_value = ray.ObjectRef.nil()
+            ref = generator._next(timeout_s=0)
+            # If the generator task fails by a systsem error,
+            # meaning the ref will raise an exception
+            # it should be returned.
+            print(ref)
+            print(generator_ref)
+            assert ref == generator_ref
+
+            # Once exception is raised, it should always
+            # raise stopIteration regardless of what
+            # the ref contains now.
+            with pytest.raises(StopIteration):
+                ref = generator._next(timeout_s=0)
+
+
+def test_streaming_object_ref_generator_network_failed_unit(mocked_worker):
+    """
+    Verify when a task is finished, but if the next ref is not available
+    on time, it raises an assertion error.
+
+    TODO(sang): Once we move the task subimssion path to use pubsub
+    to guarantee the ordering, we don't need this test anymore.
+    """
+    with patch("ray.get") as mocked_ray_get:
+        with patch("ray.wait") as mocked_ray_wait:
+            c = mocked_worker.core_worker
+            generator_ref = ray.ObjectRef.from_random()
+            generator = StreamingObjectRefGenerator(generator_ref, mocked_worker)
+
+            # Simulate the task has finished.
+            mocked_ray_wait.return_value = [generator_ref], []
+            mocked_ray_get.return_value = None
+
+            # If StopIteration is not raised within
+            # unexpected_network_failure_timeout_s second,
+            # it should fail.
+            c.try_read_next_object_ref_stream.return_value = ray.ObjectRef.nil()
+            ref = generator._next(timeout_s=0, unexpected_network_failure_timeout_s=1)
+            assert ref == ray.ObjectRef.nil()
+            time.sleep(1)
+            with pytest.raises(AssertionError):
+                generator._next(timeout_s=0, unexpected_network_failure_timeout_s=1)
+            # After that StopIteration should be raised.
+            with pytest.raises(StopIteration):
+                generator._next(timeout_s=0, unexpected_network_failure_timeout_s=1)
+
+
+if __name__ == "__main__":
+    import os
+
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2769,6 +2769,28 @@ Status CoreWorker::SealReturnObject(const ObjectID &return_id,
   return status;
 }
 
+void CoreWorker::CreateObjectRefStream(const ObjectID &generator_id) {
+  task_manager_->CreateObjectRefStream(generator_id);
+}
+
+void CoreWorker::DelObjectRefStream(const ObjectID &generator_id) {
+  task_manager_->DelObjectRefStream(generator_id);
+}
+
+Status CoreWorker::TryReadObjectRefStream(const ObjectID &generator_id,
+                                          rpc::ObjectReference *object_ref_out) {
+  ObjectID object_id;
+  const auto &status = task_manager_->TryReadObjectRefStream(generator_id, &object_id);
+  if (!status.ok()) {
+    return status;
+  }
+
+  RAY_CHECK(object_ref_out != nullptr);
+  object_ref_out->set_object_id(object_id.Binary());
+  object_ref_out->mutable_owner_address()->CopyFrom(rpc_address_);
+  return status;
+}
+
 bool CoreWorker::PinExistingReturnObject(const ObjectID &return_id,
                                          std::shared_ptr<RayObject> *return_object,
                                          const ObjectID &generator_id) {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -360,6 +360,38 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
 
   NodeID GetCurrentNodeId() const { return NodeID::FromBinary(rpc_address_.raylet_id()); }
 
+  /// Create the ObjectRefStream of generator_id.
+  ///
+  /// It is a pass-through method. See TaskManager::CreateObjectRefStream
+  /// for details.
+  ///
+  /// \param[in] generator_id The object ref id of the streaming
+  /// generator task.
+  void CreateObjectRefStream(const ObjectID &generator_id);
+
+  /// Read the next index of a ObjectRefStream of generator_id.
+  ///
+  /// \param[in] generator_id The object ref id of the streaming
+  /// generator task.
+  /// \param[out] object_ref_out The ObjectReference
+  /// that the caller can convert to its own ObjectRef.
+  /// The current process is always the owner of the
+  /// generated ObjectReference.
+  /// \return Status RayKeyError if the stream reaches to EoF.
+  /// OK otherwise.
+  Status TryReadObjectRefStream(const ObjectID &generator_id,
+                                rpc::ObjectReference *object_ref_out);
+
+  /// Delete the ObjectRefStream of generator_id
+  /// created by CreateObjectRefStream.
+  ///
+  /// It is a pass-through method. See TaskManager::DelObjectRefStream
+  /// for details.
+  ///
+  /// \param[in] generator_id The object ref id of the streaming
+  /// generator task.
+  void DelObjectRefStream(const ObjectID &generator_id);
+
   const PlacementGroupID &GetCurrentPlacementGroupId() const {
     return worker_context_.GetCurrentPlacementGroupId();
   }

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -1598,7 +1598,6 @@ TEST_F(TaskManagerTest, TestObjectRefStreamDelCleanReferences) {
   // NOTE: We panic if READ is called after DELETE. The
   // API caller should guarantee this doesn't happen.
   // So we don't test it.
-
   // WRITE 3. Should be ignored.
   auto dynamic_return_id3 = ObjectID::FromIndex(spec.TaskId(), 4);
   data = GenerateRandomBuffer();


### PR DESCRIPTION
…or interface. (#35324)

This is the second PR to support streaming generator.

The detailed design and API proposal can be found from https://docs.google.com/document/d/1hAASLe2sCoay23raqxqwJdSDiJWNMcNhlTwWJXsJOU4/edit#heading=h.w91y1fgnpu0m. The Execution plan can be found from https://docs.google.com/document/d/1hAASLe2sCoay23raqxqwJdSDiJWNMcNhlTwWJXsJOU4/edit#heading=h.kxktymq5ihf7. There will be 4 PRs to enable streaming generator for Ray Serve (phase 1).

 This PR -> introduce cpp interfaces to handle intermediate task return [1/N] Streaming Generator. Cpp interfaces and implementation #35291
 Support core worker APIs + cython generator interface. [2/N] Streaming Generator. Support core worker APIs + cython generator interface. #35324 < --- this PR
 E2e integration [3/N] Streaming Generator. E2e integration #35325 (review)
 Support async actors
This PR implements the Cython generator interface that users can use to obtain a next available object reference. ---------

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/issues/35634

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
