### PR TITLE
Switch to yaml safe_load on state list API UT

### DIFF
--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -123,7 +123,6 @@ if sys.version_info >= (3, 8, 0):
 else:
     from asyncmock import AsyncMock
 
-
 """
 Unit tests
 """
@@ -2868,9 +2867,8 @@ async def test_cli_format_print(state_api_manager):
     print(result)
     result = [ActorState(**d) for d in result.result]
     # If the format is not yaml, it will raise an exception.
-    yaml.load(
-        format_list_api_output(result, schema=ActorState, format=AvailableFormat.YAML),
-        Loader=yaml.FullLoader,
+    yaml.safe_load(
+        format_list_api_output(result, schema=ActorState, format=AvailableFormat.YAML)
     )
     # If the format is not json, it will raise an exception.
     json.loads(
@@ -3080,18 +3078,14 @@ def test_detail(shutdown_only):
 
     # Make sure when the --detail option is specified, the default formatting
     # is yaml. If the format is not yaml, the below line will raise an yaml exception.
-    print(
-        yaml.load(
-            result.output,
-            Loader=yaml.FullLoader,
-        )
-    )
+    # Retrieve yaml content from result output
+    print(yaml.safe_load(result.output.split("---")[1].split("...")[0]))
 
     # When the format is given, it should respect that formatting.
-    result = runner.invoke(ray_list, ["actors", "--detail", "--format=table"])
+    result = runner.invoke(ray_list, ["actors", "--detail", "--format=json"])
     assert result.exit_code == 0
-    with pytest.raises(yaml.YAMLError):
-        yaml.load(result.output, Loader=yaml.FullLoader)
+    # Fails if output is not JSON
+    print(json.loads(result.output))
 
 
 def _try_state_query_expect_rate_limit(api_func, res_q, start_q=None, **kwargs):

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -183,6 +183,7 @@ def output_with_format(
             explicit_start=True,
             # We want to keep the defined ordering of the states, thus sort_keys=False
             sort_keys=False,
+            explicit_end=True,
         )
     elif format == AvailableFormat.JSON:
         return json.dumps(state_data)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change is to switch state list API UT from yaml.load to yaml.safe_load. 
1. Note, current changes already uses FullLoader, switched to SafeLoader using safe_load.
2. Switch to JSON format
3. Add explicit_end for yaml output

## Related issue number

[36974](https://github.com/ray-project/ray/issues/36974)

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] ~I've included any doc changes needed for https://docs.ray.io/en/master/.~
    - [ ] ~I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.~
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] ~Release tests~
   - [ ] ~This PR is not tested :(~

## Testing
```
Results (495.90s):
     111 passed
(venv) [mde-user@ip-10-6-23-62 ray]$ python -m pytest -v -s python/ray/tests/test_state_api.py python/ray/tests/test_state_api_log.py python/ray/tests/test_state_api_summary.py
```
