### PR TITLE
[Tune] Add optimizer kwargs for `SkOptSearch`

### DIFF
--- a/python/ray/tune/search/skopt/skopt_search.py
+++ b/python/ray/tune/search/skopt/skopt_search.py
@@ -75,9 +75,10 @@ class SkOptSearch(Searcher):
         convert_to_python: SkOpt outputs numpy primitives (e.g.
             ``np.int64``) instead of Python types. If this setting is set
             to ``True``, the values will be converted to Python primitives.
-        optimizer_kwargs: Parameters to pass to the SkOpt optimizer when it's
-            not set through `optimizer`. (See ``skopt.optimizer.Optimizer``
-            for details of Parameters)
+        optimizer_kwargs: These Parameters will only be passed to the SkOpt
+            optimizer only if the `optimizer` argument of `SkOptSearch` is
+            set to `None`. (See ``skopt.optimizer.Optimizer`` for details
+            of Parameters)
 
     Tune automatically converts search spaces to SkOpt's format:
 

--- a/python/ray/tune/search/skopt/skopt_search.py
+++ b/python/ray/tune/search/skopt/skopt_search.py
@@ -75,8 +75,9 @@ class SkOptSearch(Searcher):
         convert_to_python: SkOpt outputs numpy primitives (e.g.
             ``np.int64``) instead of Python types. If this setting is set
             to ``True``, the values will be converted to Python primitives.
-        optimizer_kwargs: Parameters to pass to the SkOpt optimizer.
-            (See ``skopt.optimizer.Optimizer`` for details of Parameters)
+        optimizer_kwargs: Parameters to pass to the SkOpt optimizer when it's
+            not set through `optimizer`. (See ``skopt.optimizer.Optimizer``
+            for details of Parameters)
 
     Tune automatically converts search spaces to SkOpt's format:
 

--- a/python/ray/tune/search/skopt/skopt_search.py
+++ b/python/ray/tune/search/skopt/skopt_search.py
@@ -204,7 +204,10 @@ class SkOptSearch(Searcher):
         self._convert_to_python = convert_to_python
 
         self._skopt_opt = optimizer
-        self._skopt_opt_kwargs = optimizer_kwargs
+        if optimizer_kwargs is None:
+            self._skopt_opt_kwargs = {}
+        else:
+            self._skopt_opt_kwargs = optimizer_kwargs
         if self._skopt_opt or self._space:
             self._setup_skopt()
 

--- a/python/ray/tune/search/skopt/skopt_search.py
+++ b/python/ray/tune/search/skopt/skopt_search.py
@@ -75,7 +75,7 @@ class SkOptSearch(Searcher):
         convert_to_python: SkOpt outputs numpy primitives (e.g.
             ``np.int64``) instead of Python types. If this setting is set
             to ``True``, the values will be converted to Python primitives.
-        optimizer_kwargs: Parameters to pass to the SkOpt optimizer. 
+        optimizer_kwargs: Parameters to pass to the SkOpt optimizer.
             (See ``skopt.optimizer.Optimizer`` for details of Parameters)
 
     Tune automatically converts search spaces to SkOpt's format:
@@ -231,7 +231,9 @@ class SkOptSearch(Searcher):
                     "pass a valid `space` parameter."
                 )
 
-            self._skopt_opt = sko.Optimizer(self._parameter_ranges, **self._skopt_opt_kwargs)
+            self._skopt_opt = sko.Optimizer(
+                self._parameter_ranges, **self._skopt_opt_kwargs
+            )
 
         if self._points_to_evaluate and self._evaluated_rewards:
             skopt_points = [

--- a/python/ray/tune/tests/test_searchers.py
+++ b/python/ray/tune/tests/test_searchers.py
@@ -741,7 +741,15 @@ class SaveRestoreCheckpointTest(unittest.TestCase):
     def testSkopt(self):
         from ray.tune.search.skopt import SkOptSearch
 
-        searcher = SkOptSearch(space=self.config, metric=self.metric_name, mode="max")
+        searcher = SkOptSearch(
+            space=self.config,
+            metric=self.metric_name,
+            mode="max",
+            optimizer_kwargs={
+                "base_estimator": "GP",
+                "acq_func": "gp_hedge",
+            },
+        )
         self._save(searcher)
 
         searcher = SkOptSearch()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It adds more flexibility to customize the SkOpt Optimizer through `ray.tune.search.skopt.skopt_search.SkOptSearch`.
<!-- Please give a short summary of the change and the problem this solves. -->
This PR added a `optimizer_kwargs` parameter to the `SkOptSearch` to allow user to change the parameters of SkOpt Optimizer. The docstring is also modifed according to this new parameter.


## Related issue number
N/A

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
