### PR TITLE
[ci] mark documentation test as soft fail

### DIFF
--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -442,6 +442,7 @@
       python/ray/tests/...
 
 - label: ":book: Documentation"
+  soft_fail: true
   commands:
     - export LINT=1
     - ./ci/env/install-dependencies.sh


### PR DESCRIPTION
It has been consistently failing since the strict mode is turned back on in https://github.com/ray-project/ray/commit/cd0d3cd7adba19b3e3955418f97826bef025f621

This will make other test fixes easier to spot.
