### PR TITLE
[Core]Fix PG leakage caused by GCS restart when PG has not been successfully remove after the job died

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -454,6 +454,11 @@ void GcsPlacementGroupManager::HandleRemovePlacementGroup(
                            RAY_LOG(INFO)
                                << "Placement group of an id, " << placement_group_id
                                << " is removed successfully.";
+                         } else {
+                           RAY_LOG(WARNING)
+                               << "Failed to remove the placement group "
+                               << placement_group_id
+                               << " due to a RPC failure, status:" << status.ToString();
                          }
                          GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
                        });
@@ -815,8 +820,16 @@ void GcsPlacementGroupManager::CleanPlacementGroupIfNeededWhenJobDead(
     }
   }
 
-  for (const auto &group : groups_to_remove) {
-    RemovePlacementGroup(group, [](Status status) {});
+  for (const auto &placement_group_id : groups_to_remove) {
+    RemovePlacementGroup(placement_group_id, [placement_group_id](Status status) {
+      if (status.ok()) {
+        RAY_LOG(INFO) << "Placement group of an id, " << placement_group_id
+                      << " is successfully removed because the job died.";
+      } else {
+        RAY_LOG(WARNING) << "Failed to remove the placement group " << placement_group_id
+                         << " upon a job died, status:" << status.ToString();
+      }
+    });
   }
 }
 
@@ -835,8 +848,16 @@ void GcsPlacementGroupManager::CleanPlacementGroupIfNeededWhenActorDead(
     }
   }
 
-  for (const auto &group : groups_to_remove) {
-    RemovePlacementGroup(group, [](Status status) {});
+  for (const auto &placement_group_id : groups_to_remove) {
+    RemovePlacementGroup(placement_group_id, [placement_group_id](Status status) {
+      if (status.ok()) {
+        RAY_LOG(INFO) << "Placement group of an id, " << placement_group_id
+                      << " is successfully removed because the creator actor died.";
+      } else {
+        RAY_LOG(WARNING) << "Failed to remove the placement group " << placement_group_id
+                         << " upon an actor death, status:" << status.ToString();
+      }
+    });
   }
 }
 
@@ -884,6 +905,8 @@ void GcsPlacementGroupManager::Initialize(const GcsInitData &gcs_init_data) {
   absl::flat_hash_map<NodeID, std::vector<rpc::Bundle>> node_to_bundles;
   absl::flat_hash_map<PlacementGroupID, std::vector<std::shared_ptr<BundleSpecification>>>
       group_to_bundles;
+  std::vector<PlacementGroupID> groups_to_remove;
+  const auto &jobs = gcs_init_data.Jobs();
   for (auto &item : gcs_init_data.PlacementGroups()) {
     auto placement_group =
         std::make_shared<GcsPlacementGroup>(item.second, placement_group_state_counter_);
@@ -892,11 +915,6 @@ void GcsPlacementGroupManager::Initialize(const GcsInitData &gcs_init_data) {
       if (!placement_group->GetName().empty()) {
         named_placement_groups_[placement_group->GetRayNamespace()].emplace(
             placement_group->GetName(), placement_group->GetPlacementGroupID());
-      }
-
-      if (item.second.state() == rpc::PlacementGroupTableData::PENDING ||
-          item.second.state() == rpc::PlacementGroupTableData::RESCHEDULING) {
-        AddToPendingQueue(std::move(placement_group));
       }
 
       if (item.second.state() == rpc::PlacementGroupTableData::CREATED ||
@@ -911,6 +929,21 @@ void GcsPlacementGroupManager::Initialize(const GcsInitData &gcs_init_data) {
           }
         }
       }
+
+      auto job_iter = jobs.find(placement_group->GetCreatorJobId());
+      auto is_job_dead = (job_iter == jobs.end() || job_iter->second.is_dead());
+      if (is_job_dead) {
+        placement_group->MarkCreatorJobDead();
+        if (placement_group->IsPlacementGroupLifetimeDone()) {
+          groups_to_remove.push_back(placement_group->GetPlacementGroupID());
+          continue;
+        }
+      }
+
+      if (item.second.state() == rpc::PlacementGroupTableData::PENDING ||
+          item.second.state() == rpc::PlacementGroupTableData::RESCHEDULING) {
+        AddToPendingQueue(std::move(placement_group));
+      }
     }
   }
 
