### PR TITLE
[docs] change Getting Started title to Ray Dashboard

### DIFF
--- a/doc/source/ray-observability/getting-started.rst
+++ b/doc/source/ray-observability/getting-started.rst
@@ -1,7 +1,7 @@
 .. _observability-getting-started:
 
-Getting Started
-===============
+Ray Dashboard
+=============
 
 Ray provides a web-based dashboard for monitoring and debugging Ray applications.
 The visual representation of the system state, allows users to track the performance


### PR DESCRIPTION

## Why are these changes needed?

This page is about the Dashboard and many pages need to link to the Ray Dashboard. The name Getting Started can be confusing, so changing the name to Ray Dashboard.
cc: @scottsun94 @rkooo567 @alanwguo 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
