### PR TITLE
Add link to actor logs and message that task logs don't exist for async actors

### DIFF
--- a/dashboard/client/src/pages/serve/ServeApplicationsListPage.component.test.tsx
+++ b/dashboard/client/src/pages/serve/ServeApplicationsListPage.component.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import React from "react";
 import { getActor } from "../../service/actor";
 import { getServeApplications } from "../../service/serve";
@@ -19,7 +18,7 @@ const mockGetActor = jest.mocked(getActor);
 
 describe("ServeApplicationsListPage", () => {
   it("renders list", async () => {
-    expect.assertions(15);
+    expect.assertions(14);
 
     // Mock ServeController actor fetch
     mockGetActor.mockResolvedValue({
@@ -81,8 +80,6 @@ describe("ServeApplicationsListPage", () => {
 
     render(<ServeApplicationsListPage />, { wrapper: TEST_APP_WRAPPER });
 
-    const user = userEvent.setup();
-
     await screen.findByText("System");
     expect(screen.getByText("System")).toBeVisible();
     expect(screen.getByText("1.2.3.4")).toBeVisible();
@@ -105,11 +102,6 @@ describe("ServeApplicationsListPage", () => {
     expect(screen.getByText("second-app")).toBeVisible();
     expect(screen.getByText("/second-app")).toBeVisible();
     expect(screen.getByText("DEPLOYING")).toBeVisible();
-
-    // Config dialog
-    await user.click(screen.getAllByText("View")[0]);
-    await screen.findByText(/import_path: home:graph/);
-    expect(screen.getByText(/import_path: home:graph/)).toBeVisible();
 
     expect(screen.getByText("Metrics")).toBeVisible();
   });

--- a/dashboard/client/src/pages/task/TaskPage.tsx
+++ b/dashboard/client/src/pages/task/TaskPage.tsx
@@ -238,7 +238,6 @@ const TaskLogs = ({
     error_message,
     error_type,
     worker_id,
-    node_id,
     task_log_info,
     actor_id,
   },
@@ -254,7 +253,7 @@ const TaskLogs = ({
       : undefined;
 
   const tabs: MultiTabLogViewerTabDetails[] = [
-    ...(worker_id !== null && node_id !== null && task_log_info !== null
+    ...(worker_id !== null && task_log_info !== null
       ? ([
           {
             title: "stderr",
@@ -273,8 +272,8 @@ const TaskLogs = ({
           {
             title: "Logs",
             contents:
-              "For async actors, logs of individual tasks are not available. " +
-              'Please use the "other logs" link to access the all the logs of the actor instead.',
+              "Logs of async actor tasks or threaded actor tasks (concurency > 1) are only available " +
+              'as part of the actor logs. Please click "Other logs" link above to access the actor logs.',
           },
         ]
       : []),

--- a/dashboard/client/src/pages/task/TaskPage.tsx
+++ b/dashboard/client/src/pages/task/TaskPage.tsx
@@ -233,15 +233,28 @@ type TaskLogsProps = {
 };
 
 const TaskLogs = ({
-  task: { task_id, error_message, error_type, worker_id, node_id },
+  task: {
+    task_id,
+    error_message,
+    error_type,
+    worker_id,
+    node_id,
+    task_log_info,
+    actor_id,
+  },
 }: TaskLogsProps) => {
   const errorDetails =
     error_type !== null && error_message !== null
       ? `Error Type: ${error_type}\n\n${error_message}`
       : undefined;
 
+  const otherLogsLink =
+    task_log_info === null && actor_id !== null
+      ? `/actors/${actor_id}`
+      : undefined;
+
   const tabs: MultiTabLogViewerTabDetails[] = [
-    ...(worker_id !== null && node_id !== null
+    ...(worker_id !== null && node_id !== null && task_log_info !== null
       ? ([
           {
             title: "stderr",
@@ -255,6 +268,16 @@ const TaskLogs = ({
           },
         ] as const)
       : []),
+    ...(task_log_info === null
+      ? [
+          {
+            title: "Logs",
+            contents:
+              "For async actors, logs of individual tasks are not available. " +
+              'Please use the "other logs" link to access the all the logs of the actor instead.',
+          },
+        ]
+      : []),
     // TODO(aguo): uncomment once PID is available in the API.
     // {
     //   title: "system",
@@ -266,5 +289,5 @@ const TaskLogs = ({
       ? [{ title: "Error stack trace", contents: errorDetails }]
       : []),
   ];
-  return <MultiTabLogViewer tabs={tabs} />;
+  return <MultiTabLogViewer tabs={tabs} otherLogsLink={otherLogsLink} />;
 };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For async actors, we cannot support task logs. So add a message and link to view the logs via the actor logs

<img width="1781" alt="Screenshot 2023-05-26 at 11 52 23 AM" src="https://github.com/ray-project/ray/assets/711935/a00c1a3a-53c7-4477-9ebe-8d7a3ba86846">



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
follow-up of #35572 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
