### PR TITLE
[Data][Docs] Remove deprecated APIs from Data documentation

### DIFF
--- a/doc/source/data/api/data_representations.rst
+++ b/doc/source/data/api/data_representations.rst
@@ -26,14 +26,6 @@ Batch API
 
    block.DataBatch
 
-Row API
---------
-
-.. autosummary::
-   :toctree: doc/
-
-   row.TableRow
-
 .. _dataset-tensor-extension-api:
 
 Tensor Column Extension API
@@ -54,4 +46,3 @@ Tensor Column Extension API
    extensions.tensor_extension.ArrowTensorArray
    extensions.tensor_extension.ArrowVariableShapedTensorType
    extensions.tensor_extension.ArrowVariableShapedTensorArray
-

--- a/doc/source/data/api/dataset.rst
+++ b/doc/source/data/api/dataset.rst
@@ -128,7 +128,6 @@ Inspecting Metadata
    Dataset.count
    Dataset.columns
    Dataset.schema
-   Dataset.default_batch_format
    Dataset.num_blocks
    Dataset.size_bytes
    Dataset.input_files
@@ -153,15 +152,3 @@ Serialization
    Dataset.has_serializable_lineage
    Dataset.serialize_lineage
    Dataset.deserialize_lineage
-
-Internals
----------
-
-.. autosummary::
-   :toctree: doc/
-
-   Dataset.__init__
-   Dataset.dataset_format
-   Dataset.fully_executed
-   Dataset.is_fully_executed
-   Dataset.lazy


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We shouldn't document APIs that we don't want users to use.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
