### PR TITLE
Fix data test failure on listdir check

### DIFF
--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -852,9 +852,9 @@ def test_parquet_write_create_dir(
         assert not os.path.isdir(all_empty_path)
         assert os.path.isdir(some_empty_path)
         # Only files for the non-empty blocks should be created.
-        assert os.listdir(some_empty_path) == [
-            f"{some_empty_key}_00000{i}.parquet" for i in range(2)
-        ]
+        file_list = os.listdir(some_empty_path)
+        file_list.sort()
+        assert file_list == [f"{some_empty_key}_00000{i}.parquet" for i in range(2)]
     else:
         assert (
             fs.get_file_info(_unwrap_protocol(all_empty_path)).type


### PR DESCRIPTION
`os.listdir()` does not always return file names that are sorted.

for the test to pass reliably, one needs to sort the filenames.

Example failure: https://buildkite.com/ray-project/oss-ci-build-pr/builds/25409#0188b704-a691-442a-bc65-f365362e2846/1755-2566