### PR TITLE
[Data][Docs] Remove built-in datasources from API ref

### DIFF
--- a/doc/source/data/api/input_output.rst
+++ b/doc/source/data/api/input_output.rst
@@ -133,7 +133,7 @@ SQL Databases
    :toctree: doc/
 
    read_sql
-   
+
 Dask
 ----
 
@@ -215,25 +215,6 @@ Datasource API
    Datasource
    ReadTask
    datasource.Reader
-
-
-Built-in Datasources
-####################
-
-.. autosummary::
-   :toctree: doc/
-
-   datasource.BinaryDatasource
-   datasource.CSVDatasource
-   datasource.FileBasedDatasource
-   datasource.ImageDatasource
-   datasource.JSONDatasource
-   datasource.NumpyDatasource
-   datasource.ParquetDatasource
-   datasource.RangeDatasource
-   datasource.TFRecordDatasource
-   datasource.MongoDatasource
-   datasource.WebDatasetDatasource
 
 Partitioning API
 ----------------


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The built-in datasource references take up space but don't provide value. 

The references don't describe constructor arguments, and the class/method descriptions are all obvious. In any case, users shouldn't directly use built-in datasources -- they're internal abstractions. 

(Note that the `Datasource` interface is still documented for developers)

<img width="600" alt="image" src="https://github.com/ray-project/ray/assets/26107013/7c6b1ede-aca3-4d14-8771-4cce2161168e">

<img width="600" alt="image" src="https://github.com/ray-project/ray/assets/26107013/14a0d1aa-5a9d-445d-a978-e7096629ff6c">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
