### PR TITLE
[serve] Deflake `test_http_disconnect`

### DIFF
--- a/python/ray/serve/tests/test_streaming_response.py
+++ b/python/ray/serve/tests/test_streaming_response.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 import pytest
-import time
 from typing import AsyncGenerator
 
 from fastapi import FastAPI
@@ -259,6 +258,7 @@ def test_exception_in_generator(serve_instance, use_async: bool, use_fastapi: bo
     reason="Streaming feature flag is disabled.",
 )
 def test_http_disconnect(serve_instance):
+    """Test that response generators are cancelled when the client disconnects."""
     signal_actor = SignalActor.remote()
 
     @serve.deployment

--- a/python/ray/serve/tests/test_streaming_response.py
+++ b/python/ray/serve/tests/test_streaming_response.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import pytest
+import time
 from typing import AsyncGenerator
 
 from fastapi import FastAPI
@@ -264,11 +265,12 @@ def test_http_disconnect(serve_instance):
     class SimpleGenerator:
         def __call__(self, request: Request) -> StreamingResponse:
             async def wait_for_disconnect():
-                while not await request.is_disconnected():
-                    yield b""
-
-                print("Disconnected!")
-                signal_actor.send.remote()
+                try:
+                    yield "hi"
+                    await asyncio.sleep(100)
+                except asyncio.CancelledError:
+                    print("Cancelled!")
+                    signal_actor.send.remote()
 
             return StreamingResponse(wait_for_disconnect())
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test_http_disconnect` is flaky because `StreamingResponse` also calls `await request.is_disconnected()` and will cancel the generator task when a disconnect occurs.

Updated the test to catch the `CancellationError` instead which should not be flaky.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
