### PR TITLE
[ci/linkcheck] Fix broken link to old Ray Tune execution engine

### DIFF
--- a/doc/source/tune/tutorials/tune-lifecycle.rst
+++ b/doc/source/tune/tutorials/tune-lifecycle.rst
@@ -36,8 +36,7 @@ while Ray Tune trainable "actors" run on any node (either on the same node or on
     This actor can then asynchronously execute method calls and maintain its own internal state.
 
 The driver spawns parallel worker processes (:ref:`Ray actors <actor-guide>`)
-that are responsible for evaluating each trial using its hyperparameter configuration and the provided trainable
-(see the `ray trial executor source code <https://github.com/ray-project/ray/blob/master/python/ray/tune/ray_trial_executor.py>`__).
+that are responsible for evaluating each trial using its hyperparameter configuration and the provided trainable.
 
 While the Trainable is executing (:ref:`trainable-execution`), the Tune Driver communicates with each actor
 via actor methods to receive intermediate training results and pause/stop actors (see :ref:`trial-lifecycle`).


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
