### PR TITLE
[ci][champagne/1] script to build anyscale BYOD champagne image

### DIFF
--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -9,7 +9,12 @@ import time
 
 from ray_release.config import RELEASE_PACKAGE_DIR
 from ray_release.logger import logger
-from ray_release.test import Test
+from ray_release.test import (
+    Test,
+    DATAPLANE_ECR,
+    DATAPLANE_ECR_REPO,
+    DATAPLANE_ECR_ML_REPO,
+)
 
 DATAPLANE_S3_BUCKET = "ray-release-automation-results"
 DATAPLANE_FILENAME = "dataplane_20230622.tgz"
@@ -20,6 +25,47 @@ RELEASE_BYOD_DIR = os.path.join(RELEASE_PACKAGE_DIR, "ray_release/byod")
 REQUIREMENTS_BYOD = "requirements_byod"
 REQUIREMENTS_ML_BYOD = "requirements_ml_byod"
 PYTHON_VERSION = "3.8"
+
+
+def build_anyscale_champagne_image(
+    ray_version: str,
+    python_version: str,
+    image_type: str,
+) -> None:
+    """
+    Builds the Anyscale champagne image.
+    """
+    _download_dataplane_build_file()
+    env = os.environ.copy()
+    env["DOCKER_BUILDKIT"] = "1"
+    if image_type == "cpu":
+        ray_project = "ray"
+        anyscale_repo = DATAPLANE_ECR_REPO
+        image_suffix = ""
+    else:
+        ray_project = "ray-ml"
+        anyscale_repo = DATAPLANE_ECR_ML_REPO
+        image_suffix = f"-{image_type}"
+    ray_image = f"rayproject/{ray_project}:{ray_version}-{python_version}{image_suffix}"
+    anyscale_image = f"{DATAPLANE_ECR}/{anyscale_repo}:champagne-{ray_version}"
+
+    logger.info(f"Building champagne anyscale image from {ray_image}")
+    with open(DATAPLANE_FILENAME, "rb") as build_file:
+        subprocess.check_call(
+            [
+                "docker",
+                "build",
+                "--build-arg",
+                f"BASE_IMAGE={ray_image}",
+                "-t",
+                anyscale_image,
+                "-",
+            ],
+            stdin=build_file,
+            stdout=sys.stderr,
+            env=env,
+        )
+    _validate_and_push(anyscale_image)
 
 
 def build_anyscale_custom_byod_image(test: Test) -> None:

--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -27,11 +27,11 @@ REQUIREMENTS_ML_BYOD = "requirements_ml_byod"
 PYTHON_VERSION = "3.8"
 
 
-def build_anyscale_champagne_image(
+def build_champagne_image(
     ray_version: str,
     python_version: str,
     image_type: str,
-) -> None:
+) -> str:
     """
     Builds the Anyscale champagne image.
     """
@@ -66,6 +66,8 @@ def build_anyscale_champagne_image(
             env=env,
         )
     _validate_and_push(anyscale_image)
+
+    return anyscale_image
 
 
 def build_anyscale_custom_byod_image(test: Test) -> None:

--- a/release/ray_release/scripts/ray_champagne.py
+++ b/release/ray_release/scripts/ray_champagne.py
@@ -1,0 +1,28 @@
+import os
+
+from ray_release.byod.build import build_anyscale_champagne_image
+
+
+CHAMPAGNE_IMAGE_TYPES = [
+    # python_version, image_type
+    ("py38", "cpu"),
+    ("py38", "gpu"),
+]
+
+
+def main() -> None:
+    """
+    Builds the Anyscale champagne image.
+    """
+    branch = os.environ.get("BRANCH_TO_TEST", os.environ["BUILDKITE_BRANCH"])
+    commit = os.environ.get("COMMIT_TO_TEST", os.environ["BUILDKITE_COMMIT"])
+    assert branch.startswith(
+        "releases/"
+    ), f"Champagne building only supported on release branch, found {branch}"
+    ray_version = f"{branch[len('releases/') :]}.{commit[:6]}"
+    for python_version, image_type in CHAMPAGNE_IMAGE_TYPES:
+        build_anyscale_champagne_image(ray_version, python_version, image_type)
+
+
+if __name__ == "__main__":
+    main()

--- a/release/ray_release/scripts/ray_champagne.py
+++ b/release/ray_release/scripts/ray_champagne.py
@@ -1,18 +1,24 @@
 import os
 
-from ray_release.byod.build import build_anyscale_champagne_image
+from anyscale.sdk.anyscale_client.models.create_cluster_environment import (
+    CreateClusterEnvironment,
+)
 
