### PR TITLE
[air/output] Fix output encoding in windows

### DIFF
--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -203,8 +203,11 @@ class TuneController(_TuneControllerBase):
         # This is a bit costly, so we want to avoid running it too often
         times = deque(
             sorted(
-                (timestamp, tracked_actor)
-                for tracked_actor, timestamp in self._stopping_actors.items()
+                [
+                    (timestamp, tracked_actor)
+                    for tracked_actor, timestamp in self._stopping_actors.items()
+                ],
+                key=lambda item: item[0],
             )
         )
 

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -482,17 +482,31 @@ def _get_dict_as_table_data(
         return upper + lower
 
 
-# Copied/adjusted from tabulate
-AIR_TABULATE_TABLEFMT = TableFormat(
-    lineabove=Line("╭", "─", "─", "╮"),
-    linebelowheader=Line("├", "─", "─", "┤"),
-    linebetweenrows=None,
-    linebelow=Line("╰", "─", "─", "╯"),
-    headerrow=DataRow("│", " ", "│"),
-    datarow=DataRow("│", " ", "│"),
-    padding=1,
-    with_header_hide=None,
-)
+if sys.stdout.encoding.startswith("utf"):
+    # Copied/adjusted from tabulate
+    AIR_TABULATE_TABLEFMT = TableFormat(
+        lineabove=Line("╭", "─", "─", "╮"),
+        linebelowheader=Line("├", "─", "─", "┤"),
+        linebetweenrows=None,
+        linebelow=Line("╰", "─", "─", "╯"),
+        headerrow=DataRow("│", " ", "│"),
+        datarow=DataRow("│", " ", "│"),
+        padding=1,
+        with_header_hide=None,
+    )
+else:
+    # For non-utf output, use ascii-compatible characters.
+    # This prevents errors e.g. when legacy windows encoding is used.
+    AIR_TABULATE_TABLEFMT = TableFormat(
+        lineabove=Line("+", "-", "-", "+"),
+        linebelowheader=Line("+", "-", "-", "+"),
+        linebetweenrows=None,
+        linebelow=Line("+", "-", "-", "+"),
+        headerrow=DataRow("|", " ", "|"),
+        datarow=DataRow("|", " ", "|"),
+        padding=1,
+        with_header_hide=None,
+    )
 
 
 def _print_dict_as_table(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When tune runs in a windows session with legacy encoding (e.g. cp-1252), the characters in the new output will result in an encoding error:

```
  File "c:\install\ray\python\ray\tune\experimental\output.py", line 700, in experiment_started
    print(
  File "C:\Miniconda3\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-72: character maps to <undefined>
```

This PR detects a non-utf encoding and reverts to ascii characters which are fully compatible with windows. This is equivalent to the old Tune output format:

```
+------------------------------+----------+-------+
| Trial name                   | status   | loc   |
|------------------------------+----------+-------|
| LightningTrainer_47320_00000 | PENDING  |       |
+------------------------------+----------+-------+
```


The PR also adds a small fix in tune controller that came up when debugging this issue on windows.

To reproduce the original issue, use:

```
set PYTHONIOENCODING=windows-1252
set PYTHONLEGACYWINDOWSSTDIO=windows-1252
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
