### PR TITLE
[ci][fix] unbyod stress_test_state_api_scale

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4791,14 +4791,9 @@
   group: core-daily-test
   working_dir: nightly_tests
 
-  python: "3.8"
   frequency: nightly
   team: core
   cluster:
-    byod:
-      runtime_env:
-        - RAY_MAX_LIMIT_FROM_API_SERVER=1000000000
-        - RAY_MAX_LIMIT_FROM_DATA_SOURCE=1000000000
     cluster_env: stress_tests/state_api_app_config.yaml
     cluster_compute: stress_tests/stress_tests_compute_large.yaml
 


### PR DESCRIPTION
## Why are these changes needed?
stress_test_state_api_scale is failing on master, I suspect because of byod

CC: @rickyyx 

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   