### PR TITLE
[Data] Fix progress bar initial value

### DIFF
--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -46,7 +46,7 @@ class ProgressBar:
         self, name: str, total: int, position: int = 0, enabled: Optional[bool] = None
     ):
         self._desc = name
-        self._position = position
+        self._progress = 0
         if enabled is None:
             from ray.data import DataContext
 
@@ -107,17 +107,17 @@ class ProgressBar:
 
     def update(self, i: int) -> None:
         if self._bar and i != 0:
-            self._position += i
-            if self._bar.total is not None and self._position > self._bar.total:
+            self._progress += i
+            if self._bar.total is not None and self._progress > self._bar.total:
                 # If the progress goes over 100%, update the total.
-                self._bar.total = self._position
+                self._bar.total = self._progress
             self._bar.update(i)
 
     def close(self):
         if self._bar:
-            if self._bar.total is not None and self._position != self._bar.total:
+            if self._bar.total is not None and self._progress != self._bar.total:
                 # If the progress is not complete, update the total.
-                self._bar.total = self._position
+                self._bar.total = self._progress
                 self._bar.refresh()
             self._bar.close()
             self._bar = None

--- a/python/ray/data/tests/test_progress_bar.py
+++ b/python/ray/data/tests/test_progress_bar.py
@@ -40,7 +40,7 @@ def test_progress_bar(enable_tqdm_ray):
         pb.update(1)
     pb.close()
 
-    assert pb._position == total
+    assert pb._progress == total
     assert total_at_close == total
 
     # Test if update() exceeds the original total, the total will be updated.
@@ -52,7 +52,7 @@ def test_progress_bar(enable_tqdm_ray):
         pb.update(1)
     pb.close()
 
-    assert pb._position == new_total
+    assert pb._progress == new_total
     assert total_at_close == new_total
 
     # Test that if the bar is not complete at close(), the total will be updated.
@@ -64,5 +64,5 @@ def test_progress_bar(enable_tqdm_ray):
         pb.update(1)
     pb.close()
 
-    assert pb._position == new_total
+    assert pb._progress == new_total
     assert total_at_close == new_total


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is a bug introduced by https://github.com/ray-project/ray/pull/36679.
I thought `position` was the bar position (initial progress). But it is actually the line position to print the bar. Rename the variable to "progress", and default initial value to 0.

## Related issue number
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
