### PR TITLE
[RLlib] Make test_single_agent_gym_env_runner medium sized test

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1658,7 +1658,7 @@ py_test(
 py_test(
     name = "env/tests/test_single_agent_gym_env_runner",
     tags = ["team:rllib", "env"],
-    size = "small",
+    size = "medium",
     srcs = ["env/tests/test_single_agent_gym_env_runner.py"]
 )
 


### PR DESCRIPTION
## Why are these changes needed?

test_single_agent_gym_env_runner is flakey on master. It likes to time out 🙂 


<img width="920" alt="Screenshot 2023-06-02 at 14 31 15" src="https://github.com/ray-project/ray/assets/9356806/8b55b042-68d6-49a4-b007-2ace4a7fdd4c">
