### PR TITLE
Revert "[RLlib] add more gpu/multicpu jobs, make supported spaces tests exclusive"

### DIFF
--- a/.buildkite/pipeline.gpu.yml
+++ b/.buildkite/pipeline.gpu.yml
@@ -10,7 +10,6 @@
 
 - label: ":tv: :brain: RLlib: GPU Tests"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_AFFECTED"]
-  parallelism: 2
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
     - RLLIB_TESTING=1 ./ci/env/install-dependencies.sh
@@ -18,12 +17,8 @@
     - ./ci/env/env_info.sh
     # --jobs 1 is necessary as we only have 1 GPU on the machine and running tests in parallel
     # would cause timeouts as the other scripts would wait for the GPU to become available.
-    - ./ci/run/run_bazel_test_with_sharding.sh --config=ci $(./ci/run/bazel_export_options)
-      --build_tests_only
-      --test_tag_filters=gpu
-      --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 
-      --test_env=RLLIB_NUM_GPUS=1
-      rllib/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --jobs 1
+      --test_tag_filters=gpu --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 --test_env=RLLIB_NUM_GPUS=1 rllib/...
 
 
 - label: ":tv: :serverless: Serve Tests"

--- a/.buildkite/pipeline.gpu_large.yml
+++ b/.buildkite/pipeline.gpu_large.yml
@@ -19,7 +19,6 @@
 
 - label: ":tv: :brain: RLlib: Multi-GPU Tests"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_AFFECTED"]
-  parallelism: 2
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
     - RLLIB_TESTING=1 ./ci/env/install-dependencies.sh
@@ -28,12 +27,8 @@
     # --jobs 2 is necessary as we only need to have at least 2 gpus on the machine
     # and running tests in parallel would cause timeouts as the other scripts would
     # wait for the GPU to become available.
-    - ./ci/run/run_bazel_test_with_sharding.sh --config=ci $(./ci/run/bazel_export_options)
-      --build_tests_only
-      --jobs=2
-      --test_tag_filters=multi_gpu
-      --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 
-      rllib/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --jobs 2
+      --test_tag_filters=multi_gpu --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 rllib/...
 
 - label: ":tv: :airplane: AIR GPU tests (ray/air)"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_ML_AFFECTED"]

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2448,7 +2448,7 @@ py_test(
 
 py_test(
     name = "tests/backward_compat/test_gym_env_apis",
-    tags = ["team:rllib", "env", "exclusive"],
+    tags = ["team:rllib", "env"],
     size = "medium",
     srcs = ["tests/backward_compat/test_gym_env_apis.py"]
 )
@@ -2751,7 +2751,7 @@ py_test(
 py_test(
      name = "tests/test_supported_spaces_appo",
      main = "tests/test_supported_spaces.py",
-     tags = ["team:rllib", "tests_dir", "exclusive"],
+     tags = ["team:rllib", "tests_dir"],
      size = "large",
      srcs = ["tests/test_supported_spaces.py"],
      args = ["TestSupportedSpacesAPPO"]
@@ -2760,7 +2760,7 @@ py_test(
 py_test(
      name = "tests/test_supported_spaces_impala",
      main = "tests/test_supported_spaces.py",
-     tags = ["team:rllib", "tests_dir", "exclusive"],
+     tags = ["team:rllib", "tests_dir"],
      size = "large",
      srcs = ["tests/test_supported_spaces.py"],
      args = ["TestSupportedSpacesIMPALA"]
@@ -2769,7 +2769,7 @@ py_test(
 py_test(
      name = "tests/test_supported_spaces_a3c",
      main = "tests/test_supported_spaces.py",
-     tags = ["team:rllib", "tests_dir", "exclusive"],
+     tags = ["team:rllib", "tests_dir"],
      size = "large",
      srcs = ["tests/test_supported_spaces.py"],
      args = ["TestSupportedSpacesA3C"]
@@ -2805,7 +2805,7 @@ py_test(
 py_test(
     name = "tests/test_supported_spaces_off_policy",
     main = "tests/test_supported_spaces.py",
-    tags = ["team:rllib", "tests_dir", "exclusive"],
+    tags = ["team:rllib", "tests_dir"],
     size = "medium",
     srcs = ["tests/test_supported_spaces.py"],
     args = ["TestSupportedSpacesOffPolicy"]
@@ -4140,7 +4140,7 @@ py_test(
 py_test(
     name = "examples/learner/ppo_tuner_local_gpu_tf2",
     main = "examples/learner/ppo_tuner.py",
-    tags = ["team:rllib", "examples", "gpu", "exclusive"],
+    tags = ["team:rllib", "examples", "gpu"],
     size = "medium",
     srcs = ["examples/learner/ppo_tuner.py"],
     args = ["--framework=tf2", "--config=local-gpu"]


### PR DESCRIPTION
Reverts ray-project/ray#35735

We caused some tests to go flakey on the gpu runners. We're going to revert this and see if this was the cause of those breakages. 