### PR TITLE
[ci] fix bisect for state machine

### DIFF
--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -69,7 +69,7 @@ def main(
     logger.info(f"Blamed commit found for test {test_name}: {blamed_commit}")
     # TODO(can): this env var is used as a feature flag, in case we need to turn this
     # off quickly. We should remove this when the new db reporter is stable.
-    if os.environ.get("REPORT_TO_RAY_TEST_DB", False):
+    if os.environ.get("UPDATE_TEST_STATE_MACHINE", False):
         logger.info(f"Updating test state for test {test_name} to CONSISTENTLY_FAILING")
         _update_test_state(test, blamed_commit)
 

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -140,7 +140,7 @@ class TestStateMachine:
             "master",
             message=f"[ray-test-bot] {self.test.get_name()} failing",
             env={
-                "REPORT_TO_RAY_TEST_DB": "1",
+                "UPDATE_TEST_STATE_MACHINE": "1",
             },
         )
         failing_commit = self.test_results[0].commit


### PR DESCRIPTION
## Why are these changes needed?
Use a different env variable for bisect job. Currently it uses the same env for recording test results into DB, so bisect test results are also recorded as new test results

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests

![](https://media4.giphy.com/media/TejmLnMKgnmPInMQjV/200.gif?cid=5a38a5a29v78juhirsyi9gceyp8raspkjya7i84jhwzs9ubj&ep=v1_gifs_search&rid=200.gif&ct=g)
   