### PR TITLE
[Data][3/N] Enable optimizer: fix stats and RandomizeBlocks

### DIFF
--- a/python/ray/air/tests/test_dataset_config.py
+++ b/python/ray/air/tests/test_dataset_config.py
@@ -252,7 +252,10 @@ def test_stream_inf_window_cache_prep(ray_start_4_cpus):
         # applying the preprocessor on each epoch.
         assert results[0] == results[1], results
         stats = shard.stats()
-        assert "Stage 1 ReadRange->BatchMapper: 1/1 blocks executed " in stats, stats
+        assert (
+            "Stage 1 ReadRange->MapBatches(BatchMapper._transform_pandas): 1/1 blocks executed "
+            in stats
+        ), stats
 
     def rand(x):
         x["id"] = x["id"].multiply(x["id"])

--- a/python/ray/air/tests/test_dataset_config.py
+++ b/python/ray/air/tests/test_dataset_config.py
@@ -253,8 +253,8 @@ def test_stream_inf_window_cache_prep(ray_start_4_cpus):
         assert results[0] == results[1], results
         stats = shard.stats()
         assert (
-            "Stage 1 ReadRange->MapBatches(BatchMapper._transform_pandas): 1/1 blocks executed "
-            in stats
+            "Stage 1 ReadRange->MapBatches(BatchMapper._transform_pandas): "
+            "1/1 blocks executed " in stats
         ), stats
 
     def rand(x):

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -158,12 +158,13 @@ def _get_initial_stats_from_plan(plan: ExecutionPlan) -> DatasetStats:
     assert DataContext.get_current().optimizer_enabled
     if plan._snapshot_blocks is not None and not plan._snapshot_blocks.is_cleared():
         return plan._snapshot_stats
-    # Here we keep the same behavior as the legacy execution backend.
-    # If the input blocks is a LazyBlockList, return an empty stats.
-    # Otherwise, use `plan._in_stats`.
-    # See `_get_source_blocks_and_stages` and `_rewrite_read_stages` in `plan.py`.
-    # TODO(hchen): After removing LazyBlockList, we should pass the empty stats
-    # as the initial stats in the first place.
+    # For Datasets created from "read_xxx", `plan._in_blocks` is a LazyBlockList,
+    # and `plan._in_stats` contains useless data.
+    # For Datasets created from "from_xxx", we need to use `plan._in_stats` as
+    # the initial stats. Because the `FromXxx` logical operators will be translated to
+    # "InputDataBuffer" physical operators, which will be ignored when generating
+    # stats, see `StreamingExecutor._generate_stats`.
+    # TODO(hchen): Unify the logic by saving the initial stats in `InputDataBuffer
     if isinstance(plan._in_blocks, LazyBlockList):
         return DatasetStats(stages={}, parent=None)
     else:

--- a/python/ray/data/_internal/execution/operators/input_data_buffer.py
+++ b/python/ray/data/_internal/execution/operators/input_data_buffer.py
@@ -28,7 +28,8 @@ class InputDataBuffer(PhysicalOperator):
         """
         if input_data is not None:
             assert input_data_factory is None
-            self._input_data = input_data
+            # Copy the input data to avoid mutating the original list.
+            self._input_data = input_data[:]
             self._is_input_initialized = True
             self._initialize_metadata()
         else:

--- a/python/ray/data/_internal/lazy_block_list.py
+++ b/python/ray/data/_internal/lazy_block_list.py
@@ -593,7 +593,10 @@ class LazyBlockList(BlockList):
             self._stats_actor = _get_or_create_stats_actor()
         stats_actor = self._stats_actor
         if not self._execution_started:
-            stats_actor.record_start.remote(self._stats_uuid)
+            # NOTE: We should wait for `record_start` to finish here.
+            # Otherwise, `record_task` may arrive before `record_start`, and
+            # the stats will be lost.
+            ray.get(stats_actor.record_start.remote(self._stats_uuid))
             self._execution_started = True
         task = self._tasks[task_idx]
         context = DataContext.get_current()

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -40,7 +40,7 @@ class RandomizeBlocks(AbstractAllToAll):
         seed: Optional[int] = None,
     ):
         super().__init__(
-            "RandomizeBlocks",
+            "RandomizeBlockOrder",
             input_op,
         )
         self._seed = seed

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -5,6 +5,9 @@ from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
 from ray.data.block import UserDefinedFunction
 from ray.data.context import DEFAULT_BATCH_SIZE
 
+import inspect
+import logging
+
 
 class AbstractMap(LogicalOperator):
     """Abstract class for logical operators that should be converted to physical
@@ -27,6 +30,25 @@ class AbstractMap(LogicalOperator):
         """
         super().__init__(name, [input_op] if input_op else [])
         self._ray_remote_args = ray_remote_args or {}
+
+
+def _get_udf_name(fn: UserDefinedFunction) -> str:
+    try:
+        if inspect.isclass(fn):
+            # callable class
+            return fn.__name__
+        elif inspect.ismethod(fn):
+            # class method
+            return f"{fn.__self__.__class__.__name__}.{fn.__name__}"
+        elif inspect.isfunction(fn):
+            # normal function or lambda function.
+            return fn.__name__
+        else:
+            # callable object.
+            return fn.__class__.__name__
+    except AttributeError as e:
+        logging.error("Failed to get name of UDF %s: %s", fn, e)
+        return "<unknown>"
 
 
 class AbstractUDFMap(AbstractMap):
@@ -65,6 +87,7 @@ class AbstractUDFMap(AbstractMap):
                 tasks, or ``"actors"`` to use an autoscaling actor pool.
             ray_remote_args: Args to provide to ray.remote.
         """
+        name = f"{name}({_get_udf_name(fn)})"
         super().__init__(name, input_op, ray_remote_args)
         self._fn = fn
         self._fn_args = fn_args
