### PR TITLE
[Release Test] Pin library versions to fix LightningTrainer FSDP example

### DIFF
--- a/doc/source/ray-air/examples/dolly_lightning_fsdp_finetuning.ipynb
+++ b/doc/source/ray-air/examples/dolly_lightning_fsdp_finetuning.ipynb
@@ -23,13 +23,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Set up ray cluster \n",
     "In this example, we are using a ray cluster with 16 g4dn.4xlarge instances. Each instance has one Tesla T4 GPU (16GiB Memory). \n",
     "\n",
-    "We define a `runtime_env` to install the necessary Python libraries on each node. You can skip this step if you have already installed all the required packages in your workers' base image."
+    "We define a `runtime_env` to install the necessary Python libraries on each node. You can skip this step if you have already installed all the required packages in your workers' base image. We tested this example with `pytorch_lightning==2.0.2` and `transformers==4.29.2`."
    ]
   },
   {

--- a/release/air_examples/dolly_v2_lightning_fsdp_finetuning/dolly_v2_fsdp_env.yaml
+++ b/release/air_examples/dolly_v2_lightning_fsdp_finetuning/dolly_v2_fsdp_env.yaml
@@ -18,4 +18,4 @@ post_build_cmds:
   - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   - pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
-  - pip3 install "pytorch_lightning>=2.0.0" "transformers>=4.28.0" "accelerate>=0.18.0"
+  - pip3 install "pytorch_lightning==2.0.2" "transformers==4.29.2" "accelerate==0.19.0"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The LightningTrainer FSDP release test failed for an OOM error on 2.5.1 while succeed on 2.5.0 #36264. There's no code change between 2.5.0 and 2.5.1 related to this release test. The only difference is that we are using different versions of external libraries.
- `pytorch_lightning` upgraded from 2.0.2 -> 2.0.3
- `transformers` upgraded from 4.29.2 -> 4.30.0

Pinning these library versions fixed the release test: https://buildkite.com/ray-project/release-tests-pr/builds/41801#0188a1b8-f54e-45f5-8822-9cd948012965

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
