### PR TITLE
[doc] Fix documentation failure due to typing_extensions

### DIFF
--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -457,7 +457,7 @@
     - ./ci/env/install-horovod.sh
     # See https://stackoverflow.com/questions/63383400/error-cannot-uninstall-ruamel-yaml-while-creating-docker-image-for-azure-ml-a
     # Pin urllib to avoid downstream ssl incompatibility issues. This matches requirements-doc.txt.
-    - pip install "mosaicml==0.12.1" "urllib3<1.27" --ignore-installed
+    - pip install "mosaicml==0.12.1" "urllib3<1.27" "typing-extensions==4.5.0" --ignore-installed
     - ./ci/env/env_info.sh
     - ./ci/ci.sh build_sphinx_docs
 

--- a/python/requirements_test.txt
+++ b/python/requirements_test.txt
@@ -103,7 +103,7 @@ markdown-it-py==1.1.0
 attrs==21.4.0
 pytz==2022.7.1
 # Compatibility with spacy 3.5 (model en_core_web_sm)
-typing-extensions==4.5.0; python_version <= '3.8'
+typing-extensions==4.5.0
 networkx==2.6.3; python_version <= '3.7'
 # Aim requires segment-analytics-python, which requires backoff~=2.10,
 # which conflicts with the opentelemetry-api 1.1.0.

--- a/python/requirements_test.txt
+++ b/python/requirements_test.txt
@@ -103,7 +103,7 @@ markdown-it-py==1.1.0
 attrs==21.4.0
 pytz==2022.7.1
 # Compatibility with spacy 3.5 (model en_core_web_sm)
-typing-extensions==4.5.0
+typing-extensions==4.5.0; python_version <= '3.7'
 networkx==2.6.3; python_version <= '3.7'
 # Aim requires segment-analytics-python, which requires backoff~=2.10,
 # which conflicts with the opentelemetry-api 1.1.0.

--- a/python/requirements_test.txt
+++ b/python/requirements_test.txt
@@ -103,7 +103,7 @@ markdown-it-py==1.1.0
 attrs==21.4.0
 pytz==2022.7.1
 # Compatibility with spacy 3.5 (model en_core_web_sm)
-typing-extensions==4.5.0; python_version <= '3.7'
+typing-extensions==4.5.0; python_version <= '3.8'
 networkx==2.6.3; python_version <= '3.7'
 # Aim requires segment-analytics-python, which requires backoff~=2.10,
 # which conflicts with the opentelemetry-api 1.1.0.


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
pydantic is not compatible with typing extensions. After `pip install "mosaicml==0.12.1" "urllib3<1.27"`, `typing-extensions` somehow changes to 4.6 which is not working with pandantic.

Another way to fix this is to upgrade pandantic version, but it breaks tests.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
