### PR TITLE
Deflake test_worker_kv_calls (#35744)

### DIFF
--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -49,10 +49,6 @@ def make_function_table_key(key_type: bytes, job_id: JobID, key: Optional[bytes]
         return b":".join([key_type, job_id.hex().encode(), key])
 
 
-def make_exports_prefix(job_id: JobID) -> bytes:
-    return make_function_table_key(b"IsolatedExports", job_id)
-
-
 def make_export_key(pos: int, job_id: JobID) -> bytes:
     # big-endian for ordering in binary
     return make_function_table_key(b"IsolatedExports", job_id, pos.to_bytes(8, "big"))

--- a/python/ray/_private/import_thread.py
+++ b/python/ray/_private/import_thread.py
@@ -45,9 +45,6 @@ class ImportThread:
         self._lock = threading.Lock()
         # Protect start and join of import thread.
         self._thread_spawn_lock = threading.Lock()
-        # Try to load all FunctionsToRun so that these functions will be
-        # run before accepting tasks.
-        self._do_importing()
 
     def start(self):
         """Start the import thread."""

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -78,6 +78,7 @@ _PYARROW_VERSION = None
 
 # This global variable is used for testing only
 _CALLED_FREQ = defaultdict(lambda: 0)
+_CALLED_FREQ_LOCK = threading.Lock()
 
 
 def get_user_temp_dir():

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2123,7 +2123,8 @@ def _auto_reconnect(f):
     @wraps(f)
     def wrapper(self, *args, **kwargs):
         if "TEST_RAY_COLLECT_KV_FREQUENCY" in os.environ:
-            ray._private.utils._CALLED_FREQ[f.__name__] += 1
+            with ray._private.utils._CALLED_FREQ_LOCK:
+                ray._private.utils._CALLED_FREQ[f.__name__] += 1
         remaining_retry = self._nums_reconnect_retry
         while True:
             try:

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -244,13 +244,10 @@ def test_worker_kv_calls(monkeypatch, shutdown_only):
     freqs = ray.get(get_kv_metrics.remote())
     # So far we have the following gets
     """
-    b'fun' b'IsolatedExports:01000000:\x00\x00\x00\x00\x00\x00\x00\x01'
-    b'fun' b'IsolatedExports:01000000:\x00\x00\x00\x00\x00\x00\x00\x02'
     b'cluster' b'CLUSTER_METADATA'
-    b'fun' b'IsolatedExports:01000000:\x00\x00\x00\x00\x00\x00\x00\x01'
-    b'fun' b'IsolatedExports:01000000:\x00\x00\x00\x00\x00\x00\x00\x01'
     b'tracing' b'tracing_startup_hook'
-    ???? # unknown
+    b'fun' b'IsolatedExports:01000000:\x00\x00\x00\x00\x00\x00\x00\x01'
+    b'fun' b'RemoteFunction:01000000:'
     """
     # !!!If you want to increase this number, please let ray-core knows this!!!
     assert freqs["internal_kv_get"] == 4


### PR DESCRIPTION
Two issues:

- _CALLED_FREQ is not protected by a lock and incrementing the value of a map is not atomic.

- We call _do_importing in the ImportThread constructor and depending on whether job id is available or not, we may or may not call kv get on IsolatedExports hence the number of kv put can vary by 1. The fix is only calling _do_importing() in the _run() method and at that time, job id is guaranteed to be available. Also this part of the code will be removed soon, we no longer have any FunctionsToRun in the codebase.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Closes #36008
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
