### PR TITLE
[data] DataContext not propagated properly for streaming_split() operator

### DIFF
--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -11,7 +11,6 @@ from ray.data._internal.execution.operators.output_splitter import OutputSplitte
 from ray.data._internal.execution.streaming_executor import StreamingExecutor
 from ray.data._internal.stats import DatasetStats
 from ray.data.block import Block, BlockMetadata
-from ray.data.context import DataContext
 from ray.data.iterator import DataIterator
 from ray.types import ObjectRef
 from ray.util.debug import log_once
@@ -42,15 +41,13 @@ class StreamSplitDataIterator(DataIterator):
 
         See also: `Dataset.streaming_split`.
         """
-        ctx = DataContext.get_current()
-
         # To avoid deadlock, the concurrency on this actor must be set to at least `n`.
         coord_actor = SplitCoordinator.options(
             max_concurrency=n,
             scheduling_strategy=NodeAffinitySchedulingStrategy(
                 ray.get_runtime_context().get_node_id(), soft=False
             ),
-        ).remote(ctx, base_dataset, n, equal, locality_hints)
+        ).remote(base_dataset, n, equal, locality_hints)
 
         return [
             StreamSplitDataIterator(base_dataset, coord_actor, i, n) for i in range(n)
@@ -119,7 +116,6 @@ class SplitCoordinator:
 
     def __init__(
         self,
-        ctx: DataContext,
         dataset: "Dataset",
         n: int,
         equal: bool,
@@ -127,10 +123,9 @@ class SplitCoordinator:
     ):
         # Automatically set locality with output to the specified location hints.
         if locality_hints:
-            ctx.execution_options.locality_with_output = locality_hints
+            dataset.context.execution_options.locality_with_output = locality_hints
             logger.info(f"Auto configuring locality_with_output={locality_hints}")
 
-        DataContext._set_current(ctx)
         self._base_dataset = dataset
         self._n = n
         self._equal = equal
@@ -144,7 +139,9 @@ class SplitCoordinator:
 
         def gen_epochs():
             while True:
-                executor = StreamingExecutor(copy.deepcopy(ctx.execution_options))
+                executor = StreamingExecutor(
+                    copy.deepcopy(dataset.context.execution_options)
+                )
 
                 def add_split_op(dag):
                     return OutputSplitter(dag, n, equal, locality_hints)

--- a/python/ray/data/tests/test_context_propagation.py
+++ b/python/ray/data/tests/test_context_propagation.py
@@ -34,10 +34,17 @@ def test_context_saved_when_dataset_created(ray_start_regular_shared):
     def check2(d):
         d.take()
 
+    @ray.remote(num_cpus=0)
+    def check3(d):
+        list(d.streaming_split(1)[0].iter_batches())
+
     d1.context.execution_options.resource_limits.cpu = 0.1
     with pytest.raises(ValueError):
         ray.get(check2.remote(d1))
+    with pytest.raises(ValueError):
+        ray.get(check3.remote(d1))
     ray.get(check2.remote(d2))
+    ray.get(check3.remote(d2))
 
 
 def test_read(ray_start_regular_shared):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The context captured by the Dataset was not properly propagated to streaming split. This means that the Train<>Data integration execution options didn't work.