### PR TITLE
[Data] Deprecate `BatchPredictor`

### DIFF
--- a/python/ray/train/batch_predictor.py
+++ b/python/ray/train/batch_predictor.py
@@ -34,7 +34,7 @@ class BatchPredictor:
         warnings.warn(
             "`BatchPredictor` is deprecated. Use `Dataset.map_batches`  instead. To "
             "learn more, see http://batchinference.io.",
-            DeprecationWarning
+            DeprecationWarning,
         )
         self._checkpoint = checkpoint
         # Store as object ref so we only serialize it once for all map workers

--- a/python/ray/train/batch_predictor.py
+++ b/python/ray/train/batch_predictor.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any, Dict, Optional, List, Type, Union, Callable
 import pandas as pd
 import numpy as np
+import warnings
 
 import ray
 from ray.air import Checkpoint
@@ -11,12 +12,12 @@ from ray.air.util.data_batch_conversion import BatchFormat
 from ray.data import Dataset, DatasetPipeline, Preprocessor
 from ray.data.context import DataContext
 from ray.train.predictor import Predictor
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import Deprecated
 
 logger = logging.getLogger(__name__)
 
 
-@PublicAPI(stability="beta")
+@Deprecated
 class BatchPredictor:
     """Batch predictor class.
 
@@ -30,6 +31,11 @@ class BatchPredictor:
     def __init__(
         self, checkpoint: Checkpoint, predictor_cls: Type[Predictor], **predictor_kwargs
     ):
+        warnings.warn(
+            "`BatchPredictor` is deprecated. Use `Dataset.map_batches`  instead. To "
+            "learn more, see http://batchinference.io.",
+            DeprecationWarning
+        )
         self._checkpoint = checkpoint
         # Store as object ref so we only serialize it once for all map workers
         self._checkpoint_ref = ray.put(checkpoint)

--- a/python/ray/train/tests/test_batch_predictor.py
+++ b/python/ray/train/tests/test_batch_predictor.py
@@ -40,7 +40,7 @@ class DummyWithNumpyPreprocessor(DummyPreprocessor):
 def test_batch_predictor_warns_deprecation(shutdown_only):
     with pytest.warns(DeprecationWarning):
         BatchPredictor.from_checkpoint(
-            Checkpoint.from_dict({"factor": 2.0}),
+            Checkpoint.from_dict({"factor": 0}),
             DummyPredictorFS,
         )
 

--- a/python/ray/train/tests/test_batch_predictor.py
+++ b/python/ray/train/tests/test_batch_predictor.py
@@ -37,6 +37,14 @@ class DummyWithNumpyPreprocessor(DummyPreprocessor):
             return np_data * self.multiplier
 
 
+def test_batch_predictor_warns_deprecation(shutdown_only):
+    with pytest.warns(DeprecationWarning):
+        BatchPredictor.from_checkpoint(
+            Checkpoint.from_dict({"factor": 2.0}),
+            DummyPredictorFS,
+        )
+
+
 def test_repr(shutdown_only):
     predictor = BatchPredictor.from_checkpoint(
         Checkpoint.from_dict({"factor": 2.0}),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`BatchPredictor` has been superseded by `Dataset.map_batches`. To learn more, see https://github.com/ray-project/enhancements/pull/25.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
