### PR TITLE
[serve] Change serve build to use multi app by default

### DIFF
--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -669,6 +669,11 @@ def shutdown(address: str, yes: bool):
     ),
 )
 @click.option(
+    "--multi-app",
+    is_flag=True,
+    help="Generate a multi-application config from multiple targets.",
+)
+@click.option(
     "--single-app",
     is_flag=True,
     help="Generate a single-application config from one target.",
@@ -678,8 +683,21 @@ def build(
     app_dir: str,
     kubernetes_format: bool,
     output_path: Optional[str],
+    # This is no longer used, it is only kept here to avoid breaking existing CLI usage
+    multi_app: bool,
     single_app: bool,
 ):
+    # Add logger messages for users who are still using --multi-app
+    if multi_app:
+        cli_logger.warning(
+            "`serve build` now generates a config in multi-application format by "
+            "default. The flag `--multi-app` is now redundant and will be removed soon."
+        )
+        if single_app:
+            raise click.ClickException(
+                "You cannot specify both `--single-app` and `--multi-app`."
+            )
+
     sys.path.insert(0, app_dir)
 
     def build_app_config(import_path: str, _kubernetes_format: bool, name: str = None):

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -633,11 +633,11 @@ def shutdown(address: str, yes: bool):
 
 
 @cli.command(
-    short_help="Generate a config file for the specified application(s).",
+    short_help="Generate a config file for the specified applications.",
     help=(
-        "Imports the Application at IMPORT_PATH(S) and generates a "
-        "structured config for it. If the flag --multi-app is set, accepts multiple "
-        "Applications and generates a multi-application config. Config "
+        "Imports the applications at IMPORT_PATHS and generates a structured, multi-"
+        "application config for them. If the flag --single-app is set, accepts one "
+        "application and generates a single-application config. Config "
         "outputted from this command can be used by `serve deploy` or the REST API. "
     ),
 )
@@ -653,7 +653,10 @@ def shutdown(address: str, yes: bool):
     "--kubernetes_format",
     "-k",
     is_flag=True,
-    help="Print Serve config in Kubernetes format.",
+    help=(
+        "Print a single-application Serve config in Kubernetes format. Must be used "
+        "with the flag `--single-app`."
+    ),
 )
 @click.option(
     "--output-path",
@@ -666,21 +669,20 @@ def shutdown(address: str, yes: bool):
     ),
 )
 @click.option(
-    "--multi-app",
-    "-m",
+    "--single-app",
     is_flag=True,
-    help="Generate a multi-application config from multiple targets.",
+    help="Generate a single-application config from one target.",
 )
 def build(
     import_paths: Tuple[str],
     app_dir: str,
     kubernetes_format: bool,
     output_path: Optional[str],
-    multi_app: bool,
+    single_app: bool,
 ):
     sys.path.insert(0, app_dir)
 
-    def build_app_config(import_path: str, name: str = None):
+    def build_app_config(import_path: str, _kubernetes_format: bool, name: str = None):
         app: Application = import_attr(import_path)
         if not isinstance(app, Application):
             raise TypeError(
@@ -692,20 +694,20 @@ def build(
             import_path=import_path,
             runtime_env={},
             deployments=[
-                deployment_to_schema(d, not multi_app) for d in app.deployments.values()
+                deployment_to_schema(d, single_app) for d in app.deployments.values()
             ],
         )
         # If building a multi-app config, auto-generate names for each application.
         # Also, each ServeApplicationSchema should not have host and port set, it should
         # be set at the top level of ServeDeploySchema.
-        if multi_app:
-            schema.name = name
-            schema.route_prefix = app.ingress.route_prefix
-        else:
+        if single_app:
             schema.host = "0.0.0.0"
             schema.port = 8000
+        else:
+            schema.name = name
+            schema.route_prefix = app.ingress.route_prefix
 
-        if kubernetes_format:
+        if _kubernetes_format:
             return schema.kubernetes_dict(exclude_unset=True)
         else:
             return schema.dict(exclude_unset=True)
@@ -715,16 +717,15 @@ def build(
         f"on Ray v{ray.__version__}.\n\n"
     )
 
-    if not multi_app:
+    if single_app:
         if len(import_paths) > 1:
             raise click.ClickException(
-                "Got more than one argument. If you want to generate a multi-"
-                "application config, please rerun the command with the feature flag "
-                "`--multi-app`."
+                "Got more than one argument. Only one import path is accepted when "
+                "using the flag `--single-app`."
             )
 
         config_str += yaml.dump(
-            build_app_config(import_paths[0]),
+            build_app_config(import_paths[0], kubernetes_format),
             Dumper=ServeApplicationSchemaDumper,
             default_flow_style=False,
             sort_keys=False,
@@ -732,12 +733,14 @@ def build(
     else:
         if kubernetes_format:
             raise click.ClickException(
-                "Multi-application config is not supported in Kubernetes format yet."
+                "Multi-application config does not support Kubernetes format."
             )
 
         app_configs = []
         for app_index, import_path in enumerate(import_paths):
-            app_configs.append(build_app_config(import_path, f"app{app_index + 1}"))
+            app_configs.append(
+                build_app_config(import_path, False, f"app{app_index + 1}")
+            )
 
         deploy_config = {
             "proxy_location": "EveryNode",

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -1167,7 +1167,7 @@ TestBuildDagNode = NoArgDriver.bind(TestBuildFNode)
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
 @pytest.mark.parametrize("node", ["TestBuildFNode", "TestBuildDagNode"])
-def test_build(ray_start_stop, node):
+def test_build_single_app(ray_start_stop, node):
     with NamedTemporaryFile(mode="w+", suffix=".yaml") as tmp:
         print(f'Building node "{node}".')
         # Build an app
@@ -1175,6 +1175,7 @@ def test_build(ray_start_stop, node):
             [
                 "serve",
                 "build",
+                "--single-app",
                 f"ray.serve.tests.test_cli.{node}",
                 "-o",
                 tmp.name,
@@ -1206,7 +1207,6 @@ def test_build_multi_app(ray_start_stop):
             [
                 "serve",
                 "build",
-                "--multi-app",
                 "ray.serve.tests.test_cli.TestApp1Node",
                 "ray.serve.tests.test_cli.TestApp2Node",
                 "-o",
@@ -1249,6 +1249,7 @@ def test_build_kubernetes_flag():
             [
                 "serve",
                 "build",
+                "--single-app",
                 "ray.serve.tests.test_cli.k8sFNode",
                 "-o",
                 tmp.name,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- `serve build` now outputs a multi-application config by default.
- Add `--single-app` flag to `serve build`.
- Keep `--multi-app` flag, but it doesn't do anything and prints a warning message to users, saying multi-app is default and the flag will be removed soon.
- `--single-app` and `--multi-app` cannot be specified together.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
