### PR TITLE
[Docs][CI] Fix warnings about 'MOCK' option

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -356,6 +356,12 @@ nb_render_priority = {
 
 
 def setup(app):
+    # NOTE: 'MOCK' is a custom directive we introduced to illustrate mock outputs. Since
+    # `doctest` doesn't support this flag by default, `sphinx.ext.doctest` raises
+    # warnings when we build the documentation.
+    import doctest
+    doctest.register_optionflag("MOCK")
+
     app.connect("html-page-context", update_context)
 
     # Custom CSS

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -360,6 +360,7 @@ def setup(app):
     # `doctest` doesn't support this flag by default, `sphinx.ext.doctest` raises
     # warnings when we build the documentation.
     import doctest
+
     doctest.register_optionflag("MOCK")
 
     app.connect("html-page-context", update_context)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -356,7 +356,7 @@ nb_render_priority = {
 
 
 def setup(app):
-    # NOTE: 'MOCK' is a custom directive we introduced to illustrate mock outputs. Since
+    # NOTE: 'MOCK' is a custom option we introduced to illustrate mock outputs. Since
     # `doctest` doesn't support this flag by default, `sphinx.ext.doctest` raises
     # warnings when we build the documentation.
     import doctest


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

'MOCK' is a custom doctest option we introduced to illustrate mock outputs. Since `doctest` doesn't support this flag by default, `sphinx.ext.doctest` raises warnings when we build the documentation.

```
/ray/doc/source/data/iterating-over-data.rst:72: WARNING: 'MOCK' is not a valid option.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
