### PR TITLE
[ci][byod] validate that correct ray is installed

### DIFF
--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -50,12 +50,7 @@ def build_anyscale_custom_byod_image(test: Test) -> None:
         stdout=sys.stderr,
         env=env,
     )
-    # push the image to ecr, the image will have a tag in this format
-    # {commit_sha}-py{version}-gpu-{custom_information_dict_hash}
-    subprocess.check_call(
-        ["docker", "push", byod_image],
-        stdout=sys.stderr,
-    )
+    _validate_and_push(byod_image)
 
 
 def build_anyscale_base_byod_images(tests: List[Test]) -> None:
@@ -134,11 +129,45 @@ def build_anyscale_base_byod_images(tests: List[Test]) -> None:
                     stdout=sys.stderr,
                     env=env,
                 )
-                subprocess.check_call(
-                    ["docker", "push", byod_image],
-                    stdout=sys.stderr,
-                )
+                _validate_and_push(byod_image)
                 built.add(ray_image)
+
+
+def _validate_and_push(byod_image: str) -> None:
+    """
+    Validates the given image and pushes it to ECR.
+    """
+    docker_ray_commit = (
+        subprocess.check_output(
+            [
+                "docker",
+                "run",
+                "-ti",
+                "--entrypoint",
+                "python",
+                byod_image,
+                "-c",
+                "import ray; print(ray.__commit__)",
+            ],
+        )
+        .decode("utf-8")
+        .strip()
+    )
+    expected_ray_commit = _get_ray_commit()
+    assert (
+        docker_ray_commit == expected_ray_commit
+    ), f"Expected ray commit {expected_ray_commit}, found {docker_ray_commit}"
+    subprocess.check_call(
+        ["docker", "push", byod_image],
+        stdout=sys.stderr,
+    )
+
+
+def _get_ray_commit() -> str:
+    return os.environ.get(
+        "COMMIT_TO_TEST",
+        os.environ["BUILDKITE_COMMIT"],
+    )
 
 
 def _download_dataplane_build_file() -> None:

--- a/release/ray_release/tests/test_byod_build.py
+++ b/release/ray_release/tests/test_byod_build.py
@@ -26,6 +26,9 @@ def test_build_anyscale_custom_byod_image() -> None:
     ), patch(
         "subprocess.check_call",
         side_effect=_mock_check_call,
+    ), patch(
+        "subprocess.check_output",
+        return_value=b"abc123",
     ):
         test = Test(
             name="name",


### PR DESCRIPTION
## Why are these changes needed?
- Validate that ray is at the correct commit under test after building BYOD image. This is a feature that exists in the old way of running release tests, I just port the validation check here.

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests - https://buildkite.com/ray-project/release-tests-pr/builds/43467#0188ee54-d693-41ce-9b74-d1440781609e (just check that the main job that builds all BYOD succeed. I canceled all the tests to save capacity, since they are not what is tested here).
   