### PR TITLE
[Data] Remove `range_arrow`

### DIFF
--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -27,7 +27,6 @@ from ray.data.read_api import (  # noqa: F401
     from_tf,
     from_torch,
     range,
-    range_arrow,
     range_table,
     range_tensor,
     read_binary_files,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -255,11 +255,6 @@ def range_table(n: int, *, parallelism: int = -1) -> Dataset:
     )
 
 
-@Deprecated
-def range_arrow(*args, **kwargs):
-    raise DeprecationWarning("range_arrow() is deprecated, use range_table() instead.")
-
-
 @PublicAPI
 def range_tensor(n: int, *, shape: Tuple = (1,), parallelism: int = -1) -> Dataset:
     """Create a Tensor stream from a range of integers [0..n).


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`range_arrow` has been deprecated for several releases, and it's deprecation message points the user to another deprecated API.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
