### PR TITLE
[Core] Support auto-init ray for get_runtime_context()

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -236,6 +236,7 @@ AUTO_INIT_APIS = {
     "kill",
     "put",
     "wait",
+    "get_runtime_context",
 }
 
 # Public APIs that should not automatically trigger ray.init().
@@ -252,7 +253,6 @@ NON_AUTO_INIT_APIS = {
     "client",
     "cluster_resources",
     "cpp_function",
-    "get_runtime_context",
     "init",
     "is_initialized",
     "java_actor_class",

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Dict, Optional
 
 import ray._private.worker
+from ray._private.auto_init_hook import wrap_auto_init
 from ray._private.client_mode_hook import client_mode_hook
 from ray.runtime_env import RuntimeEnv
 from ray.util.annotations import Deprecated, PublicAPI
@@ -373,6 +374,7 @@ _runtime_context = None
 
 @PublicAPI
 @client_mode_hook
+@wrap_auto_init
 def get_runtime_context():
     """Get the runtime context of the current driver/worker.
 

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -2,7 +2,6 @@ import logging
 from typing import Any, Dict, Optional
 
 import ray._private.worker
-from ray._private.auto_init_hook import wrap_auto_init
 from ray._private.client_mode_hook import client_mode_hook
 from ray.runtime_env import RuntimeEnv
 from ray.util.annotations import Deprecated, PublicAPI
@@ -374,7 +373,6 @@ _runtime_context = None
 
 @PublicAPI
 @client_mode_hook
-@wrap_auto_init
 def get_runtime_context():
     """Get the runtime context of the current driver/worker.
 

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -344,19 +344,10 @@ def test_ids(ray_start_regular):
     ray.get(actor.foo.remote())
 
 
-# get_runtime_context() can be called outside of Ray so it should not start
-# Ray automatically.
-def test_no_auto_init(shutdown_only):
+def test_auto_init(shutdown_only):
     assert not ray.is_initialized()
     ray.get_runtime_context()
-    assert not ray.is_initialized()
-
-
-def test_errors_when_ray_not_initialized():
-    with pytest.raises(AssertionError, match="Ray has not been initialized"):
-        ray.get_runtime_context().get_job_id()
-    with pytest.raises(AssertionError, match="Ray has not been initialized"):
-        ray.get_runtime_context().get_node_id()
+    assert ray.is_initialized()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Auto init ray when ray.get_runtime_context() is called.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #35889
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
