### PR TITLE
[tune] Avoid infinite recursion in log redirection

### DIFF
--- a/python/ray/tune/tests/test_utils.py
+++ b/python/ray/tune/tests/test_utils.py
@@ -97,11 +97,14 @@ def test_tee_recursion():
 
     tee = Tee(f, g)
 
-    util_logger.addHandler(logging.StreamHandler(tee))
+    hdlr = logging.StreamHandler(tee)
+    util_logger.addHandler(hdlr)
 
     logging.info("BEFORE")
     f.close()
     logging.info("AFTER")
+
+    util_logger.removeHandler(hdlr)
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tests/test_utils.py
+++ b/python/ray/tune/tests/test_utils.py
@@ -92,17 +92,17 @@ def test_retry_fn_timeout(tmpdir):
 
 
 def test_tee_recursion():
-    f = io.TextIOBase()
-    g = io.TextIOBase()
+    f = io.StringIO()
+    g = io.StringIO()
 
     tee = Tee(f, g)
 
     hdlr = logging.StreamHandler(tee)
     util_logger.addHandler(hdlr)
 
-    logging.info("BEFORE")
+    util_logger.info("BEFORE")
     f.close()
-    logging.info("AFTER")
+    util_logger.info("AFTER")
 
     util_logger.removeHandler(hdlr)
 

--- a/python/ray/tune/tests/test_utils.py
+++ b/python/ray/tune/tests/test_utils.py
@@ -1,9 +1,12 @@
+import io
+import logging
+import sys
 import time
 
 import pytest
 
 from ray.tune.search.variant_generator import format_vars
-from ray.tune.utils.util import retry_fn
+from ray.tune.utils.util import retry_fn, Tee, logger as util_logger
 
 
 def test_format_vars():
@@ -88,7 +91,18 @@ def test_retry_fn_timeout(tmpdir):
     assert marker.exists()
 
 
-if __name__ == "__main__":
-    import sys
+def test_tee_recursion():
+    f = io.TextIOBase()
+    g = io.TextIOBase()
 
+    tee = Tee(f, g)
+
+    util_logger.addHandler(logging.StreamHandler(tee))
+
+    logging.info("BEFORE")
+    f.close()
+    logging.info("AFTER")
+
+
+if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -321,10 +321,21 @@ class Tee(object):
         self.stream1 = stream1
         self.stream2 = stream2
 
+        # If True, we are currently handling a warning.
+        # We use this flag to avoid infinite recursion.
+        self._handling_warning = False
+
     def _warn(self, op, s, args, kwargs):
+        # If we are already handling a warning, prevent infinite recursion.
+        if self._handling_warning:
+            return
+
         msg = f"ValueError when calling '{op}' on stream ({s}). "
         msg += f"args: {args} kwargs: {kwargs}"
+
+        self._handling_warning = True
         logger.warning(msg)
+        self._handling_warning = False
 
     def seek(self, *args, **kwargs):
         for s in [self.stream1, self.stream2]:

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -326,7 +326,10 @@ class Tee(object):
         self._handling_warning = False
 
     def _warn(self, op, s, args, kwargs):
-        # If we are already handling a warning, prevent infinite recursion.
+        # If we are already handling a warning, this is because
+        # `logger.warning` below triggered the same object again
+        # (e.g. because stderr is redirected to this object).
+        # In that case, exit early to avoid recursion.
         if self._handling_warning:
             return
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently there is a possibility of an infinite stack recursion in our log redirection logic:

- We redirect `sys.stderr` (which is e.g. used by loggers per default) to a `Tee` object
- This objects redirects the data into a file and into the original stream (`sys.stdout`)
- The original `sys.stderr` can be closed e.g. by other libraries
- After #31269, we warn if we can't write to a stream. However, if this stream is `sys.stderr`, the warning log will trigger the `Tee` processing again
- We end up in an infinite recursion.

The solution in this PR is to add a flag that we set and unset before and after emitting the logging message. If it is detected at the start of the function call, we are in a recursion and exit early.

## Related issue number

Closes #35034

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
