### PR TITLE
[Serve] Make `max_batch_size` and `batch_wait_timeout_s` reconfigurable

### DIFF
--- a/doc/source/serve/advanced-guides/dyn-req-batch.md
+++ b/doc/source/serve/advanced-guides/dyn-req-batch.md
@@ -34,6 +34,19 @@ You can supply two optional parameters to the decorators.
 - `max_batch_size` controls the size of the batch.
 Once the first request arrives, the batching decorator will wait for a full batch (up to `max_batch_size`) until `batch_wait_timeout_s` is reached. If the timeout is reached, the batch will be sent to the model regardless the batch size.
 
+:::{tip}
+You can reconfigure your `batch_wait_timeout_s` and `max_batch_size` parameters using the `set_batch_wait_timeout_s` and `set_max_batch_size` methods:
+
+```{literalinclude} ../doc_code/batching_guide.py
+---
+start-after: __batch_params_update_begin__
+end-before: __batch_params_update_end__
+---
+```
+
+Use these methods in the `reconfigure` [method](serve-in-production-reconfigure) to control the `@serve.batch` parameters through your Serve configuration file.
+:::
+
 ## Streaming batched requests
 
 ```{warning}

--- a/doc/source/serve/doc_code/batching_guide.py
+++ b/doc/source/serve/doc_code/batching_guide.py
@@ -36,6 +36,24 @@ assert ray.get([handle.remote(i) for i in range(8)]) == [i * 2 for i in range(8)
 # __batch_end__
 
 
+# __batch_params_update_begin__
+@serve.deployment
+class Model:
+    @serve.batch(max_batch_size=8, batch_wait_timeout_s=0.1)
+    async def __call__(self, multiple_samples: List[int]) -> List[int]:
+        # Use numpy's vectorized computation to efficiently process a batch.
+        return np.array(multiple_samples) * 2
+
+    def adjust_batch_parameters(
+        self, new_max_batch_size: int, new_batch_wait_timeout_s: float
+    ):
+        self.__call__.set_max_batch_size(new_max_batch_size)
+        self.__call__.set_batch_wait_timeout_s(new_batch_wait_timeout_s)
+
+
+# __batch_params_update_end__
+
+
 # __single_stream_begin__
 import asyncio
 from typing import AsyncGenerator

--- a/doc/source/serve/production-guide/config.md
+++ b/doc/source/serve/production-guide/config.md
@@ -171,6 +171,7 @@ Serve will set `num_replicas=5`, using the config file value, and `max_concurren
 Remember that `ray_actor_options` counts as a single setting. The entire `ray_actor_options` dictionary in the config file overrides the entire `ray_actor_options` dictionary from the graph code. If there are individual options within `ray_actor_options` (e.g. `runtime_env`, `num_gpus`, `memory`) that are set in the code but not in the config, Serve still won't use the code settings if the config has a `ray_actor_options` dictionary. It will treat these missing options as though the user never set them and will use defaults instead. This dictionary overriding behavior also applies to `user_config`.
 :::
 
+(serve-in-production-reconfigure)
 ## Dynamically adjusting parameters in deployment
 
 The `user_config` field can be used to supply structured configuration for your deployment. You can pass arbitrary JSON serializable objects to the YAML configuration. Serve will then apply it to all running and future deployment replicas. The application of user configuration *will not* restart the replica. This means you can use this field to dynamically:

