### PR TITLE
[Core] Set global logging format to %(message)s pending API review

### DIFF
--- a/python/ray/_private/log.py
+++ b/python/ray/_private/log.py
@@ -96,8 +96,9 @@ def generate_logging_config():
 
         formatters = {
             "plain": {
-                "datefmt": "[%Y-%m-%d %H:%M:%S]",
-                "format": "%(asctime)s %(package)s %(levelname)s %(name)s::%(message)s",
+                "format": (
+                    "%(asctime)s\t%(levelname)s %(filename)s:%(lineno)s -- %(message)s"
+                ),
             },
         }
         filters = {"context_filter": {"()": ContextFilter}}

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -1243,10 +1243,7 @@ class TestRayReinitialization:
 
     @pytest.fixture
     def pattern(self) -> Pattern:
-        return re.compile(
-            r"INFO ray._private.worker::Connecting to existing Ray cluster at "
-            r"address: (.*)\.\.\."
-        )
+        return re.compile(r"Connecting to existing Ray cluster at address: (.*)\.\.\.")
 
     @pytest.fixture
     def ansi_escape(self) -> Pattern:

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -47,7 +47,7 @@ ray.init(num_cpus=1)
 
     out_str = run_string_as_driver(script)
     assert "INFO" in out_str, out_str
-    assert "ray._private.worker" in out_str, out_str
+    assert len(out_str) != 0
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")


### PR DESCRIPTION
## Why are these changes needed?

@rkooo567 Informed me that changes to the logging format must go through API review, so I'm setting the log format to Python's default of `'%(message)s'`, [as per the python docs](https://docs.python.org/3/library/logging.html#formatter-objects).

@rkooo567 Do I need API review/input from the data team about this change?

## Related issue number

None.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
