### PR TITLE
redo connection error message

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1346,11 +1346,13 @@ def check_dashboard_dependencies_installed() -> bool:
         return False
 
 
-connect_error = ("Unable to connect to GCS (ray head) at {}. "
-                    "Check that (1) Ray with matching version started "
-                    "successfully at the specified address, (2) this "
-                    "node can reach the specified address, and (3) there is "
-                    "no firewall setting preventing access.")
+connect_error = (
+    "Unable to connect to GCS (ray head) at {}. "
+    "Check that (1) Ray with matching version started "
+    "successfully at the specified address, (2) this "
+    "node can reach the specified address, and (3) there is "
+    "no firewall setting preventing access."
+)
 
 
 def internal_kv_list_with_retry(gcs_client, prefix, namespace, num_retries=20):
@@ -1367,9 +1369,7 @@ def internal_kv_list_with_retry(gcs_client, prefix, namespace, num_retries=20):
                 ray._raylet.GRPC_STATUS_CODE_UNAVAILABLE,
                 ray._raylet.GRPC_STATUS_CODE_UNKNOWN,
             ):
-                logger.warning(
-                   connect_error.format(gcs_client.address) 
-                )
+                logger.warning(connect_error.format(gcs_client.address))
             else:
                 logger.exception("Internal KV List failed")
             result = None
@@ -1398,9 +1398,7 @@ def internal_kv_get_with_retry(gcs_client, key, namespace, num_retries=20):
                 ray._raylet.GRPC_STATUS_CODE_UNAVAILABLE,
                 ray._raylet.GRPC_STATUS_CODE_UNKNOWN,
             ):
-                logger.warning(
-                   connect_error.format(gcs_client.address) 
-                )
+                logger.warning(connect_error.format(gcs_client.address))
             else:
                 logger.exception("Internal KV Get failed")
             result = None
@@ -1453,9 +1451,7 @@ def internal_kv_put_with_retry(gcs_client, key, value, namespace, num_retries=20
                 ray._raylet.GRPC_STATUS_CODE_UNAVAILABLE,
                 ray._raylet.GRPC_STATUS_CODE_UNKNOWN,
             ):
-                logger.warning(
-                   connect_error.format(gcs_client.address) 
-                )
+                logger.warning(connect_error.format(gcs_client.address))
             else:
                 logger.exception("Internal KV Put failed")
             time.sleep(2)

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1346,6 +1346,13 @@ def check_dashboard_dependencies_installed() -> bool:
         return False
 
 
+connect_error = ("Unable to connect to GCS (ray head) at {}. "
+                    "Check that (1) Ray with matching version started "
+                    "successfully at the specified address, (2) this "
+                    "node can reach the specified address, and (3) there is "
+                    "no firewall setting preventing access.")
+
+
 def internal_kv_list_with_retry(gcs_client, prefix, namespace, num_retries=20):
     result = None
     if isinstance(prefix, str):
@@ -1361,10 +1368,7 @@ def internal_kv_list_with_retry(gcs_client, prefix, namespace, num_retries=20):
                 ray._raylet.GRPC_STATUS_CODE_UNKNOWN,
             ):
                 logger.warning(
-                    f"Unable to connect to GCS at {gcs_client.address}. "
-                    "Check that (1) Ray GCS with matching version started "
-                    "successfully at the specified address, and (2) there is "
-                    "no firewall setting preventing access."
+                   connect_error.format(gcs_client.address) 
                 )
             else:
                 logger.exception("Internal KV List failed")
@@ -1395,10 +1399,7 @@ def internal_kv_get_with_retry(gcs_client, key, namespace, num_retries=20):
                 ray._raylet.GRPC_STATUS_CODE_UNKNOWN,
             ):
                 logger.warning(
-                    f"Unable to connect to GCS at {gcs_client.address}. "
-                    "Check that (1) Ray GCS with matching version started "
-                    "successfully at the specified address, and (2) there is "
-                    "no firewall setting preventing access."
+                   connect_error.format(gcs_client.address) 
                 )
             else:
                 logger.exception("Internal KV Get failed")
@@ -1453,10 +1454,7 @@ def internal_kv_put_with_retry(gcs_client, key, value, namespace, num_retries=20
                 ray._raylet.GRPC_STATUS_CODE_UNKNOWN,
             ):
                 logger.warning(
-                    f"Unable to connect to GCS at {gcs_client.address}. "
-                    "Check that (1) Ray GCS with matching version started "
-                    "successfully at the specified address, and (2) there is "
-                    "no firewall setting preventing access."
+                   connect_error.format(gcs_client.address) 
                 )
             else:
                 logger.exception("Internal KV Put failed")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Issue #34094 covers the network connection problems with ray startup. One of [the conclusions](https://github.com/ray-project/ray/issues/34094#issuecomment-1551786648) was to improve the error message reported when the worker cannot connect via `ray start --address 10.0.20:1234`. It now prints (20 times)
```
[2023-06-01 10:42:56]  ERROR ray._raylet::Failed to connect to GCS. Please check
`gcs_server.out` for more details.
[2023-06-01 10:42:56]  WARNING ray._private.utils::1402 Unable to connect to GCS (ray head) at 
10.0.0.20:1234. Check that (1) Ray with matching version started successfully at the specified 
address, (2) this node can reach that address, and (3) there is no firewall setting preventing
access.
```

I am not sure 20 times is needed. That is controlled by `ray_constants.NUM_REDIS_GET_RETRIES` [here](https://github.com/ray-project/ray/blob/4fbd3f472d584788d3ea13273b4b6001462addcd/python/ray/_private/node.py#L190), which is called from [the script](https://github.com/ray-project/ray/blob/4fbd3f472d584788d3ea13273b4b6001462addcd/python/ray/scripts/scripts.py#L896)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#34094
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
