### PR TITLE
[Data] Clean up dataset type check in `to_tf`

### DIFF
--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -20,20 +20,12 @@ from ray.util.annotations import PublicAPI
 from ray.data._internal.block_batching import batch_block_refs
 from ray.data._internal.block_batching.iter_batches import iter_batches
 from ray.data._internal.stats import DatasetStats
-from ray.data._internal.util import _is_tensor_schema
 
 if TYPE_CHECKING:
     import tensorflow as tf
     import torch
     from ray.data._internal.torch_iterable_dataset import TorchTensorBatchType
     from ray.data.dataset import TensorFlowTensorBatchType, Schema
-
-
-def _is_tensor_dataset(schema) -> bool:
-    """Return ``True`` if this is an iterator over a tensor dataset."""
-    if schema is None or isinstance(schema, type):
-        return False
-    return _is_tensor_schema(schema.names)
 
 
 @PublicAPI(stability="beta")
@@ -728,20 +720,6 @@ class DataIterator(abc.ABC):
             raise ValueError("tensorflow must be installed!")
 
         schema = self.schema()
-
-        if _is_tensor_dataset(schema):
-            raise NotImplementedError(
-                "`to_tf` doesn't support single-column tensor datasets. Call the "
-                "more-flexible `iter_batches` instead."
-            )
-
-        if isinstance(schema, type):
-            raise NotImplementedError(
-                "`to_tf` doesn't support simple datasets. Call `map_batches` and "
-                "convert your data to a tabular format. Alternatively, call the more-"
-                "flexible `iter_batches` in place of `to_tf`."
-            )
-
         valid_columns = schema.names
 
         def validate_column(column: str) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We previously exposed three types of datasets: simple, tensor, and tabular. `to_tf` only supported tabular datasets, and we validated that this was the case. Now that there's only one type of dataset (tabular), the validation code isn't necessary. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
