### PR TITLE
[Object Store]Remove push requests without remaining chunks from the pending list.

### DIFF
--- a/src/ray/object_manager/push_manager.cc
+++ b/src/ray/object_manager/push_manager.cc
@@ -37,7 +37,7 @@ void PushManager::StartPush(const NodeID &dest_id,
   } else {
     RAY_LOG(DEBUG) << "Duplicate push request " << push_id.first << ", " << push_id.second
                    << ", resending all the chunks.";
-    if (it->second->NoChunkRemained()) {
+    if (it->second->NoChunksToSend()) {
       // if all the chunks have been sent, the push request needs to be re-added to
       // `push_requests_with_chunks_to_send_`.
       push_requests_with_chunks_to_send_.push_back(
@@ -83,7 +83,7 @@ void PushManager::ScheduleRemainingPushes() {
                        << " / " << max_chunks_in_flight_
                        << " max, remaining chunks: " << NumChunksRemaining();
       }
-      if (info->NoChunkRemained()) {
+      if (info->NoChunksToSend()) {
         it = push_requests_with_chunks_to_send_.erase(it);
       } else {
         it++;

--- a/src/ray/object_manager/push_manager.cc
+++ b/src/ray/object_manager/push_manager.cc
@@ -26,13 +26,22 @@ void PushManager::StartPush(const NodeID &dest_id,
                             std::function<void(int64_t)> send_chunk_fn) {
   auto push_id = std::make_pair(dest_id, obj_id);
   RAY_CHECK(num_chunks > 0);
-  if (push_info_.contains(push_id)) {
+
+  auto it = push_info_.find(push_id);
+  if (it == push_info_.end()) {
+    chunks_remaining_ += num_chunks;
+    auto push_state = std::make_shared<PushState>(num_chunks, send_chunk_fn);
+    push_info_[push_id] = push_state;
+    pending_push_requests_.push_back(std::make_pair(push_id, push_state));
+  } else {
     RAY_LOG(DEBUG) << "Duplicate push request " << push_id.first << ", " << push_id.second
                    << ", resending all the chunks.";
-    chunks_remaining_ += push_info_[push_id]->ResendAllChunks(send_chunk_fn);
-  } else {
-    chunks_remaining_ += num_chunks;
-    push_info_[push_id].reset(new PushState(num_chunks, send_chunk_fn));
+    if (it->second->NoChunkRemained()) {
+      // if all the chunks have been sent, the push request needs to be re-added to
+      // `pending_push_requests_`.
+      pending_push_requests_.push_back(std::make_pair(push_id, it->second));
+    }
+    chunks_remaining_ += it->second->ResendAllChunks(send_chunk_fn);
   }
   ScheduleRemainingPushes();
 }
@@ -57,9 +66,10 @@ void PushManager::ScheduleRemainingPushes() {
   // consider tracking the number of chunks active per-push and balancing those.
   while (chunks_in_flight_ < max_chunks_in_flight_ && keep_looping) {
     // Loop over each active push and try to send another chunk.
-    auto it = push_info_.begin();
+    auto it = pending_push_requests_.begin();
     keep_looping = false;
-    while (it != push_info_.end() && chunks_in_flight_ < max_chunks_in_flight_) {
+    while (it != pending_push_requests_.end() &&
+           chunks_in_flight_ < max_chunks_in_flight_) {
       auto push_id = it->first;
       auto &info = it->second;
       if (info->SendOneChunk()) {
@@ -71,7 +81,11 @@ void PushManager::ScheduleRemainingPushes() {
                        << " / " << max_chunks_in_flight_
                        << " max, remaining chunks: " << NumChunksRemaining();
       }
-      it++;
+      if (info->NoChunkRemained()) {
+        it = pending_push_requests_.erase(it);
+      } else {
+        it++;
+      }
     }
   }
 }

--- a/src/ray/object_manager/push_manager.h
+++ b/src/ray/object_manager/push_manager.h
@@ -67,7 +67,9 @@ class PushManager {
   int64_t NumPushesInFlight() const { return push_info_.size(); };
 
   /// Return the number of push requests with remaining chunks. For testing only.
-  int64_t NumPendingPushRequest() const { return pending_push_requests_.size(); };
+  int64_t NumPendingPushRequest() const {
+    return push_requests_with_chunks_to_send_.size();
+  };
 
   /// Record the internal metrics.
   void RecordMetrics() const;
@@ -146,10 +148,13 @@ class PushManager {
   int64_t chunks_remaining_ = 0;
 
   /// Tracks all pushes with chunk transfers in flight.
-  absl::flat_hash_map<PushID, std::shared_ptr<PushState>> push_info_;
+  /// Note: the lifecycle of PushState's pointer in `push_info_` is longer than
+  /// that in `push_requests_with_chunks_to_send_`. Please ensure this, otherwise
+  /// pointers in `push_requests_with_chunks_to_send_` may become dangling.
+  absl::flat_hash_map<PushID, std::unique_ptr<PushState>> push_info_;
 
   /// The list of push requests with chunks waiting to be sent.
-  std::list<std::pair<PushID, std::shared_ptr<PushState>>> pending_push_requests_;
+  std::list<std::pair<PushID, PushState *>> push_requests_with_chunks_to_send_;
 };
 
 }  // namespace ray

--- a/src/ray/object_manager/push_manager.h
+++ b/src/ray/object_manager/push_manager.h
@@ -67,7 +67,7 @@ class PushManager {
   int64_t NumPushesInFlight() const { return push_info_.size(); };
 
   /// Return the number of push requests with remaining chunks. For testing only.
-  int64_t NumPendingPushRequest() const {
+  int64_t NumPushRequestsWithChunksToSend() const {
     return push_requests_with_chunks_to_send_.size();
   };
 
@@ -107,12 +107,12 @@ class PushManager {
     }
 
     /// whether all the chunks have been sent.
-    bool NoChunkRemained() { return num_chunks_to_send == 0; }
+    bool NoChunksToSend() { return num_chunks_to_send == 0; }
 
     /// Send one chunck. Return true if a new chunk is sent, false if no more chunk to
     /// send.
     bool SendOneChunk() {
-      if (NoChunkRemained()) {
+      if (NoChunksToSend()) {
         return false;
       }
       num_chunks_to_send--;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In the current push manager, push requests are only removed from the pending list when all the chunks in the push request are completed and all reply is received. This results in a high complexity for the ScheduleRemainingPushes function when there are many small objects.

This PR will remove push requests without remaining chunks from the traversal list, and every push request traversed by ScheduleRemainingPushes will have remaining chunks to be sent.

Perf Impact:

- add this test case into test_object_manager.py:
``` python
@pytest.mark.parametrize(
    "ray_start_cluster_head",
    [
        {
            "object_store_memory": 1 * 1024**3,
            "_system_config": {
                "object_spilling_threshold": 1.0,
                # disable unlimited
                "oom_grace_period_s": 3600,
                # force argument to be put into object store
                "max_direct_call_object_size": 512,
                "object_manager_default_chunk_size": 10 * 1024,
            },
        }
    ],
    indirect=True,
)
def test_push_large_number_and_small_size_object(ray_start_cluster_head):
    cluster = ray_start_cluster_head
    cluster.add_node(
        object_store_memory=1 * 1024**3,
        resources={"remote_node": 8},
        num_cpus=8,
    )

    def get_small_object():
        # 1KB
        return np.random.rand(1, 1024 // 8)

    TASK_NUMBER = 100
    ARG_NUMBER = 1000

    @ray.remote(resources={"remote_node": 1})
    def get_sum(ans, *args):
        for i in args:
            ans -= i.sum()
        return abs(ans) < 1e-6

    all_args = []
    all_sums = []
    for _ in range(TASK_NUMBER * ARG_NUMBER):
        data = get_small_object()
        all_args.append(ray.put(data))
        all_sums.append(data.sum())

    tasks = []
    for index in range(TASK_NUMBER):
        ans = sum(all_sums[index * ARG_NUMBER : (index + 1) * ARG_NUMBER])
        args = all_args[index * ARG_NUMBER : (index + 1) * ARG_NUMBER]
        tasks.append(get_sum.remote(ans, *args))
    assert all(ray.get(tasks))
    # Ensure that relevant logs can be printed in Raylet.
    time.sleep(10)
```
- Add the following monitoring code to count the loops inside function `PushManager::ScheduleRemainingPushes`

![image](https://github.com/ray-project/ray/assets/11995469/8cf40249-77f6-4dbd-9267-5d0cb383556b)

- run by cmd: pytest python/ray/tests/test_object_manager.py::test_push_large_number_and_small_size_object -svx

- result:
	- branch pop_push_info(9a3414302ea4361d54661a87d07c9075a4ab9890)
		- time cost: 63s
		- Loop number: 
![image](https://github.com/ray-project/ray/assets/11995469/e32559b6-cf36-447a-bb6b-4bfcdad991b1)
	- branch master()
	    - time cost: 101s
		- Loop number:
![image](https://github.com/ray-project/ray/assets/11995469/bbee9ac1-274f-4a64-a724-c4eef283258c)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
