### PR TITLE
[Data] Correct `TorchDetectionPredictor` type hint and docstring

### DIFF
--- a/python/ray/train/torch/torch_detection_predictor.py
+++ b/python/ray/train/torch/torch_detection_predictor.py
@@ -104,31 +104,13 @@ class TorchDetectionPredictor(TorchPredictor):
 
 def _convert_outputs_to_ndarray_batch(
     outputs: List[Dict[str, torch.Tensor]],
-) -> Dict[str, np.ndarray]:
+) -> Dict[str, List[torch.Tensor]]:
     """Batch detection model outputs.
 
     TorchVision detection models return `List[Dict[Tensor]]`. Each `Dict` contain
     'boxes', 'labels, and 'scores'.
 
-    >>> import torch
-    >>> from torchvision import models
-    >>> model = models.detection.fasterrcnn_resnet50_fpn_v2()
-    >>> model.eval()  # doctest: +ELLIPSIS
-    FasterRCNN(...)
-    >>> outputs = model(torch.zeros((2, 3, 32, 32)))
-    >>> len(outputs)
-    2
-    >>> outputs[0].keys()
-    dict_keys(['boxes', 'labels', 'scores'])
-
-    This function batches values and returns a `Dict[str, np.ndarray]`.
-
-    >>> from ray.train.torch.torch_detection_predictor import _convert_outputs_to_ndarray_batch
-    >>> batch = _convert_outputs_to_ndarray_batch(outputs)
-    >>> batch.keys()
-    dict_keys(['boxes', 'labels', 'scores'])
-    >>> batch["boxes"].shape
-    (2,)
+    This function batches values and returns a `Dict[str, List[Tensor]]`.
     """  # noqa: E501
     batch = collections.defaultdict(list)
     for output in outputs:

--- a/python/ray/train/torch/torch_detection_predictor.py
+++ b/python/ray/train/torch/torch_detection_predictor.py
@@ -96,13 +96,13 @@ class TorchDetectionPredictor(TorchPredictor):
             torch.as_tensor(image, dtype=dtype).to(self.device) for image in images
         ]
         outputs = self.call_model(inputs)
-        outputs = _convert_outputs_to_ndarray_batch(outputs)
+        outputs = _convert_outputs_to_batch(outputs)
         outputs = {"pred_" + key: value for key, value in outputs.items()}
 
         return outputs
 
 
-def _convert_outputs_to_ndarray_batch(
+def _convert_outputs_to_batch(
     outputs: List[Dict[str, torch.Tensor]],
 ) -> Dict[str, List[torch.Tensor]]:
     """Batch detection model outputs.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

https://github.com/ray-project/ray/pull/35272 changed the implementation of `_convert_outputs_to_ndarray_batch`, but didn't update the type annotation or docstring.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
