### PR TITLE
[Data] Always write data to head node

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1,9 +1,11 @@
 import importlib
 import logging
 import os
+import pathlib
 from typing import Any, List, Union, Optional, TYPE_CHECKING
 from types import ModuleType
 import sys
+import urllib.parse
 
 import numpy as np
 
@@ -209,9 +211,6 @@ def _resolve_custom_scheme(path: str) -> str:
 
     The supported custom schemes are: "local", "example".
     """
-    import pathlib
-    import urllib.parse
-
     parsed_uri = urllib.parse.urlparse(path)
     if parsed_uri.scheme == _LOCAL_SCHEME:
         path = parsed_uri.netloc + parsed_uri.path
@@ -227,9 +226,6 @@ def _is_local_scheme(paths: Union[str, List[str]]) -> bool:
     Note: The paths must be in same scheme, i.e. it's invalid and
     will raise error if paths are mixed with different schemes.
     """
-    import pathlib
-    import urllib.parse
-
     if isinstance(paths, str):
         paths = [paths]
     if isinstance(paths, pathlib.Path):

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -221,6 +221,12 @@ def _resolve_custom_scheme(path: str) -> str:
     return path
 
 
+def _has_scheme(path: str) -> bool:
+    assert isinstance(path, str)
+    parse_result = urllib.parse.urlparse(path)
+    return parse_result.schema != ""
+
+
 def _is_local_scheme(paths: Union[str, List[str]]) -> bool:
     """Returns True if the given paths are in local scheme.
     Note: The paths must be in same scheme, i.e. it's invalid and

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -70,6 +70,7 @@ from ray.data._internal.equalize import _equalize
 from ray.data._internal.lazy_block_list import LazyBlockList
 from ray.data._internal.util import (
     _estimate_available_parallelism,
+    _has_scheme,
     _is_local_scheme,
     validate_compute,
     ConsumptionAPI,
@@ -2744,12 +2745,9 @@ class Dataset:
         """
         if ray_remote_args is None:
             ray_remote_args = {}
+
         path = write_args.get("path", None)
-        if path and _is_local_scheme(path):
-            if ray.util.client.ray.is_connected():
-                raise ValueError(
-                    f"The local scheme paths {path} are not supported in Ray Client."
-                )
+        if path and not _has_scheme(path) or _is_local_scheme(path):
             ray_remote_args["scheduling_strategy"] = NodeAffinitySchedulingStrategy(
                 ray.get_runtime_context().get_node_id(),
                 soft=False,

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -184,6 +184,13 @@ def test_write_datasource(ray_start_regular_shared, pipelined):
     assert ray.get(output.data_sink.get_rows_written.remote()) == 10
 
 
+def test_write_datasource_local_path(ray_started_regular_shared, tmpdir):
+    ds = ray.data.range(1)
+    path = tmpdir.mkdir("spam")
+    ds.write_csv(path)
+    assert os.listdir(path)
+
+
 def test_from_tf(ray_start_regular_shared):
     import tensorflow as tf
     import tensorflow_datasets as tfds


### PR DESCRIPTION
**Depends on**:
- [ ] #35852 

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you call `write_datasource` and specify a local directory, Ray Data randomly writes the data to that directory on different nodes. This isn't helpful, because you'd want your data on a single node. 

This PR updates the implementation to always write data to the head node.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
