### PR TITLE
[ci] fix aws_cluster_launcher test

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -6752,6 +6752,7 @@
 
   frequency: nightly
   team: core
+  python: "3.8"
   cluster:
     byod: {}
     cluster_env: aws/tests/aws_config.yaml


### PR DESCRIPTION
This BYOD test needs to run on python 3.8. Currently its BYOD fails to compile because it uses python 3.7

Test:
- Release test