### PR TITLE
[rllib] TorchMultiCategorical assumed to wrap torch.distribution but actually…

### DIFF
--- a/rllib/models/torch/torch_distributions.py
+++ b/rllib/models/torch/torch_distributions.py
@@ -318,7 +318,7 @@ class TorchMultiCategorical(Distribution):
     @override(Distribution)
     def logp(self, value: torch.Tensor) -> TensorType:
         value = torch.unbind(value, dim=1)
-        logps = torch.stack([cat.log_prob(act) for cat, act in zip(self._cats, value)])
+        logps = torch.stack([cat.logp(act) for cat, act in zip(self._cats, value)])
         return torch.sum(logps, dim=0)
 
     @override(Distribution)


### PR DESCRIPTION
… wraps TorchDistribution

## Why are these changes needed?

Basically training a PPO algorithm fails when the action space is MultiCategorical. Very interestingly APPO is not affected which somehow makes me doubt how APPO can train for a MultiCathegorical  action space. 

## Related issue number

Did not open one

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :( -> Unit test should cover unintended side effects
