### PR TITLE
[docs] re-enable build logs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -58,12 +58,12 @@ clean:
 	rm -rf ./source/rllib/package_ref/doc*
 
 html:
-	$(SPHINXBUILD) -W --keep-going -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	SKIP_LOG_RESET=True $(SPHINXBUILD) -W --keep-going -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 develop:
-	FAST=True $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	SKIP_LOG_RESET=True FAST=True $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 	@echo "View the documentation by opening a browser and going to $(BUILDDIR)/html/index.html."

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -4,7 +4,11 @@ import logging
 import os
 import sys
 
-log.generate_logging_config()
+# For cases like docs builds, we want the default logging config.
+skip_reset = os.environ.get("SKIP_LOG_RESET", False)
+if not skip_reset:
+    log.generate_logging_config()
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
makes docs warning and error messages visible again, after it had been disabled in #32741 