### PR TITLE
[core] Add logs for Redis leader discovery for observability.

### DIFF
--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -356,6 +356,7 @@ Status ConnectWithRetries(const std::string &address,
                           int port,
                           const RedisConnectFunction &connect_function,
                           RedisContext **context) {
+  RAY_LOG(INFO) << "Attempting to connect to address " << address << ":" << port << ".";
   int connection_attempts = 0;
   Status status = ConnectWithoutRetries(address, port, connect_function, context);
   while (!status.ok()) {
@@ -469,6 +470,8 @@ Status RedisContext::Connect(const std::string &address,
   RAY_CHECK(!ip_addresses.empty())
       << "Failed to resolve DNS for " << address << ":" << port;
 
+  RAY_LOG(INFO) << "Resolve Redis address to " << absl::StrJoin(ip_addresses, ", ");
+
   RAY_CHECK_OK(ConnectWithRetries(ip_addresses[0], port, redisConnect, &context_));
 
   if (enable_ssl) {
@@ -518,8 +521,10 @@ Status RedisContext::Connect(const std::string &address,
 
     Disconnect();
     // Connect to the true leader.
+    RAY_LOG(INFO) << "Redis cluster leader is " << parts[2] << ". Reconnect to it.";
     return Connect(ip_port[0], std::stoi(ip_port[1]), sharding, password, enable_ssl);
   } else {
+    RAY_LOG(INFO) << "Redis cluster leader is " << ip_addresses[0] << ":" << port;
     freeReplyObject(redis_reply);
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Right now, if there is a bug in finding the leader for Redis, it's hard to debug since there is no logs for this.

This PR prints logs for this.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
