### PR TITLE
[ci][test-tests/7(final)] move tests to jail

### DIFF
--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -31,6 +31,9 @@ class MockIssue:
     def create_comment(self, comment: str):
         self.comments.append(comment)
 
+    def get_labels(self):
+        return self.labels
+
 
 class MockIssueDB:
     issue_id = 1
@@ -142,6 +145,33 @@ def test_move_from_failing_to_passing():
     assert test.get_state() == TestState.PASSING
     assert test.get(Test.KEY_GITHUB_ISSUE_NUMBER) is None
     assert test.get(Test.KEY_BISECT_BUILD_NUMBER) is None
+
+
+def test_move_from_failing_to_jailed():
+    test = Test(name="test", team="devprod")
+    test.test_results = [
+        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
+        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
+        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
+        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
+    ]
+    sm = TestStateMachine(test)
+    sm.move()
+    assert test.get_state() == TestState.CONSITENTLY_FAILING
+    test.test_results.insert(
+        0,
+        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
+    )
+    sm = TestStateMachine(test)
+    sm.move()
+    assert test.get_state() == TestState.JAILED
+    test.test_results.insert(
+        0,
+        TestResult.from_result(Result(status=ResultStatus.SUCCESS.value)),
+    )
+    sm = TestStateMachine(test)
+    sm.move()
+    assert test.get_state() == TestState.PASSING
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?
**Context:** This is a series of PR to compute test state (JAILED|PASSING|FAILING) on-the-fly, persist them into DB and create issues and bisect automatically, etc.
- Move tests to jail when it has been failing 5 times in a row
- Move it out of jailed if it starts passing again

Probably final PR in this test state series

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   