@@ -121,7 +144,7 @@ class MapRows(AbstractUDFMap):
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(
-            "MapRows",
+            "Map",
             input_op,
             fn,
             compute=compute,

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -1,12 +1,14 @@
 from typing import Any, Dict, Iterable, Optional, Union
 
+from ray.data._internal.dataset_logger import DatasetLogger
 from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
 from ray.data.block import UserDefinedFunction
 from ray.data.context import DEFAULT_BATCH_SIZE
 
 import inspect
-import logging
+
+logger = DatasetLogger(__name__)
 
 
 class AbstractMap(LogicalOperator):
@@ -47,7 +49,7 @@ def _get_udf_name(fn: UserDefinedFunction) -> str:
             # callable object.
             return fn.__class__.__name__
     except AttributeError as e:
-        logging.error("Failed to get name of UDF %s: %s", fn, e)
+        logger.get_logger().error("Failed to get name of UDF %s: %s", fn, e)
         return "<unknown>"
 
 

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -13,6 +13,6 @@ class Read(AbstractMap):
         read_tasks: List[ReadTask],
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
-        super().__init__("Read", None, ray_remote_args)
+        super().__init__(f"Read{datasource.get_name()}", None, ray_remote_args)
         self._datasource = datasource
         self._read_tasks = read_tasks

--- a/python/ray/data/_internal/logical/rules/randomize_blocks.py
+++ b/python/ray/data/_internal/logical/rules/randomize_blocks.py
@@ -44,6 +44,9 @@ class ReorderRandomizeBlocksRule(Rule):
                     # RandomizeBlocks operator.
                     current_seed = upstream_ops[i]._seed
                     if not operators or current_seed or operators[-1]._seed:
+                        # We need to make a copy of the operator.
+                        # Because the operator instance may be shared by multiple
+                        # Datasets. We shouldn't modify it in place.
                         operators.append(copy.copy(upstream_ops[i]))
 
                     # Remove RandomizeBlocks operator from the dag and wire in new input

--- a/python/ray/data/_internal/logical/rules/randomize_blocks.py
+++ b/python/ray/data/_internal/logical/rules/randomize_blocks.py
@@ -1,3 +1,4 @@
+import copy
 from collections import deque
 
 from ray.data._internal.logical.interfaces import LogicalOperator, LogicalPlan, Rule
@@ -43,7 +44,7 @@ class ReorderRandomizeBlocksRule(Rule):
                     # RandomizeBlocks operator.
                     current_seed = upstream_ops[i]._seed
                     if not operators or current_seed or operators[-1]._seed:
-                        operators.append(upstream_ops[i])
+                        operators.append(copy.copy(upstream_ops[i]))
 
                     # Remove RandomizeBlocks operator from the dag and wire in new input
                     # dependencies.

--- a/python/ray/data/_internal/logical/util.py
+++ b/python/ray/data/_internal/logical/util.py
@@ -1,9 +1,11 @@
 from typing import Dict
 import json
+import re
 import threading
 
 from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
 from ray.data._internal.logical.interfaces import LogicalOperator
+from ray.data._internal.logical.operators.map_operator import AbstractUDFMap
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.logical.operators.write_operator import Write
 
@@ -44,12 +46,12 @@ _op_name_white_list = [
     "WriteMongo",
     "WriteCustom",
     # Map
+    "Map",
     "MapBatches",
-    "MapRows",
     "Filter",
     "FlatMap",
     # All-to-all
-    "RandomizeBlocks",
+    "RandomizeBlockOrder",
     "RandomShuffle",
     "Repartition",
     "Sort",
@@ -90,6 +92,8 @@ def _collect_operators_to_dict(op: LogicalOperator, ops_dict: Dict[str, int]):
         op_name = f"Write{op._datasource.get_name()}"
         if op_name not in _op_name_white_list:
             op_name = "WriteCustom"
+    elif isinstance(op, AbstractUDFMap):
+        op_name = re.sub("\\(.*\\)$", "", op_name)
 
     # Anonymize any operator name if not in white list.
     if op_name not in _op_name_white_list:

--- a/python/ray/data/_internal/logical/util.py
+++ b/python/ray/data/_internal/logical/util.py
@@ -93,6 +93,8 @@ def _collect_operators_to_dict(op: LogicalOperator, ops_dict: Dict[str, int]):
         if op_name not in _op_name_white_list:
             op_name = "WriteCustom"
     elif isinstance(op, AbstractUDFMap):
+        # Remove the function name from the map operator name.
+        # E.g., Map(<lambda>) -> Map
         op_name = re.sub("\\(.*\\)$", "", op_name)
 
     # Anonymize any operator name if not in white list.

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -25,7 +25,7 @@ def _plan_all_to_all_op(
     See Planner.plan() for more details.
     """
     if isinstance(op, RandomizeBlocks):
-        fn = generate_randomize_blocks_fn(op._seed)
+        fn = generate_randomize_blocks_fn(op)
     elif isinstance(op, RandomShuffle):
         fn = generate_random_shuffle_fn(op._seed, op._num_outputs, op._ray_remote_args)
     elif isinstance(op, Repartition):

--- a/python/ray/data/_internal/planner/plan_from_items_op.py
+++ b/python/ray/data/_internal/planner/plan_from_items_op.py
@@ -48,7 +48,7 @@ def _plan_from_items_op(op: FromItems) -> PhysicalOperator:
             )
             block_ref_bundle = RefBundle(
                 [(ray.put(block), block_metadata)],
-                owns_blocks=False,
+                owns_blocks=True,
             )
             ref_bundles.append(block_ref_bundle)
         return ref_bundles

--- a/python/ray/data/_internal/planner/plan_from_items_op.py
+++ b/python/ray/data/_internal/planner/plan_from_items_op.py
@@ -48,7 +48,7 @@ def _plan_from_items_op(op: FromItems) -> PhysicalOperator:
             )
             block_ref_bundle = RefBundle(
                 [(ray.put(block), block_metadata)],
-                owns_blocks=True,
+                owns_blocks=False,
             )
             ref_bundles.append(block_ref_bundle)
         return ref_bundles

--- a/python/ray/data/_internal/planner/plan_from_numpy_op.py
+++ b/python/ray/data/_internal/planner/plan_from_numpy_op.py
@@ -27,7 +27,7 @@ def _plan_from_numpy_refs_op(op: FromNumpyRefs) -> PhysicalOperator:
         blocks, metadata = map(list, zip(*res))
         metadata = ray.get(metadata)
         ref_bundles: List[RefBundle] = [
-            RefBundle([(block, block_metadata)], owns_blocks=False)
+            RefBundle([(block, block_metadata)], owns_blocks=True)
             for block, block_metadata in zip(blocks, metadata)
         ]
         return ref_bundles

--- a/python/ray/data/_internal/planner/plan_from_numpy_op.py
+++ b/python/ray/data/_internal/planner/plan_from_numpy_op.py
@@ -27,7 +27,7 @@ def _plan_from_numpy_refs_op(op: FromNumpyRefs) -> PhysicalOperator:
         blocks, metadata = map(list, zip(*res))
         metadata = ray.get(metadata)
         ref_bundles: List[RefBundle] = [
-            RefBundle([(block, block_metadata)], owns_blocks=True)
+            RefBundle([(block, block_metadata)], owns_blocks=False)
             for block, block_metadata in zip(blocks, metadata)
         ]
         return ref_bundles

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -67,6 +67,6 @@ def _plan_read_op(op: Read) -> PhysicalOperator:
     return MapOperator.create(
         do_read,
         inputs,
-        name="DoRead",
+        name=op.name,
         ray_remote_args=op._ray_remote_args,
     )

--- a/python/ray/data/_internal/planner/randomize_blocks.py
+++ b/python/ray/data/_internal/planner/randomize_blocks.py
@@ -1,5 +1,6 @@
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
+from ray.data._internal.logical.operators.all_to_all_operator import RandomizeBlocks
 from ray.data._internal.execution.interfaces import (
     AllToAllTransformFn,
     RefBundle,
@@ -9,7 +10,7 @@ from ray.data._internal.stats import StatsDict
 
 
 def generate_randomize_blocks_fn(
-    seed: Optional[int],
+    op: RandomizeBlocks,
 ) -> AllToAllTransformFn:
     """Generate function to randomize order of blocks."""
 
@@ -18,20 +19,23 @@ def generate_randomize_blocks_fn(
     ) -> Tuple[List[RefBundle], StatsDict]:
         import random
 
+        nonlocal op
         blocks_with_metadata = []
         for ref_bundle in refs:
             for block, meta in ref_bundle.blocks:
                 blocks_with_metadata.append((block, meta))
 
         if len(blocks_with_metadata) == 0:
-            return refs, {}
+            return refs, {op._name: []}
         else:
-            if seed is not None:
-                random.seed(seed)
+            if op._seed is not None:
+                random.seed(op._seed)
             input_owned = all(b.owns_blocks for b in refs)
             random.shuffle(blocks_with_metadata)
             output = []
+            meta_list = []
             for block, meta in blocks_with_metadata:
+                meta_list.append(meta)
                 output.append(
                     RefBundle(
                         [
@@ -43,6 +47,6 @@ def generate_randomize_blocks_fn(
                         owns_blocks=input_owned,
                     )
                 )
-            return output, {}
+            return output, {op._name: meta_list}
 
     return fn

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -99,7 +99,7 @@ DEFAULT_AUTO_LOG_STATS = False
 
 # Whether to enable optimizer.
 DEFAULT_OPTIMIZER_ENABLED = bool(
-    int(os.environ.get("RAY_DATA_NEW_EXECUTION_OPTIMIZER", "0"))
+    int(os.environ.get("RAY_DATA_NEW_EXECUTION_OPTIMIZER", "1"))
 )
 
 # Set this env var to enable distributed tqdm (experimental).

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -776,7 +776,7 @@ def test_read_map_chain_operator_fusion_e2e(ray_start_regular_shared, enable_opt
         18,
     ]
     name = (
-        "ReadRange->Filter(<lambda>)->Map(wraps)"
+        "ReadRange->Filter(<lambda>)->Map(<lambda>)"
         "->MapBatches(<lambda>)->FlatMap(<lambda>):"
     )
     assert name in ds.stats()

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -65,7 +65,10 @@ def _check_usage_record(op_names: List[str], clear_after_check: Optional[bool] =
     for op_name in op_names:
         assert op_name in _op_name_white_list
         with _recorded_operators_lock:
-            assert _recorded_operators.get(op_name, 0) > 0, _recorded_operators
+            assert _recorded_operators.get(op_name, 0) > 0, (
+                op_name,
+                _recorded_operators,
+            )
     if clear_after_check:
         with _recorded_operators_lock:
             _recorded_operators.clear()
@@ -77,7 +80,7 @@ def test_read_operator(ray_start_regular_shared, enable_optimizer):
     plan = LogicalPlan(op)
     physical_op = planner.plan(plan).dag
 
-    assert op.name == "Read"
+    assert op.name == "ReadParquet"
     assert isinstance(physical_op, MapOperator)
     assert len(physical_op.input_dependencies) == 1
     assert isinstance(physical_op.input_dependencies[0], InputDataBuffer)
@@ -105,6 +108,50 @@ def test_from_items_e2e(ray_start_regular_shared, enable_optimizer):
     _check_usage_record(["FromItems"])
 
 
+def test_map_operator_udf_name(ray_start_regular_shared, enable_optimizer):
+    # Test the name of the Map operator with different types of UDF.
+    def normal_function(x):
+        return x
+
+    lambda_function = lambda x: x
+
+    class CallableClass:
+        def __call__(self, x):
+            return x
+
+    class NormalClass:
+        def method(self, x):
+            return x
+
+    udf_list = [
+        # A nomral function.
+        normal_function,
+        # A lambda function
+        lambda_function,
+        # A callable class.
+        CallableClass,
+        # An instance of a callable class.
+        CallableClass(),
+        # A normal class method.
+        NormalClass().method,
+    ]
+
+    expected_names = [
+        "normal_function",
+        "<lambda>",
+        "CallableClass",
+        "CallableClass",
+        "NormalClass.method",
+    ]
+
+    for udf, expected_name in zip(udf_list, expected_names):
+        op = MapRows(
+            Read(ParquetDatasource(), []),
+            udf,
+        )
+        assert op.name == f"Map({expected_name})"
+
+
 def test_map_batches_operator(ray_start_regular_shared, enable_optimizer):
     planner = Planner()
     read_op = Read(ParquetDatasource(), [])
@@ -115,7 +162,7 @@ def test_map_batches_operator(ray_start_regular_shared, enable_optimizer):
     plan = LogicalPlan(op)
     physical_op = planner.plan(plan).dag
 
-    assert op.name == "MapBatches"
+    assert op.name == "MapBatches(<lambda>)"
     assert isinstance(physical_op, MapOperator)
     assert len(physical_op.input_dependencies) == 1
     assert isinstance(physical_op.input_dependencies[0], MapOperator)
@@ -138,7 +185,7 @@ def test_map_rows_operator(ray_start_regular_shared, enable_optimizer):
     plan = LogicalPlan(op)
     physical_op = planner.plan(plan).dag
 
-    assert op.name == "MapRows"
+    assert op.name == "Map(<lambda>)"
     assert isinstance(physical_op, MapOperator)
     assert len(physical_op.input_dependencies) == 1
     assert isinstance(physical_op.input_dependencies[0], MapOperator)
@@ -148,7 +195,7 @@ def test_map_rows_e2e(ray_start_regular_shared, enable_optimizer):
     ds = ray.data.range(5)
     ds = ds.map(column_udf("id", lambda x: x + 1))
     assert extract_values("id", ds.take_all()) == [1, 2, 3, 4, 5], ds
-    _check_usage_record(["ReadRange", "MapRows"])
+    _check_usage_record(["ReadRange", "Map"])
 
 
 def test_filter_operator(ray_start_regular_shared, enable_optimizer):
@@ -161,7 +208,7 @@ def test_filter_operator(ray_start_regular_shared, enable_optimizer):
     plan = LogicalPlan(op)
     physical_op = planner.plan(plan).dag
 
-    assert op.name == "Filter"
+    assert op.name == "Filter(<lambda>)"
     assert isinstance(physical_op, MapOperator)
     assert len(physical_op.input_dependencies) == 1
     assert isinstance(physical_op.input_dependencies[0], MapOperator)
@@ -184,7 +231,7 @@ def test_flat_map(ray_start_regular_shared, enable_optimizer):
     plan = LogicalPlan(op)
     physical_op = planner.plan(plan).dag
 
-    assert op.name == "FlatMap"
+    assert op.name == "FlatMap(<lambda>)"
     assert isinstance(physical_op, MapOperator)
     assert len(physical_op.input_dependencies) == 1
     assert isinstance(physical_op.input_dependencies[0], MapOperator)
@@ -289,8 +336,8 @@ def test_repartition_e2e(
         _check_usage_record(["ReadRange", "Repartition"])
         ds_stats: DatasetStats = ds._plan.stats()
         if shuffle:
-            assert ds_stats.base_name == "DoRead->Repartition"
-            assert "DoRead->RepartitionMap" in ds_stats.stages
+            assert ds_stats.base_name == "ReadRange->Repartition"
+            assert "ReadRange->RepartitionMap" in ds_stats.stages
         else:
             assert ds_stats.base_name == "Repartition"
             assert "RepartitionSplit" in ds_stats.stages
@@ -343,8 +390,8 @@ def test_read_map_batches_operator_fusion(ray_start_regular_shared, enable_optim
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
     physical_op = physical_plan.dag
 
-    assert op.name == "MapBatches"
-    assert physical_op.name == "DoRead->MapBatches"
+    assert op.name == "MapBatches(<lambda>)"
+    assert physical_op.name == "ReadParquet->MapBatches(<lambda>)"
     assert isinstance(physical_op, MapOperator)
     assert len(physical_op.input_dependencies) == 1
     assert isinstance(physical_op.input_dependencies[0], InputDataBuffer)
@@ -363,8 +410,11 @@ def test_read_map_chain_operator_fusion(ray_start_regular_shared, enable_optimiz
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
     physical_op = physical_plan.dag
 
-    assert op.name == "Filter"
-    assert physical_op.name == "DoRead->MapRows->MapBatches->FlatMap->Filter"
+    assert op.name == "Filter(<lambda>)"
+    assert (
+        physical_op.name
+        == "ReadParquet->Map(<lambda>)->MapBatches(<lambda>)->FlatMap(<lambda>)->Filter(<lambda>)"
+    )
     assert isinstance(physical_op, MapOperator)
     assert len(physical_op.input_dependencies) == 1
     assert isinstance(physical_op.input_dependencies[0], InputDataBuffer)
@@ -408,8 +458,8 @@ def test_read_map_batches_operator_fusion_compatible_remote_args(
         physical_plan = PhysicalOptimizer().optimize(physical_plan)
         physical_op = physical_plan.dag
 
-        assert op.name == "MapBatches", (up_remote_args, down_remote_args)
-        assert physical_op.name == "MapBatches->MapBatches", (
+        assert op.name == "MapBatches(<lambda>)", (up_remote_args, down_remote_args)
+        assert physical_op.name == "MapBatches(<lambda>)->MapBatches(<lambda>)", (
             up_remote_args,
             down_remote_args,
         )
@@ -418,7 +468,7 @@ def test_read_map_batches_operator_fusion_compatible_remote_args(
             up_remote_args,
             down_remote_args,
         )
-        assert physical_op.input_dependencies[0].name == "DoRead", (
+        assert physical_op.input_dependencies[0].name == "ReadParquet", (
             up_remote_args,
             down_remote_args,
         )
@@ -456,8 +506,8 @@ def test_read_map_batches_operator_fusion_incompatible_remote_args(
         physical_plan = PhysicalOptimizer().optimize(physical_plan)
         physical_op = physical_plan.dag
 
-        assert op.name == "MapBatches", (up_remote_args, down_remote_args)
-        assert physical_op.name == "MapBatches", (
+        assert op.name == "MapBatches(<lambda>)", (up_remote_args, down_remote_args)
+        assert physical_op.name == "MapBatches(<lambda>)", (
             up_remote_args,
             down_remote_args,
         )
@@ -466,7 +516,7 @@ def test_read_map_batches_operator_fusion_incompatible_remote_args(
             up_remote_args,
             down_remote_args,
         )
-        assert physical_op.input_dependencies[0].name == "MapBatches", (
+        assert physical_op.input_dependencies[0].name == "MapBatches(<lambda>)", (
             up_remote_args,
             down_remote_args,
         )
@@ -486,8 +536,8 @@ def test_read_map_batches_operator_fusion_compute_tasks_to_actors(
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
     physical_op = physical_plan.dag
 
-    assert op.name == "MapBatches"
-    assert physical_op.name == "DoRead->MapBatches->MapBatches"
+    assert op.name == "MapBatches(<lambda>)"
+    assert physical_op.name == "ReadParquet->MapBatches(<lambda>)->MapBatches(<lambda>)"
     assert isinstance(physical_op, MapOperator)
     assert len(physical_op.input_dependencies) == 1
     assert isinstance(physical_op.input_dependencies[0], InputDataBuffer)
@@ -505,8 +555,8 @@ def test_read_map_batches_operator_fusion_compute_read_to_actors(
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
     physical_op = physical_plan.dag
 
-    assert op.name == "MapBatches"
-    assert physical_op.name == "DoRead->MapBatches"
+    assert op.name == "MapBatches(<lambda>)"
+    assert physical_op.name == "ReadParquet->MapBatches(<lambda>)"
     assert isinstance(physical_op, MapOperator)
     assert len(physical_op.input_dependencies) == 1
     assert isinstance(physical_op.input_dependencies[0], InputDataBuffer)
@@ -525,14 +575,14 @@ def test_read_map_batches_operator_fusion_incompatible_compute(
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
     physical_op = physical_plan.dag
 
-    assert op.name == "MapBatches"
-    assert physical_op.name == "MapBatches"
+    assert op.name == "MapBatches(<lambda>)"
+    assert physical_op.name == "MapBatches(<lambda>)"
     assert isinstance(physical_op, MapOperator)
     assert len(physical_op.input_dependencies) == 1
     upstream_physical_op = physical_op.input_dependencies[0]
     assert isinstance(upstream_physical_op, MapOperator)
     # Reads should fuse into actor compute.
-    assert upstream_physical_op.name == "DoRead->MapBatches"
+    assert upstream_physical_op.name == "ReadParquet->MapBatches(<lambda>)"
 
 
 def test_read_map_batches_operator_fusion_target_block_size(
@@ -550,119 +600,15 @@ def test_read_map_batches_operator_fusion_target_block_size(
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
     physical_op = physical_plan.dag
 
-    assert op.name == "MapBatches"
+    assert op.name == "MapBatches(<lambda>)"
     # Ops are still fused.
-    assert physical_op.name == "DoRead->MapBatches->MapBatches->MapBatches"
+    assert (
+        physical_op.name
+        == "ReadParquet->MapBatches(<lambda>)->MapBatches(<lambda>)->MapBatches(<lambda>)"
+    )
     assert isinstance(physical_op, MapOperator)
     # Target block size is set to max.
     assert physical_op._block_ref_bundler._min_rows_per_bundle == 5
-    assert len(physical_op.input_dependencies) == 1
-    assert isinstance(physical_op.input_dependencies[0], InputDataBuffer)
-
-
-# TODO(hchen): The old code path supports fusing 2 actors with the same class.
-# But this doesn't seem useful in practice. Confirm whether we need this
-# for the new code path.
-@pytest.mark.skip("Optimizer doesn't supporting fusing two actors yet.")
-def test_read_map_batches_operator_fusion_callable_classes(
-    ray_start_regular_shared, enable_optimizer
-):
-    # Test that callable classes can still be fused if they're the same function.
-    planner = Planner()
-    read_op = Read(ParquetDatasource(), [])
-
-    class UDF:
-        def __call__(self, x):
-            return x
-
-    op = MapBatches(read_op, UDF, compute=ray.data.ActorPoolStrategy())
-    op = MapBatches(op, UDF, compute=ray.data.ActorPoolStrategy())
-    logical_plan = LogicalPlan(op)
-    physical_plan = planner.plan(logical_plan)
-    physical_plan = PhysicalOptimizer().optimize(physical_plan)
-    physical_op = physical_plan.dag
-
-    assert op.name == "MapBatches"
-    assert physical_op.name == "DoRead->MapBatches->MapBatches"
-    assert isinstance(physical_op, MapOperator)
-    assert len(physical_op.input_dependencies) == 1
-    assert isinstance(physical_op.input_dependencies[0], InputDataBuffer)
-
-
-def test_read_map_batches_operator_fusion_incompatible_callable_classes(
-    ray_start_regular_shared, enable_optimizer
-):
-    # Test that map operators are not fused when different callable classes are used.
-    planner = Planner()
-    read_op = Read(ParquetDatasource(), [])
-
-    class UDF:
-        def __call__(self, x):
-            return x
-
-    class UDF2:
-        def __call__(self, x):
-            return x + 1
-
-    op = MapBatches(read_op, UDF, compute=ray.data.ActorPoolStrategy())
-    op = MapBatches(op, UDF2, compute=ray.data.ActorPoolStrategy())
-    logical_plan = LogicalPlan(op)
-    physical_plan = planner.plan(logical_plan)
-    physical_plan = PhysicalOptimizer().optimize(physical_plan)
-    physical_op = physical_plan.dag
-
-    assert op.name == "MapBatches"
-    assert physical_op.name == "MapBatches"
-    assert isinstance(physical_op, MapOperator)
-    assert len(physical_op.input_dependencies) == 1
-    upstream_physical_op = physical_op.input_dependencies[0]
-    assert isinstance(upstream_physical_op, MapOperator)
-    # Reads should still fuse with first map.
-    assert upstream_physical_op.name == "DoRead->MapBatches"
-
-
-def test_read_map_batches_operator_fusion_incompatible_constructor_args(
-    ray_start_regular_shared, enable_optimizer
-):
-    # Test that map operators are not fused when callable classes have different
-    # constructor args.
-    planner = Planner()
-    read_op = Read(ParquetDatasource(), [])
-
-    class UDF:
-        def __init__(self, a):
-            self._a
-
-        def __call__(self, x):
-            return x + self._a
-
-    op = MapBatches(
-        read_op, UDF, compute=ray.data.ActorPoolStrategy(), fn_constructor_args=(1,)
-    )
-    op = MapBatches(
-        op, UDF, compute=ray.data.ActorPoolStrategy(), fn_constructor_args=(2,)
-    )
-    op = MapBatches(
-        op, UDF, compute=ray.data.ActorPoolStrategy(), fn_constructor_kwargs={"a": 1}
-    )
-    op = MapBatches(
-        op, UDF, compute=ray.data.ActorPoolStrategy(), fn_constructor_kwargs={"a": 2}
-    )
-    logical_plan = LogicalPlan(op)
-    physical_plan = planner.plan(logical_plan)
-    physical_plan = PhysicalOptimizer().optimize(physical_plan)
-    physical_op = physical_plan.dag
-
-    assert op.name == "MapBatches"
-    # Last 3 physical map operators are unfused.
-    for _ in range(3):
-        assert isinstance(physical_op, MapOperator)
-        assert physical_op.name == "MapBatches"
-        assert len(physical_op.input_dependencies) == 1
-        physical_op = physical_op.input_dependencies[0]
-    # First physical map operator is fused with read.
-    assert isinstance(physical_op, MapOperator)
-    assert physical_op.name == "DoRead->MapBatches"
     assert len(physical_op.input_dependencies) == 1
     assert isinstance(physical_op.input_dependencies[0], InputDataBuffer)
 
@@ -683,10 +629,9 @@ def test_read_map_batches_operator_fusion_with_randomize_blocks_operator(
     ds = ds.randomize_block_order()
     ds = ds.map_batches(fn, batch_size=None)
     assert set(extract_values("id", ds.take_all())) == set(range(1, n + 1))
-    assert "RandomizeBlocks" not in ds.stats()
-    assert "DoRead->MapBatches->RandomizeBlocks" not in ds.stats()
-    assert "DoRead->MapBatches" in ds.stats()
-    _check_usage_record(["ReadRange", "MapBatches", "RandomizeBlocks"])
+    assert "ReadRange->MapBatches(fn)->RandomizeBlockOrder" not in ds.stats()
+    assert "ReadRange->MapBatches(fn)" in ds.stats()
+    _check_usage_record(["ReadRange", "MapBatches", "RandomizeBlockOrder"])
 
 
 def test_read_map_batches_operator_fusion_with_random_shuffle_operator(
@@ -701,7 +646,7 @@ def test_read_map_batches_operator_fusion_with_random_shuffle_operator(
     ds = ds.map_batches(fn, batch_size=None)
     ds = ds.random_shuffle()
     assert set(extract_values("id", ds.take_all())) == set(range(1, n + 1))
-    assert "DoRead->MapBatches->RandomShuffle" in ds.stats()
+    assert "ReadRange->MapBatches(fn)->RandomShuffle" in ds.stats()
     _check_usage_record(["ReadRange", "MapBatches", "RandomShuffle"])
 
     ds = ray.data.range(n)
@@ -710,8 +655,8 @@ def test_read_map_batches_operator_fusion_with_random_shuffle_operator(
     assert set(extract_values("id", ds.take_all())) == set(range(1, n + 1))
     # TODO(Scott): Update below assertion after supporting fusion in
     # the other direction (AllToAllOperator->MapOperator)
-    assert "DoRead->RandomShuffle->MapBatches" not in ds.stats()
-    assert all(op in ds.stats() for op in ("DoRead", "RandomShuffle", "MapBatches"))
+    assert "ReadRange->RandomShuffle->MapBatches(fn)" not in ds.stats()
+    assert all(op in ds.stats() for op in ("ReadRange", "RandomShuffle", "MapBatches"))
     _check_usage_record(["ReadRange", "RandomShuffle", "MapBatches"])
 
     # Test fusing multiple `map_batches` with multiple `random_shuffle` operations.
@@ -720,7 +665,7 @@ def test_read_map_batches_operator_fusion_with_random_shuffle_operator(
         ds = ds.map_batches(fn, batch_size=None)
     ds = ds.random_shuffle()
     assert set(extract_values("id", ds.take_all())) == set(range(5, n + 5))
-    assert f"DoRead->{'MapBatches->' * 5}RandomShuffle" in ds.stats()
+    assert f"ReadRange->{'MapBatches(fn)->' * 5}RandomShuffle" in ds.stats()
 
     # For interweaved map_batches and random_shuffle operations, we expect to fuse the
     # two pairs of MapBatches->RandomShuffle, but not the resulting
@@ -731,8 +676,8 @@ def test_read_map_batches_operator_fusion_with_random_shuffle_operator(
     ds = ds.map_batches(fn, batch_size=None)
     ds = ds.random_shuffle()
     assert set(extract_values("id", ds.take_all())) == set(range(2, n + 2))
-    assert "Stage 1 DoRead->MapBatches->RandomShuffle" in ds.stats()
-    assert "Stage 2 MapBatches->RandomShuffle"
+    assert "Stage 1 ReadRange->MapBatches(fn)->RandomShuffle" in ds.stats()
+    assert "Stage 2 MapBatches(fn)->RandomShuffle" in ds.stats()
     _check_usage_record(["ReadRange", "RandomShuffle", "MapBatches"])
 
 
@@ -751,10 +696,10 @@ def test_read_map_batches_operator_fusion_with_repartition_operator(
 
     # Operator fusion is only supported for shuffle repartition.
     if shuffle:
-        assert "DoRead->MapBatches->Repartition" in ds.stats()
+        assert "ReadRange->MapBatches(fn)->Repartition" in ds.stats()
     else:
-        assert "DoRead->MapBatches->Repartition" not in ds.stats()
-        assert "DoRead->MapBatches" in ds.stats()
+        assert "ReadRange->MapBatches(fn)->Repartition" not in ds.stats()
+        assert "ReadRange->MapBatches(fn)" in ds.stats()
         assert "Repartition" in ds.stats()
     _check_usage_record(["ReadRange", "MapBatches", "Repartition"])
 
@@ -774,8 +719,8 @@ def test_read_map_batches_operator_fusion_with_sort_operator(
     ds = ds.sort("id")
     assert extract_values("id", ds.take_all()) == list(range(1, n + 1))
     # TODO(Scott): update the below assertions after we support fusion.
-    assert "DoRead->MapBatches->Sort" not in ds.stats()
-    assert "DoRead->MapBatches" in ds.stats()
+    assert "ReadRange->MapBatches->Sort" not in ds.stats()
+    assert "ReadRange->MapBatches" in ds.stats()
     assert "Sort" in ds.stats()
     _check_usage_record(["ReadRange", "MapBatches", "Sort"])
 
@@ -804,8 +749,8 @@ def test_read_map_batches_operator_fusion_with_aggregate_operator(
     )
     agg_ds.take_all() == [{"id": 0, "foo": 0.0}, {"id": 1, "foo": 1.0}]
     # TODO(Scott): update the below assertions after we support fusion.
-    assert "DoRead->MapBatches->Aggregate" not in agg_ds.stats()
-    assert "DoRead->MapBatches" in agg_ds.stats()
+    assert "ReadRange->MapBatches->Aggregate" not in agg_ds.stats()
+    assert "ReadRange->MapBatches" in agg_ds.stats()
     assert "Aggregate" in agg_ds.stats()
     _check_usage_record(["ReadRange", "MapBatches", "Aggregate"])
 
@@ -830,15 +775,15 @@ def test_read_map_chain_operator_fusion_e2e(ray_start_regular_shared, enable_opt
         -18,
         18,
     ]
-    name = "DoRead->Filter->MapRows->MapBatches->FlatMap:"
+    name = "ReadRange->Filter(<lambda>)->Map(wraps)->MapBatches(<lambda>)->FlatMap(<lambda>):"
     assert name in ds.stats()
-    _check_usage_record(["ReadRange", "Filter", "MapRows", "MapBatches", "FlatMap"])
+    _check_usage_record(["ReadRange", "Filter", "Map", "MapBatches", "FlatMap"])
 
 
 def test_write_fusion(ray_start_regular_shared, enable_optimizer, tmp_path):
     ds = ray.data.range(10, parallelism=2)
     ds.write_csv(tmp_path)
-    assert "DoRead->Write" in ds._write_ds.stats()
+    assert "ReadRange->Write" in ds._write_ds.stats()
     _check_usage_record(["ReadRange", "WriteCSV"])
 
 
@@ -1173,7 +1118,7 @@ def test_from_pandas_refs_e2e(
         assert values == rows
         assert "MapBatches" in ds2.stats()
         assert "FromPandasRefs" in ds2.stats()
-        assert ds2._plan._logical_plan.dag.name == "MapBatches"
+        assert ds2._plan._logical_plan.dag.name == "MapBatches(<lambda>)"
 
         # test from single pandas dataframe
         ds = ray.data.from_pandas_refs(ray.put(df1))
@@ -1227,7 +1172,7 @@ def test_from_numpy_refs_e2e(ray_start_regular_shared, enable_optimizer):
     np.testing.assert_array_equal(values, np.concatenate((arr1, arr2)))
     assert "MapBatches" in ds2.stats()
     assert "FromNumpyRefs" in ds2.stats()
-    assert ds2._plan._logical_plan.dag.name == "MapBatches"
+    assert ds2._plan._logical_plan.dag.name == "MapBatches(<lambda>)"
     _check_usage_record(["FromNumpyRefs", "MapBatches"])
 
     # Test from single NumPy ndarray.
@@ -1441,7 +1386,7 @@ def test_execute_to_legacy_block_list(
         assert row["id"] == i
 
     assert ds._plan._snapshot_stats is not None
-    assert "DoRead" in ds._plan._snapshot_stats.stages
+    assert "ReadRange" in ds._plan._snapshot_stats.stages
     assert ds._plan._snapshot_stats.time_total_s > 0
 
 
@@ -1456,7 +1401,7 @@ def test_execute_to_legacy_block_iterator(
         assert batch is not None
 
     assert ds._plan._snapshot_stats is not None
-    assert "DoRead" in ds._plan._snapshot_stats.stages
+    assert "ReadRange" in ds._plan._snapshot_stats.stages
     assert ds._plan._snapshot_stats.time_total_s > 0
 
 

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -113,7 +113,7 @@ def test_map_operator_udf_name(ray_start_regular_shared, enable_optimizer):
     def normal_function(x):
         return x
 
-    lambda_function = lambda x: x
+    lambda_function = lambda x: x  # noqa: E731
 
     class CallableClass:
         def __call__(self, x):
@@ -412,8 +412,8 @@ def test_read_map_chain_operator_fusion(ray_start_regular_shared, enable_optimiz
 
     assert op.name == "Filter(<lambda>)"
     assert (
-        physical_op.name
-        == "ReadParquet->Map(<lambda>)->MapBatches(<lambda>)->FlatMap(<lambda>)->Filter(<lambda>)"
+        physical_op.name == "ReadParquet->Map(<lambda>)->MapBatches(<lambda>)"
+        "->FlatMap(<lambda>)->Filter(<lambda>)"
     )
     assert isinstance(physical_op, MapOperator)
     assert len(physical_op.input_dependencies) == 1
@@ -603,8 +603,8 @@ def test_read_map_batches_operator_fusion_target_block_size(
     assert op.name == "MapBatches(<lambda>)"
     # Ops are still fused.
     assert (
-        physical_op.name
-        == "ReadParquet->MapBatches(<lambda>)->MapBatches(<lambda>)->MapBatches(<lambda>)"
+        physical_op.name == "ReadParquet->MapBatches(<lambda>)->"
+        "MapBatches(<lambda>)->MapBatches(<lambda>)"
     )
     assert isinstance(physical_op, MapOperator)
     # Target block size is set to max.
@@ -775,7 +775,10 @@ def test_read_map_chain_operator_fusion_e2e(ray_start_regular_shared, enable_opt
         -18,
         18,
     ]
-    name = "ReadRange->Filter(<lambda>)->Map(wraps)->MapBatches(<lambda>)->FlatMap(<lambda>):"
+    name = (
+        "ReadRange->Filter(<lambda>)->Map(wraps)"
+        "->MapBatches(<lambda>)->FlatMap(<lambda>):"
+    )
     assert name in ds.stats()
     _check_usage_record(["ReadRange", "Filter", "Map", "MapBatches", "FlatMap"])
 

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -374,7 +374,7 @@ def test_map_batches_basic(ray_start_regular_shared, tmp_path, restore_data_cont
 
 def test_map_batches_extra_args(shutdown_only, tmp_path):
     ray.shutdown()
-    ray.init(num_cpus=2)
+    ray.init(num_cpus=3)
 
     def put(x):
         # We only support automatic deref in the legacy backend.

--- a/python/ray/data/tests/test_mars.py
+++ b/python/ray/data/tests/test_mars.py
@@ -72,7 +72,7 @@ def test_from_mars_e2e(ray_start_regular, enable_optimizer):
     ds2 = ds.filter(lambda row: row["a"] % 2 == 0)
     assert ds2.take(5) == [{"a": 2 * i, "b": n + 2 * i} for i in range(5)]
     assert "Filter" in ds2.stats()
-    assert ds2._plan._logical_plan.dag.name == "Filter"
+    assert ds2._plan._logical_plan.dag.name == "Filter(<lambda>)"
 
     # Convert ray dataset to mars dataframe
     df2 = ds2.to_mars()

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -295,6 +295,10 @@ def _assert_has_stages(stages, stage_names):
         assert stage.name == name
 
 
+@pytest.mark.skipif(
+    ray.data.DatasetContext.get_current().optimizer_enabled,
+    reason="Deprecated with new optimizer path.",
+)
 def test_stage_linking(ray_start_regular_shared):
     # Test lazy dataset.
     ds = ray.data.range(10).lazy()
@@ -334,7 +338,7 @@ def test_optimize_reorder(ray_start_regular_shared):
     expect_stages(
         ds2,
         3,
-        ["ReadRange->RandomizeBlockOrder", "Repartition", "MapBatches(dummy_map)"],
+        ["ReadRange", "RandomizeBlockOrder", "Repartition", "MapBatches(dummy_map)"],
     )
 
 

--- a/python/ray/data/tests/test_randomize_block_order.py
+++ b/python/ray/data/tests/test_randomize_block_order.py
@@ -1,6 +1,7 @@
 import pytest
 
 import ray
+from ray.data.datasource import ParquetDatasource
 from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.logical.operators.read_operator import Read
@@ -19,7 +20,7 @@ from ray.data.tests.util import extract_values
 
 def test_randomize_blocks_operator(ray_start_regular_shared, enable_optimizer):
     planner = Planner()
-    read_op = Read(None, read_tasks=[])
+    read_op = Read(datasource=ParquetDatasource(), read_tasks=[])
     op = RandomizeBlocks(
         read_op,
         seed=0,
@@ -27,14 +28,14 @@ def test_randomize_blocks_operator(ray_start_regular_shared, enable_optimizer):
     plan = LogicalPlan(op)
     physical_op = planner.plan(plan).dag
 
-    assert op.name == "RandomizeBlocks"
+    assert op.name == "RandomizeBlockOrder"
     assert isinstance(physical_op, AllToAllOperator)
     assert len(physical_op.input_dependencies) == 1
     assert isinstance(physical_op.input_dependencies[0], MapOperator)
 
 
 def test_randomize_block_order_rule():
-    read = Read(datasource=None, read_tasks=[])
+    read = Read(datasource=ParquetDatasource(), read_tasks=[])
     operator1 = RandomizeBlocks(input_op=read, seed=None)
     operator2 = RandomizeBlocks(input_op=operator1, seed=None)
     operator3 = MapBatches(input_op=operator2, fn=lambda x: x)
@@ -57,7 +58,7 @@ def test_randomize_block_order_rule():
 
 
 def test_randomize_block_order_rule_seed():
-    read = Read(datasource=None, read_tasks=[])
+    read = Read(datasource=ParquetDatasource(), read_tasks=[])
     operator1 = RandomizeBlocks(input_op=read, seed=None)
     operator2 = RandomizeBlocks(input_op=operator1, seed=2)
     operator3 = MapBatches(input_op=operator2, fn=lambda x: x)
@@ -84,7 +85,7 @@ def test_randomize_block_order_rule_seed():
 
 
 def test_randomize_block_order_after_repartition():
-    read = Read(datasource=None, read_tasks=[])
+    read = Read(datasource=ParquetDatasource(), read_tasks=[])
     operator1 = RandomizeBlocks(input_op=read)
     operator2 = Repartition(input_op=operator1, num_outputs=1, shuffle=False)
     operator3 = RandomizeBlocks(input_op=operator2)

--- a/python/ray/data/tests/test_size_estimation.py
+++ b/python/ray/data/tests/test_size_estimation.py
@@ -197,7 +197,7 @@ def test_split_read_parquet(ray_start_regular_shared, tmp_path):
 @pytest.mark.parametrize("use_actors", [False, True])
 def test_split_map(shutdown_only, use_actors):
     ray.shutdown()
-    ray.init(num_cpus=2)
+    ray.init(num_cpus=3)
     kwargs = {}
     if use_actors:
         kwargs = {"compute": ray.data.ActorPoolStrategy()}

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -27,8 +27,7 @@ def canonicalize(stats: str) -> str:
     s3 = re.sub("[0-9]+(\.[0-9]+)?", "N", s2)
     # Replace tabs with spaces.
     s4 = re.sub("\t", "    ", s3)
-    s5 = re.sub("Map\(.*?\)", "Map", s4)
-    return s5
+    return s4
 
 
 def dummy_map_batches(x):

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -97,7 +97,7 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
             if context.new_execution_backend:
                 assert (
                     canonicalize(logger_args[0])
-                    == """Stage N Map: N/N blocks executed in T
+                    == """Stage N Map(dummy_map_batches): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -111,7 +111,7 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
             else:
                 assert (
                     canonicalize(logger_args[0])
-                    == """Stage N Map: N/N blocks executed in T
+                    == """Stage N Map(dummy_map_batches): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -138,7 +138,7 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
 * Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
 'obj_store_mem_peak': N}
 
-Stage N Map: N/N blocks executed in T
+Stage N Map(dummy_map_batches): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -174,7 +174,7 @@ Dataset iterator time breakdown:
 * Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
 'obj_store_mem_peak': N}
 
-Stage N Map: N/N blocks executed in T
+Stage N Map(dummy_map_batches): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -210,7 +210,7 @@ Dataset iterator time breakdown:
 * Extra metrics: {'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, \
 'obj_store_mem_peak': N}
 
-Stage N Map: N/N blocks executed in T
+Stage N Map(dummy_map_batches): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -244,7 +244,7 @@ Dataset iterator time breakdown:
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N Map: N/N blocks executed in T
+Stage N Map(dummy_map_batches): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -498,7 +498,7 @@ def test_dataset_stats_read_parquet(ray_start_regular_shared, tmp_path):
     if context.new_execution_backend:
         assert (
             stats
-            == """Stage N ReadParquet->Map: N/N blocks executed in T
+            == """Stage N ReadParquet->Map(<lambda>): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -512,7 +512,7 @@ def test_dataset_stats_read_parquet(ray_start_regular_shared, tmp_path):
     else:
         assert (
             stats
-            == """Stage N Read->Map: N/N blocks executed in T
+            == """Stage N Read->Map(<lambda>): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -534,7 +534,7 @@ def test_dataset_split_stats(ray_start_regular_shared, tmp_path):
         if context.new_execution_backend:
             assert (
                 stats
-                == """Stage N ReadRange->Map: N/N blocks executed in T
+                == """Stage N ReadRange->Map(<lambda>): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -566,7 +566,7 @@ Stage N Map: N/N blocks executed in T
         else:
             assert (
                 stats
-                == """Stage N Read->Map: N/N blocks executed in T
+                == """Stage N Read->Map(<lambda>): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -582,7 +582,7 @@ Stage N Split: N/N blocks executed in T
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N Map: N/N blocks executed in T
+Stage N Map(<lambda>): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -1109,7 +1109,7 @@ def test_streaming_stats_full(ray_start_regular_shared, restore_data_context):
     stats = canonicalize(ds.stats())
     assert (
         stats
-        == """Stage N ReadRange->Map: N/N blocks executed in T
+        == """Stage N ReadRange->Map(<lambda>): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -311,8 +311,9 @@ def test_dataset__repr__(ray_start_regular_shared):
         return True
 
     # TODO(hchen): The reason why `wait_for_condition` is needed here is because
-    # `to_summary` depends on an external actor (_StatsActor) that records stats asynchronously.
-    # This makes the behavior non-deterministic. See the TODO in `to_summary`.
+    # `to_summary` depends on an external actor (_StatsActor) that records stats
+    # asynchronously. This makes the behavior non-deterministic.
+    # See the TODO in `to_summary`.
     # We should make it deterministic and refine this test.
     wait_for_condition(
         check_stats,

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -11,6 +11,7 @@ from ray.data.block import BlockMetadata
 from ray.data.context import DataContext
 from ray.data.tests.util import column_udf
 from ray.tests.conftest import *  # noqa
+from ray._private.test_utils import wait_for_condition
 
 from unittest.mock import patch
 
@@ -26,7 +27,8 @@ def canonicalize(stats: str) -> str:
     s3 = re.sub("[0-9]+(\.[0-9]+)?", "N", s2)
     # Replace tabs with spaces.
     s4 = re.sub("\t", "    ", s3)
-    return s4
+    s5 = re.sub("Map\(.*?\)", "Map", s4)
+    return s5
 
 
 def dummy_map_batches(x):
@@ -268,7 +270,7 @@ def test_dataset__repr__(ray_start_regular_shared):
     assert len(ds.take_all()) == n
     ds = ds.materialize()
 
-    assert canonicalize(repr(ds._plan.stats().to_summary())) == (
+    expected_stats = (
         "DatasetStatsSummary(\n"
         "   dataset_uuid=U,\n"
         "   base_name=None,\n"
@@ -303,9 +305,24 @@ def test_dataset__repr__(ray_start_regular_shared):
         ")"
     )
 
+    def check_stats():
+        stats = canonicalize(repr(ds._plan.stats().to_summary()))
+        assert stats == expected_stats
+        return True
+
+    # TODO(hchen): The reason why `wait_for_condition` is needed here is because
+    # `to_summary` depends on an external actor (_StatsActor) that records stats asynchronously.
+    # This makes the behavior non-deterministic. See the TODO in `to_summary`.
+    # We should make it deterministic and refine this test.
+    wait_for_condition(
+        check_stats,
+        timeout=10,
+        retry_interval_ms=1000,
+    )
+
     ds2 = ds.map_batches(lambda x: x).materialize()
     assert len(ds2.take_all()) == n
-    assert canonicalize(repr(ds2._plan.stats().to_summary())) == (
+    expected_stats2 = (
         "DatasetStatsSummary(\n"
         "   dataset_uuid=U,\n"
         "   base_name=MapBatches(<lambda>),\n"
@@ -375,6 +392,17 @@ def test_dataset__repr__(ray_start_regular_shared):
         "      ),\n"
         "   ],\n"
         ")"
+    )
+
+    def check_stats2():
+        stats = canonicalize(repr(ds2._plan.stats().to_summary()))
+        assert stats == expected_stats2
+        return True
+
+    wait_for_condition(
+        check_stats2,
+        timeout=10,
+        retry_interval_ms=1000,
     )
 
 

--- a/python/ray/data/tests/util.py
+++ b/python/ray/data/tests/util.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 
+import functools
 import os
 import tempfile
 import ray
@@ -36,6 +37,7 @@ def gen_bin_files(n):
 
 
 def column_udf(col, udf):
+    @functools.wraps(udf)
     def wraps(row):
         return {col: udf(row[col])}
 

--- a/python/ray/train/tests/test_batch_predictor.py
+++ b/python/ray/train/tests/test_batch_predictor.py
@@ -116,7 +116,9 @@ def test_separate_gpu_stage(shutdown_only):
         allow_gpu=True,
     ).materialize()
     stats = ds.stats()
-    assert "Stage 1 ReadRange->MapBatches(DummyPreprocessor._transform_pandas):" in stats, stats
+    assert (
+        "Stage 1 ReadRange->MapBatches(DummyPreprocessor._transform_pandas):" in stats
+    ), stats
     assert "Stage 2 MapBatches(ScoringWrapper):" in stats, stats
     assert ds.max("id") == 36.0, ds
 

--- a/python/ray/train/tests/test_batch_predictor.py
+++ b/python/ray/train/tests/test_batch_predictor.py
@@ -116,7 +116,7 @@ def test_separate_gpu_stage(shutdown_only):
         allow_gpu=True,
     ).materialize()
     stats = ds.stats()
-    assert "Stage 1 ReadRange->DummyPreprocessor:" in stats, stats
+    assert "Stage 1 ReadRange->MapBatches(DummyPreprocessor._transform_pandas):" in stats, stats
     assert "Stage 2 MapBatches(ScoringWrapper):" in stats, stats
     assert ds.max("id") == 36.0, ds
 
@@ -160,7 +160,9 @@ def test_batch_prediction():
     test_dataset = ray.data.range(4)
     ds = batch_predictor.predict(test_dataset).materialize()
     # Check fusion occurred.
-    assert "ReadRange->DummyPreprocessor" in ds.stats(), ds.stats()
+    assert (
+        "ReadRange->MapBatches(DummyPreprocessor._transform_pandas)" in ds.stats()
+    ), ds.stats()
     assert ds.to_pandas().to_numpy().squeeze().tolist() == [
         0.0,
         4.0,
@@ -284,7 +286,9 @@ def test_batch_prediction_various_combination():
 
         ds = batch_predictor.predict(input_dataset).materialize()
         # Check no fusion needed since we're not doing a dataset read.
-        assert f"Stage 1 {preprocessor.__class__.__name__}" in ds.stats(), ds.stats()
+        assert (
+            f"Stage 1 MapBatches({preprocessor.__class__.__name__}" in ds.stats()
+        ), ds.stats()
         assert ds.to_pandas().to_numpy().squeeze().tolist() == [
             4.0,
             8.0,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is the last PR for enabling optimizer by default. It contains the following changes:
- Fix DatasetStats related issues, including:
  - Map op names not including function names.
  - Read op names not including data source names.
  - RandomizeBlocks's name.
  - `generate_randomize_blocks_fn` returning empty stats, making it being skipped in summary.
- Dropping support for fusing 2 actor-based map ops. 
  - In the old backend, we fuse 2 actors only if they are the same class and have the same constructor args. This is not useful in practice. Test changes about `num_cpus` are related to this.
- Fix the issue that  `ReorderRandomizeBlocksRule`  will modify the operator's input_dependencies in place. This is a bug because the operator instance might be shared by multiple Datasets.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #32596

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
