### PR TITLE
[RLlib] Cleanup `AlgorithmConfig.get_marl_module_spec()`.

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -719,8 +719,6 @@ class Algorithm(Trainable):
             self.learner_group = learner_group_config.build()
 
             # check if there are modules to load from the module_spec
-            marl_module_ckpt_dir = None
-            modules_to_load = None
             rl_module_ckpt_dirs = {}
             marl_module_ckpt_dir = module_spec.load_state_path
             modules_to_load = module_spec.modules_to_load

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -3085,7 +3085,8 @@ class AlgorithmConfig(_Config):
         the input framework.
 
         Returns:
-            The RLModule spec to use for this algorithm.
+            The ModuleSpec (SingleAgentRLModuleSpec or MultiAgentRLModuleSpec) to use
+            for this algorithm's RLModule.
         """
         raise NotImplementedError
 
@@ -3105,7 +3106,7 @@ class AlgorithmConfig(_Config):
         self,
         *,
         policy_dict: Dict[str, PolicySpec],
-        module_spec: Optional[SingleAgentRLModuleSpec] = None,
+        single_agent_rl_module_spec: Optional[SingleAgentRLModuleSpec] = None,
     ) -> MultiAgentRLModuleSpec:
         """Returns the MultiAgentRLModule spec based on the given policy spec dict.
 
@@ -3119,62 +3120,81 @@ class AlgorithmConfig(_Config):
                 they will get auto-filled with these values obtrained from the policy
                 spec dict. Here we are relying on the policy's logic for infering these
                 values from other sources of information (e.g. environement)
