### PR TITLE
[ci][release-test-infra] support plug-in of another test class

### DIFF
--- a/release/ray_release/alerts/default.py
+++ b/release/ray_release/alerts/default.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.result import Result, ResultStatus
 
 

--- a/release/ray_release/alerts/handle.py
+++ b/release/ray_release/alerts/handle.py
@@ -1,4 +1,4 @@
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.exception import ReleaseTestConfigError, ResultsAlert
 from ray_release.logger import logger
 from ray_release.result import Result

--- a/release/ray_release/alerts/long_running_tests.py
+++ b/release/ray_release/alerts/long_running_tests.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.result import Result
 
 

--- a/release/ray_release/alerts/tune_tests.py
+++ b/release/ray_release/alerts/tune_tests.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.result import (
     Result,
     ResultStatus,

--- a/release/ray_release/alerts/xgboost_tests.py
+++ b/release/ray_release/alerts/xgboost_tests.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.result import Result
 
 

--- a/release/ray_release/buildkite/concurrency.py
+++ b/release/ray_release/buildkite/concurrency.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from typing import Tuple, Optional, Dict
 
 from ray_release.bazel import bazel_runfile
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.template import load_test_cluster_compute
 from ray_release.logger import logger
 

--- a/release/ray_release/buildkite/filter.py
+++ b/release/ray_release/buildkite/filter.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from typing import List, Optional, Tuple, Dict, Any
 
 from ray_release.buildkite.settings import Frequency, get_frequency
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.test_automation.state_machine import TestStateMachine
 
 

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, Optional
 
 from ray_release.aws import RELEASE_AWS_BUCKET
 from ray_release.buildkite.concurrency import get_concurrency_group
+from ray_release.test_plugin import Test
 from ray_release.test import (
-    Test,
     TestState,
     DEFAULT_PYTHON_VERSION,
 )

--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -9,7 +9,7 @@ import time
 
 from ray_release.config import RELEASE_PACKAGE_DIR
 from ray_release.logger import logger
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 
 DATAPLANE_S3_BUCKET = "ray-release-automation-results"
 DATAPLANE_FILENAME = "dataplane_20230622.tgz"

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -8,7 +8,7 @@ from ray_release.aws import (
 )
 from ray_release.anyscale_util import get_project_name
 from ray_release.config import DEFAULT_AUTOSUSPEND_MINS, DEFAULT_MAXIMUM_UPTIME_MINS
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.exception import CloudInfoError
 from ray_release.util import anyscale_cluster_url, dict_hash, get_anyscale_sdk
 from ray_release.logger import logger

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -6,10 +6,8 @@ from typing import Dict, List, Optional, Tuple, Any
 
 import jsonschema
 import yaml
-from ray_release.test import (
-    Test,
-    TestDefinition,
-)
+from ray_release.test_plugin import Test
+from ray_release.test import TestDefinition
 from ray_release.anyscale_util import find_cloud_by_name
 from ray_release.bazel import bazel_runfile
 from ray_release.exception import ReleaseTestCLIError, ReleaseTestConfigError

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -12,7 +12,7 @@ from ray_release.cluster_manager.minimal import MinimalClusterManager
 from ray_release.command_runner.job_runner import JobRunner
 from ray_release.command_runner.command_runner import CommandRunner
 from ray_release.command_runner.anyscale_job_runner import AnyscaleJobRunner
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.config import (
     DEFAULT_BUILD_TIMEOUT,
     DEFAULT_CLUSTER_TIMEOUT,

--- a/release/ray_release/reporter/artifacts.py
+++ b/release/ray_release/reporter/artifacts.py
@@ -2,7 +2,7 @@ import gzip
 import json
 import os
 
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.logger import logger
 from ray_release.reporter.reporter import Reporter
 from ray_release.result import Result

--- a/release/ray_release/reporter/db.py
+++ b/release/ray_release/reporter/db.py
@@ -5,7 +5,7 @@ from botocore.config import Config
 
 from ray_release.reporter.reporter import Reporter
 from ray_release.result import Result
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.logger import logger
 from ray_release.log_aggregator import LogAggregator
 

--- a/release/ray_release/reporter/log.py
+++ b/release/ray_release/reporter/log.py
@@ -1,4 +1,4 @@
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.logger import logger
 from ray_release.reporter.reporter import Reporter
 from ray_release.result import Result

--- a/release/ray_release/reporter/ray_test_db.py
+++ b/release/ray_release/reporter/ray_test_db.py
@@ -2,7 +2,7 @@ import json
 
 from ray_release.reporter.reporter import Reporter
 from ray_release.result import Result, ResultStatus
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.test_automation.state_machine import TestStateMachine
 from ray_release.logger import logger
 

--- a/release/ray_release/reporter/reporter.py
+++ b/release/ray_release/reporter/reporter.py
@@ -1,4 +1,4 @@
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.result import Result
 from ray_release.logger import logger
 

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -17,10 +17,8 @@ from ray_release.config import (
     parse_python_version,
     DEFAULT_WHEEL_WAIT_TIMEOUT,
 )
-from ray_release.test import (
-    Test,
-    DEFAULT_PYTHON_VERSION,
-)
+from ray_release.test_plugin import Test
+from ray_release.test import DEFAULT_PYTHON_VERSION
 from ray_release.test_automation.state_machine import TestStateMachine
 from ray_release.wheels import find_and_wait_for_ray_wheels_url
 

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -82,7 +82,7 @@ class TestResult:
         return self.status == ResultStatus.SUCCESS.value
 
 
-class Test(dict):
+class OSSTest(dict):
     """A class represents a test to run on buildkite"""
 
     KEY_GITHUB_ISSUE_NUMBER = "github_issue_number"

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -3,10 +3,8 @@ from datetime import datetime, timedelta
 from github import Github
 from pybuildkite.buildkite import Buildkite
 
-from ray_release.test import (
-    Test,
-    TestState,
-)
+from ray_release.test_plugin import Test
+from ray_release.test import TestState
 from ray_release.logger import logger
 from ray_release.aws import get_secret_token
 

--- a/release/ray_release/test_plugin.py
+++ b/release/ray_release/test_plugin.py
@@ -1,3 +1,3 @@
-from ray_release.test import Test
+from ray_release.test import OSSTest
 
-Test = Test
+Test = OSSTest

--- a/release/ray_release/test_plugin.py
+++ b/release/ray_release/test_plugin.py
@@ -1,0 +1,3 @@
+from ray_release.test import Test
+
+Test = Test

--- a/release/ray_release/tests/test_alerts.py
+++ b/release/ray_release/tests/test_alerts.py
@@ -9,7 +9,7 @@ from ray_release.alerts import (
     # tune_tests,
     # xgboost_tests,
 )
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.exception import ReleaseTestConfigError, ResultsAlert
 from ray_release.result import (
     Result,

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -28,7 +28,7 @@ from ray_release.buildkite.step import (
     RELEASE_QUEUE_CLIENT,
     DOCKER_PLUGIN_KEY,
 )
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.exception import ReleaseTestConfigError
 from ray_release.wheels import (
     DEFAULT_BRANCH,

--- a/release/ray_release/tests/test_byod_build.py
+++ b/release/ray_release/tests/test_byod_build.py
@@ -4,7 +4,7 @@ import pytest
 from unittest.mock import patch
 from typing import List
 
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.byod.build import build_anyscale_custom_byod_image
 
 

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -29,7 +29,7 @@ from ray_release.tests.utils import (
     MockSDK,
 )
 from ray_release.util import get_anyscale_sdk
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 
 TEST_CLUSTER_ENV = {
     "base_image": "anyscale/ray:nightly-py37",

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -3,7 +3,7 @@ import yaml
 import pytest
 
 from ray_release.bazel import bazel_runfile
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.config import (
     read_and_validate_release_test_collection,
     validate_cluster_compute,

--- a/release/ray_release/tests/test_glue.py
+++ b/release/ray_release/tests/test_glue.py
@@ -12,7 +12,7 @@ from ray_release.alerts.handle import result_to_handle_map
 from ray_release.cluster_manager.cluster_manager import ClusterManager
 from ray_release.cluster_manager.full import FullClusterManager
 from ray_release.command_runner.command_runner import CommandRunner
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.exception import (
     ReleaseTestConfigError,
     ClusterEnvBuildError,

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -3,8 +3,8 @@ from typing import List, Optional
 
 import pytest
 
+from ray_release.test_plugin import Test
 from ray_release.test import (
-    Test,
     TestResult,
     TestState,
 )

--- a/release/ray_release/tests/test_template.py
+++ b/release/ray_release/tests/test_template.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
 
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.exception import ReleaseTestConfigError
 from ray_release.template import populate_cluster_env_variables, render_yaml_template
 

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -5,8 +5,8 @@ from unittest import mock
 import pytest
 from unittest.mock import patch
 
+from ray_release.test_plugin import Test
 from ray_release.test import (
-    Test,
     _convert_env_list_to_dict,
     DATAPLANE_ECR,
     DATAPLANE_ECR_REPO,

--- a/release/ray_release/tests/test_wheels.py
+++ b/release/ray_release/tests/test_wheels.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from freezegun import freeze_time
 
 from ray_release.bazel import bazel_runfile
-from ray_release.test import Test
+from ray_release.test_plugin import Test
 from ray_release.template import load_test_cluster_env
 from ray_release.exception import RayWheelsNotFoundError, RayWheelsTimeoutError
 from ray_release.util import url_exists


### PR DESCRIPTION
## Why are these changes needed?
Support plugin of a another test class for release test infra. This will allow us to run release tests with different implementation of it class.

## Checks
- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   