### PR TITLE
[Docs] Picks [docs] kapa ask our docs widget

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -638,4 +638,22 @@ padding: 20px;
     font-weight: 500;
 }
 
+.mantine-Modal-root {
+  z-index: 10000;
+  position: absolute;
+}
+
+.mantine-Button-root{
+    bottom: 60px !important;
+}
+
+#kapa-widget-container {
+  z-index: 10000 !important;
+  position: absolute !important;
+}
+
+.mantine-1sc70ew, .mantine-fp9t1o {
+    width: 100% !important;
+    height: 100% !important;
+}
 

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -15,6 +15,14 @@
   gtag('config', 'UA-110413294-1');
 </script>
 
+<script
+  src="https://widget.kapa.ai/kapa-widget.bundle.js"
+  data-website-id="18a8c339-4ec5-43c8-8182-db3f2bc8c6b6"
+  data-project-name="Ray"
+  data-project-color="#2C2C2C"
+  data-project-logo="https://global.discourse-cdn.com/business7/uploads/ray/original/1X/8f4dcb72f7cd34e2a332d548bd65860994bc8ff1.png"
+></script>
+
 <script>
 (function(apiKey){
     (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=o._q||[];


### PR DESCRIPTION
## Why are these changes needed?

Since dock builds on the release branch are succeeding but loading the page fails ([here](https://anyscale-ray--36096.com.readthedocs.build/en/36096/)), a simple fix to the issue causing this problem may be that we forgot to pick https://github.com/ray-project/ray/pull/35983.

This PR picks the above PR in an attempt to get rid of the following error:

<img width="653" alt="Screenshot 2023-06-07 at 13 31 13" src="https://github.com/ray-project/ray/assets/9356806/f67f7f46-190c-4988-93b7-4657a395470a">

[Angelina] I believe what happened is that I forgot to cherry-pick 35983 into the release branch. I don't know if that is the root cause of the release problems, but 35983 was meant to be included in the release, and the kapa hotfix is meant to go on top of it.