-            module_spec: The single-agent RLModule spec to use for constructing the
-                multi-agent RLModule spec. If None, the default RLModule spec for this
-                algorithm will be used.
+            single_agent_rl_module_spec: The SingleAgentRLModuleSpec to use for
+                constructing a MultiAgentRLModuleSpec. If None, the already
+                configured spec (`self.rl_module_spec`) or the default ModuleSpec for
+                this algorithm (`self.get_default_rl_module_spec()`) will be used.
         """
         # TODO (Kourosh): When we replace policy entirely there will be no need for
-        # this function to map policy_dict to marl_module_specs anymore. The module
-        # spec will be directly given by the user or inferred from env and spaces.
+        #  this function to map policy_dict to marl_module_specs anymore. The module
+        #  spec will be directly given by the user or inferred from env and spaces.
 
         # TODO (Kourosh): Raise an error if the config is not frozen (validated)
         # If the module is single-agent convert it to multi-agent spec
 
-        if isinstance(self.rl_module_spec, SingleAgentRLModuleSpec):
-            # if module_spec is provided, use it otherwise use the self.rl_module_spec
-            single_agent_spec = module_spec or self.rl_module_spec
+        # The default ModuleSpec (might be multi-agent or single-agent).
+        default_rl_module_spec = self.get_default_rl_module_spec()
+        # The currently configured ModuleSpec (might be multi-agent or single-agent).
+        # If None, use the default one.
+        current_rl_module_spec = self.rl_module_spec or default_rl_module_spec
+
+        # Algorithm is currently setup as a single-agent one.
+        if isinstance(current_rl_module_spec, SingleAgentRLModuleSpec):
+            # Use either the provided `single_agent_rl_module_spec` (a
+            # SingleAgentRLModuleSpec), the currently setup one, or the default.
+            single_agent_rl_module_spec = (
+                single_agent_rl_module_spec or current_rl_module_spec
+            )
+            # Now construct the proper MultiAgentRLModuleSpec.
             marl_module_spec = MultiAgentRLModuleSpec(
                 module_specs={
-                    k: copy.deepcopy(single_agent_spec) for k in policy_dict.keys()
+                    k: copy.deepcopy(single_agent_rl_module_spec)
+                    for k in policy_dict.keys()
                 },
             )
+        # Algorithm is currently setup as a multi-agent one.
         else:
-            cur_marl_module_spec = self.rl_module_spec
-            default_rl_module = self.get_default_rl_module_spec()
+            assert isinstance(current_rl_module_spec, MultiAgentRLModuleSpec)
 
-            if isinstance(default_rl_module, SingleAgentRLModuleSpec):
+            if isinstance(default_rl_module_spec, SingleAgentRLModuleSpec):
                 # Default is single-agent but the user has provided a multi-agent spec
                 # so the use-case is multi-agent. We need to inherit the multi-agent
-                # class from self.rl_module_spec and fill in the module_specs dict.
+                # class from `current_rl_module_spec` and fill in the module_specs dict.
                 # If the user provided a multi-agent spec, we use that for the values,
                 # otherwise we see if they have provided a multi-agent spec that
                 # specifies the SingleAgentRLModuleSpec to use instead of the default,
                 # in that case, we use that spec for the values. otherwise we use
                 # the default spec for the values.
                 if isinstance(
-                    cur_marl_module_spec.module_specs, SingleAgentRLModuleSpec
+                    current_rl_module_spec.module_specs, SingleAgentRLModuleSpec
                 ):
                     # The individual module specs are defined by the user
-                    single_agent_spec = module_spec or cur_marl_module_spec.module_specs
+                    single_agent_spec = single_agent_rl_module_spec or (
+                        current_rl_module_spec.module_specs
+                    )
                     module_specs = {
                         k: copy.deepcopy(single_agent_spec) for k in policy_dict.keys()
                     }
                 else:
                     # The individual module specs are not defined by the user,
                     # so we use the default
-                    single_agent_spec = module_spec or default_rl_module
+                    single_agent_spec = (
+                        single_agent_rl_module_spec or default_rl_module_spec
+                    )
                     module_specs = {
                         k: copy.deepcopy(
-                            cur_marl_module_spec.module_specs.get(k, single_agent_spec)
+                            current_rl_module_spec.module_specs.get(
+                                k, single_agent_spec
+                            )
                         )
                         for k in policy_dict.keys()
                     }
 
-                marl_module_spec = cur_marl_module_spec.__class__(
-                    marl_module_class=cur_marl_module_spec.marl_module_class,
+                marl_module_spec = current_rl_module_spec.__class__(
+                    marl_module_class=current_rl_module_spec.marl_module_class,
                     module_specs=module_specs,
-                    modules_to_load=cur_marl_module_spec.modules_to_load,
-                    load_state_path=cur_marl_module_spec.load_state_path,
+                    modules_to_load=current_rl_module_spec.modules_to_load,
+                    load_state_path=current_rl_module_spec.load_state_path,
                 )
             else:
                 # Default is multi-agent and user wants to override it. In this case,
@@ -3182,28 +3202,33 @@ class AlgorithmConfig(_Config):
                 # which case we use that for the values, 2) self.rl_module_spec is a
                 # spec that defines SingleAgentRLModuleSpecs to be used for everything.
                 # In this case, we need to use that spec for the values.
-                if module_spec is None:
+                if single_agent_rl_module_spec is None:
                     if isinstance(
-                        cur_marl_module_spec.module_specs, SingleAgentRLModuleSpec
+                        current_rl_module_spec.module_specs, SingleAgentRLModuleSpec
                     ):
                         # The individual module specs are not given, it is given as one
                         # SingleAgentRLModuleSpec to be re-used for all
-                        single_agent_spec = cur_marl_module_spec.module_specs
+                        single_agent_rl_module_spec = (
+                            current_rl_module_spec.module_specs
+                        )
                     else:
                         raise ValueError(
-                            "MultiAgentRLModuleSpec is given but no module_spec is "
-                            "provided when adding a policy."
+                            "We have a MultiAgentRLModuleSpec "
+                            f"({current_rl_module_spec}), but no "
+                            "`SingleAgentRLModuleSpec`s to compile the individual "
+                            "RLModules' specs! Use "
+                            "`AlgorithmConfig.get_marl_module_spec("
+                            "policy_dict=.., single_agent_rl_module_spec=..)`."
                         )
-                else:
-                    single_agent_spec = module_spec
 
-                marl_module_spec = cur_marl_module_spec.__class__(
-                    marl_module_class=cur_marl_module_spec.marl_module_class,
+                marl_module_spec = current_rl_module_spec.__class__(
+                    marl_module_class=current_rl_module_spec.marl_module_class,
                     module_specs={
-                        k: copy.deepcopy(single_agent_spec) for k in policy_dict.keys()
+                        k: copy.deepcopy(single_agent_rl_module_spec)
+                        for k in policy_dict.keys()
                     },
-                    modules_to_load=cur_marl_module_spec.modules_to_load,
-                    load_state_path=cur_marl_module_spec.load_state_path,
+                    modules_to_load=current_rl_module_spec.modules_to_load,
+                    load_state_path=current_rl_module_spec.load_state_path,
                 )
 
         # Make sure that policy_dict and marl_module_spec have similar keys
@@ -3216,15 +3241,17 @@ class AlgorithmConfig(_Config):
 
         # Fill in the missing values from the specs that we already have. By combining
         # PolicySpecs and the default RLModuleSpec.
-        default_spec = self.get_default_rl_module_spec()
+
         for module_id in policy_dict:
             policy_spec = policy_dict[module_id]
             module_spec = marl_module_spec.module_specs[module_id]
             if module_spec.module_class is None:
-                if isinstance(default_spec, SingleAgentRLModuleSpec):
-                    module_spec.module_class = default_spec.module_class
-                elif isinstance(default_spec.module_specs, SingleAgentRLModuleSpec):
-                    module_class = default_spec.module_specs.module_class
+                if isinstance(default_rl_module_spec, SingleAgentRLModuleSpec):
+                    module_spec.module_class = default_rl_module_spec.module_class
+                elif isinstance(
+                    default_rl_module_spec.module_specs, SingleAgentRLModuleSpec
+                ):
+                    module_class = default_rl_module_spec.module_specs.module_class
                     # This should be already checked in validate() but we check it
                     # again here just in case
                     if module_class is None:
@@ -3233,8 +3260,8 @@ class AlgorithmConfig(_Config):
                             "module_class under its SingleAgentRLModuleSpec."
                         )
                     module_spec.module_class = module_class
-                elif module_id in default_spec.module_specs:
-                    module_spec.module_class = default_spec.module_specs[
+                elif module_id in default_rl_module_spec.module_specs:
+                    module_spec.module_class = default_rl_module_spec.module_specs[
                         module_id
                     ].module_class
                 else:
@@ -3245,13 +3272,15 @@ class AlgorithmConfig(_Config):
                         "the algorithm."
                     )
             if module_spec.catalog_class is None:
-                if isinstance(default_spec, SingleAgentRLModuleSpec):
-                    module_spec.catalog_class = default_spec.catalog_class
-                elif isinstance(default_spec.module_specs, SingleAgentRLModuleSpec):
-                    catalog_class = default_spec.module_specs.catalog_class
+                if isinstance(default_rl_module_spec, SingleAgentRLModuleSpec):
+                    module_spec.catalog_class = default_rl_module_spec.catalog_class
+                elif isinstance(
+                    default_rl_module_spec.module_specs, SingleAgentRLModuleSpec
+                ):
+                    catalog_class = default_rl_module_spec.module_specs.catalog_class
                     module_spec.catalog_class = catalog_class
-                elif module_id in default_spec.module_specs:
-                    module_spec.catalog_class = default_spec.module_specs[
+                elif module_id in default_rl_module_spec.module_specs:
+                    module_spec.catalog_class = default_rl_module_spec.module_specs[
                         module_id
                     ].catalog_class
                 else:

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -3141,7 +3141,8 @@ class AlgorithmConfig(_Config):
         # Algorithm is currently setup as a single-agent one.
         if isinstance(current_rl_module_spec, SingleAgentRLModuleSpec):
             # Use either the provided `single_agent_rl_module_spec` (a
-            # SingleAgentRLModuleSpec), the currently setup one, or the default.
+            # SingleAgentRLModuleSpec), the currently configured one of this
+            # AlgorithmConfig object, or the default one.
             single_agent_rl_module_spec = (
                 single_agent_rl_module_spec or current_rl_module_spec
             )
@@ -3152,32 +3153,34 @@ class AlgorithmConfig(_Config):
                     for k in policy_dict.keys()
                 },
             )
+
         # Algorithm is currently setup as a multi-agent one.
         else:
+            # The user currently has a MultiAgentSpec setup (either via
+            # self.rl_module_spec or the default spec of this AlgorithmConfig).
             assert isinstance(current_rl_module_spec, MultiAgentRLModuleSpec)
 
+            # Default is single-agent but the user has provided a multi-agent spec
+            # so the use-case is multi-agent.
             if isinstance(default_rl_module_spec, SingleAgentRLModuleSpec):
-                # Default is single-agent but the user has provided a multi-agent spec
-                # so the use-case is multi-agent. We need to inherit the multi-agent
-                # class from `current_rl_module_spec` and fill in the module_specs dict.
-                # If the user provided a multi-agent spec, we use that for the values,
-                # otherwise we see if they have provided a multi-agent spec that
-                # specifies the SingleAgentRLModuleSpec to use instead of the default,
-                # in that case, we use that spec for the values. otherwise we use
-                # the default spec for the values.
+                # The individual (single-agent) module specs are defined by the user
+                # in the currently setup MultiAgentRLModuleSpec -> Use that
+                # SingleAgentRLModuleSpec.
                 if isinstance(
                     current_rl_module_spec.module_specs, SingleAgentRLModuleSpec
                 ):
-                    # The individual module specs are defined by the user
                     single_agent_spec = single_agent_rl_module_spec or (
                         current_rl_module_spec.module_specs
                     )
                     module_specs = {
                         k: copy.deepcopy(single_agent_spec) for k in policy_dict.keys()
                     }
+
+                # The individual (single-agent) module specs have not been configured
+                # via this AlgorithmConfig object -> Use provided single-agent spec or
+                # the the default spec (which is also a SingleAgentRLModuleSpec in this
+                # case).
                 else:
-                    # The individual module specs are not defined by the user,
-                    # so we use the default
                     single_agent_spec = (
                         single_agent_rl_module_spec or default_rl_module_spec
                     )
@@ -3190,19 +3193,28 @@ class AlgorithmConfig(_Config):
                         for k in policy_dict.keys()
                     }
 
+                # Now construct the proper MultiAgentRLModuleSpec.
+                # We need to infer the multi-agent class from `current_rl_module_spec`
+                # and fill in the module_specs dict.
                 marl_module_spec = current_rl_module_spec.__class__(
                     marl_module_class=current_rl_module_spec.marl_module_class,
                     module_specs=module_specs,
                     modules_to_load=current_rl_module_spec.modules_to_load,
                     load_state_path=current_rl_module_spec.load_state_path,
                 )
+
+            # Default is multi-agent and user wants to override it -> Don't use the
+            # default.
             else:
-                # Default is multi-agent and user wants to override it. In this case,
-                # we have two options: 1) the user provided a multi-agent spec, in
-                # which case we use that for the values, 2) self.rl_module_spec is a
-                # spec that defines SingleAgentRLModuleSpecs to be used for everything.
-                # In this case, we need to use that spec for the values.
-                if single_agent_rl_module_spec is None:
+                # Use has given an override SingleAgentRLModuleSpec -> Use this to
+                # construct the individual RLModules within the MultiAgentRLModuleSpec.
+                if single_agent_rl_module_spec is not None:
+                    pass
+                # User has NOT provided an override SingleAgentRLModuleSpec.
+                else:
+                    # But the currently setup multi-agent spec has a SingleAgentRLModule
+                    # spec defined -> Use that to construct the individual RLModules
+                    # within the MultiAgentRLModuleSpec.
                     if isinstance(
                         current_rl_module_spec.module_specs, SingleAgentRLModuleSpec
                     ):
@@ -3211,6 +3223,9 @@ class AlgorithmConfig(_Config):
                         single_agent_rl_module_spec = (
                             current_rl_module_spec.module_specs
                         )
+                    # The currently setup multi-agent spec has NO
+                    # SingleAgentRLModuleSpec in it -> Error (there is no way we can
+                    # infer this information from anywhere at this point).
                     else:
                         raise ValueError(
                             "We have a MultiAgentRLModuleSpec "
@@ -3221,6 +3236,7 @@ class AlgorithmConfig(_Config):
                             "policy_dict=.., single_agent_rl_module_spec=..)`."
                         )
 
+                # Now construct the proper MultiAgentRLModuleSpec.
                 marl_module_spec = current_rl_module_spec.__class__(
                     marl_module_class=current_rl_module_spec.marl_module_class,
                     module_specs={

--- a/rllib/algorithms/ppo/tests/test_ppo.py
+++ b/rllib/algorithms/ppo/tests/test_ppo.py
@@ -1,5 +1,6 @@
-import numpy as np
 import unittest
+
+import numpy as np
 
 import ray
 from ray.rllib.algorithms.callbacks import DefaultCallbacks

--- a/rllib/algorithms/tests/test_algorithm_config.py
+++ b/rllib/algorithms/tests/test_algorithm_config.py
@@ -305,7 +305,9 @@ class TestAlgorithmConfig(unittest.TestCase):
 
         marl_spec = config.get_marl_module_spec(
             policy_dict={"p1": policy_spec_ph, "p2": policy_spec_ph},
-            module_spec=SingleAgentRLModuleSpec(module_class=passed_module_class)
+            single_agent_rl_module_spec=SingleAgentRLModuleSpec(
+                module_class=passed_module_class
+            )
             if passed_module_class
             else None,
         )

--- a/rllib/core/rl_module/marl_module.py
+++ b/rllib/core/rl_module/marl_module.py
@@ -84,8 +84,8 @@ class MultiAgentRLModule(RLModule):
                 )
 
     def keys(self) -> Iterator[ModuleID]:
-        """Returns an iteratable of module ids."""
-        return self._rl_modules.keys()
+        """Returns an iterable over the module IDs in this MultiAgentRLModule."""
+        return iter(self._rl_modules.keys())
 
     @override(RLModule)
     def as_multi_agent(self) -> "MultiAgentRLModule":

--- a/rllib/core/rl_module/marl_module.py
+++ b/rllib/core/rl_module/marl_module.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 import pathlib
 import pprint
-from typing import Iterator, Mapping, Any, Union, Dict, Optional, Type, Set
+from typing import Any, Dict, KeysView, Mapping, Optional, Set, Type, Union
 
 from ray.util.annotations import PublicAPI
 from ray.rllib.utils.annotations import override, ExperimentalAPI
@@ -83,9 +83,9 @@ class MultiAgentRLModule(RLModule):
                     f"Module {module_id} is not a SingleAgentRLModuleSpec object."
                 )
 
-    def keys(self) -> Iterator[ModuleID]:
-        """Returns an iterable over the module IDs in this MultiAgentRLModule."""
-        return iter(self._rl_modules.keys())
+    def keys(self) -> KeysView[ModuleID]:
+        """Returns a keys view over the module IDs in this MultiAgentRLModule."""
+        return self._rl_modules.keys()
 
     @override(RLModule)
     def as_multi_agent(self) -> "MultiAgentRLModule":

--- a/rllib/core/rl_module/rl_module.py
+++ b/rllib/core/rl_module/rl_module.py
@@ -68,7 +68,7 @@ class SingleAgentRLModuleSpec:
     module_class: Optional[Type["RLModule"]] = None
     observation_space: Optional[gym.Space] = None
     action_space: Optional[gym.Space] = None
-    model_config_dict: Optional[Mapping[str, Any]] = None
+    model_config_dict: Optional[Dict[str, Any]] = None
     catalog_class: Optional[Type["Catalog"]] = None
     load_state_path: Optional[str] = None
 
@@ -173,7 +173,7 @@ class RLModuleConfig:
 
     observation_space: gym.Space = None
     action_space: gym.Space = None
-    model_config_dict: Mapping[str, Any] = None
+    model_config_dict: Dict[str, Any] = None
     catalog_class: Type["Catalog"] = None
 
     def get_catalog(self) -> "Catalog":

--- a/rllib/core/rl_module/tests/test_marl_module.py
+++ b/rllib/core/rl_module/tests/test_marl_module.py
@@ -14,7 +14,7 @@ from ray.rllib.utils.test_utils import check
 
 class TestMARLModule(unittest.TestCase):
     def test_from_config(self):
-
+        """Tests whether a MultiAgentRLModule can be constructed from a config."""
         env_class = make_multi_agent("CartPole-v0")
         env = env_class({"num_agents": 2})
         module1 = SingleAgentRLModuleSpec(

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -1170,7 +1170,7 @@ class RolloutWorker(ParallelIteratorWorker, EnvRunner):
             policy_dict=policy_dict_to_add,
             policy=policy,
             policy_states={policy_id: policy_state},
-            module_spec=module_spec,
+            single_agent_rl_module_spec=module_spec,
         )
 
         self.set_policy_mapping_fn(policy_mapping_fn)
@@ -1678,7 +1678,7 @@ class RolloutWorker(ParallelIteratorWorker, EnvRunner):
         policy_dict: MultiAgentPolicyConfigDict,
         policy: Optional[Policy] = None,
         policy_states: Optional[Dict[PolicyID, PolicyState]] = None,
-        module_spec: Optional[SingleAgentRLModuleSpec] = None,
+        single_agent_rl_module_spec: Optional[SingleAgentRLModuleSpec] = None,
     ) -> None:
         """Updates the policy map (and other stuff) on this worker.
 
