### PR TITLE
[Serve] [Docs] Align file names in getting_started.md

### DIFF
--- a/doc/source/serve/doc_code/getting_started/model_deployment_full.py
+++ b/doc/source/serve/doc_code/getting_started/model_deployment_full.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 
 # __deployment_full_start__
-# File name: serve_deployment.py
+# File name: serve_quickstart.py
 from starlette.requests import Request
 
 import ray

--- a/doc/source/serve/doc_code/getting_started/model_graph.py
+++ b/doc/source/serve/doc_code/getting_started/model_graph.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 
 # __start_graph__
-# File name: graph.py
+# File name: serve_quickstart_composed.py
 from starlette.requests import Request
 
 import ray

--- a/doc/source/serve/getting_started.md
+++ b/doc/source/serve/getting_started.md
@@ -139,7 +139,7 @@ To test locally, we run the script with the `serve run` CLI command. This comman
 to our deployment formatted as `module:application`. Make sure to run the command from a directory containing a local copy of this script saved as `serve_quickstart.py`, so it can import the application:
 
 ```console
-$ serve run serve_quickstart:translator_app
+$ serve run serve_deployment:translator_app
 ```
 
 This command will run the `translator_app` application and then block, streaming logs to the console. It can be killed with `Ctrl-C`, which will tear down the application.
@@ -223,10 +223,10 @@ We define the full application as follows:
 deployment_graph = Summarizer.bind(Translator.bind())
 ```
 
-Here, we bind `Translator` to its (empty) constructor arguments, and then we pass in the bound `Translator` as the constructor argument for the `Summarizer`. We can run this deployment graph using the `serve run` CLI command. Make sure to run this command from a directory containing a local copy of the `serve_quickstart_composed.py` code:
+Here, we bind `Translator` to its (empty) constructor arguments, and then we pass in the bound `Translator` as the constructor argument for the `Summarizer`. We can run this deployment graph using the `serve run` CLI command. Make sure to run this command from a directory containing a local copy of the `graph.py` code:
 
 ```console
-$ serve run serve_quickstart_composed:app
+$ serve run graph:app
 ```
 
 We can use this client script to make requests to the graph:

--- a/doc/source/serve/getting_started.md
+++ b/doc/source/serve/getting_started.md
@@ -139,7 +139,7 @@ To test locally, we run the script with the `serve run` CLI command. This comman
 to our deployment formatted as `module:application`. Make sure to run the command from a directory containing a local copy of this script saved as `serve_quickstart.py`, so it can import the application:
 
 ```console
-$ serve run serve_deployment:translator_app
+$ serve run serve_quickstart:translator_app
 ```
 
 This command will run the `translator_app` application and then block, streaming logs to the console. It can be killed with `Ctrl-C`, which will tear down the application.
@@ -223,10 +223,10 @@ We define the full application as follows:
 deployment_graph = Summarizer.bind(Translator.bind())
 ```
 
-Here, we bind `Translator` to its (empty) constructor arguments, and then we pass in the bound `Translator` as the constructor argument for the `Summarizer`. We can run this deployment graph using the `serve run` CLI command. Make sure to run this command from a directory containing a local copy of the `graph.py` code:
+Here, we bind `Translator` to its (empty) constructor arguments, and then we pass in the bound `Translator` as the constructor argument for the `Summarizer`. We can run this deployment graph using the `serve run` CLI command. Make sure to run this command from a directory containing a local copy of the `serve_quickstart_composed.py` code:
 
 ```console
-$ serve run graph:app
+$ serve run serve_quickstart_composed:app
 ```
 
 We can use this client script to make requests to the graph:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

While running through the [getting started tutorial](https://docs.ray.io/en/latest/serve/getting_started.html#getting-started) for Ray Serve, I was confused by the mismatch of the file names mentioned in the markdown explanations and the file names stated in the first line of the imported source files.
This fixes the mismatch by matching file names listed at the top of `doc/source/serve/doc_code/getting_started/model_deployment_full.py` and `doc/source/serve/doc_code/getting_started/model_graph.py` to the file names mentioned in the tutorial (`serve_quickstart.py` and `serve_quickstart_composed.py`, respectively).

## Related issue number

None.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
