### PR TITLE
[Data] Increase disk size for shuffle benchmark cluster setup

### DIFF
--- a/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
@@ -6,11 +6,11 @@ aws:
         - DeviceName: /dev/sda1
           Ebs:
             DeleteOnTermination: true
-            VolumeSize: 2000
+            VolumeSize: 5000
         - DeviceName: /dev/sda2
           Ebs:
             DeleteOnTermination: true
-            VolumeSize: 2000
+            VolumeSize: 5000
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
@@ -6,11 +6,11 @@ aws:
         - DeviceName: /dev/sda1
           Ebs:
             DeleteOnTermination: true
-            VolumeSize: 2000
+            VolumeSize: 4000
         - DeviceName: /dev/sda2
           Ebs:
             DeleteOnTermination: true
-            VolumeSize: 2000
+            VolumeSize: 4000
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
@@ -6,11 +6,11 @@ aws:
         - DeviceName: /dev/sda1
           Ebs:
             DeleteOnTermination: true
-            VolumeSize: 4000
+            VolumeSize: 3000
         - DeviceName: /dev/sda2
           Ebs:
             DeleteOnTermination: true
-            VolumeSize: 4000
+            VolumeSize: 3000
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
@@ -6,11 +6,11 @@ aws:
         - DeviceName: /dev/sda1
           Ebs:
             DeleteOnTermination: true
-            VolumeSize: 5000
+            VolumeSize: 2000
         - DeviceName: /dev/sda2
           Ebs:
             DeleteOnTermination: true
-            VolumeSize: 5000
+            VolumeSize: 2000
 
 head_node_type:
     name: head_node

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4842,7 +4842,7 @@
   cluster:
     byod:
       runtime_env:
-        - RAY_MAX_LIMIT_FROM_API_SERVER=1000000000 
+        - RAY_MAX_LIMIT_FROM_API_SERVER=1000000000
         - RAY_MAX_LIMIT_FROM_DATA_SOURCE=1000000000
     cluster_env: shuffle/shuffle_with_state_api_app_config.yaml
     cluster_compute: shuffle/shuffle_compute_single.yaml
@@ -5049,7 +5049,7 @@
   cluster:
     byod:
       runtime_env:
-        - RAY_memory_usage_threshold=0.7 
+        - RAY_memory_usage_threshold=0.7
         - RAY_task_oom_retries=-1
     cluster_env: oom/stress_tests_tune_air_oom_app_config.yaml
     cluster_compute: oom/stress_tests_tune_air_oom_compute.yaml
@@ -6040,7 +6040,7 @@
 
   run:
     timeout: 28800
-    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=100000 --partition-size=1e9 --shuffle
+    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=10000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 100
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4842,7 +4842,7 @@
   cluster:
     byod:
       runtime_env:
-        - RAY_MAX_LIMIT_FROM_API_SERVER=1000000000
+        - RAY_MAX_LIMIT_FROM_API_SERVER=1000000000 
         - RAY_MAX_LIMIT_FROM_DATA_SOURCE=1000000000
     cluster_env: shuffle/shuffle_with_state_api_app_config.yaml
     cluster_compute: shuffle/shuffle_compute_single.yaml
@@ -5049,7 +5049,7 @@
   cluster:
     byod:
       runtime_env:
-        - RAY_memory_usage_threshold=0.7
+        - RAY_memory_usage_threshold=0.7 
         - RAY_task_oom_retries=-1
     cluster_env: oom/stress_tests_tune_air_oom_app_config.yaml
     cluster_compute: oom/stress_tests_tune_air_oom_compute.yaml
@@ -6040,7 +6040,7 @@
 
   run:
     timeout: 28800
-    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=10000 --partition-size=1e9 --shuffle
+    script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=100000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 100
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`dataset_shuffle_push_based_random_shuffle_100tb` has been flaky for a few months. The direct cause is exceeding disk limits. This test takes 100 TB input data and do a pushed based shuffle. I confirmed with @stephanie-wang that it's supposed that 200TB data may be spilled to disk. Thus, increase the cluster disk volume to avoid this issue (200TB -> 300TB). 

Note, there are also occasional task OOMs in this benchmark, they shouldn't be the root cause. But we can optimize this with better resource configurations or back pressure.

## Related issue number

Closes #36275 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
