### PR TITLE
[tune] Upgrade ax-platform

### DIFF
--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -470,8 +470,6 @@ class SearchSpaceTest(unittest.TestCase):
         self.assertSequenceEqual(integers_1, integers_2)
         self.assertSequenceEqual(choices_1, choices_2)
 
-    # Todo: Upgrade ax. This will upgrade sub-dependencies that may break other parts.
-    @unittest.skip("ax tests currently failing (need to upgrade ax)")
     def testConvertAx(self):
         from ray.tune.search.ax import AxSearch
         from ax.service.ax_client import AxClient
@@ -537,7 +535,6 @@ class SearchSpaceTest(unittest.TestCase):
         self.assertTrue(5 <= config["a"] <= 6)
         self.assertTrue(8 <= config["b"] <= 9)
 
-    @unittest.skip("ax tests currently failing (need to upgrade ax)")
     def testSampleBoundsAx(self):
         from ray.tune.search.ax import AxSearch
         from ax.service.ax_client import AxClient
@@ -1689,7 +1686,6 @@ class SearchSpaceTest(unittest.TestCase):
             else:
                 self.assertDictEqual(trial_config_dict, points_to_evaluate[i])
 
-    @unittest.skip("ax tests currently failing (need to upgrade ax)")
     def testPointsToEvaluateAx(self):
         config = {
             "metric": ray.tune.search.sample.Categorical([1, 2, 3, 4]).uniform(),

--- a/python/ray/tune/tests/test_searchers.py
+++ b/python/ray/tune/tests/test_searchers.py
@@ -79,8 +79,6 @@ class InvalidValuesTest(unittest.TestCase):
             for x in buffer
         ), "Searcher checkpointing failed (unable to serialize)."
 
-    # Todo: Upgrade ax. This will upgrade sub-dependencies that may break other parts.
-    @unittest.skip("ax tests currently failing (need to upgrade ax)")
     def testAxManualSetup(self):
         from ray.tune.search.ax import AxSearch
         from ax.service.ax_client import AxClient
@@ -109,7 +107,6 @@ class InvalidValuesTest(unittest.TestCase):
         self.assertLess(out.best_trial.config["mixed_list"][1], 3)
         self.assertEqual(out.best_trial.config["mixed_list"][2], 4)
 
-    @unittest.skip("ax tests currently failing (need to upgrade ax)")
     def testAx(self):
         from ray.tune.search.ax import AxSearch
 
@@ -607,7 +604,6 @@ class SaveRestoreCheckpointTest(unittest.TestCase):
         if hasattr(searcher, "_live_trial_mapping"):
             assert "not_completed" in searcher._live_trial_mapping
 
-    @unittest.skip("ax tests currently failing (need to upgrade ax)")
     def testAx(self):
         from ray.tune.search.ax import AxSearch
         from ax.service.ax_client import AxClient

--- a/python/ray/tune/tests/test_tune_restore_warm_start.py
+++ b/python/ray/tune/tests/test_tune_restore_warm_start.py
@@ -422,7 +422,6 @@ class HEBOWarmStartTest(AbstractWarmStartTest, unittest.TestCase):
         return search_alg, cost
 
 
-@unittest.skip("ax warm start tests currently failing (need to upgrade ax)")
 class AxWarmStartTest(AbstractWarmStartTest, unittest.TestCase):
     def set_basic_conf(self):
         from ax.service.ax_client import AxClient

--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -1,11 +1,7 @@
 -r requirements_dl.txt
 
 aim==3.16.1
-ax-platform[mysql]==0.2.6
-# Newer version of gpytorch are incompatible with ax 0.2.6.
-# Todo: Remove pin when upgrading ax
-gpytorch==1.8.1
-
+ax-platform[mysql]==0.3.2
 bayesian-optimization==1.2.0
 comet-ml==3.31.9
 ConfigSpace==0.4.18

--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -1,7 +1,8 @@
 -r requirements_dl.txt
 
 aim==3.16.1
-ax-platform[mysql]==0.3.2
+ax-platform[mysql]==0.2.6; python_version < '3.8'
+ax-platform[mysql]==0.3.2; python_version >= '3.8'
 bayesian-optimization==1.2.0
 comet-ml==3.31.9
 ConfigSpace==0.4.18


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Our current installation of ax-platform is outdated and doesn't work with more recent pandas versions. This PR upgrades the ax-platform version and re-enables previously disabled tests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
