### PR TITLE
[Core][Node Labels 2/n] Add labels param in python ray.init() to setting node labels

### DIFF
--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -27,6 +27,7 @@ class RayParams:
         num_gpus: Number of GPUs to configure the raylet with.
         resources: A dictionary mapping the name of a resource to the quantity
             of that resource available.
+        labels: The key-value labels of the node.
         memory: Total available memory for workers requesting memory.
         object_store_memory: The amount of memory (in bytes) to start the
             object store with.
@@ -121,7 +122,6 @@ class RayParams:
         env_vars: Override environment variables for the raylet.
         session_name: The name of the session of the ray cluster.
         webui: The url of the UI.
-        labels: The key-value labels of the node.
     """
 
     def __init__(
@@ -131,6 +131,7 @@ class RayParams:
         num_cpus: Optional[int] = None,
         num_gpus: Optional[int] = None,
         resources: Optional[Dict[str, float]] = None,
+        labels: Optional[Dict[str, str]] = None,
         memory: Optional[float] = None,
         object_store_memory: Optional[float] = None,
         redis_max_memory: Optional[float] = None,
@@ -181,7 +182,6 @@ class RayParams:
         env_vars: Optional[Dict[str, str]] = None,
         session_name: Optional[str] = None,
         webui: Optional[str] = None,
-        labels: Optional[Dict[str, str]] = None,
     ):
         self.redis_address = redis_address
         self.gcs_address = gcs_address

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1109,6 +1109,7 @@ def init(
     num_cpus: Optional[int] = None,
     num_gpus: Optional[int] = None,
     resources: Optional[Dict[str, float]] = None,
+    labels: Optional[Dict[str, str]] = None,
     object_store_memory: Optional[int] = None,
     local_mode: bool = False,
     ignore_reinit_error: bool = False,
@@ -1188,6 +1189,7 @@ def init(
             raylet. By default, this is set based on detected GPUs.
         resources: A dictionary mapping the names of custom resources to the
             quantities for them available.
+        labels: [Experimental] The key-value labels of the node.
         object_store_memory: The amount of memory (in bytes) to start the
             object store with. By default, this is automatically set based on
             available system memory.
@@ -1480,6 +1482,7 @@ def init(
             num_cpus=num_cpus,
             num_gpus=num_gpus,
             resources=resources,
+            labels=labels,
             num_redis_shards=None,
             redis_max_clients=None,
             redis_password=_redis_password,
@@ -1521,6 +1524,11 @@ def init(
             raise ValueError(
                 "When connecting to an existing cluster, "
                 "resources must not be provided."
+            )
+        if labels is not None:
+            raise ValueError(
+                "When connecting to an existing cluster, "
+                "labels must not be provided."
             )
         if object_store_memory is not None:
             raise ValueError(

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -636,6 +636,7 @@ def start(
         num_cpus=num_cpus,
         num_gpus=num_gpus,
         resources=resources,
+        labels=labels_dict,
         autoscaling_config=autoscaling_config,
         plasma_directory=plasma_directory,
         huge_pages=False,
@@ -655,7 +656,6 @@ def start(
         no_monitor=no_monitor,
         tracing_startup_hook=tracing_startup_hook,
         ray_debugger_external=ray_debugger_external,
-        labels=labels_dict,
     )
 
     if ray_constants.RAY_START_HOOK in os.environ:

--- a/python/ray/tests/test_node_labels.py
+++ b/python/ray/tests/test_node_labels.py
@@ -27,6 +27,38 @@ def test_ray_start_set_empty_node_labels(call_ray_start):
     assert ray.nodes()[0]["Labels"] == {}
 
 
+def test_ray_init_set_node_labels(shutdown_only):
+    labels = {"gpu_type": "A100", "region": "us"}
+    ray.init(labels=labels)
+    assert ray.nodes()[0]["Labels"] == labels
+    ray.shutdown()
+    ray.init(labels={})
+    assert ray.nodes()[0]["Labels"] == {}
+
+
+def test_ray_init_set_node_labels_value_error(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=1)
+    with pytest.raises(ValueError, match="labels must not be provided"):
+        ray.init(address=cluster.address, labels={"gpu_type": "A100"})
+
+
+def test_cluster_add_node_with_labels(ray_start_cluster):
+    labels = {"gpu_type": "A100", "region": "us"}
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=1, labels=labels)
+    cluster.wait_for_nodes()
+    ray.init(address=cluster.address)
+    assert ray.nodes()[0]["Labels"] == labels
+    head_node_id = ray.nodes()[0]["NodeID"]
+
+    cluster.add_node(num_cpus=1, labels={})
+    cluster.wait_for_nodes()
+    for node in ray.nodes():
+        if node["NodeID"] != head_node_id:
+            assert node["Labels"] == {}
+
+
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))


### PR DESCRIPTION
## Why are these changes needed?
Add labels param in python ray.init() to setting node labels
user cases:
```
  labels = {"gpu_type": "A100", "region": "us"}
  ray.init(labels=labels)
  assert ray.nodes()[0]["Labels"] == labels
  ray.shutdown()
  ray.init(labels={})
  assert ray.nodes()[0]["Labels"] == {}
```

## Related issue number
Enhancing node affinity scheduling feature through node labels https://github.com/ray-project/ray/issues/34894
> (P1)Finalize the format for setting node labels in the ray.init() interface of Python worker.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
