### PR TITLE
[mac] Skip test_cli.py::test_ray_start as it's currently flaky

### DIFF
--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -282,6 +282,7 @@ def test_disable_usage_stats(monkeypatch, tmp_path):
 # it seems like interactive terminal detection works differently in python 3.8
 # compared to 3.7. Without this, tests would fail.
 # Todo: This should be removed again. Also, some tests are currently skipped.
+@pytest.mark.skipif(sys.platform == "darwin", reason="Currently failing on OSX")
 def test_ray_start(configure_lang, monkeypatch, tmp_path, cleanup_ray):
     monkeypatch.setenv("RAY_USAGE_STATS_CONFIG_PATH", str(tmp_path / "config.json"))
     runner = CliRunner(env={"RAY_USAGE_STATS_PROMPT_ENABLED": "0"})


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
