### PR TITLE
[Dependencies] Remove `urllib3` dependency

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -78,12 +78,6 @@ from ray.autoscaler.tags import (
 )
 from ray.core.generated import gcs_service_pb2, gcs_service_pb2_grpc
 
-try:
-    from urllib3.exceptions import MaxRetryError
-except ImportError:
-    MaxRetryError = None
-
-
 logger = logging.getLogger(__name__)
 
 # Status of a node e.g. "up-to-date", see ray/autoscaler/tags.py

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -40,7 +40,6 @@ colorful
 pyyaml
 rich
 gpustat>=1.0.0
-urllib3
 opentelemetry-sdk
 fastapi
 virtualenv<20.21.1,>=20.0.24

--- a/python/setup.py
+++ b/python/setup.py
@@ -264,7 +264,6 @@ if setup_spec.type == SetupType.RAY:
         ],
         "serve": ["uvicorn", "requests", "starlette", "fastapi", "aiorwlock"],
         "tune": ["pandas", "tensorboardX>=1.9", "requests", pyarrow_dep],
-        "k8s": ["urllib3"],
         "observability": [
             "opentelemetry-api",
             "opentelemetry-sdk",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`urllib3` was listed as a dependency under `ray[k8s]` (and therefore `ray[all]`), but upon inspection it seems it isn't actually used. 

This PR removes `urllib3` from the dependencies.

In this PR, `ray[k8s]` is also removed since `urllib3` was the only dependency there. I confirmed manually that `pip install ray[doesnotexist]` doesn't fail, so this PR won't break any existing user scripts that contain `pip install ray[k8s]`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
