### PR TITLE
[serve] Cancel `wait_for_message` to avoid innocuous warning message

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -247,10 +247,12 @@ def create_replica_wrapper(name: str):
                 self.replica.handle_request(query, asgi_sender=asgi_queue_sender)
             )
 
-            done = []
-            while handle_request_task not in done:
+            while True:
+                wait_for_message_task = self._event_loop.create_task(
+                    asgi_queue_sender.wait_for_message()
+                )
                 done, _ = await asyncio.wait(
-                    [handle_request_task, asgi_queue_sender.wait_for_message()],
+                    [handle_request_task, wait_for_message_task],
                     return_when=asyncio.FIRST_COMPLETED,
                 )
                 # Consume and yield all available messages in the queue.
@@ -258,6 +260,15 @@ def create_replica_wrapper(name: str):
                 # we use vanilla pickle because it's faster than cloudpickle and we
                 # know it's safe for these messages containing primitive types.
                 yield pickle.dumps(asgi_queue_sender.get_messages_nowait())
+
+                # Exit once `handle_request` has finished. In this case, all messages
+                # must have already been sent.
+                # Cancel the `wait_for_message_task` to avoid innocuous error messages.
+                if handle_request_task in done:
+                    if not wait_for_message_task.done():
+                        wait_for_message_task.cancel()
+
+                    break
 
             e = handle_request_task.exception()
             if e is not None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Without this change, we sometimes see an innocuous warning message:
```
(ServeReplica:default_MyGradioServer pid=92808) Task was destroyed but it is pending!
(ServeReplica:default_MyGradioServer pid=92808) task: <Task pending name='Task-219' coro=<ASGIHTTPQueueSender.wait_for_message() done, defined at /Users/eoakes/code/ray/python/ray/serve/_private/http_util.py:193> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x11ed5a4c0>()]>>
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
