### PR TITLE
[CI][Docs] Preserve block order during doctest

### DIFF
--- a/bazel/conftest.py
+++ b/bazel/conftest.py
@@ -7,3 +7,9 @@ import ray
 def shutdown_ray():
     ray.shutdown()
     yield
+
+
+@pytest.fixture(autouse=True)
+def preserve_block_order():
+    ray.data.context.DataContext.get_current().execution_options.preserve_order = True
+    yield

--- a/doc/source/data/glossary.rst
+++ b/doc/source/data/glossary.rst
@@ -17,9 +17,6 @@ Ray Data Glossary
         .. doctest::
 
             >>> import ray
-            >>> # Dataset is executed by streaming executor by default, which doesn't
-            >>> # preserve the order, so we explicitly set it here.
-            >>> ray.data.context.DataContext.get_current().execution_options.preserve_order = True
             >>> dataset = ray.data.range(10)
             >>> next(iter(dataset.iter_batches(batch_format="numpy", batch_size=5)))
             {'id': array([0, 1, 2, 3, 4])}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Ray Data is non-deterministic. As a result, the `:book: Doctest (CPU)` CI sometimes fails like this:

```
    2004             >>> ds = ray.data.range(1000)
  | 2005             >>> ds.limit(5).take_batch()
  | Expected:
  | {'id': array([0, 1, 2, 3, 4])}
  | Got:
  | {'id': array([124, 125, 126, 127, 128])}
```

To decrease flakiness, this PR enables the preserve block order feature.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
