### PR TITLE
[Core][Labels Scheduling 1/n]Add node labels index for labels scheduling

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1238,6 +1238,20 @@ cc_test(
 )
 
 cc_test(
+    name = "node_labels_index_test",
+    size = "small",
+    srcs = [
+        "src/ray/raylet/scheduling/node_labels_index_test.cc",
+    ],
+    copts = COPTS,
+    tags = ["team:core"],
+    deps = [
+        ":raylet_lib",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "scheduling_ids_test",
     size = "small",
     srcs = [

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -98,6 +98,7 @@ bool ClusterResourceManager::UpdateNode(scheduling::NodeID node_id,
 
 bool ClusterResourceManager::RemoveNode(scheduling::NodeID node_id) {
   received_node_resources_.erase(node_id);
+  node_labels_index_.RemoveLabels(node_id);
   return nodes_.erase(node_id) != 0;
 }
 
@@ -286,6 +287,7 @@ void ClusterResourceManager::DebugString(std::stringstream &buffer) const {
     buffer << node.second.GetLocalView().DebugString();
   }
   buffer << bundle_location_index_.DebugString();
+  buffer << "\n" << node_labels_index_.DebugString();
 }
 
 BundleLocationIndex &ClusterResourceManager::GetBundleLocationIndex() {
@@ -301,6 +303,12 @@ void ClusterResourceManager::SetNodeLabels(
     it = nodes_.emplace(node_id, node_resources).first;
   }
   it->second.GetMutableLocalView()->labels = labels;
+
+  node_labels_index_.AddLabels(node_id, labels);
+}
+
+NodeLabelsIndex &ClusterResourceManager::GetNodeLabelsIndex() {
+  return node_labels_index_;
 }
 
 }  // namespace ray

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -26,6 +26,7 @@
 #include "ray/raylet/scheduling/cluster_resource_data.h"
 #include "ray/raylet/scheduling/fixed_point.h"
 #include "ray/raylet/scheduling/local_resource_manager.h"
+#include "ray/raylet/scheduling/node_labels_index.h"
 #include "ray/util/logging.h"
 #include "src/ray/protobuf/gcs.pb.h"
 
@@ -136,6 +137,8 @@ class ClusterResourceManager {
   void SetNodeLabels(const scheduling::NodeID &node_id,
                      const absl::flat_hash_map<std::string, std::string> &labels);
 
+  NodeLabelsIndex &GetNodeLabelsIndex();
+
  private:
   friend class ClusterResourceScheduler;
   friend class gcs::GcsActorSchedulerTest;
@@ -170,6 +173,8 @@ class ClusterResourceManager {
   absl::flat_hash_map<scheduling::NodeID, NodeResources> received_node_resources_;
 
   BundleLocationIndex bundle_location_index_;
+
+  NodeLabelsIndex node_labels_index_;
 
   /// Timer to revert local changes to the resources periodically.
   ray::PeriodicalRunner timer_;

--- a/src/ray/raylet/scheduling/cluster_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager_test.cc
@@ -174,4 +174,24 @@ TEST_F(ClusterResourceManagerTest, UpdateNodeNormalTaskResources) {
   ASSERT_TRUE(node_resources.normal_task_resources.Get(ResourceID::CPU()) == 0.8);
 }
 
+TEST_F(ClusterResourceManagerTest, TestAddAndRemoveNodeLabels) {
+  absl::flat_hash_map<std::string, std::string> labels = {{"node_ip", "1.1.1.1"}};
+  absl::flat_hash_map<std::string, std::string> labels_empty;
+  manager->SetNodeLabels(node0, labels);
+  manager->SetNodeLabels(node1, labels_empty);
+  const auto &node_resources_1 = manager->GetNodeResources(node0);
+  ASSERT_EQ(node_resources_1.labels, labels);
+  const auto &node_resources_2 = manager->GetNodeResources(node1);
+  ASSERT_EQ(node_resources_2.labels, labels_empty);
+  const auto &node_resources_3 = manager->GetNodeResources(node2);
+  ASSERT_EQ(node_resources_3.labels, labels_empty);
+
+  auto result =
+      manager->GetNodeLabelsIndex().GetNodesByKeyAndValue("node_ip", {"1.1.1.1"});
+  ASSERT_EQ(result, absl::flat_hash_set<scheduling::NodeID>{node0});
+  manager->RemoveNode(node0);
+  result = manager->GetNodeLabelsIndex().GetNodesByKeyAndValue("node_ip", {"1.1.1.1"});
+  ASSERT_TRUE(result.empty());
+}
+
 }  // namespace ray

--- a/src/ray/raylet/scheduling/node_labels_index.cc
+++ b/src/ray/raylet/scheduling/node_labels_index.cc
@@ -1,0 +1,105 @@
+// Copyright 2023 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/raylet/scheduling/node_labels_index.h"
+
+using json = nlohmann::json;
+
+namespace ray {
+
+void NodeLabelsIndex::AddLabels(
+    const scheduling::NodeID &node_id,
+    const absl::flat_hash_map<std::string, std::string> &labels) {
+  if (node_to_labels_.contains(node_id)) {
+    RAY_LOG(DEBUG) << "The node id " << node_id
+                   << " already exists and will overwrite the original node labels.";
+    RemoveLabels(node_id);
+  }
+
+  for (const auto &[key, value] : labels) {
+    label_to_nodes_[key][value].insert(node_id);
+  }
+
+  node_to_labels_[node_id] = labels;
+}
+
+void NodeLabelsIndex::RemoveLabels(const scheduling::NodeID &node_id) {
+  auto iter = node_to_labels_.find(node_id);
+  if (iter == node_to_labels_.end()) {
+    return;
+  }
+  for (const auto &[key, value] : iter->second) {
+    auto &node_id_set = label_to_nodes_[key][value];
+    node_id_set.erase(node_id);
+    if (node_id_set.empty()) {
+      label_to_nodes_[key].erase(value);
+      if (label_to_nodes_[key].empty()) {
+        label_to_nodes_.erase(key);
+      }
+    }
+  }
+  node_to_labels_.erase(iter);
+}
+
+absl::flat_hash_set<scheduling::NodeID> NodeLabelsIndex::GetNodesByKeyAndValue(
+    const std::string &key, const absl::flat_hash_set<std::string> &values) const {
+  absl::flat_hash_set<scheduling::NodeID> node_ids;
+  auto iter = label_to_nodes_.find(key);
+  if (iter == label_to_nodes_.end()) {
+    return {};
+  }
+
+  const auto &value_to_nodes = iter->second;
+  for (const auto &value : values) {
+    auto node_set_iter = value_to_nodes.find(value);
+    if (node_set_iter != value_to_nodes.end()) {
+      node_ids.insert(node_set_iter->second.begin(), node_set_iter->second.end());
+    }
+  }
+  return node_ids;
+}
+
+absl::flat_hash_set<scheduling::NodeID> NodeLabelsIndex::GetNodesByKey(
+    const std::string &key) const {
+  absl::flat_hash_set<scheduling::NodeID> node_ids;
+  auto iter = label_to_nodes_.find(key);
+  if (iter == label_to_nodes_.end()) {
+    return {};
+  }
+
+  for (const auto &[value, node_id_set] : iter->second) {
+    node_ids.insert(node_id_set.begin(), node_id_set.end());
+  }
+  return node_ids;
+}
+
+std::string NodeLabelsIndex::DebugString() const {
+  json object;
+  object["label_to_nodes"] = GetLabelToNodeJsonObject(label_to_nodes_);
+  return object.dump();
+}
+
+nlohmann::json NodeLabelsIndex::GetLabelToNodeJsonObject(
+    const LabelToNodes &label_to_nodes) const {
+  json object;
+  for (const auto &[key, value_map] : label_to_nodes) {
+    for (const auto &[value, node_map] : value_map) {
+      for (const auto &node_id : node_map) {
+        object[key][value].push_back(node_id.ToInt());
+      }
+    }
+  }
+  return object;
+}
+}  // namespace ray

--- a/src/ray/raylet/scheduling/node_labels_index.h
+++ b/src/ray/raylet/scheduling/node_labels_index.h
@@ -1,0 +1,56 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "nlohmann/json.hpp"
+#include "ray/raylet/scheduling/scheduling_ids.h"
+#include "ray/util/logging.h"
+
+namespace ray {
+using LabelToNodes = absl::flat_hash_map<
+    std::string,
+    absl::flat_hash_map<std::string, absl::flat_hash_set<scheduling::NodeID>>>;
+
+class NodeLabelsIndex {
+ public:
+  void AddLabels(const scheduling::NodeID &node_id,
+                 const absl::flat_hash_map<std::string, std::string> &labels);
+
+  void RemoveLabels(const scheduling::NodeID &node_id);
+
+  absl::flat_hash_set<scheduling::NodeID> GetNodesByKeyAndValue(
+      const std::string &key, const absl::flat_hash_set<std::string> &values) const;
+
+  absl::flat_hash_set<scheduling::NodeID> GetNodesByKey(const std::string &key) const;
+
+  std::string DebugString() const;
+
+ private:
+  nlohmann::json GetLabelToNodeJsonObject(const LabelToNodes &label_to_nodes) const;
+
+  // <label_key, <lable_value, [node_id]>>
+  LabelToNodes label_to_nodes_;
+
+  // <node_id, <label_key, label_value>>
+  absl::flat_hash_map<scheduling::NodeID, absl::flat_hash_map<std::string, std::string>>
+      node_to_labels_;
+};
+}  // end namespace ray

--- a/src/ray/raylet/scheduling/node_labels_index_test.cc
+++ b/src/ray/raylet/scheduling/node_labels_index_test.cc
@@ -1,0 +1,89 @@
+// Copyright 2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/raylet/scheduling/node_labels_index.h"
+
+#include "gtest/gtest.h"
+#include "ray/common/id.h"
+
+using json = nlohmann::json;
+namespace ray {
+
+scheduling::NodeID node_id_1(NodeID::FromRandom().Binary());
+scheduling::NodeID node_id_2(NodeID::FromRandom().Binary());
+
+TEST(NodeLabelsIndexTest, TestDebugString) {
+  NodeLabelsIndex node_labels_index;
+  ASSERT_EQ(node_labels_index.DebugString(), "{\"label_to_nodes\":null}");
+
+  node_labels_index.AddLabels(node_id_1, {{"node_ip", "1.1.1.1"}, {"gpu_type", "A100"}});
+  auto json_object = json::parse(node_labels_index.DebugString());
+  ASSERT_EQ(json_object.at("label_to_nodes").at("gpu_type").at("A100")[0],
+            node_id_1.ToInt());
+}
+
+TEST(NodeLabelsIndexTest, TestBasic) {
+  NodeLabelsIndex node_labels_index;
+  auto empty_debug_str = node_labels_index.DebugString();
+  ASSERT_TRUE(node_labels_index.GetNodesByKey("node_ip").empty());
+  ASSERT_TRUE(
+      node_labels_index.GetNodesByKeyAndValue("node_ip", {"1.1.1.1", "2.2.2.2"}).empty());
+
+  // Add node_id_1
+  node_labels_index.AddLabels(node_id_1, {{"node_ip", "1.1.1.1"}, {"gpu_type", "A100"}});
+  auto result = node_labels_index.GetNodesByKey("node_ip");
+  ASSERT_EQ(result, absl::flat_hash_set<scheduling::NodeID>{node_id_1});
+  result = node_labels_index.GetNodesByKeyAndValue("node_ip", {"1.1.1.1"});
+  ASSERT_EQ(result, absl::flat_hash_set<scheduling::NodeID>{node_id_1});
+
+  // Add node_id_2
+  node_labels_index.AddLabels(node_id_2, {{"node_ip", "2.2.2.2"}, {"gpu_type", "A100"}});
+  result = node_labels_index.GetNodesByKey("node_ip");
+  ASSERT_EQ(result, (absl::flat_hash_set<scheduling::NodeID>{node_id_1, node_id_2}));
+
+  result = node_labels_index.GetNodesByKeyAndValue("node_ip", {"1.1.1.1"});
+  ASSERT_EQ(result, absl::flat_hash_set<scheduling::NodeID>{node_id_1});
+  result = node_labels_index.GetNodesByKeyAndValue("node_ip", {"1.1.1.1", "2.2.2.2"});
+  ASSERT_EQ(result, (absl::flat_hash_set<scheduling::NodeID>{node_id_1, node_id_2}));
+  result = node_labels_index.GetNodesByKeyAndValue("node_ip", {"2.2.2.2", "3.3.3.3"});
+  ASSERT_EQ(result, absl::flat_hash_set<scheduling::NodeID>{node_id_2});
+
+  result = node_labels_index.GetNodesByKeyAndValue("gpu_type", {"A100"});
+  ASSERT_EQ(result, (absl::flat_hash_set<scheduling::NodeID>{node_id_1, node_id_2}));
+
+  // Don't exist key
+  result = node_labels_index.GetNodesByKey("other_key");
+  ASSERT_TRUE(result.empty());
+  result = node_labels_index.GetNodesByKeyAndValue("other_key", {"1.1.1.1", "2.2.2.2"});
+  ASSERT_TRUE(result.empty());
+
+  // Remove node_id_1
+  node_labels_index.RemoveLabels(node_id_1);
+  result = node_labels_index.GetNodesByKeyAndValue("node_ip", {"1.1.1.1"});
+  ASSERT_TRUE(result.empty());
+  result = node_labels_index.GetNodesByKeyAndValue("gpu_type", {"A100"});
+  ASSERT_EQ(result, absl::flat_hash_set<scheduling::NodeID>{node_id_2});
+  result = node_labels_index.GetNodesByKeyAndValue("node_ip", {"2.2.2.2"});
+  ASSERT_EQ(result, absl::flat_hash_set<scheduling::NodeID>{node_id_2});
+
+  // Remove node_id_2
+  node_labels_index.RemoveLabels(node_id_2);
+  result = node_labels_index.GetNodesByKeyAndValue("node_ip", {"2.2.2.2"});
+  ASSERT_TRUE(result.empty());
+  result = node_labels_index.GetNodesByKeyAndValue("gpu_type", {"A100"});
+  ASSERT_TRUE(result.empty());
+
+  ASSERT_EQ(node_labels_index.DebugString(), empty_debug_str);
+}
+}  // namespace ray


### PR DESCRIPTION
## Why are these changes needed?
Add node labels index for node affinity with labels policy.
Build an index table based on the labels information of all nodes to improve scheduling performance.

## Related issue number
(P2)Build an index table based on the labels information of all nodes to improve scheduling performance.
#34894

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
