### PR TITLE
[Data] Refactor .distinct() to .unique()

### DIFF
--- a/doc/source/data/api/dataset.rst
+++ b/doc/source/data/api/dataset.rst
@@ -61,7 +61,7 @@ Grouped and Global Aggregations
    :toctree: doc/
 
    Dataset.groupby
-   Dataset.distinct
+   Dataset.unique
    Dataset.aggregate
    Dataset.sum
    Dataset.min

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1721,10 +1721,31 @@ class Dataset:
         """List of unique elements in the given column.
 
         Examples:
+
             >>> import ray
             >>> ds = ray.data.from_items([1, 2, 3, 2, 3])
             >>> ds.unique("item")
             [1, 2, 3]
+
+            This function is very useful for computing labels
+            in a machine learning dataset:
+
+            >>> import ray
+            >>> ds = ray.data.read_csv("example://iris.csv")
+            >>> ds.unique("variety")
+            ['Setosa', 'Versicolor', 'Virginica']
+
+            One common use case is to convert the class labels
+            into integers for training and inference:
+
+            >>> classes = {label: i for i, label in enumerate(ds.unique("variety"))}
+            >>> def preprocessor(df, classes):
+            ...     df["variety"] = df["variety"].map(classes)
+            ...     return df
+            >>> train_ds = ds.map_batches(
+            ...     preprocessor, fn_kwargs={"classes": classes}, batch_format="pandas")
+            >>> train_ds.sort("sepal.length").take(1)  # Sort to make it deterministic
+            [{'sepal.length': 4.3, 'sepal.width': 3.0, 'petal.length': 1.1, 'petal.width': 0.1, 'variety': 0}]
 
         Time complexity: O(dataset size * log(dataset size / parallelism))
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1745,7 +1745,7 @@ class Dataset:
             >>> train_ds = ds.map_batches(
             ...     preprocessor, fn_kwargs={"classes": classes}, batch_format="pandas")
             >>> train_ds.sort("sepal.length").take(1)  # Sort to make it deterministic
-            [{'sepal.length': 4.3, 'sepal.width': 3.0, 'petal.length': 1.1, 'petal.width': 0.1, 'variety': 0}]
+            [{'sepal.length': 4.3, ..., 'variety': 0}]
 
         Time complexity: O(dataset size * log(dataset size / parallelism))
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1717,7 +1717,7 @@ class Dataset:
 
         return GroupedData(self, key)
 
-    def unique(self, on: str) -> List:
+    def unique(self, column: str) -> List:
         """List of unique elements in the given column.
 
         Examples:
@@ -1728,11 +1728,14 @@ class Dataset:
 
         Time complexity: O(dataset size * log(dataset size / parallelism))
 
+        Args:
+            column (str): The column to collect unique elements over.
+
         Returns:
             A list with unique elements in the given column.
         """
-        ds = self.groupby(on).count().select_columns([on])
-        return [item[on] for item in ds.take_all()]
+        ds = self.groupby(column).count().select_columns([column])
+        return [item[column] for item in ds.take_all()]
 
     @ConsumptionAPI
     def aggregate(self, *aggs: AggregateFn) -> Union[Any, Dict[str, Any]]:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1717,7 +1717,7 @@ class Dataset:
 
         return GroupedData(self, key)
 
-    def unique(self, column: str) -> List:
+    def unique(self, column: str) -> List[Any]:
         """List of unique elements in the given column.
 
         Examples:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1729,7 +1729,7 @@ class Dataset:
         Time complexity: O(dataset size * log(dataset size / parallelism))
 
         Args:
-            column (str): The column to collect unique elements over.
+            column: The column to collect unique elements over.
 
         Returns:
             A list with unique elements in the given column.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1717,34 +1717,22 @@ class Dataset:
 
         return GroupedData(self, key)
 
-    def distinct(self) -> "Dataset":
-        """Remove duplicate rows from the :class:`~ray.data.Dataset`.
+    def unique(self, on: str) -> List:
+        """List of unique elements in the given column.
 
         Examples:
             >>> import ray
             >>> ds = ray.data.from_items([1, 2, 3, 2, 3])
-            >>> ds.distinct().take_all()
-            [{'item': 1}, {'item': 2}, {'item': 3}]
+            >>> ds.unique("item")
+            [1, 2, 3]
 
         Time complexity: O(dataset size * log(dataset size / parallelism))
 
-        .. note:: Currently distinct only supports
-            :class:`~ray.data.Dataset` with one single column.
-
         Returns:
-            A new :class:`~ray.data.Dataset` with distinct rows.
+            A list with unique elements in the given column.
         """
-        columns = self.columns(fetch_if_missing=True)
-        assert columns is not None
-        if len(columns) > 1:
-            # TODO(hchen): Remove this limitation once groupby supports
-            # multiple columns.
-            raise NotImplementedError(
-                "`distinct` currently only supports Datasets with one single column, "
-                "please apply `select_columns` before `distinct`."
-            )
-        column = columns[0]
-        return self.groupby(column).count().select_columns([column])
+        ds = self.groupby(on).count().select_columns([on])
+        return [item[on] for item in ds.take_all()]
 
     @ConsumptionAPI
     def aggregate(self, *aggs: AggregateFn) -> Union[Any, Dict[str, Any]]:

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -217,7 +217,7 @@ def test_repartition_shuffle_arrow(ray_start_regular_shared):
     assert large._block_num_rows() == [500] * 20
 
 
-def test_distinct(ray_start_regular_shared):
+def test_unique(ray_start_regular_shared):
     ds = ray.data.from_items([3, 2, 3, 1, 2, 3])
     assert set(ds.unique("item")) == {1, 2, 3}
 

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -219,22 +219,16 @@ def test_repartition_shuffle_arrow(ray_start_regular_shared):
 
 def test_distinct(ray_start_regular_shared):
     ds = ray.data.from_items([3, 2, 3, 1, 2, 3])
-    assert ds.distinct().sort("item").take_all() == [
-        {"item": 1},
-        {"item": 2},
-        {"item": 3},
-    ]
+    assert set(ds.unique("item")) == {1, 2, 3}
+
     ds = ray.data.from_items(
         [
             {"a": 1, "b": 1},
             {"a": 1, "b": 2},
         ]
     )
-    # Currently, we don't support distinct on multiple columns.
-    with pytest.raises(NotImplementedError):
-        ds.distinct().take_all()
-    # After selecting a single column, distinct should work.
-    assert ds.select_columns(["a"]).distinct().take_all() == [{"a": 1}]
+    assert set(ds.unique("a")) == {1}
+    assert set(ds.unique("b")) == {1, 2}
 
 
 def test_grouped_dataset_repr(ray_start_regular_shared):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It turns out for the use cases in https://github.com/ray-project/ray/issues/32984, the previous `.distinct()` API was not quite the right API -- the function is actually being used to get distinct labels or values in a dataset and therefore returning a list is the most convenient. This is very in line with Ray Data being a last mile data processing framework.

Also HuggingFace datasets already has a good API for this, so we are implementing a similar API here, see also https://huggingface.co/docs/datasets/v2.13.1/en/package_reference/main_classes#datasets.Dataset.unique

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
