### PR TITLE
[serve] Remove error message for serve build -k with multi app

### DIFF
--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -731,8 +731,9 @@ def build(
         )
     else:
         if kubernetes_format:
-            raise click.ClickException(
-                "Multi-application config is not supported in Kubernetes format yet."
+            cli_logger.info(
+                "Multi-application configs take the same format when used with "
+                "Kubernetes."
             )
 
         app_configs = []

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -705,7 +705,7 @@ def build(
             schema.host = "0.0.0.0"
             schema.port = 8000
 
-        if kubernetes_format:
+        if not multi_app and kubernetes_format:
             return schema.kubernetes_dict(exclude_unset=True)
         else:
             return schema.dict(exclude_unset=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Now that multi-app is supported on Kuberay, we shouldn't throw an error message when users try to use `serve build -k --multi-app`. However we should show an info message telling them that there is no difference between a normal serve config and one that is used with Kuberay.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
