### PR TITLE
[ci][fix] fix release tests

### DIFF
--- a/release/ray_release/alerts/default.py
+++ b/release/ray_release/alerts/default.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from ray_release.test import Test
-from ray_release.result import Result
+from ray_release.result import Result, ResultStatus
 
 
 def handle_result(
@@ -9,7 +9,7 @@ def handle_result(
     result: Result,
 ) -> Optional[str]:
 
-    if result.status != "finished":
+    if result.status != ResultStatus.SUCCESS.value:
         return f"Test script did not finish successfully ({result.status})."
 
     return None

--- a/release/ray_release/alerts/tune_tests.py
+++ b/release/ray_release/alerts/tune_tests.py
@@ -1,7 +1,10 @@
 from typing import Optional
 
 from ray_release.test import Test
-from ray_release.result import Result
+from ray_release.result import (
+    Result,
+    ResultStatus,
+)
 
 
 def handle_result(
@@ -11,7 +14,7 @@ def handle_result(
     test_name = test["name"]
 
     msg = ""
-    success = result.status == "finished"
+    success = result.status == ResultStatus.SUCCESS.value
     time_taken = result.results.get("time_taken", float("inf"))
     num_terminated = result.results.get("trial_states", {}).get("TERMINATED", 0)
     was_smoke_test = result.results.get("smoke_test", False)

--- a/release/ray_release/tests/test_alerts.py
+++ b/release/ray_release/tests/test_alerts.py
@@ -11,14 +11,18 @@ from ray_release.alerts import (
 )
 from ray_release.test import Test
 from ray_release.exception import ReleaseTestConfigError, ResultsAlert
-from ray_release.result import Result
+from ray_release.result import (
+    Result,
+    ResultStatus,
+)
 
 
 def test_handle_alert():
     # Unknown test suite
     with pytest.raises(ReleaseTestConfigError):
         handle.handle_result(
-            Test(name="unit_alert_test", alert="invalid"), Result(status="finished")
+            Test(name="unit_alert_test", alert="invalid"),
+            Result(status=ResultStatus.SUCCESS.value),
         )
 
     # Alert raised
@@ -30,14 +34,15 @@ def test_handle_alert():
 
     # Everything fine
     handle.handle_result(
-        Test(name="unit_alert_test", alert="default"), Result(status="finished")
+        Test(name="unit_alert_test", alert="default"),
+        Result(status=ResultStatus.SUCCESS.value),
     )
 
 
 def test_default_alert():
     test = Test(name="unit_alert_test", alert="default")
     assert default.handle_result(test, Result(status="timeout"))
-    assert not default.handle_result(test, Result(status="finished"))
+    assert not default.handle_result(test, Result(status=ResultStatus.SUCCESS.value))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?
A previous PR changed result.status to be the value of an enum (https://github.com/ray-project/ray/commit/f82e2e975b80127ec5c85d23250dca11e76ab360#diff-542132be3c6f0d88893d58435c5460eb5ec1a28999b98d30a87e8e8856e26965R387). This causes most of release tests to fail https://buildkite.com/ray-project/release-tests-pr/builds/41238#01888e32-4251-4337-91fe-fafdd4b1d39d since the error handler checks for the "finished" string.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- Testing Strategy
   - [X] Release tests