### PR TITLE
[Core]Refactor ray::stats:Metric constructor

### DIFF
--- a/python/ray/includes/metric.pxd
+++ b/python/ray/includes/metric.pxd
@@ -13,7 +13,7 @@ cdef extern from "ray/stats/metric.h" nogil:
         CMetric(const c_string &name,
                 const c_string &description,
                 const c_string &unit,
-                const c_vector[CTagKey] &tag_keys)
+                const c_vector[c_string] &tag_keys)
         c_string GetName() const
         void Record(double value)
         void Record(double value,
@@ -23,23 +23,23 @@ cdef extern from "ray/stats/metric.h" nogil:
         CGauge(const c_string &name,
                const c_string &description,
                const c_string &unit,
-               const c_vector[CTagKey] &tag_keys)
+               const c_vector[c_string] &tag_keys)
 
     cdef cppclass CCount "ray::stats::Count":
         CCount(const c_string &name,
                const c_string &description,
                const c_string &unit,
-               const c_vector[CTagKey] &tag_keys)
+               const c_vector[c_string] &tag_keys)
 
     cdef cppclass CSum "ray::stats::Sum":
         CSum(const c_string &name,
              const c_string &description,
              const c_string &unit,
-             const c_vector[CTagKey] &tag_keys)
+             const c_vector[c_string] &tag_keys)
 
     cdef cppclass CHistogram "ray::stats::Histogram":
         CHistogram(const c_string &name,
                    const c_string &description,
                    const c_string &unit,
                    const c_vector[double] &boundaries,
-                   const c_vector[CTagKey] &tag_keys)
+                   const c_vector[c_string] &tag_keys)

--- a/python/ray/includes/metric.pxi
+++ b/python/ray/includes/metric.pxi
@@ -30,12 +30,11 @@ cdef class Metric:
     """
     cdef:
         unique_ptr[CMetric] metric
-        c_vector[CTagKey] c_tag_keys
+        c_vector[c_string] c_tag_keys
 
     def __init__(self, tag_keys):
         for tag_key in tag_keys:
-            self.c_tag_keys.push_back(
-                CTagKey.Register(tag_key.encode("ascii")))
+            self.c_tag_keys.push_back(tag_key.encode("ascii"))
 
     def record(self, value, tags=None):
         """Record a measurement of metric.

--- a/src/ray/core_worker/lib/java/io_ray_runtime_metric_NativeMetric.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_metric_NativeMetric.cc
@@ -42,19 +42,11 @@ inline void MetricTransform(JNIEnv *env,
                             std::string *metric_name,
                             std::string *description,
                             std::string *unit,
-                            std::vector<TagKeyType> &tag_keys) {
+                            std::vector<std::string> *tag_keys) {
   *metric_name = JavaStringToNativeString(env, static_cast<jstring>(j_name));
   *description = JavaStringToNativeString(env, static_cast<jstring>(j_description));
   *unit = JavaStringToNativeString(env, static_cast<jstring>(j_unit));
-  std::vector<std::string> tag_key_str_list;
-  JavaStringListToNativeStringVector(env, tag_key_list, &tag_key_str_list);
-  // We just call TagKeyType::Register to get tag object since opencensus tags
-  // registry is thread-safe and registry can return a new tag or registered
-  // item when it already exists.
-  std::transform(tag_key_str_list.begin(),
-                 tag_key_str_list.end(),
-                 std::back_inserter(tag_keys),
-                 [](std::string &tag_key) { return TagKeyType::Register(tag_key); });
+  JavaStringListToNativeStringVector(env, tag_key_list, tag_keys);
 }
 
 #ifdef __cplusplus
@@ -77,7 +69,7 @@ Java_io_ray_runtime_metric_NativeMetric_registerGaugeNative(JNIEnv *env,
   std::string metric_name;
   std::string description;
   std::string unit;
-  std::vector<TagKeyType> tag_keys;
+  std::vector<std::string> tag_keys;
   MetricTransform(env,
                   j_name,
                   j_description,
@@ -86,7 +78,7 @@ Java_io_ray_runtime_metric_NativeMetric_registerGaugeNative(JNIEnv *env,
                   &metric_name,
                   &description,
                   &unit,
-                  tag_keys);
+                  &tag_keys);
   auto *gauge = new stats::Gauge(metric_name, description, unit, tag_keys);
   return reinterpret_cast<jlong>(gauge);
 }
