### PR TITLE
[ci] Fix rllib_learning_tests_ddpg_tf

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4064,11 +4064,6 @@
   team: rllib
   python: "3.8"
   cluster:
-    byod:
-      type: gpu
-      post_build_script: byod_rllib_test.sh
-      runtime_env:
-        - RLLIB_TEST_NO_JAX_IMPORT=1
     cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 


### PR DESCRIPTION
## Why are these changes needed?
rllib_learning_tests_ddpg_tf test requires an older version of MuJoCo that is currently resolved by byod: https://buildkite.com/ray-project/release-tests-pr/builds/43243#0188e526-10fe-4700-b985-4f896d8cd787

Somehow pinning the version during byod runtime_env does not downgrade the package. Remove it from byod to unbreak the test first.

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   