### PR TITLE
[Java] Upgrade TestNG to patch CVEs

### DIFF
--- a/java/dependencies.bzl
+++ b/java/dependencies.bzl
@@ -33,7 +33,7 @@ def gen_java_deps():
             maven.artifact(
                 group = "org.testng",
                 artifact = "testng",
-                version = "7.8.0",
+                version = "7.5.1",
                 exclusions = [
                     "com.google.guava:guava",
                 ]

--- a/java/dependencies.bzl
+++ b/java/dependencies.bzl
@@ -33,7 +33,7 @@ def gen_java_deps():
             maven.artifact(
                 group = "org.testng",
                 artifact = "testng",
-                version = "7.3.0",
+                version = "7.8.0",
                 exclusions = [
                     "com.google.guava:guava",
                 ]

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
-        <version>7.8.0</version>
+        <version>7.5.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
-        <version>7.3.0</version>
+        <version>7.8.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Why are these changes needed?

* TestNG has vulnerabilities in [7.3.0](https://mvnrepository.com/artifact/org.testng/testng/7.3.0). 
* Closes https://github.com/ray-project/ray/issues/35949

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

# Verification
Running `bazelisk query 'deps(//java:ray_dist_shaded.jar)'  --nohost_deps --output xml` to find `snakeyaml` as a dependency. It appears when this is 7.3.0, but not when this is 7.8.0

Graph of reverse deps (`bazelisk query 'rdeps(//java:ray_dist_shaded.jar, @maven//:org_yaml_snakeyaml)'`):

![graphviz](https://github.com/ray-project/ray/assets/21353794/1f755fdc-281d-4bed-999e-a5d92fac93c7)

After the upgrade:
```
(base) ilr@ilr-X5VXYX5M43 ray % bazelisk query 'rdeps(//java:ray_dist_shaded.jar, @maven//:org_yaml_snakeyaml)'  --nohost_deps --output graph 
DEBUG: /Users/ilr/ray/bazel/ray_deps_setup.bzl:67:14: No implicit mirrors used because urls were explicitly provided
ERROR: no such target '@maven//:org_yaml_snakeyaml': target 'org_yaml_snakeyaml' not declared in package '' defined by /private/var/tmp/_bazel_ilr/1a3fc7eeaca49f981ccc8f4351af12a6/external/maven/BUILD
Loading: 1 packages loaded
```