### PR TITLE
[docs] print dependencies in Documentation job

### DIFF
--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -458,6 +458,7 @@
     # See https://stackoverflow.com/questions/63383400/error-cannot-uninstall-ruamel-yaml-while-creating-docker-image-for-azure-ml-a
     # Pin urllib to avoid downstream ssl incompatibility issues. This matches requirements-doc.txt.
     - pip install "mosaicml==0.12.1" "urllib3<1.27" --ignore-installed
+    - ./ci/env/env_info.sh
     - ./ci/ci.sh build_sphinx_docs
 
 - label: ":octopus: Tune multinode tests"


### PR DESCRIPTION
## Why are these changes needed?

Printing out the dependencies before the test runs makes it easier to debug any dependency related issues.

<img width="1145" alt="image" src="https://github.com/ray-project/ray/assets/3967392/8141555e-1ad5-4fe7-a6ae-d4c978063236">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
