### PR TITLE
[Core]Fix internal_kv del api bug in ray client server proxy mode

### DIFF
--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -911,6 +911,17 @@ def test_get_runtime_context_gcs_client(call_ray_start_shared):
         assert context.gcs_address, "gcs_address not set"
 
 
+def test_internal_kv_in_proxy_mode(call_ray_start_shared):
+    import ray
+
+    ray.init(SHARED_CLIENT_SERVER_ADDRESS)
+    client_api = ray.util.client.ray
+    client_api._internal_kv_put(b"key", b"val")
+    assert client_api._internal_kv_get(b"key") == b"val"
+    assert client_api._internal_kv_del(b"key") == 1
+    assert client_api._internal_kv_get(b"key") is None
+
+
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -483,7 +483,7 @@ class RayletServicerProxy(ray_client_pb2_grpc.RayletDriverServicer):
         Otherwise, we proxy the call to the downstream server as usual.
         """
         if self._has_channel_for_request(context):
-            return self._call_inner_function(request, context, "KVGet")
+            return self._call_inner_function(request, context, "KVDel")
 
         with disable_client_hook():
             ray.experimental.internal_kv._internal_kv_del(request.key)


### PR DESCRIPTION
## Why are these changes needed?
Calling ray.util.client.ray._internal_kv_del won't work, it always return "0" (delete 0 number of data).
And after that, calling _internal_kv_get can still get that data.

Reproduction script
```
ray start --head
Say the client-server listened at "1.2.3.4:10001"
```
```
import ray

address = "ray://1.2.3.4:10001"
ray.init(address=address)

client_api = ray.util.client.ray

res = client_api._internal_kv_put(b"key2", b"val")
print(f"====== put result: {res} ======")  # 'False'

res = client_api._internal_kv_get(b"key2")
print(f"====== get result: {res} ======")  # 'val'

res = client_api._internal_kv_del(b"key2")
print(f"====== del result: {res} ======")  # 0, should be 1

res = client_api._internal_kv_get(b"key2")
print(f"====== get result: {res} ======")  # 'val', should be 'None
```

## Related issue number

Closes #36945

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
