### PR TITLE
[2.5.0 Release Disable further docker builds

### DIFF
--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -523,44 +523,44 @@
     #- docker run --rm --privileged -v /ray/containers:/var/lib/containers -v /ray:/ray --entrypoint /bin/bash
       #rayproject/ray-worker-container:nightly-py36-cpu /ray/ci/build/test-worker-in-container.sh
 
-#- label: ":kubernetes: operator"
-#  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
-#  instance_size: medium
-#  commands:
-#    - |
-#      cleanup() {
-#        if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi
-#        python python/ray/tests/kuberay/setup/teardown_kuberay.py || true
-#        kind delete cluster
-#      }
-#      trap cleanup EXIT
-#    - echo "--- Setting up Python 3.7 environment."
-#    - ./ci/env/install-dependencies.sh
-#    # Specifying above somehow messes up the Ray install.
-#    # Uninstall and re-install Ray so that we can use Ray Client.
-#    # (Remove thirdparty_files to sidestep an issue with psutil.)
-#    - pip uninstall -y ray && rm -rf /ray/python/ray/thirdparty_files
-#    - pip install -e /ray/python
-#    - echo "--- Setting up local kind cluster."
-#    - ./ci/k8s/prep-k8s-environment.sh
-#    - echo "--- Building py37-cpu Ray image for the test."
-#    - LINUX_WHEELS=1 ./ci/ci.sh build
-#    - pip install -q docker
-#    - python ci/build/build-docker-images.py --py-versions py37 --device-types cpu --build-type LOCAL --build-base
-#    # Tag the image built in the last step. We want to be sure to distinguish the image from the real Ray nightly.
-#    - docker tag rayproject/ray:nightly-py37-cpu ray-ci:kuberay-test
-#    # Load the image into the kind node.
-#    - kind load docker-image ray-ci:kuberay-test
-#    - echo "--- Setting up KubeRay operator."
-#    - python python/ray/tests/kuberay/setup/setup_kuberay.py
-#    - ./ci/env/env_info.sh
-#    - echo "--- Running the test."
-#    - bazel test --config=ci $(./ci/run/bazel_export_options)
-#      --test_tag_filters=kuberay_operator
-#      --test_env=RAY_IMAGE=docker.io/library/ray-ci:kuberay-test
-#      --test_env=PULL_POLICY=IfNotPresent
-#      --test_env=KUBECONFIG=/root/.kube/config
-#      python/ray/tests/...
+- label: ":kubernetes: operator"
+  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+  instance_size: medium
+  commands:
+    - |
+      cleanup() {
+        if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi
+        python python/ray/tests/kuberay/setup/teardown_kuberay.py || true
+        kind delete cluster
+      }
+      trap cleanup EXIT
+    - echo "--- Setting up Python 3.7 environment."
+    - ./ci/env/install-dependencies.sh
+    # Specifying above somehow messes up the Ray install.
+    # Uninstall and re-install Ray so that we can use Ray Client.
+    # (Remove thirdparty_files to sidestep an issue with psutil.)
+    - pip uninstall -y ray && rm -rf /ray/python/ray/thirdparty_files
+    - pip install -e /ray/python
+    - echo "--- Setting up local kind cluster."
+    - ./ci/k8s/prep-k8s-environment.sh
+    - echo "--- Building py37-cpu Ray image for the test."
+    - LINUX_WHEELS=1 ./ci/ci.sh build
+    - pip install -q docker
+    - python ci/build/build-docker-images.py --py-versions py37 --device-types cpu --build-type LOCAL --build-base
+    # Tag the image built in the last step. We want to be sure to distinguish the image from the real Ray nightly.
+    - docker tag rayproject/ray:nightly-py37-cpu ray-ci:kuberay-test
+    # Load the image into the kind node.
+    - kind load docker-image ray-ci:kuberay-test
+    - echo "--- Setting up KubeRay operator."
+    - python python/ray/tests/kuberay/setup/setup_kuberay.py
+    - ./ci/env/env_info.sh
+    - echo "--- Running the test."
+    - bazel test --config=ci $(./ci/run/bazel_export_options)
+      --test_tag_filters=kuberay_operator
+      --test_env=RAY_IMAGE=docker.io/library/ray-ci:kuberay-test
+      --test_env=PULL_POLICY=IfNotPresent
+      --test_env=KUBECONFIG=/root/.kube/config
+      python/ray/tests/...
 
 - label: ":book: Documentation"
   commands:
@@ -581,28 +581,28 @@
     - pip install "mosaicml==0.12.1" "urllib3<1.27" --ignore-installed
     - ./ci/ci.sh build
 
-#- label: ":octopus: Tune multinode tests"
-#  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TUNE_AFFECTED"]
-#  instance_size: medium
-#  commands:
-#    - LINUX_WHEELS=1 ./ci/ci.sh build
-#    - mkdir -p ~/.docker/cli-plugins/ && curl -SL https://github.com/docker/compose/releases/download/v2.0.1/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose && chmod +x ~/.docker/cli-plugins/docker-compose
-#    - pip install -U docker aws_requests_auth boto3
-#    - ./ci/env/env_info.sh
-#    - python ./ci/build/build-docker-images.py --py-versions py37 --device-types cpu --build-type LOCAL --build-base
-#    - python ./ci/build/build-multinode-image.py rayproject/ray:nightly-py37-cpu rayproject/ray:multinode-py37
-#    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only
-#      --test_tag_filters=multinode,-example,-flaky,-py37,-soft_imports,-gpu_only,-rllib
-#      python/ray/tune/...
-#      --test_env=RAY_HAS_SSH="1"
-#      --test_env=RAY_DOCKER_IMAGE="rayproject/ray:multinode-py37"
-#      --test_env=RAY_TEMPDIR="/ray-mount"
-#      --test_env=RAY_HOSTDIR="/ray"
-#      --test_env=RAY_TESTHOST="dind-daemon"
-#      --test_env=DOCKER_HOST=tcp://docker:2376
-#      --test_env=DOCKER_TLS_VERIFY=1
-#      --test_env=DOCKER_CERT_PATH=/certs/client
-#      --test_env=DOCKER_TLS_CERTDIR=/certs
+- label: ":octopus: Tune multinode tests"
+  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TUNE_AFFECTED"]
+  instance_size: medium
+  commands:
+    - LINUX_WHEELS=1 ./ci/ci.sh build
+    - mkdir -p ~/.docker/cli-plugins/ && curl -SL https://github.com/docker/compose/releases/download/v2.0.1/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose && chmod +x ~/.docker/cli-plugins/docker-compose
+    - pip install -U docker aws_requests_auth boto3
+    - ./ci/env/env_info.sh
+    - python ./ci/build/build-docker-images.py --py-versions py37 --device-types cpu --build-type LOCAL --build-base
+    - python ./ci/build/build-multinode-image.py rayproject/ray:nightly-py37-cpu rayproject/ray:multinode-py37
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only
+      --test_tag_filters=multinode,-example,-flaky,-py37,-soft_imports,-gpu_only,-rllib
+      python/ray/tune/...
+      --test_env=RAY_HAS_SSH="1"
+      --test_env=RAY_DOCKER_IMAGE="rayproject/ray:multinode-py37"
+      --test_env=RAY_TEMPDIR="/ray-mount"
+      --test_env=RAY_HOSTDIR="/ray"
+      --test_env=RAY_TESTHOST="dind-daemon"
+      --test_env=DOCKER_HOST=tcp://docker:2376
+      --test_env=DOCKER_TLS_VERIFY=1
+      --test_env=DOCKER_CERT_PATH=/certs/client
+      --test_env=DOCKER_TLS_CERTDIR=/certs
 
 - label: ":hadoop: Ray AIR HDFS tests"
   conditions: ["RAY_CI_ML_AFFECTED"]

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -83,84 +83,84 @@
 #     # Upload to latest directory.
 #     - if [ "$BUILDKITE_BRANCH" == "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
 
-- label: ":docker: Build Images: py37 (1/2)"
-  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
-  instance_size: medium
-  commands:
-    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.7 ./ci/ci.sh build
-    - pip install -q docker aws_requests_auth boto3
-    - ./ci/env/env_info.sh
-    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py37 -T cpu -T cu101 -T cu102 -T cu110 --build-type BUILDKITE --build-base
-
-- label: ":docker: Build Images: py37 (2/2)"
-  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
-  instance_size: medium
-  commands:
-    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.7 ./ci/ci.sh build
-    - pip install -q docker aws_requests_auth boto3
-    - ./ci/env/env_info.sh
-    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py37 -T cu111 -T cu112 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base
-
-- label: ":docker: Build Images: py38 (1/2)"
-  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
-  instance_size: medium
-  commands:
-    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.8 ./ci/ci.sh build
-    - pip install -q docker aws_requests_auth boto3
-    - ./ci/env/env_info.sh
-    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py38 -T cpu -T cu101 -T cu102 -T cu110 --build-type BUILDKITE --build-base
-
-- label: ":docker: Build Images: py38 (2/2)"
-  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
-  instance_size: medium
-  commands:
-    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.8 ./ci/ci.sh build
-    - pip install -q docker aws_requests_auth boto3
-    - ./ci/env/env_info.sh
-    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py38 -T cu111 -T cu112 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base
-
-- label: ":docker: Build Images: py39 (1/2)"
-  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
-  instance_size: medium
-  commands:
-    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.9 ./ci/ci.sh build
-    - pip install -q docker aws_requests_auth boto3
-    - ./ci/env/env_info.sh
-    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py39 -T cpu -T cu101 -T cu102 -T cu110 --build-type BUILDKITE --build-base
-
-- label: ":docker: Build Images: py39 (2/2)"
-  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
-  instance_size: medium
-  commands:
-    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.9 ./ci/ci.sh build
-    - pip install -q docker aws_requests_auth boto3
-    - ./ci/env/env_info.sh
-    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py39 -T cu111 -T cu112 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base
-
-- label: ":docker: Build Images: py310 (1/2)"
-  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
-  instance_size: medium
-  commands:
-    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.10 ./ci/ci.sh build
-    - pip install -q docker aws_requests_auth boto3
-    - ./ci/env/env_info.sh
-    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py310 -T cpu -T cu101 -T cu102 -T cu110 --build-type BUILDKITE --build-base
-
-- label: ":docker: Build Images: py310 (2/2)"
-  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
-  instance_size: medium
-  commands:
-    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.10 ./ci/ci.sh build
-    - pip install -q docker aws_requests_auth boto3
-    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions py310 -T cu111 -T cu112 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base
+#- label: ":docker: Build Images: py37 (1/2)"
+#  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
+#  instance_size: medium
+#  commands:
+#    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.7 ./ci/ci.sh build
+#    - pip install -q docker aws_requests_auth boto3
+#    - ./ci/env/env_info.sh
+#    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
+#    - python ./ci/build/build-docker-images.py --py-versions py37 -T cpu -T cu101 -T cu102 -T cu110 --build-type BUILDKITE --build-base
+#
+#- label: ":docker: Build Images: py37 (2/2)"
+#  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
+#  instance_size: medium
+#  commands:
+#    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.7 ./ci/ci.sh build
+#    - pip install -q docker aws_requests_auth boto3
+#    - ./ci/env/env_info.sh
+#    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
+#    - python ./ci/build/build-docker-images.py --py-versions py37 -T cu111 -T cu112 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base
+#
+#- label: ":docker: Build Images: py38 (1/2)"
+#  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
+#  instance_size: medium
+#  commands:
+#    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.8 ./ci/ci.sh build
+#    - pip install -q docker aws_requests_auth boto3
+#    - ./ci/env/env_info.sh
+#    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
+#    - python ./ci/build/build-docker-images.py --py-versions py38 -T cpu -T cu101 -T cu102 -T cu110 --build-type BUILDKITE --build-base
+#
+#- label: ":docker: Build Images: py38 (2/2)"
+#  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
+#  instance_size: medium
+#  commands:
+#    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.8 ./ci/ci.sh build
+#    - pip install -q docker aws_requests_auth boto3
+#    - ./ci/env/env_info.sh
+#    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
+#    - python ./ci/build/build-docker-images.py --py-versions py38 -T cu111 -T cu112 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base
+#
+#- label: ":docker: Build Images: py39 (1/2)"
+#  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
+#  instance_size: medium
+#  commands:
+#    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.9 ./ci/ci.sh build
+#    - pip install -q docker aws_requests_auth boto3
+#    - ./ci/env/env_info.sh
+#    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
+#    - python ./ci/build/build-docker-images.py --py-versions py39 -T cpu -T cu101 -T cu102 -T cu110 --build-type BUILDKITE --build-base
+#
+#- label: ":docker: Build Images: py39 (2/2)"
+#  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
+#  instance_size: medium
+#  commands:
+#    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.9 ./ci/ci.sh build
+#    - pip install -q docker aws_requests_auth boto3
+#    - ./ci/env/env_info.sh
+#    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
+#    - python ./ci/build/build-docker-images.py --py-versions py39 -T cu111 -T cu112 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base
+#
+#- label: ":docker: Build Images: py310 (1/2)"
+#  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
+#  instance_size: medium
+#  commands:
+#    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.10 ./ci/ci.sh build
+#    - pip install -q docker aws_requests_auth boto3
+#    - ./ci/env/env_info.sh
+#    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
+#    - python ./ci/build/build-docker-images.py --py-versions py310 -T cpu -T cu101 -T cu102 -T cu110 --build-type BUILDKITE --build-base
+#
+#- label: ":docker: Build Images: py310 (2/2)"
+#  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
+#  instance_size: medium
+#  commands:
+#    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=3.10 ./ci/ci.sh build
+#    - pip install -q docker aws_requests_auth boto3
+#    - if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then python .buildkite/copy_files.py --destination docker_login; fi
+#    - python ./ci/build/build-docker-images.py --py-versions py310 -T cu111 -T cu112 -T cu113 -T cu116 -T cu118 --build-type BUILDKITE --build-base
 
 - label: ":java: Java"
   conditions: ["RAY_CI_JAVA_AFFECTED"]
@@ -523,44 +523,44 @@
     #- docker run --rm --privileged -v /ray/containers:/var/lib/containers -v /ray:/ray --entrypoint /bin/bash
       #rayproject/ray-worker-container:nightly-py36-cpu /ray/ci/build/test-worker-in-container.sh
 
-- label: ":kubernetes: operator"
-  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
-  instance_size: medium
-  commands:
-    - |
-      cleanup() {
-        if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi
-        python python/ray/tests/kuberay/setup/teardown_kuberay.py || true
-        kind delete cluster
-      }
-      trap cleanup EXIT
-    - echo "--- Setting up Python 3.7 environment."
-    - ./ci/env/install-dependencies.sh
-    # Specifying above somehow messes up the Ray install.
-    # Uninstall and re-install Ray so that we can use Ray Client.
-    # (Remove thirdparty_files to sidestep an issue with psutil.)
-    - pip uninstall -y ray && rm -rf /ray/python/ray/thirdparty_files
-    - pip install -e /ray/python
-    - echo "--- Setting up local kind cluster."
-    - ./ci/k8s/prep-k8s-environment.sh
-    - echo "--- Building py37-cpu Ray image for the test."
-    - LINUX_WHEELS=1 ./ci/ci.sh build
-    - pip install -q docker
-    - python ci/build/build-docker-images.py --py-versions py37 --device-types cpu --build-type LOCAL --build-base
-    # Tag the image built in the last step. We want to be sure to distinguish the image from the real Ray nightly.
-    - docker tag rayproject/ray:nightly-py37-cpu ray-ci:kuberay-test
-    # Load the image into the kind node.
-    - kind load docker-image ray-ci:kuberay-test
-    - echo "--- Setting up KubeRay operator."
-    - python python/ray/tests/kuberay/setup/setup_kuberay.py
-    - ./ci/env/env_info.sh
-    - echo "--- Running the test."
-    - bazel test --config=ci $(./ci/run/bazel_export_options)
-      --test_tag_filters=kuberay_operator
-      --test_env=RAY_IMAGE=docker.io/library/ray-ci:kuberay-test
-      --test_env=PULL_POLICY=IfNotPresent
-      --test_env=KUBECONFIG=/root/.kube/config
-      python/ray/tests/...
+#- label: ":kubernetes: operator"
+#  conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
+#  instance_size: medium
+#  commands:
+#    - |
+#      cleanup() {
+#        if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi
+#        python python/ray/tests/kuberay/setup/teardown_kuberay.py || true
+#        kind delete cluster
+#      }
+#      trap cleanup EXIT
+#    - echo "--- Setting up Python 3.7 environment."
+#    - ./ci/env/install-dependencies.sh
+#    # Specifying above somehow messes up the Ray install.
+#    # Uninstall and re-install Ray so that we can use Ray Client.
+#    # (Remove thirdparty_files to sidestep an issue with psutil.)
+#    - pip uninstall -y ray && rm -rf /ray/python/ray/thirdparty_files
+#    - pip install -e /ray/python
+#    - echo "--- Setting up local kind cluster."
+#    - ./ci/k8s/prep-k8s-environment.sh
+#    - echo "--- Building py37-cpu Ray image for the test."
+#    - LINUX_WHEELS=1 ./ci/ci.sh build
+#    - pip install -q docker
+#    - python ci/build/build-docker-images.py --py-versions py37 --device-types cpu --build-type LOCAL --build-base
+#    # Tag the image built in the last step. We want to be sure to distinguish the image from the real Ray nightly.
+#    - docker tag rayproject/ray:nightly-py37-cpu ray-ci:kuberay-test
+#    # Load the image into the kind node.
+#    - kind load docker-image ray-ci:kuberay-test
+#    - echo "--- Setting up KubeRay operator."
+#    - python python/ray/tests/kuberay/setup/setup_kuberay.py
+#    - ./ci/env/env_info.sh
+#    - echo "--- Running the test."
+#    - bazel test --config=ci $(./ci/run/bazel_export_options)
+#      --test_tag_filters=kuberay_operator
+#      --test_env=RAY_IMAGE=docker.io/library/ray-ci:kuberay-test
+#      --test_env=PULL_POLICY=IfNotPresent
+#      --test_env=KUBECONFIG=/root/.kube/config
+#      python/ray/tests/...
 
 - label: ":book: Documentation"
   commands:
@@ -581,28 +581,28 @@
     - pip install "mosaicml==0.12.1" "urllib3<1.27" --ignore-installed
     - ./ci/ci.sh build
 
-- label: ":octopus: Tune multinode tests"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TUNE_AFFECTED"]
-  instance_size: medium
-  commands:
-    - LINUX_WHEELS=1 ./ci/ci.sh build
-    - mkdir -p ~/.docker/cli-plugins/ && curl -SL https://github.com/docker/compose/releases/download/v2.0.1/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose && chmod +x ~/.docker/cli-plugins/docker-compose
-    - pip install -U docker aws_requests_auth boto3
-    - ./ci/env/env_info.sh
-    - python ./ci/build/build-docker-images.py --py-versions py37 --device-types cpu --build-type LOCAL --build-base
-    - python ./ci/build/build-multinode-image.py rayproject/ray:nightly-py37-cpu rayproject/ray:multinode-py37
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only
-      --test_tag_filters=multinode,-example,-flaky,-py37,-soft_imports,-gpu_only,-rllib
-      python/ray/tune/...
-      --test_env=RAY_HAS_SSH="1"
-      --test_env=RAY_DOCKER_IMAGE="rayproject/ray:multinode-py37"
-      --test_env=RAY_TEMPDIR="/ray-mount"
-      --test_env=RAY_HOSTDIR="/ray"
-      --test_env=RAY_TESTHOST="dind-daemon"
-      --test_env=DOCKER_HOST=tcp://docker:2376
-      --test_env=DOCKER_TLS_VERIFY=1
-      --test_env=DOCKER_CERT_PATH=/certs/client
-      --test_env=DOCKER_TLS_CERTDIR=/certs
+#- label: ":octopus: Tune multinode tests"
+#  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TUNE_AFFECTED"]
+#  instance_size: medium
+#  commands:
+#    - LINUX_WHEELS=1 ./ci/ci.sh build
+#    - mkdir -p ~/.docker/cli-plugins/ && curl -SL https://github.com/docker/compose/releases/download/v2.0.1/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose && chmod +x ~/.docker/cli-plugins/docker-compose
+#    - pip install -U docker aws_requests_auth boto3
+#    - ./ci/env/env_info.sh
+#    - python ./ci/build/build-docker-images.py --py-versions py37 --device-types cpu --build-type LOCAL --build-base
+#    - python ./ci/build/build-multinode-image.py rayproject/ray:nightly-py37-cpu rayproject/ray:multinode-py37
+#    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only
+#      --test_tag_filters=multinode,-example,-flaky,-py37,-soft_imports,-gpu_only,-rllib
+#      python/ray/tune/...
+#      --test_env=RAY_HAS_SSH="1"
+#      --test_env=RAY_DOCKER_IMAGE="rayproject/ray:multinode-py37"
+#      --test_env=RAY_TEMPDIR="/ray-mount"
+#      --test_env=RAY_HOSTDIR="/ray"
+#      --test_env=RAY_TESTHOST="dind-daemon"
+#      --test_env=DOCKER_HOST=tcp://docker:2376
+#      --test_env=DOCKER_TLS_VERIFY=1
+#      --test_env=DOCKER_CERT_PATH=/certs/client
+#      --test_env=DOCKER_TLS_CERTDIR=/certs
 
 - label: ":hadoop: Ray AIR HDFS tests"
   conditions: ["RAY_CI_ML_AFFECTED"]


### PR DESCRIPTION
In order to not build further docker images and run tune multi-node tests unnecessarily, we comment out some of these tests for the 2.5.0 release branch.