### PR TITLE
[CI] [Minimal install] Check python version in minimal install

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -787,7 +787,7 @@ test_minimal() {
   ./ci/env/install-minimal.sh "$1"
   echo "Installed minimal dependencies."
   ./ci/env/env_info.sh
-  python ./ci/env/check_minimal_install.py
+  python ./ci/env/check_minimal_install.py "$1"
   run_minimal_test "$1"
 }
 

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -743,9 +743,12 @@ build() {
 }
 
 run_minimal_test() {
+  EXPECTED_PYTHON_VERSION=$1
   BAZEL_EXPORT_OPTIONS="$(./ci/run/bazel_export_options)"
   # Ignoring shellcheck is necessary because if ${BAZEL_EXPORT_OPTIONS} is wrapped by the double quotation,
   # bazel test cannot recognize the option.
+  # shellcheck disable=SC2086
+  bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 --test_env=EXPECTED_PYTHON_VERSION=$EXPECTED_PYTHON_VERSION ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_minimal_install
   # shellcheck disable=SC2086
   bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_basic
   # shellcheck disable=SC2086

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -790,7 +790,7 @@ test_minimal() {
   ./ci/env/install-minimal.sh "$1"
   echo "Installed minimal dependencies."
   ./ci/env/env_info.sh
-  python ./ci/env/check_minimal_install.py "$1"
+  python ./ci/env/check_minimal_install.py --expected-python-version "$1"
   run_minimal_test "$1"
 }
 

--- a/ci/env/check_minimal_install.py
+++ b/ci/env/check_minimal_install.py
@@ -67,10 +67,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--expected-python-version",
         type=str,
-        required=True,
         help="Expected Python version in MAJOR.MINOR format, e.g. 3.11",
+        default=None,
     )
     args = parser.parse_args()
 
     assert_packages_not_installed(DEFAULT_BLACKLIST)
-    assert_python_version(args.expected_python_version)
+
+    if args.expected_python_version is not None:
+        assert_python_version(args.expected_python_version)

--- a/ci/env/check_minimal_install.py
+++ b/ci/env/check_minimal_install.py
@@ -55,9 +55,10 @@ def assert_python_version(expected_python_version: str) -> None:
     actual_major, actual_minor = sys.version_info[:2]
     actual_version = f"{actual_major}.{actual_minor}"
     expected_version = expected_python_version.strip()
-    assert (
-        expected_version == actual_version
-    ), f"Expected Python version {expected_version=}, {actual_version=}"
+    assert expected_version == actual_version, (
+        f"Expected Python version expected_version={expected_version}, "
+        f"actual_version={actual_version}"
+    )
 
 
 if __name__ == "__main__":

--- a/ci/env/check_minimal_install.py
+++ b/ci/env/check_minimal_install.py
@@ -50,17 +50,25 @@ def assert_packages_not_installed(blacklist: List[str]):
         f"current Python environment: {blacklist}"
     )
 
+
 def assert_python_version(expected_python_version: str) -> None:
     actual_major, actual_minor = sys.version_info[:2]
-    actual_version = f'{actual_major}.{actual_minor}'
+    actual_version = f"{actual_major}.{actual_minor}"
     expected_version = expected_python_version.strip()
-    assert expected_version == actual_version, f"Expected Python version {expected_version=}, {actual_version=}"
+    assert (
+        expected_version == actual_version
+    ), f"Expected Python version {expected_version=}, {actual_version=}"
 
 
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--expected-python-version", type=str, required=True, help="Expected Python version in MAJOR.MINOR format, e.g. 3.11")
+    parser.add_argument(
+        "--expected-python-version",
+        type=str,
+        required=True,
+        help="Expected Python version in MAJOR.MINOR format, e.g. 3.11",
+    )
     args = parser.parse_args()
 
     assert_packages_not_installed(DEFAULT_BLACKLIST)

--- a/ci/env/check_minimal_install.py
+++ b/ci/env/check_minimal_install.py
@@ -4,9 +4,13 @@ current python environment.
 
 This is to ensure that tests with minimal dependencies are not tainted
 by too many installed packages.
