### PR TITLE
[serve] Add Java support for power of two choices routing (`RAY_SERVE_ENABLE_NEW_ROUTING=1`)

### DIFF
--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -10,6 +10,12 @@
   commands:
     - ./java/test.sh
 
+- label: ":java: Java (RAY_SERVE_ENABLE_NEW_ROUTING=1)"
+  conditions: ["RAY_CI_JAVA_AFFECTED"]
+  instance_size: medium
+  commands:
+    - export RAY_SERVE_ENABLE_NEW_ROUTING=1 && ./java/test.sh
+
 - label: ":serverless: Dashboard Tests"
   conditions:
     [

--- a/java/serve/src/main/java/io/ray/serve/replica/RayServeReplica.java
+++ b/java/serve/src/main/java/io/ray/serve/replica/RayServeReplica.java
@@ -15,4 +15,8 @@ public interface RayServeReplica {
   default boolean prepareForShutdown() {
     return true;
   }
+
+  default int getNumOngoingRequests() {
+    return 0;
+  }
 }

--- a/java/serve/src/main/java/io/ray/serve/replica/RayServeReplicaImpl.java
+++ b/java/serve/src/main/java/io/ray/serve/replica/RayServeReplicaImpl.java
@@ -279,6 +279,11 @@ public class RayServeReplicaImpl implements RayServeReplica {
   }
 
   @Override
+  public int getNumOngoingRequests() {
+    return numOngoingRequests.get()
+  }
+
+  @Override
   public DeploymentVersion reconfigure(byte[] deploymentConfigBytes) {
     config = DeploymentConfig.fromProtoBytes(deploymentConfigBytes);
     Object userConfig = config.getUserConfig();

--- a/java/serve/src/main/java/io/ray/serve/replica/RayServeReplicaImpl.java
+++ b/java/serve/src/main/java/io/ray/serve/replica/RayServeReplicaImpl.java
@@ -280,7 +280,7 @@ public class RayServeReplicaImpl implements RayServeReplica {
 
   @Override
   public int getNumOngoingRequests() {
-    return numOngoingRequests.get()
+    return numOngoingRequests.get();
   }
 
   @Override

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -111,6 +111,9 @@ class ActorReplicaWrapper:
         return self.replica_info.replica_tag
 
     async def get_queue_state(self) -> Tuple[str, int, bool]:
+        # NOTE(edoakes): the `get_num_ongoing_requests` method name is shared by
+        # the Python and Java replica implementations. If you change it, you need to
+        # change both (or introduce a branch here).
         queue_len = await self.actor_handle.get_num_ongoing_requests.remote()
         accepted = queue_len < self.replica_info.max_concurrent_queries
         return self.replica_id, queue_len, accepted


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is required to turn the new routing on by default. Also adds a build to test this condition.

Only required adding the same method for fetching the queue length to the Java replica.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
