### PR TITLE
[ci] add a flag to not run unstable release tests

### DIFF
--- a/release/ray_release/buildkite/filter.py
+++ b/release/ray_release/buildkite/filter.py
@@ -24,6 +24,7 @@ def filter_tests(
     test_attr_regex_filters: Optional[Dict[str, str]] = None,
     prefer_smoke_tests: bool = False,
     run_jailed_tests: bool = False,
+    run_unstable_tests: bool = False,
 ) -> List[Tuple[Test, bool]]:
     if test_attr_regex_filters is None:
         test_attr_regex_filters = {}
@@ -42,6 +43,9 @@ def filter_tests(
             clone_test = copy.deepcopy(test)
             clone_test.update_from_s3()
             if clone_test.is_jailed_with_open_issue(TestStateMachine.get_ray_repo()):
+                continue
+        if not run_unstable_tests:
+            if not test.get("stable", True):
                 continue
 
         test_frequency = get_frequency(test["frequency"])

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -56,10 +56,18 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
     default=False,
     help=("Will run jailed tests."),
 )
+@click.option(
+    "--run-unstable-tests",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help=("Will run unstable tests."),
+)
 def main(
     test_collection_file: Optional[str] = None,
     no_clone_repo: bool = False,
     run_jailed_tests: bool = False,
+    run_unstable_tests: bool = False,
 ):
     settings = get_pipeline_settings()
 
@@ -95,7 +103,7 @@ def main(
         # the modules are reloaded and use the newest files, instead of
         # old ones, which may not have the changes introduced on the
         # checked out branch.
-        cmd = _get_rerun_cmd(test_collection_file, run_jailed_tests)
+        cmd = _get_rerun_cmd(test_collection_file, run_jailed_tests, run_unstable_tests)
         subprocess.run(cmd, capture_output=False, check=True)
         return
     elif repo:
@@ -146,6 +154,7 @@ def main(
         test_attr_regex_filters=test_attr_regex_filters,
         prefer_smoke_tests=prefer_smoke_tests,
         run_jailed_tests=run_jailed_tests,
+        run_unstable_tests=run_unstable_tests,
     )
     logger.info(f"Found {len(filtered_tests)} tests to run.")
     if len(filtered_tests) == 0:
@@ -250,12 +259,15 @@ def main(
 def _get_rerun_cmd(
     test_collection_file: Optional[str] = None,
     run_jailed_tests: bool = False,
+    run_unstable_tests: bool = False,
 ):
     cmd = [sys.executable, __file__, "--no-clone-repo"]
     if test_collection_file:
         cmd += ["--test-collection-file", test_collection_file]
     if run_jailed_tests:
         cmd += ["--run-jailed-tests"]
+    if run_unstable_tests:
+        cmd += ["--run-unstable-tests"]
     return cmd
 
 


### PR DESCRIPTION
## Why are these changes needed?
Add a flag to not running unstable release tests by default. This is useful for release branches since we ignore unstable test results.

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests