### PR TITLE
[core][dashboard][state] Fix worker files in /old not retrievable

### DIFF
--- a/dashboard/modules/log/log_manager.py
+++ b/dashboard/modules/log/log_manager.py
@@ -182,11 +182,11 @@ class LogsManager:
 
         if worker_id is not None:
             log_files = await self.list_logs(
-                node_id, timeout, glob_filter=f"*{worker_id}*{suffix}"
+                node_id, timeout, glob_filter=f"**/*{worker_id}*{suffix}"
             )
         else:
             log_files = await self.list_logs(
-                node_id, timeout, glob_filter=f"*{pid}*{suffix}"
+                node_id, timeout, glob_filter=f"**/*{pid}*{suffix}"
             )
 
         # Find matching worker logs.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
1. When we have too many worker files on the ray log directory, we move those dead workers' files to `old/` , causing files not retrievable from the state API.  This PR fixes this. 

2. Change above makes the current filename resolution for task not ideal: we thus no longer store worker filename explicitly in task log info, but infer the worker filename from the worker_id. This PR also refactors this change. 



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
