### PR TITLE
[ci][test] Add team name as a tag in github test failure issue

### DIFF
--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -108,6 +108,12 @@ class Test(dict):
         issue = ray_github.get_issue(issue_number)
         return issue.state == "open"
 
+    def is_stable(self) -> bool:
+        """
+        Returns whether this test is stable.
+        """
+        return self.get("stable", True)
+
     def is_byod_cluster(self) -> bool:
         """
         Returns whether this test is running on a BYOD cluster.

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -211,12 +211,11 @@ class TestStateMachine:
         issue_number = self.ray_repo.create_issue(
             title=f"Release test {self.test.get_name()} failed",
             body=(
-                f"Release test {self.test.get_name()} failed.\n"
-                f"See {self.test_results[0].url} for more details.\n"
-                f"cc @{self.test.get_oncall()}\n\n"
-                "\t -- created by ray-test-bot"
+                f"Release test **{self.test.get_name()}** failed. "
+                f"See {self.test_results[0].url} for more details.\n\n"
+                f"Managed by OSS Test Policy"
             ),
-            labels=["P0", "bug", "release-test"],
+            labels=["P0", "bug", "release-test", self.test.get_oncall()],
             assignee="can-anyscale",
         ).number
         self.test[Test.KEY_GITHUB_ISSUE_NUMBER] = issue_number

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -208,6 +208,9 @@ class TestStateMachine:
         )
 
     def _create_github_issue(self) -> None:
+        labels = ["P0", "bug", "release-test", self.test.get_oncall()]
+        if not self.test.is_stable():
+            labels.append("unstable-release-test")
         issue_number = self.ray_repo.create_issue(
             title=f"Release test {self.test.get_name()} failed",
             body=(
@@ -215,7 +218,7 @@ class TestStateMachine:
                 f"See {self.test_results[0].url} for more details.\n\n"
                 f"Managed by OSS Test Policy"
             ),
-            labels=["P0", "bug", "release-test", self.test.get_oncall()],
+            labels=labels,
             assignee="can-anyscale",
         ).number
         self.test[Test.KEY_GITHUB_ISSUE_NUMBER] = issue_number

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -15,16 +15,21 @@ from ray_release.result import (
 from ray_release.test_automation.state_machine import TestStateMachine
 
 
+class MockLabel:
+    def __init__(self, name: str):
+        self.name = name
+
+
 class MockIssue:
     def __init__(
-        self, number: int, state: str = "open", labels: Optional[List[str]] = None
+        self, number: int, state: str = "open", labels: Optional[List[MockLabel]] = None
     ):
         self.number = number
         self.state = state
         self.labels = labels or []
         self.comments = []
 
-    def edit(self, state: str = None, labels: List[str] = None):
+    def edit(self, state: str = None, labels: List[MockLabel] = None):
         if state:
             self.state = state
         if labels:
@@ -43,8 +48,9 @@ class MockIssueDB:
 
 
 class MockRepo:
-    def create_issue(self, *args, **kwargs):
-        issue = MockIssue(MockIssueDB.issue_id)
+    def create_issue(self, labels: List[str], *args, **kwargs):
+        label_objs = [MockLabel(label) for label in labels]
+        issue = MockIssue(MockIssueDB.issue_id, labels=label_objs)
         MockIssueDB.issue_db[MockIssueDB.issue_id] = issue
         MockIssueDB.issue_id += 1
         return issue
@@ -82,7 +88,7 @@ TestStateMachine.ray_buildkite = MockBuildkite()
 
 
 def test_move_from_passing_to_failing():
-    test = Test(name="test", team="devprod")
+    test = Test(name="test", team="ci")
     # Test original state
     test.test_results = [
         TestResult.from_result(Result(status=ResultStatus.SUCCESS.value)),
@@ -111,7 +117,7 @@ def test_move_from_passing_to_failing():
 
 
 def test_move_from_failing_to_consisently_failing():
-    test = Test(name="test", team="devprod")
+    test = Test(name="test", team="ci", stable=False)
     test[Test.KEY_BISECT_BUILD_NUMBER] = 1
     test.test_results = [
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
@@ -126,10 +132,13 @@ def test_move_from_failing_to_consisently_failing():
     issue = MockIssueDB.issue_db[test.get(Test.KEY_GITHUB_ISSUE_NUMBER)]
     assert test.get_state() == TestState.CONSITENTLY_FAILING
     assert "Blamed commit: 1234567890" in issue.comments[0]
+    labels = [label.name for label in issue.get_labels()]
+    assert "ci" in labels
+    assert "unstable-release-test" in labels
 
 
 def test_move_from_failing_to_passing():
-    test = Test(name="test", team="devprod")
+    test = Test(name="test", team="ci")
     test.test_results = [
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
@@ -150,7 +159,7 @@ def test_move_from_failing_to_passing():
 
 
 def test_move_from_failing_to_jailed():
-    test = Test(name="test", team="devprod")
+    test = Test(name="test", team="ci")
     test.test_results = [
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -107,5 +107,11 @@ def test_is_jailed_with_open_issue(mock_repo, mock_issue) -> None:
     )
 
 
+def test_is_stable() -> None:
+    assert Test().is_stable()
+    assert Test(stable=True).is_stable()
+    assert not Test(stable=False).is_stable()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

Add team name as a tag in github test failure issue. Requested by core team specifically, but let's do this for everyone

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   