### PR TITLE
[Data] Fix AutoscalingRequester leak

### DIFF
--- a/python/ray/data/_internal/execution/autoscaling_requester.py
+++ b/python/ray/data/_internal/execution/autoscaling_requester.py
@@ -1,4 +1,5 @@
 import math
+import threading
 import time
 from typing import Dict, List
 
@@ -9,6 +10,7 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 # Resource requests are considered stale after this number of seconds, and
 # will be purged.
 RESOURCE_REQUEST_TIMEOUT = 60
+PURGE_INTERVAL = RESOURCE_REQUEST_TIMEOUT * 2
 
 # When the autoscaling is driven by memory pressure and there are abundant
 # CPUs to support incremental CPUs needed to launch more tasks, we'll translate
@@ -32,6 +34,22 @@ class AutoscalingRequester:
         self._resource_requests = {}
         # TTL for requests.
         self._timeout = RESOURCE_REQUEST_TIMEOUT
+
+        self._self_handle = ray.get_runtime_context().current_actor
+        # # Start a thread to purge expired requests periodically.
+        def purge_thread_run():
+            while True:
+                time.sleep(PURGE_INTERVAL)
+                # Call purge_expired_requests() as an actor task,
+                # so we don't need to handle multi-threading.
+                self._self_handle.purge_expired_requests.remote()
+
+        self._purge_thread = threading.Thread(target=purge_thread_run, daemon=True)
+        self._purge_thread.start()
+
+    def purge_expired_requests(self):
+        self._purge()
+        ray.autoscaler.sdk.request_resources(bundles=self._aggregate_requests())
 
     def request_resources(self, req: List[Dict], execution_id: str):
         # Purge expired requests before making request to autoscaler.

--- a/python/ray/data/_internal/execution/autoscaling_requester.py
+++ b/python/ray/data/_internal/execution/autoscaling_requester.py
@@ -42,7 +42,7 @@ class AutoscalingRequester:
                 time.sleep(PURGE_INTERVAL)
                 # Call purge_expired_requests() as an actor task,
                 # so we don't need to handle multi-threading.
-                self._self_handle.purge_expired_requests.remote()
+                ray.get(self._self_handle.purge_expired_requests.remote())
 
         self._purge_thread = threading.Thread(target=purge_thread_run, daemon=True)
         self._purge_thread.start()

--- a/python/ray/data/_internal/execution/autoscaling_requester.py
+++ b/python/ray/data/_internal/execution/autoscaling_requester.py
@@ -37,7 +37,7 @@ class AutoscalingRequester:
 
         self._self_handle = ray.get_runtime_context().current_actor
 
-        # # Start a thread to purge expired requests periodically.
+        # Start a thread to purge expired requests periodically.
         def purge_thread_run():
             while True:
                 time.sleep(PURGE_INTERVAL)

--- a/python/ray/data/_internal/execution/autoscaling_requester.py
+++ b/python/ray/data/_internal/execution/autoscaling_requester.py
@@ -36,6 +36,7 @@ class AutoscalingRequester:
         self._timeout = RESOURCE_REQUEST_TIMEOUT
 
         self._self_handle = ray.get_runtime_context().current_actor
+
         # # Start a thread to purge expired requests periodically.
         def purge_thread_run():
             while True:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

AutoscalingRequester only purges expired requests when a new request comes. This makes the last request to be leaked. 
Add a thread that periodically purges expired requests.

## Related issue number

Closes #37014
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
