### PR TITLE
Unskip test_get_release_wheel_url for mac

### DIFF
--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -81,18 +81,12 @@ def test_get_release_wheel_url():
     # This should be a commit for which wheels have already been built for
     # all platforms and python versions at
     # `s3://ray-wheels/releases/2.2.0/<commit>/`.
-    test_commits = {"2.3.0": "cf7a56b4b0b648c324722df7c99c168e92ff0b45"}
+    test_commits = {"2.5.0": "ddf0ccab7aa87be5cf6cf7df9d6e24a3611fb345"}
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             for version, commit in test_commits.items():
                 # TODO(https://github.com/ray-project/ray/issues/31362)
                 if py_version == (3, 11) and sys_platform != "linux":
-                    continue
-
-                # TODO(https://github.com/ray-project/ray/issues/33396)
-                # We currently don't have a release with the new wheel names with the
-                # x86_64 suffix.
-                if sys_platform == "darwin":
                     continue
 
                 url = get_release_wheel_url(commit, sys_platform, version, py_version)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Unskip test_get_release_wheel_url for mac since now we have generated wheels ends with `x86_64.whl`
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #33396
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
