### PR TITLE
[ci] fix type object 'TestStateMachine' has no attribute 'init_ray_repo'

### DIFF
--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -46,7 +46,7 @@ class TestStateMachine:
 
     @classmethod
     def get_ray_repo(cls):
-        cls.init_ray_repo()
+        cls._init_ray_repo()
         return cls.ray_repo
 
     @classmethod


### PR DESCRIPTION
## Why are these changes needed?
The attribute should have been _init_ray_repo

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   