### PR TITLE
[ci][test-states/6] move test state after a successful bisect

### DIFF
--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -73,6 +73,7 @@ class Test(dict):
 
     KEY_GITHUB_ISSUE_NUMBER = "github_issue_number"
     KEY_BISECT_BUILD_NUMBER = "bisect_build_number"
+    KEY_BISECT_BLAMED_COMMIT = "bisect_blamed_commit"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -1,4 +1,5 @@
 import sys
+from typing import List
 
 import pytest
 
@@ -15,22 +16,36 @@ from ray_release.test_automation.state_machine import TestStateMachine
 
 
 class MockIssue:
-    def __init__(self, number: int):
+    def __init__(self, number: int, state: str = "open", labels: List[str] = []):
         self.number = number
+        self.state = state
+        self.labels = labels
+        self.comments = []
 
-    def edit(self, *args, **kwargs):
-        return self
+    def edit(self, state: str = None, labels: List[str] = None):
+        if state:
+            self.state = state
+        if labels:
+            self.labels = labels
 
-    def create_comment(self, *args, **kwargs):
-        return self
+    def create_comment(self, comment: str):
+        self.comments.append(comment)
+
+
+class MockIssueDB:
+    issue_id = 1
+    issue_db = {}
 
 
 class MockRepo:
     def create_issue(self, *args, **kwargs):
-        return MockIssue(10)
+        issue = MockIssue(MockIssueDB.issue_id)
+        MockIssueDB.issue_db[MockIssueDB.issue_id] = issue
+        MockIssueDB.issue_id += 1
+        return issue
 
-    def get_issue(self, *args, **kwargs):
-        return MockIssue(10)
+    def get_issue(self, number: int):
+        return MockIssueDB.issue_db[number]
 
 
 class MockBuildkiteBuild:
@@ -87,7 +102,25 @@ def test_move_from_passing_to_failing():
     sm = TestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.CONSITENTLY_FAILING
-    assert test[Test.KEY_GITHUB_ISSUE_NUMBER] == 10
+    assert test[Test.KEY_GITHUB_ISSUE_NUMBER] == MockIssueDB.issue_id - 1
+
+
+def test_move_from_failing_to_consisently_failing():
+    test = Test(name="test", team="devprod")
+    test[Test.KEY_BISECT_BUILD_NUMBER] = 1
+    test.test_results = [
+        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
+    ]
+    sm = TestStateMachine(test)
+    sm.move()
+    assert test.get_state() == TestState.FAILING
+    test[Test.KEY_BISECT_BLAMED_COMMIT] = "1234567890"
+    sm = TestStateMachine(test)
+    sm.move()
+    sm.comment_blamed_commit_on_github_issue()
+    issue = MockIssueDB.issue_db[test.get(Test.KEY_GITHUB_ISSUE_NUMBER)]
+    assert test.get_state() == TestState.CONSITENTLY_FAILING
+    assert "Blamed commit: 1234567890" in issue.comments[0]
 
 
 def test_move_from_failing_to_passing():
@@ -99,7 +132,7 @@ def test_move_from_failing_to_passing():
     sm = TestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.CONSITENTLY_FAILING
-    assert test[Test.KEY_GITHUB_ISSUE_NUMBER] == 10
+    assert test[Test.KEY_GITHUB_ISSUE_NUMBER] == MockIssueDB.issue_id - 1
     test.test_results.insert(
         0,
         TestResult.from_result(Result(status=ResultStatus.SUCCESS.value)),

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -31,6 +31,9 @@ class MockIssue:
     def create_comment(self, comment: str):
         self.comments.append(comment)
 
+    def get_labels(self):
+        return self.labels
+
 
 class MockIssueDB:
     issue_id = 1
@@ -142,6 +145,33 @@ def test_move_from_failing_to_passing():
     assert test.get_state() == TestState.PASSING
     assert test.get(Test.KEY_GITHUB_ISSUE_NUMBER) is None
     assert test.get(Test.KEY_BISECT_BUILD_NUMBER) is None
+
+
+def test_move_from_failing_to_jailed():
+    test = Test(name="test", team="devprod")
+    test.test_results = [
+        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
+        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
+        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
+        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
+    ]
+    sm = TestStateMachine(test)
+    sm.move()
+    assert test.get_state() == TestState.CONSITENTLY_FAILING
+    test.test_results.insert(
+        0,
+        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
+    )
+    sm = TestStateMachine(test)
+    sm.move()
+    assert test.get_state() == TestState.JAILED
+    test.test_results.insert(
+        0,
+        TestResult.from_result(Result(status=ResultStatus.SUCCESS.value)),
+    )
+    sm = TestStateMachine(test)
+    sm.move()
+    assert test.get_state() == TestState.PASSING
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?
Context: This is a series of PR to compute test state (JAILED|PASSING|FAILING) on-the-fly, persist them into DB and create issues and bisect automatically, etc.
- Move test state after a successful bisect

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests - bisect job https://buildkite.com/ray-project/release-tests-bisect/builds/194#01886f39-3d15-49e7-ad46-97ebd13a0e0d commented on https://github.com/ray-project/ray/issues/35915