### PR TITLE
[autoscaler] Improve event summary logging with explicit summary tag appended. 

### DIFF
--- a/python/ray/autoscaler/_private/event_summarizer.py
+++ b/python/ray/autoscaler/_private/event_summarizer.py
@@ -59,6 +59,8 @@ class EventSummarizer:
         with self.lock:
             out = []
             for template, quantity in self.events_by_key.items():
+                # Indicate explicitly this is a summarized message over time.
+                template = "[SUMMARY] " + template
                 out.append(template.format(quantity))
             out.extend(self.messages_to_send)
         return out

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -721,9 +721,9 @@ class AutoscalingTest(unittest.TestCase):
         # Just one node (node_id 1) terminated in the last update.
         # Validates that we didn't try to double-terminate node 0.
         assert sorted(events) == [
-            "Adding 1 node(s) of type ray.worker.new.",
-            "Adding 1 node(s) of type ray.worker.old.",
-            "Removing 1 nodes of type ray.worker.old (not "
+            "[SUMMARY] Adding 1 node(s) of type ray.worker.new.",
+            "[SUMMARY] Adding 1 node(s) of type ray.worker.old.",
+            "[SUMMARY] Removing 1 nodes of type ray.worker.old (not "
             "in available_node_types: ['ray.head.new', 'ray.worker.new']).",
         ]
 
@@ -1145,7 +1145,7 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
 
         # Expect the next two messages in the logs.
-        msg = "Failed to launch 2 node(s) of type worker."
+        msg = "[SUMMARY] Failed to launch 2 node(s) of type worker."
 
         def expected_message_logged():
             return msg in autoscaler.event_summarizer.summary()
@@ -1187,7 +1187,7 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
 
         # Expect the next message in the logs.
-        msg = "Failed to launch 2 node(s) of type worker. " "(didn't work): never did."
+        msg = "[SUMMARY] Failed to launch 2 node(s) of type worker. " "(didn't work): never did."
 
         def expected_message_logged():
             print(autoscaler.event_summarizer.summary())
@@ -1230,7 +1230,7 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
 
         # Expect the next message in the logs.
-        msg = "Failed to launch 2 node(s) of type worker. " "(didn't work): never did."
+        msg = "[SUMMARY] Failed to launch 2 node(s) of type worker. " "(didn't work): never did."
 
         def expected_message_logged():
             print(autoscaler.event_summarizer.summary())
@@ -1419,7 +1419,7 @@ class AutoscalingTest(unittest.TestCase):
         # Check the outdated node removal event is generated.
         autoscaler.update()
         events = autoscaler.event_summarizer.summary()
-        assert "Removing 10 nodes of type " "worker (outdated)." in events, events
+        assert "[SUMMARY] Removing 10 nodes of type " "worker (outdated)." in events, events
         assert mock_metrics.stopped_nodes.inc.call_count == 10
         mock_metrics.started_nodes.inc.assert_called_with(5)
         assert mock_metrics.worker_create_node_time.observe.call_count == 5
@@ -1627,7 +1627,7 @@ class AutoscalingTest(unittest.TestCase):
 
         # Check the scale-down event is generated.
         events = autoscaler.event_summarizer.summary()
-        assert "Removing 1 nodes of type worker " "(max_workers_per_type)." in events
+        assert "[SUMMARY] Removing 1 nodes of type worker " "(max_workers_per_type)." in events
         assert mock_metrics.stopped_nodes.inc.call_count == 1
 
         # Update the config to increase the cluster size
@@ -2308,7 +2308,7 @@ class AutoscalingTest(unittest.TestCase):
         # Check the launch failure event is generated.
         autoscaler.update()
         events = autoscaler.event_summarizer.summary()
-        assert "Removing 2 nodes of type " "worker (launch failed)." in events, events
+        assert "[SUMMARY] Removing 2 nodes of type " "worker (launch failed)." in events, events
 
     def testConfiguresOutdatedNodes(self):
         from ray.autoscaler._private.cli_logger import cli_logger