@@ -101,7 +93,7 @@ Java_io_ray_runtime_metric_NativeMetric_registerCountNative(JNIEnv *env,
   std::string metric_name;
   std::string description;
   std::string unit;
-  std::vector<TagKeyType> tag_keys;
+  std::vector<std::string> tag_keys;
   MetricTransform(env,
                   j_name,
                   j_description,
@@ -110,7 +102,7 @@ Java_io_ray_runtime_metric_NativeMetric_registerCountNative(JNIEnv *env,
                   &metric_name,
                   &description,
                   &unit,
-                  tag_keys);
+                  &tag_keys);
   auto *count = new stats::Count(metric_name, description, unit, tag_keys);
   return reinterpret_cast<jlong>(count);
 }
@@ -125,7 +117,7 @@ Java_io_ray_runtime_metric_NativeMetric_registerSumNative(JNIEnv *env,
   std::string metric_name;
   std::string description;
   std::string unit;
-  std::vector<TagKeyType> tag_keys;
+  std::vector<std::string> tag_keys;
   MetricTransform(env,
                   j_name,
                   j_description,
@@ -134,7 +126,7 @@ Java_io_ray_runtime_metric_NativeMetric_registerSumNative(JNIEnv *env,
                   &metric_name,
                   &description,
                   &unit,
-                  tag_keys);
+                  &tag_keys);
   auto *sum = new stats::Sum(metric_name, description, unit, tag_keys);
   return reinterpret_cast<jlong>(sum);
 }
@@ -150,7 +142,7 @@ Java_io_ray_runtime_metric_NativeMetric_registerHistogramNative(JNIEnv *env,
   std::string metric_name;
   std::string description;
   std::string unit;
-  std::vector<TagKeyType> tag_keys;
+  std::vector<std::string> tag_keys;
   MetricTransform(env,
                   j_name,
                   j_description,
@@ -159,7 +151,7 @@ Java_io_ray_runtime_metric_NativeMetric_registerHistogramNative(JNIEnv *env,
                   &metric_name,
                   &description,
                   &unit,
-                  tag_keys);
+                  &tag_keys);
   std::vector<double> boundaries;
 
   JavaDoubleArrayToNativeDoubleVector(env, j_boundaries, &boundaries);

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -105,17 +105,7 @@ class Metric {
   Metric(const std::string &name,
          const std::string &description,
          const std::string &unit,
-         const std::vector<opencensus::tags::TagKey> &tag_keys = {})
-      : name_(name),
-        description_(description),
-        unit_(unit),
-        tag_keys_(tag_keys),
-        measure_(nullptr) {}
-
-  Metric(const std::string &name,
-         const std::string &description,
-         const std::string &unit,
-         const std::vector<std::string> &tag_keys);
+         const std::vector<std::string> &tag_keys = {});
 
   virtual ~Metric();
 
@@ -159,13 +149,7 @@ class Gauge : public Metric {
   Gauge(const std::string &name,
         const std::string &description,
         const std::string &unit,
-        const std::vector<opencensus::tags::TagKey> &tag_keys = {})
-      : Metric(name, description, unit, tag_keys) {}
-
-  Gauge(const std::string &name,
-        const std::string &description,
-        const std::string &unit,
-        const std::vector<std::string> &tag_keys)
+        const std::vector<std::string> &tag_keys = {})
       : Metric(name, description, unit, tag_keys) {}
 
  private:
@@ -179,14 +163,7 @@ class Histogram : public Metric {
             const std::string &description,
             const std::string &unit,
             const std::vector<double> boundaries,
-            const std::vector<opencensus::tags::TagKey> &tag_keys = {})
-      : Metric(name, description, unit, tag_keys), boundaries_(boundaries) {}
-
-  Histogram(const std::string &name,
-            const std::string &description,
-            const std::string &unit,
-            const std::vector<double> boundaries,
-            const std::vector<std::string> &tag_keys)
+            const std::vector<std::string> &tag_keys = {})
       : Metric(name, description, unit, tag_keys), boundaries_(boundaries) {}
 
  private:
