### PR TITLE
[java] fix compile warnings

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/functionmanager/FunctionManager.java
+++ b/java/runtime/src/main/java/io/ray/runtime/functionmanager/FunctionManager.java
@@ -138,7 +138,7 @@ public class FunctionManager {
                   })
               .toArray(URL[]::new);
       classLoader = new URLClassLoader(urls);
-      LOGGER.debug("Resource loaded from path {}.", urls);
+      LOGGER.debug("Resource loaded from path {}.", (Object[]) (urls));
     }
 
     return new JobFunctionTable(classLoader);

--- a/java/runtime/src/main/java/io/ray/runtime/utils/parallelactor/ParallelActorExecutorImpl.java
+++ b/java/runtime/src/main/java/io/ray/runtime/utils/parallelactor/ParallelActorExecutorImpl.java
@@ -26,7 +26,7 @@ public class ParallelActorExecutorImpl {
     RayFunction init = functionManager.getFunction(javaFunctionDescriptor);
     Thread.currentThread().setContextClassLoader(init.classLoader);
     for (int i = 0; i < parallelism; ++i) {
-      Object instance = init.getMethod().invoke(null, null);
+      Object instance = init.getMethod().invoke(null);
       instances.put(i, instance);
     }
   }


### PR DESCRIPTION
```
INFO: From Building java/libio_ray_ray_runtime-class.jar (81 source files, 3 source jars):
java/runtime/src/main/java/io/ray/runtime/functionmanager/FunctionManager.java:141: warning: non-varargs call of varargs method with inexact argument type for last parameter;
      LOGGER.debug("Resource loaded from path {}.", urls);
                                                    ^
  cast to Object for a varargs call
  cast to Object[] for a non-varargs call and to suppress this warning
java/runtime/src/main/java/io/ray/runtime/utils/parallelactor/ParallelActorExecutorImpl.java:29: warning: non-varargs call of varargs method with inexact argument type for last parameter;
      Object instance = init.getMethod().invoke(null, null);
                                                      ^
  cast to Object for a varargs call
  cast to Object[] for a non-varargs call and to suppress this warning
```
