### PR TITLE
[ci] deprecated jail field in release test definition

### DIFF
--- a/release/ray_release/buildkite/filter.py
+++ b/release/ray_release/buildkite/filter.py
@@ -39,8 +39,6 @@ def filter_tests(
         if attr_mismatch:
             continue
         if not run_jailed_tests:
-            if test.get("jailed", False):
-                continue
             clone_test = copy.deepcopy(test)
             clone_test.update_from_s3()
             if clone_test.is_jailed_with_open_issue(TestStateMachine.get_ray_repo()):

--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -21,9 +21,6 @@
 				"stable": {
 					"type": "boolean"
 				},
-				"jailed": {
-					"type": "boolean"
-				},
 				"python": {
 					"type": "string",
 					"enum": [

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -562,7 +562,7 @@ class BuildkiteSettingsTest(unittest.TestCase):
         self.assertEqual(len(grouped["y"]), 1)
 
     def testGetStep(self):
-        test = Test(
+        test = MockTest(
             {
                 "name": "test",
                 "frequency": "nightly",
@@ -691,7 +691,7 @@ class BuildkiteSettingsTest(unittest.TestCase):
             with open(cluster_config_smoke_path, "w") as fp:
                 yaml.safe_dump(cluster_config_smoke, fp)
 
-            test = Test(
+            test = MockTest(
                 {
                     "name": "test_1",
                     "cluster": {"cluster_compute": cluster_config_full_path},
@@ -707,14 +707,14 @@ class BuildkiteSettingsTest(unittest.TestCase):
             self.assertEquals(step["concurrency_group"], "small")
 
     def testStepQueueClient(self):
-        test_regular = Test(
+        test_regular = MockTest(
             {
                 "name": "test",
                 "frequency": "nightly",
                 "run": {"script": "test_script.py"},
             }
         )
-        test_client = Test(
+        test_client = MockTest(
             {
                 "name": "test",
                 "frequency": "nightly",

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -692,7 +692,6 @@
   working_dir: air_tests/air_benchmarks/mlperf-train
 
   stable: false
-  jailed: true
 
   frequency: nightly
   python: "3.8"
@@ -725,7 +724,6 @@
   working_dir: air_tests/air_benchmarks/mlperf-train
 
   stable: false
-  jailed: true
 
   frequency: nightly
   python: "3.8"
@@ -758,7 +756,6 @@
   working_dir: air_tests/air_benchmarks/mlperf-train
 
   stable: false
-  jailed: true
 
   frequency: nightly
   team: data
@@ -4811,7 +4808,6 @@
   working_dir: nightly_tests
 
   stable: false 
-  jailed: true
 
   python: "3.8"
   frequency: nightly
@@ -5064,7 +5060,6 @@
   working_dir: air_tests
 
   stable: false
-  jailed: true
 
   frequency: nightly
   team: core


### PR DESCRIPTION
## Why are these changes needed?
Currently the test can be jailed via two ways, either through this 'jailed' field in test definition, or by test state machine. Deprecated this jailed field and let the state machine does it job. This refuses confusion around how to unjail and jail a test.

Also improve the logic of soft fail and append the [jailed] to the buildkite step name. We should not soft fail when the test is jailed.

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests