### PR TITLE
[ci][py11/2] support docker build image for arm64

### DIFF
--- a/.buildkite/pipeline.arm64.yml
+++ b/.buildkite/pipeline.arm64.yml
@@ -46,6 +46,7 @@
     - py38
     - py39
     - py310
+    - py311
 
 - label: ":mechanical_arm: :docker: Build Images: {{matrix}} [aarch64] cu117/cu118"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
@@ -61,3 +62,4 @@
     - py38
     - py39
     - py310
+    - py311

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -64,7 +64,7 @@
     # Upload to latest directory.
     - if [ "$BUILDKITE_BRANCH" == "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
 
-- label: ":docker: Build Images: {{matrix}} - cpu/cu115/cu116"
+- label: ":docker: Build Images: {{matrix}} - cpu/cu115/116"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: medium
   commands:

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -64,7 +64,7 @@
     # Upload to latest directory.
     - if [ "$BUILDKITE_BRANCH" == "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
 
-- label: ":docker: Build Images: {{matrix}} - cpu/cu115/116"
+- label: ":docker: Build Images: {{matrix}} - cpu/cu115/cu116"
   conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
   instance_size: medium
   commands:

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -76,7 +76,7 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
     # We install cmake temporarily to get psutil
     && sudo apt-get autoremove -y cmake zlib1g-dev \
         # We keep g++ on GPU images, because uninstalling removes CUDA Devel tooling
-        $(if [ "$BASE_IMAGE" = "ubuntu:focal" ]; then echo \
+        $(if [[ "$BASE_IMAGE" == "ubuntu:focal" && "$HOSTTYPE" == "x86_64" ]]; then echo \
         g++; fi) \
     # Either install kubectl or remove wget 
     && (if [ "$AUTOSCALER" = "autoscaler" ]; \


### PR DESCRIPTION
## Why are these changes needed?
Support py311 docker build on arm64. On arm64, py311 needs g++ to compile grpc

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   