### PR TITLE
[Core]Fix the issue of frequent logging after sched_cls_id is too large

### DIFF
--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -46,10 +46,7 @@ SchedulingClass TaskSpecification::GetSchedulingClass(
   if (it == sched_cls_to_id_.end()) {
     sched_cls_id = ++next_sched_id_;
     // TODO(ekl) we might want to try cleaning up task types in these cases
-    if (sched_cls_id > 100) {
-      RAY_LOG(WARNING) << "More than " << sched_cls_id
-                       << " types of tasks seen, this may reduce performance.";
-    } else if (sched_cls_id > 1000) {
+    if (sched_cls_id >= 1000 && sched_cls_id % 100 == 0) {
       RAY_LOG(ERROR) << "More than " << sched_cls_id
                      << " types of tasks seen, this may reduce performance.";
     }


### PR DESCRIPTION
## Why are these changes needed?
1. There is a bug in this section - the "else if" branch is never executed;
2. If the number of placement groups created keeps increasing, then the sched_cls_id will continue to rise. Fix the issue of frequent logging after sched_cls_id is too large. 

## Related issue number

#35445

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