@@ -202,13 +179,7 @@ class Count : public Metric {
   Count(const std::string &name,
         const std::string &description,
         const std::string &unit,
-        const std::vector<opencensus::tags::TagKey> &tag_keys = {})
-      : Metric(name, description, unit, tag_keys) {}
-
-  Count(const std::string &name,
-        const std::string &description,
-        const std::string &unit,
-        const std::vector<std::string> &tag_keys)
+        const std::vector<std::string> &tag_keys = {})
       : Metric(name, description, unit, tag_keys) {}
 
  private:
@@ -221,13 +192,7 @@ class Sum : public Metric {
   Sum(const std::string &name,
       const std::string &description,
       const std::string &unit,
-      const std::vector<opencensus::tags::TagKey> &tag_keys = {})
-      : Metric(name, description, unit, tag_keys) {}
-
-  Sum(const std::string &name,
-      const std::string &description,
-      const std::string &unit,
-      const std::vector<std::string> &tag_keys)
+      const std::vector<std::string> &tag_keys = {})
       : Metric(name, description, unit, tag_keys) {}
 
  private:

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -131,7 +131,7 @@ static Histogram GcsLatency("gcs_latency",
                             "The latency of a GCS (by default Redis) operation.",
                             "us",
                             {100, 200, 300, 400, 500, 600, 700, 800, 900, 1000},
-                            {CustomKey});
+                            {kCustomKey});
 
 ///
 /// Raylet Metrics
@@ -141,12 +141,12 @@ static Histogram GcsLatency("gcs_latency",
 static Gauge TestMetrics("local_available_resource",
                          "The available resources on this node.",
                          "",
-                         {ResourceNameKey});
+                         {kResourceNameKey});
 
 static Gauge LocalTotalResource("local_total_resource",
                                 "The total resources on this node.",
                                 "",
-                                {ResourceNameKey});
+                                {kResourceNameKey});
 
 /// Object Manager.
 static Gauge ObjectStoreAvailableMemory(
@@ -267,7 +267,7 @@ static Histogram GcsUpdateResourceUsageTime(
     "The average RTT of a UpdateResourceUsage RPC.",
     "ms",
     {1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000},
-    {CustomKey});
+    {kCustomKey});
 
 /// Testing
 static Gauge LiveActors("live_actors", "Number of live actors.", "actors");

