### PR TITLE
[Tune] Fix param space placeholder injection for numpy/pandas objects

### DIFF
--- a/python/ray/tune/impl/placeholder.py
+++ b/python/ray/tune/impl/placeholder.py
@@ -61,7 +61,7 @@ def _is_primitive(x):
 
     Primitive types are int, float, str, bool, and None.
     """
-    return isinstance(x, (int, float, str, bool)) or not x
+    return isinstance(x, (int, float, str, bool)) or x is None
 
 
 @DeveloperAPI

--- a/python/ray/tune/tests/test_placeholder.py
+++ b/python/ray/tune/tests/test_placeholder.py
@@ -1,3 +1,4 @@
+import numpy as np
 import unittest
 
 from ray import tune
@@ -84,7 +85,7 @@ class PlaceholderTest(unittest.TestCase):
             [(_RefResolver.TOKEN, "35397f1a"), "not ok"],
         )
 
-        # Pretend we picked a choice from the grid searches.
+        # Pretend we picked a choice from the categoricals.
         config["param2"][1] = (_RefResolver.TOKEN, "e6a5a3d5")
         config["param3"]["param4"] = "not ok"
 
@@ -92,6 +93,28 @@ class PlaceholderTest(unittest.TestCase):
 
         self.assertEqual(config["param2"][1].value, "ok")
         self.assertEqual(config["param3"]["param4"], "not ok")
+
+    def _testNonSearchSpaceRef(self, value):
+        """Tests that non-primitives (numpy, lambda fn) get replaced by a reference."""
+        config = {"param": tune.choice([value, "other", value])}
+
+        replaced = create_resolvers_map()
+        config = inject_placeholders(config, replaced)
+
+        self.assertEqual(
+            config["param"].categories,
+            [
+                (_RefResolver.TOKEN, "ab9affa5"),
+                "other",
+                (_RefResolver.TOKEN, "ceae296d"),
+            ],
+        )
+
+    def testNumpyToRef(self):
+        self._testNonSearchSpaceRef(np.arange(10))
+
+    def testLambdaToRef(self):
+        self._testNonSearchSpaceRef(lambda x: x)
 
     def testFunction(self):
         config = {
@@ -174,10 +197,6 @@ class PlaceholderTest(unittest.TestCase):
         self.assertEqual(config["param3"]["param4"][1][1].value, "not ok")
 
     def testOtherDomains(self):
-        class Dummy:
-            def __init__(self, value):
-                self.value = value
-
         config = {
             "param1": tune.uniform(0, 1),
             "param2": tune.randint(2, 3),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
[Failing doctests from `tune_sklearn` revealed this issue](https://github.com/ray-project/tune-sklearn/actions/runs/5074468040/jobs/9114668646?pr=264) when numpy / pandas objects are specified in a Tune param space.

We should use `x is None` to check for the `None` primitive rather than `not`, since that will raise an error such as:

```
ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```



### Repro

```
>>> from ray import tune
>>> import numpy as np
>>> def train(config):
...     pass
...
>>> tune.run(train, config={"a": tune.choice([np.arange(10)])})
[2023-05-24 23:56:28]  INFO ray._private.worker::Started a local Ray instance. View the dashboard at http://127.0.0.1:8265
[2023-05-24 23:56:29] [Ray Tune] INFO ray.tune.tune::Initializing Ray automatically. For cluster usage or custom Ray initialization, call `ray.init(...)` before `tune.run(...)`.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/tune.py", line 808, in run
    config = inject_placeholders(
  File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/impl/placeholder.py", line 136, in inject_placeholders
    return {
  File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/impl/placeholder.py", line 137, in <dictcomp>
    k: inject_placeholders(v, resolvers, id_prefix + (k,), path_prefix + (k,))
  File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/impl/placeholder.py", line 154, in inject_placeholders
    config.categories = [
  File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/impl/placeholder.py", line 158, in <listcomp>
    inject_placeholders(choice, resolvers, id_prefix + (i,), path_prefix)
  File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/impl/placeholder.py", line 150, in inject_placeholders
    elif _is_primitive(config):
  File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/impl/placeholder.py", line 64, in _is_primitive
    return isinstance(x, (int, float, str, bool)) or not x
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
