### PR TITLE
[RLlib] Fix bug in Multi-Categorical distribution. It should use logp and not log_p.

### DIFF
--- a/rllib/core/models/tests/test_catalog.py
+++ b/rllib/core/models/tests/test_catalog.py
@@ -371,7 +371,10 @@ class TestCatalog(unittest.TestCase):
                     msg=f"Expected {expected_cls_dict[framework]}, "
                     f"got {type(dist)}",
                 )
+                # Test if sampling works
                 actions = dist.sample()
+                # Test is logp works
+                dist.logp(actions)
 
                 # For any array of actions in a possibly nested space, convert to
                 # numpy and pick the first one to check if it is in the action space.

--- a/rllib/models/torch/torch_distributions.py
+++ b/rllib/models/torch/torch_distributions.py
@@ -318,7 +318,7 @@ class TorchMultiCategorical(Distribution):
     @override(Distribution)
     def logp(self, value: torch.Tensor) -> TensorType:
         value = torch.unbind(value, dim=1)
-        logps = torch.stack([cat.log_prob(act) for cat, act in zip(self._cats, value)])
+        logps = torch.stack([cat.logp(act) for cat, act in zip(self._cats, value)])
         return torch.sum(logps, dim=0)
 
     @override(Distribution)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The bug was originally reported and fixed in this PR: https://github.com/ray-project/ray/pull/36803
I added unittests to it.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
