### PR TITLE
[Core] Add get_worker_id() to runtime context

### DIFF
--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -17,7 +17,6 @@ from ray._private.ray_constants import (
     RAY_DEDUP_LOGS_ALLOW_REGEX,
     RAY_DEDUP_LOGS_SKIP_REGEX,
 )
-from ray._private.utils import binary_to_hex
 from ray.util.debug import log_once
 
 
@@ -212,10 +211,7 @@ def get_worker_log_file_name(worker_type, job_id=None):
     # Make sure these values are set already.
     assert ray._private.worker._global_node is not None
     assert ray._private.worker.global_worker is not None
-    filename = (
-        f"{worker_name}-"
-        f"{binary_to_hex(ray._private.worker.global_worker.worker_id)}-"
-    )
+    filename = f"{worker_name}-{ray.get_runtime_context().get_worker_id()}-"
     if job_id:
         filename += f"{job_id}-"
     filename += f"{os.getpid()}"

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -108,6 +108,17 @@ class RuntimeContext(object):
         node_id = self.worker.current_node_id
         return node_id.hex()
 
+    def get_worker_id(self) -> str:
+        """Get current worker ID for this worker or driver process.
+
+        Returns:
+            A worker id in hex format for this worker or driver process.
+        """
+        assert ray.is_initialized(), (
+            "Worker ID is not available because " "Ray has not been initialized."
+        )
+        return self.worker.worker_id.hex()
+
     @property
     @Deprecated(message="Use get_task_id() instead", warning=True)
     def task_id(self):

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -115,7 +115,7 @@ class RuntimeContext(object):
             A worker id in hex format for this worker or driver process.
         """
         assert ray.is_initialized(), (
-            "Worker ID is not available because " "Ray has not been initialized."
+            "Worker ID is not available because Ray has not been initialized."
         )
         return self.worker.worker_id.hex()
 

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -114,9 +114,9 @@ class RuntimeContext(object):
         Returns:
             A worker id in hex format for this worker or driver process.
         """
-        assert ray.is_initialized(), (
-            "Worker ID is not available because Ray has not been initialized."
-        )
+        assert (
+            ray.is_initialized()
+        ), "Worker ID is not available because Ray has not been initialized."
         return self.worker.worker_id.hex()
 
     @property

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -605,7 +605,7 @@ class HTTPProxyActor:
             # of cross-language scenarios. Java can't deserialize a Python tuple.
             return json.dumps(
                 [
-                    ray._private.worker.global_worker.worker_id.hex(),
+                    ray.get_runtime_context().get_worker_id(),
                     get_component_logger_file_path(),
                 ]
             )

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -297,7 +297,7 @@ def create_replica_wrapper(name: str):
             return (
                 os.getpid(),
                 ray.get_runtime_context().get_actor_id(),
-                ray._private.worker.global_worker.worker_id.hex(),
+                ray.get_runtime_context().get_worker_id(),
                 ray.get_runtime_context().get_node_id(),
                 ray.util.get_node_ip_address(),
                 get_component_logger_file_path(),

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -172,7 +172,7 @@ class ServeController:
             node_ip=ray.util.get_node_ip_address(),
             actor_id=ray.get_runtime_context().get_actor_id(),
             actor_name=self.controller_name,
-            worker_id=ray._private.worker.global_worker.worker_id.hex(),
+            worker_id=ray.get_runtime_context().get_worker_id(),
             log_file_path=get_component_logger_file_path(),
         )
 

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -36,14 +36,14 @@ def test_remote_functions_not_scheduled_on_actors(ray_start_regular):
             pass
 
         def get_id(self):
-            return ray._private.worker.global_worker.worker_id
+            return ray.get_runtime_context().get_worker_id()
 
     a = Actor.remote()
     actor_id = ray.get(a.get_id.remote())
 
     @ray.remote
     def f():
-        return ray._private.worker.global_worker.worker_id
+        return ray.get_runtime_context().get_worker_id()
 
     resulting_ids = ray.get([f.remote() for _ in range(100)])
     assert actor_id not in resulting_ids


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add get_worker_id() to runtime context
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