+
+It also ensures the correct Python version.
 """
 
 from typing import List
+import argparse
+import sys
 
 # These are taken from `setup.py` for ray[default]
 DEFAULT_BLACKLIST = [
@@ -46,6 +50,18 @@ def assert_packages_not_installed(blacklist: List[str]):
         f"current Python environment: {blacklist}"
     )
 
+def assert_python_version(expected_python_version: str) -> None:
+    actual_major, actual_minor = sys.version_info[:2]
+    actual_version = f'{actual_major}.{actual_minor}'
+    expected_version = expected_python_version.strip()
+    assert expected_version == actual_version, f"Expected Python version {expected_version=}, {actual_version=}"
+
 
 if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected-python-version", type=str, required=True, help="Expected Python version in MAJOR.MINOR format, e.g. 3.11")
+    args = parser.parse_args()
+
     assert_packages_not_installed(DEFAULT_BLACKLIST)
+    assert_python_version(args.expected_python_version)

--- a/ci/env/install-minimal.sh
+++ b/ci/env/install-minimal.sh
@@ -3,6 +3,8 @@
 if [ "$1" == "3.11" ]; then
     # TODO: fix build wheels unsupported tags in the future
     echo "'set -xe' not working for Python 3.11"
+    echo "[cade] setting -xe anyways"
+    set -xe
 else
     set -xe
 fi
@@ -32,7 +34,7 @@ echo "Python version is ${PYTHON_VERSION}"
 ROOT_DIR=$(cd "$(dirname "$0")/$(dirname "$(test -L "$0" && readlink "$0" || echo "/")")" || exit; pwd)
 WORKSPACE_DIR="${ROOT_DIR}/../.."
 
-# Installs conda and python 3.7
+# Installs conda and the specified python version
 MINIMAL_INSTALL=1 PYTHON=${PYTHON_VERSION} "${WORKSPACE_DIR}/ci/env/install-dependencies.sh"
 
 # Re-install Ray wheels

--- a/ci/env/install-minimal.sh
+++ b/ci/env/install-minimal.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 
-if [ "$1" == "3.11" ]; then
-    # TODO: fix build wheels unsupported tags in the future
-    echo "'set -xe' not working for Python 3.11"
-    echo "[cade] setting -xe anyways"
-    set -xe
-else
-    set -xe
-fi
+set -xe
 
 # Python version can be specified as 3.7, 3.8, 3.9, etc..
 if [ -z "$1" ]; then

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -199,6 +199,7 @@ py_test_module_list(
     "test_metrics_agent_2.py",
     "test_microbenchmarks.py",
     "test_mini.py",
+    "test_minimal_install.py",
     "test_numba.py",
     "test_redis_tls.py",
     "test_raylet_output.py",

--- a/python/ray/tests/test_minimal_install.py
+++ b/python/ray/tests/test_minimal_install.py
@@ -19,13 +19,14 @@ def test_correct_python_version():
     expected_python_version = os.environ.get("EXPECTED_PYTHON_VERSION", "").strip()
     assert (
         expected_python_version
-    ), f"EXPECTED_PYTHON_VERSION is {expected_python_version=}"
+    ), f"EXPECTED_PYTHON_VERSION is {expected_python_version}"
 
     actual_major, actual_minor = sys.version_info[:2]
     actual_version = f"{actual_major}.{actual_minor}"
-    assert (
-        actual_version == expected_python_version
-    ), f"{expected_python_version=} {actual_version=}"
+    assert actual_version == expected_python_version, (
+        f"expected_python_version={expected_python_version}"
+        f"actual_version={actual_version}"
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_minimal_install.py
+++ b/python/ray/tests/test_minimal_install.py
@@ -7,17 +7,26 @@ import pytest
 import os
 import sys
 
-@pytest.mark.skipif(os.environ.get("RAY_MINIMAL", "0") != "1", reason="Skip unless running in a minimal install.")
+
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL", "0") != "1",
+    reason="Skip unless running in a minimal install.",
+)
 def test_correct_python_version():
     """
     Validate that Bazel uses the correct Python version in our minimal tests.
     """
-    expected_python_version = os.environ.get("EXPECTED_PYTHON_VERSION", '').strip()
-    assert expected_python_version, f"EXPECTED_PYTHON_VERSION is {expected_python_version=}"
+    expected_python_version = os.environ.get("EXPECTED_PYTHON_VERSION", "").strip()
+    assert (
+        expected_python_version
+    ), f"EXPECTED_PYTHON_VERSION is {expected_python_version=}"
 
     actual_major, actual_minor = sys.version_info[:2]
     actual_version = f"{actual_major}.{actual_minor}"
-    assert actual_version == expected_python_version, f"{expected_python_version=} {actual_version=}"
+    assert (
+        actual_version == expected_python_version
+    ), f"{expected_python_version=} {actual_version=}"
+
 
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_minimal_install.py
+++ b/python/ray/tests/test_minimal_install.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+"""
+Tests that are specific to minimal installations.
+"""
+
+import pytest
+import os
+import sys
+
+@pytest.mark.skipif(os.environ.get("RAY_MINIMAL", "0") != "1", reason="Skip unless running in a minimal install.")
+def test_correct_python_version():
+    """
+    Validate that Bazel uses the correct Python version in our minimal tests.
+    """
+    expected_python_version = os.environ.get("EXPECTED_PYTHON_VERSION", '').strip()
+    assert expected_python_version, f"EXPECTED_PYTHON_VERSION is {expected_python_version=}"
+
+    actual_major, actual_minor = sys.version_info[:2]
+    actual_version = f"{actual_major}.{actual_minor}"
+    assert actual_version == expected_python_version, f"{expected_python_version=} {actual_version=}"
+
+if __name__ == "__main__":
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
This PR improves our CI by asserting the expected Python version in our minimal install tests. We use these tests to validate basic Ray functionality for each Python version we support (3.7-3.11). In the past, we saw an issue where the 3.11 tests actually used a different Python version because the conda env we consumed hadn't yet been built for 3.11. Now, the tests will fail if the actual Python version differs from the expected one.

See also https://github.com/ray-project/ray/issues/33401