### PR TITLE
[tune] BOHB: Fix nested bracket processing

### DIFF
--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -43,6 +43,7 @@ from ray.util.debug import log_once
 
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 @DeveloperAPI

--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -43,7 +43,6 @@ from ray.util.debug import log_once
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 
 @DeveloperAPI

--- a/python/ray/tune/schedulers/hb_bohb.py
+++ b/python/ray/tune/schedulers/hb_bohb.py
@@ -111,6 +111,8 @@ class HyperBandForBOHB(HyperBandScheduler):
             # TODO(team-ml): Refactor alongside HyperBandForBOHB
             trial_runner.search_alg.searcher.on_pause(trial.trial_id)
             return TrialScheduler.PAUSE
+
+        logger.debug(f"Processing bracket after trial {trial} result")
         action = self._process_bracket(trial_runner, bracket)
         if action == TrialScheduler.PAUSE:
             trial_runner.search_alg.searcher.on_pause(trial.trial_id)
@@ -150,6 +152,7 @@ class HyperBandForBOHB(HyperBandScheduler):
                         for trial in bracket.current_trials()
                     ):
                         # This will change the trial state
+                        logger.debug("Processing bracket since no trial is running.")
                         self._process_bracket(trial_runner, bracket)
 
                         # If there are pending trials now, suggest one.

--- a/python/ray/tune/schedulers/hyperband.py
+++ b/python/ray/tune/schedulers/hyperband.py
@@ -251,15 +251,15 @@ class HyperBandScheduler(FIFOScheduler):
                 bracket.cleanup_full(trial_runner)
                 return TrialScheduler.STOP
 
-            if bracket.is_being_processed:
-                logger.debug("Bracket is currently being processed.")
-                return TrialScheduler.NOOP
-
             bracket.is_being_processed = True
 
             good, bad = bracket.successive_halving(self._metric, self._metric_op)
 
-            logger.debug(f"Processing {len(good)} good and {len(bad)} bad trials.")
+            logger.debug(
+                f"Processing {len(good)} good and {len(bad)} bad trials in "
+                f"bracket {bracket}.\n"
+                f"Good: {good}\nBad: {bad}"
+            )
 
             # kill bad trials
             self._num_stopped += len(bad)
