### PR TITLE
[AIR][Telemetry] Add back renamed `HuggingFaceTrainer` for telemetry tracking

### DIFF
--- a/python/ray/air/_internal/usage.py
+++ b/python/ray/air/_internal/usage.py
@@ -28,6 +28,7 @@ AIR_TRAINERS = {
     "TensorflowTrainer",
     "TorchTrainer",
     "XGBoostTrainer",
+    "HuggingFaceTrainer",  # Deprecated: Remove in 2.7.
 }
 
 # searchers implemented by Ray Tune.
@@ -54,7 +55,6 @@ TUNE_SEARCHER_WRAPPERS = {
 
 TUNE_SCHEDULERS = {
     "FIFOScheduler",
-    "AsyncHyperBandScheduler",
     "AsyncHyperBandScheduler",
     "MedianStoppingRule",
     "HyperBandScheduler",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `HuggingFaceTrainer` was renamed to `TransformersTrainer` in 2.5, but it's still possible to use `HuggingFaceTrainer`, which is just a wrapper subclass on `TransformersTrainer`. This entry got renamed in the telemetry allow-list, which makes `HuggingFaceTrainer` usage get logged as `Custom`.

Verified with a manual test:

```python
from ray.train.huggingface import HuggingFaceTrainer
trainer = HuggingFaceTrainer(lambda a, b, c: None)
```

**Before:**

```
trainer_name: Custom
<HuggingFaceTrainer>
```

**After:**

```
trainer_name: HuggingFaceTrainer
<HuggingFaceTrainer>
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
