### PR TITLE
[jobs] Fix `test_backwards_compatibility.py` by pinning `pydantic<2`

### DIFF
--- a/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
+++ b/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
@@ -34,8 +34,7 @@ do
     conda create -y -n "${env_name}" python="${PYTHON_VERSION}"
     conda activate "${env_name}"
 
-    pip install -U ray=="${RAY_VERSION}"
-    pip install -U ray[default]=="${RAY_VERSION}"
+    pip install -U "pydantic<2" ray=="${RAY_VERSION}" ray[default]=="${RAY_VERSION}"
 
     printf "\n\n\n"
     echo "========================================================="

--- a/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
+++ b/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
@@ -34,6 +34,7 @@ do
     conda create -y -n "${env_name}" python="${PYTHON_VERSION}"
     conda activate "${env_name}"
 
+    # Pin pydantic version due to: https://github.com/ray-project/ray/issues/36990.
     pip install -U "pydantic<2" ray=="${RAY_VERSION}" ray[default]=="${RAY_VERSION}"
 
     printf "\n\n\n"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This appears to be the same issue as https://github.com/ray-project/ray/issues/36990

Pinning the version in the install in `test_backwards_compatibility.sh`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
