### PR TITLE
[ci] do not record transient infra error test result

### DIFF
--- a/release/ray_release/reporter/ray_test_db.py
+++ b/release/ray_release/reporter/ray_test_db.py
@@ -1,7 +1,7 @@
 import json
 
 from ray_release.reporter.reporter import Reporter
-from ray_release.result import Result
+from ray_release.result import Result, ResultStatus
 from ray_release.test import Test
 from ray_release.test_automation.state_machine import TestStateMachine
 from ray_release.logger import logger
@@ -17,6 +17,12 @@ class RayTestDBReporter(Reporter):
     """
 
     def report_result(self, test: Test, result: Result) -> None:
+        if result.status == ResultStatus.TRANSIENT_INFRA_ERROR.value:
+            logger.info(
+                f"Skip recording result for test {test.get_name()} due to transient "
+                "infra error result"
+            )
+            return
         logger.info(
             f"Updating test object {test.get_name()} with result {result.status}"
         )


### PR DESCRIPTION
## Why are these changes needed?
Do not record transient infra error test result, since they will be retried automatically. Only record the final result.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   
![](https://media4.giphy.com/media/GQI382aMVej0k/200.gif?cid=5a38a5a2awbgnxrzjnpnw108rj2g8tao4baqar69oh8ile8h&ep=v1_gifs_search&rid=200.gif&ct=g)