### PR TITLE
[Core][C++ Worker]Add error message for unsupported Object Ref parameters in C++ Worker

### DIFF
--- a/cpp/include/ray/api/arguments.h
+++ b/cpp/include/ray/api/arguments.h
@@ -32,7 +32,14 @@ class Arguments {
                            std::vector<TaskArg> *task_args,
                            InputArgTypes &&arg) {
     if constexpr (is_object_ref_v<OriginArgType>) {
-      PushReferenceArg(task_args, std::forward<InputArgTypes>(arg));
+      if (RayRuntimeHolder::Instance().Runtime()->IsLocalMode()) {
+        PushReferenceArg(task_args, std::forward<InputArgTypes>(arg));
+      } else {
+        // After the Object Ref parameter is supported, this exception will be deleted.
+        throw std::invalid_argument(
+            "At present, the Ray C++ API does not support the passing of "
+            "`ray::ObjectRef` parameters. Will support later.");
+      }
     } else if constexpr (is_object_ref_v<InputArgTypes>) {
       // core_worker submitting task callback will get the value of an ObjectRef arg, but
       // local mode we don't call core_worker submit task, so we need get the value of an

--- a/cpp/src/ray/test/cluster/cluster_mode_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_test.cc
@@ -677,6 +677,17 @@ TEST(RayClusterModeTest, RuntimeEnvJobLevelEnvVarsTest) {
   ray::Shutdown();
 }
 
+TEST(RayClusterModeTest, UnsupportObjectRefTest) {
+  ray::RayConfig config;
+  ray::Init(config, cmd_argc, cmd_argv);
+  ray::ActorHandle<Counter> actor = ray::Actor(RAY_FUNC(Counter::FactoryCreate)).Remote();
+  auto int_ref = ray::Put(1);
+  EXPECT_THROW(actor.Task(&Counter::GetIntByObjectRef).Remote(int_ref),
+               std::invalid_argument);
+
+  ray::Shutdown();
+}
+
 int main(int argc, char **argv) {
   absl::ParseCommandLine(argc, argv);
   cmd_argc = argc;

--- a/cpp/src/ray/test/cluster/counter.cc
+++ b/cpp/src/ray/test/cluster/counter.cc
@@ -102,6 +102,10 @@ int Counter::Plus1ForActor(ray::ActorHandle<Counter> actor) {
   return *actor.Task(&Counter::Plus1).Remote().Get();
 }
 
+int Counter::GetIntByObjectRef(ray::ObjectRef<int> object_ref) {
+  return *object_ref.Get();
+}
+
 RAY_REMOTE(RAY_FUNC(Counter::FactoryCreate),
            Counter::FactoryCreateException,
            RAY_FUNC(Counter::FactoryCreate, int),
@@ -124,7 +128,8 @@ RAY_REMOTE(RAY_FUNC(Counter::FactoryCreate),
            &Counter::CreateNestedChildActor,
            &Counter::GetBytes,
            &Counter::echoBytes,
-           &Counter::echoString);
+           &Counter::echoString,
+           &Counter::GetIntByObjectRef);
 
 RAY_REMOTE(ActorConcurrentCall::FactoryCreate, &ActorConcurrentCall::CountDown);
 

--- a/cpp/src/ray/test/cluster/counter.h
+++ b/cpp/src/ray/test/cluster/counter.h
@@ -73,6 +73,8 @@ class Counter {
     return value == NULL ? "" : std::string(value);
   }
 
+  int GetIntByObjectRef(ray::ObjectRef<int> object_ref);
+
  private:
   int count;
   bool is_restared = false;


### PR DESCRIPTION
## Why are these changes needed?
C++ Worker currently does not support passing Object Ref parameters, so we are adding an error message to notify users that this functionality is not supported. 

C++ Worker will support ObjectRef parameters in the future development.

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
