### PR TITLE
Cherry-pick: Add error details for failed jobs

### DIFF
--- a/dashboard/client/src/pages/job/JobDetailInfoPage.tsx
+++ b/dashboard/client/src/pages/job/JobDetailInfoPage.tsx
@@ -99,7 +99,18 @@ export const JobMetadataSection = ({ job }: JobMetadataSectionProps) => {
         },
         {
           label: "Status",
-          content: <JobStatusWithIcon job={job} />,
+          content: (
+            <React.Fragment>
+              <JobStatusWithIcon job={job} />{" "}
+              {job.message && (
+                <CodeDialogButton
+                  title="Status details"
+                  code={job.message}
+                  buttonText="View details"
+                />
+              )}
+            </React.Fragment>
+          ),
         },
         {
           label: "Job ID",

--- a/dashboard/client/src/pages/job/JobRow.tsx
+++ b/dashboard/client/src/pages/job/JobRow.tsx
@@ -2,6 +2,7 @@ import { Link, TableCell, TableRow, Tooltip } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import React from "react";
 import { Link as RouterLink } from "react-router-dom";
+import { CodeDialogButtonWithPreview } from "../../common/CodeDialogButton";
 import { DurationText } from "../../common/DurationText";
 import { formatDateFromTimeMs } from "../../common/formatUtils";
 import { JobStatusWithIcon } from "../../common/JobStatus";
@@ -22,6 +23,10 @@ const useStyles = makeStyles((theme) => ({
     overflow: "hidden",
     whiteSpace: "nowrap",
   },
+  statusMessage: {
+    maxWidth: 250,
+    display: "inline-flex",
+  },
 }));
 
 type JobRowProps = {
@@ -34,6 +39,7 @@ export const JobRow = ({ job }: JobRowProps) => {
     submission_id,
     driver_info,
     status,
+    message,
     start_time,
     end_time,
     entrypoint,
@@ -86,6 +92,17 @@ export const JobRow = ({ job }: JobRowProps) => {
       </TableCell>
       <TableCell align="center">
         <JobStatusWithIcon job={job} />
+      </TableCell>
+      <TableCell align="center">
+        {message ? (
+          <CodeDialogButtonWithPreview
+            className={classes.statusMessage}
+            title="Status message"
+            code={message}
+          />
+        ) : (
+          "-"
+        )}
       </TableCell>
       <TableCell align="center">
         {start_time && start_time > 0 ? (

--- a/dashboard/client/src/pages/job/index.tsx
+++ b/dashboard/client/src/pages/job/index.tsx
@@ -39,6 +39,7 @@ const columns = [
   { label: "Submission ID" },
   { label: "Entrypoint" },
   { label: "Status" },
+  { label: "Status message" },
   { label: "Duration" },
   {
     label: "Tasks",

--- a/dashboard/client/src/pages/serve/ServeApplicationDetailPage.tsx
+++ b/dashboard/client/src/pages/serve/ServeApplicationDetailPage.tsx
@@ -36,6 +36,10 @@ const useStyles = makeStyles((theme) =>
     helpInfo: {
       marginLeft: theme.spacing(1),
     },
+    statusMessage: {
+      display: "inline-flex",
+      maxWidth: "100%",
+    },
   }),
 );
 
@@ -91,7 +95,19 @@ export const ServeApplicationDetailPage = () => {
           {
             label: "Status",
             content: (
-              <StatusChip type="serveApplication" status={application.status} />
+              <React.Fragment>
+                <StatusChip
+                  type="serveApplication"
+                  status={application.status}
+                />{" "}
+                {application.message && (
+                  <CodeDialogButton
+                    title="Status details"
+                    code={application.message}
+                    buttonText="View details"
+                  />
+                )}
+              </React.Fragment>
             ),
           },
           {

--- a/dashboard/client/src/pages/serve/ServeDeploymentRow.tsx
+++ b/dashboard/client/src/pages/serve/ServeDeploymentRow.tsx
@@ -33,6 +33,10 @@ const useStyles = makeStyles((theme) =>
       fontSize: "1.5em",
       verticalAlign: "middle",
     },
+    statusMessage: {
+      maxWidth: 400,
+      display: "inline-flex",
+    },
   }),
 );
 
@@ -100,6 +104,7 @@ export const ServeDeploymentRow = ({
         <TableCell align="center">
           {message ? (
             <CodeDialogButtonWithPreview
+              className={classes.statusMessage}
               title="Message details"
               code={message}
             />

--- a/dashboard/client/src/pages/serve/ServeSystemActorDetailPage.tsx
+++ b/dashboard/client/src/pages/serve/ServeSystemActorDetailPage.tsx
@@ -145,7 +145,10 @@ export const ServeSystemActorDetail = ({
             label: "Status",
             content:
               actor.type === "httpProxy" ? (
-                <StatusChip type="serveReplica" status={actor.detail.status} />
+                <StatusChip
+                  type="serveHttpProxy"
+                  status={actor.detail.status}
+                />
               ) : fetchedActor ? (
                 <StatusChip
                   type="serveController"


### PR DESCRIPTION
Add error details for failed jobs in the job list view and job detail view Add error details for failed serve apps in the application detail view Fix color of StatusChip for HTTPPRoxy detail page
Add max width for error details for Serve deployments

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Cherry-pick of #35691
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
