### PR TITLE
[ci][fix] add --run-jailed-tests when build-pipeline invoke itself

### DIFF
--- a/release/BUILD
+++ b/release/BUILD
@@ -509,6 +509,21 @@ py_test(
 )
 
 py_test(
+    name = "test_build_pipeline",
+    size = "small",
+    srcs = ["ray_release/tests/test_build_pipeline.py"],
+    exec_compatible_with = [":hermetic_python"],
+    tags = [
+        "release_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":ray_release",
+        bk_require("pytest"),
+    ],
+)
+
+py_test(
     name = "test_cluster_manager",
     size = "small",
     srcs = ["ray_release/tests/test_cluster_manager.py"],

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -92,9 +92,7 @@ def main(
         # the modules are reloaded and use the newest files, instead of
         # old ones, which may not have the changes introduced on the
         # checked out branch.
-        cmd = [sys.executable, __file__, "--no-clone-repo"]
-        if test_collection_file:
-            cmd += ["--test-collection-file", test_collection_file]
+        cmd = _get_rerun_cmd(test_collection_file, run_jailed_tests)
         subprocess.run(cmd, capture_output=False, check=True)
         return
     elif repo:
@@ -240,6 +238,18 @@ def main(
 
     steps_str = json.dumps(steps)
     print(steps_str)
+
+
+def _get_rerun_cmd(
+    test_collection_file: Optional[str] = None,
+    run_jailed_tests: bool = False,
+):
+    cmd = [sys.executable, __file__, "--no-clone-repo"]
+    if test_collection_file:
+        cmd += ["--test-collection-file", test_collection_file]
+    if run_jailed_tests:
+        cmd += ["--run-jailed-tests"]
+    return cmd
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_build_pipeline.py
+++ b/release/ray_release/tests/test_build_pipeline.py
@@ -1,0 +1,14 @@
+import sys
+
+import pytest
+
+from ray_release.scripts.build_pipeline import _get_rerun_cmd
+
+
+def test_get_rerun_cmd():
+    cmd = " ".join(_get_rerun_cmd("collection", True))
+    assert "--test-collection-file collection --run-jailed-tests" in cmd
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why are these changes needed?
build-pipeline script sometimes invoke itself, but does not inherit all the flag from its origin. Add the `--run-jailed-tests` when it invokes itself.

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests

![](https://media4.giphy.com/media/TejmLnMKgnmPInMQjV/200.gif?cid=5a38a5a2pereowbhbqwmp1lyntxpdibvydgu2i77sl8mwkaw&ep=v1_gifs_search&rid=200.gif&ct=g)