### PR TITLE
[Serve] Only update RUNNING replicas

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -507,7 +507,7 @@ class ActorReplicaWrapper:
                 deployment_config.user_config
             )
             self._ready_obj_ref = self._actor_handle.reconfigure.remote(
-                deployment_config, self._ready_obj_ref
+                deployment_config
             )
 
         self._version = version
@@ -1390,7 +1390,7 @@ class DeploymentState:
         """
         replicas_to_update = self._replicas.pop(
             exclude_version=self._target_state.version,
-            states=[ReplicaState.STARTING, ReplicaState.RUNNING],
+            states=[ReplicaState.RUNNING],
             max_replicas=max_to_stop,
             ranking_function=rank_replicas_for_stopping,
         )

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -472,8 +472,10 @@ class ActorReplicaWrapper:
             replica_ready_check_func = self._actor_handle.initialize_and_get_metadata
             self._ready_obj_ref = replica_ready_check_func.remote(
                 deployment_config,
-                # Ensure that `is_allocated` will execute before `reconfigure`,
-                # because `reconfigure` runs user code that could block the replica
+                # Ensure that `is_allocated` will execute
+                # before `initialize_and_get_metadata`,
+                # because `initialize_and_get_metadata` runs
+                # user code that could block the replica
                 # asyncio loop. If that happens before `is_allocated` is executed,
                 # the `is_allocated` call won't be able to run.
                 self._allocated_obj_ref,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -505,7 +505,7 @@ class ActorReplicaWrapper:
                 deployment_config.user_config
             )
             self._ready_obj_ref = self._actor_handle.reconfigure.remote(
-                deployment_config
+                deployment_config, self._ready_obj_ref
             )
 
         self._version = version

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -351,10 +351,7 @@ def create_replica_wrapper(name: str):
         async def reconfigure(
             self,
             deployment_config: DeploymentConfig,
-            _after: Optional[Any] = None,
         ) -> Tuple[DeploymentConfig, DeploymentVersion]:
-            # Unused `_after` argument is for scheduling: passing an ObjectRef
-            # allows delaying this call until after the `_after` call has returned.
             try:
                 await self.replica.reconfigure(deployment_config)
                 return await self._get_metadata()

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -329,7 +329,7 @@ def create_replica_wrapper(name: str):
             _after: Optional[Any] = None,
         ) -> Tuple[DeploymentConfig, DeploymentVersion]:
             # Unused `_after` argument is for scheduling: passing an ObjectRef
-            # allows delaying reconfiguration until after this call has returned.
+            # allows delaying this call until after the `_after` call has returned.
             try:
                 # Ensure that initialization is only performed once.
                 # When controller restarts, it will call this method again.
@@ -349,8 +349,12 @@ def create_replica_wrapper(name: str):
                 raise RuntimeError(traceback.format_exc()) from None
 
         async def reconfigure(
-            self, deployment_config: DeploymentConfig
+            self,
+            deployment_config: DeploymentConfig,
+            _after: Optional[Any] = None,
         ) -> Tuple[DeploymentConfig, DeploymentVersion]:
+            # Unused `_after` argument is for scheduling: passing an ObjectRef
+            # allows delaying this call until after the `_after` call has returned.
             try:
                 await self.replica.reconfigure(deployment_config)
                 return await self._get_metadata()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Disallow STARTING -> UPDATING transition. By only updating running replicas, we don't need to worry about the ordering issue between `initialize_and_get_metadata` and `reconfigure` as show in #24052 and will make the code easier to reason about.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
