### PR TITLE
[Serve] [Docs] Remove unnecessary tab in Ray Serve quickstart

### DIFF
--- a/doc/source/serve/index.md
+++ b/doc/source/serve/index.md
@@ -38,11 +38,7 @@ Define a simple "hello world" application, run it locally, and query it over HTT
 :language: python
 ```
 
-::::{tab-set} 
-
 ## More examples
-
-::::
 
 ::::{tab-set}
 

--- a/doc/source/serve/index.md
+++ b/doc/source/serve/index.md
@@ -40,11 +40,7 @@ Define a simple "hello world" application, run it locally, and query it over HTT
 
 ::::{tab-set} 
 
-:::{tab-item} More examples
-
-For more examples, select from the tabs.
-
-:::
+## More examples
 
 ::::
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `More Examples` section in the [Ray Serve Quickstart](https://docs.ray.io/en/releases-2.5.1/serve/index.html#quickstart) is a tab instead fo a header:

<img width="694" alt="Screen Shot 2023-06-23 at 7 31 43 PM" src="https://github.com/ray-project/ray/assets/92341594/cec9a5b1-6344-4661-8426-ad8c12274769">

This change converts it to a header.

## Related issue number

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change only affects documentation.
