### PR TITLE
[Data] Disable Limit Pushdown rule in new execution plan optimizer

### DIFF
--- a/python/ray/data/_internal/logical/optimizers.py
+++ b/python/ray/data/_internal/logical/optimizers.py
@@ -10,7 +10,6 @@ from ray.data._internal.logical.rules import (
     OperatorFusionRule,
     ReorderRandomizeBlocksRule,
 )
-from ray.data._internal.logical.rules.limit_pushdown import LimitPushdownRule
 from ray.data._internal.planner.planner import Planner
 
 
@@ -19,7 +18,10 @@ class LogicalOptimizer(Optimizer):
 
     @property
     def rules(self) -> List[Rule]:
-        return [ReorderRandomizeBlocksRule(), LimitPushdownRule()]
+        # TODO(scottjlee): add back LimitPushdownRule once we
+        # enforce number of input/output rows remains the same
+        # for Map/MapBatches ops.
+        return [ReorderRandomizeBlocksRule()]
 
 
 class PhysicalOptimizer(Optimizer):

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -1272,6 +1272,10 @@ def test_from_torch_e2e(ray_start_regular_shared, enable_optimizer, tmp_path):
     _check_usage_record(["FromItems"])
 
 
+@pytest.mark.skip(
+    reason="Limit pushdown currently disabled, see "
+    "https://github.com/ray-project/ray/issues/36295"
+)
 def test_limit_pushdown(ray_start_regular_shared, enable_optimizer):
     def f1(x):
         return x


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The Limit Pushdown optimization rule, originally implemented in https://github.com/ray-project/ray/pull/35950, makes the assumption that `Map` and `MapBatches` operators do not change the number of input and output rows. We currently do not have any checks to enforce this condition, so as a result, if this row count invariant condition is not met, it is possible that the output will be incorrect if Limit Pushdown is applied.

This row check was expected to be a relatively small change to be implemented in https://github.com/ray-project/ray/issues/36295, but this spawned additional discussion around whether we should enforce this in the first place (particularly around filtering with map_batches, current users' typical use cases, etc). 

We will delay implementing the row count invariant condition until Ray 2.7, so for Ray 2.6 release, we will disable the Limit Pushdown rule, and re-enable it once the aforementioned row count invariant discussion is resolved.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #36821
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
