### PR TITLE
[docs]Made the install ray card clickable

### DIFF
--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -67,14 +67,14 @@
         <p style="color:#515151;">Understand how the Ray framework scales your ML workflows.</p>      
         <p style="font-weight:600;">Learn more > </p>  
   </div> </a>  
-   <div class="info-box">
+   <a class="no-underline" href="./ray-overview/installation.html" target="_blank"> <div class="info-box">
         <div class="image-header" style="padding:0px;">
             <img src="_static/img/download.png" width="44px" height="44px" />
             <h3 style="font-size:20px;">Install Ray</h3>
         </div>
         <p><pre style="border:none; margin:0px;"><code class="nohighlight" style="margin:10px;">pip install "ray[default]"</code></pre></p>      
-        <a class="no-underline" href="./ray-overview/installation.html" target="_blank"> <p style="font-weight:600; margin-bottom: 0px;">Installation guide ></p></a>
-  </div>
+        <p style="font-weight:600; margin-bottom: 0px;">Installation guide ></p>
+  </div></a>
   <a class="no-underline" href="https://colab.research.google.com/github/ray-project/ray-educational-materials/blob/main/Introductory_modules/Quickstart_with_Ray_AIR_Colab.ipynb"  target="_blank" 
         ><div class="info-box">
         <div class="image-header" style="padding:0px;">


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The installation card on the landing page was not clickable. This PR fixes that. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
[35397](https://github.com/ray-project/ray/issues/35397)
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
