### PR TITLE
add setting s3 endpoint-url via env var

### DIFF
--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -695,7 +695,10 @@ async def download_and_unpack_package(
                             "`pip install boto3` to fetch URIs in s3 "
                             "bucket. " + install_warning
                         )
-                    tp = {"client": boto3.client("s3")}
+                    s3_endpoint_url = os.environ.get(
+                        "S3_ENDPOINT_URL", None
+                    ) or os.environ.get("AWS_ENDPOINT_URL", None)
+                    tp = {"client": boto3.client("s3", endpoint_url=s3_endpoint_url)}
                 elif protocol == Protocol.GS:
                     try:
                         from google.cloud import storage  # noqa: F401


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Support providing custom S3 endpoint URL via environment variable.

This is needed for when `ray` is used with S3-like storage (MinIO, VAST, etc.)

I have added support for two standard env var names:

- `AWS_ENDPOINT_URL`
- `S3_ENDPOINT_URL`

I will update the docs accordingly once this is approved

## Related issue number

Closes #30601

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
