### PR TITLE
Fix stress_test_state_api_scale

### DIFF
--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -63,11 +63,15 @@ class ClusterManager(abc.ABC):
         ] = f"test_name={self.test.get_name()};smoke_test={self.smoke_test}"
 
         if self.test.is_byod_cluster():
-            self.cluster_env_name = (
+            byod_image_name_normalized = (
                 self.test.get_anyscale_byod_image()
                 .replace("/", "_")
                 .replace(":", "_")
                 .replace(".", "_")
+            )
+            self.cluster_env_name = (
+                f"{byod_image_name_normalized}"
+                f"__env__{dict_hash(self.test.get_byod_runtime_env())}"
             )
         else:
             self.cluster_env_name = (

--- a/release/ray_release/cluster_manager/minimal.py
+++ b/release/ray_release/cluster_manager/minimal.py
@@ -66,7 +66,7 @@ class MinimalClusterManager(ClusterManager):
                             config_json=dict(
                                 docker_image=self.test.get_anyscale_byod_image(),
                                 ray_version="nightly",
-                                env_vars={},
+                                env_vars=self.test.get_byod_runtime_env(),
                             ),
                         )
                     )


### PR DESCRIPTION
Fix stress_test_state_api_scale. The test is currently failing on BYOD because it needs some env vars that be set before `ray start`, and runtime_env happens after `ray start`. Need to build the env vars into a part of the docker image for this to work.

Fix #36445

Test
- [Release test](https://buildkite.com/ray-project/release-tests-pr/builds/43740)