### PR TITLE
Revert "Revert "[Data] Implement Operators for `union()`""

### DIFF
--- a/python/ray/data/_internal/execution/bulk_executor.py
+++ b/python/ray/data/_internal/execution/bulk_executor.py
@@ -62,7 +62,7 @@ class BulkExecutor(Executor):
                 for i, ref_bundles in enumerate(inputs):
                     for r in ref_bundles:
                         op.add_input(r, input_index=i)
-                op.inputs_done()
+                op.all_inputs_done()
                 output = _naive_run_until_complete(op)
             finally:
                 op.shutdown()

--- a/python/ray/data/_internal/execution/interfaces.py
+++ b/python/ray/data/_internal/execution/interfaces.py
@@ -396,7 +396,15 @@ class PhysicalOperator(Operator):
         """
         raise NotImplementedError
 
-    def inputs_done(self) -> None:
+    def input_done(self, input_index: int) -> None:
+        """Called when the upstream operator at index `input_index` has completed().
+
+        After this is called, the executor guarantees that no more inputs will be added
+        via `add_input` for the given input index.
+        """
+        pass
+
+    def all_inputs_done(self) -> None:
         """Called when all upstream operators have completed().
 
         After this is called, the executor guarantees that no more inputs will be added

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -14,10 +14,12 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
     TaskContext,
 )
-from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
+from ray.data._internal.execution.operators.base_physical_operator import (
+    AllToAllOperator,
+)
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
+from ray.data._internal.execution.operators.limit_operator import LimitOperator
 from ray.data._internal.execution.operators.map_operator import MapOperator
-from ray.data._internal.execution.operators.one_to_one_operator import LimitOperator
 from ray.data._internal.execution.util import make_callable_class_concurrent
 from ray.data._internal.lazy_block_list import LazyBlockList
 from ray.data._internal.logical.optimizers import get_execution_plan

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -230,10 +230,10 @@ class ActorPoolMapOperator(MapOperator):
         # For either a completed task or ready worker, we try to dispatch queued tasks.
         self._dispatch_tasks()
 
-    def inputs_done(self):
+    def all_inputs_done(self):
         # Call base implementation to handle any leftover bundles. This may or may not
         # trigger task dispatch.
-        super().inputs_done()
+        super().all_inputs_done()
 
         # Mark inputs as done so future task dispatch will kill all inactive workers
         # once the bundle queue is exhausted.

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -6,8 +6,32 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
     TaskContext,
 )
+from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.stats import StatsDict
+
+
+class OneToOneOperator(PhysicalOperator):
+    """An operator that has one input and one output dependency.
+
+    This operator serves as the base for map, filter, limit, etc.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        input_op: PhysicalOperator,
+    ):
+        """Create a OneToOneOperator.
+        Args:
+            input_op: Operator generating input data for this op.
+            name: The name of this operator.
+        """
+        super().__init__(name, [input_op])
+
+    @property
+    def input_dependency(self) -> PhysicalOperator:
+        return self.input_dependencies[0]
 
 
 class AllToAllOperator(PhysicalOperator):
@@ -25,7 +49,6 @@ class AllToAllOperator(PhysicalOperator):
         name: str = "AllToAll",
     ):
         """Create an AllToAllOperator.
-
         Args:
             bulk_fn: The blocking transformation function to run. The inputs are the
                 list of input ref bundles, and the outputs are the output ref bundles
@@ -57,7 +80,7 @@ class AllToAllOperator(PhysicalOperator):
         assert input_index == 0, input_index
         self._input_buffer.append(refs)
 
-    def inputs_done(self) -> None:
+    def all_inputs_done(self) -> None:
         ctx = TaskContext(
             task_idx=self._next_task_index,
             sub_progress_bar_dict=self._sub_progress_bar_dict,
@@ -65,7 +88,7 @@ class AllToAllOperator(PhysicalOperator):
         self._output_buffer, self._stats = self._bulk_fn(self._input_buffer, ctx)
         self._next_task_index += 1
         self._input_buffer.clear()
-        super().inputs_done()
+        super().all_inputs_done()
 
     def has_next(self) -> bool:
         return len(self._output_buffer) > 0
@@ -102,3 +125,23 @@ class AllToAllOperator(PhysicalOperator):
         if self._sub_progress_bar_dict is not None:
             for sub_bar in self._sub_progress_bar_dict.values():
                 sub_bar.close()
+
+
+class NAryOperator(PhysicalOperator):
+    """An operator that has multiple input dependencies and one output.
+
+    This operator serves as the base for union, zip, etc.
+    """
+
+    def __init__(
+        self,
+        *input_ops: LogicalOperator,
+    ):
+        """Create a OneToOneOperator.
+        Args:
+            input_op: Operator generating input data for this op.
+            name: The name of this operator.
+        """
+        input_names = ", ".join([op._name for op in input_ops])
+        op_name = f"{self.__class__.__name__}({input_names})"
+        super().__init__(op_name, list(input_ops))

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -4,33 +4,13 @@ from typing import Deque, List, Optional, Tuple
 
 import ray
 from ray.data._internal.execution.interfaces import PhysicalOperator, RefBundle
+from ray.data._internal.execution.operators.base_physical_operator import (
+    OneToOneOperator,
+)
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.stats import StatsDict
 from ray.data.block import Block, BlockAccessor, BlockMetadata
 from ray.types import ObjectRef
-
-
-class OneToOneOperator(PhysicalOperator):
-    """An operator that has one input and one output dependency.
-    This operator serves as the base for map, filter, limit, etc.
-    """
-
-    def __init__(
-        self,
-        name: str,
-        input_op: PhysicalOperator,
-    ):
-        """Create a OneToOneOperator.
-
-        Args:
-            input_op: Operator generating input data for this op.
-            name: The name of this operator.
-        """
-        super().__init__(name, [input_op])
-
-    @property
-    def input_dependency(self) -> PhysicalOperator:
-        return self.input_dependencies[0]
 
 
 class LimitOperator(OneToOneOperator):
@@ -49,7 +29,7 @@ class LimitOperator(OneToOneOperator):
         self._cur_output_bundles = 0
         super().__init__(self._name, input_op)
         if self._limit <= 0:
-            self.inputs_done()
+            self.all_inputs_done()
 
     def _limit_reached(self) -> bool:
         return self._consumed_rows >= self._limit
@@ -99,7 +79,7 @@ class LimitOperator(OneToOneOperator):
         )
         self._buffer.append(out_refs)
         if self._limit_reached():
