### PR TITLE
[Train] Support DeepSpeed Strategy in LightningTrainer 

### DIFF
--- a/python/ray/train/lightning/_lightning_utils.py
+++ b/python/ray/train/lightning/_lightning_utils.py
@@ -125,7 +125,7 @@ class _RayStrategyFactory:
         self.ray_registry = dict()
         self.register_ray_strategies()
 
-        self.strategy_whitelist = {
+        self.whitelist = {
             name
             for name, registry in self.ptl_registry.items()
             if registry["strategy"] in self.ray_registry
@@ -144,8 +144,8 @@ class _RayStrategyFactory:
         registry = self.ptl_registry[name]
 
         # Check if the strategy is in the list of supported strategies
-        if name not in self.strategy_whitelist:
-            raise ValueError(f"LightningTrainer doesn't support {name} yet. Please choose from {self.strategy_whitelist}.")
+        if name not in self.whitelist:
+            raise ValueError(f"LightningTrainer doesn't support {name} yet. Please choose from {self.whitelist}.")
 
         strategy_cls = registry["strategy"]
         ray_strategy_cls = self.ray_registry[strategy_cls]

--- a/python/ray/train/lightning/lightning_trainer.py
+++ b/python/ray/train/lightning/lightning_trainer.py
@@ -140,17 +140,18 @@ class LightningConfigBuilder:
     def strategy(self, name: str = "ddp", **kwargs) -> "LightningConfigBuilder":
         """Set up the configurations of ``pytorch_lightning.strategies.Strategy``.
 
-        The entire list of available strategies can be accessed in
-        `pytorch_lightning.strategies.StrategyRegistry`. As of the current
-        implementation, only the strategies of the classes `DDPStrategy`,
-        `FSDPStrategy`, and `DeepSpeedStrategy` are supported.
+        A full list of available strategy names can be accessed in 
+        `pytorch_lightning.strategies.StrategyRegistry`. As of the current 
+        implementation, only strategies of the "DDPStrategy", "FSDPStrategy" 
+        and "DeepSpeedStrategy" classes are supported.
 
         Args:
-            name: The name of your distributed strategy. Possible options include
+            name: The name of your training strategy. Possible options include
                 "ddp", "fsdp", "deepspeed", and other variants. Default: "ddp".
-            kwargs: Initialization parameters for the strategy object. If you specified
-                a registered strategy with init params (e.g. deepspeed_stage_2_offload),
-                the kwargs specified here will update the original init params.
+            kwargs: Initialization parameters for the strategy object. If you 
+                specify a registered strategy name with a predefined parameter 
+                list (e.g. deepspeed_stage_2_offload), the kwargs here will 
+                update the original initialization parameters.
 
                 For valid arguments to pass, please refer to:
                 ddp:

--- a/python/ray/train/tests/test_lightning_trainer.py
+++ b/python/ray/train/tests/test_lightning_trainer.py
@@ -196,11 +196,11 @@ def test_trainer_with_categorical_ray_data(ray_start_6_cpus_2_gpus, accelerator)
 
 def test_strategy_factory():
     # Test unsupported strategy names in the whitelist
-    for name in RayStrategyFactory.strategy_whitelist:
+    for name in RayStrategyFactory.whitelist:
         RayStrategyFactory.create_strategy(name)
 
     # Test unsupported strategy names
-    unsupported_list = StrategyRegistry.keys() - RayStrategyFactory.strategy_whitelist
+    unsupported_list = StrategyRegistry.keys() - RayStrategyFactory.whitelist
     for name in unsupported_list:
         with pytest.raises(
             ValueError, match=f"LightningTrainer doesn't support {name} yet.*"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Support DeepSpeedStrategy for LightningTrainer.

Previously we only support DDP and FSDP strategy in LightningTrianer. Now many users are currently using deepspeed for model parallelism to train large models, and it is necessary for us to support Deepspeed in LightningTrainer. 

This PR mainly include the following changes:
- Integrated `DeepSpeedStrategy` in `LightningTrainer` 
- Create a `RayStrategyFactory` to generate Strategy objects from registered names.

TODO:
- Write an end-to-end example that illustrate the usage of deepspeed with LightningTrainer.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #35913 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