+from ray_release.aws import maybe_fetch_api_token
+from ray_release.byod.build import build_champagne_image
+from ray_release.logger import logger
+from ray_release.util import get_anyscale_sdk
 
 CHAMPAGNE_IMAGE_TYPES = [
-    # python_version, image_type
-    ("py38", "cpu"),
-    ("py38", "gpu"),
+    # python_version, image_type, cluster_env_name
+    ("py38", "cpu", "ray-champagne-cpu"),
+    ("py38", "gpu", "ray-champagne-gpu"),
 ]
 
 
 def main() -> None:
     """
-    Builds the Anyscale champagne image.
+    Builds the Ray champagne image.
     """
     branch = os.environ.get("BRANCH_TO_TEST", os.environ["BUILDKITE_BRANCH"])
     commit = os.environ.get("COMMIT_TO_TEST", os.environ["BUILDKITE_COMMIT"])
@@ -20,8 +26,32 @@ def main() -> None:
         "releases/"
     ), f"Champagne building only supported on release branch, found {branch}"
     ray_version = f"{branch[len('releases/') :]}.{commit[:6]}"
-    for python_version, image_type in CHAMPAGNE_IMAGE_TYPES:
-        build_anyscale_champagne_image(ray_version, python_version, image_type)
+    for python_version, image_type, cluster_env_name in CHAMPAGNE_IMAGE_TYPES:
+        logger.info(f"Building champagne image for {python_version} {image_type}")
+        anyscale_image = build_champagne_image(
+            ray_version,
+            python_version,
+            image_type,
+        )
+        logger.info(f"Updating cluster environment {cluster_env_name}")
+        _build_champaign_cluster_environment(anyscale_image, cluster_env_name)
+
+
+def _build_champaign_cluster_environment(
+    anyscale_image: str,
+    cluster_env_name: str,
+) -> None:
+    maybe_fetch_api_token()
+    get_anyscale_sdk().build_cluster_environment(
+        create_cluster_environment=CreateClusterEnvironment(
+            name=cluster_env_name,
+            config_json=dict(
+                docker_image=anyscale_image,
+                ray_version="nightly",
+                env_vars={},
+            ),
+        ),
+    )
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_byod_build.py
+++ b/release/ray_release/tests/test_byod_build.py
@@ -5,7 +5,42 @@ from unittest.mock import patch
 from typing import List
 
 from ray_release.test import Test
-from ray_release.byod.build import build_anyscale_custom_byod_image
+from ray_release.byod.build import (
+    build_anyscale_custom_byod_image,
+    build_anyscale_champagne_image,
+    DATAPLANE_FILENAME,
+)
+
+
+def test_build_anyscale_champagne_image() -> None:
+    cmds = []
+
+    def _mock_check_call(
+        cmd: List[str],
+        *args,
+        **kwargs,
+    ) -> None:
+        cmds.append(cmd)
+
+    with patch.dict(
+        "os.environ",
+        {"BUILDKITE_COMMIT": "abc123", "BUILDKITE_BRANCH": "master"},
+    ), patch(
+        "ray_release.byod.build._download_dataplane_build_file",
+        return_value=None,
+    ), patch(
+        "subprocess.check_call",
+        side_effect=_mock_check_call,
+    ), patch(
+        "subprocess.check_output",
+        return_value=b"abc123",
+    ), open(
+        DATAPLANE_FILENAME, "wb"
+    ) as _:
+        build_anyscale_champagne_image("2.5.1", "py37", "cpu")
+        assert "docker build --build-arg BASE_IMAGE=rayproject/ray:2.5.1-py37 -t "
+        "029272617770.dkr.ecr.us-west-2.amazonaws.com/"
+        "anyscale/ray:champagne-2.5.1 -" == " ".join(cmds[0])
 
 
 def test_build_anyscale_custom_byod_image() -> None:

--- a/release/ray_release/tests/test_byod_build.py
+++ b/release/ray_release/tests/test_byod_build.py
@@ -7,7 +7,7 @@ from typing import List
 from ray_release.test import Test
 from ray_release.byod.build import (
     build_anyscale_custom_byod_image,
-    build_anyscale_champagne_image,
+    build_champagne_image,
     DATAPLANE_FILENAME,
 )
 
@@ -37,7 +37,7 @@ def test_build_anyscale_champagne_image() -> None:
     ), open(
         DATAPLANE_FILENAME, "wb"
     ) as _:
-        build_anyscale_champagne_image("2.5.1", "py37", "cpu")
+        build_champagne_image("2.5.1", "py37", "cpu")
         assert "docker build --build-arg BASE_IMAGE=rayproject/ray:2.5.1-py37 -t "
         "029272617770.dkr.ecr.us-west-2.amazonaws.com/"
         "anyscale/ray:champagne-2.5.1 -" == " ".join(cmds[0])


### PR DESCRIPTION
A script to build champagne (dog-fooding) ray image for SA. 

Buildkite pipeline is created here and verify that it builds: https://buildkite.com/ray-project/release-tests-champagne/builds/5

Next step, I'll hook the pipeline up with OSS CI postmerge job so we can create a champagne image for every new commit in a release branch.