-            self.inputs_done()
+            self.all_inputs_done()
 
     def has_next(self) -> bool:
         return len(self._buffer) > 0

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -19,7 +19,9 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
     TaskContext,
 )
-from ray.data._internal.execution.operators.one_to_one_operator import OneToOneOperator
+from ray.data._internal.execution.operators.base_physical_operator import (
+    OneToOneOperator,
+)
 from ray.data._internal.memory_tracing import trace_allocation
 from ray.data._internal.stats import StatsDict
 from ray.data.block import Block, BlockAccessor, BlockExecStats, BlockMetadata
@@ -280,13 +282,13 @@ class MapOperator(OneToOneOperator, ABC):
         if self._metrics.cur > self._metrics.peak:
             self._metrics.peak = self._metrics.cur
 
-    def inputs_done(self):
+    def all_inputs_done(self):
         self._block_ref_bundler.done_adding_bundles()
         if self._block_ref_bundler.has_bundle():
             # Handle any leftover bundles in the bundler.
             bundle = self._block_ref_bundler.get_next_bundle()
             self._add_bundled_input(bundle)
-        super().inputs_done()
+        super().all_inputs_done()
 
     def has_next(self) -> bool:
         assert self._started

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -101,8 +101,8 @@ class OutputSplitter(PhysicalOperator):
         self._buffer.append(bundle)
         self._dispatch_bundles()
 
-    def inputs_done(self) -> None:
-        super().inputs_done()
+    def all_inputs_done(self) -> None:
+        super().all_inputs_done()
         if not self._equal:
             self._dispatch_bundles(dispatch_all=True)
             assert not self._buffer, "Should have dispatched all bundles."

--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -1,0 +1,107 @@
+from typing import List, Optional
+
+from ray.data._internal.execution.interfaces import (
+    ExecutionOptions,
+    PhysicalOperator,
+    RefBundle,
+)
+from ray.data._internal.execution.operators.base_physical_operator import NAryOperator
+from ray.data._internal.stats import StatsDict
+
+
+class UnionOperator(NAryOperator):
+    """An operator that combines output blocks from
+    two or more input operators into a single output."""
+
+    def __init__(
+        self,
+        *input_ops: PhysicalOperator,
+    ):
+        """Create a UnionOperator.
+
+        Args:
+            input_ops: Operators generating input data for this operator to union.
+        """
+
+        # By default, union does not preserve the order of output blocks.
+        # To preserve the order, configure ExecutionOptions accordingly.
+        self._preserve_order = False
+
+        # Intermediary buffers used to store blocks from each input dependency.
+        # Only used when `self._prserve_order` is True.
+        self._input_buffers: List[List[RefBundle]] = [[] for _ in range(len(input_ops))]
+
+        # The index of the input dependency that is currently the source of
+        # the output buffer. New inputs from this input dependency will be added
+        # directly to the output buffer. Only used when `self._preserve_order` is True.
+        self._input_idx_to_output = 0
+
+        self._output_buffer: List[RefBundle] = []
+        self._stats: StatsDict = {}
+        super().__init__(*input_ops)
+
+    def start(self, options: ExecutionOptions):
+        # Whether to preserve the order of the input data (both the
+        # order of the input operators and the order of the blocks within).
+        self._preserve_order = options.preserve_order
+        super().start(options)
+
+    def num_outputs_total(self) -> Optional[int]:
+        num_outputs = 0
+        for input_op in self.input_dependencies:
+            op_num_outputs = input_op.num_outputs_total()
+            # If at least one of the input ops has an unknown number of outputs,
+            # the number of outputs of the union operator is unknown.
+            if op_num_outputs is None:
+                return None
+            num_outputs += op_num_outputs
+        return num_outputs
+
+    def add_input(self, refs: RefBundle, input_index: int) -> None:
+        assert not self.completed()
+        assert 0 <= input_index <= len(self._input_dependencies), input_index
+
+        if not self._preserve_order:
+            self._output_buffer.append(refs)
+        else:
+            if input_index == self._input_idx_to_output:
+                self._output_buffer.append(refs)
+            else:
+                self._input_buffers[input_index].append(refs)
+
+    def input_done(self, input_index: int) -> None:
+        """When `self._preserve_order` is True, change the
+        output buffer source to the next input dependency
+        once the current input dependency calls `input_done()`."""
+        if not self._preserve_order:
+            return
+        if not input_index == self._input_idx_to_output:
+            return
+        next_input_idx = self._input_idx_to_output + 1
+        if next_input_idx < len(self._input_buffers):
+            self._output_buffer.extend(self._input_buffers[next_input_idx])
+            self._input_buffers[next_input_idx].clear()
+            self._input_idx_to_output = next_input_idx
+        super().input_done(input_index)
+
+    def all_inputs_done(self) -> None:
+        # Note that in the case where order is not preserved, all inputs
+        # are directly added to the output buffer as soon as they are received,
+        # so there is no need to check any intermediary buffers.
+        if self._preserve_order:
+            for idx, input_buffer in enumerate(self._input_buffers):
+                assert len(input_buffer) == 0, (
+                    f"Input at index {idx} still has "
+                    f"{len(input_buffer)} blocks remaining."
+                )
+        super().all_inputs_done()
+
+    def has_next(self) -> bool:
+        # Check if the output buffer still contains at least one block.
+        return len(self._output_buffer) > 0
+
+    def get_next(self) -> RefBundle:
+        return self._output_buffer.pop(0)
+
+    def get_stats(self) -> StatsDict:
+        return self._stats

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -59,13 +59,13 @@ class ZipOperator(PhysicalOperator):
         else:
             self._right_buffer.append(refs)
 
-    def inputs_done(self) -> None:
+    def all_inputs_done(self) -> None:
         self._output_buffer, self._stats = self._zip(
             self._left_buffer, self._right_buffer
         )
         self._left_buffer.clear()
         self._right_buffer.clear()
-        super().inputs_done()
+        super().all_inputs_done()
 
     def has_next(self) -> bool:
         return len(self._output_buffer) > 0

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -27,6 +27,7 @@ from ray.data._internal.execution.streaming_executor_state import (
     build_streaming_topology,
     process_completed_tasks,
     select_operator_to_run,
+    update_operator_states,
 )
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.stats import DatasetStats
@@ -256,6 +257,8 @@ class StreamingExecutor(Executor, threading.Thread):
                 execution_id=self._execution_id,
                 autoscaling_state=self._autoscaling_state,
             )
+
+        update_operator_states(topology)
 
         # Update the progress bar to reflect scheduling decisions.
         for op_state in topology.values():

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -19,7 +19,9 @@ from ray.data._internal.execution.interfaces import (
     PhysicalOperator,
     RefBundle,
 )
-from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
+from ray.data._internal.execution.operators.base_physical_operator import (
+    AllToAllOperator,
+)
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.util import memory_string
 from ray.data._internal.progress_bar import ProgressBar
@@ -120,6 +122,8 @@ class OpState:
         self.progress_bar = None
         self.num_completed_tasks = 0
         self.inputs_done_called = False
+        # Tracks whether `input_done` is called for each input op.
+        self.input_done_called = [False] * len(op.input_dependencies)
         self.dependents_completed_called = False
 
     def initialize_progress_bars(self, index: int, verbose_progress: bool) -> int:
