### PR TITLE
[Train][Docs] Skip flaky example in Train FAQ

### DIFF
--- a/doc/source/train/faq.rst
+++ b/doc/source/train/faq.rst
@@ -82,7 +82,7 @@ To resolve these issues, you can do the following:
    gets propagated to all training workers.
 
 .. FIXME: This snippet fails ~10% of runs. See
-   https://buildkite.com/ray-project/oss-ci-build-branch/builds/4447#0188b20e-7680-433f-838a-7874abc2b72d.
+   https://github.com/ray-project/ray/issues/36399.
 
 .. testcode::
     :skipif: True

--- a/doc/source/train/faq.rst
+++ b/doc/source/train/faq.rst
@@ -81,11 +81,14 @@ To resolve these issues, you can do the following:
 3. Set this as the value for the `NCCL_SOCKET_IFNAME` environment variable. You must do this via Ray runtime environments so that it
    gets propagated to all training workers.
 
+.. FIXME: This snippet fails ~10% of runs. See
+   https://buildkite.com/ray-project/oss-ci-build-branch/builds/4447#0188b20e-7680-433f-838a-7874abc2b72d.
+
 .. testcode::
+    :skipif: True
 
     import ray
 
     # Add this at the top of your Ray application.
     runtime_env = {"env_vars": {"NCCL_SOCKET_IFNAME": "ens5"}}
     ray.init(runtime_env=runtime_env, ignore_reinit_error=True)
-


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The Train FAQ fails ~10% doctest runs. Since the issue is likely related to a race condition and might take a while to debug, I'm skipping the test.

```
______________________________ [doctest] faq.rst _______________________________
--
  | 082    gets propagated to all training workers.
  | 083
  | 084 .. testcode::
  | 085
  | 086     import ray
  | 087
  | 088     # Add this at the top of your Ray application.
  | 089     runtime_env = {"env_vars": {"NCCL_SOCKET_IFNAME": "ens5"}}
  | 090     ray.init(runtime_env=runtime_env, ignore_reinit_error=True)
  | 091
  | UNEXPECTED EXCEPTION: AttributeError("'NoneType' object has no attribute 'address_info'")
  | Traceback (most recent call last):
  | File "/opt/miniconda/lib/python3.7/site-packages/pytest_sphinx.py", line 457, in _DocTestRunner__run
  | test.globs,
  | File "<doctest faq.rst[0]>", line 5, in <module>
  | File "/ray/python/ray/_private/client_mode_hook.py", line 103, in wrapper
  | return func(*args, **kwargs)
  | File "/ray/python/ray/_private/worker.py", line 1451, in init
  | return RayContext(dict(_global_node.address_info, node_id=node_id.hex()))
  | AttributeError: 'NoneType' object has no attribute 'address_info'
```

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/ray-project/ray/pull/35380

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
