### PR TITLE
[Serve] [Docs] Add note about `DAGDriver` redirect

### DIFF
--- a/doc/source/serve/deploy-many-models/multi-app.md
+++ b/doc/source/serve/deploy-many-models/multi-app.md
@@ -87,6 +87,14 @@ Query the applications at their respective endpoints, `/calculator` and `/greet`
 'Good morning Bob!'
 ```
 
+:::{tip}
+If you prefer to use `cURL` to ping these endpoints, add the `-L` flag. The `DAGDriver` does an HTTP redirect, and the flag ensures that `cURL` follows the redirect:
+
+```
+curl -L -X POST -H "Content-Type: application/json" -d '["ADD", 5]' localhost:8000/calculator
+```
+:::
+
 ### Check Status
 Check the status of the applications by running `serve status`.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `DAGDrvier` does an HTTP redirect when processing requests. If users query a `DAGDriver` endpoint with `curl`, the request won't return anything unless they include the `-L` flag, which makes `curl` follow redirects.

This change adds a note about this.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #36773.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
