### PR TITLE
[Job] [python 3.11] Fixes agent info container type

### DIFF
--- a/dashboard/modules/job/job_head.py
+++ b/dashboard/modules/job/job_head.py
@@ -203,7 +203,7 @@ class JobHead(dashboard_utils.DashboardHeadModule):
         else:
             # Randomly select one from among all agents, it is possible that
             # the selected one already exists in `self._agents`
-            node_id = sample(set(agent_infos), 1)[0]
+            node_id = sample(sorted(agent_infos), 1)[0]
             agent_info = agent_infos[node_id]
 
             if node_id not in self._agents:


### PR DESCRIPTION
## Why are these changes needed?

Breaking change introduced in python 3.11 to the random package https://docs.python.org/3.11/library/random.html#random.sample

Sample throws a type error when passed a non-sequence object (in this case, a set).

This PR changes the `set` type to `sorted`, as per the error message:
`TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).`

## Related issue number

Fixes https://github.com/ray-project/ray/issues/36578

## Checks - TODO

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR. 
- [ ] I've run `scripts/format.sh` to lint the changes in this PR. - See comment in issue. Can't build project dependencies in python `3.11`
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