--- a/src/ray/stats/metric_exporter_client_test.cc
+++ b/src/ray/stats/metric_exporter_client_test.cc
@@ -159,16 +159,18 @@ TEST_F(MetricExporterClientTest, decorator_test) {
 TEST_F(MetricExporterClientTest, exporter_client_caculation_test) {
   const stats::TagKeyType tag1 = stats::TagKeyType::Register("k1");
   const stats::TagKeyType tag2 = stats::TagKeyType::Register("k2");
-  static stats::Count random_counter("ray.random.counter", "", "", {tag1, tag2});
-  static stats::Gauge random_gauge("ray.random.gauge", "", "", {tag1, tag2});
-  static stats::Sum random_sum("ray.random.sum", "", "", {tag1, tag2});
+  static stats::Count random_counter(
+      "ray.random.counter", "", "", {tag1.name(), tag2.name()});
+  static stats::Gauge random_gauge(
+      "ray.random.gauge", "", "", {tag1.name(), tag2.name()});
+  static stats::Sum random_sum("ray.random.sum", "", "", {tag1.name(), tag2.name()});
 
   std::vector<double> hist_vector;
   for (int i = 0; i < 50; i++) {
     hist_vector.push_back((double)(i * 10.0));
   }
   static stats::Histogram random_hist(
-      "ray.random.hist", "", "", hist_vector, {tag1, tag2});
+      "ray.random.hist", "", "", hist_vector, {tag1.name(), tag2.name()});
   for (size_t i = 0; i < 500; ++i) {
     random_counter.Record(i, {{tag1, std::to_string(i)}, {tag2, std::to_string(i * 2)}});
     random_gauge.Record(i, {{tag1, std::to_string(i)}, {tag2, std::to_string(i * 2)}});

--- a/src/ray/stats/stats_test.cc
+++ b/src/ray/stats/stats_test.cc
@@ -84,7 +84,8 @@ class StatsTest : public ::testing::Test {
     absl::Duration harvest_interval = absl::Milliseconds(kReportFlushInterval / 2);
     ray::stats::StatsConfig::instance().SetReportInterval(report_interval);
     ray::stats::StatsConfig::instance().SetHarvestInterval(harvest_interval);
-    const stats::TagsType global_tags = {{stats::ResourceNameKey, "CPU"}};
+    const stats::TagsType global_tags = {
+        {stats::TagKeyType::Register(stats::kResourceNameKey), "CPU"}};
     std::shared_ptr<stats::MetricExporterClient> exporter(
         new stats::StdoutExporterClient());
     ray::stats::Init(global_tags, MetricsAgentPort, WorkerID::Nil(), exporter);
@@ -141,8 +142,8 @@ TEST(Metric, MultiThreadMetricRegisterViewTest) {
       new stats::StdoutExporterClient());
   ray::stats::Init({}, MetricsAgentPort, WorkerID::Nil(), exporter);
   std::vector<std::thread> threads;
-  const stats::TagKeyType tag1 = stats::TagKeyType::Register("k1");
-  const stats::TagKeyType tag2 = stats::TagKeyType::Register("k2");
+  const std::string tag1 = "k1";
+  const std::string tag2 = "k2";
   for (int index = 0; index < 10; ++index) {
     threads.emplace_back([tag1, tag2, index]() {
       for (int i = 0; i < 100; i++) {

--- a/src/ray/stats/tag_defs.cc
+++ b/src/ray/stats/tag_defs.cc
@@ -20,8 +20,6 @@ const TagKeyType ComponentKey = TagKeyType::Register("Component");
 
 const TagKeyType JobNameKey = TagKeyType::Register("JobName");
 
-const TagKeyType CustomKey = TagKeyType::Register("CustomKey");
-
 const TagKeyType NodeAddressKey = TagKeyType::Register("NodeAddress");
 
 const TagKeyType VersionKey = TagKeyType::Register("Version");
@@ -31,8 +29,6 @@ const TagKeyType LanguageKey = TagKeyType::Register("Language");
 const TagKeyType WorkerPidKey = TagKeyType::Register("WorkerPid");
 
 const TagKeyType DriverPidKey = TagKeyType::Register("DriverPid");
-
-const TagKeyType ResourceNameKey = TagKeyType::Register("ResourceName");
 
 const TagKeyType ActorIdKey = TagKeyType::Register("ActorId");
 

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -24,8 +24,6 @@ extern const TagKeyType ComponentKey;
 
 extern const TagKeyType JobNameKey;
 
-extern const TagKeyType CustomKey;
-
 extern const TagKeyType NodeAddressKey;
 
 extern const TagKeyType VersionKey;
@@ -35,8 +33,6 @@ extern const TagKeyType LanguageKey;
 extern const TagKeyType WorkerPidKey;
 
 extern const TagKeyType DriverPidKey;
-
-extern const TagKeyType ResourceNameKey;
 
 extern const TagKeyType ActorIdKey;
 
@@ -52,6 +48,11 @@ extern const TagKeyType SourceKey;
 
 // Object store memory location tag constants
 extern const TagKeyType LocationKey;
+
+constexpr char kResourceNameKey[] = "ResourceName";
+
+constexpr char kCustomKey[] = "CustomKey";
+
 constexpr char kObjectLocMmapShm[] = "MMAP_SHM";
 constexpr char kObjectLocMmapDisk[] = "MMAP_DISK";
 constexpr char kObjectLocSpilled[] = "SPILLED";


### PR DESCRIPTION
## Why are these changes needed?
**1. Now the Metric class has two constructors, we will refactor and remove one of them. Reduce code.**
![image](https://github.com/ray-project/ray/assets/11072802/9ddd7641-c1e1-4c4f-a174-06169bdc19f8)

**2. `opencensus::tags::TagKey` is actually an internal implementation of Ray Core Metric and does not need to be exposed externally. We can use the string type instead.**


## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
