### PR TITLE
[RLlib] Remove `policy_config` property from RolloutWorker (not needed).

### DIFF
--- a/rllib/algorithms/dqn/learner_thread.py
+++ b/rllib/algorithms/dqn/learner_thread.py
@@ -36,7 +36,7 @@ class LearnerThread(threading.Thread):
 
     def run(self):
         # Switch on eager mode if configured.
-        if self.local_worker.policy_config.get("framework") == "tf2":
+        if self.local_worker.config.framework_str == "tf2":
             tf1.enable_eager_execution()
         while not self.stopped:
             self.step()

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -460,7 +460,7 @@ class RolloutWorker(ParallelIteratorWorker, FaultAwareApply):
             deprecation_warning(
                 old="RolloutWorker(.., tf_session_creator=.., ..)",
                 new="config.framework(tf_session_args={..}); "
-                    "RolloutWorker(config=config, ..)",
+                "RolloutWorker(config=config, ..)",
                 error=False,
             )
 

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -459,7 +459,8 @@ class RolloutWorker(ParallelIteratorWorker, FaultAwareApply):
         if tf_session_creator != DEPRECATED_VALUE:
             deprecation_warning(
                 old="RolloutWorker(.., tf_session_creator=.., ..)",
-                new="RolloutWorker(.., policy_config={tf_session_options=..}, ..)",
+                new="config.framework(tf_session_args={..}); "
+                    "RolloutWorker(config=config, ..)",
                 error=False,
             )
 
@@ -492,9 +493,6 @@ class RolloutWorker(ParallelIteratorWorker, FaultAwareApply):
         ParallelIteratorWorker.__init__(self, gen_rollouts, False)
 
         self.config = config
-        # TODO: Remove this backward compatibility.
-        #  This property (old-style python config dict) should no longer be used!
-        self.policy_config = config.to_dict()
 
         self.num_workers = (
             num_workers if num_workers is not None else self.config.num_rollout_workers

--- a/rllib/examples/custom_metrics_and_callbacks.py
+++ b/rllib/examples/custom_metrics_and_callbacks.py
@@ -80,7 +80,7 @@ class MyCallbacks(DefaultCallbacks):
     ):
         # Check if there are multiple episodes in a batch, i.e.
         # "batch_mode": "truncate_episodes".
-        if worker.policy_config["batch_mode"] == "truncate_episodes":
+        if worker.config.batch_mode == "truncate_episodes":
             # Make sure this episode is really done.
             assert episode.batch_builder.policy_collectors["default_policy"].batches[
                 -1

--- a/rllib/execution/learner_thread.py
+++ b/rllib/execution/learner_thread.py
@@ -68,7 +68,7 @@ class LearnerThread(threading.Thread):
 
     def run(self) -> None:
         # Switch on eager mode if configured.
-        if self.local_worker.policy_config.get("framework") == "tf2":
+        if self.local_worker.config.framework_str == "tf2":
             tf1.enable_eager_execution()
         while not self.stopped:
             self.step()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Remove `policy_config` property from RolloutWorker (not needed).
* Use RolloutWorker.config (an AlgorithmConfig) instead.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
