### PR TITLE
[release/air] Fix `air_example_gptj_deepspeed_fine_tuning.gce` failing...

### DIFF
--- a/doc/source/ray-air/examples/gptj_deepspeed_fine_tuning.ipynb
+++ b/doc/source/ray-air/examples/gptj_deepspeed_fine_tuning.ipynb
@@ -223,7 +223,7 @@
     "            \"aws\",\n",
     "            \"s3\",\n",
     "            \"sync\",\n",
-    "            \"--quiet\",\n",
+    "            \"--no-sign-request\",\n",
     "            \"s3://large-dl-models-mirror/models--EleutherAI--gpt-j-6B/main/\",\n",
     "            os.path.join(path, \"snapshots\", \"main\"),\n",
     "        ]\n",

--- a/python/ray/train/huggingface/transformers/_transformers_utils.py
+++ b/python/ray/train/huggingface/transformers/_transformers_utils.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Iterator, Optional, Tuple, Type
 
 import datasets.iterable_dataset
 import transformers.trainer
@@ -62,19 +62,22 @@ def wrap_transformers_trainer(
 
 
 # TODO(ml-team): Replace with a Datasets-HuggingFace integration when available.
-class RayDatasetHFIterable(datasets.iterable_dataset.ExamplesIterable):
-    """HF ExamplesIterable backed by a Dataset."""
+class RayDatasetHFIterable(datasets.iterable_dataset._BaseExamplesIterable):
+    """HF ``_BaseExamplesIterable`` backed by a ``ray.data.DataIterator``.
+
+    The other abstract methods of shuffling and sharding the data are not implemented,
+    since those operations should be done by Ray Data. For example, the dataset
+    is already sharded to each data parallel worker and is disabled
+    (see ``wrap_transformers_trainer`` above).
+    """
 
     def __init__(self, dataset: DataIterator) -> None:
+        super().__init__()
         self.dataset = dataset
-        self.generate_examples_fn = self.dataset.iter_rows
 
-        # Required for the superclass
-        self.kwargs = {}
-
-    def __iter__(self):
-        for row in self.generate_examples_fn(**self.kwargs):
-            yield (0, {k: v for k, v in row.items()})
+    def __iter__(self) -> Iterator[Tuple[int, dict]]:
+        for idx, row in enumerate(self.dataset.iter_rows()):
+            yield (idx, {k: v for k, v in row.items()})
 
 
 def process_dataset_for_hf(

--- a/python/ray/train/huggingface/transformers/_transformers_utils.py
+++ b/python/ray/train/huggingface/transformers/_transformers_utils.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterator, Optional, Tuple, Type
 
@@ -8,12 +9,16 @@ from transformers.trainer_utils import IntervalStrategy
 
 from ray.air import session
 from ray.data import DataIterator
+from ray.data.dataset import MaterializedDataset
+from ray.data._internal.iterator.stream_split_iterator import StreamSplitDataIterator
 from ray.train.huggingface.transformers.transformers_checkpoint import (
     TransformersCheckpoint,
 )
 
 if TYPE_CHECKING:
     from torch.utils.data import IterableDataset
+
+logger = logging.getLogger(__name__)
 
 
 def maybe_add_length(obj: Any, length: Optional[int]) -> Any:
@@ -90,11 +95,27 @@ def process_dataset_for_hf(
         hf_iterable, format_type="torch"
     ).with_format("torch")
 
-    try:
-        dataset_length = dataset._base_dataset.count()
-    except (ValueError, AttributeError):
-        # pipeline case
-        dataset_length = None
+    if isinstance(dataset, StreamSplitDataIterator):
+        if isinstance(dataset._base_dataset, MaterializedDataset):
+            # In the materialized case, we can count efficiently. TODO(ekl) avoid
+            # using the internal API here by passing in the base dataset from Train.
+            dataset_length = dataset._base_dataset.count() // dataset.world_size()
+        else:
+            # Otherwise don't count to avoid breaking streaming.
+            dataset_length = None
+            logger.warning(
+                f"The length for {dataset._base_dataset} cannot be determined "
+                "since it is a streaming dataset. HF transformers requires "
+                "`max_steps` to be passed in this case, or you can materialize the "
+                "dataset with `ds.materialize()`."
+            )
+    else:
+        # Legacy + non-split case.
+        try:
+            dataset_length = dataset._base_dataset.count()
+        except (ValueError, AttributeError):
+            # pipeline case
+            dataset_length = None
 
     iterable_dataset = maybe_add_length(iterable_dataset, dataset_length)
     # Trigger logic in `wrap_transformers_trainer` to disable built-in

--- a/python/ray/train/huggingface/transformers/_transformers_utils.py
+++ b/python/ray/train/huggingface/transformers/_transformers_utils.py
@@ -1,6 +1,5 @@
-import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterator, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Type
 
 import datasets.iterable_dataset
 import transformers.trainer
@@ -9,16 +8,12 @@ from transformers.trainer_utils import IntervalStrategy
 
 from ray.air import session
 from ray.data import DataIterator
-from ray.data.dataset import MaterializedDataset
-from ray.data._internal.iterator.stream_split_iterator import StreamSplitDataIterator
 from ray.train.huggingface.transformers.transformers_checkpoint import (
     TransformersCheckpoint,
 )
 
 if TYPE_CHECKING:
     from torch.utils.data import IterableDataset
-
-logger = logging.getLogger(__name__)
 
 
 def maybe_add_length(obj: Any, length: Optional[int]) -> Any:
@@ -67,22 +62,19 @@ def wrap_transformers_trainer(
 
 
 # TODO(ml-team): Replace with a Datasets-HuggingFace integration when available.
-class RayDatasetHFIterable(datasets.iterable_dataset._BaseExamplesIterable):
-    """HF ``_BaseExamplesIterable`` backed by a ``ray.data.DataIterator``.
-
-    The other abstract methods of shuffling and sharding the data are not implemented,
-    since those operations should be done by Ray Data. For example, the dataset
-    is already sharded to each data parallel worker and is disabled
-    (see ``wrap_transformers_trainer`` above).
-    """
+class RayDatasetHFIterable(datasets.iterable_dataset.ExamplesIterable):
+    """HF ExamplesIterable backed by a Dataset."""
 
     def __init__(self, dataset: DataIterator) -> None:
-        super().__init__()
         self.dataset = dataset
+        self.generate_examples_fn = self.dataset.iter_rows
 
-    def __iter__(self) -> Iterator[Tuple[int, dict]]:
-        for idx, row in enumerate(self.dataset.iter_rows()):
-            yield (idx, {k: v for k, v in row.items()})
+        # Required for the superclass
+        self.kwargs = {}
+
+    def __iter__(self):
+        for row in self.generate_examples_fn(**self.kwargs):
+            yield (0, {k: v for k, v in row.items()})
 
 
 def process_dataset_for_hf(
@@ -95,27 +87,11 @@ def process_dataset_for_hf(
         hf_iterable, format_type="torch"
     ).with_format("torch")
 
-    if isinstance(dataset, StreamSplitDataIterator):
-        if isinstance(dataset._base_dataset, MaterializedDataset):
-            # In the materialized case, we can count efficiently. TODO(ekl) avoid
-            # using the internal API here by passing in the base dataset from Train.
-            dataset_length = dataset._base_dataset.count() // dataset.world_size()
-        else:
-            # Otherwise don't count to avoid breaking streaming.
-            dataset_length = None
-            logger.warning(
-                f"The length for {dataset._base_dataset} cannot be determined "
-                "since it is a streaming dataset. HF transformers requires "
-                "`max_steps` to be passed in this case, or you can materialize the "
-                "dataset with `ds.materialize()`."
-            )
-    else:
-        # Legacy + non-split case.
-        try:
-            dataset_length = dataset._base_dataset.count()
-        except (ValueError, AttributeError):
-            # pipeline case
-            dataset_length = None
+    try:
+        dataset_length = dataset._base_dataset.count()
+    except (ValueError, AttributeError):
+        # pipeline case
+        dataset_length = None
 
     iterable_dataset = maybe_add_length(iterable_dataset, dataset_length)
     # Trigger logic in `wrap_transformers_trainer` to disable built-in

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -810,7 +810,7 @@
     cluster_compute: gptj_deepspeed_compute_aws.yaml
 
   run:
-    timeout: 3600
+    timeout: 4500
     script: python test_myst_doc.py --path gptj_deepspeed_fine_tuning.ipynb
 
   variations:


### PR DESCRIPTION
... to pull model from a public s3 bucket (#36276)

This PR fixes the `air_example_gptj_deepspeed_fine_tuning.gce` release test. It was failing due to our GCE nodes not having an AWS credentials file. This is not needed due to the s3 bucket being public, so we just pass a `--no-sign-request` flag to use AWS cli as an anonymous user. This also removes the `--quiet` flag since this cell is not shown to users anyways, and it'd help us catch some aws cli error in the future.

This PR also fixes the recent `datasets==2.13.0` breaking `TransformersTrainer`.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #36507

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
