### PR TITLE
[RLlib] Make repro simple q and state swap tests exclusive

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2200,7 +2200,7 @@ py_test(
 
 py_test(
     name = "policy/tests/test_policy_state_swapping",
-    tags = ["team:rllib", "policy", "gpu"],
+    tags = ["team:rllib", "policy", "gpu", "exclusive"],
     size = "medium",
     srcs = ["policy/tests/test_policy_state_swapping.py"]
 )

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1223,7 +1223,7 @@ py_test(
 # SimpleQ Reproducibility
 py_test(
     name = "test_repro_simple_q",
-    tags = ["team:rllib", "algorithms_dir", "gpu"],
+    tags = ["team:rllib", "algorithms_dir", "gpu", "exclusive"],
     size = "large",
     srcs = ["algorithms/simple_q/tests/test_repro_simple_q.py"]
 )


### PR DESCRIPTION
The tests in question fail on CI right.
For example with the following error:
<img width="531" alt="Screenshot 2023-05-29 at 22 34 44" src="https://github.com/ray-project/ray/assets/9356806/6c9963b5-66fb-4225-a377-653b7f688fdd">

This is not the root cause of the problem. Rather, [we set parallelism set to 2 for GPU tests](https://github.com/ray-project/ray/commit/3d124ccaba5582ef9aa39ddbc5e7851d9a78c656#diff-c08ff0e8a60a7481aaf5f39c5b96f5df9db24593e1b4c3f5225293aa3e925688) recently and so these tests OOM unless we run them exclusively (like other tests in the referred PR).

<img width="469" alt="Screenshot 2023-05-29 at 22 34 25" src="https://github.com/ray-project/ray/assets/9356806/03107107-14c4-4fed-b618-335d895dffc7">
