### PR TITLE
[Metrics] Use autoscaler-emitted metrics for pending/active/failed no…

### DIFF
--- a/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
@@ -327,16 +327,16 @@ DEFAULT_GRAFANA_PANELS = [
         unit="nodes",
         targets=[
             Target(
-                expr="sum(ray_cluster_active_nodes{{{global_filters}}}) by (node_type)",
-                legend="Active Nodes: {{node_type}}",
+                expr="sum(autoscaler_active_nodes{{{global_filters}}}) by (NodeType)",
+                legend="Active Nodes: {{NodeType}}",
             ),
             Target(
-                expr="sum(ray_cluster_failed_nodes{{{global_filters}}}) by (node_type)",
-                legend="Failed Nodes: {{node_type}}",
+                expr="sum(autoscaler_recently_failed_nodes{{{global_filters}}}) by (NodeType)",
+                legend="Failed Nodes: {{NodeType}}",
             ),
             Target(
-                expr="sum(ray_cluster_pending_nodes{{{global_filters}}}) by (node_type)",
-                legend="Pending Nodes: {{node_type}}",
+                expr="sum(autoscaler_pending_nodes{{{global_filters}}}) by (NodeType)",
+                legend="Pending Nodes: {{NodeType}}",
             ),
         ],
     ),

--- a/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
@@ -251,16 +251,16 @@ SERVE_GRAFANA_PANELS = [
         targets=[
             # TODO(aguo): Update this to use autoscaler metrics instead
             Target(
-                expr="sum(ray_cluster_active_nodes{{{global_filters}}}) by (node_type)",
-                legend="Active Nodes: {{node_type}}",
+                expr="sum(autoscaler_active_nodes{{{global_filters}}}) by (NodeType)",
+                legend="Active Nodes: {{NodeType}}",
             ),
             Target(
-                expr="sum(ray_cluster_failed_nodes{{{global_filters}}}) by (node_type)",
-                legend="Failed Nodes: {{node_type}}",
+                expr="sum(autoscaler_recently_failed_nodes{{{global_filters}}}) by (NodeType)",
+                legend="Failed Nodes: {{NodeType}}",
             ),
             Target(
-                expr="sum(ray_cluster_pending_nodes{{{global_filters}}}) by (node_type)",
-                legend="Pending Nodes: {{node_type}}",
+                expr="sum(autoscaler_pending_nodes{{{global_filters}}}) by (NodeType)",
+                legend="Pending Nodes: {{NodeType}}",
             ),
         ],
         grid_pos=GridPos(8, 4, 8, 8),


### PR DESCRIPTION
…des.  (#35884)

This PR uses autoscaler-emitted metrics for pending/active/failed nodes. The previous implementation was buggy and wasn't properly cleaned up, which displays the incorrect graph to the dashboard.

This PR keeps the backward compatibility by only changing namespace of metrics that we will use from the dashboard. I didn't touch other metrics because they are not used anywhere anyway (we can probably remove them or rethink in the future).

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/35864

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
