### PR TITLE
Revert "[air/output] Switch on per default (#35389)"

### DIFF
--- a/doc/source/ray-air/experimental-features.rst
+++ b/doc/source/ray-air/experimental-features.rst
@@ -33,9 +33,9 @@ Context-aware progress reporting
 
 .. note::
 
-    This feature is *enabled by default* in Ray 2.6.
+    This feature is *disabled by default* in Ray 2.5.
 
-    To disable, set the environment variable ``RAY_AIR_NEW_OUTPUT=0``.
+    To enable, set the environment variable ``RAY_AIR_NEW_OUTPUT=1``.
 
 A context-aware output engine is available for Ray Train and Ray Tune runs.
 

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -727,12 +727,12 @@ class RunConfig:
             intermediate experiment progress. Defaults to CLIReporter if
             running in command-line, or JupyterNotebookReporter if running in
             a Jupyter notebook.
-        verbose: 0, 1, or 2. Verbosity mode.
-            0 = silent, 1 = default, 2 = verbose. Defaults to 1.
-            If the ``RAY_AIR_NEW_OUTPUT=1`` environment variable is set,
-            uses the old verbosity settings:
+        verbose: 0, 1, 2, or 3. Verbosity mode.
             0 = silent, 1 = only status updates, 2 = status and brief
-            results, 3 = status and detailed results.
+            results, 3 = status and detailed results. Defaults to 3.
+            If the ``RAY_AIR_NEW_OUTPUT=1`` environment variable is set,
+            uses the new context-aware verbosity settings:
+            0 = silent, 1 = default, 2 = verbose.
         log_to_file: Log stdout and stderr to files in
             trial directories. If this is `False` (default), no files
             are written. If `true`, outputs are written to `trialdir/stdout`

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -99,9 +99,6 @@ class AirVerbosity(IntEnum):
     DEFAULT = 1
     VERBOSE = 2
 
-    def __repr__(self):
-        return str(self.value)
-
 
 IS_NOTEBOOK = ray.widgets.util.in_notebook()
 
@@ -109,7 +106,7 @@ IS_NOTEBOOK = ray.widgets.util.in_notebook()
 def get_air_verbosity(
     verbose: Union[int, AirVerbosity, Verbosity]
 ) -> Optional[AirVerbosity]:
-    if os.environ.get("RAY_AIR_NEW_OUTPUT", "1") == "0":
+    if os.environ.get("RAY_AIR_NEW_OUTPUT", "0") == "0":
         return None
 
     if isinstance(verbose, AirVerbosity):

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -449,12 +449,12 @@ def run(
             training workers.
         checkpoint_upload_from_workers: Whether to upload checkpoint files
             directly from distributed training workers.
-        verbose: 0, 1, or 2. Verbosity mode.
-            0 = silent, 1 = default, 2 = verbose. Defaults to 1.
-            If the ``RAY_AIR_NEW_OUTPUT=1`` environment variable is set,
-            uses the old verbosity settings:
+        verbose: 0, 1, 2, or 3. Verbosity mode.
             0 = silent, 1 = only status updates, 2 = status and brief
-            results, 3 = status and detailed results.
+            results, 3 = status and detailed results. Defaults to 3.
+            If the ``RAY_AIR_NEW_OUTPUT=1`` environment variable is set,
+            uses the new context-aware verbosity settings:
+            0 = silent, 1 = default, 2 = verbose.
         progress_reporter: Progress reporter for reporting
             intermediate experiment progress. Defaults to CLIReporter if
             running in command-line, or JupyterNotebookReporter if running in


### PR DESCRIPTION
This reverts commit 6e9dfd9b87358e2776821a4408537fc8dd85ecd2.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It breaks `windows://python/ray/tests:test_task_events`
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
