### PR TITLE
[util] NVIDIA_TESLA_A100 -> NVIDIA_AMPERE_A100

### DIFF
--- a/python/ray/util/accelerators/accelerators.py
+++ b/python/ray/util/accelerators/accelerators.py
@@ -3,5 +3,9 @@ NVIDIA_TESLA_P100 = "P100"
 NVIDIA_TESLA_T4 = "T4"
 NVIDIA_TESLA_P4 = "P4"
 NVIDIA_TESLA_K80 = "K80"
-NVIDIA_TESLA_A100 = "A100"
 NVIDIA_TESLA_A10G = "A10G"
+
+NVIDIA_AMPERE_A100 = "A100"
+
+# A100 is not an Nvidia Tesla, but this name was used by mistake, and is kept for backward compatibility.
+NVIDIA_TESLA_A100 = NVIDIA_AMPERE_A100

--- a/python/ray/util/accelerators/accelerators.py
+++ b/python/ray/util/accelerators/accelerators.py
@@ -7,5 +7,6 @@ NVIDIA_TESLA_A10G = "A10G"
 
 NVIDIA_AMPERE_A100 = "A100"
 
-# A100 is not an Nvidia Tesla, but this name was used by mistake, and is kept for backward compatibility.
+# A100 is not an Nvidia Tesla, but this name was used by mistake.
+# It is kept for backward compatibility.
 NVIDIA_TESLA_A100 = NVIDIA_AMPERE_A100


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

One minor issue I noticed in this file: https://github.com/ray-project/ray/blob/master/python/ray/util/accelerators/accelerators.py#L6
A100 is not an NVIDIA Tesla architecture processor [it is the new Ampere architecture.](https://www.nvidia.com/en-us/data-center/a100/)

Here is a PR to add the corrected name (I kept. old name for backward compatibility) 

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
