### PR TITLE
[Experimental] Raysort: clean up logging configuration

### DIFF
--- a/python/ray/experimental/raysort/logging_utils.py
+++ b/python/ray/experimental/raysort/logging_utils.py
@@ -1,9 +1,0 @@
-import logging
-
-
-def init():
-    fmt = "%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
-    logging.basicConfig(
-        format=fmt,
-        level=logging.INFO,
-    )


### PR DESCRIPTION
## Why are these changes needed?

This PR cleans up the logging configuration in `raysort`. This PR was broken off from a [separate logging configuration cleanup PR](https://github.com/ray-project/ray/pull/33821).

Changes:
* Log messages are now handled by the appropriate module-level loggers instead of the root logger
* Removed `python/ray/experimental/raysort/logging_utils.py`, as it was just calling `basicConfig` to set up a root logger. These are library level log messages; the configuration of the root logger should be left to the user.

## Related issue number

* See https://github.com/ray-project/ray/pull/33821 for discussion.
* See https://github.com/ray-project/ray/issues/30005 for the original RFC.
* See https://github.com/ray-project/ray/pull/35690 for the related RLlib PR.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