@@ -306,7 +310,8 @@ def build_streaming_topology(
 
 
 def process_completed_tasks(topology: Topology) -> None:
-    """Process any newly completed tasks and update operator state."""
+    """Process any newly completed tasks. To update operator
+    states, call `update_operator_states()` afterwards."""
 
     # Update active tasks.
     active_tasks: Dict[ray.ObjectRef, PhysicalOperator] = {}
@@ -332,18 +337,26 @@ def process_completed_tasks(topology: Topology) -> None:
         while op.has_next():
             op_state.add_output(op.get_next())
 
+
+def update_operator_states(topology: Topology) -> None:
+    """Update operator states accordingly for newly completed tasks.
+    Should be called after `process_completed_tasks()`."""
+
     # Call inputs_done() on ops where no more inputs are coming.
     for op, op_state in topology.items():
         if op_state.inputs_done_called:
             continue
-        inputs_done = all(
-            [
-                dep.completed() and not topology[dep].outqueue
-                for dep in op.input_dependencies
-            ]
-        )
-        if inputs_done:
-            op.inputs_done()
+        all_inputs_done = True
+        for idx, dep in enumerate(op.input_dependencies):
+            if dep.completed() and not topology[dep].outqueue:
+                if not op_state.input_done_called[idx]:
+                    op.input_done(idx)
+                    op_state.input_done_called[idx] = True
+            else:
+                all_inputs_done = False
+
+        if all_inputs_done:
+            op.all_inputs_done()
             op_state.inputs_done_called = True
 
     # Traverse the topology in reverse topological order.

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -1,7 +1,21 @@
 from ray.data._internal.logical.interfaces import LogicalOperator
 
 
-class Zip(LogicalOperator):
+class NAry(LogicalOperator):
+    """Base class for n-ary operators, which take multiple input operators."""
+
+    def __init__(
+        self,
+        *input_ops: LogicalOperator,
+    ):
+        """
+        Args:
+            input_ops: The input operators.
+        """
+        super().__init__(self.__class__.__name__, list(input_ops))
+
+
+class Zip(NAry):
     """Logical operator for zip."""
 
     def __init__(
@@ -14,4 +28,14 @@ class Zip(LogicalOperator):
             left_input_ops: The input operator at left hand side.
             right_input_op: The input operator at right hand side.
         """
-        super().__init__("Zip", [left_input_op, right_input_op])
+        super().__init__(left_input_op, right_input_op)
+
+
+class Union(NAry):
+    """Logical operator for union."""
+
+    def __init__(
+        self,
+        *input_ops: LogicalOperator,
+    ):
+        super().__init__(*input_ops)

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -10,7 +10,9 @@ from ray.data._internal.execution.interfaces import (
 from ray.data._internal.execution.operators.actor_pool_map_operator import (
     ActorPoolMapOperator,
 )
-from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
+from ray.data._internal.execution.operators.base_physical_operator import (
+    AllToAllOperator,
+)
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.task_pool_map_operator import (
     TaskPoolMapOperator,

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -1,5 +1,7 @@
 from ray.data._internal.execution.interfaces import PhysicalOperator
-from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
+from ray.data._internal.execution.operators.base_physical_operator import (
+    AllToAllOperator,
+)
 from ray.data._internal.logical.operators.all_to_all_operator import (
     AbstractAllToAll,
     Aggregate,

--- a/python/ray/data/_internal/planner/plan_limit_op.py
+++ b/python/ray/data/_internal/planner/plan_limit_op.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from ray.data._internal.execution.operators.one_to_one_operator import LimitOperator
+from ray.data._internal.execution.operators.limit_operator import LimitOperator
 
 if TYPE_CHECKING:
     from ray.data._internal.execution.interfaces import PhysicalOperator

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 from ray.data._internal.execution.interfaces import PhysicalOperator
+from ray.data._internal.execution.operators.union_operator import UnionOperator
 from ray.data._internal.execution.operators.zip_operator import ZipOperator
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
@@ -11,7 +12,7 @@ from ray.data._internal.logical.operators.all_to_all_operator import AbstractAll
 from ray.data._internal.logical.operators.from_operators import AbstractFrom
 from ray.data._internal.logical.operators.input_data_operator import InputData
 from ray.data._internal.logical.operators.map_operator import AbstractUDFMap
-from ray.data._internal.logical.operators.n_ary_operator import Zip
+from ray.data._internal.logical.operators.n_ary_operator import Union, Zip
 from ray.data._internal.logical.operators.one_to_one_operator import Limit
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.logical.operators.write_operator import Write
@@ -66,6 +67,9 @@ class Planner:
         elif isinstance(logical_op, Zip):
             assert len(physical_children) == 2
             physical_op = ZipOperator(physical_children[0], physical_children[1])
+        elif isinstance(logical_op, Union):
+            assert len(physical_children) >= 2
+            physical_op = UnionOperator(*physical_children)
         elif isinstance(logical_op, Limit):
             assert len(physical_children) == 1
             physical_op = _plan_limit_op(logical_op, physical_children[0])

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -57,6 +57,9 @@ from ray.data._internal.logical.operators.map_operator import (
     MapBatches,
     MapRows,
 )
+from ray.data._internal.logical.operators.n_ary_operator import (
+    Union as UnionLogicalOperator,
+)
 from ray.data._internal.logical.operators.n_ary_operator import Zip
 from ray.data._internal.logical.operators.one_to_one_operator import Limit
 from ray.data._internal.logical.operators.write_operator import Write
@@ -1615,14 +1618,25 @@ class Dataset:
         if has_nonlazy:
             blocks = []
             metadata = []
-            for bl in bls:
+            ops_to_union = []
+            for idx, bl in enumerate(bls):
                 if isinstance(bl, LazyBlockList):
                     bs, ms = bl._get_blocks_with_metadata()
                 else:
+                    assert isinstance(bl, BlockList), type(bl)
                     bs, ms = bl._blocks, bl._metadata
+                op_logical_plan = getattr(datasets[idx]._plan, "_logical_plan", None)
+                if isinstance(op_logical_plan, LogicalPlan):
+                    ops_to_union.append(op_logical_plan.dag)
+                else:
+                    ops_to_union.append(None)
                 blocks.extend(bs)
                 metadata.extend(ms)
             blocklist = BlockList(blocks, metadata, owned_by_consumer=owned_by_consumer)
+
+            logical_plan = None
+            if all(ops_to_union):
+                logical_plan = LogicalPlan(UnionLogicalOperator(*ops_to_union))
         else:
             tasks: List[ReadTask] = []
             block_partition_refs: List[ObjectRef[BlockPartition]] = []
@@ -1650,6 +1664,16 @@ class Dataset:
                 owned_by_consumer=owned_by_consumer,
             )
 
+            logical_plan = self._logical_plan
+            logical_plans = [
+                getattr(union_ds, "_logical_plan", None) for union_ds in datasets
+            ]
+            if all(logical_plans):
+                op = UnionLogicalOperator(
+                    *[plan.dag for plan in logical_plans],
+                )
+                logical_plan = LogicalPlan(op)
+
         epochs = [ds._get_epoch() for ds in datasets]
         max_epoch = max(*epochs)
         if len(set(epochs)) > 1:
@@ -1669,6 +1693,7 @@ class Dataset:
             ExecutionPlan(blocklist, stats, run_by_consumer=owned_by_consumer),
             max_epoch,
             self._lazy,
+            logical_plan,
         )
 
     def groupby(self, key: Optional[str]) -> "GroupedData":

--- a/python/ray/data/tests/test_bulk_executor.py
+++ b/python/ray/data/tests/test_bulk_executor.py
@@ -8,7 +8,9 @@ import ray
 from ray.data._internal.compute import ActorPoolStrategy
 from ray.data._internal.execution.bulk_executor import BulkExecutor
 from ray.data._internal.execution.interfaces import ExecutionOptions, RefBundle
-from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
+from ray.data._internal.execution.operators.base_physical_operator import (
+    AllToAllOperator,
+)
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.util import make_ref_bundles

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -6,10 +6,14 @@ import pandas as pd
 import pytest
 
 import ray
+from ray.data._internal.execution.interfaces import ExecutionOptions
 from ray.data._internal.execution.legacy_compat import _blocks_to_input_buffer
-from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
+from ray.data._internal.execution.operators.base_physical_operator import (
+    AllToAllOperator,
+)
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.union_operator import UnionOperator
 from ray.data._internal.execution.operators.zip_operator import ZipOperator
 from ray.data._internal.logical.interfaces import LogicalPlan
 from ray.data._internal.logical.operators.all_to_all_operator import (
@@ -30,7 +34,7 @@ from ray.data._internal.logical.operators.map_operator import (
     MapBatches,
     MapRows,
 )
-from ray.data._internal.logical.operators.n_ary_operator import Zip
+from ray.data._internal.logical.operators.n_ary_operator import Union, Zip
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.logical.operators.write_operator import Write
 from ray.data._internal.logical.optimizers import PhysicalOptimizer
@@ -42,6 +46,8 @@ from ray.data._internal.logical.util import (
 from ray.data._internal.planner.planner import Planner
 from ray.data._internal.stats import DatasetStats
 from ray.data.aggregate import Count
+from ray.data.datasource.datasource import RangeDatasource
+from ray.data.datasource.json_datasource import JSONDatasource
 from ray.data.datasource.parquet_datasource import ParquetDatasource
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.util import column_udf, extract_values, named_values
@@ -372,6 +378,74 @@ def test_repartition_e2e(
     assert ds.sum() == sum(range(10))
     assert ds._block_num_rows() == [10], ds._block_num_rows()
     _check_repartition_usage_and_stats(ds)
+
+
+@pytest.mark.parametrize("preserve_order", (True, False))
+def test_union_operator(ray_start_regular_shared, enable_optimizer, preserve_order):
+    planner = Planner()
+    read_parquet_op = Read(ParquetDatasource(), [])
+    read_range_op = Read(RangeDatasource(), [])
+    read_json_op = Read(JSONDatasource(), [])
+    union_op = Union(
+        read_parquet_op,
+        read_range_op,
+        read_json_op,
+    )
+    plan = LogicalPlan(union_op)
+    physical_op = planner.plan(plan).dag
+
+    assert union_op.name == "Union"
+    assert isinstance(physical_op, UnionOperator)
+    assert len(physical_op.input_dependencies) == 3
+    for input_op in physical_op.input_dependencies:
+        assert isinstance(input_op, MapOperator)
+
+
+@pytest.mark.parametrize("preserve_order", (True, False))
+def test_union_e2e(ray_start_regular_shared, enable_optimizer, preserve_order):
+    execution_options = ExecutionOptions(preserve_order=preserve_order)
+    ctx = ray.data.DataContext.get_current()
+    ctx.execution_options = execution_options
+
+    ds = ray.data.range(20, parallelism=10)
+
+    # Test lazy union.
+    ds = ds.union(ds, ds, ds, ds)
+    assert ds.num_blocks() == 50
+    assert ds.count() == 100
+    assert ds.sum() == 950
+    _check_usage_record(["ReadRange", "Union"])
+    ds_result = [{"id": i} for i in range(20)] * 5
+    if preserve_order:
+        assert ds.take_all() == ds_result
+
+    ds = ds.union(ds)
+    assert ds.count() == 200
+    assert ds.sum() == (950 * 2)
+    _check_usage_record(["ReadRange", "Union"])
+    if preserve_order:
+        assert ds.take_all() == ds_result * 2
+
+    # Test materialized union.
+    ds2 = ray.data.from_items([{"id": i} for i in range(1, 5 + 1)])
+    assert ds2.count() == 5
+    assert ds2.sum() == 15
+    _check_usage_record(["FromItems"])
+
+    ds2 = ds2.union(ds2)
+    assert ds2.count() == 10
+    assert ds2.sum() == 30
+    _check_usage_record(["FromItems", "Union"])
+    ds2_result = ([{"id": i} for i in range(1, 5 + 1)]) * 2
+    if preserve_order:
+        assert ds2.take_all() == ds2_result
+
+    ds2 = ds2.union(ds)
+    assert ds2.count() == 210
+    assert ds2.sum() == (950 * 2 + 30)
+    _check_usage_record(["FromItems", "Union"])
+    if preserve_order:
+        assert ds2.take_all() == (ds2_result + ds_result * 2)
 
 
 def test_read_map_batches_operator_fusion(ray_start_regular_shared, enable_optimizer):

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -210,7 +210,7 @@ def test_actor_pool_resource_reporting(ray_start_10_cpus_shared):
     assert usage.object_store_memory == pytest.approx(2560, rel=0.5), usage
 
     # Indicate that no more inputs will arrive.
-    op.inputs_done()
+    op.all_inputs_done()
 
     # Wait until tasks are done.
     work_refs = op.get_work_refs()
@@ -294,7 +294,7 @@ def test_actor_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     assert usage.object_store_memory == pytest.approx(3200, rel=0.5), usage
 
     # Indicate that no more inputs will arrive.
-    op.inputs_done()
+    op.all_inputs_done()
 
     # Wait until tasks are done.
     work_refs = op.get_work_refs()

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -19,17 +19,20 @@ from ray.data._internal.execution.interfaces import (
 from ray.data._internal.execution.operators.actor_pool_map_operator import (
     ActorPoolMapOperator,
 )
-from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
+from ray.data._internal.execution.operators.base_physical_operator import (
+    AllToAllOperator,
+)
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
+from ray.data._internal.execution.operators.limit_operator import LimitOperator
 from ray.data._internal.execution.operators.map_operator import (
     MapOperator,
     _BlockRefBundler,
 )
-from ray.data._internal.execution.operators.one_to_one_operator import LimitOperator
 from ray.data._internal.execution.operators.output_splitter import OutputSplitter
 from ray.data._internal.execution.operators.task_pool_map_operator import (
     TaskPoolMapOperator,
 )
+from ray.data._internal.execution.operators.union_operator import UnionOperator
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data.block import Block
 from ray.tests.conftest import *  # noqa
@@ -88,7 +91,7 @@ def test_all_to_all_operator():
     op.start(ExecutionOptions())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
-    op.inputs_done()
+    op.all_inputs_done()
 
     # Check we return transformed bundles.
     assert not op.completed()
@@ -143,7 +146,7 @@ def test_map_operator_bulk(ray_start_regular_shared, use_actors):
             assert op.internal_queue_size() == i
         else:
             assert op.internal_queue_size() == 0
-    op.inputs_done()
+    op.all_inputs_done()
     work_refs = op.get_work_refs()
     while work_refs:
         for work_ref in work_refs:
@@ -239,7 +242,7 @@ def test_split_operator(ray_start_regular_shared, equal, chunk_size):
             assert ref.owns_blocks, ref
             for block, _ in ref.blocks:
                 output_splits[ref.output_split_idx].extend(list(ray.get(block)["id"]))
-    op.inputs_done()
+    op.all_inputs_done()
     if equal:
         for i in range(3):
             assert len(output_splits[i]) == 33 * chunk_size, output_splits
@@ -266,7 +269,7 @@ def test_split_operator_random(ray_start_regular_shared, equal, random_seed):
     op.start(ExecutionOptions())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
-    op.inputs_done()
+    op.all_inputs_done()
     while op.has_next():
         ref = op.get_next()
         assert ref.owns_blocks, ref
@@ -303,7 +306,7 @@ def test_split_operator_locality_hints(ray_start_regular_shared):
     op.start(ExecutionOptions())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
-    op.inputs_done()
+    op.all_inputs_done()
     while op.has_next():
         ref = op.get_next()
         assert ref.owns_blocks, ref
@@ -391,7 +394,7 @@ def test_map_operator_min_rows_per_bundle(ray_start_regular_shared, use_actors):
     op.start(ExecutionOptions())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
-    op.inputs_done()
+    op.all_inputs_done()
     work_refs = op.get_work_refs()
     while work_refs:
         for work_ref in work_refs:
@@ -436,7 +439,7 @@ def test_map_operator_output_unbundling(
     assert len(inputs) == 10
     for input_ in inputs:
         op.add_input(input_, 0)
-    op.inputs_done()
+    op.all_inputs_done()
     work_refs = op.get_work_refs()
     while work_refs:
         for work_ref in work_refs:
@@ -471,7 +474,7 @@ def test_map_operator_ray_args(shutdown_only, use_actors):
     op.start(ExecutionOptions())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
-    op.inputs_done()
+    op.all_inputs_done()
     work_refs = op.get_work_refs()
     while work_refs:
         for work_ref in work_refs:
@@ -602,7 +605,7 @@ def test_limit_operator(ray_start_regular_shared):
         refs = make_ref_bundles([[i] * num_rows_per_block for i in range(num_refs)])
         input_op = InputDataBuffer(refs)
         limit_op = LimitOperator(limit, input_op)
-        limit_op.inputs_done = MagicMock(wraps=limit_op.inputs_done)
+        limit_op.all_inputs_done = MagicMock(wraps=limit_op.all_inputs_done)
         if limit == 0:
             # If the limit is 0, the operator should be completed immediately.
             assert limit_op.completed()
@@ -624,16 +627,16 @@ def test_limit_operator(ray_start_regular_shared):
                 limit_op.get_next()
             cur_rows += num_rows_per_block
             if cur_rows >= limit:
-                assert limit_op.inputs_done.call_count == 1, limit
+                assert limit_op.all_inputs_done.call_count == 1, limit
                 assert limit_op.completed(), limit
                 assert limit_op._limit_reached(), limit
                 assert not limit_op.need_more_inputs(), limit
             else:
-                assert limit_op.inputs_done.call_count == 0, limit
+                assert limit_op.all_inputs_done.call_count == 0, limit
                 assert not limit_op.completed(), limit
                 assert not limit_op._limit_reached(), limit
                 assert limit_op.need_more_inputs(), limit
-        limit_op.inputs_done()
+        limit_op.all_inputs_done()
         # After inputs done, the number of output bundles
         # should be the same as the number of `add_input`s.
         assert limit_op.num_outputs_total() == loop_count, limit
@@ -645,6 +648,81 @@ def _get_bundles(bundle: RefBundle):
     for block, _ in bundle.blocks:
         output.extend(list(ray.get(block)["id"]))
     return output
+
+
+@pytest.mark.parametrize("preserve_order", (True, False))
+def test_union_operator(ray_start_regular_shared, preserve_order):
+    """Test basic functionalities of UnionOperator."""
+    execution_options = ExecutionOptions(preserve_order=preserve_order)
+    ctx = ray.data.DataContext.get_current()
+    ctx.execution_options = execution_options
+
+    num_rows_per_block = 3
+    data0 = make_ref_bundles([[i] * num_rows_per_block for i in range(3)])
+    data1 = make_ref_bundles([[i] * num_rows_per_block for i in range(2)])
+    data2 = make_ref_bundles([[i] * num_rows_per_block for i in range(1)])
+
+    op0 = InputDataBuffer(data0)
+    op1 = InputDataBuffer(data1)
+    op2 = InputDataBuffer(data2)
+    union_op = UnionOperator(op0, op1, op2)
+    union_op.start(execution_options)
+
+    assert not union_op.has_next()
+    union_op.add_input(op0.get_next(), 0)
+    assert union_op.has_next()
+
+    assert union_op.get_next() == data0[0]
+    assert not union_op.has_next()
+
+    union_op.add_input(op0.get_next(), 0)
+    union_op.add_input(op0.get_next(), 0)
+    assert union_op.get_next() == data0[1]
+    assert union_op.get_next() == data0[2]
+
+    union_op.input_done(0)
+    assert not union_op.completed()
+    if preserve_order:
+        assert union_op._input_idx_to_output == 1
+
+    if preserve_order:
+        union_op.add_input(op1.get_next(), 1)
+        union_op.add_input(op2.get_next(), 2)
+        assert union_op._input_idx_to_output == 1
+
+        assert union_op.get_next() == data1[0]
+        assert not union_op.has_next()
+
+        # Check the case where an input op which is not the op
+        # corresponding to _input_idx_to_output finishes first.
+        union_op.input_done(2)
+        assert union_op._input_idx_to_output == 1
+
+        union_op.add_input(op1.get_next(), 1)
+        assert union_op.has_next()
+        assert union_op.get_next() == data1[1]
+        assert not union_op.has_next()
+        # Marking the current output buffer source op will
+        # increment _input_idx_to_output to the next source.
+        union_op.input_done(1)
+        assert union_op._input_idx_to_output == 2
+        assert union_op.has_next()
+        assert union_op.get_next() == data2[0]
+    else:
+        union_op.add_input(op1.get_next(), 1)
+        union_op.add_input(op2.get_next(), 2)
+        union_op.add_input(op1.get_next(), 1)
+        # The output will be in the same order as the inputs
+        # were added with `add_input()`.
+        assert union_op.get_next() == data1[0]
+        assert union_op.get_next() == data2[0]
+        assert union_op.get_next() == data1[1]
+
+    assert all([len(b) == 0 for b in union_op._input_buffers])
+
+    _take_outputs(union_op)
+    union_op.all_inputs_done()
+    assert union_op.completed()
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_randomize_block_order.py
+++ b/python/ray/data/tests/test_randomize_block_order.py
@@ -1,7 +1,9 @@
 import pytest
 
 import ray
-from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
+from ray.data._internal.execution.operators.base_physical_operator import (
+    AllToAllOperator,
+)
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.logical.interfaces import LogicalPlan
 from ray.data._internal.logical.operators.all_to_all_operator import (

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -25,6 +25,7 @@ from ray.data._internal.execution.streaming_executor_state import (
     build_streaming_topology,
     process_completed_tasks,
     select_operator_to_run,
+    update_operator_states,
 )
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data.tests.conftest import *  # noqa
@@ -91,6 +92,7 @@ def test_process_completed_tasks():
     # Test processing output bundles.
     assert len(topo[o1].outqueue) == 0, topo
     process_completed_tasks(topo)
+    update_operator_states(topo)
     assert len(topo[o1].outqueue) == 20, topo
 
     # Test processing completed work items.
@@ -98,29 +100,32 @@ def test_process_completed_tasks():
     done_ref = ray.put("done")
     o2.get_work_refs = MagicMock(return_value=[sleep_ref, done_ref])
     o2.notify_work_completed = MagicMock()
-    o2.inputs_done = MagicMock()
+    o2.all_inputs_done = MagicMock()
     o1.all_dependents_complete = MagicMock()
     process_completed_tasks(topo)
+    update_operator_states(topo)
     o2.notify_work_completed.assert_called_once_with(done_ref)
-    o2.inputs_done.assert_not_called()
+    o2.all_inputs_done.assert_not_called()
     o1.all_dependents_complete.assert_not_called()
 
     # Test input finalization.
     o2.get_work_refs = MagicMock(return_value=[done_ref])
     o2.notify_work_completed = MagicMock()
-    o2.inputs_done = MagicMock()
+    o2.all_inputs_done = MagicMock()
     o1.all_dependents_complete = MagicMock()
     o1.completed = MagicMock(return_value=True)
     topo[o1].outqueue.clear()
     process_completed_tasks(topo)
+    update_operator_states(topo)
     o2.notify_work_completed.assert_called_once_with(done_ref)
-    o2.inputs_done.assert_called_once()
+    o2.all_inputs_done.assert_called_once()
     o1.all_dependents_complete.assert_not_called()
 
     # Test dependents completed.
     o2.need_more_inputs = MagicMock(return_value=False)
     o1.all_dependents_complete = MagicMock()
     process_completed_tasks(topo)
+    update_operator_states(topo)
     o1.all_dependents_complete.assert_called_once()
 
 

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -15,7 +15,9 @@ from ray.data._internal.execution.interfaces import (
     ExecutionResources,
     RefBundle,
 )
-from ray.data._internal.execution.operators.all_to_all_operator import AllToAllOperator
+from ray.data._internal.execution.operators.base_physical_operator import (
+    AllToAllOperator,
+)
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.output_splitter import OutputSplitter


### PR DESCRIPTION
Reverts ray-project/ray#36583, originally implemented in ray-project/ray#36242. The changes made in the original PR seem unrelated to the failures on `linux://python/ray/dashboard:modules/job/tests/test_http_job_server` (`:serverless: Dashboard Tests`: `test_http_job_server.py:test_ray_tune_basic`). In the [revert PR CI tests](https://buildkite.com/ray-project/oss-ci-build-branch/builds/4531#0188d4bd-9d52-4d00-b8ca-511509f7137b/3584-3992), we see the same issue, so I'm thinking that the original PR is not the culprit for the underlying test failure.

```


E       Traceback (most recent call last):
--
  | E         File "ray_tune_basic.py", line 14, in <module>
  | E           tune.run(objective)
  | E         File "/ray/python/ray/tune/tune.py", line 965, in run
  | E           callbacks = _create_default_callbacks(
  | E         File "/ray/python/ray/tune/utils/callback.py", line 141, in _create_default_callbacks
  | E           callbacks.append(TBXLoggerCallback())
  | E         File "/ray/python/ray/tune/logger/tensorboardx.py", line 173, in __init__
  | E           from tensorboardX import SummaryWriter
  | E         File "/opt/miniconda/lib/python3.8/site-packages/tensorboardX/__init__.py", line 5, in <module>
  | E           from .torchvis import TorchVis
  | E         File "/opt/miniconda/lib/python3.8/site-packages/tensorboardX/torchvis.py", line 11, in <module>
  | E           from .writer import SummaryWriter
  | E         File "/opt/miniconda/lib/python3.8/site-packages/tensorboardX/writer.py", line 17, in <module>
  | E           from .comet_utils import CometLogger
  | E         File "/opt/miniconda/lib/python3.8/site-packages/tensorboardX/comet_utils.py", line 6, in <module>
  | E           from .summary import _clean_tag
  | E         File "/opt/miniconda/lib/python3.8/site-packages/tensorboardX/summary.py", line 13, in <module>
  | E           from .proto.summary_pb2 import Summary
  | E         File "/opt/miniconda/lib/python3.8/site-packages/tensorboardX/proto/summary_pb2.py", line 16, in <module>
  | E           from tensorboardX.proto import tensor_pb2 as tensorboardX_dot_proto_dot_tensor__pb2
  | E         File "/opt/miniconda/lib/python3.8/site-packages/tensorboardX/proto/tensor_pb2.py", line 16, in <module>
  | E           from tensorboardX.proto import resource_handle_pb2 as tensorboardX_dot_proto_dot_resource__handle__pb2
  | E         File "/opt/miniconda/lib/python3.8/site-packages/tensorboardX/proto/resource_handle_pb2.py", line 36, in <module>
  | E           _descriptor.FieldDescriptor(
  | E         File "/opt/miniconda/lib/python3.8/site-packages/google/protobuf/descriptor.py", line 561, in __new__
  | E           _message.Message._CheckCalledFromGeneratedFile()
  | E       TypeError: Descriptors cannot not be created directly.
  | E       If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
  | E       If you cannot immediately regenerate your protos, some other possible workarounds are:
  | E        1. Downgrade the protobuf package to 3.20.x or lower.
  | E        2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
  | E
  | E       More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```