### PR TITLE
[Train/Tune] Clear stale lazy checkpointing markers on all workers.

### DIFF
--- a/python/ray/train/data_parallel_trainer.py
+++ b/python/ray/train/data_parallel_trainer.py
@@ -452,6 +452,17 @@ class DataParallelTrainer(BaseTrainer):
         )
 
         def clear_lazy_checkpoint_marker():
+            """Clear the stale lazy checkpointing marker on all worker nodes.
+
+            After recovery, the trainer may be scheduled on another node.
+            We should delete the marker files created earlier on each node to
+            Avoid converting checkpoints to string paths.
+
+            Please note that we need to clear the flag before the initialization
+            of the checkpoint_manager, during which it will create a new lazy
+            checkpointing marker file.
+            """
+
             marker_file = Path(trial_info.logdir) / LAZY_CHECKPOINT_MARKER_FILE
             if marker_file.exists():
                 logger.debug(

--- a/python/ray/train/data_parallel_trainer.py
+++ b/python/ray/train/data_parallel_trainer.py
@@ -11,7 +11,7 @@ from ray.air import session
 from ray.air.checkpoint import Checkpoint
 from ray.air._internal.checkpointing import add_preprocessor_to_checkpoint
 from ray.air.config import DatasetConfig, RunConfig, ScalingConfig, CheckpointConfig
-from ray.air.constants import MODEL_KEY, PREPROCESSOR_KEY
+from ray.air.constants import MODEL_KEY, PREPROCESSOR_KEY, LAZY_CHECKPOINT_MARKER_FILE
 from ray.air._internal.checkpoint_manager import _TrackedCheckpoint
 from ray.train import BackendConfig, TrainingIterator
 from ray.train._internal.backend_executor import BackendExecutor, TrialInfo
@@ -451,12 +451,20 @@ class DataParallelTrainer(BaseTrainer):
             checkpoint_config=self.run_config.checkpoint_config,
         )
 
+        def clear_lazy_checkpoint_marker():
+            marker_file = Path(trial_info.logdir) / LAZY_CHECKPOINT_MARKER_FILE
+            if marker_file.exists():
+                logger.debug(
+                    f"Deleting the stale lazy checkpoint marker file: {marker_file}."
+                )
+                marker_file.unlink()
+
+        # Start the remote actors.
+        backend_executor.start(initialization_hook=clear_lazy_checkpoint_marker)
+
         checkpoint_manager = self._checkpoint_manager_cls(
             preprocessor=self.preprocessor
         )
-
-        # Start the remote actors.
-        backend_executor.start(initialization_hook=None)
 
         # Disable TrainingIterator's CheckpointManager from handling
         # checkpoints itself by setting num_to_keep to None.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`TuneCheckpointManager` drops a marker file if lazy checkpointing is enabled. However, if we restore from an application failure and a new Trainer is scheduled on a different node, two nodes will have this marker file (one on the current Trainer node and one on the previous Trainer node).

If we are using distributed checkpointing, as both of these nodes will enable lazy checkpointing when reporting checkpoints, which will try to convert the checkpoint into a path string. Then, the new Trainer will try to load a checkpoint path string on the old Trainer node, leading to an `File not found` error.

This PR solved the issue by removing all the old marker files when the BackendExecutor starts, then the `TuneCheckpointManager` will place a new marker later.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
