### PR TITLE
[release/air] Fix numba/numpy incompatibility for `workspace_template_many_model_training` release test

### DIFF
--- a/doc/source/templates/testing/cluster_envs/02_many_model_training.yaml
+++ b/doc/source/templates/testing/cluster_envs/02_many_model_training.yaml
@@ -9,3 +9,8 @@ post_build_cmds:
 python:
   pip_packages:
     - statsforecast==1.5.0
+    # numba doesn't support numpy > 1.24
+    # See: https://github.com/numba/numba/issues/8698
+    # NOTE: This is only an issue when `statsforecast` is installed with
+    # `pip install -U`, which is what's happening for this cluster env.
+    - numpy<1.25.0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR fixes the many model training template release test to use numpy < 1.25.0 (which just got released).

### Cause

* `numpy==1.25.0` just got released, which is causing this test to fail since installing `statsforecast` with `pip install -U` will lead to `numba` being incompatible with the new numpy version. I've linked the numba issue in a comment.
* The instructions in the template installs `statsforecast` without upgrading existing packages, so anyone running through the example is not running into this issue, since the ray-ml docker image comes with numpy 1.24.3.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
