### PR TITLE
[ci] remove /root/bazel-3.2.0/output

### DIFF
--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -38,12 +38,6 @@ echo "java_bin path ${JAVA_BIN}"
 export JAVA_HOME="${JAVA_BIN%jre/bin/java}"
 
 /ray/ci/env/install-bazel.sh
-# Put bazel into the PATH if building Bazel from source
-# export PATH=/root/bazel-3.2.0/output:$PATH:/root/bin
-
-# If converting down to manylinux2010, the following configuration should
-# be set for bazel
-#echo "build --config=manylinux2010" >> /root/.bazelrc
 echo "build --incompatible_linkopts_to_linklibs" >> /root/.bazelrc
 
 if [[ -n "${RAY_INSTALL_JAVA:-}" ]]; then
@@ -104,11 +98,11 @@ for PYTHON_NUMPY in "${PYTHON_NUMPYS[@]}" ; do
     fi
 
     # build ray wheel
-    PATH="/opt/python/${PYTHON}/bin:/root/bazel-3.2.0/output:$PATH" \
+    PATH="/opt/python/${PYTHON}/bin:$PATH" \
     "/opt/python/${PYTHON}/bin/python" setup.py bdist_wheel
 
     # build ray-cpp wheel
-    PATH="/opt/python/${PYTHON}/bin:/root/bazel-3.2.0/output:$PATH" \
+    PATH="/opt/python/${PYTHON}/bin:$PATH" \
     RAY_INSTALL_CPP=1 "/opt/python/${PYTHON}/bin/python" setup.py bdist_wheel
 
     # In the future, run auditwheel here.


### PR DESCRIPTION
We are no longer building bazel from source anymore, the path is no longer being used.