--- a/doc/source/serve/production-guide/config.md
+++ b/doc/source/serve/production-guide/config.md
@@ -171,7 +171,8 @@ Serve will set `num_replicas=5`, using the config file value, and `max_concurren
 Remember that `ray_actor_options` counts as a single setting. The entire `ray_actor_options` dictionary in the config file overrides the entire `ray_actor_options` dictionary from the graph code. If there are individual options within `ray_actor_options` (e.g. `runtime_env`, `num_gpus`, `memory`) that are set in the code but not in the config, Serve still won't use the code settings if the config has a `ray_actor_options` dictionary. It will treat these missing options as though the user never set them and will use defaults instead. This dictionary overriding behavior also applies to `user_config`.
 :::
 
-(serve-in-production-reconfigure)
+(serve-in-production-reconfigure)=
+
 ## Dynamically adjusting parameters in deployment
 
 The `user_config` field can be used to supply structured configuration for your deployment. You can pass arbitrary JSON serializable objects to the YAML configuration. Serve will then apply it to all running and future deployment replicas. The application of user configuration *will not* restart the replica. This means you can use this field to dynamically:

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -246,7 +246,7 @@ class _BatchQueue:
 class _LazyBatchQueueWrapper:
     """Stores a _BatchQueue and updates its settings.
 
-    _BatchQueue cannot be pickled, so it must be constructed lazily
+    _BatchQueue cannot be pickled, you must construct it lazily
     at runtime inside a replica. This class initializes a queue only upon
     first access.
     """

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -116,7 +116,7 @@ class _BatchQueue:
         batch = []
         batch.append(await self.queue.get())
 
-        # Cache current max_batch_size and batch_wait_timeout_s for this batch
+        # Cache current max_batch_size and batch_wait_timeout_s for this batch.
         max_batch_size = self.max_batch_size
         batch_wait_timeout_s = self.batch_wait_timeout_s
 

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -470,9 +470,6 @@ def batch(
             batch_queue.put(_SingleRequest(self, flattened_args, future))
             return future
 
-        # nonlocal max_batch_size, batch_wait_timeout_s
-        # batch_queue = batch_queue_cls(max_batch_size, batch_wait_timeout_s, _func)
-
         # TODO (shrekris-anyscale): deprecate batch_queue_cls argument and
         # convert batch_wrapper into a class once `self` argument is no
         # longer needed in `enqueue_request`.

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -94,8 +94,7 @@ class _BatchQueue:
 
         self._handle_batch_task = None
         if handle_batch_func is not None:
-            self.background_event_loop = get_or_create_event_loop()
-            self._handle_batch_task = self.background_event_loop.create_task(
+            self._handle_batch_task = get_or_create_event_loop().create_task(
                 self._process_batches(handle_batch_func)
             )
 
@@ -230,31 +229,6 @@ class _BatchQueue:
                 except Exception as e:
                     for future in futures:
                         future.set_exception(e)
-
-    async def update_params(
-        self, max_batch_size: int, batch_wait_timeout_s: float
-    ) -> None:
-        """Update all parameters for this queue in a single async call."""
-        self.max_batch_size = max_batch_size
-        self.batch_wait_timeout_s = batch_wait_timeout_s
-
-    def safely_update_params(
-        self, max_batch_size: int, batch_wait_timeout_s: float
-    ) -> None:
-        """Safely update all parameters for this queue.
-        
-        Request runs in the same event loop as the batch-creation task. Calling
-        this method ensures that the batch-creation task only ever uses a
-        consistent set of parameters. It won't mix parameters from different
-        settings.
-        """
-        asyncio.wait_for(
-            self.background_event_loop.create_task(
-                self.update_params(
-                    self.update_params(max_batch_size, batch_wait_timeout_s)
-                )
-            )
-        )
 
     def __del__(self):
         if (

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -296,7 +296,7 @@ class _LazyBatchQueueWrapper:
         return self.max_batch_size
 
     def get_batch_wait_timeout_s(self) -> float:
-        return self.get_batch_wait_timeout_s
+        return self.batch_wait_timeout_s
 
 
 def _validate_max_batch_size(max_batch_size):

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -488,8 +488,8 @@ def batch(
         else:
             wrapper = batch_wrapper
 
-        # We make the batch queue wrapper's getters and setters batch_wrapper
-        # attributes, so they can be accessed in user code.
+        # We store the lazy_batch_queue_wrapper's getters and setters as
+        # batch_wrapper attributes, so they can be accessed in user code.
         wrapper._get_max_batch_size = lazy_batch_queue_wrapper.get_max_batch_size
         wrapper._get_batch_wait_timeout_s = (
             lazy_batch_queue_wrapper.get_batch_wait_timeout_s

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -365,6 +365,10 @@ def batch(
     and executed asynchronously once there is a batch of `max_batch_size`
     or `batch_wait_timeout_s` has elapsed, whichever occurs first.
 
+    `max_batch_size` and `batch_wait_timeout_s` can be updated using setter
+    methods from the batch_handler (`set_max_batch_size` and
+    `set_batch_wait_timeout_s`).
+
     Example:
 
     .. code-block:: python
@@ -382,6 +386,10 @@ def batch(
                         response_batch.append(f"Hello {name}!")
 
                     return response_batch
+
+                def update_batch_params(self, max_batch_size, batch_wait_timeout_s):
+                    self.batch_handler.set_max_batch_size(max_batch_size)
+                    self.batch_handler.set_batch_wait_timeout_s(batch_wait_timeout_s)
 
                 async def __call__(self, request: Request):
                     return await self.batch_handler(request)

--- a/python/ray/serve/tests/test_batching.py
+++ b/python/ray/serve/tests/test_batching.py
@@ -387,8 +387,8 @@ async def test_batch_setters(use_class):
         async def func(key1, key2):
             return [(key1[i], key2[i]) for i in range(len(key1))]
 
-    assert func._queue.max_batch_size == 2
-    assert func._queue.batch_wait_timeout_s == 1000
+    assert func._get_max_batch_size() == 2
+    assert func._get_batch_wait_timeout_s() == 1000
 
     # @serve.batch should create batches of size 2
     coros = [func("hi1", "hi2"), func("hi3", "hi4")]
@@ -401,8 +401,8 @@ async def test_batch_setters(use_class):
     func.set_max_batch_size(3)
     func.set_batch_wait_timeout_s(15000)
 
-    assert func._queue.max_batch_size == 3
-    assert func._queue.batch_wait_timeout_s == 15000
+    assert func._get_max_batch_size() == 3
+    assert func._get_batch_wait_timeout_s() == 15000
 
     # @serve.batch should create batches of size 3
     coros = [func("hi1", "hi2"), func("hi3", "hi4"), func("hi5", "hi6")]
@@ -426,15 +426,15 @@ async def test_batch_use_earliest_setters():
     async def func(key1, key2):
         return [(key1[i], key2[i]) for i in range(len(key1))]
 
-    assert func._queue.max_batch_size == 2
-    assert func._queue.batch_wait_timeout_s == 1000
+    assert func._get_max_batch_size() == 2
+    assert func._get_batch_wait_timeout_s() == 1000
 
     # Set new values
     func.set_max_batch_size(3)
     func.set_batch_wait_timeout_s(15000)
 
-    assert func._queue.max_batch_size == 3
-    assert func._queue.batch_wait_timeout_s == 15000
+    assert func._get_max_batch_size() == 3
+    assert func._get_batch_wait_timeout_s() == 15000
 
     # Should create batches of size 3, even if setters are called while
     # batch is accumulated
@@ -447,8 +447,8 @@ async def test_batch_use_earliest_setters():
     func.set_max_batch_size(1)
     func.set_batch_wait_timeout_s(0)
 
-    assert func._queue.max_batch_size == 1
-    assert func._queue.batch_wait_timeout_s == 0
+    assert func._get_max_batch_size() == 1
+    assert func._get_batch_wait_timeout_s() == 0
 
     # Batch should still be waiting for last request
     done, pending = await asyncio.wait(coros, timeout=0.1)
@@ -585,8 +585,8 @@ async def test_batch_generator_setters():
         for _ in range(3):
             yield [(key1[i], key2[i]) for i in range(len(key1))]
 
-    assert yield_three_times._queue.max_batch_size == 2
-    assert yield_three_times._queue.batch_wait_timeout_s == 1000
+    assert yield_three_times._get_max_batch_size() == 2
+    assert yield_three_times._get_batch_wait_timeout_s() == 1000
 
     args_list = [("hi1", "hi2"), ("hi3", "hi4")]
     coros = [yield_three_times(*args) for args in args_list]
@@ -600,8 +600,8 @@ async def test_batch_generator_setters():
     yield_three_times.set_max_batch_size(3)
     yield_three_times.set_batch_wait_timeout_s(15000)
 
-    assert yield_three_times._queue.max_batch_size == 3
-    assert yield_three_times._queue.batch_wait_timeout_s == 15000
+    assert yield_three_times._get_max_batch_size() == 3
+    assert yield_three_times._get_batch_wait_timeout_s() == 15000
 
     # Execute three more requests
     args_list_2 = [("hi1", "hi2"), ("hi3", "hi4"), ("hi5", "hi6")]

--- a/python/ray/serve/tests/test_batching.py
+++ b/python/ray/serve/tests/test_batching.py
@@ -390,8 +390,11 @@ async def test_batch_setters(use_class):
     assert func.max_batch_size == 2
     assert func.batch_wait_timeout_s == 1000
 
+    # @serve.batch should create batches of size 2
     coros = [func("hi1", "hi2"), func("hi3", "hi4")]
-    result = await asyncio.gather(*coros)
+    done, pending = await asyncio.wait(*coros, timeout=0.1)
+    assert len(pending) == 0
+    result = asyncio.gather(*done)
     assert result == [("hi1", "hi2"), ("hi3", "hi4")]
 
     # Set new values
@@ -401,9 +404,65 @@ async def test_batch_setters(use_class):
     assert func.max_batch_size == 3
     assert func.batch_wait_timeout_s == 15000
 
+    # @serve.batch should create batches of size 3
     coros = [func("hi1", "hi2"), func("hi3", "hi4"), func("hi5", "hi6")]
-    result = await asyncio.gather(*coros)
+    done, pending = await asyncio.wait(*coros, timeout=0.1)
+    assert len(pending) == 0
+    result = asyncio.gather(*done)
     assert result == [("hi1", "hi2"), ("hi3", "hi4"), ("hi5", "hi6")]
+
+
+@pytest.mark.asyncio
+async def test_batch_use_earliest_setters():
+    """@serve.batch should use the right settings when constructing a batch.
+
+    When the @serve.batch setters get called before a batch has started
+    accumulating, the next batch should use the setters' values. When they
+    get called while a batch is accumulating, the previous values should be
+    used.
+    """
+
+    @serve.batch(max_batch_size=2, batch_wait_timeout_s=1000)
+    async def func(key1, key2):
+        return [(key1[i], key2[i]) for i in range(len(key1))]
+
+    assert func.max_batch_size == 2
+    assert func.batch_wait_timeout_s == 1000
+
+    # Set new values
+    func.set_max_batch_size(3)
+    func.set_batch_wait_timeout_s(15000)
+
+    assert func.max_batch_size == 3
+    assert func.batch_wait_timeout_s == 15000
+
+    # Should create batches of size 3, even if setters are called while
+    # batch is accumulated
+    coros = [func("hi1", "hi2"), func("hi3", "hi4")]
+
+    func.set_max_batch_size(1)
+    func.set_batch_wait_timeout_s(0)
+
+    assert func.max_batch_size == 1
+    assert func.batch_wait_timeout_s == 0
+
+    # Batch should still be waiting for last request
+    done, pending = await asyncio.wait(*coros, timeout=0.1)
+    assert len(done) == 0 and len(pending) == 2
+
+    # Batch should execute after last request
+    coros.append(func("hi5", "hi6"))
+    done, pending = await asyncio.wait(*coros, timeout=0.1)
+    assert len(pending) == 0
+    result = asyncio.gather(*done)
+    assert result == [("hi1", "hi2"), ("hi3", "hi4"), ("hi5", "hi6")]
+
+    # Next batch should use updated values
+    coros = [func("hi1", "hi2")]
+    done, pending = await asyncio.wait(*coros, timeout=0.1)
+    assert len(pending) == 0
+    result = asyncio.gather(*done)
+    assert result == [("hi1", "hi2")]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `@serve.batch` decorator has two parameters: `max_batch_size` and `batch_wait_timeout_s`. These parameters can be set in the decorator. However, they cannot be reconfigured after the Serve application starts.

This change adds two setter methods: `set_max_batch_size` and `set_batch_wait_timeout_s`. Users can reconfigure their `@serve.batch` parameters using these methods:

```python
@serve.batch(max_batch_size=1, batch_wait_timeout_s=0.1)
def batch_handler(self, request_list):
    ...

self.batch_handler.set_max_batch_size(5)
self.batch_handler.set_batch_wait_timeout_s(0.5)
```

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #36844

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds unit tests to `test_batching.py`.
