### PR TITLE
[Core]Change the log level of key placement group logs to facilitate troubleshooting of PG-related issues

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -425,12 +425,12 @@ void GcsPlacementGroupManager::HandleCreatePlacementGroup(
       JobID::FromBinary(request.placement_group_spec().creator_job_id());
   auto placement_group = std::make_shared<GcsPlacementGroup>(
       request, get_ray_namespace_(job_id), placement_group_state_counter_);
-  RAY_LOG(DEBUG) << "Registering placement group, " << placement_group->DebugString();
+  RAY_LOG(INFO) << "Registering placement group, " << placement_group->DebugString();
   RegisterPlacementGroup(placement_group,
                          [reply, send_reply_callback, placement_group](Status status) {
                            if (status.ok()) {
-                             RAY_LOG(DEBUG) << "Finished registering placement group, "
-                                            << placement_group->DebugString();
+                             RAY_LOG(INFO) << "Finished registering placement group, "
+                                           << placement_group->DebugString();
                            } else {
                              RAY_LOG(INFO) << "Failed to register placement group, "
                                            << placement_group->DebugString()

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -181,8 +181,8 @@ void GcsPlacementGroupScheduler::PrepareResources(
 
   const auto lease_client = GetLeaseClientFromNode(node.value());
   const auto node_id = NodeID::FromBinary(node.value()->node_id());
-  RAY_LOG(DEBUG) << "Preparing resource from node " << node_id
-                 << " for bundles: " << GetDebugStringForBundles(bundles);
+  RAY_LOG(INFO) << "Preparing resource from node " << node_id
+                << " for bundles: " << GetDebugStringForBundles(bundles);
 
   lease_client->PrepareBundleResources(
       bundles,
@@ -191,11 +191,11 @@ void GcsPlacementGroupScheduler::PrepareResources(
         auto result = reply.success() ? Status::OK()
                                       : Status::IOError("Failed to reserve resource");
         if (result.ok()) {
-          RAY_LOG(DEBUG) << "Finished leasing resource from " << node_id
-                         << " for bundles: " << GetDebugStringForBundles(bundles);
+          RAY_LOG(INFO) << "Finished leasing resource from " << node_id
+                        << " for bundles: " << GetDebugStringForBundles(bundles);
         } else {
-          RAY_LOG(DEBUG) << "Failed to lease resource from " << node_id
-                         << " for bundles: " << GetDebugStringForBundles(bundles);
+          RAY_LOG(INFO) << "Failed to lease resource from " << node_id
+                        << " for bundles: " << GetDebugStringForBundles(bundles);
         }
         callback(result);
       });
@@ -209,18 +209,18 @@ void GcsPlacementGroupScheduler::CommitResources(
   const auto lease_client = GetLeaseClientFromNode(node.value());
   const auto node_id = NodeID::FromBinary(node.value()->node_id());
 
-  RAY_LOG(DEBUG) << "Committing resource to a node " << node_id
-                 << " for bundles: " << GetDebugStringForBundles(bundles);
+  RAY_LOG(INFO) << "Committing resource to a node " << node_id
+                << " for bundles: " << GetDebugStringForBundles(bundles);
   lease_client->CommitBundleResources(
       bundles,
       [bundles, node_id, callback](const Status &status,
                                    const rpc::CommitBundleResourcesReply &reply) {
         if (status.ok()) {
-          RAY_LOG(DEBUG) << "Finished committing resource to " << node_id
-                         << " for bundles: " << GetDebugStringForBundles(bundles);
+          RAY_LOG(INFO) << "Finished committing resource to " << node_id
+                        << " for bundles: " << GetDebugStringForBundles(bundles);
         } else {
-          RAY_LOG(DEBUG) << "Failed to commit resource to " << node_id
-                         << " for bundles: " << GetDebugStringForBundles(bundles);
+          RAY_LOG(INFO) << "Failed to commit resource to " << node_id
+                        << " for bundles: " << GetDebugStringForBundles(bundles);
         }
         RAY_CHECK(callback);
         callback(status);


### PR DESCRIPTION
## Why are these changes needed?
- The preparing resource and committing resource stages are time-consuming and often error-prone stages during PG creation. Therefore, these logs are critical for troubleshooting slow PG scheduling and PG scheduling errors in production environments.
- Currently, the key logs for PG scheduling are set to DEBUG level, which results in limited logs available for troubleshooting PG scheduling issues in production environments.
- The logs that I modified will not be frequently printed.

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
