### PR TITLE
[air/output] Fix excluded keys in results and config

### DIFF
--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -456,7 +456,7 @@ def _render_table_item(
     elif isinstance(item, dict):
         flattened = flatten_dict(item)
         for k, v in sorted(flattened.items()):
-            yield key + "/" + k, _max_len(v)
+            yield key + "/" + str(k), _max_len(v)
 
     else:
         yield key, _max_len(item, 20)

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -453,6 +453,11 @@ def _render_table_item(
         # tabulate does not work well with mixed-type columns, so we format
         # numbers ourselves.
         yield key, f"{item:.5f}".rstrip("0")
+    elif isinstance(item, dict):
+        flattened = flatten_dict(item)
+        for k, v in sorted(flattened.items()):
+            yield key + "/" + k, _max_len(v)
+
     else:
         yield key, _max_len(item, 20)
 
@@ -470,9 +475,7 @@ def _get_dict_as_table_data(
     upper = []
     lower = []
 
-    flattened = flatten_dict(data)
-
-    for key, value in sorted(flattened.items()):
+    for key, value in sorted(data.items()):
         if include and key not in include:
             continue
         if key in exclude:

--- a/python/ray/tune/tests/output/test_output.py
+++ b/python/ray/tune/tests/output/test_output.py
@@ -215,10 +215,11 @@ def test_result_table_no_divison():
             "x": 19.123123123,
             "c": 5,
             "ignore": 9,
+            "nested_ignore": {"value": 5},
             "y": 20,
             "z": {"m": 4, "n": {"o": "p"}},
         },
-        exclude={"ignore"},
+        exclude={"ignore", "nested_ignore"},
     )
 
     assert data == [
@@ -240,10 +241,11 @@ def test_result_table_divison():
             "x": 19.123123123,
             "c": 5,
             "ignore": 9,
+            "nested_ignore": {"value": 5},
             "y": 20,
             "z": {"m": 4, "n": {"o": "p"}},
         },
-        exclude={"ignore"},
+        exclude={"ignore", "nested_ignore"},
         upper_keys={"x", "y", "z", "z/m", "z/n/o"},
     )
 

--- a/python/ray/tune/tests/output/test_output.py
+++ b/python/ray/tune/tests/output/test_output.py
@@ -260,5 +260,27 @@ def test_result_table_divison():
     ]
 
 
+def test_result_include():
+    data = _get_dict_as_table_data(
+        {
+            "b": 6,
+            "a": 8,
+            "x": 19.123123123,
+            "c": 5,
+            "ignore": 9,
+            "nested_ignore": {"value": 5},
+            "y": 20,
+            "z": {"m": 4, "n": {"o": "p"}},
+        },
+        include={"y", "z"},
+        exclude={"z/n/o"},
+    )
+
+    assert data == [
+        ["y", 20],
+        ["z/m", 4],
+    ]
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We are currently applying the `exclude` keys on the flattened results, but this will not work if the excluded keys are dictionaries, such as the `config` value in the results dict. Instead, we should operate on the original results dict and only flatten from the second level onwards.

## Related issue number

Closes #36756

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
