### PR TITLE
[Data][Docs] Replace `code-block:: python` with `testcode` in Data docs

### DIFF
--- a/doc/source/data/examples/custom-datasource.rst
+++ b/doc/source/data/examples/custom-datasource.rst
@@ -16,7 +16,8 @@ a custom one for your use case. This guide walks through building
 a custom datasource, using `MongoDB <https://www.mongodb.com/docs/manual/introduction/>`__ as an example.
 By the end of the guide, you will have a ``MongoDatasource`` that you can use to create dataset as follows:
 
-.. code-block:: python
+.. testcode::
+    :skipif: True
 
     # Read from custom MongoDB datasource to create a dataset.
     ds = ray.data.read_datasource(
@@ -56,7 +57,7 @@ Here are the key design choices we will make in this guide:
 For example, suppose you have a MongoDB collection with 4 documents, which have a ``partition_field`` with values 0, 1, 2, 3.
 You can compose two MongoDB pipelines (each handled by a :class:`~ray.data.ReadTask`) as follows to read the collection in parallel:
 
-.. code-block:: python
+.. testcode::
 
     # A list of pipelines. Each pipeline is a series of stages, typed as List[Dict].
     my_pipelines = [
@@ -65,7 +66,7 @@ You can compose two MongoDB pipelines (each handled by a :class:`~ray.data.ReadT
           {
             "$match": {
                 "partition_field": {
-                    "$gte": 0
+                    "$gte": 0,
                     "$lt": 2
                 }
             }
@@ -76,7 +77,7 @@ You can compose two MongoDB pipelines (each handled by a :class:`~ray.data.ReadT
           {
             "$match": {
                 "partition_field": {
-                    "$gte": 2
+                    "$gte": 2,
                     "$lt": 4
                 }
 
@@ -172,7 +173,8 @@ a ``MongoDatasource``.
 Now you can create a Dataset from and write back to MongoDB, just like
 any other datasource.
 
-.. code-block:: python
+.. testcode::
+    :skipif: True
 
     # Read from MongoDB datasource and create a dataset.
     # The args are passed to MongoDatasource.create_reader().

--- a/doc/source/data/examples/random-access.rst
+++ b/doc/source/data/examples/random-access.rst
@@ -4,9 +4,15 @@
 Random Data Access (Experimental)
 ---------------------------------
 
-Any Arrow-format dataset can be enabled for random access by calling ``ds.to_random_access_dataset(key="col_name")``. This partitions the data across the cluster by the given sort key, providing efficient random access to records via binary search. A number of worker actors are created, each of which has zero-copy access to the underlying sorted data blocks of the Dataset.
+Any Arrow-format dataset can be enabled for random access by calling
+``ds.to_random_access_dataset(key="col_name")``. This partitions the data across the
+cluster by the given sort key, providing efficient random access to records via binary
+search. A number of worker actors are created, each of which has zero-copy access to the
+underlying sorted data blocks of the Dataset.
 
-.. code-block:: python
+.. testcode::
+
+    import ray
 
     # Generate a dummy embedding table as an example.
     ds = ray.data.range(100)
@@ -53,17 +59,29 @@ To debug performance problems, use ``random_access_ds.stats()``. This will retur
 
 It is important to note that the client (Ray worker process) can also be a bottleneck. To scale past the throughput of a single client, use multiple tasks to gather the data, for example:
 
-.. code-block:: python
+.. testcode::
+
+    import numpy as np
+    import ray
 
     @ray.remote
     def fetch(rmap, keys):
         return rmap.multiget(keys)
 
+    # Generate a dummy embedding table as an example.
+    rmap = (
+        ray.data.range(1000)
+        .add_column("embedding", lambda row: row["id"] ** 2)
+        .to_random_access_dataset(key="id", num_workers=4)
+    )
+
     # Split the list of keys we want to fetch into 10 pieces.
-    pieces = np.array_split(all_keys, 10)
+    requested_keys = list(range(0, 1000, 2))
+    pieces = np.array_split(requested_keys, 10)
 
     # Fetch from the RandomAccessDataset in parallel using 10 remote tasks.
     print(ray.get([fetch.remote(rmap, p) for p in pieces]))
+
 
 Fault Tolerance
 ---------------

--- a/doc/source/data/examples/random-access.rst
+++ b/doc/source/data/examples/random-access.rst
@@ -78,7 +78,6 @@ It is important to note that the client (Ray worker process) can also be a bottl
     # Fetch from the RandomAccessDataset in parallel using 10 remote tasks.
     print(ray.get([fetch.remote(rmap, p) for p in pieces]))
 
-
 Fault Tolerance
 ---------------
 

--- a/doc/source/data/examples/random-access.rst
+++ b/doc/source/data/examples/random-access.rst
@@ -4,11 +4,7 @@
 Random Data Access (Experimental)
 ---------------------------------
 
-Any Arrow-format dataset can be enabled for random access by calling
-``ds.to_random_access_dataset(key="col_name")``. This partitions the data across the
-cluster by the given sort key, providing efficient random access to records via binary
-search. A number of worker actors are created, each of which has zero-copy access to the
-underlying sorted data blocks of the Dataset.
+Any Arrow-format dataset can be enabled for random access by calling ``ds.to_random_access_dataset(key="col_name")``. This partitions the data across the cluster by the given sort key, providing efficient random access to records via binary search. A number of worker actors are created, each of which has zero-copy access to the underlying sorted data blocks of the Dataset.
 
 .. testcode::
 

--- a/doc/source/data/performance-tips.rst
+++ b/doc/source/data/performance-tips.rst
@@ -15,7 +15,7 @@ Debugging Statistics
 You can view debug stats for your Dataset executions via :meth:`ds.stats() <ray.data.Dataset.stats>`.
 These stats can be used to understand the performance of your Dataset workload and can help you debug problematic bottlenecks. Note that both execution and iterator statistics are available:
 
-.. code-block:: python
+.. testcode::
 
     import ray
     import time
@@ -24,16 +24,19 @@ These stats can be used to understand the performance of your Dataset workload a
         time.sleep(.0001)
         return x
 
-    ds = ray.data.range(10000)
-    ds = ds.map(lambda x: str(x + 1))
-    ds = ds.map(pause)
+    ds = (
+        ray.data.read_csv("s3://anonymous@air-example-data/iris.csv")
+        .map(lambda x: x)
+        .map(pause)
+    )
 
-    for x in ds.iter_batches():
+    for batch in ds.iter_batches():
         pass
 
     print(ds.stats())
 
-.. code-block::
+.. testoutput::
+    :options: +MOCK
 
     Stage 1 ReadRange->Map->Map: 16/16 blocks executed in 0.37s
     * Remote wall time: 101.55ms min, 331.39ms max, 135.24ms mean, 2.16s total
@@ -175,15 +178,14 @@ To try out push-based shuffle, set the environment variable ``RAY_DATA_PUSH_BASE
 You can also specify the shuffle implementation during program execution by
 setting the ``DataContext.use_push_based_shuffle`` flag:
 
-.. code-block:: python
+.. testcode::
 
-    import ray.data
+    import ray
 
     ctx = ray.data.DataContext.get_current()
     ctx.use_push_based_shuffle = True
 
-    n = 1000
-    parallelism=10
-    ds = ray.data.range(n, parallelism=parallelism)
-    print(ds.random_shuffle().take(10))
-    # [954, 405, 434, 501, 956, 762, 488, 920, 657, 834]
+    ds = (
+        ray.data.range(1000)
+        .random_shuffle()
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`code-block:: python` blocks aren't tested, so this PR replaces them with `testcode` blocks.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
