### PR TITLE
[Train] Skip some Trainer docstring examples

### DIFF
--- a/python/ray/train/huggingface/accelerate/accelerate_trainer.py
+++ b/python/ray/train/huggingface/accelerate/accelerate_trainer.py
@@ -110,7 +110,7 @@ class AccelerateTrainer(TorchTrainer):
     It is tested with ``accelerate==0.17.1``.
 
     Example:
-        .. testcode::
+        .. code-block:: python
 
             import torch
             import torch.nn as nn
@@ -224,12 +224,6 @@ class AccelerateTrainer(TorchTrainer):
 
             # Assert loss is less 0.09
             assert best_checkpoint_loss <= 0.09
-
-    .. testoutput::
-        :hide:
-        :options: +ELLIPSIS
-
-        ...
 
     Args:
         train_loop_per_worker: The training function to execute.

--- a/python/ray/train/lightning/lightning_predictor.py
+++ b/python/ray/train/lightning/lightning_predictor.py
@@ -15,7 +15,7 @@ class LightningPredictor(TorchPredictor):
     """A predictor for PyTorch Lightning modules.
 
     Example:
-        .. testcode:: python
+        .. testcode::
 
             import torch
             import numpy as np
@@ -54,11 +54,6 @@ class LightningPredictor(TorchPredictor):
             output = predictor.predict(batch)
 
             assert output["predictions"].shape == (batch_size, output_dim)
-
-
-        .. testoutput::
-            :hide:
-            :options: +ELLIPSIS
 
     Args:
         model: The PyTorch Lightning module to use for predictions.

--- a/python/ray/train/lightning/lightning_trainer.py
+++ b/python/ray/train/lightning/lightning_trainer.py
@@ -238,7 +238,7 @@ class LightningTrainer(TorchTrainer):
     run ``pytorch_lightning.Trainer.fit``.
 
     Example:
-        .. testcode::
+        .. code-block:: python
 
             import torch
             import torch.nn.functional as F
@@ -325,12 +325,6 @@ class LightningTrainer(TorchTrainer):
             )
             result = trainer.fit()
             result
-
-    .. testoutput::
-        :hide:
-        :options: +ELLIPSIS
-
-        ...
 
     Args:
         lightning_config: Configuration for setting up the Pytorch Lightning Trainer.

--- a/python/ray/train/tensorflow/tensorflow_trainer.py
+++ b/python/ray/train/tensorflow/tensorflow_trainer.py
@@ -85,7 +85,7 @@ class TensorflowTrainer(DataParallelTrainer):
 
     Example:
 
-    .. testcode::
+    .. code-block:: python
 
         import tensorflow as tf
 
@@ -136,12 +136,6 @@ class TensorflowTrainer(DataParallelTrainer):
             train_loop_config={"num_epochs": 2},
         )
         result = trainer.fit()
-
-    .. testoutput::
-        :hide:
-        :options: +ELLIPSIS
-
-        ...
 
     Args:
         train_loop_per_worker: The training function to execute.

--- a/python/ray/train/torch/torch_trainer.py
+++ b/python/ray/train/torch/torch_trainer.py
@@ -129,7 +129,7 @@ class TorchTrainer(DataParallelTrainer):
 
     Example:
 
-        .. testcode::
+        .. code-block:: python
 
             import torch
             import torch.nn as nn
@@ -228,12 +228,6 @@ class TorchTrainer(DataParallelTrainer):
 
             # Assert loss is less 0.09
             assert best_checkpoint_loss <= 0.09   # doctest: +SKIP
-
-    .. testoutput::
-        :hide:
-        :options: +ELLIPSIS
-
-        ...
 
     Args:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Temporarily skipping some Train examples to unblock #35286. Once we that PR is merged, we'll update these docstrings to run with GPUs. 

Two reasons for the change:

1. The examples are slow and can cause doctest to timeout.
2. By switching to `code-block:: python`, we can track this as an example that needs to be updated.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
