### PR TITLE
[RLlib] Make learner group with non blocking update return multiple results

### DIFF
--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -217,8 +217,7 @@ class LearnerGroup:
                 )
             )
 
-        # TODO (Kourosh): Maybe we should use LearnerInfoBuilder() here?
-        # No reduce function -> Return results as is: (possibly empty) list of mappings.
+        # TODO(sven): Move reduce_fn to the training_step
         if reduce_fn is None:
             return results
         else:
@@ -318,6 +317,7 @@ class LearnerGroup:
             # ready.
             results = self._get_async_results(results)
 
+            # TODO(sven): Move reduce_fn to the training_step
             if reduce_fn is None:
                 return results
             else:
@@ -396,6 +396,7 @@ class LearnerGroup:
             results = self._get_results(results)
             if reduce_fn is None:
                 return results
+            # TODO(sven): Move reduce_fn to the training_step
             return reduce_fn(results)
 
     def add_module(

--- a/rllib/core/learner/tests/test_learner_group.py
+++ b/rllib/core/learner/tests/test_learner_group.py
@@ -248,7 +248,7 @@ class TestLearnerGroup(unittest.TestCase):
         fws = ["torch", "tf2"]
         # async_update only needs to be tested for the most complex case.
         # so we'll only test it for multi-gpu-ddp.
-        scaling_modes = ["multi-cpu-ddp"]
+        scaling_modes = ["multi-gpu-ddp"]
         test_iterator = itertools.product(fws, scaling_modes)
 
         for fw, scaling_mode in test_iterator:

--- a/rllib/core/learner/tests/test_learner_group.py
+++ b/rllib/core/learner/tests/test_learner_group.py
@@ -246,9 +246,9 @@ class TestLearnerGroup(unittest.TestCase):
     def test_async_update(self):
         """Test that async style updates converge to the same result as sync."""
         fws = ["torch", "tf2"]
-        # block=True only needs to be tested for the most complex case.
+        # async_update only needs to be tested for the most complex case.
         # so we'll only test it for multi-gpu-ddp.
-        scaling_modes = ["multi-gpu-ddp"]
+        scaling_modes = ["multi-cpu-ddp"]
         test_iterator = itertools.product(fws, scaling_modes)
 
         for fw, scaling_mode in test_iterator:
@@ -264,10 +264,10 @@ class TestLearnerGroup(unittest.TestCase):
             timer_sync = _Timer()
             timer_async = _Timer()
             with timer_sync:
-                learner_group.update(batch.as_multi_agent(), block=True, reduce_fn=None)
+                learner_group.update(batch.as_multi_agent(), reduce_fn=None)
             with timer_async:
-                result_async = learner_group.update(
-                    batch.as_multi_agent(), block=False, reduce_fn=None
+                result_async = learner_group.async_update(
+                    batch.as_multi_agent(), reduce_fn=None
                 )
             # ideally the the first async update will return nothing, and an easy
             # way to check that is if the time for an async update call is faster
@@ -278,8 +278,8 @@ class TestLearnerGroup(unittest.TestCase):
             iter_i = 0
             while True:
                 batch = reader.next()
-                async_results = learner_group.update(
-                    batch.as_multi_agent(), block=False, reduce_fn=None
+                async_results = learner_group.async_update(
+                    batch.as_multi_agent(), reduce_fn=None
                 )
                 if not async_results:
                     continue


### PR DESCRIPTION
Signed-off-by: Avnish <avnishnarayan@gmail.com>

The results aggregation of the learner was broken becasue we upped the amount of async requests for the learner. This change should fix that problem.


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
