### PR TITLE
[Serve] Fix flaky test_deployment_graph_autoscaling test

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -760,6 +760,8 @@ class RayServeReplica:
         # We set the del method to noop after successfully calling it so the
         # destructor is called only once.
         async with self.delete_lock:
+            del self.metrics_pusher
+
             if not hasattr(self, "callable"):
                 return
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -760,7 +760,7 @@ class RayServeReplica:
         # We set the del method to noop after successfully calling it so the
         # destructor is called only once.
         async with self.delete_lock:
-            del self.metrics_pusher
+            self.metrics_pusher = None
 
             if not hasattr(self, "callable"):
                 return


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test_deployment_graph_autoscaling` failed in the shutdown sequence for MetricsPusher. Delete metrics pusher explicitly when the replica is ready to be shutdown.

## Related issue number

Closes https://github.com/ray-project/ray/issues/37120

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
