### PR TITLE
[Linter] Fix interfaces.py linter error

### DIFF
--- a/python/ray/data/_internal/block_batching/interfaces.py
+++ b/python/ray/data/_internal/block_batching/interfaces.py
@@ -1,5 +1,4 @@
 import abc
-
 from dataclasses import dataclass
 from typing import Any, List
 


### PR DESCRIPTION
## Why are these changes needed?

Linter is currently broken on master for interfaces.py

<img width="920" alt="Screenshot 2023-06-02 at 14 14 41" src="https://github.com/ray-project/ray/assets/9356806/3f318003-eb3c-4557-8f70-acbdec3cbbac">
