### PR TITLE
[cherry-pick][core] Add metrics for object size distribution in object store (#37005)

### DIFF
--- a/src/ray/object_manager/plasma/stats_collector.cc
+++ b/src/ray/object_manager/plasma/stats_collector.cc
@@ -35,15 +35,23 @@ void ObjectStatsCollector::OnObjectCreated(const LocalObject &obj) {
   if (kSource == plasma::flatbuf::ObjectSource::CreatedByWorker) {
     num_objects_created_by_worker_++;
     num_bytes_created_by_worker_ += kObjectSize;
+    ray::stats::STATS_object_store_dist.Record(
+        kObjectSize, {{ray::stats::SourceKey, "CreatedByWorker"}});
   } else if (kSource == plasma::flatbuf::ObjectSource::RestoredFromStorage) {
     num_objects_restored_++;
     num_bytes_restored_ += kObjectSize;
+    ray::stats::STATS_object_store_dist.Record(
+        kObjectSize, {{ray::stats::SourceKey, "RestoredFromStorage"}});
   } else if (kSource == plasma::flatbuf::ObjectSource::ReceivedFromRemoteRaylet) {
     num_objects_received_++;
     num_bytes_received_ += kObjectSize;
+    ray::stats::STATS_object_store_dist.Record(
+        kObjectSize, {{ray::stats::SourceKey, "ReceivedFromRemoteRaylet"}});
   } else if (kSource == plasma::flatbuf::ObjectSource::ErrorStoredByRaylet) {
     num_objects_errored_++;
     num_bytes_errored_ += kObjectSize;
+    ray::stats::STATS_object_store_dist.Record(
+        kObjectSize, {{ray::stats::SourceKey, "ErrorStoredByRaylet"}});
   }
 
   RAY_CHECK(!obj.Sealed());

--- a/src/ray/stats/metric_defs.cc
+++ b/src/ray/stats/metric_defs.cc
@@ -98,6 +98,25 @@ DEFINE_stats(
     (),
     ray::stats::GAUGE);
 
+double operator""_MB(unsigned long long int x) {
+  return static_cast<double>(1024L * 1024L * x);
+}
+
+DEFINE_stats(object_store_dist,
+             "The distribution of object size in bytes",
+             ("Source"),
+             ({32_MB,
+               64_MB,
+               128_MB,
+               256_MB,
+               512_MB,
+               1024_MB,
+               2048_MB,
+               4096_MB,
+               8192_MB,
+               16384_MB}),
+             ray::stats::HISTOGRAM);
+
 /// Placement group metrics from the GCS.
 DEFINE_stats(placement_groups,
              "Number of placement groups broken down by state.",

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -108,6 +108,7 @@ DECLARE_stats(gcs_task_manager_task_events_reported);
 
 /// Object Store
 DECLARE_stats(object_store_memory);
+DECLARE_stats(object_store_dist);
 
 /// Placement Group
 DECLARE_stats(gcs_placement_group_creation_latency_ms);

--- a/src/ray/stats/tag_defs.cc
+++ b/src/ray/stats/tag_defs.cc
@@ -47,5 +47,7 @@ const TagKeyType NameKey = TagKeyType::Register("Name");
 const TagKeyType LocationKey = TagKeyType::Register("Location");
 
 const TagKeyType ObjectStateKey = TagKeyType::Register("ObjectState");
+
+const TagKeyType SourceKey = TagKeyType::Register("Source");
 }  // namespace stats
 }  // namespace ray

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -48,6 +48,8 @@ extern const TagKeyType SessionNameKey;
 
 extern const TagKeyType NameKey;
 
+extern const TagKeyType SourceKey;
+
 // Object store memory location tag constants
 extern const TagKeyType LocationKey;
 constexpr char kObjectLocMmapShm[] = "MMAP_SHM";


### PR DESCRIPTION
## Why are these changes needed?
This PR add the metrics for the object size distribution to help the user understand how the objects are used in the script.

## Related issue number
#36923

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
