### PR TITLE
[core][autoscaler] Remove usage of grpcio from autoscaler SDK

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2303,6 +2303,24 @@ cdef class GcsClient:
             }
         return result
 
+    ########################################################
+    # Interface for rpc::autoscaler::AutoscalerStateService
+    ########################################################
+
+    @_auto_reconnect
+    def request_cluster_resource_constraint(
+            self,
+            bundles: c_vector[unordered_map[c_string, double]],
+            timeout=None):
+        cdef:
+            int64_t timeout_ms = round(1000 * timeout) if timeout else -1
+        with nogil:
+            check_status(self.inner.get().RequestClusterResourceConstraint(
+                timeout_ms, bundles))
+
+    #############################################################
+    # Interface for rpc::autoscaler::AutoscalerStateService ends
+    #############################################################
 cdef class GcsPublisher:
     """Cython wrapper class of C++ `ray::gcs::PythonGcsPublisher`."""
     cdef:

--- a/python/ray/autoscaler/v2/sdk.py
+++ b/python/ray/autoscaler/v2/sdk.py
@@ -32,7 +32,4 @@ def request_cluster_resources(
         timeout: Timeout in seconds for the request to be timeout
 
     """
-    if not ray.is_initialized():
-        raise RuntimeError("Ray is not initialized yet")
-
     get_gcs_client().request_cluster_resource_constraint(to_request, timeout=timeout)

--- a/python/ray/autoscaler/v2/sdk.py
+++ b/python/ray/autoscaler/v2/sdk.py
@@ -1,20 +1,18 @@
 from typing import List
 
 import ray
-import ray._private.ray_constants as ray_constants
-from ray.core.generated.experimental import autoscaler_pb2, autoscaler_pb2_grpc
+
+DEFAULT_RPC_TIMEOUT_S = 10
 
 
-def _autoscaler_state_service_stub():
-    """Get the grpc stub for the autoscaler state service"""
-    gcs_address = ray.get_runtime_context().gcs_address
-    gcs_channel = ray._private.utils.init_grpc_channel(
-        gcs_address, ray_constants.GLOBAL_GRPC_OPTIONS
-    )
-    return autoscaler_pb2_grpc.AutoscalerStateServiceStub(gcs_channel)
+def get_gcs_client():
+    """Get GCS client from the worker"""
+    return ray.worker.global_worker.node.get_gcs_client()
 
 
-def request_cluster_resources(to_request: List[dict], timeout: int = 10):
+def request_cluster_resources(
+    to_request: List[dict], timeout: int = DEFAULT_RPC_TIMEOUT_S
+):
     """Request resources from the autoscaler.
 
     This will add a cluster resource constraint to GCS. GCS will asynchronously
@@ -34,18 +32,7 @@ def request_cluster_resources(to_request: List[dict], timeout: int = 10):
         timeout: Timeout in seconds for the request to be timeout
 
     """
+    if not ray.is_initialized():
+        raise RuntimeError("Ray is not initialized yet")
 
-    # NOTE: We could also use a GCS python client. However, current GCS rpc client
-    # expects GcsStatus as part of the reply, which is a protocol internal to Ray.
-    # So we use the rpc stub directly to avoid that dependency.
-    stub = _autoscaler_state_service_stub()
-    min_bundles = [
-        autoscaler_pb2.ResourceRequest(resources_bundle=bundle) for bundle in to_request
-    ]
-    request = autoscaler_pb2.RequestClusterResourceConstraintRequest(
-        cluster_resource_constraint=autoscaler_pb2.ClusterResourceConstraint(
-            min_bundles=min_bundles
-        )
-    )
-
-    stub.RequestClusterResourceConstraint(request, timeout=timeout)
+    get_gcs_client().request_cluster_resource_constraint(to_request, timeout=timeout)

--- a/python/ray/autoscaler/v2/tests/test_sdk.py
+++ b/python/ray/autoscaler/v2/tests/test_sdk.py
@@ -6,13 +6,21 @@ from typing import List
 import pytest  # noqa
 
 import ray
+import ray._private.ray_constants as ray_constants
 from ray._private.test_utils import wait_for_condition
-from ray.autoscaler.v2.sdk import (
-    _autoscaler_state_service_stub,
-    request_cluster_resources,
-)
+from ray.autoscaler.v2.sdk import request_cluster_resources
 from ray.autoscaler.v2.tests.util import get_cluster_resource_state
+from ray.core.generated.experimental import autoscaler_pb2_grpc
 from ray.core.generated.experimental.autoscaler_pb2 import GetClusterResourceStateReply
+
+
+def _autoscaler_state_service_stub():
+    """Get the grpc stub for the autoscaler state service"""
+    gcs_address = ray.get_runtime_context().gcs_address
+    gcs_channel = ray._private.utils.init_grpc_channel(
+        gcs_address, ray_constants.GLOBAL_GRPC_OPTIONS
+    )
+    return autoscaler_pb2_grpc.AutoscalerStateServiceStub(gcs_channel)
 
 
 def assert_cluster_resource_constraints(

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -361,6 +361,9 @@ cdef extern from "ray/gcs/gcs_client/gcs_client.h" nogil:
             int64_t timeout_ms, c_vector[CGcsNodeInfo]& result)
         CRayStatus GetAllJobInfo(
             int64_t timeout_ms, c_vector[CJobTableData]& result)
+        CRayStatus RequestClusterResourceConstraint(
+            int64_t timeout_ms,
+            const c_vector[unordered_map[c_string, double]] &bundles)
 
 cdef extern from "ray/gcs/gcs_client/gcs_client.h" namespace "ray::gcs" nogil:
     unordered_map[c_string, double] PythonGetResourcesTotal(

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -152,6 +152,7 @@ Status PythonGcsClient::Connect() {
   runtime_env_stub_ = rpc::RuntimeEnvGcsService::NewStub(channel_);
   node_info_stub_ = rpc::NodeInfoGcsService::NewStub(channel_);
   job_info_stub_ = rpc::JobInfoGcsService::NewStub(channel_);
+  autoscaler_stub_ = rpc::autoscaler::AutoscalerStateService::NewStub(channel_);
   return Status::OK();
 }
 
@@ -392,6 +393,31 @@ Status PythonGcsClient::GetAllJobInfo(int64_t timeout_ms,
       return Status::OK();
     }
     return HandleGcsError(reply.status());
+  }
+  return Status::RpcError(status.error_message(), status.error_code());
+}
+
+Status PythonGcsClient::RequestClusterResourceConstraint(
+    int64_t timeout_ms,
+    const std::vector<std::unordered_map<std::string, double>> &bundles) {
+  grpc::ClientContext context;
+  GrpcClientContextWithTimeoutMs(context, timeout_ms);
+
+  rpc::autoscaler::RequestClusterResourceConstraintRequest request;
+  rpc::autoscaler::RequestClusterResourceConstraintReply reply;
+
+  for (auto bundle : bundles) {
+    request.mutable_cluster_resource_constraint()
+        ->add_min_bundles()
+        ->mutable_resources_bundle()
+        ->insert(bundle.begin(), bundle.end());
+  }
+
+  grpc::Status status =
+      autoscaler_stub_->RequestClusterResourceConstraint(&context, request, &reply);
+
+  if (status.ok()) {
+    return Status::OK();
   }
   return Status::RpcError(status.error_message(), status.error_code());
 }

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -31,6 +31,7 @@
 #include "ray/gcs/pubsub/gcs_pub_sub.h"
 #include "ray/rpc/gcs_server/gcs_rpc_client.h"
 #include "ray/util/logging.h"
+#include "src/ray/protobuf/experimental/autoscaler.grpc.pb.h"
 
 namespace ray {
 
@@ -224,12 +225,18 @@ class RAY_EXPORT PythonGcsClient {
   Status GetAllNodeInfo(int64_t timeout_ms, std::vector<rpc::GcsNodeInfo> &result);
   Status GetAllJobInfo(int64_t timeout_ms, std::vector<rpc::JobTableData> &result);
 
+  // For rpc::autoscaler::AutoscalerStateService
+  Status RequestClusterResourceConstraint(
+      int64_t timeout_ms,
+      const std::vector<std::unordered_map<std::string, double>> &bundles);
+
  private:
   GcsClientOptions options_;
   std::unique_ptr<rpc::InternalKVGcsService::Stub> kv_stub_;
   std::unique_ptr<rpc::RuntimeEnvGcsService::Stub> runtime_env_stub_;
   std::unique_ptr<rpc::NodeInfoGcsService::Stub> node_info_stub_;
   std::unique_ptr<rpc::JobInfoGcsService::Stub> job_info_stub_;
+  std::unique_ptr<rpc::autoscaler::AutoscalerStateService::Stub> autoscaler_stub_;
   std::shared_ptr<grpc::Channel> channel_;
 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Since we should not be using grpcio python (aligning with this https://github.com/ray-project/ray/issues/35472)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
