### PR TITLE
Support path_prefix for overriding where the Dashboard UI is served from

### DIFF
--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -35,6 +35,7 @@ routes = dashboard_optional_utils.ClassMethodRouteTable
 ENV_VAR_DASHBOARD_UI_ROUTE_PREFIX = "RAY_DASHBOARD_UI_ROUTE_PREFIX"
 DASHBOARD_UI_ROUTE_PREFIX = os.environ.get(ENV_VAR_DASHBOARD_UI_ROUTE_PREFIX, None)
 
+
 def setup_static_dir():
     build_dir = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "client", "build"

--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -29,6 +29,11 @@ from ray._raylet import GcsClient
 logger = logging.getLogger(__name__)
 routes = dashboard_optional_utils.ClassMethodRouteTable
 
+# This flag updates the route where index.html is served from. This is useful
+# for running the dashboard behind a reverse proxy that does not support
+# path rewriting. This does not update ALL routes, just the index.html route.
+ENV_VAR_DASHBOARD_UI_ROUTE_PREFIX = "RAY_DASHBOARD_UI_ROUTE_PREFIX"
+DASHBOARD_UI_ROUTE_PREFIX = os.environ.get(ENV_VAR_DASHBOARD_UI_ROUTE_PREFIX, None)
 
 def setup_static_dir():
     build_dir = os.path.join(
@@ -97,7 +102,7 @@ class HttpServerDashboardHead:
         else:
             self.http_session = aiohttp.ClientSession()
 
-    @routes.get("/")
+    @routes.get(f"/{DASHBOARD_UI_ROUTE_PREFIX}" if DASHBOARD_UI_ROUTE_PREFIX else "/")
     async def get_index(self, req) -> aiohttp.web.FileResponse:
         try:
             # This API will be no-op after the first report.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Adds a new env var `RAY_DASHBOARD_UI_ROUTE_PREFIX` which allows users to update the route that the dashboard html is served from.

Note: This does not change the other routes of the dashboard API and the dashboard UI will still fetch APIs from the existing routes without the path_prefix.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
fixes #35269
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
