### PR TITLE
[Doc][Tune] Fix double reference in tune docs

### DIFF
--- a/doc/source/train/examples/lightning/lightning_exp_tracking.ipynb
+++ b/doc/source/train/examples/lightning/lightning_exp_tracking.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "\n",
     ":::{note}\n",
-    "This guide shows how to use the native [Logger](https://lightning.ai/docs/pytorch/stable/extensions/logging.html) integrations in PyTorch Lightning. Ray AIR also provides {ref}`experiment tracking integrations <tune-experiment-tracking-ref>` for all the tools mentioned in this example. We recommend sticking with the PyTorch Lightning loggers.\n",
+    "This guide shows how to use the native [Logger](https://lightning.ai/docs/pytorch/stable/extensions/logging.html) integrations in PyTorch Lightning. Ray AIR also provides {ref}`experiment tracking integrations <tune-experiment-tracking-examples>` for all the tools mentioned in this example. We recommend sticking with the PyTorch Lightning loggers.\n",
     ":::\n"
    ]
   },

--- a/doc/source/tune/examples/experiment-tracking.rst
+++ b/doc/source/tune/examples/experiment-tracking.rst
@@ -1,5 +1,3 @@
-.. _tune-experiment-tracking-ref:
-
 Tune Experiment Tracking Examples
 ---------------------------------
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This fixes the following error in the doc build:

```
source/tune/examples/experiment-tracking.rst:4: WARNING: duplicate label tune-experiment-tracking-ref, other instance in /ray/doc/source/tune/examples/experiment-tracking.rst
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
