### PR TITLE
[serve] Clean up `num_returns` and `http_arg_is_pickled` fields

### DIFF
--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -439,7 +439,7 @@ class ServeControllerClient:
         deployment_name: str,
         missing_ok: Optional[bool] = False,
         sync: bool = True,
-        _internal_pickled_http_request: bool = False,
+        _is_for_http_requests: bool = False,
         _stream: bool = False,
     ) -> Union[RayServeHandle, RayServeSyncHandle]:
         """Retrieve RayServeHandle for service deployment to invoke it from Python.
@@ -451,7 +451,7 @@ class ServeControllerClient:
             sync: If true, then Serve will return a ServeHandle that
                 works everywhere. Otherwise, Serve will return a ServeHandle
                 that's only usable in asyncio loop.
-            _internal_pickled_http_request: Indicates that this handle will be used
+            _is_for_http_requests: Indicates that this handle will be used
                 to send HTTP requests from the proxy to ingress deployment replicas.
             _stream: Indicates that this handle should use
                 `num_returns="streaming"`.
@@ -473,14 +473,14 @@ class ServeControllerClient:
             handle = RayServeSyncHandle(
                 self._controller,
                 deployment_name,
-                _internal_pickled_http_request=_internal_pickled_http_request,
+                _is_for_http_requests=_is_for_http_requests,
                 _stream=_stream,
             )
         else:
             handle = RayServeHandle(
                 self._controller,
                 deployment_name,
-                _internal_pickled_http_request=_internal_pickled_http_request,
+                _is_for_http_requests=_is_for_http_requests,
                 _stream=_stream,
             )
 

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -340,7 +340,7 @@ class HTTPProxy:
                 name,
                 sync=False,
                 missing_ok=True,
-                _internal_pickled_http_request=True,
+                _is_for_http_requests=True,
                 _stream=RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING,
             )
 

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -83,7 +83,7 @@ logger = logging.getLogger(SERVE_LOGGER_NAME)
 def parse_request_item(request_item):
     if len(request_item.args) == 1:
         arg = request_item.args[0]
-        if request_item.metadata.http_arg_is_pickled:
+        if request_item.metadata.is_http_request:
             assert isinstance(arg, bytes)
             arg: HTTPRequestWrapper = pickle.loads(arg)
             return (build_starlette_request(arg.scope, arg.body),), {}

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -118,14 +118,14 @@ class RayServeHandle:
         handle_options: Optional[HandleOptions] = None,
         *,
         _router: Optional[Router] = None,
-        _internal_pickled_http_request: bool = False,
+        _is_for_http_requests: bool = False,
         _stream: bool = False,
     ):
         self.controller_handle = controller_handle
         self.deployment_name = deployment_name
         self.handle_options = handle_options or HandleOptions()
         self.handle_tag = f"{self.deployment_name}#{get_random_letters()}"
-        self._pickled_http_request = _internal_pickled_http_request
+        self._is_for_http_requests = _is_for_http_requests
         self._stream = _stream
 
         self.request_counter = metrics.Counter(
@@ -190,7 +190,7 @@ class RayServeHandle:
             self.deployment_name,
             new_options,
             _router=self.router,
-            _internal_pickled_http_request=self._pickled_http_request,
+            _is_for_http_requests=self._is_for_http_requests,
         )
 
     def options(
@@ -221,7 +221,7 @@ class RayServeHandle:
             _request_context.request_id,
             deployment_name,
             call_method=handle_options.method_name,
-            http_arg_is_pickled=self._pickled_http_request,
+            is_http_request=self._is_for_http_requests,
             route=_request_context.route,
             app_name=_request_context.app_name,
             multiplexed_model_id=_request_context.multiplexed_model_id,
@@ -269,7 +269,7 @@ class RayServeHandle:
             "controller_handle": self.controller_handle,
             "deployment_name": self.deployment_name,
             "handle_options": self.handle_options,
-            "_internal_pickled_http_request": self._pickled_http_request,
+            "_is_for_http_requests": self._is_for_http_requests,
         }
         return RayServeHandle._deserialize, (serialized_data,)
 
@@ -363,7 +363,7 @@ class RayServeSyncHandle(RayServeHandle):
             "controller_handle": self.controller_handle,
             "deployment_name": self.deployment_name,
             "handle_options": self.handle_options,
-            "_internal_pickled_http_request": self._pickled_http_request,
+            "_is_for_http_requests": self._is_for_http_requests,
         }
         return RayServeSyncHandle._deserialize, (serialized_data,)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Carving off more independent cleanups from https://github.com/ray-project/ray/pull/35953

`num_returns` is not necessary (just do it in the caller) and `http_arg_is_pickled` is an implementation detail.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
