### PR TITLE
[CI] Pin `joblib` to `1.2.0` in CI

### DIFF
--- a/python/requirements_test.txt
+++ b/python/requirements_test.txt
@@ -31,6 +31,7 @@ google-api-python-client==2.65.0
 google-cloud-storage==2.5.0
 gradio==3.11; platform_system != "Windows"
 websockets==11.0.3
+joblib==1.2.0
 jsonpatch==1.32
 kubernetes==24.2.0
 llvmlite==0.39.1; python_version < '3.11'


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_joblib` has been failing `master` over the past day:

<img width="1342" alt="Screen Shot 2023-06-28 at 5 44 13 PM" src="https://github.com/ray-project/ray/assets/92341594/8ed76ecc-dd06-4eae-8e67-348e7a5aaf65">

Reverting the first PR that failed still doesn't fix the tests (see [revert PR](https://github.com/ray-project/ray/pull/36924)). The cause is likely that a new `joblib` version was released today (1.3.0), causing the test to start failing. Thanks @rkooo567 for catching this, and thanks @can-anyscale for giving pointers on what files to change.

This change pins `joblib` to 1.2.0 in the CI. It should fix `test_joblib`.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - `test_joblib` should start passing.
