### PR TITLE
[RLlib] Remove legacy (<1.9.0) torch versions

### DIFF
--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -241,7 +241,7 @@
   instance_size: medium
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - TORCH_VERSION=1.6 ./ci/env/install-dependencies.sh
+    - TORCH_VERSION=1.9.0 ./ci/env/install-dependencies.sh
     - 'git clone https://github.com/wg/wrk.git /tmp/wrk && pushd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin && popd'
     - ./ci/env/env_info.sh
     - bazel test --config=ci $(./ci/run/bazel_export_options)
@@ -259,7 +259,7 @@
   instance_size: large
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - TORCH_VERSION=1.6 ./ci/env/install-dependencies.sh
+    - TORCH_VERSION=1.9.0 ./ci/env/install-dependencies.sh
     - 'git clone https://github.com/wg/wrk.git /tmp/wrk && pushd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin && popd'
     - ./ci/env/env_info.sh
     - >-
@@ -286,7 +286,7 @@
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
     - echo "--- Setting up Python 3.7 environment."
-    - TORCH_VERSION=1.6 ./ci/env/install-dependencies.sh
+    - TORCH_VERSION=1.9.0 ./ci/env/install-dependencies.sh
     # Specifying above somehow messes up the Ray install.
     # Uninstall and re-install Ray so that we can use Ray Client.
     # (Remove thirdparty_files to sidestep an issue with psutil.)

--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -111,7 +111,7 @@ steps:
   conditions: ["RAY_CI_CORE_CPP_AFFECTED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DASHBOARD_AFFECTED"]
   commands:
     - *prelude_commands
-    - TORCH_VERSION=1.6 ./ci/env/install-dependencies.sh
+    - TORCH_VERSION=1.9.0 ./ci/env/install-dependencies.sh
     # Use --dynamic_mode=off until MacOS CI runs on Big Sur or newer. Otherwise there are problems with running tests
     # with dynamic linking.
     - bazel test --config=ci --dynamic_mode=off --test_env=CI $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-post_wheel_build --

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -431,10 +431,6 @@ install_pip_packages() {
       if [ -n "${TORCH_VERSION-}" ]; then
         case "${TORCH_VERSION-1.9.0}" in
           1.9.0) TORCHVISION_VERSION=0.10.0;;
-          1.8.1) TORCHVISION_VERSION=0.9.1;;
-          1.6) TORCHVISION_VERSION=0.7.0;;
-          1.5) TORCHVISION_VERSION=0.6.0;;
-          *) TORCHVISION_VERSION=0.5.0;;
         esac
         # Install right away, as some dependencies (e.g. torch-spline-conv) need
         # torch to be installed for their own install.


### PR DESCRIPTION
## Why are these changes needed?

The serve test in question is failing because RLlib from now on depends on torch>= 1.7.0.
The serve test in question installs torch 1.6.0, which is three years old and we might want to get rid of that dependency anyway.
<img width="631" alt="Screenshot 2023-06-02 at 13 55 39" src="https://github.com/ray-project/ray/assets/9356806/76883356-acc8-463f-983e-6d2a835b3e5e">


Error:
https://buildkite.com/ray-project/oss-ci-build-branch/builds/4266#01887d57-3828-475b-b6cc-7d42b5cb5ac5
<img width="631" alt="Screenshot 2023-06-02 at 13 54 39" src="https://github.com/ray-project/ray/assets/9356806/9e488310-910e-4e9b-a402-fbc98dc631f3">
