### PR TITLE
[serve] Ensure the dropping keep alive object is not logged to stdout

### DIFF
--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -366,7 +366,10 @@ class HTTPProxy:
         """
         self._ongoing_requests -= 1
         if self._ongoing_requests == 0:
-            logger.info("Dropping keep alive object reference to allow downscaling.")
+            logger.info(
+                "Dropping keep alive object reference to allow downscaling.",
+                extra={"log_to_stderr": False},
+            )
             self._prevent_node_downscale_ref = None
 
     async def __call__(self, scope, receive, send):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Right now the dropping keep alive message is logged to stdout. This PR changes to only log in the log files.

## Related issue number

NA

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
