### PR TITLE
[Ray Core] Issue#35880 Fix the Exception error message bug which convert byte array to String

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/task/ArgumentsBuilder.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/ArgumentsBuilder.java
@@ -14,7 +14,6 @@ import io.ray.runtime.object.ObjectSerializer;
 import io.ray.runtime.util.SystemConfig;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /** Helper methods to convert arguments from/to objects. */
@@ -49,7 +48,7 @@ public class ArgumentsBuilder {
             throw new IllegalArgumentException(
                 String.format(
                     "Can't transfer %s data to %s",
-                    Arrays.toString(value.metadata), language.getValueDescriptor().getName()));
+                    new String(value.metadata), language.getValueDescriptor().getName()));
           }
         }
         if (value.data.length > SystemConfig.getLargestSizePassedByValue()) {


### PR DESCRIPTION
Hi, I just get a strange exception message when I call the Ray.task() with a non-basic class type.

![ray_pr](https://github.com/ray-project/ray/assets/18530950/3b7ea33d-e0e8-4baf-883f-3b727bedc422)

It seems like a wrong convert from byte[] to String with Arrays.toString().