### PR TITLE
[Cherry-pick][Streaming Generator] Fix a reference leak when pinning requests are …

### DIFF
--- a/python/ray/tests/test_streaming_generator.py
+++ b/python/ray/tests/test_streaming_generator.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 import numpy as np
 import sys
@@ -399,7 +400,248 @@ def test_generator_dist_chain(ray_start_cluster):
 
     for ref in chain_actor_4.get_data.options(num_returns="streaming").remote():
         assert np.array_equal(np.ones(5 * 1024 * 1024), ray.get(ref))
+        print("getting the next data")
         del ref
+
+
+def test_generator_slow_pinning_requests(monkeypatch, shutdown_only):
+    """
+    Verify when the Object pinning request from the raylet
+    is reported slowly, there's no refernece leak.
+    """
+    with monkeypatch.context() as m:
+        # defer for 10s for the second node.
+        m.setenv(
+            "RAY_testing_asio_delay_us",
+            "CoreWorkerService.grpc_server.PubsubLongPolling=1000000:1000000",
+        )
+
+        @ray.remote
+        def f():
+            yield np.ones(5 * 1024 * 1024)
+
+        for ref in f.options(num_returns="streaming").remote():
+            del ref
+
+        print(list_objects())
+
+
+@pytest.mark.parametrize("store_in_plasma", [False, True])
+def test_actor_streaming_generator(shutdown_only, store_in_plasma):
+    """Test actor/async actor with sync/async generator interfaces."""
+    ray.init()
+
+    @ray.remote
+    class Actor:
+        def f(self, ref):
+            for i in range(3):
+                yield i
+
+        async def async_f(self, ref):
+            for i in range(3):
+                await asyncio.sleep(0.1)
+                yield i
+
+        def g(self):
+            return 3
+
+    a = Actor.remote()
+    if store_in_plasma:
+        arr = np.random.rand(5 * 1024 * 1024)
+    else:
+        arr = 3
+
+    def verify_sync_task_executor():
+        generator = a.f.options(num_returns="streaming").remote(ray.put(arr))
+        # Verify it works with next.
+        assert isinstance(generator, StreamingObjectRefGenerator)
+        assert ray.get(next(generator)) == 0
+        assert ray.get(next(generator)) == 1
+        assert ray.get(next(generator)) == 2
+        with pytest.raises(StopIteration):
+            ray.get(next(generator))
+
+        # Verify it works with for.
+        generator = a.f.options(num_returns="streaming").remote(ray.put(3))
+        for index, ref in enumerate(generator):
+            assert index == ray.get(ref)
+
+    def verify_async_task_executor():
+        # Verify it works with next.
+        generator = a.async_f.options(num_returns="streaming").remote(ray.put(arr))
+        assert isinstance(generator, StreamingObjectRefGenerator)
+        assert ray.get(next(generator)) == 0
+        assert ray.get(next(generator)) == 1
+        assert ray.get(next(generator)) == 2
+
+        # Verify it works with for.
+        generator = a.f.options(num_returns="streaming").remote(ray.put(3))
+        for index, ref in enumerate(generator):
+            assert index == ray.get(ref)
+
+    async def verify_sync_task_async_generator():
+        # Verify anext
+        async_generator = a.f.options(num_returns="streaming").remote(ray.put(arr))
+        assert isinstance(async_generator, StreamingObjectRefGenerator)
+        for expected in range(3):
+            ref = await async_generator.__anext__()
+            assert await ref == expected
+        with pytest.raises(StopAsyncIteration):
+            await async_generator.__anext__()
+
+        # Verify async for.
+        async_generator = a.f.options(num_returns="streaming").remote(ray.put(arr))
+        expected = 0
+        async for ref in async_generator:
+            value = await ref
+            assert value == value
+            expected += 1
+
+    async def verify_async_task_async_generator():
+        async_generator = a.async_f.options(num_returns="streaming").remote(
+            ray.put(arr)
+        )
+        assert isinstance(async_generator, StreamingObjectRefGenerator)
+        for expected in range(3):
+            ref = await async_generator.__anext__()
+            assert await ref == expected
+        with pytest.raises(StopAsyncIteration):
+            await async_generator.__anext__()
+
+        # Verify async for.
+        async_generator = a.async_f.options(num_returns="streaming").remote(
+            ray.put(arr)
+        )
+        expected = 0
+        async for value in async_generator:
+            value = await ref
+            assert value == value
+            expected += 1
+
+    verify_sync_task_executor()
+    verify_async_task_executor()
+    asyncio.run(verify_sync_task_async_generator())
+    asyncio.run(verify_async_task_async_generator())
+
+
+def test_streaming_generator_exception(shutdown_only):
+    # Verify the exceptions are correctly raised.
+    # Also verify the followup next will raise StopIteration.
+    ray.init()
+
+    @ray.remote
+    class Actor:
+        def f(self):
+            raise ValueError
+            yield 1  # noqa
+
+        async def async_f(self):
+            raise ValueError
+            yield 1  # noqa
+
+    a = Actor.remote()
+    g = a.f.options(num_returns="streaming").remote()
+    with pytest.raises(ValueError):
+        ray.get(next(g))
+
+    with pytest.raises(StopIteration):
+        ray.get(next(g))
+
+    with pytest.raises(StopIteration):
+        ray.get(next(g))
+
+    g = a.async_f.options(num_returns="streaming").remote()
+    with pytest.raises(ValueError):
+        ray.get(next(g))
+
+    with pytest.raises(StopIteration):
+        ray.get(next(g))
+
+    with pytest.raises(StopIteration):
+        ray.get(next(g))
+
+
+def test_threaded_actor_generator(shutdown_only):
+    ray.init()
+
+    @ray.remote(max_concurrency=10)
+    class Actor:
+        def f(self):
+            for i in range(30):
+                time.sleep(0.1)
+                yield np.ones(1024 * 1024) * i
+
+    @ray.remote(max_concurrency=20)
+    class AsyncActor:
+        async def f(self):
+            for i in range(30):
+                await asyncio.sleep(0.1)
+                yield np.ones(1024 * 1024) * i
+
+    async def main():
+        a = Actor.remote()
+        asy = AsyncActor.remote()
+
+        async def run():
+            i = 0
+            async for ref in a.f.options(num_returns="streaming").remote():
+                val = ray.get(ref)
+                print(val)
+                print(ref)
+                assert np.array_equal(val, np.ones(1024 * 1024) * i)
+                i += 1
+                del ref
+
+        async def run2():
+            i = 0
+            async for ref in asy.f.options(num_returns="streaming").remote():
+                val = await ref
+                print(ref)
+                print(val)
+                assert np.array_equal(val, np.ones(1024 * 1024) * i), ref
+                i += 1
+                del ref
+
+        coroutines = [run() for _ in range(10)]
+        coroutines = [run2() for _ in range(20)]
+
+        await asyncio.gather(*coroutines)
+
+    asyncio.run(main())
+
+
+def test_generator_dist_gather(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=0, object_store_memory=1 * 1024 * 1024 * 1024)
+    ray.init()
+    cluster.add_node(num_cpus=1)
+    cluster.add_node(num_cpus=1)
+    cluster.add_node(num_cpus=1)
+    cluster.add_node(num_cpus=1)
+
+    @ray.remote(num_cpus=1)
+    class Actor:
+        def __init__(self, child=None):
+            self.child = child
+
+        def get_data(self):
+            for _ in range(10):
+                time.sleep(0.1)
+                yield np.ones(5 * 1024 * 1024)
+
+    async def all_gather():
+        actor = Actor.remote()
+        async for ref in actor.get_data.options(num_returns="streaming").remote():
+            val = await ref
+            assert np.array_equal(np.ones(5 * 1024 * 1024), val)
+            del ref
+
+    async def main():
+        await asyncio.gather(all_gather(), all_gather(), all_gather(), all_gather())
+
+    asyncio.run(main())
+    summary = ray._private.internal_api.memory_summary(stats_only=True)
+    print(summary)
 
 
 if __name__ == "__main__":

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3286,10 +3286,9 @@ void CoreWorker::ProcessSubscribeForObjectEviction(
     const auto generator_id = ObjectID::FromBinary(message.generator_id());
     RAY_CHECK(!generator_id.IsNil());
     if (task_manager_->ObjectRefStreamExists(generator_id)) {
-      // It is possible this reference will leak if the ObjectRefStream is
-      // deleted or the corresponding object ID is not reported via
-      // HandleReportGeneratorItemReturns. TODO(sang): Handle the edge case.
-      reference_counter_->OwnDynamicStreamingTaskReturnRef(object_id, generator_id);
+      // ObjectRefStreamExists is used to distinguigsh num_returns="dynamic" vs
+      // "streaming".
+      task_manager_->TemporarilyOwnGeneratorReturnRefIfNeeded(object_id, generator_id);
     } else {
       reference_counter_->AddDynamicReturn(object_id, generator_id);
     }
@@ -3425,12 +3424,10 @@ void CoreWorker::AddSpilledObjectLocationOwner(
     // object is spilled before the reply from the task that created the
     // object. Add the dynamically created object to our ref counter so that we
     // know that it exists.
-    RAY_CHECK(!generator_id->IsNil());
     if (task_manager_->ObjectRefStreamExists(*generator_id)) {
-      // It is possible this reference will leak if the ObjectRefStream is
-      // deleted or the corresponding object ID is not reported via
-      // HandleReportGeneratorItemReturns. TODO(sang): Handle the edge case.
-      reference_counter_->OwnDynamicStreamingTaskReturnRef(object_id, *generator_id);
+      // ObjectRefStreamExists is used to distinguigsh num_returns="dynamic" vs
+      // "streaming".
+      task_manager_->TemporarilyOwnGeneratorReturnRefIfNeeded(object_id, *generator_id);
     } else {
       reference_counter_->AddDynamicReturn(object_id, *generator_id);
     }
@@ -3462,10 +3459,10 @@ void CoreWorker::AddObjectLocationOwner(const ObjectID &object_id,
   const auto &maybe_generator_id = task_manager_->TaskGeneratorId(object_id.TaskId());
   if (!maybe_generator_id.IsNil()) {
     if (task_manager_->ObjectRefStreamExists(maybe_generator_id)) {
-      // It is possible this reference will leak if the ObjectRefStream is
-      // deleted or the corresponding object ID is not reported via
-      // HandleReportGeneratorItemReturns. TODO(sang): Handle the edge case.
-      reference_counter_->OwnDynamicStreamingTaskReturnRef(object_id, maybe_generator_id);
+      // ObjectRefStreamExists is used to distinguigsh num_returns="dynamic" vs
+      // "streaming".
+      task_manager_->TemporarilyOwnGeneratorReturnRefIfNeeded(object_id,
+                                                              maybe_generator_id);
     } else {
       // The task is a generator and may not have finished yet. Add the internal
       // ObjectID so that we can update its location.


### PR DESCRIPTION
…received after refs are consumed. (#35712)

When we put a new object or an object is spilled, raylet sends a RPC to the owner. For example, it sends a request to the owner to pin the plasma object until the ref goes out of scope.

For none-generator tasks, we always guarantee to create return references, so we can handle these RPCs properly, However, when a generator task is used, we don't know the references ahead of time, which means it is not guaranteed to own the references when the RPC is received. In this case, we own a reference before it is reported from the executor. See the code below for more details.

ray/src/ray/core_worker/core_worker.cc

Line 3292 in 5acf41e

 reference_counter_->OwnDynamicStreamingTaskReturnRef(object_id, generator_id);
However, this code is prone to error and causes reference leaks. Here are some examples. Imagine "WRITE 0" means the generator task return is written to a stream index 0. PinObjectRPCRecieved means the raylet RPC is received. READ 0 means we read the index 0 from a stream.

Example 1
WRITE 0
READ 0
PinObjectRPCRecieved
-> This means the reference is already consumed, and the PinObjectRPCRecieved comes after that. In this case, we shouldn't add a reference to the object, otherwise, it will leak because we cannot read this ref anymore (cuz it is already consumed).

Example 2
PinObjectRPCRecieved
In this case, WRITE 0 is failed. So, the when the object is owned by PinObjectRPCRecieved, it will be never be cleaned up.

To handle all these cases, we introduce a new API TemporarilyInsertToStreamIfNeeded. This API will own the object only when

the corresponding ref was never consumed
The stream has not been deleted.
And add the object ref to the temporary refs until it is reported. If the report fails, all the references will be removed when the stream is deleted.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/issues/35634

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
