### PR TITLE
[Core] Introduce fail_on_unavailable option for hard NodeAffinitySchedulingStrategy

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -3121,6 +3121,8 @@ cdef class CoreWorker:
                 python_scheduling_strategy.soft)
             c_node_affinity_scheduling_strategy[0].set_spill_on_unavailable(
                 python_scheduling_strategy._spill_on_unavailable)
+            c_node_affinity_scheduling_strategy[0].set_fail_on_unavailable(
+                python_scheduling_strategy._fail_on_unavailable)
         else:
             raise ValueError(
                 f"Invalid scheduling_strategy value "

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -178,6 +178,7 @@ cdef extern from "src/ray/protobuf/common.pb.h" nogil:
         void set_node_id(const c_string& node_id)
         void set_soft(c_bool soft)
         void set_spill_on_unavailable(c_bool spill_on_unavailable)
+        void set_fail_on_unavailable(c_bool fail_on_unavailable)
     cdef cppclass CSchedulingStrategy "ray::rpc::SchedulingStrategy":
         CSchedulingStrategy()
         void clear_scheduling_strategy()

--- a/python/ray/util/scheduling_strategies.py
+++ b/python/ray/util/scheduling_strategies.py
@@ -55,7 +55,13 @@ class NodeAffinitySchedulingStrategy:
             or be scheduled somewhere else if soft is True.
     """
 
-    def __init__(self, node_id: str, soft: bool, _spill_on_unavailable: bool = False):
+    def __init__(
+        self,
+        node_id: str,
+        soft: bool,
+        _spill_on_unavailable: bool = False,
+        _fail_on_unavailable: bool = False,
+    ):
         # This will be removed once we standardize on node id being hex string.
         if not isinstance(node_id, str):
             node_id = node_id.hex()
@@ -63,6 +69,7 @@ class NodeAffinitySchedulingStrategy:
         self.node_id = node_id
         self.soft = soft
         self._spill_on_unavailable = _spill_on_unavailable
+        self._fail_on_unavailable = _fail_on_unavailable
 
 
 SchedulingStrategyT = Union[

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -47,7 +47,9 @@ inline bool operator==(const ray::rpc::SchedulingStrategy &lhs,
            (lhs.node_affinity_scheduling_strategy().soft() ==
             rhs.node_affinity_scheduling_strategy().soft()) &&
            (lhs.node_affinity_scheduling_strategy().spill_on_unavailable() ==
-            rhs.node_affinity_scheduling_strategy().spill_on_unavailable());
+            rhs.node_affinity_scheduling_strategy().spill_on_unavailable()) &&
+           (lhs.node_affinity_scheduling_strategy().fail_on_unavailable() ==
+            rhs.node_affinity_scheduling_strategy().fail_on_unavailable());
   }
   case ray::rpc::SchedulingStrategy::kPlacementGroupSchedulingStrategy: {
     return (lhs.placement_group_scheduling_strategy().placement_group_id() ==
@@ -118,6 +120,8 @@ struct hash<ray::rpc::SchedulingStrategy> {
           scheduling_strategy.node_affinity_scheduling_strategy().soft());
       hash ^= static_cast<size_t>(
           scheduling_strategy.node_affinity_scheduling_strategy().spill_on_unavailable());
+      hash ^= static_cast<size_t>(
+          scheduling_strategy.node_affinity_scheduling_strategy().fail_on_unavailable());
     } else if (scheduling_strategy.scheduling_strategy_case() ==
                ray::rpc::SchedulingStrategy::kPlacementGroupSchedulingStrategy) {
       hash ^= std::hash<std::string>()(

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -53,6 +53,7 @@ message NodeAffinitySchedulingStrategy {
   bytes node_id = 1;
   bool soft = 2;
   bool spill_on_unavailable = 3;
+  bool fail_on_unavailable = 4;
 }
 
 message PlacementGroupSchedulingStrategy {

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -160,7 +160,9 @@ scheduling::NodeID ClusterResourceScheduler::GetBestSchedulableNode(
             scheduling_strategy.node_affinity_scheduling_strategy().node_id(),
             scheduling_strategy.node_affinity_scheduling_strategy().soft(),
             scheduling_strategy.node_affinity_scheduling_strategy()
-                .spill_on_unavailable()));
+                .spill_on_unavailable(),
+            scheduling_strategy.node_affinity_scheduling_strategy()
+                .fail_on_unavailable()));
   } else if (IsAffinityWithBundleSchedule(scheduling_strategy) &&
              !is_local_node_with_raylet_) {
     // This scheduling strategy is only used for gcs scheduling for the time being.

--- a/src/ray/raylet/scheduling/policy/node_affinity_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/node_affinity_scheduling_policy.cc
@@ -24,7 +24,8 @@ scheduling::NodeID NodeAffinitySchedulingPolicy::Schedule(
   scheduling::NodeID target_node_id = scheduling::NodeID(options.node_affinity_node_id);
   if (nodes_.contains(target_node_id) && is_node_alive_(target_node_id) &&
       nodes_.at(target_node_id).GetLocalView().IsFeasible(resource_request)) {
-    if (!options.node_affinity_spill_on_unavailable) {
+    if (!options.node_affinity_spill_on_unavailable &&
+        !options.node_affinity_fail_on_unavailable) {
       return target_node_id;
     } else if (nodes_.at(target_node_id).GetLocalView().IsAvailable(resource_request)) {
       return target_node_id;

--- a/src/ray/raylet/scheduling/policy/scheduling_options.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_options.h
@@ -79,10 +79,10 @@ struct SchedulingOptions {
                                         bool spill_on_unavailable = false,
                                         bool fail_on_unavailable = false) {
     if (spill_on_unavailable) {
-      RAY_CHECK(soft);
+      RAY_CHECK(soft) << "spill_on_unavailable only works with soft == true";
     }
     if (fail_on_unavailable) {
-      RAY_CHECK(!soft);
+      RAY_CHECK(!soft) << "fail_on_unavailable only works with soft == false";
     }
     SchedulingOptions scheduling_options =
         Hybrid(avoid_local_node, require_node_available);

--- a/src/ray/raylet/scheduling/policy/scheduling_options.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_options.h
@@ -76,9 +76,13 @@ struct SchedulingOptions {
                                         bool require_node_available,
                                         std::string node_id,
                                         bool soft,
-                                        bool spill_on_unavailable = false) {
+                                        bool spill_on_unavailable = false,
+                                        bool fail_on_unavailable = false) {
     if (spill_on_unavailable) {
       RAY_CHECK(soft);
+    }
+    if (fail_on_unavailable) {
+      RAY_CHECK(!soft);
     }
     SchedulingOptions scheduling_options =
         Hybrid(avoid_local_node, require_node_available);
@@ -86,6 +90,7 @@ struct SchedulingOptions {
     scheduling_options.node_affinity_node_id = node_id;
     scheduling_options.node_affinity_soft = soft;
     scheduling_options.node_affinity_spill_on_unavailable = spill_on_unavailable;
+    scheduling_options.node_affinity_fail_on_unavailable = fail_on_unavailable;
     return scheduling_options;
   }
 
@@ -165,6 +170,7 @@ struct SchedulingOptions {
   std::string node_affinity_node_id;
   bool node_affinity_soft = false;
   bool node_affinity_spill_on_unavailable = false;
+  bool node_affinity_fail_on_unavailable = false;
   // The node where the task is preferred to be placed. By default, this node id
   // is empty, which means no preferred node.
   std::string preferred_node_id;

--- a/src/ray/raylet/scheduling/policy/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/scheduling_policy_test.cc
@@ -104,6 +104,13 @@ TEST_F(SchedulingPolicyTest, NodeAffinityPolicyTest) {
   ASSERT_EQ(to_schedule, scheduling::NodeID("unavailable"));
 
   to_schedule = scheduling_policy.Schedule(
+      req,
+      SchedulingOptions::NodeAffinity(
+          false, false, "unavailable", false, false, /*fail_on_unavailable=*/true));
+  // The task is unschedulable since soft is false and fail_on_unavailable is true.
+  ASSERT_TRUE(to_schedule.IsNil());
+
+  to_schedule = scheduling_policy.Schedule(
       req, SchedulingOptions::NodeAffinity(false, false, "unavailable", true, true));
   // The task is scheduled somewhere else since soft is true and spill_on_unavailable is
   // also true.


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add an experimental  fail_on_unavailable option to try out application level scheduling
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
