### PR TITLE
[ci][byod] disable byod on PRs

### DIFF
--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -112,6 +112,9 @@ class Test(dict):
         """
         Returns whether this test is running on a BYOD cluster.
         """
+        if os.environ.get("BUILDKITE_PULL_REQUEST", False):
+            # Do not run BYOD tests on PRs
+            return False
         return self["cluster"].get("byod") is not None
 
     def get_byod_type(self) -> Optional[str]:

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -29,6 +29,8 @@ def test_is_byod_cluster():
     assert not _stub_test({}).is_byod_cluster()
     assert _stub_test({"cluster": {"byod": {}}}).is_byod_cluster()
     assert _stub_test({"cluster": {"byod": {"type": "gpu"}}}).is_byod_cluster()
+    with mock.patch.dict(os.environ, {"BUILDKITE_PULL_REQUEST": "1"}):
+        assert not _stub_test({"cluster": {"byod": {}}}).is_byod_cluster()
 
 
 def test_convert_env_list_to_dict():


### PR DESCRIPTION
## Why are these changes needed?
Disable running tests as BYOD on PRs, since that is now well supported yet. On PRs, let run tests using the old way.

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   