### PR TITLE
Revert "[core][dashboard] Task backend GC policy - worker update [1/3…

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -485,10 +485,6 @@ RAY_CONFIG(uint64_t, task_events_max_buffer_size, 100 * 1000)
 /// the message size, and also the processing work on GCS.
 RAY_CONFIG(uint64_t, task_events_send_batch_size, 10 * 1000)
 
-/// Max number of dropped task attempt info to be sent in a single rpc call to
-/// GCS for task events in rpc::TaskEventsData
-RAY_CONFIG(uint64_t, task_events_drop_task_attempt_batch_size, 10 * 1000)
-
 /// Max number of profile events allowed for a single task when sent to GCS.
 /// NOTE: this limit only applies to the profile events per task in a single
 /// report gRPC call. A task could have more profile events in GCS from multiple

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -225,8 +225,8 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
 
   // Initialize the task state event buffer.
   auto task_event_gcs_client = std::make_unique<gcs::GcsClient>(options_.gcs_options);
-  task_event_buffer_ = std::make_unique<worker::TaskEventBufferImpl>(
-      std::move(task_event_gcs_client), worker_context_.GetCurrentJobID());
+  task_event_buffer_ =
+      std::make_unique<worker::TaskEventBufferImpl>(std::move(task_event_gcs_client));
   if (RayConfig::instance().task_events_report_interval_ms() > 0) {
     if (!task_event_buffer_->Start().ok()) {
       RAY_CHECK(!task_event_buffer_->Enabled()) << "TaskEventBuffer should be disabled.";

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -138,10 +138,8 @@ bool TaskProfileEvent::ToRpcTaskEventsOrDrop(rpc::TaskEvents *rpc_task_events) {
   return false;
 }
 
-TaskEventBufferImpl::TaskEventBufferImpl(std::unique_ptr<gcs::GcsClient> gcs_client,
-                                         const JobID &job_id)
-    : job_id_(job_id),
-      work_guard_(boost::asio::make_work_guard(io_service_)),
+TaskEventBufferImpl::TaskEventBufferImpl(std::unique_ptr<gcs::GcsClient> gcs_client)
+    : work_guard_(boost::asio::make_work_guard(io_service_)),
       periodical_runner_(io_service_),
       gcs_client_(std::move(gcs_client)),
       buffer_() {}
@@ -218,37 +216,32 @@ void TaskEventBufferImpl::AddTaskEvent(std::unique_ptr<TaskEvent> task_event) {
   if (!enabled_) {
     return;
   }
+  size_t num_profile_events_dropped = 0;
+  size_t num_status_events_dropped = 0;
   size_t num_add = 0;
 
   absl::MutexLock lock(&mutex_);
   size_t prev_size = buffer_.size();
-  size_t num_profile_events_dropped = 0;
   {
-    if (task_attempts_dropped_.count(task_event->GetTaskAttempt())) {
-      // We are already dropping events for this task attempt.
-      // So don't add it to the buffer.
-      if (task_event->IsProfileEvent()) {
-        num_profile_events_dropped++;
-      }
-      return;
-    }
-
     if (buffer_.full()) {
       const auto &to_evict = buffer_.front();
       if (to_evict->IsProfileEvent()) {
         num_profile_events_dropped++;
       } else {
-        // Mark task attempt to be dropped.
-        task_attempts_dropped_.insert(to_evict->GetTaskAttempt());
+        num_status_events_dropped++;
       }
     }
     buffer_.push_back(std::move(task_event));
     num_add = buffer_.size() - prev_size;
   }
-  stats_counter_.Increment(TaskEventBufferCounter::kNumTaskEventsStored, num_add);
+
   stats_counter_.Increment(
       TaskEventBufferCounter::kNumTaskProfileEventDroppedSinceLastFlush,
       num_profile_events_dropped);
+  stats_counter_.Increment(
+      TaskEventBufferCounter::kNumTaskStatusEventDroppedSinceLastFlush,
+      num_status_events_dropped);
+  stats_counter_.Increment(TaskEventBufferCounter::kNumTaskEventsStored, num_add);
 }
 
 void TaskEventBufferImpl::FlushEvents(bool forced) {
@@ -257,7 +250,7 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
   }
   std::vector<std::unique_ptr<TaskEvent>> to_send;
   to_send.reserve(RayConfig::instance().task_events_send_batch_size());
-  absl::flat_hash_set<TaskAttempt> task_attempts_dropped;
+
   {
     absl::MutexLock lock(&mutex_);
 
@@ -269,18 +262,6 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
              "Skipping reporting task state events and retry later."
           << "[cur_buffer_size=" << buffer_.size() << "].";
       return;
-    }
-
-    // Get the data loss info.
-    size_t task_attempt_count = 0;
-    // iterate and erase task attempt dropped.
-    while (task_attempt_count <
-               RayConfig::instance().task_events_drop_task_attempt_batch_size() &&
-           !task_attempts_dropped_.empty()) {
-      auto itr = task_attempts_dropped_.begin();
-      task_attempts_dropped.insert(*itr);
-      task_attempts_dropped_.erase(itr);
-      task_attempt_count++;
     }
 
     // No data to send.
@@ -297,15 +278,9 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
     buffer_.erase(buffer_.begin(), buffer_.begin() + num_to_send);
   }
 
-  // Aggregate data to be sent.
+  // Aggregate
   absl::flat_hash_map<TaskAttempt, rpc::TaskEvents> agg_task_events;
-  auto to_rpc_event_fn = [this, &agg_task_events, &task_attempts_dropped](
-                             std::unique_ptr<TaskEvent> &event) {
-    if (task_attempts_dropped.count(event->GetTaskAttempt())) {
-      // We are dropping all events from the task attempt due to data loss.
-      return;
-    }
-
+  auto to_rpc_event_fn = [this, &agg_task_events](std::unique_ptr<TaskEvent> &event) {
     if (!agg_task_events.count(event->GetTaskAttempt())) {
       auto inserted =
           agg_task_events.insert({event->GetTaskAttempt(), rpc::TaskEvents()});
@@ -313,16 +288,11 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
     }
 
     auto itr = agg_task_events.find(event->GetTaskAttempt());
-    if (event->IsProfileEvent()) {
-      if (event->ToRpcTaskEventsOrDrop(&(itr->second))) {
-        // We are dropping profile events since there are too many for a single task
-        // attempt. This happens frequently for driver task submitting many tasks.
-        stats_counter_.Increment(
-            TaskEventBufferCounter::kNumTaskProfileEventDroppedSinceLastFlush);
-      }
-    } else {
-      // We will not be dropping any status changes during conversion to rpc::TaskEvents.
-      RAY_CHECK(!event->ToRpcTaskEventsOrDrop(&(itr->second)));
+
+    if (event->ToRpcTaskEventsOrDrop(&(itr->second))) {
+      RAY_CHECK(event->IsProfileEvent());
+      stats_counter_.Increment(
+          TaskEventBufferCounter::kNumTaskProfileEventDroppedSinceLastFlush);
     }
   };
   std::for_each(to_send.begin(), to_send.end(), to_rpc_event_fn);
@@ -330,30 +300,39 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
   // Convert to rpc::TaskEventsData
   auto data = std::make_unique<rpc::TaskEventData>();
   size_t num_task_events = to_send.size();
+  size_t num_profile_event_to_send = 0;
+  size_t num_status_event_to_send = 0;
   for (auto &[_task_attempt, task_event] : agg_task_events) {
     auto events_by_task = data->add_events_by_task();
+    if (task_event.has_profile_events()) {
+      num_profile_event_to_send++;
+    }
+    if (task_event.has_state_updates()) {
+      num_status_event_to_send++;
+    }
     *events_by_task = std::move(task_event);
-  }
-
-  // Add the data loss info.
-  auto num_profile_events_dropped_since_last_flush = stats_counter_.Get(
-      TaskEventBufferCounter::kNumTaskProfileEventDroppedSinceLastFlush);
-  data->set_num_profile_events_dropped(num_profile_events_dropped_since_last_flush);
-  // Reset the counter
-  stats_counter_.Decrement(
-      TaskEventBufferCounter::kNumTaskProfileEventDroppedSinceLastFlush,
-      num_profile_events_dropped_since_last_flush);
-  data->set_job_id(job_id_.Binary());
-
-  for (auto &task_attempt : task_attempts_dropped) {
-    rpc::TaskAttempt rpc_task_attempt;
-    rpc_task_attempt.set_task_id(task_attempt.first.Binary());
-    rpc_task_attempt.set_attempt_number(task_attempt.second);
-    *(data->add_dropped_task_attempts()) = rpc_task_attempt;
   }
 
   // Send and reset the counters
   stats_counter_.Decrement(TaskEventBufferCounter::kNumTaskEventsStored, to_send.size());
+  size_t num_profile_task_events_dropped = stats_counter_.Get(
+      TaskEventBufferCounter::kNumTaskProfileEventDroppedSinceLastFlush);
+  stats_counter_.Decrement(
+      TaskEventBufferCounter::kNumTaskProfileEventDroppedSinceLastFlush,
+      num_profile_task_events_dropped);
+  stats_counter_.Increment(TaskEventBufferCounter::kTotalNumTaskProfileEventDropped,
+                           num_profile_task_events_dropped);
+
+  size_t num_status_task_events_dropped = stats_counter_.Get(
+      TaskEventBufferCounter::kNumTaskStatusEventDroppedSinceLastFlush);
+  stats_counter_.Decrement(
+      TaskEventBufferCounter::kNumTaskStatusEventDroppedSinceLastFlush,
+      num_status_task_events_dropped);
+  stats_counter_.Increment(TaskEventBufferCounter::kTotalNumTaskStatusEventDropped,
+                           num_status_task_events_dropped);
+
+  data->set_num_profile_task_events_dropped(num_profile_task_events_dropped);
+  data->set_num_status_task_events_dropped(num_status_task_events_dropped);
 
   gcs::TaskInfoAccessor *task_accessor;
   {
@@ -369,11 +348,6 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
       RAY_LOG(WARNING) << "Failed to push " << num_task_events
                        << " task state events to GCS. Data will be lost. [status="
                        << status.ToString() << "]";
-      stats_counter_.Increment(TaskEventBufferCounter::kTotalNumTaskEventsDropped,
-                               num_task_events);
-    } else {
-      stats_counter_.Increment(TaskEventBufferCounter::kTotalNumTaskEventsReported,
-                               num_task_events);
     }
     grpc_in_progress_ = false;
   };
@@ -390,8 +364,10 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
       grpc_in_progress_ = false;
 
       // Fail to send, currently dropping events.
-      stats_counter_.Increment(TaskEventBufferCounter::kTotalNumTaskEventsDropped,
-                               num_task_events);
+      stats_counter_.Increment(TaskEventBufferCounter::kTotalNumTaskProfileEventDropped,
+                               num_profile_event_to_send);
+      stats_counter_.Increment(TaskEventBufferCounter::kTotalNumTaskStatusEventDropped,
+                               num_status_event_to_send);
     }
   }
 }
