### PR TITLE
[Data] Simplify Preprocessor fitted status

### DIFF
--- a/doc/source/data/examples/pytorch_resnet_batch_prediction.ipynb
+++ b/doc/source/data/examples/pytorch_resnet_batch_prediction.ipynb
@@ -641,7 +641,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.8"
   },
   "vscode": {
    "interpreter": {

--- a/doc/source/data/examples/pytorch_resnet_batch_prediction.ipynb
+++ b/doc/source/data/examples/pytorch_resnet_batch_prediction.ipynb
@@ -641,7 +641,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.8.13"
   },
   "vscode": {
    "interpreter": {

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -64,7 +64,7 @@ class Preprocessor(abc.ABC):
     def fit_status(self) -> "Preprocessor.FitStatus":
         if not self._is_fittable:
             return Preprocessor.FitStatus.NOT_FITTABLE
-        elif self._check_is_fitted():
+        elif hasattr(self, "_fitted") and self._fitted:
             return Preprocessor.FitStatus.FITTED
         else:
             return Preprocessor.FitStatus.NOT_FITTED
@@ -112,7 +112,9 @@ class Preprocessor(abc.ABC):
                 "All previously fitted state will be overwritten!"
             )
 
-        return self._fit(ds)
+        fitted_ds = self._fit(ds)
+        self._fitted = True
+        return fitted_ds
 
     def fit_transform(self, ds: "Dataset") -> "Dataset":
         """Fit this Preprocessor to the Dataset and then transform the Dataset.
@@ -203,15 +205,6 @@ class Preprocessor(abc.ABC):
             )
 
         return self._transform(pipeline)
-
-    def _check_is_fitted(self) -> bool:
-        """Returns whether this preprocessor is fitted.
-
-        We use the convention that attributes with a trailing ``_`` are set after
-        fitting is complete.
-        """
-        fitted_vars = [v for v in vars(self) if v.endswith("_")]
-        return bool(fitted_vars)
 
     @DeveloperAPI
     def _fit(self, ds: "Dataset") -> "Preprocessor":

--- a/python/ray/data/tests/preprocessors/test_preprocessors.py
+++ b/python/ray/data/tests/preprocessors/test_preprocessors.py
@@ -114,6 +114,19 @@ def test_repr(preprocessor):
     assert pattern.match(representation)
 
 
+def test_fitted_preprocessor_without_stats():
+    """Tests that Preprocessors can be fitted without needing to set self.stats_."""
+
+    class FittablePreprocessor(Preprocessor):
+        def _fit(self, ds):
+            return ds
+
+    preprocessor = FittablePreprocessor()
+    ds = ray.data.from_items([1])
+    _ = preprocessor.fit(ds)
+    assert preprocessor.fit_status() == Preprocessor.FitStatus.FITTED
+
+
 @patch.object(warnings, "warn")
 def test_fit_twice(mocked_warn):
     """Tests that a warning msg should be printed."""

--- a/python/ray/train/tests/test_lightgbm_trainer.py
+++ b/python/ray/train/tests/test_lightgbm_trainer.py
@@ -161,7 +161,7 @@ def test_preprocessor_in_checkpoint(ray_start_6_cpus, tmpdir):
             super().__init__()
             self.is_same = True
 
-        def fit(self, dataset):
+        def _fit(self, dataset):
             self.fitted_ = True
 
         def _transform_pandas(self, df: "pd.DataFrame") -> "pd.DataFrame":

--- a/python/ray/train/tests/test_sklearn_trainer.py
+++ b/python/ray/train/tests/test_sklearn_trainer.py
@@ -106,7 +106,7 @@ def test_preprocessor_in_checkpoint(ray_start_4_cpus, tmpdir):
             super().__init__()
             self.is_same = True
 
-        def fit(self, dataset):
+        def _fit(self, dataset):
             self.fitted_ = True
 
         def _transform_pandas(self, df: "pd.DataFrame") -> "pd.DataFrame":

--- a/python/ray/train/tests/test_sklearn_trainer.py
+++ b/python/ray/train/tests/test_sklearn_trainer.py
@@ -76,7 +76,7 @@ def test_no_auto_cpu_params(ray_start_4_cpus, tmpdir):
             super().__init__()
             self.is_same = True
 
-        def fit(self, dataset):
+        def _fit(self, dataset):
             self.fitted_ = True
 
         def _transform_pandas(self, df: "pd.DataFrame") -> "pd.DataFrame":

--- a/python/ray/train/tests/test_xgboost_trainer.py
+++ b/python/ray/train/tests/test_xgboost_trainer.py
@@ -176,7 +176,7 @@ def test_preprocessor_in_checkpoint(ray_start_4_cpus, tmpdir):
             super().__init__()
             self.is_same = True
 
-        def fit(self, dataset):
+        def _fit(self, dataset):
             self.fitted_ = True
 
         def _transform_pandas(self, df: "pd.DataFrame") -> "pd.DataFrame":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Previously, Preprocessors are only considered fitted if they have defined instance attributes that end with `_`. This behavior is not intuitive for users who are defining their own preprocessors.

Instead, we change the logic to consider preprocessors to be fitted if `fit` has been called.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
