### PR TITLE
[serve] Clear `replica_updated_event` in streaming router to avoid blocking proxy event loop

### DIFF
--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -178,6 +178,12 @@ class HTTPProxy:
         self.self_actor_handle = ray.get_runtime_context().current_actor
         self.asgi_receive_queues: Dict[str, ASGIMessageQueue] = dict()
 
+        if RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING:
+            logger.info(
+                "Experimental streaming feature flag enabled.",
+                extra={"log_to_stderr": False},
+            )
+
         def get_handle(name):
             return serve.context.get_global_client().get_handle(
                 name,

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -108,6 +108,8 @@ class RoundRobinStreamingReplicaScheduler(ReplicaScheduler):
                     f"{self._deployment_name} but none available.",
                     extra={"log_to_stderr": False},
                 )
+                # Clear before waiting to avoid immediately waking up if there
+                # had ever been an update before.
                 self._replicas_updated_event.clear()
                 await self._replicas_updated_event.wait()
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -127,7 +127,7 @@ class RoundRobinStreamingReplicaScheduler(ReplicaScheduler):
         )
 
     def update_running_replicas(self, running_replicas: List[RunningReplicaInfo]):
-        new_replica_ids = set(r.replica_tag for r in running_replicas)
+        new_replica_ids = {r.replica_tag for r in running_replicas}
         if new_replica_ids != self._replica_id_set:
             self._replica_id_set = new_replica_ids
             logger.info(

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -108,7 +108,7 @@ class RoundRobinStreamingReplicaScheduler(ReplicaScheduler):
                     f"{self._deployment_name} but none available.",
                     extra={"log_to_stderr": False},
                 )
-                # self._replicas_updated_event.clear()
+                self._replicas_updated_event.clear()
                 await self._replicas_updated_event.wait()
 
         if replica.is_cross_language:

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -89,7 +89,9 @@ class RoundRobinStreamingReplicaScheduler(ReplicaScheduler):
     This policy does *not* respect `max_concurrent_queries`.
     """
 
-    def __init__(self):
+    def __init__(self, deployment_name: str):
+        self._deployment_name = deployment_name
+        self._replica_id_set = set()
         self._replica_iterator = itertools.cycle([])
         self._replicas_updated_event = asyncio.Event()
 
@@ -102,9 +104,11 @@ class RoundRobinStreamingReplicaScheduler(ReplicaScheduler):
                 replica = next(self._replica_iterator)
             except StopIteration:
                 logger.info(
-                    "Tried to assign replica but none available",
+                    "Tried to assign replica for deployment "
+                    f"{self._deployment_name} but none available.",
                     extra={"log_to_stderr": False},
                 )
+                # self._replicas_updated_event.clear()
                 await self._replicas_updated_event.wait()
 
         if replica.is_cross_language:
@@ -121,6 +125,15 @@ class RoundRobinStreamingReplicaScheduler(ReplicaScheduler):
         )
 
     def update_running_replicas(self, running_replicas: List[RunningReplicaInfo]):
+        new_replica_ids = set(r.replica_tag for r in running_replicas)
+        if new_replica_ids != self._replica_id_set:
+            self._replica_id_set = new_replica_ids
+            logger.info(
+                "Got updated replicas for deployment "
+                f"{self._deployment_name}: {new_replica_ids}.",
+                extra={"log_to_stderr": False},
+            )
+
         random.shuffle(running_replicas)
         self._replica_iterator = itertools.cycle(running_replicas)
         self._replicas_updated_event.set()
@@ -384,7 +397,9 @@ class Router:
         """
         self._event_loop = event_loop
         if _stream:
-            self._replica_scheduler = RoundRobinStreamingReplicaScheduler()
+            self._replica_scheduler = RoundRobinStreamingReplicaScheduler(
+                deployment_name
+            )
         else:
             self._replica_scheduler = RoundRobinReplicaScheduler(event_loop)
 

--- a/python/ray/serve/tests/test_failure.py
+++ b/python/ray/serve/tests/test_failure.py
@@ -212,36 +212,49 @@ def test_no_available_replicas_does_not_block_proxy(serve_instance):
 
     This is essential so that other requests and health checks can pass while a
     deployment is deploying/updating.
+
+    See https://github.com/ray-project/ray/issues/36460.
     """
-    signal_actor = SignalActor.remote()
 
     @serve.deployment
     class SlowStarter:
-        def __init__(self):
-            ray.get(signal_actor.wait.remote())
+        def __init__(self, starting_actor, finish_starting_actor):
+            ray.get(starting_actor.send.remote())
+            ray.get(finish_starting_actor.wait.remote())
 
         def __call__(self):
             return "hi"
 
-    serve.run(SlowStarter.bind(), _blocking=False)
-
     @ray.remote
     def make_blocked_request():
-        print("MAKE BLOCKED")
         r = requests.get("http://localhost:8000/")
         r.raise_for_status()
-        print("BLOCKED DONE:", r.text)
         return r.text
 
-    blocked_ref = make_blocked_request.remote()
-    with pytest.raises(TimeoutError):
-        ray.get(blocked_ref, timeout=1)
+    # Loop twice: first iteration tests deploying from nothing, second iteration
+    # tests updating the replicas of an existing deployment.
+    for _ in range(2):
+        starting_actor = SignalActor.remote()
+        finish_starting_actor = SignalActor.remote()
+        serve.run(
+            SlowStarter.bind(starting_actor, finish_starting_actor), _blocking=False
+        )
 
-    requests.get("http://localhost:8000/-/routes").raise_for_status()
-    requests.get("http://localhost:8000/-/healthz").raise_for_status()
+        # Ensure that the replica has been started (we use _blocking=False).
+        ray.get(starting_actor.wait.remote())
 
-    ray.get(signal_actor.send.remote())
-    assert ray.get(blocked_ref) == "hi"
+        # The request shouldn't complete until the replica has finished started.
+        blocked_ref = make_blocked_request.remote()
+        with pytest.raises(TimeoutError):
+            ray.get(blocked_ref, timeout=1)
+
+        # If the proxy's loop was blocked, these would hang.
+        requests.get("http://localhost:8000/-/routes").raise_for_status()
+        requests.get("http://localhost:8000/-/healthz").raise_for_status()
+
+        # Signal the replica to finish starting; request should complete.
+        ray.get(finish_starting_actor.send.remote())
+        assert ray.get(blocked_ref) == "hi"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`replica_updated_event` was not being cleared. It seems that even though we were `await`ing the event, it was not yielding the loop because the event was always set. This cause the `while replica is not None` loop to busy-spin, blocking the HTTP proxy event loop.

Closes https://github.com/ray-project/ray/issues/36460

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
