### PR TITLE
[serve] Don't allow empty app names

### DIFF
--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -310,6 +310,7 @@ class ServeApplicationSchema(BaseModel, extra=Extra.forbid):
         description=(
             "Application name, the name should be unique within the serve instance"
         ),
+        min_length=1,
     )
     route_prefix: Optional[str] = Field(
         default="/",
@@ -567,13 +568,6 @@ class ServeDeploySchema(BaseModel, extra=Extra.forbid):
                 f"Found duplicate applications for {routes_str}. Please ensure each "
                 "application's route_prefix is unique."
             )
-        return v
-
-    @validator("applications")
-    def application_names_nonempty(cls, v):
-        for app in v:
-            if len(app.name) == 0:
-                raise ValueError("Application names must be nonempty.")
         return v
 
     @root_validator

--- a/python/ray/serve/tests/test_schema.py
+++ b/python/ray/serve/tests/test_schema.py
@@ -539,6 +539,14 @@ class TestServeApplicationSchema:
         with pytest.raises(ValidationError):
             ServeApplicationSchema.parse_obj({"host": "127.0.0.1", "port": 8000})
 
+    def test_serve_application_empty_name(self):
+        """Application name cannot be empty."""
+
+        serve_application_schema = self.get_valid_serve_application_schema()
+        serve_application_schema["name"] = ""
+        with pytest.raises(ValidationError):
+            ServeApplicationSchema.parse_obj(serve_application_schema)
+
 
 class TestServeDeploySchema:
     def test_deploy_config_duplicate_apps(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Now that the default app name is `"default"`, we should have a universal requirement that app names should be nonempty.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
