### PR TITLE
[Test][Core] Handled the case where memories is empty for dashboard test

### DIFF
--- a/release/benchmarks/distributed/dashboard_test.py
+++ b/release/benchmarks/distributed/dashboard_test.py
@@ -122,9 +122,7 @@ class DashboardTestAtScale:
                         memories.append(sample.value)
 
         return Result(
-            success=True,
-            result=result,
-            memory_mb=max(memories),
+            success=True, result=result, memory_mb=max(memories) if memories else None
         )
 
     def update_release_test_result(self, release_result: dict):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Sometimes, the test is really short. For example, many_pgs_smoke test usually takes only 2 seconds, and it is not long enough to record dashboard metrics. In this case, the `memories` field could be empty, which fails the test.

This fixes the issue by setting it to None when nothing is reported. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/35943

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