@@ -415,7 +391,11 @@ const std::string TaskEventBufferImpl::DebugString() {
      << 1.0 * stats[TaskEventBufferCounter::kTotalTaskEventsBytesReported] / 1024 / 1024
      << " MiB"
      << "\n\ttotal number of task events sent: "
-     << stats[TaskEventBufferCounter::kTotalNumTaskEventsReported];
+     << stats[TaskEventBufferCounter::kTotalTaskEventsReported]
+     << "\n\tnum status task events dropped: "
+     << stats[TaskEventBufferCounter::kTotalNumTaskProfileEventDropped]
+     << "\n\tnum profile task events dropped: "
+     << stats[TaskEventBufferCounter::kTotalNumTaskStatusEventDropped] << "\n";
 
   return ss.str();
 }

--- a/src/ray/core_worker/task_event_buffer.h
+++ b/src/ray/core_worker/task_event_buffer.h
@@ -50,15 +50,13 @@ class TaskEvent {
 
   virtual ~TaskEvent() = default;
 
-  /// Convert itself a rpc::TaskEvents or drop it if there is data loss.
+  /// Convert itself a rpc::TaskEvents or drop itself due to data limit.
   ///
   /// NOTE: this method will modify internal states by moving fields to the
   /// rpc::TaskEvents.
   /// \param[out] rpc_task_events The rpc task event to be filled.
-  /// \return True if data is dropped, false otherwise.
+  /// \return If it's dropped due to data limit.
   virtual bool ToRpcTaskEventsOrDrop(rpc::TaskEvents *rpc_task_events) = 0;
-
-  virtual JobID GetJobId() const { return job_id_; }
 
   /// If it is a profile event.
   virtual bool IsProfileEvent() const = 0;
@@ -165,17 +163,13 @@ class TaskProfileEvent : public TaskEvent {
 
 /// @brief An enum class defining counters to be used in TaskEventBufferImpl.
 enum TaskEventBufferCounter {
-  /// Number of task events stored in the buffer.
-  kNumTaskEventsStored,
-  /// Number of dropped task attempt stored in the buffer.
-  kNumTaskAttemptsDroppedStored,
-  /// Total number of task events dropped on the worker due to network issue.
-  kTotalNumTaskEventsDropped,
-  /// Number of profile events dropped since the last report.
   kNumTaskProfileEventDroppedSinceLastFlush,
-  /// Total number of task events reported to GCS.
-  kTotalNumTaskEventsReported,
-  /// Total bytes of task events reported to GCS.
+  kNumTaskStatusEventDroppedSinceLastFlush,
+  kNumTaskEventsStored,
+  /// Below stats are updated every flush.
+  kTotalNumTaskProfileEventDropped,
+  kTotalNumTaskStatusEventDropped,
+  kTotalTaskEventsReported,
   kTotalTaskEventsBytesReported,
 };
 
@@ -184,24 +178,13 @@ enum TaskEventBufferCounter {
 ///
 /// Dropping of task events
 /// ========================
-/// Task events from task attempts will be lost in the below cases for now:
+/// Task events will be lost in the below cases for now:
 ///   1. If any of the gRPC call failed, the task events will be dropped and warnings
 ///   logged. This is probably fine since this usually indicated a much worse issue.
 ///
 ///   2. More than `RAY_task_events_max_buffer_size` tasks have been stored
-///   in the buffer, oldest events in the buffer will be dropped. In this case, the task
-///   attempts info will also be included in subsequent flush to GCS.
-///
-/// For profiling events:
-///   - If the number of profiling events for a task attempt exceeds the limit specified
-///   by `RAY_task_events_max_num_profile_events_for_task`, any new profiling events will
-///   be dropped. Dropping of profile events will not result in the entire task attempt
-///   being dropped.
-///
-/// For task status events:
-///   - If any task status change event is dropped, the entire task attempt will be
-///   dropped. The dropped task attempt info will be sent to GCS, and GCS will then drop
-///   all new and existing events from the task attempt.
+///   in the buffer, any new task events will be dropped. In this case, the number of
+///   dropped task events will also be included in the next flush to surface this.
 ///
 /// No overloading of GCS
 /// =====================
@@ -266,8 +249,7 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   /// Constructor
   ///
   /// \param gcs_client GCS client
-  /// \param job_id Corresponding Job ID
-  TaskEventBufferImpl(std::unique_ptr<gcs::GcsClient> gcs_client, const JobID &job_id);
+  TaskEventBufferImpl(std::unique_ptr<gcs::GcsClient> gcs_client);
 
   void AddTaskEvent(std::unique_ptr<TaskEvent> task_event)
       LOCKS_EXCLUDED(mutex_) override;
@@ -289,16 +271,22 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   }
 
   /// Test only functions.
-  size_t GetNumTaskEventsDropped() {
-    return stats_counter_.Get(TaskEventBufferCounter::kTotalNumTaskEventsDropped);
+  size_t GetTotalNumStatusTaskEventsDropped() {
+    return stats_counter_.Get(TaskEventBufferCounter::kTotalNumTaskStatusEventDropped);
   }
 
-  /// Test only function.
-  size_t GetNumTaskEventsReported() {
-    return stats_counter_.Get(TaskEventBufferCounter::kTotalNumTaskEventsReported);
+  /// Test only functions.
+  size_t GetNumStatusTaskEventsDroppedSinceLastFlush() {
+    return stats_counter_.Get(
+        TaskEventBufferCounter::kNumTaskStatusEventDroppedSinceLastFlush);
   }
 
-  /// Test only function.
+  /// Test only functions.
+  size_t GetTotalNumProfileTaskEventsDropped() {
+    return stats_counter_.Get(TaskEventBufferCounter::kTotalNumTaskProfileEventDropped);
+  }
+
+  /// Test only functions.
   size_t GetNumProfileTaskEventsDroppedSinceLastFlush() {
     return stats_counter_.Get(
         TaskEventBufferCounter::kNumTaskProfileEventDroppedSinceLastFlush);
@@ -310,14 +298,8 @@ class TaskEventBufferImpl : public TaskEventBuffer {
     return gcs_client_.get();
   }
 
-  /// Test only functions.
-  const JobID &GetJobId() const { return job_id_; }
-
   /// Mutex guarding task_events_data_.
   absl::Mutex mutex_;
-
-  /// Job id.
-  const JobID job_id_;
 
   /// IO service event loop owned by TaskEventBuffer.
   instrumented_io_context io_service_;
@@ -347,10 +329,6 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   /// GCS with too many calls. There is no point sending more events if GCS could not
   /// process them quick enough.
   std::atomic<bool> grpc_in_progress_ = false;
-
-  /// Task attempts dropped on this worker that are to be reported to GCS. Reported
-  /// data loss will be removed.
-  absl::flat_hash_set<TaskAttempt> task_attempts_dropped_ GUARDED_BY(mutex_);
 
   FRIEND_TEST(TaskEventBufferTestManualStart, TestGcsClientFail);
   FRIEND_TEST(TaskEventBufferTestBatchSend, TestBatchedSend);

--- a/src/ray/core_worker/test/task_event_buffer_test.cc
+++ b/src/ray/core_worker/test/task_event_buffer_test.cc
@@ -44,7 +44,7 @@ class TaskEventBufferTest : public ::testing::Test {
   )");
 
     task_event_buffer_ = std::make_unique<TaskEventBufferImpl>(
-        std::make_unique<ray::gcs::MockGcsClient>(), JobID::FromInt(1));
+        std::make_unique<ray::gcs::MockGcsClient>());
   }
 
   virtual void SetUp() { RAY_CHECK_OK(task_event_buffer_->Start(/*auto_flush*/ false)); }
@@ -66,15 +66,13 @@ class TaskEventBufferTest : public ::testing::Test {
         task_id, JobID::FromInt(0), attempt_num, rpc::TaskStatus::RUNNING, running_ts);
   }
 
-  std::unique_ptr<TaskEvent> GenProfileTaskEvent(TaskID task_id,
-                                                 int32_t attempt_num,
-                                                 JobID job_id = JobID::FromInt(0)) {
+  std::unique_ptr<TaskEvent> GenProfileTaskEvent(TaskID task_id, int32_t attempt_num) {
     return std::make_unique<TaskProfileEvent>(
-        task_id, job_id, attempt_num, "", "", "", "test_event", 1);
+        task_id, JobID::FromInt(0), attempt_num, "", "", "", "test_event", 1);
   }
 
-  static void CompareTaskEventData(rpc::TaskEventData &actual_data,
-                                   rpc::TaskEventData &expect_data) {
+  static void CompareTaskEventData(const rpc::TaskEventData &actual_data,
+                                   const rpc::TaskEventData &expect_data) {
     // Sort and compare
     std::vector<std::string> actual_events;
     std::vector<std::string> expect_events;
@@ -91,22 +89,10 @@ class TaskEventBufferTest : public ::testing::Test {
       EXPECT_EQ(actual_events[i], expect_events[i]);
     }
 
-    // sort and compare data loss
-    std::vector<std::string> actual_attempts;
-    std::vector<std::string> expect_attempts;
-    for (const auto &t : actual_data.dropped_task_attempts()) {
-      actual_attempts.push_back(t.DebugString());
-    }
-    for (const auto &t : expect_data.dropped_task_attempts()) {
-      expect_attempts.push_back(t.DebugString());
-    }
-    std::sort(actual_attempts.begin(), actual_attempts.end());
-    std::sort(expect_attempts.begin(), expect_attempts.end());
-
-    EXPECT_EQ(actual_attempts.size(), expect_attempts.size());
-    for (size_t i = 0; i < actual_attempts.size(); ++i) {
-      EXPECT_EQ(actual_attempts[i], expect_attempts[i]);
-    }
+    EXPECT_EQ(actual_data.num_profile_task_events_dropped(),
+              expect_data.num_profile_task_events_dropped());
+    EXPECT_EQ(actual_data.num_status_task_events_dropped(),
+              expect_data.num_status_task_events_dropped());
   }
 
   std::unique_ptr<TaskEventBufferImpl> task_event_buffer_ = nullptr;
@@ -188,6 +174,8 @@ TEST_F(TaskEventBufferTest, TestFlushEvents) {
 
   // Expect data flushed match
   rpc::TaskEventData expected_data;
+  expected_data.set_num_profile_task_events_dropped(0);
+  expected_data.set_num_status_task_events_dropped(0);
   for (const auto &task_event : task_events) {
     auto event = expected_data.add_events_by_task();
     task_event->ToRpcTaskEventsOrDrop(event);
@@ -244,9 +232,9 @@ TEST_F(TaskEventBufferTest, TestFailedFlush) {
   task_event_buffer_->FlushEvents(false);
 
   // Expect the number of dropped events incremented.
-  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsDropped(),
-            num_status_events + num_profile_events);
-  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsReported(), 0);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumStatusTaskEventsDropped(), num_status_events);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumProfileTaskEventsDropped(),
+            num_profile_events);
 
   // Adding some more events
   for (size_t i = 0; i < num_status_events + num_profile_events; ++i) {
@@ -258,12 +246,11 @@ TEST_F(TaskEventBufferTest, TestFailedFlush) {
     }
   }
 
-  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(),
-            num_status_events + num_profile_events);
+  // Flush successfully will reset the num events dropped.
   task_event_buffer_->FlushEvents(false);
-  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsDropped(),
-            num_status_events + num_profile_events);
-  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), 0);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumStatusTaskEventsDropped(), num_status_events);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumProfileTaskEventsDropped(),
+            num_profile_events);
 }
 
 TEST_F(TaskEventBufferTest, TestBackPressure) {
@@ -352,18 +339,33 @@ TEST_F(TaskEventBufferTestBatchSend, TestBatchedSend) {
 
 TEST_F(TaskEventBufferTest, TestBufferSizeLimit) {
   size_t num_limit = 100;  // Synced with test setup
+  size_t num_profile = 50;
+  size_t num_status = 50;
 
   // Generate 2 batches of events each, where batch 1 will be evicted by batch 2.
+  std::vector<std::unique_ptr<TaskEvent>> profile_events_1;
   std::vector<std::unique_ptr<TaskEvent>> status_events_1;
+  std::vector<std::unique_ptr<TaskEvent>> profile_events_2;
   std::vector<std::unique_ptr<TaskEvent>> status_events_2;
 
   // Generate data
-  for (size_t i = 0; i < num_limit; ++i) {
+  for (size_t i = 0; i < 50; ++i) {
     status_events_1.push_back(GenStatusTaskEvent(RandomTaskId(), 0));
     status_events_2.push_back(GenStatusTaskEvent(RandomTaskId(), 0));
+    profile_events_1.push_back(GenProfileTaskEvent(RandomTaskId(), 0));
+    profile_events_2.push_back(GenProfileTaskEvent(RandomTaskId(), 0));
   }
 
   rpc::TaskEventData expected_data;
+  expected_data.set_num_profile_task_events_dropped(num_profile);
+  expected_data.set_num_status_task_events_dropped(num_status);
+  for (const auto &event_ptr : profile_events_2) {
+    auto expect_event = expected_data.add_events_by_task();
+    // Copy the data
+    auto event = std::make_unique<TaskProfileEvent>(
+        *static_cast<TaskProfileEvent *>(event_ptr.get()));
+    event->ToRpcTaskEventsOrDrop(expect_event);
+  }
   for (const auto &event_ptr : status_events_2) {
     auto expect_event = expected_data.add_events_by_task();
     // Copy the data
@@ -372,26 +374,19 @@ TEST_F(TaskEventBufferTest, TestBufferSizeLimit) {
     event->ToRpcTaskEventsOrDrop(expect_event);
   }
 
-  // Add the data profile_events_1 and status_events_1 will be evicted.
+  // Add the data
+  for (auto &event : profile_events_1) {
+    task_event_buffer_->AddTaskEvent(std::move(event));
+  }
   for (auto &event : status_events_1) {
-    rpc::TaskAttempt rpc_attempt;
-    rpc_attempt.set_task_id(event->GetTaskAttempt().first.Binary());
-    rpc_attempt.set_attempt_number(event->GetTaskAttempt().second);
-    *(expected_data.add_dropped_task_attempts()) = rpc_attempt;
-
-    // Copy the data
-    auto event_copy =
-        std::make_unique<TaskStatusEvent>(*static_cast<TaskStatusEvent *>(event.get()));
-    task_event_buffer_->AddTaskEvent(std::move(event_copy));
+    task_event_buffer_->AddTaskEvent(std::move(event));
+  }
+  for (auto &event : profile_events_2) {
+    task_event_buffer_->AddTaskEvent(std::move(event));
   }
   for (auto &event : status_events_2) {
     task_event_buffer_->AddTaskEvent(std::move(event));
   }
-  // Status events from the same task attempt that were dropped should be dropped
-  for (auto &event : status_events_1) {
-    task_event_buffer_->AddTaskEvent(std::move(event));
-  }
-
   // Expect only limit in buffer.
   ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), num_limit);
 
@@ -403,25 +398,30 @@ TEST_F(TaskEventBufferTest, TestBufferSizeLimit) {
   EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData(_, _))
       .WillOnce([&](std::unique_ptr<rpc::TaskEventData> actual_data,
                     ray::gcs::StatusCallback callback) {
+        // Sort and compare
         CompareTaskEventData(*actual_data, expected_data);
         return Status::OK();
       });
 
   task_event_buffer_->FlushEvents(false);
 
+  // Expect data flushed.
   ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), 0);
+  ASSERT_EQ(task_event_buffer_->GetNumProfileTaskEventsDroppedSinceLastFlush(), 0);
+  ASSERT_EQ(task_event_buffer_->GetNumStatusTaskEventsDroppedSinceLastFlush(), 0);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumProfileTaskEventsDropped(), num_profile);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumStatusTaskEventsDropped(), num_status);
 }
 
 TEST_F(TaskEventBufferTestLimitProfileEvents, TestLimitProfileEventsPerTask) {
-  size_t num_profile_events_per_task = 10;  // sync with class config.
+  size_t num_profile_events_per_task = 10;
   size_t num_total_profile_events = 1000;
   std::vector<std::unique_ptr<TaskEvent>> profile_events;
-  auto task_id1 = RandomTaskId();
-  const auto &job_id = task_event_buffer_->GetJobId();
+  auto task_id = RandomTaskId();
 
-  // Generate data for the same task attempts from job 1
+  // Generate data for the same task attempts.
   for (size_t i = 0; i < num_total_profile_events; ++i) {
-    profile_events.push_back(GenProfileTaskEvent(task_id1, 0, job_id));
+    profile_events.push_back(GenProfileTaskEvent(task_id, 0));
   }
 
   // Add all
@@ -429,25 +429,11 @@ TEST_F(TaskEventBufferTestLimitProfileEvents, TestLimitProfileEventsPerTask) {
     task_event_buffer_->AddTaskEvent(std::move(event));
   }
 
-  auto task_gcs_accessor =
-      static_cast<ray::gcs::MockGcsClient *>(task_event_buffer_->GetGcsClient())
-          ->mock_task_accessor;
-
-  // With batch size = 10, there should be 10 flush calls
-  EXPECT_CALL(*task_gcs_accessor, AsyncAddTaskEventData)
-      .WillOnce([&](std::unique_ptr<rpc::TaskEventData> actual_data,
-                    ray::gcs::StatusCallback callback) {
-        EXPECT_EQ(actual_data->num_profile_events_dropped(),
-                  num_total_profile_events - num_profile_events_per_task);
-        EXPECT_EQ(actual_data->job_id(), job_id.Binary());
-        callback(Status::OK());
-        return Status::OK();
-      });
-
+  // Assert dropped count
   task_event_buffer_->FlushEvents(false);
-
-  // Counter is reset correctly.
-  EXPECT_EQ(task_event_buffer_->GetNumProfileTaskEventsDroppedSinceLastFlush(), 0);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumProfileTaskEventsDropped(),
+            num_total_profile_events - num_profile_events_per_task);
+  ASSERT_EQ(task_event_buffer_->GetTotalNumStatusTaskEventsDropped(), 0);
 }
 
 }  // namespace worker

