### PR TITLE
[Autoscaler] Frequent update to Raycluster headpod's annotation "ray.io/autoscaler-update-timestamp" causing reconciliation by argocd

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -343,8 +343,8 @@ class KuberayNodeProvider(BatchingNodeProvider):  # type: ignore
         return True
 
     def _get_pods_resource_version(self) -> str:
-        """Extract a recent pods resource version by patching the head pod's annotations
-        and reading the metadata.resourceVersion of the response.
+        """
+        Extract a recent pods resource version by reading the head pod's metadata.resourceVersion of the response.
         """
         if not RAY_HEAD_POD_NAME:
             return None

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -348,16 +348,7 @@ class KuberayNodeProvider(BatchingNodeProvider):  # type: ignore
         """
         if not RAY_HEAD_POD_NAME:
             return None
-        # Patch the head pod.
-        resource_path = f"pods/{RAY_HEAD_POD_NAME}"
-        # Patch the annotation "ray.io/autoscaler-update-timestamp"
-        patch_path = "/metadata/annotations/ray.io~1autoscaler-update-timestamp"
-        # Mimic the timestamp format used by K8s.
-        value = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        payload = [replace_patch(patch_path, value)]
-        pod_resp = self._patch(resource_path, payload)
-        # The response carries the pod resource version at which the patch
-        # was accepted.
+        pod_resp = self._get(f"pods/{RAY_HEAD_POD_NAME}")
         return pod_resp["metadata"]["resourceVersion"]
 
     def _scale_request_to_patch_payload(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Frequent updates to the head Pod may lead to performance degradation of the Kubernetes API Server. The annotation `ray.io/autoscaler-update-timestamp` appears to be solely for user observability purposes and is not utilized in either Ray or KubeRay. That's why I decide to use `GET` instead of `PATCH`.

## Related issue number
https://github.com/ray-project/kuberay/issues/1182

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
