### PR TITLE
[RFC] Dev container support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/universal
+{
+	"name": "Ray Core Dev Container",
+	"build": {
+		// Path is relataive to the devcontainer.json file.
+		"dockerfile": "../docker/devcontainer/Dockerfile",
+		"context": ".."
+	},
+	"workspaceMount": "source=${localWorkspaceFolder},target=/ray,type=bind",
+	"workspaceFolder": "/ray",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "cd /ray && ./ci/env/install-bazel.sh --system && echo 'build --remote_upload_local_results=false' >> $HOME/.bazelrc && bazel build //:ray_pkg || bazel build --jobs 1 //:ray_pkg && pip install -e /ray/python",
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {},
+			"extensions": [
+				"ms-python.autopep8",
+				"ms-python.python",
+				"ms-vscode.cpptools",
+				"ms-vscode.cpptools-extension-pack"
+			]
+		}
+	}
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/docker/devcontainer/Dockerfile
+++ b/docker/devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+# The devcontainer Dockerfile to set up an hermetic enviornment with all needed dependencies.
+
+FROM rayproject/ray-deps:2023-06-26-cu116-aarch64
+COPY . /ray
+# Install dependencies needed to build ray
+RUN sudo apt-get update && sudo apt-get install -y curl unzip cmake gcc g++ && sudo apt-get clean
+RUN sudo chown -R ray:users /ray && cd /ray && git init && ./ci/env/install-bazel.sh --system
+ENV PATH=$PATH:/home/ray/bin
+RUN echo 'build --remote_upload_local_results=false' >> $HOME/.bazelrc 
+WORKDIR /ray


### PR DESCRIPTION
## Why are these changes needed?

Adds vscode dev container support. This provides an hermetic environment with all needed dependencies.

## How to use

1. If you are on mac: install "Docker for mac"
2. prepare a clean git environment.
3. open vscode, install "Dev Containers" extension.
4. open the workspace with dev containers
5. Now you are in a container with proper environments.

## Sharp edges

- If some C++ headers from deps are "not found": bazel build your pkg first.
- I used a `-aarch64` base image for my M1 mac.
- I can't get `bazel build //:ray_pkg` to work, it complains something like `python/ray/serve/generated/sedXhx0Ry` permission denied.