### PR TITLE
Fix mypy error: Module "ray" does not explicitly export attribute "remote"

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -183,7 +183,8 @@ serialization = _DeprecationWrapper("serialization", ray._private.serialization)
 state = _DeprecationWrapper("state", ray._private.state)
 
 
-RAY_APIS = {
+# Pulic Ray APIs
+__all__ = [
     "__version__",
     "_config",
     "get_runtime_context",
@@ -214,7 +215,7 @@ RAY_APIS = {
     "LOCAL_MODE",
     "SCRIPT_MODE",
     "WORKER_MODE",
-}
+]
 
 # Public APIs that should automatically trigger ray.init().
 AUTO_INIT_APIS = {
@@ -254,14 +255,11 @@ NON_AUTO_INIT_APIS = {
     "timeline",
 }
 
-assert RAY_APIS == AUTO_INIT_APIS | NON_AUTO_INIT_APIS
+assert set(__all__) == AUTO_INIT_APIS | NON_AUTO_INIT_APIS
 from ray._private.auto_init_hook import wrap_auto_init_for_all_apis  # noqa: E402
 
 wrap_auto_init_for_all_apis(AUTO_INIT_APIS)
 del wrap_auto_init_for_all_apis
-
-
-__all__ = list(RAY_APIS)
 
 # Subpackages
 __all__ += [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#34730 changed `__all__` in `__init__.py` to a computed list. mypy doesn't support this. Reverting it back to a literal list to fix this issue.

Repro:
`mypy --strict --follow-imports=skip --ignore-missing-imports 1.py`

```python
# 1.py
import ray

@ray.remote
def foo() -> None:
    pass
```

Note, the reason why CI didn't catch this issue is because we don't enable strict mode, see [here](https://github.com/ray-project/ray/blob/407062499038344b0f3edb54b2c7985c3320d1ec/ci/lint/format.sh#L135). Currently we have too many issues if enabling strict mode. 

## Related issue number

Closes #36252
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
