### PR TITLE
[Serve] support -h to serve cli

### DIFF
--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -49,7 +49,6 @@ RAY_DASHBOARD_ADDRESS_HELP_STR = (
     "http://localhost:52365). Can also be specified using the "
     "RAY_AGENT_ADDRESS environment variable."
 )
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 # See https://stackoverflow.com/a/33300001/11162437
@@ -125,7 +124,7 @@ def convert_args_to_dict(args: Tuple[str]) -> Dict[str, str]:
 
 @click.group(
     help="CLI for managing Serve applications on a Ray cluster.",
-    context_settings=CONTEXT_SETTINGS,
+    context_settings=dict(help_option_names=["-h", "--help"]),
 )
 def cli():
     pass

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -49,6 +49,7 @@ RAY_DASHBOARD_ADDRESS_HELP_STR = (
     "http://localhost:52365). Can also be specified using the "
     "RAY_AGENT_ADDRESS environment variable."
 )
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 # See https://stackoverflow.com/a/33300001/11162437
@@ -122,7 +123,10 @@ def convert_args_to_dict(args: Tuple[str]) -> Dict[str, str]:
     return args_dict
 
 
-@click.group(help="CLI for managing Serve applications on a Ray cluster.")
+@click.group(
+    help="CLI for managing Serve applications on a Ray cluster.",
+    context_settings=CONTEXT_SETTINGS,
+)
 def cli():
     pass
 

--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -122,6 +122,7 @@ if __name__ == "__main__":
         skip_list=args.skip,
         local_path="../../../dashboard",
     )
+    do_link("serve", force=args.yes, skip_list=args.skip)
     print(
         "Created links.\n\nIf you run into issues initializing Ray, please "
         "ensure that your local repo and the installed Ray are in sync "

--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -122,7 +122,6 @@ if __name__ == "__main__":
         skip_list=args.skip,
         local_path="../../../dashboard",
     )
-    do_link("serve", force=args.yes, skip_list=args.skip)
     print(
         "Created links.\n\nIf you run into issues initializing Ray, please "
         "ensure that your local repo and the installed Ray are in sync "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- `-h` is a common pattern and is not currently supported on `serve` cli. This PR adds the support to call `serve -h`

## Related issue number

Closes #35734

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Tested by running `python python/ray/setup-dev.py -y` then seeing `serve -h` working
