### PR TITLE
[air/output] Only wrap header columns in rich

### DIFF
--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -359,6 +359,7 @@ def _get_trial_table_data(
     param_keys: List[str],
     metric_keys: List[str],
     all_rows: bool = False,
+    wrap_headers: bool = False,
 ) -> _TrialTableData:
     """Generate a table showing the current progress of tuning trials.
 
@@ -369,6 +370,7 @@ def _get_trial_table_data(
             Including both default and user defined.
             Will only be shown if at least one trial is having the key.
         all_rows: Force to show all rows.
+        wrap_headers: If True, header columns can be wrapped with ``\n``.
 
     Returns:
         Trial table data, including header and trial table per each status.
@@ -390,11 +392,11 @@ def _get_trial_table_data(
 
     # get header from metric keys
     formatted_metric_columns = [
-        _max_len(k, max_len=max_column_length, wrap=True) for k in metric_keys
+        _max_len(k, max_len=max_column_length, wrap=wrap_headers) for k in metric_keys
     ]
 
     formatted_param_columns = [
-        _max_len(k, max_len=max_column_length, wrap=True) for k in param_keys
+        _max_len(k, max_len=max_column_length, wrap=wrap_headers) for k in param_keys
     ]
 
     metric_header = [
@@ -633,6 +635,7 @@ def _detect_reporter(
 
 class TuneReporterBase(ProgressReporter):
     _heartbeat_threshold = AirVerbosity.DEFAULT
+    _wrap_headers = False
 
     def __init__(
         self,
@@ -688,6 +691,7 @@ class TuneReporterBase(ProgressReporter):
             param_keys=self._inferred_params,
             metric_keys=all_metrics,
             all_rows=force_full_output,
+            wrap_headers=self._wrap_headers,
         )
         return result, trial_table_data
 
@@ -764,6 +768,8 @@ class TuneTerminalReporter(TuneReporterBase):
 
 
 class TuneRichReporter(TuneReporterBase):
+    _wrap_headers = True
+
     def __init__(
         self,
         verbosity: AirVerbosity,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In the Ray AIR status table, we currently always try to wrap header columns that are too long using a newline character. However, in the regular console output, this breaks the design. The wraps only work in the rich reporter. 

This PR updates the output module to not wrap headers columns per default (cut off instead).



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
