### PR TITLE
[RLlib] Fix broken rllib doc test

### DIFF
--- a/doc/source/rllib/doc_code/catalog_guide.py
+++ b/doc/source/rllib/doc_code/catalog_guide.py
@@ -41,7 +41,7 @@ catalog = Catalog(env.observation_space, env.action_space, model_config_dict={})
 # We expect a categorical distribution for CartPole.
 action_dist_class = catalog.get_action_dist_cls(framework="torch")
 # Therefore, we need `env.action_space.n` action distribution inputs.
-expected_action_dist_input_dims = (env.action_space.n,)
+expected_action_dist_input_dims = (int(env.action_space.n),)
 # Build an encoder that fits CartPole's observation space.
 encoder = catalog.build_encoder(framework="torch")
 # Build a suitable head model for the action distribution.

--- a/rllib/algorithms/ppo/ppo_rl_module.py
+++ b/rllib/algorithms/ppo/ppo_rl_module.py
@@ -9,6 +9,7 @@ from ray.rllib.core.models.base import ActorCriticEncoder
 from ray.rllib.core.models.specs.specs_dict import SpecDict
 from ray.rllib.core.rl_module.rl_module import RLModule
 from ray.rllib.models.distributions import Distribution
+from ray.rllib.models.tf.tf_distributions import TfDeterministic
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import ExperimentalAPI
 from ray.rllib.utils.annotations import override
@@ -37,7 +38,7 @@ class PPORLModule(RLModule, abc.ABC):
         return self.action_dist_cls
 
     def get_inference_action_dist_cls(self) -> Type[Distribution]:
-        return self.action_dist_cls
+        return TfDeterministic
 
     @override(RLModule)
     def get_initial_state(self) -> dict:

--- a/rllib/algorithms/ppo/tf/ppo_tf_rl_module.py
+++ b/rllib/algorithms/ppo/tf/ppo_tf_rl_module.py
@@ -26,7 +26,8 @@ class PPOTfRLModule(TfRLModule, PPORLModule):
 
         # Actions
         action_logits = self.pi(encoder_outs[ENCODER_OUT][ACTOR])
-        output[SampleBatch.ACTION_DIST_INPUTS] = action_logits
+        loc = tf.math.argmax(tf.math.softmax(tf.math.exp(action_logits)), axis=1)
+        output[SampleBatch.ACTION_DIST_INPUTS] = loc
 
         return output
 


### PR DESCRIPTION
Signed-off-by: Avnish <avnishnarayan@gmail.com>

The rllib doc code in training.py for PPO
    assumes that the PPO is using the old non-learner
    non-rl-module APIs, so this pr fixes that by
    updating the training.py example to show how to use
    forward_train, forward_inference, and forward_exploration

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
