### PR TITLE
Pin pydantic to < 2.0.0

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -60,5 +60,5 @@ starlette
 typer
 fsspec
 pandas>=1.3
-pydantic
+pydantic<2
 py-spy>=0.2.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -250,7 +250,7 @@ if setup_spec.type == SetupType.RAY:
             "requests",
             "gpustat >= 1.0.0",  # for windows
             "opencensus",
-            "pydantic",
+            "pydantic < 2",  # 2.0.0 brings breaking changes
             "prometheus_client >= 0.7.1",
             "smart_open",
             "virtualenv >=20.0.24, < 20.21.1",  # For pip runtime env.


### PR DESCRIPTION
2.0.0 brings breaking changes

Cherry-pick of  #37000

Here's a failed CI run: https://buildkite.com/ray-project/oss-ci-build-pr/builds/27338#01890d26-94ff-42f2-80be-c2ac0a86e8d3/447-762

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
