### PR TITLE
[Dashboard] Add datasource param for grafana dashboard

### DIFF
--- a/dashboard/client/src/App.tsx
+++ b/dashboard/client/src/App.tsx
@@ -81,6 +81,10 @@ export type GlobalContextType = {
    * The name of the currently running ray session.
    */
   sessionName: string | undefined;
+  /**
+   * The name of the current selected datasource.
+   */
+  dashboardDatasource: string | undefined;
 };
 export const GlobalContext = React.createContext<GlobalContextType>({
   nodeMap: {},
@@ -92,6 +96,7 @@ export const GlobalContext = React.createContext<GlobalContextType>({
   dashboardUids: undefined,
   prometheusHealth: undefined,
   sessionName: undefined,
+  dashboardDatasource: undefined,
 });
 
 const App = () => {
@@ -105,6 +110,7 @@ const App = () => {
     dashboardUids: undefined,
     prometheusHealth: undefined,
     sessionName: undefined,
+    dashboardDatasource: undefined,
   });
   useEffect(() => {
     getNodeList().then((res) => {
@@ -131,8 +137,13 @@ const App = () => {
   // Detect if grafana is running
   useEffect(() => {
     const doEffect = async () => {
-      const { grafanaHost, sessionName, prometheusHealth, dashboardUids } =
-        await getMetricsInfo();
+      const {
+        grafanaHost,
+        sessionName,
+        prometheusHealth,
+        dashboardUids,
+        dashboardDatasource,
+      } = await getMetricsInfo();
       setContext((existingContext) => ({
         ...existingContext,
         metricsContextLoaded: true,
@@ -140,6 +151,7 @@ const App = () => {
         dashboardUids,
         sessionName,
         prometheusHealth,
+        dashboardDatasource,
       }));
     };
     doEffect();

--- a/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
@@ -20,6 +20,7 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
         nodeMap: {},
         nodeMapByIp: {},
         namespaceMap: {},
+        dashboardDatasource: "Prometheus",
       }}
     >
       {children}
@@ -44,6 +45,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
         nodeMap: {},
         nodeMapByIp: {},
         namespaceMap: {},
+        dashboardDatasource: "Prometheus",
       }}
     >
       {children}

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -195,11 +195,18 @@ const METRICS_CONFIG: MetricsSectionConfig[] = [
 
 export const Metrics = () => {
   const classes = useStyles();
-  const { grafanaHost, sessionName, prometheusHealth, dashboardUids } =
-    useContext(GlobalContext);
+  const {
+    grafanaHost,
+    sessionName,
+    prometheusHealth,
+    dashboardUids,
+    dashboardDatasource,
+  } = useContext(GlobalContext);
 
   const grafanaDefaultDashboardUid =
     dashboardUids?.default ?? "rayDefaultDashboard";
+
+  const grafanaDefaultDatasource = dashboardDatasource ?? "Prometheus";
 
   const [timeRangeOption, setTimeRangeOption] = useState<TimeRangeOptions>(
     TimeRangeOptions.FIVE_MINS,
@@ -232,7 +239,7 @@ export const Metrics = () => {
         <div>
           <Paper className={classes.topBar}>
             <Button
-              href={`${grafanaHost}/d/${grafanaDefaultDashboardUid}`}
+              href={`${grafanaHost}/d/${grafanaDefaultDashboardUid}/?var-datasource=${grafanaDefaultDatasource}`}
               target="_blank"
               rel="noopener noreferrer"
               endIcon={<RiExternalLinkLine />}
@@ -274,7 +281,7 @@ export const Metrics = () => {
                   {contents.map(({ title, pathParams }) => {
                     const path =
                       `/d-solo/${grafanaDefaultDashboardUid}?${pathParams}` +
-                      `&refresh${timeRangeParams}&var-SessionName=${sessionName}`;
+                      `&refresh${timeRangeParams}&var-SessionName=${sessionName}&var-datasource=${dashboardDatasource}`;
                     return (
                       <Paper
                         key={pathParams}

--- a/dashboard/client/src/pages/metrics/utils.ts
+++ b/dashboard/client/src/pages/metrics/utils.ts
@@ -16,6 +16,7 @@ type GrafanaHealthcheckRsp = {
     grafanaHost: string;
     sessionName: string;
     dashboardUids: DashboardUids;
+    dashboardDatasource: string;
   };
 };
 
@@ -37,6 +38,7 @@ type MetricsInfo = {
   sessionName?: string;
   prometheusHealth?: boolean;
   dashboardUids?: DashboardUids;
+  dashboardDatasource?: string;
 };
 
 export const getMetricsInfo = async () => {
@@ -45,6 +47,7 @@ export const getMetricsInfo = async () => {
     sessionName: undefined,
     prometheusHealth: undefined,
     dashboardUids: undefined,
+    dashboardDatasource: undefined,
   };
   try {
     const resp = await fetchGrafanaHealthcheck();
@@ -52,6 +55,7 @@ export const getMetricsInfo = async () => {
       info.grafanaHost = resp.data.data.grafanaHost;
       info.sessionName = resp.data.data.sessionName;
       info.dashboardUids = resp.data.data.dashboardUids;
+      info.dashboardDatasource = resp.data.data.dashboardDatasource;
     }
   } catch (e) {}
   try {

--- a/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
+++ b/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
@@ -81,6 +81,7 @@ const Wrapper =
             nodeMap: {},
             nodeMapByIp: {},
             namespaceMap: {},
+            dashboardDatasource: "Prometheus",
           }}
         >
           {children}

--- a/dashboard/client/src/pages/overview/cards/ClusterUtilizationCard.tsx
+++ b/dashboard/client/src/pages/overview/cards/ClusterUtilizationCard.tsx
@@ -46,10 +46,11 @@ export const ClusterUtilizationCard = ({
     prometheusHealth,
     sessionName,
     dashboardUids,
+    dashboardDatasource,
   } = useContext(GlobalContext);
   const grafanaDefaultDashboardUid =
     dashboardUids?.default ?? "rayDefaultDashboard";
-  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=1&theme=light&panelId=41`;
+  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=1&theme=light&panelId=41&var-datasource=${dashboardDatasource}`;
   const timeRangeParams = "&from=now-30m&to=now";
 
   if (!metricsContextLoaded || grafanaHost === "DISABLED") {

--- a/dashboard/client/src/pages/overview/cards/NodeCountCard.tsx
+++ b/dashboard/client/src/pages/overview/cards/NodeCountCard.tsx
@@ -44,10 +44,11 @@ export const NodeCountCard = ({ className }: NodeCountCardProps) => {
     prometheusHealth,
     sessionName,
     dashboardUids,
+    dashboardDatasource,
   } = useContext(GlobalContext);
   const grafanaDefaultDashboardUid =
     dashboardUids?.default ?? "rayDefaultDashboard";
-  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=1&theme=light&panelId=24`;
+  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=1&theme=light&panelId=24&var-datasource=${dashboardDatasource}`;
   const timeRangeParams = "&from=now-30m&to=now";
 
   if (!metricsContextLoaded || grafanaHost === "DISABLED") {

--- a/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.component.test.tsx
+++ b/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.component.test.tsx
@@ -20,6 +20,7 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
         nodeMap: {},
         nodeMapByIp: {},
         namespaceMap: {},
+        dashboardDatasource: "Prometheus",
       }}
     >
       {children}
@@ -44,6 +45,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
         nodeMap: {},
         nodeMapByIp: {},
         namespaceMap: {},
+        dashboardDatasource: "Prometheus",
       }}
     >
       {children}

--- a/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
@@ -86,7 +86,7 @@ export const ServeReplicaMetricsSection = ({
   className,
 }: ServeDeploymentMetricsSectionProps) => {
   const classes = useStyles();
-  const { grafanaHost, prometheusHealth, dashboardUids } =
+  const { grafanaHost, prometheusHealth, dashboardUids, dashboardDatasource } =
     useContext(GlobalContext);
   const grafanaServeDashboardUid =
     dashboardUids?.serveDeployment ?? "rayServeDashboard";
@@ -149,7 +149,9 @@ export const ServeReplicaMetricsSection = ({
               `/d-solo/${grafanaServeDashboardUid}?${pathParams}` +
               `&refresh${timeRangeParams}&var-Deployment=${encodeURIComponent(
                 deploymentName,
-              )}&var-Replica=${encodeURIComponent(replicaId)}`;
+              )}&var-Replica=${encodeURIComponent(
+                replicaId,
+              )}&var-datasource=${dashboardDatasource}`;
             return (
               <Paper
                 key={pathParams}
@@ -177,7 +179,7 @@ export const useViewServeDeploymentMetricsButtonUrl = (
   deploymentName: string,
   replicaId?: string,
 ) => {
-  const { grafanaHost, prometheusHealth, dashboardUids } =
+  const { grafanaHost, prometheusHealth, dashboardUids, dashboardDatasource } =
     useContext(GlobalContext);
   const grafanaServeDashboardUid =
     dashboardUids?.serveDeployment ?? "rayServeDashboard";
@@ -190,5 +192,5 @@ export const useViewServeDeploymentMetricsButtonUrl = (
     ? null
     : `${grafanaHost}/d/${grafanaServeDashboardUid}?var-Deployment=${encodeURIComponent(
         deploymentName,
-      )}${replicaStr}`;
+      )}${replicaStr}&var-datasource=${dashboardDatasource}`;
 };

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
@@ -20,6 +20,7 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
         nodeMap: {},
         nodeMapByIp: {},
         namespaceMap: {},
+        dashboardDatasource: "Prometheus",
       }}
     >
       {children}
@@ -44,6 +45,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
         nodeMap: {},
         nodeMapByIp: {},
         namespaceMap: {},
+        dashboardDatasource: "Prometheus",
       }}
     >
       {children}

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -81,7 +81,7 @@ export const ServeMetricsSection = ({
   className,
 }: ServeMetricsSectionProps) => {
   const classes = useStyles();
-  const { grafanaHost, prometheusHealth, dashboardUids } =
+  const { grafanaHost, prometheusHealth, dashboardUids, dashboardDatasource } =
     useContext(GlobalContext);
   const grafanaServeDashboardUid = dashboardUids?.serve ?? "rayServeDashboard";
 
@@ -106,7 +106,7 @@ export const ServeMetricsSection = ({
       <div>
         <Paper className={classes.topBar}>
           <Button
-            href={`${grafanaHost}/d/${grafanaServeDashboardUid}`}
+            href={`${grafanaHost}/d/${grafanaServeDashboardUid}?var-datasource=${dashboardDatasource}`}
             target="_blank"
             rel="noopener noreferrer"
             endIcon={<RiExternalLinkLine />}
@@ -134,7 +134,7 @@ export const ServeMetricsSection = ({
           {METRICS_CONFIG.map(({ title, pathParams }) => {
             const path =
               `/d-solo/${grafanaServeDashboardUid}?${pathParams}` +
-              `&refresh${timeRangeParams}`;
+              `&refresh${timeRangeParams}&var-datasource=${dashboardDatasource}`;
             return (
               <Paper
                 key={pathParams}

--- a/dashboard/client/src/util/test-utils.tsx
+++ b/dashboard/client/src/util/test-utils.tsx
@@ -20,6 +20,7 @@ export const TEST_APP_WRAPPER = ({ children }: PropsWithChildren<{}>) => {
     },
     prometheusHealth: true,
     sessionName: "session-name",
+    dashboardDatasource: "Prometheus",
   };
 
   return (

--- a/dashboard/modules/metrics/dashboards/default_grafana_dashboard_base.json
+++ b/dashboard/modules/metrics/dashboards/default_grafana_dashboard_base.json
@@ -25,11 +25,30 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false
+        },
+        "description": "Filter queries of a specific Prometheus type.",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": ".+",
         "current": {
           "selected": false
         },
-        "datasource": "Prometheus",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
         "definition": "label_values(ray_node_network_receive_speed{{{global_filters}}}, SessionName)",
         "description": "Filter queries to specific ray sessions.",
         "error": null,
@@ -64,7 +83,10 @@
             "$__all"
           ]
         },
-        "datasource": "Prometheus",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
         "definition": "label_values(ray_node_network_receive_speed{{SessionName=\"$SessionName\",{global_filters}}}, instance)",
         "description": null,
         "error": null,

--- a/dashboard/modules/metrics/dashboards/serve_grafana_dashboard_base.json
+++ b/dashboard/modules/metrics/dashboards/serve_grafana_dashboard_base.json
@@ -25,6 +25,22 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false
+        },
+        "description": "Filter queries to specific prometheus type.",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": ".*",
         "current": {
           "selected": true,
@@ -35,7 +51,10 @@
             "$__all"
           ]
         },
-        "datasource": "Prometheus",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
         "definition": "label_values(ray_serve_num_http_requests{{{global_filters}}}, route)",
         "description": null,
         "error": null,

--- a/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -40,7 +40,7 @@ PANEL_TEMPLATE = {
     "bars": False,
     "dashLength": 10,
     "dashes": False,
-    "datasource": "Prometheus",
+    "datasource": {"type": "prometheus", "uid": r"${datasource}"},
     "description": "<Description>",
     "fieldConfig": {"defaults": {}, "overrides": []},
     "fill": 10,
@@ -218,6 +218,8 @@ def _generate_grafana_dashboard(dashboard_config: DashboardConfig) -> str:
     global_filters_str = ",".join(global_filters)
     variables = base_json.get("templating", {}).get("list", [])
     for variable in variables:
+        if "definition" not in variable:
+            continue
         variable["definition"] = variable["definition"].format(
             global_filters=global_filters_str
         )

--- a/dashboard/modules/metrics/grafana_datasource_template.py
+++ b/dashboard/modules/metrics/grafana_datasource_template.py
@@ -1,7 +1,7 @@
 GRAFANA_DATASOURCE_TEMPLATE = """apiVersion: 1
 
 datasources:
-  - name: Prometheus
+  - name: {prometheus_name}
     url: {prometheus_host}
     type: prometheus
     isDefault: true

--- a/dashboard/modules/metrics/metrics_head.py
+++ b/dashboard/modules/metrics/metrics_head.py
@@ -37,6 +37,8 @@ METRICS_RECORD_INTERVAL_S = 5
 
 DEFAULT_PROMETHEUS_HOST = "http://localhost:9090"
 PROMETHEUS_HOST_ENV_VAR = "RAY_PROMETHEUS_HOST"
+DEFAULT_PROMETHEUS_NAME = "Prometheus"
+PROMETHEUS_NAME_ENV_VAR = "RAY_PROMETHEUS_NAME"
 PROMETHEUS_CONFIG_INPUT_PATH = os.path.join(
     METRICS_INPUT_ROOT, "prometheus", "prometheus.yml"
 )
@@ -78,6 +80,10 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
         self._grafana_dashboard_output_dir = os.environ.get(
             GRAFANA_DASHBOARD_OUTPUT_DIR_ENV_VAR,
             os.path.join(grafana_config_output_path, "dashboards"),
+        )
+
+        self._prometheus_name = os.environ.get(
+            PROMETHEUS_NAME_ENV_VAR, DEFAULT_PROMETHEUS_NAME
         )
 
         # To be set later when dashboards gets generated
@@ -131,6 +137,7 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
                     grafana_host=grafana_iframe_host,
                     session_name=self._session_name,
                     dashboard_uids=self._dashboard_uids,
+                    dashboard_datasource=self._prometheus_name,
                 )
 
         except Exception as e:
@@ -236,7 +243,12 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
             ),
             "w",
         ) as f:
-            f.write(GRAFANA_DATASOURCE_TEMPLATE.format(prometheus_host=prometheus_host))
+            f.write(
+                GRAFANA_DATASOURCE_TEMPLATE.format(
+                    prometheus_host=prometheus_host,
+                    prometheus_name=self._prometheus_name,
+                )
+            )
         with open(
             os.path.join(
                 self._grafana_dashboard_output_dir,

--- a/doc/source/cluster/configure-manage-dashboard.md
+++ b/doc/source/cluster/configure-manage-dashboard.md
@@ -193,15 +193,20 @@ To view embedded time-series visualizations in Ray Dashboard, the following must
 1. The head node of the cluster is able to access Prometheus and Grafana
 2. The browser of the dashboard user is able to access Grafana. 
 
-Configure these settings using the `RAY_GRAFANA_HOST`, `RAY_PROMETHEUS_HOST`, and `RAY_GRAFANA_IFRAME_HOST` environment variables when you start the Ray Clusters.
+Configure these settings using the `RAY_GRAFANA_HOST`, `RAY_PROMETHEUS_HOST`, `RAY_PROMETHEUS_NAME`, and `RAY_GRAFANA_IFRAME_HOST` environment variables when you start the Ray Clusters.
 
 * Set `RAY_GRAFANA_HOST` to an address that the head node can use to access Grafana. Head node does health checks on Grafana on the backend.
 * Set `RAY_PROMETHEUS_HOST` to an address the head node can use to access Prometheus.
-* Set `RAY_GRAFANA_IFRAME_HOST` to an address that the user's browsers can use to access Grafana and embed visualizations. If `RAY_GRAFANA_IFRAME_HOST` not set, Ray Dashboard uses the value of `RAY_GRAFANA_HOST`.
+* Set `RAY_PROMETHEUS_NAME` is used when you select a different data source to use for the Grafana dashboard panles. Default is "Prometheus".
+* Set `RAY_GRAFANA_IFRAME_HOST` to an address that the user's browsers can use to access Grafana and embed visualizations. If `RAY_GRAFANA_IFRAME_HOST` is not set, Ray Dashboard uses the value of `RAY_GRAFANA_HOST`.
 
 For example, if the IP of the head node is 55.66.77.88 and Grafana is hosted on port 3000. Set the value to `RAY_GRAFANA_HOST=55.66.77.88:3000`.
 
 If all the environment variables are set properly, you should see time-series metrics in {ref}`Ray Dashboard <observability-getting-started>`.
+
+:::{note}
+If you use a different Prometheus server for each Ray Cluster and use the same Grafana server for all Clusters, set the `RAY_PROMETHEUS_NAME` environment variable to different values for each Ray Cluster and add these datasources in Grafana. Follow {ref}`these instructions <grafana>` to set up Grafana.
+:::
 
 #### Alternate Prometheus host location
 By default, Ray Dashboard assumes Prometheus is hosted at `localhost:9090`. You can choose to run Prometheus on a non-default port or on a different machine. In this case, make sure that Prometheus can scrape the metrics from your Ray nodes following instructions {ref}`here <scrape-metrics>`.

--- a/doc/source/cluster/metrics.md
+++ b/doc/source/cluster/metrics.md
@@ -229,14 +229,7 @@ You can then start or restart the services with `brew services start grafana` an
 
 After your Grafana server is running, find the Ray-provided default Grafana dashboard JSON at `/tmp/ray/session_latest/metrics/grafana/dashboards/default_grafana_dashboard.json`. [Import this dashboard](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/#import-a-dashboard) to your Grafana.
 
-If Grafana reports that datasource is not found, [add a datasource variable](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/?pg=graf&plcmt=data-sources-prometheus-btn-1#add-a-data-source-variable) and using [JSON model view](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/modify-dashboard-settings/#view-dashboard-json-model), change all values of `datasource` key in the imported `default_grafana_dashboard.json` to the name of the variable. For example, if the variable name is `data_source`, all `"datasource"` mappings should be:
-
-```json
-"datasource": {
-  "type": "prometheus",
-  "uid": "$data_source"
-  }
-```
+If Grafana reports that the datasource is not found, [add a datasource variable](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/?pg=graf&plcmt=data-sources-prometheus-btn-1#add-a-data-source-variable). The datasource's name must be the same as value in the `RAY_PROMETHEUS_NAME` environment. By default, `RAY_PROMETHEUS_NAME` equals `Prometheus`.
 :::
 
 ::::


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We had some K8s clusters run ray clusters, and each K8s cluster had one Prometheus and share the same Grafana, but ray not support this scenario.

We use the `R` as the the Ray Cluster, and `K` as the K8s cluster, and `P` as the prometheus cluster, and `G` as the Grafana.

`R1` run on `K1` and use `P1` to collect the metrics. `R2` run on `K2` and use `P2` to collect the metrics. Now, we only use `G1` to view all the cluster's metrics by only switch the dashboard's datasource.

## Related issue number

Closes #36300

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
