### PR TITLE
[RLlib] Fix run connector policy

### DIFF
--- a/rllib/examples/connectors/run_connector_policy.py
+++ b/rllib/examples/connectors/run_connector_policy.py
@@ -33,7 +33,12 @@ def run(checkpoint_path, policy_id):
         # Use local_policy_inference() to run inference, so we do not have to
         # provide policy states or extra fetch dictionaries.
         # "env_1" and "agent_1" are dummy env and agent IDs to run connectors with.
-        policy_outputs = local_policy_inference(policy, "env_1", "agent_1", obs)
+        policy_outputs = local_policy_inference(
+            policy,
+            "env_1",
+            "agent_1",
+            obs,
+            explore=False)
         assert len(policy_outputs) == 1
         action, _, _ = policy_outputs[0]
         print(f"step {step}", obs, action)

--- a/rllib/examples/connectors/run_connector_policy.py
+++ b/rllib/examples/connectors/run_connector_policy.py
@@ -34,11 +34,8 @@ def run(checkpoint_path, policy_id):
         # provide policy states or extra fetch dictionaries.
         # "env_1" and "agent_1" are dummy env and agent IDs to run connectors with.
         policy_outputs = local_policy_inference(
-            policy,
-            "env_1",
-            "agent_1",
-            obs,
-            explore=False)
+            policy, "env_1", "agent_1", obs, explore=False
+        )
         assert len(policy_outputs) == 1
         action, _, _ = policy_outputs[0]
         print(f"step {step}", obs, action)

--- a/rllib/utils/policy.py
+++ b/rllib/utils/policy.py
@@ -185,6 +185,8 @@ def local_policy_inference(
     terminated: Optional[bool] = None,
     truncated: Optional[bool] = None,
     info: Optional[Mapping] = None,
+    explore: bool = None,
+    timestep: Optional[int] = None,
 ) -> TensorStructType:
     """Run a connector enabled policy using environment observation.
 
@@ -215,6 +217,9 @@ def local_policy_inference(
             require this extra information.
         info: Info that is potentially used durin inference. If not required,
             may be left empty. Some policies have ViewRequirements that require this.
+        explore: Whether to pick an exploitation or exploration action
+            (default: None -> use self.config["explore"]).
+        timestep: The current (sampling) time step.
 
     Returns:
         List of outputs from policy forward pass.
@@ -247,7 +252,11 @@ def local_policy_inference(
     ac_outputs: List[AgentConnectorsOutput] = policy.agent_connectors(acd_list)
     outputs = []
     for ac in ac_outputs:
-        policy_output = policy.compute_actions_from_input_dict(ac.data.sample_batch)
+        policy_output = policy.compute_actions_from_input_dict(
+            ac.data.sample_batch,
+            explore=explore,
+            timestep=timestep,
+        )
 
         # Note (Kourosh): policy output is batched, the AgentConnectorDataType should
         # not be batched during inference. This is the assumption made in AgentCollector


### PR DESCRIPTION
run_connector_policy does not take into account timestep or explore=True/False.
This is not convenient for users.

Closes https://github.com/ray-project/ray/issues/35663