### PR TITLE
[Metrics] Fixed metrics with no required tags currently being blackhole'd

### DIFF
--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -730,6 +730,58 @@ def test_basic_custom_metrics(metric_mock):
     metric_mock.record.assert_called_with(8, tags=tags)
 
 
+def test_custom_metrics_with_extra_tags(metric_mock):
+    base_tags = {"a": "1"}
+    extra_tags = {"a": "1", "b": "2"}
+
+    # -- Counter --
+    count = Counter("count", tag_keys=("a",))
+    with pytest.raises(ValueError):
+        count.inc(1)
+
+    count._metric = metric_mock
+
+    # Increment with base tags
+    count.inc(1, tags=base_tags)
+    metric_mock.record.assert_called_with(1, tags=base_tags)
+    metric_mock.reset_mock()
+
+    # Increment with extra tags
+    count.inc(1, tags=extra_tags)
+    metric_mock.record.assert_called_with(1, tags=extra_tags)
+    metric_mock.reset_mock()
+
+    # -- Gauge --
+    gauge = Gauge("gauge", description="gauge", tag_keys=("a",))
+    gauge._metric = metric_mock
+
+    # Record with base tags
+    gauge.record(4, tags=base_tags)
+    metric_mock.record.assert_called_with(4, tags=base_tags)
+    metric_mock.reset_mock()
+
+    # Record with extra tags
+    gauge.record(4, tags=extra_tags)
+    metric_mock.record.assert_called_with(4, tags=extra_tags)
+    metric_mock.reset_mock()
+
+    # -- Histogram
+    histogram = Histogram(
+        "hist", description="hist", boundaries=[1.0, 3.0], tag_keys=("a",)
+    )
+    histogram._metric = metric_mock
+
+    # Record with base tags
+    histogram.observe(8, tags=base_tags)
+    metric_mock.record.assert_called_with(8, tags=base_tags)
+    metric_mock.reset_mock()
+
+    # Record with extra tags
+    histogram.observe(8, tags=extra_tags)
+    metric_mock.record.assert_called_with(8, tags=extra_tags)
+    metric_mock.reset_mock()
+
+
 def test_custom_metrics_info(metric_mock):
     # Make sure .info public method works.
     histogram = Histogram(
@@ -820,11 +872,6 @@ def test_custom_metrics_validation(shutdown_only):
 
     with pytest.raises(ValueError):
         metric.inc(1.0, {"a": "2"})
-
-    # Extra tag not in tag_keys.
-    metric = Counter("name", tag_keys=("a",))
-    with pytest.raises(ValueError):
-        metric.inc(1.0, {"a": "1", "b": "2"})
 
     # tag_keys must be tuple.
     with pytest.raises(TypeError):

--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -78,7 +78,10 @@ class Metric:
         return self
 
     def record(
-        self, value: Union[int, float], tags: Optional[Dict[str, str]] = None, _internal=False
+        self,
+        value: Union[int, float],
+        tags: Optional[Dict[str, str]] = None,
+        _internal=False,
     ) -> None:
         """Record the metric point of the metric.
 

--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -78,7 +78,7 @@ class Metric:
         return self
 
     def record(
-        self, value: Union[int, float], tags: Dict[str, str] = None, _internal=False
+        self, value: Union[int, float], tags: Optional[Dict[str, str]] = None, _internal=False
     ) -> None:
         """Record the metric point of the metric.
 
@@ -110,23 +110,29 @@ class Metric:
                 "instead."
             )
 
-        if tags is not None:
-            for val in tags.values():
-                if not isinstance(val, str):
-                    raise TypeError(f"Tag values must be str, got {type(val)}.")
+        final_tags = self._get_final_tags(tags)
+        self._validate_tags(final_tags)
+        self._metric.record(value, tags=final_tags)
 
-        final_tags = {}
-        tags_copy = tags.copy() if tags else {}
+    def _get_final_tags(self, tags):
+        if not tags:
+            return self._default_tags
+
+        for val in tags.values():
+            if not isinstance(val, str):
+                raise TypeError(f"Tag values must be str, got {type(val)}.")
+
+        return {**self._default_tags, **tags}
+
+    def _validate_tags(self, final_tags):
+        missing_tags = []
         for tag_key in self._tag_keys:
             # Prefer passed tags over default tags.
-            if tags is not None and tag_key in tags:
-                final_tags[tag_key] = tags_copy.pop(tag_key)
-            elif tag_key in self._default_tags:
-                final_tags[tag_key] = self._default_tags[tag_key]
-            else:
-                raise ValueError(f"Missing value for tag key {tag_key}.")
+            if tag_key not in final_tags:
+                missing_tags.append(tag_key)
 
-        self._metric.record(value, tags=final_tags)
+        if missing_tags:
+            raise ValueError(f"Missing value for tag key(s): {','.join(missing_tags)}.")
 
     @property
     def info(self) -> Dict[str, Any]:

--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -126,9 +126,6 @@ class Metric:
             else:
                 raise ValueError(f"Missing value for tag key {tag_key}.")
 
-        if len(tags_copy) > 0:
-            raise ValueError(f"Unrecognized tag keys: {list(tags_copy.keys())}.")
-
         self._metric.record(value, tags=final_tags)
 
     @property


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, `Metric` implementation requires you to specify `tag_keys` of the tags that have to be recorded. However it also does NOT allow you to record additional tags on top of the ones you have provided during creation.

This is problematic since it couples metric creation with its usage: you can't, say add new tags to metric usage w/o updating its definition (which might be in a separate module, library, etc)

One straightforward example: if you haven't specified any `tag_keys` during metric creation it's impossible for you to add any tags during recording.

Proposal:

Treat `tag_keys` as only a set of _required_ tags (ie allow additional tags to be specified during recording)


## Related issue number

N/A

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
