### PR TITLE
[ci][fix] un-byod a jailed test

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5047,10 +5047,6 @@
   frequency: nightly
   team: core
   cluster:
-    byod:
-      runtime_env:
-        - RAY_memory_usage_threshold=0.7 
-        - RAY_task_oom_retries=-1
     cluster_env: oom/stress_tests_tune_air_oom_app_config.yaml
     cluster_compute: oom/stress_tests_tune_air_oom_compute.yaml
 


### PR DESCRIPTION
## Why are these changes needed?
This tune_air_oom  test is jailed  so it has not been tested for so long. Remove it from byod since it is currently failing. Also it is missing a python: 3.8 entry for it to be a boyd.

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   