### PR TITLE
[ci][champagne/2] update champagne cluster environment

### DIFF
--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -31,7 +31,7 @@ def build_anyscale_champagne_image(
     ray_version: str,
     python_version: str,
     image_type: str,
-) -> None:
+) -> str:
     """
     Builds the Anyscale champagne image.
     """
@@ -66,6 +66,8 @@ def build_anyscale_champagne_image(
             env=env,
         )
     _validate_and_push(anyscale_image)
+
+    return anyscale_image
 
 
 def build_anyscale_custom_byod_image(test: Test) -> None:

--- a/release/ray_release/scripts/ray_champagne.py
+++ b/release/ray_release/scripts/ray_champagne.py
@@ -1,12 +1,18 @@
 import os
 
-from ray_release.byod.build import build_anyscale_champagne_image
+from anyscale.sdk.anyscale_client.models.create_cluster_environment import (
+    CreateClusterEnvironment,
+)
 
+from ray_release.aws import maybe_fetch_api_token
+from ray_release.byod.build import build_anyscale_champagne_image
+from ray_release.logger import logger
+from ray_release.util import get_anyscale_sdk
 
 CHAMPAGNE_IMAGE_TYPES = [
-    # python_version, image_type
-    ("py38", "cpu"),
-    ("py38", "gpu"),
+    # python_version, image_type, cluster_env_name
+    ("py38", "cpu", "ray-champagne-cpu"),
+    ("py38", "gpu", "ray-champagne-gpu"),
 ]
 
 
@@ -20,8 +26,32 @@ def main() -> None:
         "releases/"
     ), f"Champagne building only supported on release branch, found {branch}"
     ray_version = f"{branch[len('releases/') :]}.{commit[:6]}"
-    for python_version, image_type in CHAMPAGNE_IMAGE_TYPES:
-        build_anyscale_champagne_image(ray_version, python_version, image_type)
+    for python_version, image_type, cluster_env_name in CHAMPAGNE_IMAGE_TYPES:
+        logger.info(f"Building champagne image for {python_version} {image_type}")
+        anyscale_image = build_anyscale_champagne_image(
+            ray_version,
+            python_version,
+            image_type,
+        )
+        logger.info(f"Updating cluster environment {cluster_env_name}")
+        _build_champaign_cluster_environment(anyscale_image, cluster_env_name)
+
+
+def _build_champaign_cluster_environment(
+    anyscale_image: str,
+    cluster_env_name: str,
+) -> None:
+    maybe_fetch_api_token()
+    get_anyscale_sdk().build_cluster_environment(
+        create_cluster_environment=CreateClusterEnvironment(
+            name=cluster_env_name,
+            config_json=dict(
+                docker_image=anyscale_image,
+                ray_version="nightly",
+                env_vars={},
+            ),
+        ),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Second PR to setup a ray champagne environment for SA to use. This PR builds a new version of a pre-defined set of cluster environment name (on anyscale production by default).

Testing:
- Run the job https://buildkite.com/ray-project/release-tests-champagne/builds/7#01890983-26d8-47c5-b524-889b428cca21. Check that cluster environment is built: https://console.anyscale.com/o/anyscale-internal/configurations/app-config-details/bld_9nrkw9pfv76mtuw8gqt6ymzsht