### PR TITLE
[Tune] Cancel `pg.ready()` task for pending trials that end up reusing an actor

### DIFF
--- a/python/ray/air/execution/resources/placement_group.py
+++ b/python/ray/air/execution/resources/placement_group.py
@@ -151,6 +151,10 @@ class PlacementGroupResourceManager(ResourceManager):
             # PG was staging
             future = self._pg_to_staging_future.pop(pg)
             self._staging_future_to_pg.pop(future)
+
+            # Cancel the pg.ready task. Otherwise, it will be pending node
+            # assignment forever and accumulate throughout the job lifetime.
+            ray.cancel(future)
         else:
             # PG might be ready
             pg = self._request_to_ready_pgs[resource_request].pop()

--- a/python/ray/air/execution/resources/placement_group.py
+++ b/python/ray/air/execution/resources/placement_group.py
@@ -152,8 +152,8 @@ class PlacementGroupResourceManager(ResourceManager):
             future = self._pg_to_staging_future.pop(pg)
             self._staging_future_to_pg.pop(future)
 
-            # Cancel the pg.ready task. Otherwise, it will be pending node
-            # assignment forever and accumulate throughout the job lifetime.
+            # Cancel the pg.ready task.
+            # Otherwise, it will be pending node assignment forever.
             ray.cancel(future)
         else:
             # PG might be ready


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR cancels `pg.ready()` tasks that are pending node assignment forever, in the case that trials are reusing actors. For Tune experiments with many trials, this clutters the user's dashboard with a bunch of these `pg.ready()` tasks that don't go away. The trials corresponding to these requests have already been assigned different actors, so there is no point keeping the futures around.

### Context

Currently, the `PlacementGroupResourceManager` uses the `pg.ready()` future to determine when a placement group is ready for an actor to be created with it.

Let's say we're on a cluster with 10 CPUs, each trial needs 2 CPUs, and we want to run 100 trials. Tune will schedule 5 actors, and Tune will also have some number of pending trials that also try to allocate a placement group (the default is 16 pending in this case I believe, see [the `TUNE_MAX_PENDING_TRIALS_PG` env var](https://docs.ray.io/en/latest/tune/api/env.html)).

In the beginning, the state will be:
- 5 trials with 2 CPUs each.
- 16 trials, associated with 16 pending `pg.ready()` futures.

Then, when the first trial finishes, one of the 16 pending trials will end up reusing the actor of the finished trial.
The resources will not be relinquished from that actor, so the new trial's `pg.ready()` will never finish, and we've also lost the reference.

@jjyao  **Question: Why isn't it garbage collected automatically?** I think it's because `pg.ready()` calls some global function that always has at least 1 reference:  `bundle_reservation_check_func`.

So, the pending futures will just keep accumulating as trials keep reusing actors. This leads to the dashboard looking like:

![Screen Shot 2023-04-27 at 1 25 09 PM](https://github.com/ray-project/ray/assets/3887863/05e6e6b9-4113-4b2d-b671-d29e9ef18b97)

After this change, there will only ever be ~16 pending futures, which are just the PENDING trials that will eventually reuse an actor and cancel the future.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
