### PR TITLE
[Core]Fix the error message prompt for command-line parameters in JSON format(--resources)

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1421,13 +1421,17 @@ def parse_resources_json(
     try:
         resources = json.loads(resources)
         if not isinstance(resources, dict):
-            raise ValueError
-    except Exception:
-        cli_logger.error("`{}` is not a valid JSON string.", cf.bold(command_arg))
+            raise ValueError("The format after deserialization is not a dict")
+    except Exception as e:
+        cli_logger.error(
+            "`{}` is not a valid JSON string, detail error:{}",
+            cf.bold(f"{command_arg}={resources}"),
+            str(e),
+        )
         cli_logger.abort(
             "Valid values look like this: `{}`",
             cf.bold(
-                f'{command_arg}=\'{{"CustomResource3": 1, ' '"CustomResource2": 2}}\''
+                f'{command_arg}=\'{{"CustomResource3": 1, "CustomResource2": 2}}\''
             ),
         )
     return resources
@@ -1439,12 +1443,16 @@ def parse_metadata_json(
     try:
         metadata = json.loads(metadata)
         if not isinstance(metadata, dict):
-            raise ValueError
-    except Exception:
-        cli_logger.error("`{}` is not a valid JSON string.", cf.bold(command_arg))
+            raise ValueError("The format after deserialization is not a dict")
+    except Exception as e:
+        cli_logger.error(
+            "`{}` is not a valid JSON string, detail error:{}",
+            cf.bold(f"{command_arg}={metadata}"),
+            str(e),
+        )
         cli_logger.abort(
             "Valid values look like this: `{}`",
-            cf.bold(f'{command_arg}=\'{{"key1": "value1", ' '"key2": "value2"}}\''),
+            cf.bold(f'{command_arg}=\'{{"key1": "value1", "key2": "value2"}}\''),
         )
     return metadata
 
@@ -1925,11 +1933,11 @@ def parse_node_labels_json(
     except Exception as e:
         cli_logger.error(
             "`{}` is not a valid JSON string, detail error:{}",
-            cf.bold(command_arg),
+            cf.bold(f"{command_arg}={labels_json}"),
             str(e),
         )
         cli_logger.abort(
             "Valid values look like this: `{}`",
-            cf.bold(f'{command_arg}=\'{{"gpu_type": "A100", ' '"region": "us"}}\''),
+            cf.bold(f'{command_arg}=\'{{"gpu_type": "A100", "region": "us"}}\''),
         )
     return labels


### PR DESCRIPTION
## Why are these changes needed?

1. Fix error info:  double `}`
![image](https://github.com/ray-project/ray/assets/11072802/b9aff558-87e1-4ad6-a86e-9a58c2d95462)

2. Different shells may have different rules for command line parsing. As a result, there may be a difference between the string entered by the user and the string passed to the python script. So when an error is reported, the resources string is printed out to prompt the user.

3. Increase the error reporting of json format parsing exception

![image](https://github.com/ray-project/ray/assets/11072802/d7ab5da2-2dc3-4c37-8844-d9f036adfafe)

## Related issue number

Custom Resources from using ray start in CLI do not work as intended #36374

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
