### PR TITLE
[air/output] Add newlines between status blocks

### DIFF
--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -1069,7 +1069,7 @@ class AirResultProgressCallback(Callback):
         else:
             print(
                 f"{self._addressing_tmpl.format(trial)} "
-                f"started without custom configuration.\n"
+                f"started without custom configuration."
             )
         print("")
 

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -1032,7 +1032,7 @@ class AirResultProgressCallback(Callback):
             finished_iter = trial.last_result[TRAINING_ITERATION]
         print(
             f"{self._addressing_tmpl.format(trial)} "
-            f"completed training after {finished_iter} iterations "
+            f"completed after {finished_iter} iterations "
             f"at {curr_time_str}. Total running time: " + running_time_str
         )
         self._print_result(trial)

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -453,6 +453,11 @@ def _render_table_item(
         # tabulate does not work well with mixed-type columns, so we format
         # numbers ourselves.
         yield key, f"{item:.5f}".rstrip("0")
+    elif isinstance(item, dict):
+        flattened = flatten_dict(item)
+        for k, v in sorted(flattened.items()):
+            yield key + "/" + k, _max_len(v)
+
     else:
         yield key, _max_len(item, 20)
 
@@ -470,9 +475,7 @@ def _get_dict_as_table_data(
     upper = []
     lower = []
 
-    flattened = flatten_dict(data)
-
-    for key, value in sorted(flattened.items()):
+    for key, value in sorted(data.items()):
         if include and key not in include:
             continue
         if key in exclude:
@@ -1016,6 +1019,7 @@ class AirResultProgressCallback(Callback):
             f"at {curr_time_str}. Total running time: " + running_time_str
         )
         self._print_result(trial, result)
+        print("")
 
     def on_trial_complete(
         self, iteration: int, trials: List[Trial], trial: Trial, **info
@@ -1032,6 +1036,7 @@ class AirResultProgressCallback(Callback):
             f"at {curr_time_str}. Total running time: " + running_time_str
         )
         self._print_result(trial)
+        print("")
 
     def on_checkpoint(
         self,
@@ -1052,6 +1057,7 @@ class AirResultProgressCallback(Callback):
             f"saved a checkpoint for iteration {saved_iter} "
             f"at: {checkpoint.dir_or_data}"
         )
+        print("")
 
     def on_trial_start(self, iteration: int, trials: List[Trial], trial: Trial, **info):
         if self._verbosity < self._start_end_verbosity:
@@ -1066,8 +1072,9 @@ class AirResultProgressCallback(Callback):
         else:
             print(
                 f"{self._addressing_tmpl.format(trial)} "
-                f"started without custom configuration."
+                f"started without custom configuration.\n"
             )
+        print("")
 
 
 class TuneResultProgressCallback(AirResultProgressCallback):

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -453,11 +453,6 @@ def _render_table_item(
         # tabulate does not work well with mixed-type columns, so we format
         # numbers ourselves.
         yield key, f"{item:.5f}".rstrip("0")
-    elif isinstance(item, dict):
-        flattened = flatten_dict(item)
-        for k, v in sorted(flattened.items()):
-            yield key + "/" + k, _max_len(v)
-
     else:
         yield key, _max_len(item, 20)
 
@@ -475,7 +470,9 @@ def _get_dict_as_table_data(
     upper = []
     lower = []
 
-    for key, value in sorted(data.items()):
+    flattened = flatten_dict(data)
+
+    for key, value in sorted(flattened.items()):
         if include and key not in include:
             continue
         if key in exclude:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds newlines between status output blocks and fixes a phrasing issue with the train reporter.

## Related issue number

Closes #36755

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
