### PR TITLE
[Data] Remove `_convert_block_to_tabular_block`

### DIFF
--- a/python/ray/data/datasource/binary_datasource.py
+++ b/python/ray/data/datasource/binary_datasource.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 from ray.data._internal.arrow_block import ArrowBlockBuilder
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
@@ -57,28 +57,6 @@ class BinaryDatasource(FileBasedDatasource):
                 return [(path, data)]
             else:
                 return [data]
-
-    def _convert_block_to_tabular_block(
-        self,
-        block: List[Union[bytes, Tuple[bytes, str]]],
-        column_name: Optional[str] = None,
-    ) -> "pyarrow.Table":
-        import pyarrow as pa
-
-        if isinstance(block, pa.Table):
-            return block
-        else:
-            if column_name is None:
-                column_name = self._COLUMN_NAME
-
-            assert len(block) == 1
-            record = block[0]
-
-            if isinstance(record, tuple):
-                path, data = record
-                return pa.table({column_name: [data], "path": [path]})
-            else:
-                return pa.table({column_name: [record]})
 
     def _rows_per_file(self):
         return 1

--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.util import _check_import
-from ray.data.block import Block, BlockMetadata
+from ray.data.block import BlockMetadata
 from ray.data.datasource.binary_datasource import BinaryDatasource
 from ray.data.datasource.datasource import Reader
 from ray.data.datasource.file_based_datasource import (
@@ -66,15 +66,6 @@ class ImageDatasource(BinaryDatasource):
         return _ImageDatasourceReader(
             self, size=size, mode=mode, include_paths=include_paths, **reader_args
         )
-
-    def _convert_block_to_tabular_block(
-        self, block: Block, column_name: Optional[str] = None
-    ) -> Block:
-        import pandas as pd
-        import pyarrow as pa
-
-        assert isinstance(block, (pa.Table, pd.DataFrame))
-        return block
 
     def _read_file(
         self,

--- a/python/ray/data/datasource/numpy_datasource.py
+++ b/python/ray/data/datasource/numpy_datasource.py
@@ -1,9 +1,9 @@
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict
 
 import numpy as np
 
-from ray.data.block import Block, BlockAccessor
+from ray.data.block import BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 from ray.util.annotations import PublicAPI
 
@@ -36,16 +36,6 @@ class NumpyDatasource(FileBasedDatasource):
         buf.write(data)
         buf.seek(0)
         return BlockAccessor.batch_to_block({"data": np.load(buf, allow_pickle=True)})
-
-    def _convert_block_to_tabular_block(
-        self, block: Block, column_name: Optional[str] = None
-    ) -> "pyarrow.Table":
-        if column_name is None:
-            column_name = self._COLUMN_NAME
-
-        column_names = block.column_names
-        column_names[0] = column_name
-        return block.rename_columns(column_names)
 
     def _write_block(
         self,

--- a/python/ray/data/datasource/text_datasource.py
+++ b/python/ray/data/datasource/text_datasource.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List
 
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data.datasource.binary_datasource import BinaryDatasource
@@ -32,16 +32,6 @@ class TextDatasource(BinaryDatasource):
             builder.add(item)
 
         block = builder.build()
-        return block
-
-    def _convert_block_to_tabular_block(
-        self,
-        block: List[str],
-        column_name: Optional[str] = None,
-    ) -> "pyarrow.Table":
-        import pyarrow as pa
-
-        assert isinstance(block, pa.Table)
         return block
 
     def _rows_per_file(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`_convert_block_to_tabular_block` is dead code. This PR removes it.

**Context**

https://github.com/ray-project/ray/pull/28413 introduced the `partitioning` parameter. With this feature, you could include data from file paths in your dataset. For example, if you read a Parquet file like `s3://bucket/year=2023/piece.parquet`, the year would be included in your dataset.

The problem was that `Datasets` could represent unstructured data like a list of numbers. In this case, we needed to convert the `Dataset` to a tabular dataset before adding the partition data.

With https://github.com/ray-project/ray/pull/36472, `Datasets` always represent structured data, so `_convert_block_to_tabular_block` is unused.
 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
