### PR TITLE
[ci][test-states/8(final-2)] skip running jailed tests

### DIFF
--- a/release/ray_release/buildkite/filter.py
+++ b/release/ray_release/buildkite/filter.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Tuple, Dict, Any
 
 from ray_release.buildkite.settings import Frequency, get_frequency
 from ray_release.test import Test
+from ray_release.test_automation.state_machine import TestStateMachine
 
 
 def _unflattened_lookup(lookup: Dict, flat_key: str, delimiter: str = "/") -> Any:
@@ -36,8 +37,12 @@ def filter_tests(
                 break
         if attr_mismatch:
             continue
-        if not run_jailed_tests and test.get("jailed", False):
-            continue
+        if not run_jailed_tests:
+            if test.get("jailed", False):
+                continue
+            test.update_from_s3()
+            if test.is_jailed_with_open_issue(TestStateMachine.get_ray_repo()):
+                continue
 
         test_frequency = get_frequency(test["frequency"])
 

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 import boto3
 from botocore.exceptions import ClientError
+from github import Repository
 
 from ray_release.result import (
     ResultStatus,
@@ -90,6 +91,22 @@ class Test(dict):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.test_results = None
+
+    def is_jailed_with_open_issue(self, ray_github: Repository) -> bool:
+        """
+        Returns whether this test is jailed with open issue.
+        """
+        # is jailed
+        state = self.get_state()
+        if state != TestState.JAILED:
+            return False
+
+        # has open issue
+        issue_number = self.get(self.KEY_GITHUB_ISSUE_NUMBER)
+        if issue_number is None:
+            return False
+        issue = ray_github.get_issue(issue_number)
+        return issue.state == "open"
 
     def is_byod_cluster(self) -> bool:
         """

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -35,13 +35,26 @@ class TestStateMachine:
     def __init__(self, test: Test) -> None:
         self.test = test
         self.test_results = test.get_test_results()
-        if not self.ray_repo:
+        TestStateMachine._init_ray_repo()
+        TestStateMachine._init_ray_buildkite()
+
+    @classmethod
+    def _init_ray_repo(cls):
+        if not cls.ray_repo:
             github_token = get_secret_token(AWS_SECRET_GITHUB)
-            self.ray_repo = Github(github_token).get_repo(RAY_REPO)
-        if not self.ray_buildkite:
+            cls.ray_repo = Github(github_token).get_repo(RAY_REPO)
+
+    @classmethod
+    def get_ray_repo(cls):
+        cls.init_ray_repo()
+        return cls.ray_repo
+
+    @classmethod
+    def _init_ray_buildkite(cls):
+        if not cls.ray_buildkite:
             buildkite_token = get_secret_token(AWS_SECRET_BUILDKITE)
-            self.ray_buildkite = Buildkite()
-            self.ray_buildkite.set_access_token(buildkite_token)
+            cls.ray_buildkite = Buildkite()
+            cls.ray_buildkite.set_access_token(buildkite_token)
 
     def move(self) -> None:
         """
@@ -51,6 +64,7 @@ class TestStateMachine:
         to_state = self._next_state(from_state)
         self.test.set_state(to_state)
         self._move_hook(from_state, to_state)
+        self._state_hook(to_state)
 
     def _next_state(self, current_state) -> TestState:
         """
@@ -102,6 +116,15 @@ class TestStateMachine:
         elif change == (TestState.JAILED, TestState.PASSING):
             self._close_github_issue()
             self.test.pop(Test.KEY_BISECT_BUILD_NUMBER, None)
+
+    def _state_hook(self, state: TestState) -> None:
+        """
+        Action performed when test is in a particular state. This is where we do things
+        to keep an invariant for a state. For example, we can keep the github issue open
+        if the test is failing.
+        """
+        if state == TestState.JAILED:
+            self._keep_github_issue_open()
 
     def _jail_test(self) -> None:
         """
@@ -206,6 +229,19 @@ class TestStateMachine:
         issue.create_comment(f"Test passed on latest run: {self.test_results[0].url}")
         issue.edit(state="closed")
         self.test.pop(Test.KEY_GITHUB_ISSUE_NUMBER, None)
+
+    def _keep_github_issue_open(self) -> None:
+        github_issue_number = self.test.get(Test.KEY_GITHUB_ISSUE_NUMBER)
+        if not github_issue_number:
+            return
+        issue = self.ray_repo.get_issue(github_issue_number)
+        if issue.state == "open":
+            return
+        issue.edit(state="open")
+        issue.create_comment(
+            "Re-opening issue as test is still failing. "
+            f"Latest run: {self.test_results[0].url}"
+        )
 
     def _jailed_to_passing(self) -> bool:
         return len(self.test_results) > 0 and self.test_results[0].is_passing()

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -374,7 +374,13 @@ class BuildkiteSettingsTest(unittest.TestCase):
         filtered = filter_tests(*args, **kwargs)
         return [(t[0]["name"], t[1]) for t in filtered]
 
-    def testFilterTests(self):
+    @patch("ray_release.test.Test.update_from_s3", return_value=None)
+    @patch("ray_release.test.Test.is_jailed_with_open_issue", return_value=False)
+    @patch(
+        "ray_release.test_automation.state_machine.TestStateMachine.get_ray_repo",
+        return_value=None,
+    )
+    def testFilterTests(self, *args):
         tests = [
             Test(
                 {

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -167,6 +167,20 @@ def test_move_from_failing_to_jailed():
     sm = TestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.JAILED
+
+    # Test moving from jailed to jailed
+    issue = MockIssueDB.issue_db[test.get(Test.KEY_GITHUB_ISSUE_NUMBER)]
+    issue.edit(state="closed")
+    test.test_results.insert(
+        0,
+        TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
+    )
+    sm = TestStateMachine(test)
+    sm.move()
+    assert test.get_state() == TestState.JAILED
+    assert issue.state == "open"
+
+    # Test moving from jailed to passing
     test.test_results.insert(
         0,
         TestResult.from_result(Result(status=ResultStatus.SUCCESS.value)),
@@ -174,6 +188,8 @@ def test_move_from_failing_to_jailed():
     sm = TestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.PASSING
+    assert test.get(Test.KEY_GITHUB_ISSUE_NUMBER) is None
+    assert issue.state == "closed"
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -3,6 +3,7 @@ import os
 from unittest import mock
 
 import pytest
+from unittest.mock import patch
 
 from ray_release.test import (
     Test,
@@ -84,6 +85,21 @@ def test_get_anyscale_byod_image():
             }
         ).get_anyscale_byod_image()
         == f"{DATAPLANE_ECR}/{DATAPLANE_ECR_ML_REPO}:123456-py38-gpu"
+    )
+
+
+@patch("github.Repository")
+@patch("github.Issue")
+def test_is_jailed_with_open_issue(mock_repo, mock_issue) -> None:
+    assert not Test(state="passing").is_jailed_with_open_issue(mock_repo)
+    mock_repo.get_issue.return_value = mock_issue
+    mock_issue.state = "open"
+    assert Test(state="jailed", github_issue_number="1").is_jailed_with_open_issue(
+        mock_repo
+    )
+    mock_issue.state = "closed"
+    assert not Test(state="jailed", github_issue_number="1").is_jailed_with_open_issue(
+        mock_repo
     )
 
 


### PR DESCRIPTION
## Why are these changes needed?
**Context:** This is a series of PR to compute test state (JAILED|PASSING|FAILING) on-the-fly, persist them into DB and create issues and bisect automatically, etc.

- Stop running tests that are in jailed state and have existing issues opened
- Make sure to keep jailed github issue open if test is still failing

Indeed the final PR in this test state series

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests