### PR TITLE
[core] Fix issues with worker churn in WorkerPool

### DIFF
--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -35,7 +35,7 @@ def test_worker_stats(shutdown_only):
         ray._private.worker.show_in_dashboard("test")
         return os.getpid()
 
-    @ray.remote
+    @ray.remote(num_cpus=1)
     class Actor:
         def __init__(self):
             pass

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -273,11 +273,12 @@ def test_no_spurious_worker_startup(shutdown_only, runtime_env_class):
     start = time.time()
     got_num_workers = False
     while time.time() - start < 10:
-        # Check that no more workers were started.
+        # Check that no more than one extra worker is started. We add one
+        # because Ray will prestart an idle worker for the one available CPU.
         num_workers = get_num_workers()
         if num_workers is not None:
             got_num_workers = True
-            assert num_workers <= 1
+            assert num_workers <= 2
         time.sleep(0.1)
     assert got_num_workers, "failed to read num workers for 10 seconds"
 

--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -266,7 +266,7 @@ def test_idle_workers(shutdown_only):
     # We start exactly as many workers as there are CPUs.
     for _ in range(3):
         pids = set(ray.get([getpid.remote() for _ in range(4)]))
-        assert len(pids) == 2, pids
+        assert len(pids) <= 2, pids
         # Wait for at least the idle worker timeout.
         time.sleep(0.1)
 
@@ -277,7 +277,7 @@ def test_idle_workers(shutdown_only):
 
     for _ in range(3):
         pids = set(ray.get([getpid.remote() for _ in range(4)]))
-        assert len(pids) == 2, pids
+        assert len(pids) <= 2, pids
         # Wait for at least the idle worker timeout.
         time.sleep(0.1)
 
@@ -286,7 +286,7 @@ def test_idle_workers(shutdown_only):
     del a2
     for _ in range(3):
         pids = set(ray.get([getpid.remote() for _ in range(4)]))
-        assert len(pids) == 2, pids
+        assert len(pids) <= 2, pids
         # Wait for at least the idle worker timeout.
         time.sleep(0.1)
 

--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -245,6 +245,52 @@ def test_spillback(ray_start_cluster):
     ray.cancel(refs[0], force=True)
 
 
+def test_idle_workers(shutdown_only):
+    ray.init(
+        num_cpus=2,
+        _system_config={
+            "idle_worker_killing_time_threshold_ms": 10,
+        },
+    )
+
+    @ray.remote(num_cpus=0)
+    class Actor:
+        def get(self):
+            pass
+
+    @ray.remote
+    def getpid():
+        time.sleep(0.1)
+        return os.getpid()
+
+    # We start exactly as many workers as there are CPUs.
+    for _ in range(3):
+        pids = set(ray.get([getpid.remote() for _ in range(4)]))
+        assert len(pids) == 2, pids
+        # Wait for at least the idle worker timeout.
+        time.sleep(0.1)
+
+    # Now test with two actors that uses 1 process each but 0 CPUs.
+    a1 = Actor.remote()
+    a2 = Actor.remote()
+    ray.get([a1.get.remote(), a2.get.remote()])
+
+    for _ in range(3):
+        pids = set(ray.get([getpid.remote() for _ in range(4)]))
+        assert len(pids) == 2, pids
+        # Wait for at least the idle worker timeout.
+        time.sleep(0.1)
+
+    # Kill the actors and test again.
+    del a1
+    del a2
+    for _ in range(3):
+        pids = set(ray.get([getpid.remote() for _ in range(4)]))
+        assert len(pids) == 2, pids
+        # Wait for at least the idle worker timeout.
+        time.sleep(0.1)
+
+
 if __name__ == "__main__":
     os.environ["RAY_worker_cap_enabled"] = "true"
     if os.environ.get("PARALLEL_CI"):

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -553,8 +553,10 @@ RAY_CONFIG(uint64_t, kill_idle_workers_interval_ms, 200)
 /// The idle time threshold for an idle worker to be killed.
 RAY_CONFIG(int64_t, idle_worker_killing_time_threshold_ms, 1000)
 
-/// The soft limit of the number of workers.
-/// -1 means using num_cpus instead.
+/// The soft limit of the number of workers to keep around.
+/// We apply this limit to the idle workers instead of total workers,
+/// because the total number of workers used depends on the
+/// application. -1 means using the available number of CPUs.
 RAY_CONFIG(int64_t, num_workers_soft_limit, -1)
 
 // The interval where metrics are exported in milliseconds.

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -207,9 +207,8 @@ int main(int argc, char *argv[]) {
                        << node_manager_config.resource_config.DebugString();
         node_manager_config.node_manager_address = node_ip_address;
         node_manager_config.node_manager_port = node_manager_port;
-        auto soft_limit_config = RayConfig::instance().num_workers_soft_limit();
         node_manager_config.num_workers_soft_limit =
-            soft_limit_config >= 0 ? soft_limit_config : num_cpus;
+            RayConfig::instance().num_workers_soft_limit();
         node_manager_config.num_prestart_python_workers = num_prestart_python_workers;
         node_manager_config.maximum_startup_concurrency = maximum_startup_concurrency;
         node_manager_config.min_worker_port = min_worker_port;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -137,7 +137,7 @@ NodeManager::NodeManager(instrumented_io_context &io_service,
           io_service,
           self_node_id_,
           config.node_manager_address,
-          [this]() {
+          [this, config]() {
             // Callback to determine the maximum number of idle workers to keep
             // around.
             if (config.num_workers_soft_limit >= 0) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -138,6 +138,13 @@ NodeManager::NodeManager(instrumented_io_context &io_service,
           self_node_id_,
           config.node_manager_address,
           [this]() {
+            // Callback to determine the maximum number of idle workers to keep
+            // around.
+            if (config.num_workers_soft_limit >= 0) {
+              return config.num_workers_soft_limit;
+            }
+            // If no limit is provided, use the available number of CPUs,
+            // assuming that each incoming task will likely require 1 CPU.
             // We floor the available CPUs to the nearest integer to avoid starting too
             // many workers when there is less than 1 CPU left. Otherwise, we could end
             // up repeatedly starting the worker, then killing it because it idles for

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1882,14 +1882,7 @@ void NodeManager::HandleRequestWorkerLease(rpc::RequestWorkerLeaseRequest reques
   }
 
   auto task_spec = task.GetTaskSpecification();
-  // We floor the available CPUs to the nearest integer to avoid starting too
-  // many workers when there is less than 1 CPU left. Otherwise, we could end
-  // up repeatedly starting the worker, then killing it because it idles for
-  // too long. The downside is that we will be slower to schedule tasks that
-  // could use a fraction of a CPU.
-  int64_t available_cpus = static_cast<int64_t>(
-      cluster_resource_scheduler_->GetLocalResourceManager().GetLocalAvailableCpus());
-  worker_pool_.PrestartWorkers(task_spec, request.backlog_size(), available_cpus);
+  worker_pool_.PrestartWorkers(task_spec, request.backlog_size());
 
   auto send_reply_callback_wrapper =
       [this, is_actor_creation_task, actor_id, reply, send_reply_callback](

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -76,7 +76,7 @@ struct NodeManagerConfig {
   /// on. This takes precedence over min_worker_port and max_worker_port.
   std::vector<int> worker_ports;
   /// The soft limit of the number of workers.
-  int num_workers_soft_limit;
+  int64_t num_workers_soft_limit;
   /// Number of initial Python workers to start when raylet starts.
   int num_prestart_python_workers;
   /// The maximum number of workers that can be started concurrently by a

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1053,8 +1053,9 @@ void WorkerPool::TryKillingIdleWorkers() {
       KillIdleWorker(idle_worker, it->second);
       it = idle_of_all_languages_.erase(it);
     } else {
-      if (it->second == -1 || now - it->second >
-          RayConfig::instance().idle_worker_killing_time_threshold_ms()) {
+      if (it->second == -1 ||
+          now - it->second >
+              RayConfig::instance().idle_worker_killing_time_threshold_ms()) {
         // The job has not yet finished and the worker has been idle for longer
         // than the timeout.
         num_killable_idle_workers++;
@@ -1077,8 +1078,9 @@ void WorkerPool::TryKillingIdleWorkers() {
                  << ", num workers desired " << num_desired_idle_workers;
   while (num_killable_idle_workers > num_desired_idle_workers &&
          it != idle_of_all_languages_.end()) {
-    if (it->second == -1 || now - it->second >
-        RayConfig::instance().idle_worker_killing_time_threshold_ms()) {
+    if (it->second == -1 ||
+        now - it->second >
+            RayConfig::instance().idle_worker_killing_time_threshold_ms()) {
       RAY_LOG(DEBUG) << "Number of idle workers " << num_killable_idle_workers
                      << " is larger than the number of desired workers "
                      << num_desired_idle_workers << " killing idle worker with PID "
@@ -1310,8 +1312,8 @@ void WorkerPool::PopWorker(const TaskSpecification &task_spec,
 }
 
 void WorkerPool::PrestartWorkers(const TaskSpecification &task_spec,
-                                 int64_t backlog_size,
-                                 int64_t num_available_cpus) {
+                                 int64_t backlog_size) {
+  int64_t num_available_cpus = get_num_cpus_available_();
   // Code path of task that needs a dedicated worker.
   RAY_LOG(DEBUG) << "PrestartWorkers, num_available_cpus " << num_available_cpus
                  << " backlog_size " << backlog_size << " task spec "

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -71,7 +71,7 @@ namespace raylet {
 WorkerPool::WorkerPool(instrumented_io_context &io_service,
                        const NodeID node_id,
                        const std::string node_address,
-                       int num_workers_soft_limit,
+                       const std::function<int64_t()> &get_num_cpus_available,
                        int num_prestarted_python_workers,
                        int maximum_startup_concurrency,
                        int min_worker_port,
@@ -87,7 +87,7 @@ WorkerPool::WorkerPool(instrumented_io_context &io_service,
       io_service_(&io_service),
       node_id_(node_id),
       node_address_(node_address),
-      num_workers_soft_limit_(num_workers_soft_limit),
+      get_num_cpus_available_(get_num_cpus_available),
       maximum_startup_concurrency_(maximum_startup_concurrency),
       gcs_client_(std::move(gcs_client)),
       native_library_path_(native_library_path),
@@ -157,7 +157,17 @@ WorkerPool::~WorkerPool() {
 void WorkerPool::Start() {
   if (RayConfig::instance().kill_idle_workers_interval_ms() > 0) {
     periodical_runner_.RunFnPeriodically(
-        [this] { TryKillingIdleWorkers(); },
+        [this] {
+          if (reset_num_workers_to_prestart_) {
+            num_workers_to_prestart_ = -1;
+          } else {
+            // On the next interval, reset the number of workers to prestart.
+            // This ensures that we will try to fulfill a request to prestart a
+            // worker for at least the idle worker timeout.
+            reset_num_workers_to_prestart_ = true;
+          }
+          TryKillingIdleWorkers();
+        },
         RayConfig::instance().kill_idle_workers_interval_ms(),
         "RayletWorkerPool.deadline_timer.kill_idle_workers");
   }
@@ -1007,7 +1017,6 @@ void WorkerPool::PushWorker(const std::shared_ptr<WorkerInterface> &worker) {
     state.idle.insert(worker);
     int64_t now = get_time_();
     idle_of_all_languages_.emplace_back(worker, now);
-    idle_of_all_languages_map_[worker] = now;
   } else if (!found) {
     RAY_LOG(INFO) << "Worker not returned to the idle pool after being used. This may "
                      "cause a worker leak, worker id:"
@@ -1020,131 +1029,118 @@ void WorkerPool::PushWorker(const std::shared_ptr<WorkerInterface> &worker) {
 }
 
 void WorkerPool::TryKillingIdleWorkers() {
-  RAY_CHECK(idle_of_all_languages_.size() == idle_of_all_languages_map_.size());
-
   int64_t now = get_time_();
-  size_t running_size = 0;
-  for (const auto &worker : GetAllRegisteredWorkers()) {
-    if (!worker->IsDead() && worker->GetWorkerType() == rpc::WorkerType::WORKER) {
-      running_size++;
-    }
-  }
-  // Subtract the number of pending exit workers first. This will help us killing more
-  // idle workers that it needs to.
-  RAY_CHECK(running_size >= pending_exit_idle_workers_.size());
-  running_size -= pending_exit_idle_workers_.size();
-  // Kill idle workers in FIFO order.
-  for (const auto &idle_pair : idle_of_all_languages_) {
-    const auto &idle_worker = idle_pair.first;
-    const auto &job_id = idle_worker->GetAssignedJobId();
 
-    RAY_LOG(DEBUG) << " Checking idle worker "
-                   << idle_worker->GetAssignedTask().GetTaskSpecification().DebugString()
-                   << " worker id " << idle_worker->WorkerId();
-
-    if (running_size <= static_cast<size_t>(num_workers_soft_limit_)) {
-      if (!finished_jobs_.contains(job_id)) {
-        // Ignore the soft limit for jobs that have already finished, as we
-        // should always clean up these workers.
-        RAY_LOG(DEBUG) << "job not finished. Not going to kill worker "
-                       << idle_worker->WorkerId();
-        continue;
-      }
-    }
-
-    if (now - idle_pair.second <
-        RayConfig::instance().idle_worker_killing_time_threshold_ms()) {
-      break;
-    }
-
+  // Filter out all idle workers that are already dead and/or associated with
+  // jobs that have already finished.
+  int64_t num_killable_idle_workers = 0;
+  for (auto it = idle_of_all_languages_.begin(); it != idle_of_all_languages_.end();) {
+    const auto &idle_worker = it->first;
     if (idle_worker->IsDead()) {
-      RAY_LOG(DEBUG) << "idle worker is already dead. Not going to kill worker "
-                     << idle_worker->WorkerId();
-      // This worker has already been killed.
-      // It will be removed from idle_of_all_languages_ later.
-      // This happens when ExitReply is received but the worker is not removed from
-      // idle_of_all_languages_ yet.
+      it = idle_of_all_languages_.erase(it);
       continue;
     }
 
-    // Skip killing the worker process if there's any inflight `Exit` RPC requests to
-    // this worker process.
-    if (pending_exit_idle_workers_.count(idle_worker->WorkerId())) {
-      continue;
-    }
-
-    RAY_LOG(DEBUG) << "The worker pool has " << running_size
-                   << " registered workers which exceeds the soft limit of "
-                   << num_workers_soft_limit_ << ", and worker "
-                   << idle_worker->WorkerId() << " with pid "
-                   << idle_worker->GetProcess().GetId()
-                   << " has been idle for a a while. Kill it.";
-    // To avoid object lost issue caused by forcibly killing, send an RPC request to the
-    // worker to allow it to do cleanup before exiting. We kill it anyway if the driver
-    // is already exited.
-    RAY_LOG(DEBUG) << "Sending exit message to worker " << idle_worker->WorkerId();
-    // Register the worker to pending exit so that we can correctly calculate the
-    // running_size.
-    // This also means that there's an inflight `Exit` RPC request to the worker.
-    pending_exit_idle_workers_.emplace(idle_worker->WorkerId(), idle_worker);
-    auto rpc_client = idle_worker->rpc_client();
-    RAY_CHECK(rpc_client);
-    RAY_CHECK(running_size > 0);
-    running_size--;
-    rpc::ExitRequest request;
-    if (finished_jobs_.contains(job_id) &&
-        RayConfig::instance().kill_idle_workers_of_terminated_job()) {
-      RAY_LOG(INFO) << "Force exiting worker whose job has exited "
-                    << idle_worker->WorkerId();
-      request.set_force_exit(true);
-    }
-    rpc_client->Exit(
-        request, [this, idle_worker](const ray::Status &status, const rpc::ExitReply &r) {
-          RAY_CHECK(pending_exit_idle_workers_.erase(idle_worker->WorkerId()));
-          if (!status.ok()) {
-            RAY_LOG(ERROR) << "Failed to send exit request: " << status.ToString();
-          }
-
-          // In case of failed to send request, we remove it from pool as well
-          // TODO (iycheng): We should handle the grpc failure in better way.
-          if (!status.ok() || r.success()) {
-            RAY_LOG(DEBUG) << "Removed worker " << idle_worker->WorkerId();
-            auto &worker_state = GetStateForLanguage(idle_worker->GetLanguage());
-            // If we could kill the worker properly, we remove them from the idle
-            // pool.
-            RemoveWorker(worker_state.idle, idle_worker);
-            // We always mark the worker as dead.
-            // If the worker is not idle at this moment, we'd want to mark it as dead
-            // so it won't be reused later.
-            if (!idle_worker->IsDead()) {
-              idle_worker->MarkDead();
-            }
-          } else {
-            RAY_LOG(DEBUG) << "Failed to remove worker " << idle_worker->WorkerId();
-            // We re-insert the idle worker to the back of the queue if it fails to
-            // kill the worker (e.g., when the worker owns the object). Without this,
-            // if the first N workers own objects, it can't kill idle workers that are
-            // >= N+1.
-            const auto &idle_pair = idle_of_all_languages_.front();
-            idle_of_all_languages_.push_back(idle_pair);
-            idle_of_all_languages_.pop_front();
-            RAY_CHECK(idle_of_all_languages_.size() == idle_of_all_languages_map_.size());
-          }
-        });
-  }
-
-  std::list<std::pair<std::shared_ptr<WorkerInterface>, int64_t>>
-      new_idle_of_all_languages;
-  idle_of_all_languages_map_.clear();
-  for (const auto &idle_pair : idle_of_all_languages_) {
-    if (!idle_pair.first->IsDead()) {
-      new_idle_of_all_languages.push_back(idle_pair);
-      idle_of_all_languages_map_.emplace(idle_pair);
+    const auto &job_id = idle_worker->GetAssignedJobId();
+    if (finished_jobs_.count(job_id) > 0) {
+      // The job has finished, so we should kill the worker immediately.
+      KillIdleWorker(idle_worker, it->second);
+      it = idle_of_all_languages_.erase(it);
+    } else {
+      if (now - it->second >
+          RayConfig::instance().idle_worker_killing_time_threshold_ms()) {
+        // The job has not yet finished and the worker has been idle for longer
+        // than the timeout.
+        num_killable_idle_workers++;
+      }
+      it++;
     }
   }
 
-  idle_of_all_languages_ = std::move(new_idle_of_all_languages);
-  RAY_CHECK(idle_of_all_languages_.size() == idle_of_all_languages_map_.size());
+  // Iterate through the list and try to kill enough workers so that we are at
+  // the soft limit.
+  auto it = idle_of_all_languages_.begin();
+  const int64_t num_cpus_available = get_num_cpus_available_();
+  const int64_t num_desired_idle_workers =
+      std::max(num_cpus_available, num_workers_to_prestart_);
+  RAY_LOG(DEBUG) << "Idle workers: " << idle_of_all_languages_.size()
+                 << ", idle workers that are eligible to kill: "
+                 << num_killable_idle_workers
+                 << ", num CPUs available: " << num_cpus_available
+                 << ", num workers to prestart: " << num_workers_to_prestart_
+                 << ", num workers desired " << num_desired_idle_workers;
+  while (num_killable_idle_workers > num_desired_idle_workers &&
+         it != idle_of_all_languages_.end()) {
+    if (now - it->second >
+        RayConfig::instance().idle_worker_killing_time_threshold_ms()) {
+      RAY_LOG(DEBUG) << "Number of idle workers " << num_killable_idle_workers
+                     << " is larger than the number of desired workers "
+                     << num_desired_idle_workers << " killing idle worker with PID "
+                     << it->first->GetProcess().GetId();
+      KillIdleWorker(it->first, it->second);
+      it = idle_of_all_languages_.erase(it);
+      // The job has not yet finished and the worker has been idle for longer
+      // than the timeout.
+      num_killable_idle_workers--;
+    } else {
+      it++;
+    }
+  }
+}
+
+void WorkerPool::KillIdleWorker(std::shared_ptr<WorkerInterface> idle_worker,
+                                int64_t last_time_used_ms) {
+  // To avoid object lost issue caused by forcibly killing, send an RPC request to the
+  // worker to allow it to do cleanup before exiting. We kill it anyway if the driver
+  // is already exited.
+  RAY_LOG(DEBUG) << "Sending exit message to worker " << idle_worker->WorkerId();
+  // Register the worker to pending exit so that we can correctly calculate the
+  // running_size.
+  // This also means that there's an inflight `Exit` RPC request to the worker.
+  pending_exit_idle_workers_.emplace(idle_worker->WorkerId(), idle_worker);
+  auto rpc_client = idle_worker->rpc_client();
+  RAY_CHECK(rpc_client);
+  rpc::ExitRequest request;
+  const auto &job_id = idle_worker->GetAssignedJobId();
+  if (finished_jobs_.contains(job_id) &&
+      RayConfig::instance().kill_idle_workers_of_terminated_job()) {
+    RAY_LOG(INFO) << "Force exiting worker whose job has exited "
+                  << idle_worker->WorkerId();
+    request.set_force_exit(true);
+  }
+  rpc_client->Exit(
+      request,
+      [this, idle_worker, last_time_used_ms](const ray::Status &status,
+                                             const rpc::ExitReply &r) {
+        RAY_CHECK(pending_exit_idle_workers_.erase(idle_worker->WorkerId()));
+        if (!status.ok()) {
+          RAY_LOG(ERROR) << "Failed to send exit request: " << status.ToString();
+        }
+
+        // In case of failed to send request, we remove it from pool as well
+        // TODO (iycheng): We should handle the grpc failure in better way.
+        if (!status.ok() || r.success()) {
+          RAY_LOG(DEBUG) << "Removed worker " << idle_worker->WorkerId();
+          auto &worker_state = GetStateForLanguage(idle_worker->GetLanguage());
+          // If we could kill the worker properly, we remove them from the idle
+          // pool.
+          RemoveWorker(worker_state.idle, idle_worker);
+          // We always mark the worker as dead.
+          // If the worker is not idle at this moment, we'd want to mark it as dead
+          // so it won't be reused later.
+          if (!idle_worker->IsDead()) {
+            idle_worker->MarkDead();
+          }
+        } else {
+          RAY_LOG(DEBUG) << "Failed to remove worker " << idle_worker->WorkerId();
+          // We re-insert the idle worker to the back of the queue if it fails to
+          // kill the worker (e.g., when the worker owns the object). Without this,
+          // if the first N workers own objects, it can't kill idle workers that are
+          // >= N+1.
+          idle_of_all_languages_.push_back(
+              std::make_pair(idle_worker, last_time_used_ms));
+        }
+      });
 }
 
 void WorkerPool::PopWorker(const TaskSpecification &task_spec,
@@ -1245,7 +1241,6 @@ void WorkerPool::PopWorker(const TaskSpecification &task_spec,
     lit--;
     worker = std::move(lit->first);
     idle_of_all_languages_.erase(lit);
-    idle_of_all_languages_map_.erase(worker);
     break;
   }
 
@@ -1336,8 +1331,15 @@ void WorkerPool::PrestartWorkers(const TaskSpecification &task_spec,
     // Account for workers that are idle or already starting.
     int64_t num_needed = desired_usable_workers - num_usable_workers;
     RAY_LOG(DEBUG) << "Prestarting " << num_needed << " workers given task backlog size "
-                   << backlog_size << " and available CPUs " << num_available_cpus;
+                   << backlog_size << " and available CPUs " << num_available_cpus
+                   << " num idle workers " << state.idle.size()
+                   << " num registered workers " << state.registered_workers.size();
     PrestartDefaultCpuWorkers(task_spec.GetLanguage(), num_needed);
+  }
+
+  if (backlog_size > num_workers_to_prestart_) {
+    num_workers_to_prestart_ = desired_usable_workers;
+    reset_num_workers_to_prestart_ = false;
   }
 }
 
@@ -1395,7 +1397,6 @@ void WorkerPool::DisconnectWorker(const std::shared_ptr<WorkerInterface> &worker
        it++) {
     if (it->first == worker) {
       idle_of_all_languages_.erase(it);
-      idle_of_all_languages_map_.erase(worker);
       break;
     }
   }

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1070,10 +1070,10 @@ void WorkerPool::TryKillingIdleWorkers() {
     if (it->second == -1 ||
         now - it->second >
             RayConfig::instance().idle_worker_killing_time_threshold_ms()) {
-      RAY_LOG(INFO) << "Number of idle workers " << num_killable_idle_workers
-                    << " is larger than the number of desired workers "
-                    << num_desired_idle_workers << " killing idle worker with PID "
-                    << it->first->GetProcess().GetId();
+      RAY_LOG(DEBUG) << "Number of idle workers " << num_killable_idle_workers
+                     << " is larger than the number of desired workers "
+                     << num_desired_idle_workers << " killing idle worker with PID "
+                     << it->first->GetProcess().GetId();
       KillIdleWorker(it->first, it->second);
       it = idle_of_all_languages_.erase(it);
       num_killable_idle_workers--;

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -702,19 +702,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   const NodeID node_id_;
   /// Address of the current node.
   const std::string node_address_;
-  /// The number of workers that should be prestarted.
-  /// We record this after requests to prestart workers to make sure that we do
-  /// not prematurely kill prestarted workers.
-  /// This is reset after the same time interval used to kill idle workers, to
-  /// make sure that we eventually kill pre-started workers that are never
-  /// going to be used.
-  /// TODO(swang): This does not differentiate between idle workers of
-  /// different languages.
-  int64_t num_workers_to_prestart_ = -1;
-  /// Whether to reset the num_workers_to_prestart_ variable.
-  /// We use this flag to make sure that we will try to fulfill a request to
-  /// prestart a worker for at least the idle worker timeout.
-  bool reset_num_workers_to_prestart_ = true;
   /// A callback to get the number of CPUs available. We use this to determine
   /// how many idle workers to keep around.
   std::function<int64_t()> get_num_cpus_available_;

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -349,11 +349,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   ///
   /// \param task_spec The returned worker must be able to execute this task.
   /// \param backlog_size The number of tasks in the client backlog of this shape.
-  /// \param num_available_cpus The number of CPUs that are currently unused.
   /// We aim to prestart 1 worker per CPU, up to the the backlog size.
-  void PrestartWorkers(const TaskSpecification &task_spec,
-                       int64_t backlog_size,
-                       int64_t num_available_cpus);
+  void PrestartWorkers(const TaskSpecification &task_spec, int64_t backlog_size);
 
   /// Try to prestart a number of CPU workers with the given language.
   ///

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -163,7 +163,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   ///
   /// \param node_id The id of the current node.
   /// \param node_address The address of the current node.
-  /// \param num_workers_soft_limit The soft limit of the number of workers.
   /// \param num_prestarted_python_workers The number of prestarted Python
   /// workers.
   /// \param maximum_startup_concurrency The maximum number of worker processes
@@ -706,8 +705,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   const NodeID node_id_;
   /// Address of the current node.
   const std::string node_address_;
-  /// The soft limit of the number of registered workers.
-  int num_workers_soft_limit_;
   /// The number of workers that should be prestarted.
   /// We record this after requests to prestart workers to make sure that we do
   /// not prematurely kill prestarted workers.

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -31,7 +31,7 @@ namespace raylet {
 int MAXIMUM_STARTUP_CONCURRENCY = 15;
 int PYTHON_PRESTART_WORKERS = 15;
 int MAX_IO_WORKER_SIZE = 2;
-int POOL_SIZE_SOFT_LIMIT = 5;
+int POOL_SIZE_SOFT_LIMIT = 3;
 int WORKER_REGISTER_TIMEOUT_SECONDS = 3;
 JobID JOB_ID = JobID::FromInt(1);
 JobID JOB_ID2 = JobID::FromInt(2);
@@ -133,7 +133,7 @@ class WorkerPoolMock : public WorkerPool {
             io_service,
             NodeID::FromRandom(),
             "",
-            POOL_SIZE_SOFT_LIMIT,
+            []() { return POOL_SIZE_SOFT_LIMIT; },
             PYTHON_PRESTART_WORKERS,
             MAXIMUM_STARTUP_CONCURRENCY,
             0,
@@ -656,17 +656,17 @@ TEST_F(WorkerPoolDriverRegisteredTest, InitialWorkerProcessCount) {
 TEST_F(WorkerPoolDriverRegisteredTest, TestPrestartingWorkers) {
   const auto task_spec = ExampleTaskSpec();
   // Prestarts 2 workers.
-  worker_pool_->PrestartWorkers(task_spec, 2, /*num_available_cpus=*/5);
+  worker_pool_->PrestartWorkers(task_spec, 2);
   ASSERT_EQ(worker_pool_->NumWorkersStarting(), 2);
   // Prestarts 1 more worker.
-  worker_pool_->PrestartWorkers(task_spec, 3, /*num_available_cpus=*/5);
+  worker_pool_->PrestartWorkers(task_spec, 3);
   ASSERT_EQ(worker_pool_->NumWorkersStarting(), 3);
   // No more needed.
-  worker_pool_->PrestartWorkers(task_spec, 1, /*num_available_cpus=*/5);
+  worker_pool_->PrestartWorkers(task_spec, 1);
   ASSERT_EQ(worker_pool_->NumWorkersStarting(), 3);
   // Capped by soft limit of 5.
-  worker_pool_->PrestartWorkers(task_spec, 20, /*num_available_cpus=*/5);
-  ASSERT_EQ(worker_pool_->NumWorkersStarting(), 5);
+  worker_pool_->PrestartWorkers(task_spec, 20);
+  ASSERT_EQ(worker_pool_->NumWorkersStarting(), POOL_SIZE_SOFT_LIMIT);
 }
 
 TEST_F(WorkerPoolDriverRegisteredTest, HandleWorkerPushPop) {
@@ -1168,7 +1168,7 @@ TEST_F(WorkerPoolDriverRegisteredTest, TestWorkerCapping) {
   RegisterDriver(Language::PYTHON, job_id);
 
   ///
-  /// Register 7 workers (2 more than soft limit).
+  /// Register 4 workers (2 more than soft limit).
   ///
   std::vector<std::shared_ptr<WorkerInterface>> workers;
   int num_workers = POOL_SIZE_SOFT_LIMIT + 2;
@@ -1186,10 +1186,10 @@ TEST_F(WorkerPoolDriverRegisteredTest, TestWorkerCapping) {
     worker_pool_->PushWorker(worker);
   }
   ///
-  /// Pop 2 workers for tasks.
+  /// Pop all workers to reset their order.
   ///
   std::vector<std::shared_ptr<WorkerInterface>> popped_workers;
-  for (int i = 0; i < 2; i++) {
+  for (int i = 0; i < num_workers; i++) {
     // Pop workers for actor creation tasks.
     auto task_spec =
         ExampleTaskSpec(/*actor_id=*/ActorID::Nil(), Language::PYTHON, job_id);
@@ -1199,7 +1199,7 @@ TEST_F(WorkerPoolDriverRegisteredTest, TestWorkerCapping) {
     ASSERT_EQ(worker->GetAssignedJobId(), job_id);
   }
   // After scheduling an actor and task, there's no more idle worker.
-  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), num_workers - 2);
+  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), 0);
 
   ///
   /// Return workers and test KillingIdleWorkers
@@ -1216,60 +1216,41 @@ TEST_F(WorkerPoolDriverRegisteredTest, TestWorkerCapping) {
   // 2000 ms has passed, so idle workers should be killed.
   worker_pool_->SetCurrentTimeMs(2000);
   worker_pool_->TryKillingIdleWorkers();
-  // Idle workers haven't been killed because the workers haven't replied yet.
-  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), num_workers);
+  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), POOL_SIZE_SOFT_LIMIT);
 
   // The first core worker exits, so one of idle workers should've been killed.
   // Since the idle workers are killed in FIFO, we can assume the first entry in the idle
   // workers will be killed.
-  auto mock_rpc_client_it = mock_worker_rpc_clients_.find(
-      worker_pool_->GetIdleWorkers().front().first->WorkerId());
+  auto mock_rpc_client_it = mock_worker_rpc_clients_.find(popped_workers[0]->WorkerId());
   ASSERT_EQ(mock_rpc_client_it->second->exit_count, 1);
   ASSERT_EQ(mock_rpc_client_it->second->last_exit_forced, false);
   mock_rpc_client_it->second->ExitReplySucceed();
   worker_pool_->TryKillingIdleWorkers();
-  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), num_workers - 1);
+  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), POOL_SIZE_SOFT_LIMIT);
 
   // The second core worker doesn't exit, meaning idle worker shouldn't have been killed.
-  mock_rpc_client_it = mock_worker_rpc_clients_.find(
-      worker_pool_->GetIdleWorkers().front().first->WorkerId());
+  mock_rpc_client_it = mock_worker_rpc_clients_.find(popped_workers[1]->WorkerId());
   ASSERT_EQ(mock_rpc_client_it->second->exit_count, 1);
   ASSERT_EQ(mock_rpc_client_it->second->last_exit_forced, false);
   mock_rpc_client_it->second->ExitReplyFailed();
+  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), POOL_SIZE_SOFT_LIMIT + 1);
+  // Try killing the idle workers again.
   worker_pool_->TryKillingIdleWorkers();
-  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), num_workers - 1);
+  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), POOL_SIZE_SOFT_LIMIT);
 
-  // Another 1000ms has passed, and we kill the idle worker again.
-  worker_pool_->SetCurrentTimeMs(3000);
-  worker_pool_->TryKillingIdleWorkers();
-
-  // Make sure 1000ms has passed again, and it won't kill new worker because there's still
-  // a pending exiting worker.
-  worker_pool_->SetCurrentTimeMs(4000);
-  worker_pool_->TryKillingIdleWorkers();
-  mock_rpc_client_it = mock_worker_rpc_clients_.find(
-      worker_pool_->GetIdleWorkers().back().first->WorkerId());
-  ASSERT_EQ(mock_rpc_client_it->second->exit_count, 1);
-  ASSERT_EQ(mock_rpc_client_it->second->last_exit_forced, false);
-  ASSERT_FALSE(mock_rpc_client_it->second->ExitReplySucceed());
-
-  // Now let's make sure the pending exiting workers exitted properly.
-  mock_rpc_client_it = mock_worker_rpc_clients_.find(
-      worker_pool_->GetIdleWorkers().front().first->WorkerId());
-  ASSERT_EQ(mock_rpc_client_it->second->exit_count, 1);
-  ASSERT_EQ(mock_rpc_client_it->second->last_exit_forced, false);
+  // We retry the exit request at the next worker in the queue.
+  // This tests that if a worker can't be killed (e.g., because it owns
+  // objects), we will still try to cap the workers by killing other workers
+  // that may have been idle for less time.
+  mock_rpc_client_it = mock_worker_rpc_clients_.find(popped_workers[2]->WorkerId());
   mock_rpc_client_it->second->ExitReplySucceed();
-  worker_pool_->TryKillingIdleWorkers();
-  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), num_workers - 2);
 
   // Now that we have the number of workers == soft limit, it shouldn't kill any idle
   // worker.
-  worker_pool_->SetCurrentTimeMs(5000);
   worker_pool_->TryKillingIdleWorkers();
-  mock_rpc_client_it = mock_worker_rpc_clients_.find(
-      worker_pool_->GetIdleWorkers().front().first->WorkerId());
-  ASSERT_EQ(mock_rpc_client_it->second->exit_count, 0);
-  ASSERT_FALSE(mock_rpc_client_it->second->ExitReplySucceed());
+  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), POOL_SIZE_SOFT_LIMIT);
+  worker_pool_->TryKillingIdleWorkers();
+  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), POOL_SIZE_SOFT_LIMIT);
 
   // Start two IO workers. These don't count towards the limit.
   {
@@ -1297,7 +1278,7 @@ TEST_F(WorkerPoolDriverRegisteredTest, TestWorkerCapping) {
   // All workers still alive.
   worker_pool_->SetCurrentTimeMs(10000);
   worker_pool_->TryKillingIdleWorkers();
-  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), num_workers - 2);
+  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), POOL_SIZE_SOFT_LIMIT);
   for (auto &worker : worker_pool_->GetIdleWorkers()) {
     mock_rpc_client_it = mock_worker_rpc_clients_.find(worker.first->WorkerId());
     ASSERT_EQ(mock_rpc_client_it->second->last_exit_forced, false);
@@ -1309,70 +1290,6 @@ TEST_F(WorkerPoolDriverRegisteredTest, TestWorkerCapping) {
   worker_pool_->PopRestoreWorker(callback);
   ASSERT_EQ(num_callbacks, 2);
   worker_pool_->ClearProcesses();
-}
-
-TEST_F(WorkerPoolDriverRegisteredTest, TestWorkerCappingLaterNWorkersNotOwningObjects) {
-  ///
-  /// When there are 2 * N idle workers where the first N workers own objects,
-  /// make sure the later N workers are properly killed.
-  ///
-  auto job_id = JOB_ID;
-
-  // The driver of job 1 is already registered. Here we register the driver for job 2.
-  RegisterDriver(Language::PYTHON, job_id);
-
-  ///
-  /// Register 10 workers
-  ///
-  std::vector<std::shared_ptr<WorkerInterface>> workers;
-  int num_workers = POOL_SIZE_SOFT_LIMIT * 2;
-  for (int i = 0; i < num_workers; i++) {
-    PopWorkerStatus status;
-    auto [proc, token] = worker_pool_->StartWorkerProcess(
-        Language::PYTHON, rpc::WorkerType::WORKER, job_id, &status);
-    auto worker = worker_pool_->CreateWorker(Process(), Language::PYTHON, job_id);
-    worker->SetStartupToken(worker_pool_->GetStartupToken(proc));
-    workers.push_back(worker);
-    RAY_CHECK_OK(worker_pool_->RegisterWorker(
-        worker, proc.GetId(), worker_pool_->GetStartupToken(proc), [](Status, int) {}));
-    worker_pool_->OnWorkerStarted(worker);
-    ASSERT_EQ(worker_pool_->GetRegisteredWorker(worker->Connection()), worker);
-    worker_pool_->PushWorker(worker);
-  }
-  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), num_workers);
-
-  ///
-  /// The first N workers will always failed to be killed because they own objects.
-  ///
-  // 2000 ms has passed, so idle workers should be killed.
-  worker_pool_->SetCurrentTimeMs(1000);
-  worker_pool_->TryKillingIdleWorkers();
-
-  for (int i = 0; i < num_workers / 2; i++) {
-    auto mock_rpc_client_it = mock_worker_rpc_clients_.find(workers[i]->WorkerId());
-    ASSERT_TRUE(mock_rpc_client_it->second->ExitReplyFailed());
-  }
-  worker_pool_->TryKillingIdleWorkers();
-  // None of first N workers are killed because they own objects.
-  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), num_workers);
-
-  ///
-  /// After 1000ms, when it kills idle workers, it should kill the rest of them.
-  ///
-  worker_pool_->SetCurrentTimeMs(2000);
-  worker_pool_->TryKillingIdleWorkers();
-  for (int i = 0; i < num_workers / 2; i++) {
-    auto mock_rpc_client_it = mock_worker_rpc_clients_.find(workers[i]->WorkerId());
-    // These workers shouldn't get any Exit request.
-    ASSERT_FALSE(mock_rpc_client_it->second->ExitReplyFailed());
-  }
-  for (int i = num_workers / 2; i < num_workers; i++) {
-    auto mock_rpc_client_it = mock_worker_rpc_clients_.find(workers[i]->WorkerId());
-    // These workers shouldn't get any Exit request.
-    ASSERT_TRUE(mock_rpc_client_it->second->ExitReplySucceed());
-  }
-  worker_pool_->TryKillingIdleWorkers();
-  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), num_workers / 2);
 }
 
 TEST_F(WorkerPoolDriverRegisteredTest, TestWorkerCappingWithExitDelay) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#36669 lists some issues found with workers not being reused. This turns out to have two root causes:
- We use the total number of CPUs as a soft limit for the total number of worker processes allowed. This leads to worker churn when there are some processes that are actively using resources but less than 1 CPU (e.g., actors), and other tasks that are trying to use the remaining cores. We will always end up over the soft limit, so we have to keep killing and restarting workers.
- (less serious) Workers are usually slow on their first task. Workers are selected for tasks in LIFO order and currently a worker that has just been started up is inserted last, which leads to slowdown on the next task. This isn't serious on its own, but becomes a performance issue when there is worker churn, and we end up killing a warmed up idle worker instead of the cold one.

This PR makes some changes to improve the idle worker killing:
- Use the available CPUs as a limit for the number of idle workers allowed, instead of total CPUs as a limit for total workers allowed. When no CPUs are being used and/or all tasks use exactly 1 CPU, the new policy is equivalent to the old one.
- The `num_workers_soft_limit` config override option is now used as a soft limit for idle workers instead of total workers.
- Workers that were just started are now inserted at the beginning of the idle worker queue so that they are prioritized to be killed over warmed up workers. They will be kept alive for at least the idle timeout as usual.

## Related issue number

Closes #36669.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
