### PR TITLE
[serve] Remove replicas from scheduling consideration upon `RayActorError`

### DIFF
--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -490,7 +490,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
             if t.exception() is not None:
                 msg = (
                     "Failed to fetch queue length for "
-                    f"replica {t.replica_id}: {t.exception()}"
+                    f"replica {t.replica_id}: '{t.exception()}'"
                 )
                 # If we get a RayActorError, it means the replica actor has died. This
                 # is not recoverable (the controller will start a new replica in its

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -145,8 +145,8 @@ class ReplicaWrapper(ABC):
         """Set of model IDs on this replica."""
         pass
 
-    async def get_queue_state(self) -> Tuple[str, int, bool]:
-        """Returns tuple of (replica_id, queue_len, accepted)."""
+    async def get_queue_state(self) -> Tuple[int, bool]:
+        """Returns tuple of (queue_len, accepted)."""
         pass
 
     def send_query(
@@ -174,13 +174,13 @@ class ActorReplicaWrapper:
     def multiplexed_model_ids(self) -> Set[str]:
         return self._multiplexed_model_ids
 
-    async def get_queue_state(self) -> Tuple[str, int, bool]:
+    async def get_queue_state(self) -> Tuple[int, bool]:
         # NOTE(edoakes): the `get_num_ongoing_requests` method name is shared by
         # the Python and Java replica implementations. If you change it, you need to
         # change both (or introduce a branch here).
         queue_len = await self._actor_handle.get_num_ongoing_requests.remote()
         accepted = queue_len < self._replica_info.max_concurrent_queries
-        return self.replica_id, queue_len, accepted
+        return queue_len, accepted
 
     def _send_query_java(self, query: Query) -> ray.ObjectRef:
         """Send the query to a Java replica.
@@ -470,7 +470,12 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
         Among replicas that respond within the deadline and accept the request (don't
         have full queues), the one with the lowest queue length is chosen.
         """
-        get_queue_state_tasks = [c.get_queue_state() for c in candidates]
+        get_queue_state_tasks = []
+        for c in candidates:
+            t = self._loop.create_task(c.get_queue_state())
+            t.replica_id = c.replica_id
+            get_queue_state_tasks.append(t)
+
         done, pending = await asyncio.wait(
             get_queue_state_tasks,
             timeout=self.queue_len_response_deadline_s,
@@ -481,15 +486,25 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
 
         chosen_replica_id = None
         lowest_queue_len = math.inf
-        for task in done:
-            if task.exception() is not None:
-                logger.warning(
-                    f"Failed to fetch queue length for replica: {task.exception()}"
+        for t in done:
+            if t.exception() is not None:
+                msg = (
+                    "Failed to fetch queue length for "
+                    f"replica {t.replica_id}: {t.exception()}"
                 )
+                # If we get a RayActorError, it means the replica actor has died. This
+                # is not recoverable (the controller will start a new replica in its
+                # place), so we should no longer consider it for requests.
+                if isinstance(t.exception(), RayActorError):
+                    self._replicas.pop(t.replica_id, None)
+                    self._replica_id_set.discard(t.replica_id)
+                    msg += " This replica will no longer be considered for requests."
+
+                logger.warning(msg)
             else:
-                replica_id, queue_len, accepted = task.result()
+                queue_len, accepted = t.result()
                 if accepted and queue_len < lowest_queue_len:
-                    chosen_replica_id = replica_id
+                    chosen_replica_id = t.replica_id
                     lowest_queue_len = queue_len
 
         if chosen_replica_id is None:

--- a/python/ray/serve/tests/test_replica_scheduler.py
+++ b/python/ray/serve/tests/test_replica_scheduler.py
@@ -471,7 +471,7 @@ async def test_replica_responds_after_being_removed(pow_2_scheduler, fake_query)
 @pytest.mark.asyncio
 async def test_replica_blacklisted_after_actor_error(pow_2_scheduler, fake_query):
     """
-    Verify that if a replica is removed from the set if it returns a RayActorError.
+    Verify that a replica is removed from the set if it returns a RayActorError.
     Subsequent requests should not be sent to it.
     """
     s = pow_2_scheduler

--- a/python/ray/serve/tests/test_replica_scheduler.py
+++ b/python/ray/serve/tests/test_replica_scheduler.py
@@ -509,8 +509,8 @@ async def test_replica_not_blacklisted_after_unexpected_error(
     pow_2_scheduler, fake_query
 ):
     """
-    Verify that if a replica is removed from the set if it returns a RayActorError.
-    Subsequent requests should not be sent to it.
+    Verify that if a replica is not removed from the set if it returns an unexpected
+    error. This should go through the normal backoff/retry logic.
     """
     s = pow_2_scheduler
     loop = get_or_create_event_loop()

--- a/python/ray/serve/tests/test_replica_scheduler.py
+++ b/python/ray/serve/tests/test_replica_scheduler.py
@@ -522,7 +522,7 @@ async def test_replica_not_blacklisted_after_unexpected_error(
     assert await s.choose_replica_for_query(fake_query) == r1
 
     # Set the replica to raise an unknown exception, it shouldn't be scheduled.
-    r1.set_queue_state_response(0, exception=RuntimeError())
+    r1.set_queue_state_response(0, exception=RuntimeError("oopsies"))
     task = loop.create_task(s.choose_replica_for_query(fake_query))
     done, _ = await asyncio.wait([task], timeout=0.1)
     assert len(done) == 0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If we receive a `RayActorError` from a replica, it's unrecoverable (the controller will start a new replica in its place).

This is an optimization to avoid attempting a dead replica repeatedly until the controller broadcasts an update removing the replica.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
