### PR TITLE
[RLlib] Enabling RLModule by default for PPO broke our doc-test. This fixes it.

### DIFF
--- a/doc/source/rllib/doc_code/training.py
+++ b/doc/source/rllib/doc_code/training.py
@@ -31,13 +31,15 @@ prep.transform(obs).shape
 import numpy as np
 from ray.rllib.algorithms.ppo import PPOConfig
 
-algo = (
+config = (
     PPOConfig()
     .environment("CartPole-v1")
     .framework("tf2")
+    .rl_module(_enable_rl_module_api=False)
+    .training(_enable_learner_api=False)
     .rollouts(num_rollout_workers=0)
-    .build()
 )
+algo = config.build()
 # <ray.rllib.algorithms.ppo.PPO object at 0x7fd020186384>
 
 policy = algo.get_policy()


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
