### PR TITLE
[Doc][Train] Fix `RLTrainer` examples

### DIFF
--- a/doc/source/ray-air/examples/rl_offline_example.ipynb
+++ b/doc/source/ray-air/examples/rl_offline_example.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !pip install -qU \"ray[rllib]\" gymnasium"
+    "# !pip install -qU \"ray[rllib]\" gymnasium\n"
    ]
   },
   {
@@ -280,7 +280,7 @@
     "from ray.air.config import ScalingConfig\n",
     "from ray.air.result import Result\n",
     "from ray.rllib.algorithms.bc import BC\n",
-    "from ray.tune.tuner import Tuner"
+    "from ray.tune.tuner import Tuner\n"
    ]
   },
   {
@@ -315,10 +315,10 @@
     "                \"max_num_samples_per_file\": 1,\n",
     "            },\n",
     "            \"batch_mode\": \"complete_episodes\",\n",
-    "            \"framework\": \"torch\"\n",
+    "            \"framework\": \"torch\",\n",
     "        },\n",
     "    )\n",
-    "    trainer.fit()"
+    "    trainer.fit()\n"
    ]
   },
   {
@@ -344,7 +344,10 @@
     "    )\n",
     "\n",
     "    trainer = RLTrainer(\n",
-    "        run_config=RunConfig(stop={\"training_iteration\": 5}),\n",
+    "        run_config=RunConfig(\n",
+    "            stop={\"training_iteration\": 5},\n",
+    "            checkpoint_config=CheckpointConfig(checkpoint_at_end=True),\n",
+    "        ),\n",
     "        scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=use_gpu),\n",
     "        datasets={\"train\": dataset},\n",
     "        algorithm=BC,\n",
@@ -354,20 +357,12 @@
     "            \"evaluation_num_workers\": 1,\n",
     "            \"evaluation_interval\": 1,\n",
     "            \"evaluation_config\": {\"input\": \"sampler\"},\n",
-    "            \"framework\": \"torch\"\n",
+    "            \"framework\": \"torch\",\n",
     "        },\n",
     "    )\n",
     "\n",
-    "    # Todo (krfricke/xwjiang): Enable checkpoint config in RunConfig\n",
-    "    # result = trainer.fit()\n",
-    "    tuner = Tuner(\n",
-    "        trainer,\n",
-    "        run_config=RunConfig(\n",
-    "            checkpoint_config=CheckpointConfig(checkpoint_at_end=True)\n",
-    "        ),\n",
-    "    )\n",
-    "    result = tuner.fit()[0]\n",
-    "    return result"
+    "    result = trainer.fit()\n",
+    "    return result\n"
    ]
   },
   {
@@ -402,7 +397,7 @@
     "            reward += r\n",
     "        rewards.append(reward)\n",
     "\n",
-    "    return rewards"
+    "    return rewards\n"
    ]
   },
   {
@@ -943,7 +938,7 @@
     "# ray.init(num_cpus=8)\n",
     "\n",
     "path = \"/tmp/out\"\n",
-    "generate_offline_data(path)"
+    "generate_offline_data(path)\n"
    ]
   },
   {
@@ -1401,7 +1396,7 @@
     }
    ],
    "source": [
-    "result = train_rl_bc_offline(path=path, num_workers=2, use_gpu=False)"
+    "result = train_rl_bc_offline(path=path, num_workers=2, use_gpu=False)\n"
    ]
   },
   {
@@ -1440,7 +1435,7 @@
     "num_eval_episodes = 3\n",
     "\n",
     "rewards = evaluate_using_checkpoint(result.checkpoint, num_episodes=num_eval_episodes)\n",
-    "print(f\"Average reward over {num_eval_episodes} episodes: \" f\"{np.mean(rewards)}\")"
+    "print(f\"Average reward over {num_eval_episodes} episodes: \" f\"{np.mean(rewards)}\")\n"
    ]
   },
   {

--- a/doc/source/ray-air/examples/rl_online_example.ipynb
+++ b/doc/source/ray-air/examples/rl_online_example.ipynb
@@ -69,7 +69,7 @@
     "from ray.air.config import ScalingConfig\n",
     "from ray.air.result import Result\n",
     "from ray.rllib.algorithms.bc import BC\n",
-    "from ray.tune.tuner import Tuner"
+    "from ray.tune.tuner import Tuner\n"
    ]
   },
   {
@@ -91,7 +91,10 @@
     "def train_rl_ppo_online(num_workers: int, use_gpu: bool = False) -> Result:\n",
     "    print(\"Starting online training\")\n",
     "    trainer = RLTrainer(\n",
-    "        run_config=RunConfig(stop={\"training_iteration\": 5}),\n",
+    "        run_config=RunConfig(\n",
+    "            stop={\"training_iteration\": 5},\n",
+    "            checkpoint_config=CheckpointConfig(checkpoint_at_end=True),\n",
+    "        ),\n",
     "        scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=use_gpu),\n",
     "        algorithm=\"PPO\",\n",
     "        config={\n",
@@ -99,16 +102,8 @@
     "            \"framework\": \"tf\",\n",
     "        },\n",
     "    )\n",
-    "    # Todo (krfricke/xwjiang): Enable checkpoint config in RunConfig\n",
-    "    # result = trainer.fit()\n",
-    "    tuner = Tuner(\n",
-    "        trainer,\n",
-    "        run_config=RunConfig(\n",
-    "            checkpoint_config=CheckpointConfig(checkpoint_at_end=True)\n",
-    "        ),\n",
-    "    )\n",
-    "    result = tuner.fit()[0]\n",
-    "    return result"
+    "    result = trainer.fit()\n",
+    "    return result\n"
    ]
   },
   {
@@ -143,7 +138,7 @@
     "            reward += r\n",
     "        rewards.append(reward)\n",
     "\n",
-    "    return rewards"
+    "    return rewards\n"
    ]
   },
   {
@@ -1298,7 +1293,7 @@
     }
    ],
    "source": [
-    "result = train_rl_ppo_online(num_workers=2, use_gpu=False)"
+    "result = train_rl_ppo_online(num_workers=2, use_gpu=False)\n"
    ]
   },
   {
@@ -1343,7 +1338,7 @@
     "num_eval_episodes = 3\n",
     "\n",
     "rewards = evaluate_using_checkpoint(result.checkpoint, num_episodes=num_eval_episodes)\n",
-    "print(f\"Average reward over {num_eval_episodes} episodes: \" f\"{np.mean(rewards)}\")"
+    "print(f\"Average reward over {num_eval_episodes} episodes: \" f\"{np.mean(rewards)}\")\n"
    ]
   }
  ],

