### PR TITLE
[Serve] Let batch handler yield unhashable objects

### DIFF
--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -179,8 +179,8 @@ class _BatchQueue:
                     if future is FINISHED_TOKEN:
                         # This caller has already terminated.
                         next_futures.append(FINISHED_TOKEN)
-                    elif result in {StopIteration, StopAsyncIteration}:
-                        # User's code returned SENTINEL.VALUE. No values left
+                    elif result in [StopIteration, StopAsyncIteration]:
+                        # User's code returned sentinel. No values left
                         # for caller. Terminate iteration for caller.
                         future.set_exception(StopAsyncIteration)
                         next_futures.append(FINISHED_TOKEN)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change lets users yield unhashable objects in their `@serve.batch`-decorated generators.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - `test_batch_generator_streaming_response_integration_test` has been modified to yield unhashable types.
