### PR TITLE
[Train] Fix lazy checkpoint marker clearing race condition

### DIFF
--- a/python/ray/train/data_parallel_trainer.py
+++ b/python/ray/train/data_parallel_trainer.py
@@ -464,7 +464,8 @@ class DataParallelTrainer(BaseTrainer):
             """
 
             marker_file = Path(trial_info.logdir) / LAZY_CHECKPOINT_MARKER_FILE
-            if marker_file.exists():
+            # Delete the marker on each node's rank 0 worker to avoid race conditions.
+            if session.get_local_rank() == 0 and marker_file.exists():
                 logger.debug(
                     f"Deleting the stale lazy checkpoint marker file: {marker_file}."
                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR deletes the marker on every local rank 0 worker, rather than on every worker, to prevent a file not found error raising due to a worker trying to delete the file that's already gone.

This will fix this flaky test:

<img width="474" alt="Screen Shot 2023-06-14 at 2 11 34 PM" src="https://github.com/ray-project/ray/assets/3887863/d9e9d1b2-6082-4b6d-aede-13c1dabc3cfc">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
