### PR TITLE
[ci][release-test-infra] move test static constants to its class

### DIFF
--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -6,12 +6,11 @@ import pytest
 from unittest.mock import patch
 
 from ray_release.test_plugin import Test
-from ray_release.test import (
-    _convert_env_list_to_dict,
-    DATAPLANE_ECR,
-    DATAPLANE_ECR_REPO,
-    DATAPLANE_ECR_ML_REPO,
-)
+from ray_release.test import _convert_env_list_to_dict
+
+DATAPLANE_ECR = Test.DATAPLANE_ECR
+DATAPLANE_ECR_REPO = Test.DATAPLANE_ECR_REPO
+DATAPLANE_ECR_ML_REPO = Test.DATAPLANE_ECR_ML_REPO
 
 
 def _stub_test(val: dict) -> Test:


### PR DESCRIPTION
## Why are these changes needed?
Move some static constants to OSSTest class. This will allow us to override these values via subclasses

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   