### PR TITLE
[RLlib] Use zero rollout workers for test_gymnasium_old_api_using_auto_wrap

### DIFF
--- a/rllib/tests/backward_compat/test_gym_env_apis.py
+++ b/rllib/tests/backward_compat/test_gym_env_apis.py
@@ -148,7 +148,8 @@ class TestGymEnvAPIs(unittest.TestCase):
         algo = (
             PPOConfig()
             .environment(env=GymnasiumOldAPI, auto_wrap_old_gym_envs=True)
-            .rollouts(num_envs_per_worker=2, num_rollout_workers=2)
+            # Speeds the test up.
+            .rollouts(num_rollout_workers=0)
             .build()
         )
         algo.train()


### PR DESCRIPTION
## Why are these changes needed?

When [attempting to deflakte linux://rllib:tests/backward_compat/test_gym_env_apis on CI,](https://github.com/ray-project/ray/pull/35653) we left out one test.
In all recent CI failures for this test, the failure is a timeout that times out at test_gymnasium_old_api_using_auto_wrap.
This PR makes it so that test_gymnasium_old_api_using_auto_wrap runs with 0 rollout workers as well, which might aid with some congestion that's happening there.
Other than that, we might simply want to increase the size of the test.