--- a/src/ray/gcs/gcs_server/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.cc
@@ -387,25 +387,15 @@ void GcsTaskManager::HandleGetTaskEvents(rpc::GetTaskEventsRequest request,
   return;
 }
 
-void GcsTaskManager::RecordDataLossFromWorker(const rpc::TaskEventData &data) {
-  // TODO(rickyx): GCS side GC will be changed in another PR. This is a temporary
-  // routine for supporting legacy behaviour with worker side changes.
-  if (data.dropped_task_attempts_size() > 0) {
-    stats_counter_.Increment(kTotalNumStatusTaskEventsDropped,
-                             data.dropped_task_attempts_size());
-  }
-
-  if (data.num_profile_events_dropped() > 0) {
-    stats_counter_.Increment(kTotalNumProfileTaskEventsDropped,
-                             data.num_profile_events_dropped());
-  }
-}
-
 void GcsTaskManager::HandleAddTaskEventData(rpc::AddTaskEventDataRequest request,
                                             rpc::AddTaskEventDataReply *reply,
                                             rpc::SendReplyCallback send_reply_callback) {
   auto data = std::move(request.data());
-  RecordDataLossFromWorker(data);
+  // Update counters.
+  stats_counter_.Increment(kTotalNumProfileTaskEventsDropped,
+                           data.num_profile_task_events_dropped());
+  stats_counter_.Increment(kTotalNumStatusTaskEventsDropped,
+                           data.num_status_task_events_dropped());
 
   for (auto events_by_task : *data.mutable_events_by_task()) {
     stats_counter_.Increment(kTotalNumTaskEventsReported);

--- a/src/ray/gcs/gcs_server/gcs_task_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.h
@@ -277,13 +277,6 @@ class GcsTaskManager : public rpc::TaskInfoHandler {
   };
 
  private:
-  /// Record data loss from worker.
-  ///
-  /// TODO(rickyx): This will be updated to record task attempt loss properly.
-  ///
-  /// \param data The task event data.
-  void RecordDataLossFromWorker(const rpc::TaskEventData &data);
-
   /// Test only
   size_t GetTotalNumStatusTaskEventsDropped() {
     return stats_counter_.Get(kTotalNumStatusTaskEventsDropped);

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -267,16 +267,9 @@ struct Mocker {
       auto new_events = data.add_events_by_task();
       new_events->CopyFrom(events);
     }
+    data.set_num_profile_task_events_dropped(num_profile_task_events_dropped);
+    data.set_num_status_task_events_dropped(num_status_task_events_dropped);
 
-    for (int i = 0; i < num_status_task_events_dropped; ++i) {
-      rpc::TaskAttempt rpc_task_attempt;
-      rpc_task_attempt.set_task_id(RandomTaskId().Binary());
-      rpc_task_attempt.set_attempt_number(0);
-      *(data.add_dropped_task_attempts()) = rpc_task_attempt;
-    }
-
-    data.set_num_profile_events_dropped(num_profile_task_events_dropped);
-    data.set_job_id(JobID::FromInt(0).Binary());
     return data;
   }
 };

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -260,26 +260,15 @@ message TaskEvents {
   bytes job_id = 6;
 }
 
-message TaskAttempt {
-  // The task id of the task attempt.
-  bytes task_id = 1;
-  // The attempt number of the task attempt.
-  int32 attempt_number = 2;
-}
-
 // Represents a compact list of task state events by different tasks,
 // where each task has a list of state change events.
 message TaskEventData {
   // A batch of task state change events.
   repeated TaskEvents events_by_task = 1;
-  // A list of task attempts that were dropped on the worker.
-  // We only drop task attempts if task state update is lost on the worker
-  // due to too many events being generated.
-  repeated TaskAttempt dropped_task_attempts = 2;
-  // Number of profile events dropped on the worker.
-  int32 num_profile_events_dropped = 3;
-  // Current job the worker is reporting data for.
-  bytes job_id = 4;
+  // Number of dropped profile task events due to buffer size limit on workers.
+  int32 num_profile_task_events_dropped = 3;
+  // Number of dropped status task events due to buffer size limit on workers.
+  int32 num_status_task_events_dropped = 4;
 }
 
 message ResourceTableData {


### PR DESCRIPTION
…] (   ray-project#34896) (#35917)

This PR seems to be the root cause of stress_test_many_tasks and "1:n async-actor calls async per second" (10%).

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes two regressions from stage 3 and 1:n async-actor calls async per second


## Related issue number

Closes https://github.com/ray-project/ray/issues/35940

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
