### PR TITLE
[RLlib] Don't use rl module api for lstm/attention tests in PPO

### DIFF
--- a/release/rllib_tests/multi_gpu_with_attention_learning_tests/multi_gpu_with_attention_learning_tests.yaml
+++ b/release/rllib_tests/multi_gpu_with_attention_learning_tests/multi_gpu_with_attention_learning_tests.yaml
@@ -153,6 +153,9 @@ ppo-stateless-cartpole:
             attention_position_wise_mlp_dim: 32
         # Double batch size (2 GPUs).
         train_batch_size: 8000
+    # TODO (Artur): Enable RLModule once LSTM is supported
+    _enable_rl_module_api: false
+    _enable_learner_api: false
 
 # TODO (Kourosh): Activate these tests back when the new modeling stack is merged
 # r2d2-stateless-cartpole:

--- a/release/rllib_tests/multi_gpu_with_attention_learning_tests/multi_gpu_with_attention_learning_tests.yaml
+++ b/release/rllib_tests/multi_gpu_with_attention_learning_tests/multi_gpu_with_attention_learning_tests.yaml
@@ -153,9 +153,9 @@ ppo-stateless-cartpole:
             attention_position_wise_mlp_dim: 32
         # Double batch size (2 GPUs).
         train_batch_size: 8000
-    # TODO (Artur): Enable RLModule once LSTM is supported
-    _enable_rl_module_api: false
-    _enable_learner_api: false
+      # TODO (Artur): Enable RLModule once attention is supported
+      _enable_rl_module_api: false
+      _enable_learner_api: false
 
 # TODO (Kourosh): Activate these tests back when the new modeling stack is merged
 # r2d2-stateless-cartpole:

--- a/release/rllib_tests/multi_gpu_with_lstm_learning_tests/multi_gpu_with_lstm_learning_tests.yaml
+++ b/release/rllib_tests/multi_gpu_with_lstm_learning_tests/multi_gpu_with_lstm_learning_tests.yaml
@@ -133,7 +133,7 @@ ppo-stateless-cartpole:
             use_lstm: true
         # Double batch size (2 GPUs).
         train_batch_size: 8000
-    # TODO (Artur): Enable RLModule once LSTM is supported
+    # TODO (Artur): Enable RLModule once we support LSTM
     _enable_rl_module_api: false
     _enable_learner_api: false
 

--- a/release/rllib_tests/multi_gpu_with_lstm_learning_tests/multi_gpu_with_lstm_learning_tests.yaml
+++ b/release/rllib_tests/multi_gpu_with_lstm_learning_tests/multi_gpu_with_lstm_learning_tests.yaml
@@ -133,6 +133,9 @@ ppo-stateless-cartpole:
             use_lstm: true
         # Double batch size (2 GPUs).
         train_batch_size: 8000
+    # TODO (Artur): Enable RLModule once LSTM is supported
+    _enable_rl_module_api: false
+    _enable_learner_api: false
 
 # TODO (Kourosh): Activate these tests back when the new modeling stack is merged
 # r2d2-stateless-cartpole:

--- a/release/rllib_tests/multi_gpu_with_lstm_learning_tests/multi_gpu_with_lstm_learning_tests.yaml
+++ b/release/rllib_tests/multi_gpu_with_lstm_learning_tests/multi_gpu_with_lstm_learning_tests.yaml
@@ -133,9 +133,9 @@ ppo-stateless-cartpole:
             use_lstm: true
         # Double batch size (2 GPUs).
         train_batch_size: 8000
-    # TODO (Artur): Enable RLModule once we support LSTM
-    _enable_rl_module_api: false
-    _enable_learner_api: false
+      # TODO (Artur): Enable RLModule once we support LSTM
+      _enable_rl_module_api: false
+      _enable_learner_api: false
 
 # TODO (Kourosh): Activate these tests back when the new modeling stack is merged
 # r2d2-stateless-cartpole:


### PR DESCRIPTION
## Why are these changes needed?

https://github.com/ray-project/ray/issues/36208
https://github.com/ray-project/ray/issues/36207

These tests have been failing since we enable RLModules for PPO because they are not ready for LSTM/Attention.