### PR TITLE
[ci][byod] add runtime_env setting for byod cluster

### DIFF
--- a/release/ray_release/command_runner/anyscale_job_runner.py
+++ b/release/ray_release/command_runner/anyscale_job_runner.py
@@ -222,13 +222,12 @@ class AnyscaleJobRunner(JobRunner):
         )
 
         full_env = self.get_full_command_env(env)
-        env_str = _get_env_str(full_env)
 
         no_raise_on_timeout_str = (
             " --test-no-raise-on-timeout" if not raise_on_timeout else ""
         )
         full_command = (
-            f"{env_str}python anyscale_job_wrapper.py '{command}' "
+            f"python anyscale_job_wrapper.py '{command}' "
             f"--test-workload-timeout {timeout}{no_raise_on_timeout_str} "
             "--results-cloud-storage-uri "
             f"'{join_cloud_storage_paths(self.upload_path, self._RESULT_OUTPUT_JSON)}' "

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -310,7 +310,7 @@ def _running_test_script(
     command_timeout: int,
 ) -> None:
     command = test["run"]["script"]
-    command_env = {}
+    command_env = test.get_byod_runtime_env()
 
     if smoke_test:
         command = f"{command} --smoke-test"

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -56,14 +56,13 @@ class AnyscaleJobManager:
         env = os.environ.copy()
         env.setdefault("ANYSCALE_HOST", str(ANYSCALE_HOST))
 
-        full_cmd = " ".join(f"{k}={v}" for k, v in env_vars.items()) + " " + cmd_to_run
         logger.info(f"Executing {cmd_to_run} with {env_vars} via Anyscale job submit")
 
         anyscale_client = self.sdk
 
-        runtime_env = None
+        runtime_env = {"env_vars": env_vars}
         if working_dir:
-            runtime_env = {"working_dir": working_dir}
+            runtime_env["working_dir"] = working_dir
             if upload_path:
                 runtime_env["upload_path"] = upload_path
 
@@ -74,7 +73,7 @@ class AnyscaleJobManager:
                     description=f"Smoke test: {self.cluster_manager.smoke_test}",
                     project_id=self.cluster_manager.project_id,
                     config=dict(
-                        entrypoint=full_cmd,
+                        entrypoint=cmd_to_run,
                         runtime_env=runtime_env,
                         build_id=self.cluster_manager.cluster_env_build_id,
                         compute_config_id=self.cluster_manager.cluster_compute_id,

--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -111,6 +111,9 @@
 				},
 				"pre_run_cmds": {
 					"type": "array"
+				},
+				"runtime_env": {
+					"type": "array"
 				}
 			},
 			"required": [

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -1,9 +1,12 @@
 import sys
 import os
+from unittest import mock
+
 import pytest
 
 from ray_release.test import (
     Test,
+    _convert_env_list_to_dict,
     DATAPLANE_ECR,
     DATAPLANE_ECR_REPO,
     DATAPLANE_ECR_ML_REPO,
@@ -25,6 +28,15 @@ def test_is_byod_cluster():
     assert not _stub_test({}).is_byod_cluster()
     assert _stub_test({"cluster": {"byod": {}}}).is_byod_cluster()
     assert _stub_test({"cluster": {"byod": {"type": "gpu"}}}).is_byod_cluster()
+
+
+def test_convert_env_list_to_dict():
+    with mock.patch.dict(os.environ, {"ENV": "env"}):
+        assert _convert_env_list_to_dict(["a=b", "c=d=e", "ENV"]) == {
+            "a": "b",
+            "c": "d=e",
+            "ENV": "env",
+        }
 
 
 def test_get_python_version():

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2224,8 +2224,8 @@
   team: core
   cluster:
     byod:
-      pre_run_cmds:
-        - export RLLIB_TEST_NO_JAX_IMPORT=1
+      runtime_env:
+        - RLLIB_TEST_NO_JAX_IMPORT=1
     cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
@@ -2337,8 +2337,8 @@
   team: core
   cluster:
     byod:
-      pre_run_cmds:
-        - export RLLIB_TEST_NO_JAX_IMPORT=1
+      runtime_env:
+        - RLLIB_TEST_NO_JAX_IMPORT=1
     cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
@@ -2377,8 +2377,8 @@
   team: core
   cluster:
     byod:
-      pre_run_cmds:
-        - export RLLIB_TEST_NO_JAX_IMPORT=1
+      runtime_env:
+        - RLLIB_TEST_NO_JAX_IMPORT=1
     cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
@@ -2458,8 +2458,8 @@
   team: core
   cluster:
     byod:
-      pre_run_cmds:
-        - export RLLIB_TEST_NO_JAX_IMPORT=1
+      runtime_env:
+        - RLLIB_TEST_NO_JAX_IMPORT=1
     cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
@@ -2498,8 +2498,8 @@
   team: core
   cluster:
     byod:
-      pre_run_cmds:
-        - export RLLIB_TEST_NO_JAX_IMPORT=1
+      runtime_env:
+        - RLLIB_TEST_NO_JAX_IMPORT=1
     cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
@@ -2538,8 +2538,8 @@
   team: core
   cluster:
     byod:
-      pre_run_cmds:
-        - export RLLIB_TEST_NO_JAX_IMPORT=1
+      runtime_env:
+        - RLLIB_TEST_NO_JAX_IMPORT=1
     cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
@@ -4547,8 +4547,8 @@
   team: core
   cluster:
     byod:
-      pre_run_cmds:
-        - export RAY_worker_killing_policy=retriable_lifo
+      runtime_env:
+        - RAY_worker_killing_policy=retriable_lifo
     cluster_env: shuffle/shuffle_app_config.yaml
     cluster_compute: shuffle/shuffle_compute_multi.yaml
 
@@ -4627,8 +4627,8 @@
   team: core
   cluster:
     byod:
-      pre_run_cmds:
-        - export RAY_worker_killing_policy=retriable_lifo
+      runtime_env:
+        - RAY_worker_killing_policy=retriable_lifo
     cluster_env: shuffle/shuffle_app_config.yaml
     cluster_compute: shuffle/shuffle_compute_autoscaling.yaml
 


### PR DESCRIPTION
## Why are these changes needed?
For BYOD release tests, we are currently using pre_run_cmds and export ENV_VAR=value to set runtime environment variable. That is a wrong approach since env_var is local in a subprocess, so setting them through pre_run_cmds do not populate the env_var globally.

- This PR use anyscale runtime_env feature to set runtime environment istead.
- Also add an option to control the test branch (BRANCH_TO_TEST) for easier testing
-
## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests - https://buildkite.com/ray-project/release-tests-pr/builds/41387#01889311-2c30-4073-8529-f2ea49cc96c2

Env var is set properly: https://console.anyscale-staging.com/o/anyscale-internal/configurations/runtime-env-production-job/prodjob_zryhhe7kmx1pciivhq7h917mfg
   