### PR TITLE
[Train] Remove loss assertion in torch trainer doctest

### DIFF
--- a/python/ray/train/torch/torch_trainer.py
+++ b/python/ray/train/torch/torch_trainer.py
@@ -202,9 +202,11 @@ class TorchTrainer(DataParallelTrainer):
 
                     # Report and record metrics, checkpoint model at end of each
                     # epoch
-                    session.report({"loss": loss.item(), "epoch": epoch},
-                                         checkpoint=Checkpoint.from_dict(
-                                         dict(epoch=epoch, model=model.state_dict()))
+                    session.report(
+                        {"loss": loss.item(), "epoch": epoch},
+                        checkpoint=Checkpoint.from_dict(
+                            dict(epoch=epoch, model=model.state_dict())
+                        ),
                     )
 
             torch.manual_seed(42)
@@ -220,14 +222,12 @@ class TorchTrainer(DataParallelTrainer):
                 train_loop_per_worker=train_loop_per_worker,
                 scaling_config=scaling_config,
                 run_config=run_config,
-                datasets={"train": train_dataset})
+                datasets={"train": train_dataset},
+            )
 
             result = trainer.fit()
 
             best_checkpoint_loss = result.metrics['loss']
-
-            # Assert loss is less 0.09
-            assert best_checkpoint_loss <= 0.09   # doctest: +SKIP
 
     .. testoutput::
         :hide:

--- a/python/ray/train/torch/torch_trainer.py
+++ b/python/ray/train/torch/torch_trainer.py
@@ -174,15 +174,18 @@ class TorchTrainer(DataParallelTrainer):
                 # This moves the data and prepares model for distributed
                 # execution
                 loss_fn = nn.MSELoss()
-                optimizer = torch.optim.Adam(model.parameters(),
-                            lr=0.01,
-                            weight_decay=0.01)
+                optimizer = torch.optim.Adam(
+                    model.parameters(),
+                    lr=0.01,
+                    weight_decay=0.01,
+                )
                 model = train.torch.prepare_model(model)
 
                 # Iterate over epochs and batches
                 for epoch in range(num_epochs):
-                    for batches in dataset_shard.iter_torch_batches(batch_size=32,
-                                dtypes=torch.float):
+                    for batches in dataset_shard.iter_torch_batches(
+                        batch_size=32, dtypes=torch.float
+                    ):
 
                         # Add batch or unsqueeze as an additional dimension [32, x]
                         inputs, labels = torch.unsqueeze(batches["x"], 1), batches["y"]
@@ -200,8 +203,7 @@ class TorchTrainer(DataParallelTrainer):
                         if epoch % 20 == 0:
                             print(f"epoch: {epoch}/{num_epochs}, loss: {loss:.3f}")
 
-                    # Report and record metrics, checkpoint model at end of each
-                    # epoch
+                    # Report and record metrics, checkpoint model at end of each epoch
                     session.report(
                         {"loss": loss.item(), "epoch": epoch},
                         checkpoint=Checkpoint.from_dict(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This has been flaky for a long time. We added a skip doctest comment, but that doesn't work for code blocks wrapped inside `test-code`.

This docstring test shouldn't be the one asserting the correctness of TorchTrainer -- that should be handled by unit tests and torch release tests. In a future PR, we can create a unit test that launches a "deterministic" Train run that we assert always stays the same. (The current docstring is not deterministic due to Ray Data shuffling most likely.)

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/32639

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