@@ -918,6 +951,19 @@ void GcsPlacementGroupManager::Initialize(const GcsInitData &gcs_init_data) {
   gcs_placement_group_scheduler_->ReleaseUnusedBundles(node_to_bundles);
   gcs_placement_group_scheduler_->Initialize(group_to_bundles);
 
+  for (const auto &placement_group_id : groups_to_remove) {
+    RemovePlacementGroup(placement_group_id, [placement_group_id](Status status) {
+      if (status.ok()) {
+        RAY_LOG(INFO)
+            << "Placement group of an id, " << placement_group_id
+            << " is successfully removed because the job died during the placement "
+               "group manager initialization.";
+      } else {
+        RAY_LOG(WARNING) << "Failed to remove the placement group " << placement_group_id
+                         << " upon GCS restart, status:" << status.ToString();
+      }
+    });
+  }
   SchedulePendingPlacementGroups();
 }
 

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -193,10 +193,12 @@ class GcsPlacementGroupManagerTest : public ::testing::Test {
   absl::flat_hash_map<JobID, std::string> job_namespace_table_;
   std::shared_ptr<CounterMap<rpc::PlacementGroupTableData::PlacementGroupState>> counter_;
 
+ protected:
+  std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
+
  private:
   std::unique_ptr<std::thread> thread_io_service_;
   instrumented_io_context io_service_;
-  std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   ClusterResourceManager cluster_resource_manager_;
   std::shared_ptr<gcs::GcsResourceManager> gcs_resource_manager_;
   std::shared_ptr<gcs::GcsPublisher> gcs_publisher_;
@@ -535,7 +537,15 @@ TEST_F(GcsPlacementGroupManagerTest, TestRescheduleWhenNodeDead) {
 
 TEST_F(GcsPlacementGroupManagerTest, TestSchedulerReinitializeAfterGcsRestart) {
   // Create a placement group and make sure it has been created successfully.
-  auto request = Mocker::GenCreatePlacementGroupRequest();
+  auto job_id = JobID::FromInt(1);
+  auto request = Mocker::GenCreatePlacementGroupRequest(
+      /* name */ "",
+      rpc::PlacementStrategy::SPREAD,
+      /* bundles_count */ 2,
+      /* cpu_num */ 1.0,
+      /* job_id */ job_id);
+  auto job_table_data = Mocker::GenJobTableData(job_id);
+  RAY_CHECK_OK(gcs_table_storage_->JobTable().Put(job_id, *job_table_data, nullptr));
   std::atomic<int> registered_placement_group_count(0);
   RegisterPlacementGroup(request, [&registered_placement_group_count](Status status) {
     ++registered_placement_group_count;
@@ -561,6 +571,7 @@ TEST_F(GcsPlacementGroupManagerTest, TestSchedulerReinitializeAfterGcsRestart) {
       Initialize(testing::Contains(testing::Key(placement_group->GetPlacementGroupID()))))
       .Times(1);
   gcs_placement_group_manager_->Initialize(*gcs_init_data);
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::CREATED);
 }
 
 TEST_F(GcsPlacementGroupManagerTest, TestAutomaticCleanupWhenActorDeadAndJobDead) {
@@ -917,6 +928,43 @@ TEST_F(GcsPlacementGroupManagerTest, TestGetAllPlacementGroupInfoLimit) {
     ASSERT_EQ(reply.placement_group_table_data().size(), 2);
     ASSERT_EQ(reply.total(), 3);
   }
+}
+
+TEST_F(GcsPlacementGroupManagerTest, TestCheckCreatorJobIsDeadWhenGcsRestart) {
+  auto job_id = JobID::FromInt(1);
+  auto request = Mocker::GenCreatePlacementGroupRequest(
+      /* name */ "",
+      rpc::PlacementStrategy::SPREAD,
+      /* bundles_count */ 2,
+      /* cpu_num */ 1.0,
+      /* job_id */ job_id);
+  auto job_table_data = Mocker::GenJobTableData(job_id);
+  job_table_data->set_is_dead(true);
+  RAY_CHECK_OK(gcs_table_storage_->JobTable().Put(job_id, *job_table_data, nullptr));
+
+  std::atomic<int> registered_placement_group_count(0);
+  RegisterPlacementGroup(request, [&registered_placement_group_count](Status status) {
+    ++registered_placement_group_count;
+  });
+  ASSERT_EQ(registered_placement_group_count, 1);
+  WaitForExpectedPgCount(1);
+
+  auto placement_group = mock_placement_group_scheduler_->placement_groups_.back();
+  OnPlacementGroupCreationSuccess(placement_group);
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::CREATED);
+  // Reinitialize the placement group manager and the job is dead.
+  auto gcs_init_data = LoadDataFromDataStorage();
+  ASSERT_EQ(1, gcs_init_data->PlacementGroups().size());
+  EXPECT_TRUE(
+      gcs_init_data->PlacementGroups().find(placement_group->GetPlacementGroupID()) !=
+      gcs_init_data->PlacementGroups().end());
+  EXPECT_CALL(
+      *mock_placement_group_scheduler_,
+      Initialize(testing::Contains(testing::Key(placement_group->GetPlacementGroupID()))))
+      .Times(1);
+  gcs_placement_group_manager_->Initialize(*gcs_init_data);
+  // Make sure placement group is removed after gcs restart for the creator job is dead
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::REMOVED);
 }
 
 }  // namespace gcs


### PR DESCRIPTION
## Why are these changes needed?
Reproduction steps:  
1 . Task has finished. 
2. Start deleting the PG of this task. 
3. However, when PG has not been deleted successfully, GCS restarts. 
4. This will lead to PG leakage after gcs restarts, and PG remains in the "creating" status.


I will continue to analyze the problem of GCS restart when creating Actor is released, and I will fix this similar issue in a new PR In a few days.

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