@@ -307,7 +307,7 @@ class HyperBandScheduler(FIFOScheduler):
         not finished."""
         bracket, _ = self._trial_info[trial]
         bracket.cleanup_trial(trial)
-        if not bracket.finished():
+        if not bracket.finished() and not bracket.is_being_processed:
             logger.debug(f"Processing bracket after trial {trial} removed")
             self._process_bracket(trial_runner, bracket)
 

--- a/python/ray/tune/schedulers/hyperband.py
+++ b/python/ray/tune/schedulers/hyperband.py
@@ -12,7 +12,6 @@ from ray.tune.error import TuneError
 from ray.util import PublicAPI
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 
 # Implementation notes:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes an issue in Hyperband (and thus BOHB) where a bracket is processed twice (and recursively).

Current failure path:

- Trial A resolves a future
- Bracket is processed. Trial B and Trial C are bad trials.
- Trial B is stopped
- This triggers another (nested!) bracket processing! 
- This time, trial C is considered good. It is set to PENDING
- Inner bracket processing finishes
- Outer bracket processing still considers C bad. It tries to stop it and runs into the bad status.

The fix is to set a flag if a bracket is being processed and not re-process the bracket.

This should fix `bohb_example`

Logs:

```

2023-06-20 15:52:08,041	DEBUG tune_controller.py:843 -- Future TRAIN RESOLVED for trial MyTrainableClass_759d6177: ({'episode_reward_mean': 99.29610560174883, 'done': False, 'training_iteration': 5, 'trial_id': '759d6177', 'date': '2023-06-20_15-52-08', 'timestamp': 1687269128, 'time_this_iter_s': 0.10202193260192871, 'time_total_s': 0.5183539390563965, 'pid': 91898, 'hostname': 'kai-GV42X9JCQ3.fritz.box', 'node_ip': '127.0.0.1', 'config': {'iterations': 100, 'width': 0.6189525838449828, 'height': 99.29612471606782, 'activation': 'relu'}, 'time_since_restore': 0.5183539390563965, 'iterations_since_restore': 5},), {}
2023-06-20 15:52:08,041	DEBUG hb_bohb.py:116 -- Processing bracket after trial MyTrainableClass_759d6177 result
2023-06-20 15:52:08,041	DEBUG hyperband.py:263 -- Processing 2 good and 2 bad trials in bracket Bracket(Max Size (n)=2, Milestone (r)=5, completed=66.7%): {PAUSED: 3, RUNNING: 1} .
Good: [MyTrainableClass_510906e6, MyTrainableClass_759d6177]
Bad: [MyTrainableClass_ba16e7a9, MyTrainableClass_37b63127]
2023-06-20 15:52:08,041	DEBUG hyperband.py:271 -- Stopping other trial MyTrainableClass_ba16e7a9
2023-06-20 15:52:08,041	DEBUG hyperband.py:314 -- Processing bracket after trial MyTrainableClass_ba16e7a9 removed
2023-06-20 15:52:08,041	DEBUG hyperband.py:263 -- Processing 3 good and 0 bad trials in bracket Bracket(Max Size (n)=2, Milestone (r)=5, completed=66.7%): {PAUSED: 3, RUNNING: 1} .
Good: {MyTrainableClass_510906e6: {'episode_reward_mean': 95.81896333788562, 'done': False, 'training_iteration': 5, 'trial_id': '510906e6', 'date': '2023-06-20_15-52-03', 'timestamp': 1687269123, 'time_this_iter_s': 0.10419201850891113, 'time_total_s': 0.5178318023681641, 'pid': 91863, 'hostname': 'kai-GV42X9JCQ3.fritz.box', 'node_ip': '127.0.0.1', 'time_since_restore': 0.5178318023681641, 'iterations_since_restore': 5, 'config/iterations': 100, 'config/width': 1.4647873281236574, 'config/height': 96.02695920717196, 'config/activation': 'relu', 'hyperband_info': {'budget': 5}}, MyTrainableClass_37b63127: {'episode_reward_mean': 94.33733828027894, 'done': False, 'training_iteration': 5, 'trial_id': '37b63127', 'date': '2023-06-20_15-52-05', 'timestamp': 1687269125, 'time_this_iter_s': 0.10412120819091797, 'time_total_s': 0.5199413299560547, 'pid': 91880, 'hostname': 'kai-GV42X9JCQ3.fritz.box', 'node_ip': '127.0.0.1', 'time_since_restore': 0.5199413299560547, 'iterations_since_restore': 5, 'config/iterations': 100, 'config/width': 1.3982419044353545, 'config/height': 94.48526617481309, 'config/activation': 'relu', 'hyperband_info': {'budget': 5}}, MyTrainableClass_759d6177: {'episode_reward_mean': 99.29610560174883, 'done': False, 'training_iteration': 5, 'trial_id': '759d6177', 'date': '2023-06-20_15-52-08', 'timestamp': 1687269128, 'time_this_iter_s': 0.10202193260192871, 'time_total_s': 0.5183539390563965, 'pid': 91898, 'hostname': 'kai-GV42X9JCQ3.fritz.box', 'node_ip': '127.0.0.1', 'time_since_restore': 0.5183539390563965, 'iterations_since_restore': 5, 'config/iterations': 100, 'config/width': 0.6189525838449828, 'config/height': 99.29612471606782, 'config/activation': 'relu', 'hyperband_info': {'budget': 5}}}
Bad: []
2023-06-20 15:52:08,041	DEBUG hyperband.py:293 -- Unpausing trial MyTrainableClass_510906e6
2023-06-20 15:52:08,041	DEBUG tune_controller.py:344 -- Setting status for trial MyTrainableClass_510906e6 from PAUSED to PENDING
2023-06-20 15:52:08,042	DEBUG hyperband.py:293 -- Unpausing trial MyTrainableClass_37b63127
2023-06-20 15:52:08,042	DEBUG tune_controller.py:344 -- Setting status for trial MyTrainableClass_37b63127 from PAUSED to PENDING
2023-06-20 15:52:08,042	DEBUG hyperband.py:297 -- Continuing current trial MyTrainableClass_759d6177
2023-06-20 15:52:08,044	DEBUG tune_controller.py:914 -- Requesting to STOP actor for trial MyTrainableClass_ba16e7a9
2023-06-20 15:52:08,044	DEBUG tune_controller.py:344 -- Setting status for trial MyTrainableClass_ba16e7a9 from PAUSED to TERMINATED
2023-06-20 15:52:08,044	DEBUG tune_controller.py:926 -- Will not STOP trial actor as it is not live: MyTrainableClass_ba16e7a9
2023-06-20 15:52:08,044	DEBUG tune_controller.py:850 -- Error handling TRAIN result for trial MyTrainableClass_759d6177: Trial with unexpected bad status encountered: MyTrainableClass_37b63127 is PENDING
2023-06-20 15:52:08,044	DEBUG tune_controller.py:417 -- CLEANING UP all trials
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
