### PR TITLE
[Autoscaler] monitor: do not call logger.Exception in sig handler

### DIFF
--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -548,7 +548,6 @@ class Monitor:
                 time.sleep(2)
 
     def _handle_failure(self, error):
-        logger.exception("Error in monitor loop")
         if (
             self.autoscaler is not None
             and os.environ.get("RAY_AUTOSCALER_FATESHARE_WORKERS", "") == "1"
@@ -595,6 +594,7 @@ class Monitor:
             self._initialize_autoscaler()
             self._run()
         except Exception:
+            logger.exception("Error in monitor loop")
             self._handle_failure(traceback.format_exc())
             raise
 


### PR DESCRIPTION
Otherwise, it will print the following message on normal exiting:

````
2023-06-16 06:33:59,740	ERROR monitor.py:551 -- Error in monitor loop
NoneType: None
````

Fix https://github.com/ray-project/ray/issues/33747