### PR TITLE
[RLlib] Update fetch release logs

### DIFF
--- a/release/release_logs/fetch_release_logs.py
+++ b/release/release_logs/fetch_release_logs.py
@@ -42,16 +42,17 @@ BUILDKITE_PIPELINE = "release-tests-branch"
 
 # Format: job name regex --> filename to save results to
 RESULTS_TO_FETCH = {
-    r"^microbenchmark \(.+\)$": "microbenchmark.json",
-    r"^many_actors \(.+\)$": "benchmarks/many_actors.json",
-    r"^many_nodes \(.+\)$": "benchmarks/many_nodes.json",
-    r"^many_pgs \(.+\)$": "benchmarks/many_pgs.json",
-    r"^many_tasks \(.+\)$": "benchmarks/many_tasks.json",
-    r"^object_store \(.+\)$": "scalability/object_store.json",
-    r"^single_node \(.+\)$": "scalability/single_node.json",
-    r"^stress_test_dead_actors \(.+\)$": "stress_tests/stress_test_dead_actors.json",
-    r"^stress_test_many_tasks \(.+\)$": "stress_tests/stress_test_many_tasks.json",
-    r"^stress_test_placement_group \(.+\)$": (
+    r"^microbenchmark.aws \(.+\)$": "microbenchmark.json",
+    r"^many_actors.aws \(.+\)$": "benchmarks/many_actors.json",
+    r"^many_nodes.aws \(.+\)$": "benchmarks/many_nodes.json",
+    r"^many_pgs.aws \(.+\)$": "benchmarks/many_pgs.json",
+    r"^many_tasks.aws \(.+\)$": "benchmarks/many_tasks.json",
+    r"^object_store.aws \(.+\)$": "scalability/object_store.json",
+    r"^single_node.aws \(.+\)$": "scalability/single_node.json",
+    r"^stress_test_dead_actors.aws \(.+\)$":
+        "stress_tests/stress_test_dead_actors.json",
+    r"^stress_test_many_tasks.aws \(.+\)$": "stress_tests/stress_test_many_tasks.json",
+    r"^stress_test_placement_group.aws \(.+\)$": (
         "stress_tests/" "stress_test_placement_group.json"
     ),
 }

--- a/release/release_logs/fetch_release_logs.py
+++ b/release/release_logs/fetch_release_logs.py
@@ -53,7 +53,7 @@ RESULTS_TO_FETCH = {
         "stress_tests/stress_test_dead_actors.json",
     r"^stress_test_many_tasks.aws \(.+\)$": "stress_tests/stress_test_many_tasks.json",
     r"^stress_test_placement_group.aws \(.+\)$": (
-        "stress_tests/" "stress_test_placement_group.json"
+        "stress_tests/stress_test_placement_group.json"
     ),
 }
 

--- a/release/release_logs/fetch_release_logs.py
+++ b/release/release_logs/fetch_release_logs.py
@@ -49,8 +49,9 @@ RESULTS_TO_FETCH = {
     r"^many_tasks.aws \(.+\)$": "benchmarks/many_tasks.json",
     r"^object_store.aws \(.+\)$": "scalability/object_store.json",
     r"^single_node.aws \(.+\)$": "scalability/single_node.json",
-    r"^stress_test_dead_actors.aws \(.+\)$":
-        "stress_tests/stress_test_dead_actors.json",
+    r"^stress_test_dead_actors.aws \(.+\)$": (
+        "stress_tests/stress_test_dead_actors.json"
+    ),
     r"^stress_test_many_tasks.aws \(.+\)$": "stress_tests/stress_test_many_tasks.json",
     r"^stress_test_placement_group.aws \(.+\)$": (
         "stress_tests/stress_test_placement_group.json"


### PR DESCRIPTION
Since we set up release tests to run on AWS and GCP, the AWS got a suffix ".aws".
These changes reflect that in the fetch_release_logs.py script that helps us with release management.