### PR TITLE
[Cluster launcher] Update availability zone in TPU yaml

### DIFF
--- a/python/ray/autoscaler/gcp/tpu.yaml
+++ b/python/ray/autoscaler/gcp/tpu.yaml
@@ -27,8 +27,8 @@ available_node_types:
 provider:
     type: gcp
     region: us-central1
-    availability_zone: us-central1-f
-    project_id: null
+    availability_zone: us-central1-b
+    project_id: null # Replace this with your GCP project ID.
 
 setup_commands:
   - sudo apt install python-is-python3 -y


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Follow-up to #32083 . Updates the zone from `us-central1-f` to `us-central1-b`.  The [docs](https://cloud.google.com/tpu/docs/regions-zones#overview) say "Note: Zone us-central1-f is available only to [TPU Research Cloud (TRC) participants](https://sites.research.google/trc)." So this change will make the YAML work for more users.

This PR also includes a comment on the `project: null` field (which needs to be manually filled in by the user).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
