### PR TITLE
[RLlib] Enhance `run_regression_tests.py`: Allow overriding `--env` and `--framework` on command line.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2471,7 +2471,7 @@ py_test(
 py_test(
     name = "tests/backward_compat/test_gym_env_apis",
     tags = ["team:rllib", "env"],
-    size = "medium",
+    size = "large",
     srcs = ["tests/backward_compat/test_gym_env_apis.py"]
 )
 

--- a/rllib/tests/run_regression_tests.py
+++ b/rllib/tests/run_regression_tests.py
@@ -20,7 +20,6 @@ import argparse
 import os
 from pathlib import Path
 import sys
-from typing import Optional
 import yaml
 
 import ray
@@ -33,11 +32,11 @@ from ray.rllib.utils.deprecation import deprecation_warning
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    type=Optional[str],
+    type=str,
     choices=["torch", "tf2", "tf"],
     default=None,
     help="The deep learning framework to use. If not provided, try using the one "
-         "specified in the file, otherwise, use RLlib's default: `torch`.",
+    "specified in the file, otherwise, use RLlib's default: `torch`.",
 )
 parser.add_argument(
     "--dir",
@@ -47,10 +46,10 @@ parser.add_argument(
 )
 parser.add_argument(
     "--env",
-    type=Optional[str],
+    type=str,
     default=None,
     help="An optional env override setting. If not provided, try using the one "
-         "specified in the file.",
+    "specified in the file.",
 )
 parser.add_argument("--num-cpus", type=int, default=None)
 parser.add_argument(

--- a/rllib/tests/run_regression_tests.py
+++ b/rllib/tests/run_regression_tests.py
@@ -20,6 +20,7 @@ import argparse
 import os
 from pathlib import Path
 import sys
+from typing import Optional
 import yaml
 
 import ray
@@ -32,15 +33,24 @@ from ray.rllib.utils.deprecation import deprecation_warning
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--framework",
-    choices=["jax", "tf2", "tf", "torch"],
-    default="tf",
-    help="The deep learning framework to use.",
+    type=Optional[str],
+    choices=["torch", "tf2", "tf"],
+    default=None,
+    help="The deep learning framework to use. If not provided, try using the one "
+         "specified in the file, otherwise, use RLlib's default: `torch`.",
 )
 parser.add_argument(
     "--dir",
     type=str,
     required=True,
     help="The directory or file in which to find all tests.",
+)
+parser.add_argument(
+    "--env",
+    type=Optional[str],
+    default=None,
+    help="An optional env override setting. If not provided, try using the one "
+         "specified in the file.",
 )
 parser.add_argument("--num-cpus", type=int, default=None)
 parser.add_argument(
@@ -108,7 +118,14 @@ if __name__ == "__main__":
         ), "Error, can only run a single experiment per file!"
 
         exp = list(experiments.values())[0]
-        exp["config"]["framework"] = args.framework
+
+        # Override framework setting with the command line one, if provided.
+        # Otherwise, will use framework setting in file (or default: torch).
+        if args.framework is not None:
+            exp["config"]["framework"] = args.framework
+        # Override env setting if given on command line.
+        if args.env is not None:
+            exp["config"]["env"] = args.env
 
         # Override the mean reward if specified. This is used by the ray ci
         # for overriding the episode reward mean for tf2 tests for off policy


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Enhance `run_regression_tests.py`: Allow overriding `--env` and `--framework` on command line.

Now allows setting the env on the command line, making it possible to have one yaml file for various env variations (e.g. one file for all Atari problems).

Fixes: Thus far, the script - when run without any command line `--framework` option - showed the strange behavior of running with fw="tf2" even though in the file it was specified as "torch".

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