--- a/doc/source/ray-air/examples/rl_serving_example.ipynb
+++ b/doc/source/ray-air/examples/rl_serving_example.ipynb
@@ -61,7 +61,7 @@
     "from ray.air.result import Result\n",
     "from ray.serve import PredictorDeployment\n",
     "from ray import serve\n",
-    "from ray.tune.tuner import Tuner"
+    "from ray.tune.tuner import Tuner\n"
    ]
   },
   {
@@ -83,7 +83,10 @@
     "def train_rl_ppo_online(num_workers: int, use_gpu: bool = False) -> Result:\n",
     "    print(\"Starting online training\")\n",
     "    trainer = RLTrainer(\n",
-    "        run_config=RunConfig(stop={\"training_iteration\": 5}),\n",
+    "        run_config=RunConfig(\n",
+    "            stop={\"training_iteration\": 5},\n",
+    "            checkpoint_config=CheckpointConfig(checkpoint_at_end=True),\n",
+    "        ),\n",
     "        scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=use_gpu),\n",
     "        algorithm=\"PPO\",\n",
     "        config={\n",
@@ -91,16 +94,8 @@
     "            \"framework\": \"tf\",\n",
     "        },\n",
     "    )\n",
-    "    # Todo (krfricke/xwjiang): Enable checkpoint config in RunConfig\n",
-    "    # result = trainer.fit()\n",
-    "    tuner = Tuner(\n",
-    "        trainer,\n",
-    "        run_config=RunConfig(\n",
-    "            checkpoint_config=CheckpointConfig(checkpoint_at_end=True)\n",
-    "        ),\n",
-    "    )\n",
-    "    result = tuner.fit()[0]\n",
-    "    return result"
+    "    result = trainer.fit()\n",
+    "    return result\n"
    ]
   },
   {
@@ -125,12 +120,8 @@
     "    This function will start Ray Serve and deploy a model wrapper\n",
     "    that loads the RL checkpoint into a RLPredictor.\n",
     "    \"\"\"\n",
-    "    serve.run(\n",
-    "        PredictorDeployment.options(name=name).bind(\n",
-    "            RLPredictor, checkpoint\n",
-    "        )\n",
-    "    )\n",
-    "    return f\"http://localhost:8000/\""
+    "    serve.run(PredictorDeployment.options(name=name).bind(RLPredictor, checkpoint))\n",
+    "    return f\"http://localhost:8000/\"\n"
    ]
   },
   {
@@ -178,7 +169,7 @@
     "    RL policy model and return the result.\n",
     "    \"\"\"\n",
     "    action_dict = requests.post(endpoint_uri, json={\"array\": obs.tolist()}).json()\n",
-    "    return action_dict"
+    "    return action_dict\n"
    ]
   },
   {
@@ -1361,7 +1352,7 @@
     "num_workers = 2\n",
     "use_gpu = False\n",
     "\n",
-    "result = train_rl_ppo_online(num_workers=num_workers, use_gpu=use_gpu)"
+    "result = train_rl_ppo_online(num_workers=num_workers, use_gpu=use_gpu)\n"
    ]
   },
   {
@@ -1401,7 +1392,7 @@
     }
    ],
    "source": [
-    "endpoint_uri = serve_rl_model(result.checkpoint)"
+    "endpoint_uri = serve_rl_model(result.checkpoint)\n"
    ]
   },
   {
@@ -3797,7 +3788,7 @@
     }
    ],
    "source": [
-    "rewards = evaluate_served_policy(endpoint_uri=endpoint_uri)"
+    "rewards = evaluate_served_policy(endpoint_uri=endpoint_uri)\n"
    ]
   },
   {
@@ -3815,7 +3806,7 @@
     }
    ],
    "source": [
-    "print(\"Episode rewards:\", rewards)"
+    "print(\"Episode rewards:\", rewards)\n"
    ]
   },
   {
@@ -3872,7 +3863,7 @@
     }
    ],
    "source": [
-    "serve.shutdown()"
+    "serve.shutdown()\n"
    ]
   }
  ],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
https://github.com/ray-project/ray/pull/35321 changed these examples to use the `checkpoint_at_end` rather than passing it through `_tuner_kwargs`. However, it did this using a different `RunConfig` that took precedence over the Trainer's 
 `RunConfig` that had a `stop` criteria, causing the experiments to run forever and timeout.

The extra edits on this PR are due to my IDE formatting the notebooks.

<img width="460" alt="Screen Shot 2023-05-31 at 5 13 55 PM" src="https://github.com/ray-project/ray/assets/3887863/1d6b1b91-6658-4071-8454-b766819e1360">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
