### PR TITLE
[core] Feature flag actor task logs with off by default (#35921)

### DIFF
--- a/dashboard/client/src/pages/task/TaskPage.tsx
+++ b/dashboard/client/src/pages/task/TaskPage.tsx
@@ -272,8 +272,10 @@ const TaskLogs = ({
           {
             title: "Logs",
             contents:
-              "Logs of async actor tasks or threaded actor tasks (concurency > 1) are only available " +
-              'as part of the actor logs. Please click "Other logs" link above to access the actor logs.',
+              "Logs of actor tasks are only available " +
+              "as part of the actor logs by default due to performance reason. " +
+              'Please click "Other logs" link above to access the actor logs. \n' +
+              "To record actor task log by default, you could set the runtime env of the actor or start the cluster with RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING=1 ",
           },
         ]
       : []),

--- a/dashboard/modules/log/log_manager.py
+++ b/dashboard/modules/log/log_manager.py
@@ -323,10 +323,11 @@ class LogsManager:
             # This is a concurrent actor task. The logs will be interleaved.
             # So we return the log file of the actor instead.
             raise FileNotFoundError(
-                f"For concurrent actor task, please query actor log for "
-                f"actor({actor_id}): e.g. ray logs actor --id {actor_id} ."
-                "Because tasks from concurrent actor will have logs interleaved, "
-                "and Ray is not able to locate the exact log file for the task."
+                f"For actor task, please query actor log for "
+                f"actor({actor_id}): e.g. ray logs actor --id {actor_id} . Or "
+                "set RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING=1 in actor's runtime env "
+                "or when starting the cluster. Recording actor task's log could be "
+                "expensive, so Ray turns it off by default."
             )
         elif log_info is None:
             raise FileNotFoundError(

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -429,7 +429,11 @@ RAY_ALLOWED_CACHED_PORTS = {
     "gcs_server_port",  # the `port` option for gcs port.
 }
 
-RAY_ENABLE_RECORD_TASK_LOGGING = env_bool("RAY_ENABLE_RECORD_TASK_LOGGING", True)
+# Turn this on if actor task log's offsets are expected to be recorded.
+# With this enabled, actor tasks' log could be queried with task id.
+RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING = env_bool(
+    "RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING", False
+)
 
 WORKER_SETUP_HOOK_ENV_VAR = "__RAY_WORKER_SETUP_HOOK_ENV_VAR"
 RAY_WORKER_SETUP_HOOK_LOAD_TIMEOUT_ENV_VAR = "RAY_WORKER_SETUP_HOOK_LOAD_TIMEOUT"

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -456,7 +456,9 @@ class Worker:
         self.ray_debugger_external = False
         self._load_code_from_local = False
         # Opened file descriptor to stdout/stderr for this python worker.
-        self._enable_record_task_log = ray_constants.RAY_ENABLE_RECORD_TASK_LOGGING
+        self._enable_record_actor_task_log = (
+            ray_constants.RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING
+        )
         self._out_file = None
         self._err_file = None
         # Create the lock here because the serializer will use it before
@@ -546,14 +548,11 @@ class Worker:
     def record_task_log_start(self):
         """Record the task log info when task starts executing for
         non concurrent actor tasks."""
-        if self.core_worker.current_actor_max_concurrency() != 1:
-            # This is a concurrent actor task, we will not record the start.
-            # We are skipping concurrent actor tasks because high contention
-            # and slow IO on concurrent actors would result in perf regression.
+        if not self._enable_record_actor_task_log and not self.actor_id.is_nil():
+            # We are not recording actor task log if not enabled explicitly.
+            # Recording actor task log is expensive and should be enabled only
+            # when needed.
             # https://github.com/ray-project/ray/issues/35598
-            return
-
-        if not self._enable_record_task_log:
             return
 
         self.core_worker.record_task_log_start(
@@ -566,14 +565,11 @@ class Worker:
     def record_task_log_end(self):
         """Record the task log info when task finishes executing for
         non concurrent actor tasks."""
-        if self.core_worker.current_actor_max_concurrency() != 1:
-            # This is a concurrent actor task, we will not record the end.
-            # We are skipping concurrent actor tasks because high contention
-            # and slow IO on concurrent actors would result in perf regression.
+        if not self._enable_record_actor_task_log and not self.actor_id.is_nil():
+            # We are not recording actor task log if not enabled explicitly.
+            # Recording actor task log is expensive and should be enabled only
+            # when needed.
             # https://github.com/ray-project/ray/issues/35598
-            return
-
-        if not self._enable_record_task_log:
             return
 
         self.core_worker.record_task_log_end(

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -739,7 +739,7 @@ def check_file(type, task_name, expected_log, expect_no_end=False):
 
 
 @pytest.mark.skipif(
-    not ray_constants.RAY_ENABLE_RECORD_TASK_LOGGING or sys.platform == "win32",
+    not ray_constants.RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING or sys.platform == "win32",
     reason=(
         "Skipping if not recording task logs offsets, "
         "and windows has logging race issues."
@@ -801,7 +801,7 @@ def test_task_logs_info_basic(shutdown_only):
 
 
 @pytest.mark.skipif(
-    not ray_constants.RAY_ENABLE_RECORD_TASK_LOGGING,
+    not ray_constants.RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING,
     reason="Skipping if not recording task logs offsets.",
 )
 def test_task_logs_info_disabled(shutdown_only, monkeypatch):
@@ -830,7 +830,7 @@ def test_task_logs_info_disabled(shutdown_only, monkeypatch):
 
 
 @pytest.mark.skipif(
-    not ray_constants.RAY_ENABLE_RECORD_TASK_LOGGING,
+    not ray_constants.RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING,
     reason="Skipping if not recording task logs offsets.",
 )
 def test_task_logs_info_running_task(shutdown_only):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
With this PR, actor tasks logs should be retrieved with actor id by default. Users could turn on the flag `RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING` so that actor logs could be retrieved using task id. 

This is needed to prevent regression since recording task logs is currently expensive due to Ray flushing all log lines for log monitoring. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
By default
<img width="1411" alt="image" src="https://github.com/ray-project/ray/assets/11676094/4843ec60-c2a1-4b02-8db6-283e3787d265">

--------
When set `RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING=1`
<img width="1202" alt="image" src="https://github.com/ray-project/ray/assets/11676094/446cf294-1582-4d59-9fed-617c1f5f7b04">


## Related issue number
Closes https://github.com/ray-project/ray/issues/35919
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
