### PR TITLE
[serve] Enable passing starlette requests w/ a warning

### DIFF
--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -93,10 +93,15 @@ class Query:
                 replacement_table = dict(zip(tasks, resolved))
                 self.args, self.kwargs = scanner.replace_nodes(replacement_table)
         finally:
-            # Make the scanner GCable to avoid memory leak
+            # Make the scanner GC-able to avoid memory leaks.
             scanner.clear()
 
     async def buffer_starlette_requests_and_warn(self):
+        """Buffer any `starlette.request.Requests` objects to make them serializable.
+
+        This is an anti-pattern because the requests will not be fully functional, so
+        warn the user. We may fully disallow it in the future.
+        """
         global WARNED_ABOUT_STARLETTE_REQUESTS_ONCE
         scanner = _PyObjScanner(source_type=Request)
 
@@ -120,7 +125,7 @@ class Query:
                 request._send = empty_send
                 request._receive = make_buffered_asgi_receive(await request.body())
         finally:
-            # Make the scanner GCable to avoid memory leak
+            # Make the scanner GC-able to avoid memory leaks.
             scanner.clear()
 
 

--- a/python/ray/serve/http_adapters.py
+++ b/python/ray/serve/http_adapters.py
@@ -8,7 +8,6 @@ import starlette.requests
 
 from ray.util.annotations import PublicAPI
 from ray.serve._private.utils import require_packages
-from ray.serve._private.http_util import make_buffered_asgi_receive
 
 
 _1DArray = List[float]
@@ -63,16 +62,11 @@ def json_to_multi_ndarray(payload: Dict[str, NdArray]) -> Dict[str, np.ndarray]:
 
 
 @PublicAPI(stability="beta")
-async def starlette_request(
+def starlette_request(
     request: starlette.requests.Request,
 ) -> starlette.requests.Request:
     """Returns the raw request object."""
-    # NOTE(edoakes): the raw Request passed in may not be serializable so we
-    # need to convert it to a version that just wraps the body bytes.
-    return starlette.requests.Request(
-        request.scope,
-        make_buffered_asgi_receive(await request.body()),
-    )
+    return request
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -1,21 +1,24 @@
 import asyncio
 import os
-from typing import Optional
+from typing import Dict, Optional
 
 from fastapi import FastAPI
 import requests
 from pydantic import BaseModel, ValidationError
 import pytest
 import starlette.responses
+from starlette.requests import Request
 
 import ray
-from ray import serve
 from ray._private.test_utils import SignalActor, wait_for_condition
+
+from ray import serve
 from ray.serve.built_application import BuiltApplication
 from ray.serve.deployment import Application
 from ray.serve.deployment_graph import RayServeDAGHandle
 from ray.serve.drivers import DAGDriver
 from ray.serve.exceptions import RayServeException
+from ray.serve.handle import RayServeHandle
 from ray.serve._private.api import call_app_builder_with_args_if_necessary
 from ray.serve._private.constants import (
     SERVE_DEFAULT_APP_NAME,
@@ -845,6 +848,40 @@ def test_no_slash_route_prefix(serve_instance):
         ValueError, match=r"The route_prefix must start with a forward slash \('/'\)"
     ):
         serve.run(f.bind(), route_prefix="no_slash")
+
+
+def test_pass_starlette_request_over_handle(serve_instance):
+    @serve.deployment
+    class Downstream:
+        async def __call__(self, request: Request) -> Dict[str, str]:
+            r = await request.json()
+            r["foo"] = request.headers["foo"]
+            r.update(request.query_params)
+            return r
+
+    @serve.deployment
+    class Upstream:
+        def __init__(self, downstream: RayServeHandle):
+            self._downstream = downstream
+
+        async def __call__(self, request: Request) -> Dict[str, str]:
+            ref = await self._downstream.remote(request)
+            return await ref
+
+    serve.run(Upstream.bind(Downstream.bind()))
+
+    r = requests.get(
+        "http://127.0.0.1:8000/",
+        json={"hello": "world"},
+        headers={"foo": "bar"},
+        params={"baz": "quux"},
+    )
+    r.raise_for_status()
+    assert r.json() == {
+        "hello": "world",
+        "foo": "bar",
+        "baz": "quux",
+    }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In the new streaming codepath, the `starlette.requests.Request` object is no longer serializable so it cannot be passed directly via `ServeHandle`.

This is an anti-pattern because the request may not be fully functioning (e.g., detecting disconnects won't work). However, some existing code may rely on it, so in this change we add support by buffering the requests but print a warning message to discourage usage.

## Related issue number

https://github.com/ray-project/ray/issues/37027

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
