### PR TITLE
[ci] collapse sphinix lint into build_sphinx_docs

### DIFF
--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -457,7 +457,7 @@
     # See https://stackoverflow.com/questions/63383400/error-cannot-uninstall-ruamel-yaml-while-creating-docker-image-for-azure-ml-a
     # Pin urllib to avoid downstream ssl incompatibility issues. This matches requirements-doc.txt.
     - pip install "mosaicml==0.12.1" "urllib3<1.27" --ignore-installed
-    - ./ci/ci.sh build
+    - ./ci/ci.sh build_sphinx_docs
 
 - label: ":octopus: Tune multinode tests"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TUNE_AFFECTED"]


### PR DESCRIPTION
So that the code path is separated from code and wheel building.

Pure refactoring on the CI set up; no CI logic change.