### PR TITLE
Add "all" option for SessionName (#35408)

### DIFF
--- a/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
@@ -393,6 +393,6 @@ default_dashboard_config = DashboardConfig(
     name="DEFAULT",
     default_uid="rayDefaultDashboard",
     panels=DEFAULT_GRAFANA_PANELS,
-    standard_global_filters=['SessionName="$SessionName"'],
+    standard_global_filters=['SessionName=~"$SessionName"'],
     base_json_file_name="default_grafana_dashboard_base.json",
 )

--- a/dashboard/modules/metrics/dashboards/default_grafana_dashboard_base.json
+++ b/dashboard/modules/metrics/dashboards/default_grafana_dashboard_base.json
@@ -25,7 +25,7 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
+        "allValue": ".+",
         "current": {
           "selected": false
         },
@@ -34,7 +34,7 @@
         "description": "Filter queries to specific ray sessions.",
         "error": null,
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": null,
         "multi": false,
         "name": "SessionName",

--- a/python/ray/tests/test_metrics_head.py
+++ b/python/ray/tests/test_metrics_head.py
@@ -97,7 +97,7 @@ def test_metrics_folder_with_dashboard_override(
             for panel in contents["panels"]:
                 for target in panel["targets"]:
                     # Check for standard_global_filters
-                    assert 'SessionName="$SessionName"' in target["expr"]
+                    assert 'SessionName=~"$SessionName"' in target["expr"]
                     # Check for custom global_filters
                     assert global_filters in target["expr"]
             for variable in contents["templating"]["list"]:


### PR DESCRIPTION
This opens as default in the Grafana page but for the Dashboard UI, the default is still scoped to the latest session.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
