### PR TITLE
[Core] Check that temp_dir must be absolute path.

### DIFF
--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -96,7 +96,7 @@ class RayParams:
         raylet_socket_name: If provided, it will specify the socket path
             used by the raylet process.
         temp_dir: If provided, it will specify the root temporary
-            directory for the Ray process.
+            directory for the Ray process. Must be an absolute path.
         storage: Specify a URI for persistent cluster-wide storage. This storage path
             must be accessible by all nodes of the cluster, otherwise an error will be
             raised.
@@ -427,6 +427,9 @@ class RayParams:
                 "Using ray with numpy < 1.16.0 will result in slow "
                 "serialization. Upgrade numpy if using with ray."
             )
+
+        if self.temp_dir is not None and not os.path.isabs(self.temp_dir):
+            raise ValueError("temp_dir must be absolute path or None.")
 
     def _format_ports(self, pre_selected_ports):
         """Format the pre-selected ports information to be more human-readable."""

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1240,8 +1240,8 @@ def init(
         _redis_password: Prevents external clients without the password
             from connecting to Redis if provided.
         _temp_dir: If provided, specifies the root temporary
-            directory for the Ray process. Defaults to an OS-specific
-            conventional location, e.g., "/tmp/ray".
+            directory for the Ray process. Must be an absolute path. Defaults to an
+            OS-specific conventional location, e.g., "/tmp/ray".
         _metrics_export_port: Port number Ray exposes system metrics
             through a Prometheus endpoint. It is currently under active
             development, and the API is subject to change.

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1116,7 +1116,7 @@ def test_import_ray_does_not_import_grpc():
 
 # https://github.com/ray-project/ray/issues/36431
 def test_temp_dir_must_be_absolute(shutdown_only):
-    # This test fails with the flag set to false.
+    # This test fails with a relative path _temp_dir.
     with pytest.raises(ValueError):
         ray.init(_temp_dir='relative_path')
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1114,12 +1114,6 @@ def test_import_ray_does_not_import_grpc():
     import grpc  # noqa: F401
 
 
-# https://github.com/ray-project/ray/issues/36431
-def test_temp_dir_must_be_absolute(shutdown_only):
-    # This test fails with a relative path _temp_dir.
-    with pytest.raises(ValueError):
-        ray.init(_temp_dir='relative_path')
-
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1115,9 +1115,9 @@ def test_import_ray_does_not_import_grpc():
 
 
 # https://github.com/ray-project/ray/issues/36431
-def test_temp_dir_must_be_absolute():
+def test_temp_dir_must_be_absolute(shutdown_only):
     # This test fails with the flag set to false.
-    with pytest.Raises(ValueError):
+    with pytest.raises(ValueError):
         ray.init(_temp_dir='relative_path')
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1114,6 +1114,12 @@ def test_import_ray_does_not_import_grpc():
     import grpc  # noqa: F401
 
 
+# https://github.com/ray-project/ray/issues/36431
+def test_temp_dir_must_be_absolute():
+    # This test fails with the flag set to false.
+    with pytest.Raises(ValueError):
+        ray.init(_temp_dir='relative_path')
+
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -124,7 +124,7 @@ def test_hosted_external_dashboard_url(override_url, shutdown_only, monkeypatch)
             expected_dashboard_url = "127.0.0.1:8265"
         elif "://" in override_url:
             # External dashboard url with https protocol included
-            expected_dashboard_url = override_url[override_url.index("://") + 3:]
+            expected_dashboard_url = override_url[override_url.index("://") + 3 :]
         else:
             # External dashboard url with no protocol
             expected_dashboard_url = override_url
@@ -329,7 +329,7 @@ def test_get_ray_address_from_environment(monkeypatch):
 def test_temp_dir_must_be_absolute(shutdown_only):
     # This test fails with a relative path _temp_dir.
     with pytest.raises(ValueError):
-        ray.init(_temp_dir='relative_path')
+        ray.init(_temp_dir="relative_path")
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -124,7 +124,7 @@ def test_hosted_external_dashboard_url(override_url, shutdown_only, monkeypatch)
             expected_dashboard_url = "127.0.0.1:8265"
         elif "://" in override_url:
             # External dashboard url with https protocol included
-            expected_dashboard_url = override_url[override_url.index("://") + 3 :]
+            expected_dashboard_url = override_url[override_url.index("://") + 3:]
         else:
             # External dashboard url with no protocol
             expected_dashboard_url = override_url
@@ -323,6 +323,13 @@ def test_get_ray_address_from_environment(monkeypatch):
         ray._private.services.get_ray_address_from_environment("addr", None)
         == "env_addr"
     )
+
+
+# https://github.com/ray-project/ray/issues/36431
+def test_temp_dir_must_be_absolute(shutdown_only):
+    # This test fails with a relative path _temp_dir.
+    with pytest.raises(ValueError):
+        ray.init(_temp_dir='relative_path')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

`ray.init` accepts a `_temp_dir` arg. The arg should be absolute path because it makes no sense to have a "relative path" on all nodes. However the code did not check that and proceeds as if it is absolute path. This makes the init code to hang and timeout.

Example issues for treating it as absolute: the `latest_session` symlink links to the temp_dir and if it is relative path it won't work.

## Compatibility Analysis

The call `ray.init()` times out when the arg is relative path, so it never worked and now we forbid it. This won't break any existing usage.

## Related issue number

Closes #30650.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
