### PR TITLE
[Core] Print out an info message when a runtime env uri is reused

### DIFF
--- a/python/ray/_private/runtime_env/plugin.py
+++ b/python/ray/_private/runtime_env/plugin.py
@@ -254,7 +254,11 @@ async def create_for_plugin_if_needed(
             size_bytes = await plugin.create(uri, runtime_env, context, logger=logger)
             uri_cache.add(uri, size_bytes, logger=logger)
         else:
-            logger.debug(f"Cache hit for URI {uri}.")
+            logger.info(
+                f"Runtime env {plugin.name} {uri} is already installed "
+                "and will be reused. Search "
+                "all runtime_env_setup-*.log to find the corresponding setup log."
+            )
             uri_cache.mark_used(uri, logger=logger)
 
     plugin.modify_context(uris, runtime_env, context, logger)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Runtime env can be reused across jobs. That means only the first job that creates the runtime env will have the setup log. runtime_env_setup-*.log of future jobs that use the same runtime env will be empty and confuses people. This PR adds a short term fix where we print out a message saying the runtime env is already installed and reused.

Now instead of being empty, the setup log will contain something like 
```
023-06-28 11:43:15,369 INFO plugin.py:257 -- Runtime env working_dir gcs://_ray_pkg_c11d7218d9cb0a21.zip is already installed and will be reused. Search all runtime_env_setup-*.log to find the corresponding setup log.
2023-06-28 11:43:15,369 INFO plugin.py:257 -- Runtime env pip pip://97a1f04ee5a942cff1f5e9b453e5ddebffbf4ff2 is already installed and will be reused. Search all runtime_env_setup-*.log to find the corresponding setup log.
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#36518 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
