### PR TITLE
[ci][test-states/4] trigger bisect on test first failure

### DIFF
--- a/release/BUILD
+++ b/release/BUILD
@@ -419,6 +419,7 @@ py_library(
         bk_require("click"),
         bk_require("google-cloud-storage"),
         bk_require("jinja2"),
+        bk_require("pybuildkite"),
         bk_require("pygithub"),
         bk_require("retry"),
     ],

--- a/release/ray_release/aws.py
+++ b/release/ray_release/aws.py
@@ -28,6 +28,12 @@ RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING = [
 ]
 
 
+def get_secret_token(secret_id: str) -> str:
+    return boto3.client("secretsmanager", region_name="us-west-2").get_secret_value(
+        SecretId=secret_id
+    )["SecretString"]
+
+
 def maybe_fetch_api_token():
     from anyscale.authenticate import AuthenticationBlock
 

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -32,6 +32,7 @@ class TestState(enum.Enum):
 
     JAILED = "jailed"
     FAILING = "failing"
+    CONSITENTLY_FAILING = "consistently_failing"
     PASSING = "passing"
 
 
@@ -71,6 +72,7 @@ class Test(dict):
     """A class represents a test to run on buildkite"""
 
     KEY_GITHUB_ISSUE_NUMBER = "github_issue_number"
+    KEY_BISECT_BUILD_NUMBER = "bisect_build_number"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -1,13 +1,21 @@
-import boto3
+from datetime import datetime, timedelta
+
 from github import Github
+from pybuildkite.buildkite import Buildkite
 
 from ray_release.test import (
     Test,
     TestState,
 )
+from ray_release.logger import logger
+from ray_release.aws import get_secret_token
 
 RAY_REPO = "ray-project/ray"
 AWS_SECRET_GITHUB = "ray_ci_github_token"
+AWS_SECRET_BUILDKITE = "ray_ci_buildkite_token"
+MAX_BISECT_PER_DAY = 10  # Max number of bisects to run per day for all tests
+BUILDKITE_ORGANIZATION = "ray-project"
+BUILDKITE_BISECT_PIPELINE = "release-tests-bisect"
 
 
 class TestStateMachine:
