### PR TITLE
[Streaming Generator] Fix a reference leak when pinning requests are received after refs are consumed.

### DIFF
--- a/python/ray/tests/test_streaming_generator.py
+++ b/python/ray/tests/test_streaming_generator.py
@@ -399,7 +399,30 @@ def test_generator_dist_chain(ray_start_cluster):
 
     for ref in chain_actor_4.get_data.options(num_returns="streaming").remote():
         assert np.array_equal(np.ones(5 * 1024 * 1024), ray.get(ref))
+        print("getting the next data")
         del ref
+
+
+def test_generator_slow_pinning_requests(monkeypatch, shutdown_only):
+    """
+    Verify when the Object pinning request from the raylet
+    is reported slowly, there's no refernece leak.
+    """
+    with monkeypatch.context() as m:
+        # defer for 10s for the second node.
+        m.setenv(
+            "RAY_testing_asio_delay_us",
+            "CoreWorkerService.grpc_server.PubsubLongPolling=1000000:1000000",
+        )
+
+        @ray.remote
+        def f():
+            yield np.ones(5 * 1024 * 1024)
+
+        for ref in f.options(num_returns="streaming").remote():
+            del ref
+
+        print(list_objects())
 
 
 if __name__ == "__main__":

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3286,10 +3286,9 @@ void CoreWorker::ProcessSubscribeForObjectEviction(
     const auto generator_id = ObjectID::FromBinary(message.generator_id());
     RAY_CHECK(!generator_id.IsNil());
     if (task_manager_->ObjectRefStreamExists(generator_id)) {
-      // It is possible this reference will leak if the ObjectRefStream is
-      // deleted or the corresponding object ID is not reported via
-      // HandleReportGeneratorItemReturns. TODO(sang): Handle the edge case.
-      reference_counter_->OwnDynamicStreamingTaskReturnRef(object_id, generator_id);
+      // ObjectRefStreamExists is used to distinguigsh num_returns="dynamic" vs
+      // "streaming".
+      task_manager_->TemporarilyOwnGeneratorReturnRefIfNeeded(object_id, generator_id);
     } else {
       reference_counter_->AddDynamicReturn(object_id, generator_id);
     }
@@ -3425,12 +3424,10 @@ void CoreWorker::AddSpilledObjectLocationOwner(
     // object is spilled before the reply from the task that created the
     // object. Add the dynamically created object to our ref counter so that we
     // know that it exists.
-    RAY_CHECK(!generator_id->IsNil());
     if (task_manager_->ObjectRefStreamExists(*generator_id)) {
-      // It is possible this reference will leak if the ObjectRefStream is
-      // deleted or the corresponding object ID is not reported via
-      // HandleReportGeneratorItemReturns. TODO(sang): Handle the edge case.
-      reference_counter_->OwnDynamicStreamingTaskReturnRef(object_id, *generator_id);
+      // ObjectRefStreamExists is used to distinguigsh num_returns="dynamic" vs
+      // "streaming".
+      task_manager_->TemporarilyOwnGeneratorReturnRefIfNeeded(object_id, *generator_id);
     } else {
       reference_counter_->AddDynamicReturn(object_id, *generator_id);
     }
@@ -3462,10 +3459,10 @@ void CoreWorker::AddObjectLocationOwner(const ObjectID &object_id,
   const auto &maybe_generator_id = task_manager_->TaskGeneratorId(object_id.TaskId());
   if (!maybe_generator_id.IsNil()) {
     if (task_manager_->ObjectRefStreamExists(maybe_generator_id)) {
-      // It is possible this reference will leak if the ObjectRefStream is
-      // deleted or the corresponding object ID is not reported via
-      // HandleReportGeneratorItemReturns. TODO(sang): Handle the edge case.
-      reference_counter_->OwnDynamicStreamingTaskReturnRef(object_id, maybe_generator_id);
+      // ObjectRefStreamExists is used to distinguigsh num_returns="dynamic" vs
+      // "streaming".
+      task_manager_->TemporarilyOwnGeneratorReturnRefIfNeeded(object_id,
+                                                              maybe_generator_id);
     } else {
       // The task is a generator and may not have finished yet. Add the internal
       // ObjectID so that we can update its location.

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -43,6 +43,10 @@ std::vector<ObjectID> ObjectRefStream::GetItemsUnconsumed() const {
       result.push_back(object_id);
     }
   }
+  // Temporarily owned refs are not consumed.
+  for (const auto &object_id : temporarily_owned_refs_) {
+    result.push_back(object_id);
+  }
   return result;
 }
 
@@ -80,6 +84,28 @@ Status ObjectRefStream::TryReadNextItem(ObjectID *object_id_out) {
   return Status::OK();
 }
 
+bool ObjectRefStream::TemporarilyInsertToStreamIfNeeded(const ObjectID &object_id) {
+  // Write to a stream if the object ID is not consumed yet.
+  auto last_consumed_index = next_index_ - 1;
+  if (item_index_to_refs_.find(last_consumed_index) != item_index_to_refs_.end()) {
+    // Object ID from the generator task always increment. I.e., the first
+    // return has a lower ObjectID bytes than the second return.
+    // If the last conusumed object ID's index is lower than a given ObjectID,
+    // it means the given ref is not consumed yet, meaning we should
+    // write to a stream.
+    auto not_consumed_yet =
+        item_index_to_refs_[last_consumed_index].ObjectIndex() < object_id.ObjectIndex();
+    return not_consumed_yet;
+  }
+
+  if (refs_written_to_stream_.find(object_id) == refs_written_to_stream_.end()) {
+    temporarily_owned_refs_.insert(object_id);
+    return true;
+  }
+
+  return false;
+}
+
 bool ObjectRefStream::InsertToStream(const ObjectID &object_id, int64_t item_index) {
   if (end_of_stream_index_ != -1) {
     RAY_CHECK(next_index_ <= end_of_stream_index_);
@@ -89,6 +115,11 @@ bool ObjectRefStream::InsertToStream(const ObjectID &object_id, int64_t item_ind
     // Index is already used. Don't write it to the stream.
     return false;
   }
+
+  if (temporarily_owned_refs_.find(object_id) != temporarily_owned_refs_.end()) {
+    temporarily_owned_refs_.erase(object_id);
+  }
+  refs_written_to_stream_.insert(object_id);
 
   auto it = item_index_to_refs_.find(item_index);
   if (it != item_index_to_refs_.end()) {
@@ -509,6 +540,29 @@ bool TaskManager::HandleReportGeneratorItemReturns(
   }
 
   return num_objects_written != 0;
+}
+
+bool TaskManager::TemporarilyOwnGeneratorReturnRefIfNeeded(const ObjectID &object_id,
+                                                           const ObjectID &generator_id) {
+  bool inserted_to_stream = false;
+  {
+    absl::MutexLock lock(&mu_);
+    auto stream_it = object_ref_streams_.find(generator_id);
+    if (stream_it == object_ref_streams_.end()) {
+      return false;
+    }
+
+    auto &stream = stream_it->second;
+    inserted_to_stream = stream.TemporarilyInsertToStreamIfNeeded(object_id);
+  }
+
+  // We shouldn't hold a lock when calling refernece counter API.
+  if (inserted_to_stream) {
+    reference_counter_->OwnDynamicStreamingTaskReturnRef(object_id, generator_id);
+    return true;
+  }
+
+  return false;
 }
 
 void TaskManager::CompletePendingTask(const TaskID &task_id,

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -444,7 +444,7 @@ void TaskManager::DelObjectRefStream(const ObjectID &generator_id) {
   for (const auto &object_id : object_ids_unconsumed) {
     std::vector<ObjectID> deleted;
     reference_counter_->RemoveLocalReference(object_id, &deleted);
-    RAY_CHECK_EQ(deleted.size(), 1UL);
+    RAY_CHECK_GE(deleted.size(), 1UL);
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When we put a new object or an object is spilled, raylet sends a RPC to the owner. For example, it sends a request to the owner to pin the plasma object until the ref goes out of scope.

For none-generator tasks, we always guarantee to create return references, so we can handle these RPCs properly, However, when a generator task is used, we don't know the references ahead of time, which means it is not guaranteed to own the references when the RPC is received. In this case, we own a reference before it is reported from the executor. See the code below for more details.

https://github.com/ray-project/ray/blob/5acf41e29fc542164f221c1df61b5f613b957310/src/ray/core_worker/core_worker.cc#L3292

However, this code is prone to error and causes reference leaks. Here are some examples. Imagine "WRITE 0" means the generator task return is written to a stream index 0. PinObjectRPCRecieved means the raylet RPC is received. READ 0 means we read the index 0 from a stream.

### Example 1

```
WRITE 0
READ 0
PinObjectRPCRecieved
```
-> This means the reference is already consumed, and the PinObjectRPCRecieved comes after that. In this case, we shouldn't add a reference to the object, otherwise, it will leak because we cannot read this ref anymore (cuz it is already consumed).

### Example 2
```
PinObjectRPCRecieved
# And WRITE 0 failed
```
In this case, WRITE 0 is failed. So, the when the object is owned by PinObjectRPCRecieved, it will be never be cleaned up.

To handle all these cases, we introduce a new API `TemporarilyInsertToStreamIfNeeded`. This API will own the object only when

- the corresponding ref was never consumed
- The stream has not been deleted.
- And add the object ref to the temporary refs until it is reported. If the report fails, all the references will be removed when the stream is deleted. 


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