@@ -1697,8 +1697,10 @@ class RolloutWorker(ParallelIteratorWorker, EnvRunner):
             policy_dict: The policy dict to update the policy map with.
             policy: The policy to update the policy map with.
             policy_states: The policy states to update the policy map with.
-            module_spec: The RLModuleSpec to add to the marl_module_spec. If None, the
-                default_rl_module_spec will be used to create the policy with.
+            single_agent_rl_module_spec: The SingleAgentRLModuleSpec to add to the
+                MultiAgentRLModuleSpec. If None, the config's
+                `get_default_rl_module_spec` method's output will be used to create
+                the policy with.
         """
 
         # Update the input policy dict with the postprocessed observation spaces and
@@ -1708,7 +1710,8 @@ class RolloutWorker(ParallelIteratorWorker, EnvRunner):
         # Use the updated policy dict to create the marl_module_spec if necessary
         if self.config._enable_rl_module_api:
             spec = self.config.get_marl_module_spec(
-                policy_dict=updated_policy_dict, module_spec=module_spec
+                policy_dict=updated_policy_dict,
+                single_agent_rl_module_spec=single_agent_rl_module_spec,
             )
             if self.marl_module_spec is None:
                 # this is the first time, so we should create the marl_module_spec


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

The current implementation of `AlgorithmConfig.get_marl_module_spec()` is quite messy and needs cleanup and clarification via better comments.

Also, a simple test as follows would fail due to the logic in the method not pulling the default ModuleSpec where it would make sense:

```
config = (
    PPOConfig()
    .environment(
        observation_space=gym.spaces.Box(-1.0, 0.0, (64, 64, 3), np.float32),
        action_space=gym.spaces.Discrete(6),
    )
)
# Create our RLModule to compute actions with.
policy_dict, _ = config.get_multi_agent_setup()
module_spec = config.get_marl_module_spec(
    policy_dict=policy_dict,
    single_agent_rl_module_spec=None,  # <- None is the default here
)
module_spec.build()
```

Fails with:
```
File "/Users/sven/opt/anaconda3/envs/ray/lib/python3.8/site-packages/ray/rllib/algorithms/algorithm_config.py", line 3155, in get_marl_module_spec
    cur_marl_module_spec.module_specs, SingleAgentRLModuleSpec
AttributeError: 'NoneType' object has no attribute 'module_specs'
```


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
