### PR TITLE
[Data] Deprecate `output_arrow_format` of `from_items`

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1,5 +1,6 @@
 import collections
 import logging
+import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -118,12 +119,17 @@ def from_items(
         items: List of local Python objects.
         parallelism: The amount of parallelism to use for the dataset.
             Parallelism may be limited by the number of items.
-        output_arrow_format: If True, always return data in Arrow format, raising an
-            error if this is not possible. Defaults to False.
 
     Returns:
         MaterializedDataset holding the items.
     """
+    if output_arrow_format:
+        warnings.warn(
+            DeprecationWarning,
+            "`output_arrow_format` is deprecated. In Ray 2.5+, `from_items` always "
+            "tries to store items in Arrow format.",
+        )
+
     ctx = ray.data.DataContext.get_current()
     if ctx.strict_mode:
         output_arrow_format = True


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Previously, `from_items` stored items in Python lists and offered the option to store them in Arrow tables with `output_arrow_format`. In Ray 2.5+, `from_items` always tries to store items in Arrow tables, so the option is obsolete.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
