### PR TITLE
[Streaming Generator] Allow to raise an exception to avoid check failures.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -950,6 +950,7 @@ cdef execute_streaming_generator(
 
     cdef:
         CoreWorker core_worker = worker.core_worker
+        c_pair[CObjectID, shared_ptr[CRayObject]] return_obj
 
     generator_index = 0
     is_async = inspect.isasyncgen(generator)
@@ -971,7 +972,7 @@ cdef execute_streaming_generator(
         except StopIteration:
             break
         except Exception as e:
-            error_obj = create_generator_error_object(
+            create_generator_error_object(
                 e,
                 worker,
                 task_type,
@@ -986,11 +987,12 @@ cdef execute_streaming_generator(
                 return_size,
                 generator_index,
                 is_async,
+                &return_obj,
                 is_retryable_error,
                 application_error
             )
             CCoreWorkerProcess.GetCoreWorker().ReportGeneratorItemReturns(
-                error_obj,
+                return_obj,
                 generator_id,
                 caller_address,
                 generator_index,
@@ -999,7 +1001,7 @@ cdef execute_streaming_generator(
             break
         else:
             # Report the intermediate result if there was no error.
-            generator_return_obj = create_generator_return_obj(
+            create_generator_return_obj(
                 output,
                 generator_id,
                 worker,
@@ -1007,7 +1009,8 @@ cdef execute_streaming_generator(
                 task_id,
                 return_size,
                 generator_index,
-                is_async)
+                is_async,
+                &return_obj)
             # Del output here so that we can GC the memory
             # usage asap.
             del output
@@ -1016,7 +1019,7 @@ cdef execute_streaming_generator(
                 "Writes to a ObjectRefStream of an "
                 "index {}".format(generator_index))
             CCoreWorkerProcess.GetCoreWorker().ReportGeneratorItemReturns(
-                generator_return_obj,
+                return_obj,
                 generator_id,
                 caller_address,
                 generator_index,
@@ -1036,7 +1039,7 @@ cdef execute_streaming_generator(
         True)  # finished.
 
 
-cdef c_pair[CObjectID, shared_ptr[CRayObject]] create_generator_return_obj(
+cdef create_generator_return_obj(
         output,
         const CObjectID &generator_id,
         worker: "Worker",
@@ -1044,7 +1047,8 @@ cdef c_pair[CObjectID, shared_ptr[CRayObject]] create_generator_return_obj(
         TaskID task_id,
         return_size,
         generator_index,
-        is_async):
+        is_async,
+        c_pair[CObjectID, shared_ptr[CRayObject]] *return_object):
     """Create a generator return object based on a given output.
 
     Args:
@@ -1059,9 +1063,7 @@ cdef c_pair[CObjectID, shared_ptr[CRayObject]] create_generator_return_obj(
         generator_index: The index of a current error object.
         is_async: Whether or not the given object is created within
             an async actor.
-
-    Returns:
-        A Ray Object that contains the given output.
+        return_object(out): A Ray Object that contains the given output.
     """
     cdef:
         c_vector[c_pair[CObjectID, shared_ptr[CRayObject]]] intermediate_result
@@ -1083,10 +1085,10 @@ cdef c_pair[CObjectID, shared_ptr[CRayObject]] create_generator_return_obj(
         &intermediate_result,
         generator_id)
 
-    return intermediate_result.back()
+    return_object[0] = intermediate_result.back()
 
 
-cdef c_pair[CObjectID, shared_ptr[CRayObject]] create_generator_error_object(
+cdef create_generator_error_object(
         e: Exception,
         worker: "Worker",
         CTaskType task_type,
@@ -1101,6 +1103,7 @@ cdef c_pair[CObjectID, shared_ptr[CRayObject]] create_generator_error_object(
         return_size,
         generator_index,
         is_async,
+        c_pair[CObjectID, shared_ptr[CRayObject]] *error_object,
         c_bool *is_retryable_error,
         c_string *application_error):
     """Create a generator error object.
@@ -1132,13 +1135,11 @@ cdef c_pair[CObjectID, shared_ptr[CRayObject]] create_generator_error_object(
         generator_index: The index of a current error object.
         is_async: Whether or not the given object is created within
             an async actor.
+        error_object(out): A Ray Object that contains the given error exception.
         is_retryable_error(out): It is set to True if the generator
             raises an exception, and the error is retryable.
         application_error(out): It is set if the generator raises an
             application error.
-
-    Returns:
-        A Ray Object that contains the given error exception.
     """
     cdef:
         c_vector[c_pair[CObjectID, shared_ptr[CRayObject]]] intermediate_result
@@ -1186,7 +1187,7 @@ cdef c_pair[CObjectID, shared_ptr[CRayObject]] create_generator_error_object(
                 caller_address,
                 &intermediate_result, application_error)
 
-    return intermediate_result.back()
+    error_object[0] = intermediate_result.back()
 
 
 cdef execute_dynamic_generator_and_store_task_outputs(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In Cython, when you specify cdef + c return type, the function is considered as a c function. If any Python function raises an exception within the c function, the whole exceptions are ignored.

https://github.com/ray-project/ray/blob/98a446bb97575e0960186c2035e555b7d4a5823d/python/ray/_raylet.pyx#L1089

However, inside this method, we have a function that can potentially raise an exception. This part of code can raise an exception when an exception cannot be serialized for example.

https://github.com/ray-project/ray/blob/98a446bb97575e0960186c2035e555b7d4a5823d/python/ray/_raylet.pyx#L1180

When an exception is raised here, the exception is ignored, and the function stops running. When this happens, some of states are corrupted, which can cause the check failures.

To fix the issue, I allow `create_generator_error_object` and `create_generator_return_obj` raise ane exception by removing the return type from the method. The return object will be written via pointer argument.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
