### PR TITLE
[Jobs] Redact any passwords in the Ray address url during job submission

### DIFF
--- a/dashboard/modules/job/cli.py
+++ b/dashboard/modules/job/cli.py
@@ -1,5 +1,6 @@
 import os
 import pprint
+import re
 import time
 from subprocess import list2cmdline
 from typing import Optional, Tuple, Union
@@ -24,6 +25,9 @@ def _get_sdk_client(
 ) -> JobSubmissionClient:
     client = JobSubmissionClient(address, create_cluster_if_needed, verify=verify)
     client_address = client.get_address()
+    secret = re.findall("https?:\/\/.*:(.*)@.*$", client_address)
+    if len(secret) > 0:
+        client_address = client_address.replace(f":{secret[0]}@", ":<redacted>@")
     cli_logger.labeled_value("Job submission server address", client_address)
     return client
 

--- a/dashboard/modules/job/cli.py
+++ b/dashboard/modules/job/cli.py
@@ -25,10 +25,10 @@ def _get_sdk_client(
 ) -> JobSubmissionClient:
     client = JobSubmissionClient(address, create_cluster_if_needed, verify=verify)
     client_address = client.get_address()
-    if isinstance(client_address, str):
-        secret = re.findall("https?:\/\/.*:(.*)@.*$", client_address)
-        if len(secret) > 0:
-            client_address = client_address.replace(f":{secret[0]}@", ":<redacted>@")
+    # redact any passwords in the client address
+    secret = re.findall("https?:\/\/.*:(.*)@.*$", client_address)
+    if secret is not None and len(secret) > 0:
+        client_address = client_address.replace(f":{secret[0]}@", ":<redacted>@")
     cli_logger.labeled_value("Job submission server address", client_address)
     return client
 

--- a/dashboard/modules/job/cli.py
+++ b/dashboard/modules/job/cli.py
@@ -25,9 +25,10 @@ def _get_sdk_client(
 ) -> JobSubmissionClient:
     client = JobSubmissionClient(address, create_cluster_if_needed, verify=verify)
     client_address = client.get_address()
-    secret = re.findall("https?:\/\/.*:(.*)@.*$", client_address)
-    if len(secret) > 0:
-        client_address = client_address.replace(f":{secret[0]}@", ":<redacted>@")
+    if isinstance(client_address, str):
+        secret = re.findall("https?:\/\/.*:(.*)@.*$", client_address)
+        if len(secret) > 0:
+            client_address = client_address.replace(f":{secret[0]}@", ":<redacted>@")
     cli_logger.labeled_value("Job submission server address", client_address)
     return client
 

--- a/dashboard/modules/job/tests/test_cli.py
+++ b/dashboard/modules/job/tests/test_cli.py
@@ -41,6 +41,9 @@ def mock_sdk_client():
         # 'async for' requires an object with __aiter__ method, got MagicMock"
         mock_client().tail_job_logs.return_value = AsyncIterator(range(10))
 
+        # We need to return a string for the address and not a MagicMock
+        mock_client().get_address.return_value = ""
+
         yield mock_client
 
 

--- a/dashboard/modules/job/tests/test_utils.py
+++ b/dashboard/modules/job/tests/test_utils.py
@@ -8,6 +8,7 @@ from ray.dashboard.modules.job.utils import (
     file_tail_iterator,
     strip_keys_with_value_none,
     parse_and_validate_request,
+    redact_url_password,
 )
 
 
@@ -24,6 +25,27 @@ def test_strip_keys_with_value_none():
     assert strip_keys_with_value_none(d) == d
     d = {"a": 1, "b": None, "c": None}
     assert strip_keys_with_value_none(d) == {"a": 1}
+
+
+def test_redact_url_password():
+    url = "http://user:password@host:port"
+    assert redact_url_password(url) == "http://user:<redacted>@host:port"
+    url = "http://user:password@host:port?query=1"
+    assert redact_url_password(url) == "http://user:<redacted>@host:port?query=1"
+    url = "http://user:password@host:port?query=1&password=2"
+    assert (
+        redact_url_password(url)
+        == "http://user:<redacted>@host:port?query=1&password=2"
+    )
+    url = "https://user:password@127.0.0.1:8080"
+    assert redact_url_password(url) == "https://user:<redacted>@127.0.0.1:8080"
+    url = "https://user:password@host:port?query=1"
+    assert redact_url_password(url) == "https://user:<redacted>@host:port?query=1"
+    url = "https://user:password@host:port?query=1&password=2"
+    assert (
+        redact_url_password(url)
+        == "https://user:<redacted>@host:port?query=1&password=2"
+    )
 
 
 # Mock for aiohttp.web.Request, which should not be constructed directly.

--- a/dashboard/modules/job/utils.py
+++ b/dashboard/modules/job/utils.py
@@ -1,6 +1,7 @@
 import dataclasses
 import logging
 import os
+import re
 import traceback
 from dataclasses import dataclass
 from typing import Iterator, List, Optional, Any, Dict, Tuple, Union
@@ -51,6 +52,15 @@ MAX_CHUNK_CHAR_LENGTH = 20000
 def strip_keys_with_value_none(d: Dict[str, Any]) -> Dict[str, Any]:
     """Strip keys with value None from a dictionary."""
     return {k: v for k, v in d.items() if v is not None}
+
+
+def redact_url_password(url: str) -> str:
+    """Redact any passwords in a URL."""
+    secret = re.findall("https?:\/\/.*:(.*)@.*", url)
+    if len(secret) > 0:
+        url = url.replace(f":{secret[0]}@", ":<redacted>@")
+
+    return url
 
 
 def file_tail_iterator(path: str) -> Iterator[Optional[List[str]]]:


### PR DESCRIPTION
## Why are these changes needed?

The job submission prints, and will also log, passwords when they are being used in the Ray address.

For example using https://my-user:secret-token@ray-address/ will be logged as: 
```bash
Job submission server address: https://my-user:secret-token@ray-address/
```

When using a reverse proxy in front of the Ray dashboard to implement authentication having the token/password is unavoidable so it would be best if Ray does not log them.

This PR change will result in the above example being logged as:
```bash
Job submission server address: https://my-user:<redacted>@ray-address/
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
