### PR TITLE
[DATA] Enable `RAY_DATA_ENABLE_TENSOR_EXTENSION_CASTING` environment variable

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -101,7 +101,9 @@ DEFAULT_DECODING_SIZE_ESTIMATION_ENABLED = True
 
 # Whether to automatically cast NumPy ndarray columns in Pandas DataFrames to tensor
 # extension columns.
-DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING = True
+DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING = bool(
+    int(os.environ.get("RAY_DATA_DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING", "1"))
+)
 
 # Whether to automatically print Dataset stats after execution.
 # If disabled, users can still manually print stats with Dataset.stats().

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -102,7 +102,7 @@ DEFAULT_DECODING_SIZE_ESTIMATION_ENABLED = True
 # Whether to automatically cast NumPy ndarray columns in Pandas DataFrames to tensor
 # extension columns.
 DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING = bool(
-    int(os.environ.get("RAY_DATA_DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING", "1"))
+    int(os.environ.get("RAY_DATA_ENABLE_TENSOR_EXTENSION_CASTING", "1"))
 )
 
 # Whether to automatically print Dataset stats after execution.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Casting ndarray columns to tensor extension columns cannot be set via an os environment variable

## Related issue number

See https://github.com/aws/aws-sdk-pandas/issues/2358

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
