### PR TITLE
[docs] Seventh cherry pick 2.5

### DIFF
--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -55,39 +55,7 @@
 </div>
 
 
-<div class="container" style="margin-bottom:30px; margin-top:80px; padding:0px;">
-    <h2 style="font-weight:600;">Getting Started</h2>
-    
-<div class="grid-container">
-  <a class="no-underline" href="./ray-overview/index.html" target="_blank"> <div class="info-box" style="height:100%;">
-        <div class="image-header" style="padding:0px;">
-            <img src="_static/img/ray_logo.png" width="44px" height="44px" />
-            <h3 style="font-size:20px;">Learn basics</h3>
-        </div>
-        <p style="color:#515151;">Understand how the Ray framework scales your ML workflows.</p>      
-        <p style="font-weight:600;">Learn more > </p>  
-  </div> </a>  
 
-   <a class="no-underline" href="./ray-overview/installation.html" target="_blank"> <div class="info-box" style="height:100%;">
-        <div class="image-header" style="padding:0px;">
-            <img src="_static/img/download.png" width="44px" height="44px" />
-            <h3 style="font-size:20px;">Install Ray</h3>
-        </div>
-        <p><pre style="border:none; margin:0px;"><code class="nohighlight" style="margin:10px;">pip install -U "ray[air]"</code></pre></p>      
-
-        <p style="font-weight:600; margin-bottom: 0px;">Installation guide ></p>
-  </div></a>
-  <a class="no-underline" href="https://colab.research.google.com/github/ray-project/ray-educational-materials/blob/main/Introductory_modules/Quickstart_with_Ray_AIR_Colab.ipynb"  target="_blank" 
-        ><div class="info-box" style="height:100%;">
-        <div class="image-header" style="padding:0px;">
-            <img src="_static/img/code.png" width="44px" height="44px" />
-            <h3 style="font-size:20px;">Try it out</h3>
-        </div>
-        <p style="color:#515151;">Experiment with Ray with an introductory notebook.</p>
-        <p style="font-weight:600;">Open the notebook></p> 
-  </div></a>
-</div>
-  
 <div class="container remove-mobile" style="margin-bottom:30px; margin-top:80px; padding:0px;">
 
 
@@ -310,6 +278,39 @@ ppo_algo.evaluate()
     </div>
 </div>
   
+</div>
+
+
+
+<div class="container" style="margin-bottom:30px; margin-top:80px; padding:0px;">
+    <h2 style="font-weight:600;">Getting Started</h2>
+    
+<div class="grid-container">
+  <a class="no-underline" href="./ray-overview/index.html" target="_blank"> <div class="info-box" style="height:100%;">
+        <div class="image-header" style="padding:0px;">
+            <img src="_static/img/ray_logo.png" width="44px" height="44px" />
+            <h3 style="font-size:20px;">Learn basics</h3>
+        </div>
+        <p style="color:#515151;">Understand how the Ray framework scales your ML workflows.</p>      
+        <p style="font-weight:600;">Learn more > </p>  
+  </div> </a>  
+   <a class="no-underline" href="./ray-overview/installation.html" target="_blank"> <div class="info-box" style="height:100%;">
+        <div class="image-header" style="padding:0px;">
+            <img src="_static/img/download.png" width="44px" height="44px" />
+            <h3 style="font-size:20px;">Install Ray</h3>
+        </div>
+        <p><pre style="border:none; margin:0px;"><code class="nohighlight" style="margin:10px;">pip install -U "ray[air]"</code></pre></p>      
+        <p style="font-weight:600; margin-bottom: 0px;">Installation guide ></p>
+  </div></a>
+  <a class="no-underline" href="https://colab.research.google.com/github/ray-project/ray-educational-materials/blob/main/Introductory_modules/Quickstart_with_Ray_AIR_Colab.ipynb"  target="_blank" 
+        ><div class="info-box" style="height:100%;">
+        <div class="image-header" style="padding:0px;">
+            <img src="_static/img/code.png" width="44px" height="44px" />
+            <h3 style="font-size:20px;">Try it out</h3>
+        </div>
+        <p style="color:#515151;">Experiment with Ray with an introductory notebook.</p>
+        <p style="font-weight:600;">Open the notebook></p> 
+  </div></a>
 </div>
 
 


### PR DESCRIPTION
Based on user click data, we see that the Scaling with Ray section is much more popular than the Getting Started row of cards. The video is the least clicked on but we don't have enough time to redo the layout satisfactorily for v2.5.0, so we are moving the Scaling with Ray to above the fold as a compromise.
cc: @zhe-thoughts @ArturNiederfahrenhorst 

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
