### PR TITLE
[Core][Label Scheduling 1/n]Add NodeLabelSchedulingStrategy API in python

### DIFF
--- a/python/ray/_private/ray_option_utils.py
+++ b/python/ray/_private/ray_option_utils.py
@@ -10,6 +10,7 @@ from ray.util.placement_group import PlacementGroup
 from ray.util.scheduling_strategies import (
     NodeAffinitySchedulingStrategy,
     PlacementGroupSchedulingStrategy,
+    NodeLabelSchedulingStrategy,
 )
 
 
@@ -129,6 +130,7 @@ _common_options = {
             str,
             PlacementGroupSchedulingStrategy,
             NodeAffinitySchedulingStrategy,
+            NodeLabelSchedulingStrategy,
         )
     ),
     "_metadata": Option((dict, type(None))),

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -61,6 +61,7 @@ py_test_module_list(
     "test_healthcheck.py",
     "test_kill_raylet_signal_log.py",
     "test_memstat.py",
+    "test_node_label_scheduling_strategy.py",
     "test_protobuf_compatibility.py"
   ],
   size = "medium",

--- a/python/ray/tests/test_node_label_scheduling_strategy.py
+++ b/python/ray/tests/test_node_label_scheduling_strategy.py
@@ -1,0 +1,106 @@
+import os
+import sys
+import pytest
+
+import ray
+from ray.util.scheduling_strategies import (
+    In,
+    NotIn,
+    Exists,
+    DoesNotExist,
+    NodeLabelSchedulingStrategy,
+)
+
+
+@ray.remote
+class MyActor:
+    def __init__(self):
+        pass
+
+    def double(self, x):
+        return 2 * x
+
+
+@pytest.mark.parametrize(
+    "call_ray_start",
+    ['ray start --head --labels={"gpu_type":"A100","region":"us"}'],
+    indirect=True,
+)
+def test_node_label_scheduling_basic(call_ray_start):
+    ray.init(address=call_ray_start)
+    MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy(
+            {"gpu_type": In("A100", "T100"), "region": Exists()}
+        )
+    )
+
+    MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy(
+            {"gpu_type": NotIn("A100", "T100"), "other_key": DoesNotExist()}
+        )
+    )
+
+    MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy(
+            hard={"gpu_type": Exists()},
+            soft={"gpu_type": In("A100")},
+        )
+    )
+
+
+def test_node_label_scheduling_invalid_paramter(call_ray_start):
+    ray.init(address=call_ray_start)
+    with pytest.raises(
+        ValueError, match="Type of value in position 0 for the In operator must be str"
+    ):
+        MyActor.options(
+            scheduling_strategy=NodeLabelSchedulingStrategy({"gpu_type": In(123)})
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Type of value in position 0 for the NotIn operator must be str",
+    ):
+        MyActor.options(
+            scheduling_strategy=NodeLabelSchedulingStrategy({"gpu_type": NotIn(123)})
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="The variadic parameter of the In operator must be a non-empty tuple",
+    ):
+        MyActor.options(
+            scheduling_strategy=NodeLabelSchedulingStrategy({"gpu_type": In()})
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="The variadic parameter of the NotIn operator must be a non-empty tuple",
+    ):
+        MyActor.options(
+            scheduling_strategy=NodeLabelSchedulingStrategy({"gpu_type": NotIn()})
+        )
+
+    with pytest.raises(ValueError, match="The soft parameter must be a map"):
+        MyActor.options(
+            scheduling_strategy=NodeLabelSchedulingStrategy(hard=None, soft=["1"])
+        )
+
+    with pytest.raises(
+        ValueError, match="The map key of the hard parameter must be of type str"
+    ):
+        MyActor.options(scheduling_strategy=NodeLabelSchedulingStrategy({111: "1111"}))
+
+    with pytest.raises(
+        ValueError, match="must be one of the `In`, `NotIn`, `Exists` or `DoesNotExist`"
+    ):
+        MyActor.options(
+            scheduling_strategy=NodeLabelSchedulingStrategy({"gpu_type": "1111"})
+        )
+
+
+if __name__ == "__main__":
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -49,6 +49,43 @@ enum TaskType {
   DRIVER_TASK = 3;
 }
 
+message LabelIn {
+  repeated string values = 1;
+}
+
+message LabelNotIn {
+  repeated string values = 1;
+}
+
+message LabelExists {}
+
+message LabelDoesNotExist {}
+
+message LabelOperator {
+  oneof LabelOperator {
+    LabelIn label_in = 1;
+    LabelNotIn label_not_in = 2;
+    LabelExists label_exists = 3;
+    LabelDoesNotExist label_does_not_exist = 4;
+  }
+}
+
+message LabelMatchExpression {
+  string key = 1;
+  LabelOperator operator = 2;
+}
+
+message LabelMatchExpressions {
+  repeated LabelMatchExpression expressions = 1;
+}
+
+message NodeLabelSchedulingStrategy {
+  // Required expressions to be satisfied
+  LabelMatchExpressions hard = 1;
+  // Preferred expressions to be satisfied
+  LabelMatchExpressions soft = 2;
+}
+
 message NodeAffinitySchedulingStrategy {
   bytes node_id = 1;
   bool soft = 2;
@@ -80,6 +117,7 @@ message SchedulingStrategy {
     // Best effort spread scheduling strategy.
     SpreadSchedulingStrategy spread_scheduling_strategy = 3;
     NodeAffinitySchedulingStrategy node_affinity_scheduling_strategy = 4;
+    NodeLabelSchedulingStrategy node_label_scheduling_strategy = 5;
   }
 }
 


### PR DESCRIPTION
## Why are these changes needed?
After our offline discussion, we have come up with the following plan. This API plan will review and finalization by more people in the future.

Complete form of API:
```
MyActor.options(
        scheduling_strategy=NodeLabelSchedulingStrategy(
            [
                {
                    "region": IN("us"), 
                    "gpu_type": IN("A100")
                },
                {
                    "region": IN("asia", "europe"), 
                    "gpu_type": IN("T100")
                 },
            ]
        )
).remote()
```

User also can use more simple api:
```
 MyActor.options(
        scheduling_strategy=NodeLabelSchedulingStrategy(
                {
                    "region": IN("us"), 
                    "gpu_type": IN("A100")
                }
)).remote()
```

## Related issue number

[Core][Labels Scheduling]Finalize the new node affinity scheduling with node labels API in the Python worker #36419 
## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
