### PR TITLE
[CI] skip vllm_example

### DIFF
--- a/.buildkite/pipeline.gpu_large.yml
+++ b/.buildkite/pipeline.gpu_large.yml
@@ -50,7 +50,7 @@
     ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_TUNE_AFFECTED", "RAY_CI_DOC_AFFECTED"]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - DOC_TESTING=1 TRAIN_TESTING=1 TUNE_TESTING=1 INSTALL_VLLM=1 ./ci/env/install-dependencies.sh
+    - DOC_TESTING=1 TRAIN_TESTING=1 TUNE_TESTING=1 ./ci/env/install-dependencies.sh
     - pip install -Ur ./python/requirements/ml/requirements_ml_docker.txt
     - ./ci/env/env_info.sh
     # Test examples with newer version of `transformers`

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -394,11 +394,6 @@ install_pip_packages() {
     requirements_packages+=("holidays==0.24") # holidays 0.25 causes `import prophet` to fail.
   fi
 
-  # Additional dependency for vllm.
-  if [ "${INSTALL_VLLM-}" = 1 ]; then
-    requirements_packages+=("vllm")
-  fi
-
   # Data processing test dependencies.
   if [ "${DATA_PROCESSING_TESTING-}" = 1 ] || [ "${DOC_TESTING-}" = 1 ]; then
     requirements_files+=("${WORKSPACE_DIR}/python/requirements/data_processing/requirements.txt")

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -281,15 +281,6 @@ py_test_run_all_subdirectory(
 )
 
 py_test(
-    name = "vllm_example",
-    size = "large",
-    include = ["source/serve/doc_code/vllm_example.py"],
-    exclude = [],
-    extra_srcs = [],
-    tags = ["exclusive", "team:serve", "gpu"],
-)
-
-py_test(
     name = "pytorch_resnet_finetune",
     size = "large",
     main = "test_myst_doc.py",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
vllm requires cuda to be build, which is not available in our CI gpu docker image. 
```


No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
--
  | Traceback (most recent call last):
  | File "/opt/miniconda/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
  | main()
  | File "/opt/miniconda/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
  | json_out['return_val'] = hook(**hook_input['kwargs'])
  | File "/opt/miniconda/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
  | return hook(config_settings)
  | File "/tmp/pip-build-env-b4hl6g1_/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
  | return self._get_build_requires(config_settings, requirements=['wheel'])
  | File "/tmp/pip-build-env-b4hl6g1_/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
  | self.run_setup()
  | File "/tmp/pip-build-env-b4hl6g1_/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 338, in run_setup
  | exec(code, locals())
  | File "<string>", line 24, in <module>
  | RuntimeError: Cannot find CUDA at CUDA_HOME: /usr/local/cuda. CUDA must be available in order to build the package.


```

Also there is a bug in the build rule https://github.com/ray-project/ray/commit/cc983fc3e64c1ba215e981a43dd0119c03c74ff1#r119162333

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