@@ -2426,8 +2426,8 @@ class AutoscalingTest(unittest.TestCase):
         self.waitForNodes(8, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
         assert autoscaler.pending_launches.value == 0
         events = autoscaler.event_summarizer.summary()
-        assert "Removing 1 nodes of type m4.large (max_workers_per_type)." in events
-        assert "Removing 2 nodes of type p2.8xlarge (max_workers_per_type)." in events
+        assert "[SUMMARY] Removing 1 nodes of type m4.large (max_workers_per_type)." in events
+        assert "[SUMMARY] Removing 2 nodes of type p2.8xlarge (max_workers_per_type)." in events
 
         # We should not be starting/stopping empty_node at all.
         for event in events:
@@ -2499,7 +2499,7 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
         events = autoscaler.event_summarizer.summary()
         assert (
-            "Restarting 1 nodes of type " "worker (lost contact with raylet)." in events
+            "[SUMMARY] Restarting 1 nodes of type " "worker (lost contact with raylet)." in events
         ), events
         assert mock_metrics.drain_node_exceptions.inc.call_count == 0
 
@@ -2609,7 +2609,7 @@ class AutoscalingTest(unittest.TestCase):
             autoscaler.update()
             events = autoscaler.event_summarizer.summary()
             assert (
-                "Removing 1 nodes of type "
+                "[SUMMARY] Removing 1 nodes of type "
                 "worker (lost contact with raylet)." in events
             ), events
 
@@ -3404,7 +3404,7 @@ class AutoscalingTest(unittest.TestCase):
         # Missed heartbeat triggered recovery for both nodes.
         events = autoscaler.event_summarizer.summary()
         assert (
-            "Restarting 2 nodes of type "
+            "[SUMMARY] Restarting 2 nodes of type "
             "ray.worker.default (lost contact with raylet)." in events
         ), events
         # Node 0 was terminated during the last update.
@@ -3434,11 +3434,11 @@ class AutoscalingTest(unittest.TestCase):
         # Just one node (node_id 1) terminated in the last update.
         # Validates that we didn't try to double-terminate node 0.
         assert (
-            "Removing 1 nodes of type ray.worker.default (launch failed)." in events
+            "[SUMMARY] Removing 1 nodes of type ray.worker.default (launch failed)." in events
         ), events
         # To be more explicit,
         assert (
-            "Removing 2 nodes of type "
+            "[SUMMARY] Removing 2 nodes of type "
             "ray.worker.default (launch failed)." not in events
         ), events
 

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -1187,7 +1187,10 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
 
         # Expect the next message in the logs.
-        msg = "[SUMMARY] Failed to launch 2 node(s) of type worker. " "(didn't work): never did."
+        msg = (
+            "[SUMMARY] Failed to launch 2 node(s) of type worker. "
+            "(didn't work): never did."
+        )
 
         def expected_message_logged():
             print(autoscaler.event_summarizer.summary())
@@ -1230,7 +1233,10 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
 
         # Expect the next message in the logs.
-        msg = "[SUMMARY] Failed to launch 2 node(s) of type worker. " "(didn't work): never did."
+        msg = (
+            "[SUMMARY] Failed to launch 2 node(s) of type worker. "
+            "(didn't work): never did."
+        )
 
         def expected_message_logged():
             print(autoscaler.event_summarizer.summary())
@@ -1419,7 +1425,9 @@ class AutoscalingTest(unittest.TestCase):
         # Check the outdated node removal event is generated.
         autoscaler.update()
         events = autoscaler.event_summarizer.summary()
-        assert "[SUMMARY] Removing 10 nodes of type " "worker (outdated)." in events, events
+        assert (
+            "[SUMMARY] Removing 10 nodes of type " "worker (outdated)." in events
+        ), events
         assert mock_metrics.stopped_nodes.inc.call_count == 10
         mock_metrics.started_nodes.inc.assert_called_with(5)
         assert mock_metrics.worker_create_node_time.observe.call_count == 5
@@ -1627,7 +1635,10 @@ class AutoscalingTest(unittest.TestCase):
 
         # Check the scale-down event is generated.
         events = autoscaler.event_summarizer.summary()
-        assert "[SUMMARY] Removing 1 nodes of type worker " "(max_workers_per_type)." in events
+        assert (
+            "[SUMMARY] Removing 1 nodes of type worker "
+            "(max_workers_per_type)." in events
+        )
         assert mock_metrics.stopped_nodes.inc.call_count == 1
 
         # Update the config to increase the cluster size
@@ -2308,7 +2319,9 @@ class AutoscalingTest(unittest.TestCase):
         # Check the launch failure event is generated.
         autoscaler.update()
         events = autoscaler.event_summarizer.summary()
-        assert "[SUMMARY] Removing 2 nodes of type " "worker (launch failed)." in events, events
+        assert (
+            "[SUMMARY] Removing 2 nodes of type " "worker (launch failed)." in events
+        ), events
 
     def testConfiguresOutdatedNodes(self):
         from ray.autoscaler._private.cli_logger import cli_logger
@@ -2426,8 +2439,14 @@ class AutoscalingTest(unittest.TestCase):
         self.waitForNodes(8, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
         assert autoscaler.pending_launches.value == 0
         events = autoscaler.event_summarizer.summary()
-        assert "[SUMMARY] Removing 1 nodes of type m4.large (max_workers_per_type)." in events
-        assert "[SUMMARY] Removing 2 nodes of type p2.8xlarge (max_workers_per_type)." in events
+        assert (
+            "[SUMMARY] Removing 1 nodes of type m4.large (max_workers_per_type)."
+            in events
+        )
+        assert (
+            "[SUMMARY] Removing 2 nodes of type p2.8xlarge (max_workers_per_type)."
+            in events
+        )
 
         # We should not be starting/stopping empty_node at all.
         for event in events:
@@ -2499,7 +2518,8 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
         events = autoscaler.event_summarizer.summary()
         assert (
-            "[SUMMARY] Restarting 1 nodes of type " "worker (lost contact with raylet)." in events
+            "[SUMMARY] Restarting 1 nodes of type "
+            "worker (lost contact with raylet)." in events
         ), events
         assert mock_metrics.drain_node_exceptions.inc.call_count == 0
 
@@ -3434,7 +3454,8 @@ class AutoscalingTest(unittest.TestCase):
         # Just one node (node_id 1) terminated in the last update.
         # Validates that we didn't try to double-terminate node 0.
         assert (
-            "[SUMMARY] Removing 1 nodes of type ray.worker.default (launch failed)." in events
+            "[SUMMARY] Removing 1 nodes of type ray.worker.default (launch failed)."
+            in events
         ), events
         # To be more explicit,
         assert (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When some operations are done (e.g. failed to allocate nodes), we log the failed operation + adding to the summary, and we log the summary periodically

**Before**
It's confusing when the summary is logged since it's actually the same error message with the per-instance log. For example:
```
Removing 10 nodes of type ray.worker.old # This could be from the summary or on actual removal
```

**Now**
A per operation log will be: 
```
Removing 10 nodes of type ray.worker.old 
```

And a summary log will be:
```
[SUMMARY] Removing 10 nodes of type ray.worker.old 
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
