### PR TITLE
[RLlib] Fix failing catalog docs include

### DIFF
--- a/doc/source/rllib/rllib-catalogs.rst
+++ b/doc/source/rllib/rllib-catalogs.rst
@@ -149,7 +149,7 @@ Inject your custom model or action distributions into RLModules
 You can make a :py:class:`~ray.rllib.core.models.catalog.Catalog` build custom ``models`` by overriding the Catalog’s methods used by RLModules to build ``models``.
 Have a look at these lines from the constructor of the :py:class:`~ray.rllib.algorithms.ppo.ppo_torch_rl_module.PPOTorchRLModule` to see how Catalogs are being used by an :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule`:
 
-.. literalinclude:: ../../../rllib/algorithms/ppo/ppo_base_rl_module.py
+.. literalinclude:: ../../../rllib/algorithms/ppo/ppo_rl_module.py
     :language: python
     :start-after: __sphinx_doc_begin__
     :end-before: __sphinx_doc_end__


### PR DESCRIPTION
## Why are these changes needed?

In the space indicated in the below picture, there is an include missing.
This is because we moved the related file.

The long term fix is to not include the constructor here, as has been discussed before.
But this bug is also in the 2.5.0 docs, so we should go with the short-term fix for now and make it a small pick for 2.5.0.

<img width="802" alt="Screenshot 2023-06-05 at 12 58 18" src="https://github.com/ray-project/ray/assets/9356806/111f58be-00e1-4227-a869-540b3c6c6bf5">
