### PR TITLE
[docs][serve] Fix command in HA guide

### DIFF
--- a/doc/source/serve/production-guide/fault-tolerance.md
+++ b/doc/source/serve/production-guide/fault-tolerance.md
@@ -379,7 +379,7 @@ redis-75c8b8b65d-4qgfz                                    1/1     Running   0   
 Port-forward to one of your worker pods. Make sure this pod is on a separate node from the head node, so you can kill the head node without crashing the worker:
 
 ```console
-$ kubectl port-forward ervice-sample-raycluster-thwmr-worker-small-group-bdv6q
+$ kubectl port-forward ervice-sample-raycluster-thwmr-worker-small-group-bdv6q 8000:8000
 Forwarding from 127.0.0.1:8000 -> 8000
 Forwarding from [::1]:8000 -> 8000
 ```


### PR DESCRIPTION
Fix command syntax by adding ports to port-forwarding.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Small cleanup to a command in documentation

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
