### PR TITLE
[ci][fix] fix byod disable on PR

### DIFF
--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -112,7 +112,7 @@ class Test(dict):
         """
         Returns whether this test is running on a BYOD cluster.
         """
-        if os.environ.get("BUILDKITE_PULL_REQUEST", False):
+        if os.environ.get("BUILDKITE_PULL_REQUEST", "false") != "false":
             # Do not run BYOD tests on PRs
             return False
         return self["cluster"].get("byod") is not None

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -31,6 +31,8 @@ def test_is_byod_cluster():
     assert _stub_test({"cluster": {"byod": {"type": "gpu"}}}).is_byod_cluster()
     with mock.patch.dict(os.environ, {"BUILDKITE_PULL_REQUEST": "1"}):
         assert not _stub_test({"cluster": {"byod": {}}}).is_byod_cluster()
+    with mock.patch.dict(os.environ, {"BUILDKITE_PULL_REQUEST": "false"}):
+        assert _stub_test({"cluster": {"byod": {}}}).is_byod_cluster()
 
 
 def test_convert_env_list_to_dict():


### PR DESCRIPTION
## Why are these changes needed?
The current checks disable byod on PR. However, currently it disable byod everywhere because BUILDKITE_PULL_REQUEST is default to the string "false" when the commit is not a PR (otherwise it is the PR number)

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests - https://buildkite.com/ray-project/release-tests-pr/builds/42126#0188b6f2-aa0d-4bb3-8836-51aa0e52c815 (test runs correctly using byod)
   