### PR TITLE
[serve] add early return when there are still in progress http health check

### DIFF
--- a/python/ray/serve/_private/http_state.py
+++ b/python/ray/serve/_private/http_state.py
@@ -191,6 +191,7 @@ class HTTPProxyState:
                     f"{self._node_id} after {DEFAULT_HEALTH_CHECK_TIMEOUT_S}s"
                 )
                 self.try_update_status(HTTPProxyStatus.UNHEALTHY)
+            return
 
         # If there's no active in-progress health check and it has been more than 10
         # seconds since the last health check, perform another health check.

--- a/python/ray/serve/_private/http_state.py
+++ b/python/ray/serve/_private/http_state.py
@@ -191,7 +191,14 @@ class HTTPProxyState:
                     f"{self._node_id} after {DEFAULT_HEALTH_CHECK_TIMEOUT_S}s"
                 )
                 self.try_update_status(HTTPProxyStatus.UNHEALTHY)
-            return
+            else:
+                # This return is important to not trigger a new health check when
+                # there is an in progress health check. When the health check object
+                # is still in progress and before the timeout is triggered, we will
+                # do an early return here to signal the completion of this update call
+                # and to prevent another health check object from recreated in the
+                # code below.
+                return
 
         # If there's no active in-progress health check and it has been more than 10
         # seconds since the last health check, perform another health check.

--- a/python/ray/serve/tests/test_http_state.py
+++ b/python/ray/serve/tests/test_http_state.py
@@ -418,7 +418,7 @@ def test_http_proxy_state_update_healthy_check_health_always_fails():
 
 @patch("ray.serve._private.http_state.DEFAULT_HEALTH_CHECK_TIMEOUT_S", 0.1)
 @patch("ray.serve._private.http_state.PROXY_HEALTH_CHECK_PERIOD_S", 0.1)
-def test_http_proxy_state_check_health_always_timeout_timtout_eq_period():
+def test_http_proxy_state_check_health_always_timeout_timeout_eq_period():
     """Test calling update method on HTTPProxyState when the proxy state is HEALTHY and
     when the ready call always timed out and health check timeout and period equals.
 

--- a/python/ray/serve/tests/test_http_state.py
+++ b/python/ray/serve/tests/test_http_state.py
@@ -463,7 +463,7 @@ def test_http_proxy_state_check_health_always_timeout_timtout_eq_period():
 
 @patch("ray.serve._private.http_state.DEFAULT_HEALTH_CHECK_TIMEOUT_S", 1)
 @patch("ray.serve._private.http_state.PROXY_HEALTH_CHECK_PERIOD_S", 0.1)
-def test_http_proxy_state_check_health_always_timeout_timtout_greater_than_period():
+def test_http_proxy_state_check_health_always_timeout_timeout_greater_than_period():
     """Test calling update method on HTTPProxyState when the proxy state is HEALTHY and
     when the ready call always timed out and health check timeout greater than period.
 


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently there is a missing early return when there is a in progress http health check. Due to the default health check period (10s) shorter than the health check timeout (30s), we are always recreating new health check objects and will never fall into the timeout case when the health check hangs. TDD seeing this is the case in the test and seeing adding the missing early return fixes the issue. 

## Related issue number

Closes #36458

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
