### PR TITLE
[Bug Fix] Fix incorrect worker launch time

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2131,6 +2131,10 @@ def connect(
             finshes launching. If the worker is not launched by raylet (e.g.,
             driver), this must be -1 (default value).
     """
+    # set launcher launch time
+    if mode == SCRIPT_MODE:
+        worker_launch_time_ms = int(time.time() * 1000)
+
     # Do some basic checking to make sure we didn't call ray.init twice.
     error_message = "Perhaps you called ray.init twice by accident?"
     assert not worker.connected, error_message
@@ -2299,7 +2303,7 @@ def connect(
         session_name,
         "" if mode != SCRIPT_MODE else entrypoint,
         worker_launch_time_ms,
-        worker_launched_time_ms,
+        worker_launched_time_ms if mode != SCRIPT_MODE else int(time.time() * 1000),
     )
 
     # Notify raylet that the core worker is ready.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Timestamp was not set for when triggering the launcher, resulting in default timestamp being set as 18446744073709551615 (2^64)

## Related issue number
https://github.com/ray-project/ray/issues/35130

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests

## Testing Done
I started a driver script locally and verified `worker_launch_time_ms` and `worker_launched_time_ms` are updated to the right timestamps. 

```
$ ray list workers --detail 
---
-   worker_id: 01000000ffffffffffffffffffffffffffffffffffffffffffffffff
    is_alive: false
    worker_type: DRIVER
    exit_type: INTENDED_USER_EXIT
    node_id: afbbab66b9f89a09ed83846b495a02a065a2547c2127282819e2f7a3
    ip: 127.0.0.1
    pid: 46042
    exit_detail: Shutdown by ray.shutdown().
    worker_launch_time_ms: '2023-05-31 22:49:54.282000'
    worker_launched_time_ms: '2023-05-31 22:49:54.285000'
    start_time_ms: '2023-05-31 22:49:54.879000'
    end_time_ms: '2023-05-31 22:50:00.498000'
```
