### PR TITLE
[Ray Core] Issue#35880  Fix the Exception error message bug which convert byte array to String.

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/task/ArgumentsBuilder.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/ArgumentsBuilder.java
@@ -49,7 +49,7 @@ public class ArgumentsBuilder {
             throw new IllegalArgumentException(
                 String.format(
                     "Can't transfer %s data to %s",
-                    Arrays.toString(value.metadata), language.getValueDescriptor().getName()));
+                    new String(value.metadata), language.getValueDescriptor().getName()));
           }
         }
         if (value.data.length > SystemConfig.getLargestSizePassedByValue()) {


### PR DESCRIPTION
Hello, I just get a strange exception message when I call the Ray.task() with a non-basic class type.

![ray_pr](https://github.com/ray-project/ray/assets/18530950/372bd37a-9743-4a5b-95a9-81d4cd2d0eb4)


It seems like a wrong convert from byte[] to String with Arrays.toString().