### PR TITLE
[core] Fix the GCS crash when connecting to a redis cluster with TLS

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -125,7 +125,6 @@ def get_redis_cli(port, enable_tls):
 def start_redis_instance(
     session_dir_path: str,
     port: int,
-    free_port: int,
     redis_max_clients: Optional[int] = None,
     num_retries: int = 20,
     stdout_file: Optional[str] = None,
@@ -139,6 +138,7 @@ def start_redis_instance(
     replica_of=None,
     leader_id=None,
     db_dir=None,
+    free_port=0,
 ):
     """Start a single Redis server.
 

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -98,9 +98,34 @@ def redis_replicas():
     return int(os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS", "1"))
 
 
+def get_redis_cli(port, enable_tls):
+    try:
+        # If there is no redis libs installed, skip the check.
+        # This could happen In minimal test, where we don't have
+        # redis.
+        import redis
+    except Exception:
+        return True
+
+    params = {}
+    if enable_tls:
+        from ray._raylet import Config
+
+        params = {"ssl": True, "ssl_cert_reqs": "required"}
+        if Config.REDIS_CA_CERT():
+            params["ssl_ca_certs"] = Config.REDIS_CA_CERT()
+        if Config.REDIS_CLIENT_CERT():
+            params["ssl_certfile"] = Config.REDIS_CLIENT_CERT()
+        if Config.REDIS_CLIENT_KEY():
+            params["ssl_keyfile"] = Config.REDIS_CLIENT_KEY()
+
+    return redis.Redis("localhost", str(port), **params)
+
+
 def start_redis_instance(
     session_dir_path: str,
     port: int,
+    free_port: int,
     redis_max_clients: Optional[int] = None,
     num_retries: int = 20,
     stdout_file: Optional[str] = None,
@@ -166,11 +191,6 @@ def start_redis_instance(
     if redis_replicas() > 1:
         command += ["--cluster-enabled", "yes", "--cluster-config-file", f"node-{port}"]
     if enable_tls:
-        import socket
-
-        with socket.socket() as s:
-            s.bind(("", 0))
-            free_port = s.getsockname()[1]
         command += [
             "--tls-port",
             str(port),
@@ -193,7 +213,9 @@ def start_redis_instance(
             command += ["--tls-cert-file", Config.REDIS_CLIENT_CERT()]
         if Config.REDIS_CLIENT_KEY():
             command += ["--tls-key-file", Config.REDIS_CLIENT_KEY()]
-        command += ["--tls-replication", "yes"]
+        if replica_of is not None:
+            command += ["--tls-replication", "yes"]
+        command += ["--tls-auth-clients", "no", "--tls-cluster", "yes"]
     if sys.platform != "win32":
         command += ["--save", "", "--appendonly", "no"]
     if db_dir is not None:
@@ -212,13 +234,13 @@ def start_redis_instance(
 
         while True:
             try:
-                redis_cli = redis.Redis("localhost", str(port))
+                redis_cli = get_redis_cli(port, enable_tls)
                 if replica_of is None:
                     slots = [str(i) for i in range(16384)]
                     redis_cli.cluster("addslots", *slots)
                 else:
-                    redis_cli.cluster("meet", "127.0.0.1", str(replica_of))
-                    redis_cli.cluster("replicate", leader_id)
+                    print(redis_cli.cluster("meet", "127.0.0.1", str(replica_of)))
+                    print(redis_cli.cluster("replicate", leader_id))
                 node_id = redis_cli.cluster("myid")
                 break
             except (
@@ -227,7 +249,7 @@ def start_redis_instance(
             ) as e:
                 from time import sleep
 
-                print(f"Waiting for redis to be up {e}")
+                print(f"Waiting for redis to be up {e} ")
                 sleep(0.1)
 
     return node_id, process_info

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -33,6 +33,7 @@ from ray._private.test_utils import (
     teardown_tls,
     enable_external_redis,
     redis_replicas,
+    get_redis_cli,
     start_redis_instance,
     find_available_port,
 )
@@ -172,18 +173,19 @@ def start_redis(db_dir):
     while True:
         is_need_restart = False
         # Setup external Redis and env var for initialization.
-        redis_ports = find_available_port(49159, 55536, redis_replicas())
-
+        redis_ports = find_available_port(49159, 55535, redis_replicas() * 2)
+        redis_ports = list(zip(redis_ports[0:redis_replicas()], redis_ports[redis_replicas():]))
         processes = []
         enable_tls = "RAY_REDIS_CA_CERT" in os.environ
         leader_port = None
         leader_id = None
-        for port in redis_ports:
+        for port, free_port in redis_ports:
             print("Start Redis with port: ", port)
             temp_dir = ray._private.utils.get_ray_temp_dir()
             node_id, proc = start_redis_instance(
                 temp_dir,
                 port,
+                free_port,
                 enable_tls=enable_tls,
                 replica_of=leader_port,
                 leader_id=leader_id,
@@ -214,12 +216,12 @@ def start_redis(db_dir):
         if redis_replicas() > 1:
             import redis
 
-            redis_cli = redis.Redis("localhost", str(leader_port))
+            redis_cli = get_redis_cli(str(leader_port), True)
             while redis_cli.cluster("info")["cluster_state"] != "ok":
                 pass
 
         scheme = "rediss://" if enable_tls else ""
-        address_str = f"{scheme}127.0.0.1:{redis_ports[-1]}"
+        address_str = f"{scheme}127.0.0.1:{redis_ports[-1][0]}"
         return address_str, processes
 
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -217,7 +217,7 @@ def start_redis(db_dir):
 
         if redis_replicas() > 1:
 
-            redis_cli = get_redis_cli(str(leader_port), True)
+            redis_cli = get_redis_cli(str(leader_port), enable_tls)
             while redis_cli.cluster("info")["cluster_state"] != "ok":
                 pass
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -187,11 +187,11 @@ def start_redis(db_dir):
             node_id, proc = start_redis_instance(
                 temp_dir,
                 port,
-                free_port,
                 enable_tls=enable_tls,
                 replica_of=leader_port,
                 leader_id=leader_id,
                 db_dir=db_dir,
+                free_port=free_port,
             )
             if leader_port is None:
                 leader_port = port

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -174,7 +174,9 @@ def start_redis(db_dir):
         is_need_restart = False
         # Setup external Redis and env var for initialization.
         redis_ports = find_available_port(49159, 55535, redis_replicas() * 2)
-        redis_ports = list(zip(redis_ports[0:redis_replicas()], redis_ports[redis_replicas():]))
+        redis_ports = list(
+            zip(redis_ports[0 : redis_replicas()], redis_ports[redis_replicas() :])
+        )
         processes = []
         enable_tls = "RAY_REDIS_CA_CERT" in os.environ
         leader_port = None
@@ -214,7 +216,6 @@ def start_redis(db_dir):
             continue
 
         if redis_replicas() > 1:
-            import redis
 
             redis_cli = get_redis_cli(str(leader_port), True)
             while redis_cli.cluster("info")["cluster_state"] != "ok":

--- a/python/ray/tests/test_redis_tls.py
+++ b/python/ray/tests/test_redis_tls.py
@@ -46,9 +46,15 @@ openssl dhparam -out {str(tmp_path)}/tls/redis.dh 2048
     yield tmp_path
 
 
+@pytest.fixture
+def setup_replicas(request, monkeypatch):
+    monkeypatch.setenv("TEST_EXTERNAL_REDIS_REPLICAS", str(request.param))
+    yield
+
 @pytest.mark.skipif(not enable_external_redis(), reason="Only work for redis mode")
 @pytest.mark.skipif(sys.platform != "linux", reason="Only work in linux")
-def test_redis_tls(setup_tls, ray_start_cluster_head):
+@pytest.mark.parametrize("setup_replicas", [1, 3], indirect=True)
+def test_redis_tls(setup_tls, setup_replicas, ray_start_cluster_head):
     @ray.remote
     def hello():
         return "world"

--- a/python/ray/tests/test_redis_tls.py
+++ b/python/ray/tests/test_redis_tls.py
@@ -51,6 +51,7 @@ def setup_replicas(request, monkeypatch):
     monkeypatch.setenv("TEST_EXTERNAL_REDIS_REPLICAS", str(request.param))
     yield
 
+
 @pytest.mark.skipif(not enable_external_redis(), reason="Only work for redis mode")
 @pytest.mark.skipif(sys.platform != "linux", reason="Only work in linux")
 @pytest.mark.parametrize("setup_replicas", [1, 3], indirect=True)

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -267,17 +267,20 @@ RedisContext::RedisContext(instrumented_io_context &io_service)
       << redisSSLContextGetError(ssl_error);
 }
 
-RedisContext::~RedisContext() { Disconnect(); }
+RedisContext::~RedisContext() {
+  Disconnect();
+  if (ssl_context_) {
+    redisFreeSSLContext(ssl_context_);
+    ssl_context_ = nullptr;
+  }
+}
 
 void RedisContext::Disconnect() {
   if (context_) {
     redisFree(context_);
     context_ = nullptr;
   }
-  if (ssl_context_) {
-    redisFreeSSLContext(ssl_context_);
-    ssl_context_ = nullptr;
-  }
+
   redis_async_context_.reset();
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The algorithm to find the leader node is first talk with any node and get the leader node address. Then it'll close the current connection and connect to the leader node again.

When TLS is enabled, it'll crash because the tls context is initialized in the constructor and freed when disconnect. So when connecting for the second time, it'll crash because it's freed.

This PR fixed it by reusing the TLS context and destruct in the destructor.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #36792
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
