### PR TITLE
[Serve] Support generators in `@serve.batch`

### DIFF
--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -310,7 +310,7 @@ def batch(
                 else:
                     future = async_response.next_future
                 yield async_response.result
-        
+
         def enqueue_request(args, kwargs):
             self = extract_self_if_method_call(args, _func)
             flattened_args: List = flatten_args(extract_signature(_func), args, kwargs)
@@ -339,11 +339,11 @@ def batch(
             future = get_or_create_event_loop().create_future()
             batch_queue.put(_SingleRequest(self, flattened_args, future))
             return future
-        
+
         @wraps(_func)
         def generator_batch_wrapper(*args, **kwargs):
             first_future = enqueue_request(args, kwargs)
-            return batch_handler_generator(first_future) 
+            return batch_handler_generator(first_future)
 
         @wraps(_func)
         async def batch_wrapper(*args, **kwargs):

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -18,7 +18,7 @@ END_ASYNC_ITER_TOKEN = None
 
 @dataclass
 class _SingleRequest:
-    self_arg: Optional[Any]
+    self_arg: Any
     flattened_args: List[Any]
     future: asyncio.Future
 

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -325,7 +325,7 @@ def batch(
     def _batch_decorator(_func):
         async def batch_handler_generator(
             first_future: asyncio.Future,
-        ) -> AsyncGenerator[Any, None, None]:
+        ) -> AsyncGenerator:
             """Generator that handles generator batch functions."""
 
             future = first_future

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -25,7 +25,7 @@ class _SingleRequest:
 
 @dataclass
 class _GeneratorIterResponse:
-    result: Optional[Any]
+    result: Any
     next_future: Union[asyncio.Future, END_ASYNC_ITER_TOKEN]
 
 

--- a/python/ray/serve/tests/test_batching.py
+++ b/python/ray/serve/tests/test_batching.py
@@ -12,13 +12,6 @@ from ray.serve.exceptions import RayServeException
 from ray._private.utils import get_or_create_event_loop
 
 
-@pytest.fixture()
-def ray_instance():
-    yield ray.init()
-    serve.shutdown()
-    ray.shutdown()
-
-
 def test_batching(serve_instance):
     @serve.deployment
     class BatchingExample:
@@ -382,7 +375,7 @@ async def test_batch_generator_exceptions(error_type):
 
 
 @pytest.mark.asyncio
-async def test_batch_generator_streaming_response_integration_test(ray_instance):
+async def test_batch_generator_streaming_response_integration_test(serve_instance):
     NUM_YIELDS = 10
 
     @serve.deployment

--- a/python/ray/serve/tests/test_batching.py
+++ b/python/ray/serve/tests/test_batching.py
@@ -4,6 +4,7 @@ import pytest
 
 import ray
 from ray import serve
+from ray.serve.exceptions import RayServeException
 from ray._private.utils import get_or_create_event_loop
 
 
@@ -289,6 +290,84 @@ async def test_batch_args_kwargs(mode, use_class):
 
     result = await asyncio.gather(*coros)
     assert result == [("hi1", "hi2"), ("hi3", "hi4")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["args", "kwargs", "mixed", "out-of-order"])
+@pytest.mark.parametrize("use_class", [True, False])
+@pytest.mark.parametrize("generator_length", [0, 2, 5])
+async def test_batch_generator_basic(mode, use_class, generator_length):
+    if use_class:
+
+        class MultipleArgs:
+            @serve.batch(max_batch_size=2, batch_wait_timeout_s=1000)
+            async def method(self, key1, key2):
+                for gen_idx in range(generator_length):
+                    yield [(gen_idx, key1[i], key2[i]) for i in range(len(key1))]
+
+        instance = MultipleArgs()
+        func = instance.method
+
+    else:
+
+        @serve.batch(max_batch_size=2, batch_wait_timeout_s=1000)
+        async def func(key1, key2):
+            for gen_idx in range(generator_length):
+                yield [(gen_idx, key1[i], key2[i]) for i in range(len(key1))]
+
+    if mode == "args":
+        generators = [func("hi1", "hi2"), func("hi3", "hi4")]
+    elif mode == "kwargs":
+        generators = [func(key1="hi1", key2="hi2"), func(key1="hi3", key2="hi4")]
+    elif mode == "mixed":
+        generators = [func("hi1", key2="hi2"), func("hi3", key2="hi4")]
+    elif mode == "out-of-order":
+        generators = [func(key2="hi2", key1="hi1"), func(key2="hi4", key1="hi3")]
+
+    results = [
+        [result async for result in generators[0]],
+        [result async for result in generators[1]],
+    ]
+
+    assert results == [
+        [(gen_idx, "hi1", "hi2") for gen_idx in range(generator_length)],
+        [(gen_idx, "hi3", "hi4") for gen_idx in range(generator_length)],
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", ["runtime_error", "mismatched_lengths"])
+async def test_batch_generator_exceptions(error_type):
+    GENERATOR_LENGTH = 5
+    ERROR_IDX = 2
+    ERROR_MSG = "Testing error"
+
+    @serve.batch(max_batch_size=2, batch_wait_timeout_s=1000)
+    async def func(key1, key2):
+        for gen_idx in range(GENERATOR_LENGTH):
+            results = [(gen_idx, key1[i], key2[i]) for i in range(len(key1))]
+            if gen_idx == ERROR_IDX:
+                if error_type == "runtime_error":
+                    raise RuntimeError(ERROR_MSG)
+                elif error_type == "mismatched_lengths":
+                    yield results * 2
+            yield results
+
+    generators = [func("hi1", "hi2"), func("hi3", "hi4")]
+
+    for generator in generators:
+        for _ in range(ERROR_IDX):
+            await generator.__anext__()
+
+        if error_type == "runtime_error":
+            with pytest.raises(RuntimeError, match=ERROR_MSG):
+                await generator.__anext__()
+        elif error_type == "mismatched_lengths":
+            with pytest.raises(RayServeException):
+                await generator.__anext__()
+
+        with pytest.raises(StopAsyncIteration):
+            await generator.__anext__()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When `@serve.batch` decorates a function, incoming requests are batched. The function can process the batch and return the results, and `@serve.batch` disaggregates the results and sends them back their original callers.

This change extends `@serve.batch` to support generator functions.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #35644

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - I added unit tests to `test_batching.py`.