@@ -21,48 +29,104 @@ class TestStateMachine:
     """
 
     ray_repo = None
+    ray_buildkite = None
 
     def __init__(self, test: Test) -> None:
         self.test = test
         self.test_results = test.get_test_results()
-        self.state_machine = {
-            # jailed -> passing
-            TestState.JAILED: TestState.PASSING
-            if self._jailed_to_passing()
-            else TestState.JAILED,
-            # passing -> failing
-            TestState.PASSING: TestState.FAILING
-            if self._passing_to_failing()
-            else TestState.PASSING,
-            # failing -> passing OR failing -> jailed
-            TestState.FAILING: TestState.PASSING
-            if self._failing_to_passing()
-            else (TestState.JAILED if self._failing_to_jailed() else TestState.FAILING),
-        }
         if not self.ray_repo:
-            github_token = TestStateMachine.github_token = boto3.client(
-                "secretsmanager", region_name="us-west-2"
-            ).get_secret_value(SecretId=AWS_SECRET_GITHUB)["SecretString"]
+            github_token = get_secret_token(AWS_SECRET_GITHUB)
             self.ray_repo = Github(github_token).get_repo(RAY_REPO)
+        if not self.ray_buildkite:
+            buildkite_token = get_secret_token(AWS_SECRET_BUILDKITE)
+            self.ray_buildkite = Buildkite()
+            self.ray_buildkite.set_access_token(buildkite_token)
 
     def move(self) -> None:
         """
         Move the test to the next state.
         """
         from_state = self.test.get_state()
-        to_state = self.state_machine[from_state]
+        to_state = self._next_state(from_state)
         self.test.set_state(to_state)
         self._move_hook(from_state, to_state)
+
+    def _next_state(self, current_state) -> TestState:
+        """
+        Compute the next state of the test based on the current state and the test
+        """
+        if current_state == TestState.PASSING:
+            if self._passing_to_consistently_failing():
+                return TestState.CONSITENTLY_FAILING
+            if self._passing_to_failing():
+                return TestState.FAILING
+
+        if current_state == TestState.FAILING:
+            if self._failing_to_consistently_failing():
+                return TestState.CONSITENTLY_FAILING
+            if self._failing_to_passing():
+                return TestState.PASSING
+
+        return current_state
 
     def _move_hook(self, from_state: TestState, to_state: TestState) -> None:
         """
         Action performed when test transitions to a different state. This is where we do
         things like creating and closing github issues, trigger bisects, etc.
         """
-        if (from_state, to_state) == (TestState.PASSING, TestState.FAILING):
+        change = (from_state, to_state)
+        if change == (TestState.PASSING, TestState.CONSITENTLY_FAILING):
             self._create_github_issue()
-        elif (from_state, to_state) == (TestState.FAILING, TestState.PASSING):
+        elif change == (TestState.FAILING, TestState.CONSITENTLY_FAILING):
+            self._create_github_issue()
+        elif change == (TestState.CONSITENTLY_FAILING, TestState.PASSING):
             self._close_github_issue()
+        elif change == (TestState.PASSING, TestState.FAILING):
+            self._trigger_bisect()
+
+    def _bisect_rate_limit_exceeded(self) -> bool:
+        """
+        Check if we have exceeded the rate limit of bisects per day.
+        """
+        builds = self.ray_buildkite.builds().list_all_for_pipeline(
+            BUILDKITE_ORGANIZATION,
+            BUILDKITE_BISECT_PIPELINE,
+            created_from=datetime.now() - timedelta(days=1),
+            branch="master",
+        )
+        return len(builds) >= MAX_BISECT_PER_DAY
+
+    def _trigger_bisect(self) -> None:
+        if self._bisect_rate_limit_exceeded():
+            logger.info(f"Skip bisect {self.test.get_name()} due to rate limit")
+            return
+        build = self.ray_buildkite.builds().create_build(
+            BUILDKITE_ORGANIZATION,
+            BUILDKITE_BISECT_PIPELINE,
+            "HEAD",
+            "master",
+            message=f"[ray-test-bot] {self.test.get_name()} failing",
+        )
+        failing_commit = self.test_results[0].commit
+        passing_commits = [r.commit for r in self.test_results if r.is_passing()]
+        if not passing_commits:
+            logger.info(f"Skip bisect {self.test.get_name()} due to no passing commit")
+            return
+        passing_commit = passing_commits[0]
+        self.ray_buildkite.jobs().unblock_job(
+            BUILDKITE_ORGANIZATION,
+            BUILDKITE_BISECT_PIPELINE,
+            build["number"],
+            build["jobs"][0]["id"],  # first job is the blocked job
+            fields={
+                "test-name": self.test.get_name(),
+                "passing-commit": passing_commit,
+                "failing-commit": failing_commit,
+                "concurrency": "3",
+                "run-per-commit": "1",
+            },
+        )
+        self.test[Test.KEY_BISECT_BUILD_NUMBER] = build["number"]
 
     def _create_github_issue(self) -> None:
         issue_number = self.ray_repo.create_issue(
@@ -82,11 +146,14 @@ class TestStateMachine:
         # TODO(can): implement this
         pass
 
-    def _jailed_to_passing(self) -> bool:
-        # TODO(can): implement this
-        return False
-
     def _passing_to_failing(self) -> bool:
+        return (
+            len(self.test_results) > 0
+            and self.test_results[0].is_failing()
+            and not self._passing_to_consistently_failing()
+        )
+
+    def _passing_to_consistently_failing(self) -> bool:
         return (
             len(self.test_results) > 1
             and self.test_results[0].is_failing()
@@ -94,9 +161,7 @@ class TestStateMachine:
         )
 
     def _failing_to_passing(self) -> bool:
-        # TODO(can): implement this
-        return True
+        return len(self.test_results) > 0 and self.test_results[0].is_passing()
 
-    def _failing_to_jailed(self) -> bool:
-        # TODO(can): implement this
-        return True
+    def _failing_to_consistently_failing(self) -> bool:
+        return self._passing_to_consistently_failing()

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -24,20 +24,43 @@ class MockRepo:
         return MockIssue(10)
 
 
+class MockBuildkiteBuild:
+    def create_build(self, *args, **kwargs):
+        return {
+            "number": 1,
+            "jobs": [{"id": "1"}],
+        }
+
+    def list_all_for_pipeline(self, *args, **kwargs):
+        return []
+
+
+class MockBuildkiteJob:
+    def unblock_job(self, *args, **kwargs):
+        return {}
+
+
+class MockBuildkite:
+    def builds(self):
+        return MockBuildkiteBuild()
+
+    def jobs(self):
+        return MockBuildkiteJob()
+
+
 TestStateMachine.ray_repo = MockRepo()
+TestStateMachine.ray_buildkite = MockBuildkite()
 
 
 def test_move_from_passing_to_failing():
     test = Test(name="test", team="devprod")
     # Test original state
     test.test_results = [
-        TestResult.from_result(Result(status=ResultStatus.SUCCESS.value))
+        TestResult.from_result(Result(status=ResultStatus.SUCCESS.value)),
     ]
     assert test.get_state() == TestState.PASSING
-    test.test_results.insert(
-        0,
-        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
-    )
+
+    # Test moving from passing to failing
     test.test_results.insert(
         0,
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
@@ -45,8 +68,16 @@ def test_move_from_passing_to_failing():
     sm = TestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.FAILING
+    assert test[Test.KEY_BISECT_BUILD_NUMBER] == 1
 
-    # Test github issue is created
+    # Test moving from failing to consistently failing
+    test.test_results.insert(
+        0,
+        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
+    )
+    sm = TestStateMachine(test)
+    sm.move()
+    assert test.get_state() == TestState.CONSITENTLY_FAILING
     assert test[Test.KEY_GITHUB_ISSUE_NUMBER] == 10
 
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1714,21 +1714,6 @@
 #######################
 # Tune cloud  tests
 #######################
-- name: remove_before_commit
-  group: Devprod tests
-  working_dir: tune_tests/cloud_tests
-  frequency: manual
-  team: ml
-
-  cluster:
-    cluster_env: app_config.yaml
-    cluster_compute: tpl_aws_4x2.yaml
-
-  run:
-    timeout: 600
-    script: exit 40
-
-
 - name: tune_cloud_no_sync_down
   group: Tune cloud tests
   working_dir: tune_tests/cloud_tests

--- a/release/requirements.txt
+++ b/release/requirements.txt
@@ -6,6 +6,7 @@ slackclient
 boto3
 google-cloud-storage
 jinja2
+pybuildkite
 PyGithub
 pydantic < 1.10.0
 pyyaml

--- a/release/requirements_buildkite.in
+++ b/release/requirements_buildkite.in
@@ -11,6 +11,7 @@ protobuf >= 3.15.3, != 3.19.5
 pydantic < 1.10.0
 pytest
 pyyaml
+pybuildkite
 PyGithub
 requests
 retry

--- a/release/requirements_buildkite.txt
+++ b/release/requirements_buildkite.txt
@@ -830,6 +830,10 @@ pyasn1-modules==0.3.0 \
     # via
     #   google-auth
     #   oauth2client
+pybuildkite==1.2.2 \
+    --hash=sha256:338ff4edd3e32e8f32480fe92d3bedd485052ed0c4bb09ddaa10dc1a9eed8006 \
+    --hash=sha256:9079f2d2ec6f429dd3b66f4e3cee26a364b408af25c92cee9516abad6938219a
+    # via -r release/requirements_buildkite.in
 pycparser==2.21 \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \
     --hash=sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206
@@ -993,6 +997,7 @@ requests==2.31.0 \
     #   anyscale
     #   google-api-core
     #   google-cloud-storage
+    #   pybuildkite
     #   pygithub
 retry==0.9.2 \
     --hash=sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606 \


### PR DESCRIPTION
## Why are these changes needed?
**Context:** This is a series of PR to compute test state (JAILED|PASSING|FAILING) on-the-fly, persist them into DB and create issues and bisect automatically, etc.
- Add a new state FAILING vs. CONSISTENTLY_FAILING
- Trigger bisect when test moves to FAILING state
- Create github issue when test moves to CONSISTENTLY_FAILING state

## Checks
- [X ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests - https://buildkite.com/ray-project/release-tests-pr/builds/40512 fails and trigger an automated bisect https://buildkite.com/ray-project/release-tests-bisect/builds/193#01886f2a-a126-49bb-9efd-a590d4bba8d9