### PR TITLE
[Tune] `bohb_example` patch fix

### DIFF
--- a/python/ray/tune/schedulers/hyperband.py
+++ b/python/ray/tune/schedulers/hyperband.py
@@ -8,7 +8,6 @@ from ray.tune.execution import trial_runner
 from ray.tune.result import DEFAULT_METRIC
 from ray.tune.schedulers.trial_scheduler import FIFOScheduler, TrialScheduler
 from ray.tune.experiment import Trial
-from ray.tune.error import TuneError
 from ray.util import PublicAPI
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The `bohb_example` is super flaky after https://github.com/ray-project/ray/pull/35338 modified the example to run more trials. This is just a patch fix to deflake the example. There is still some underlying root cause to investigate. The other BOHB example (the Jupyter notebook) is also flaky, but for a different reason. See https://github.com/ray-project/ray/issues/35428.

<img width="756" alt="Screen Shot 2023-06-08 at 1 39 49 AM" src="https://github.com/ray-project/ray/assets/3887863/82aaa660-8ab9-416e-8629-1bdf9c5b8af8">

In general, I unsure about the current hyperband implementation. See comments below for parts that I don't really understand.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
