### PR TITLE
[core][autoscaler] Fix idle time duration when node resource is not updated periodically 

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
@@ -205,15 +205,16 @@ void GcsAutoscalerStateManager::GetNodeStates(
 
       // We approximate the idle duration by the time since the last idle report
       // plus the idle duration reported by the node:
-      //  idle_dur = <idle-dur-reported-by-raylet> + <time-since-last-reported-on-gcs>
+      //  idle_dur = <idle-dur-reported-by-raylet> + <time-since-gcs-gets-last-report>
       //
       // This is because with lightweight resource update, we don't keep reporting
       // the idle time duration when there's no resource change. We also don't want to
       // use raylet reported idle timestamp since there might be clock skew.
+      RAY_CHECK(node_resource_data.last_resource_update_time != absl::nullopt);
       node_state_proto->set_idle_duration_ms(
           node_resource_data.idle_resource_duration_ms +
-          absl::ToInt64Milliseconds(absl::Now() -
-                                    node_resource_data.last_resource_update_time));
+          absl::ToInt64Milliseconds(
+              absl::Now() - node_resource_data.last_resource_update_time.value()));
     } else {
       node_state_proto->set_status(rpc::autoscaler::NodeStatus::RUNNING);
     }

--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
@@ -199,11 +199,12 @@ void GcsAutoscalerStateManager::GetNodeStates(
     // THe node is alive. We need to check if the node is idle.
     auto const &node_resource_data = cluster_resource_manager_.GetNodeResources(
         scheduling::NodeID(node_state_proto->node_id()));
-    if (node_resource_data.idle_resource_duration_ms > 0) {
+    if (node_resource_data.idle_resource_timestamp_ms > 0) {
       // The node is idle.
       node_state_proto->set_status(rpc::autoscaler::NodeStatus::IDLE);
       node_state_proto->set_idle_duration_ms(
-          node_resource_data.idle_resource_duration_ms);
+          absl::ToUnixMillis(absl::Now()) -
+          node_resource_data.idle_resource_timestamp_ms);
     } else {
       node_state_proto->set_status(rpc::autoscaler::NodeStatus::RUNNING);
     }

--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -436,8 +436,11 @@ class NodeResources {
   // The key-value labels of this node.
   absl::flat_hash_map<std::string, std::string> labels;
 
-  // The idle timestamp of the node from resources.
-  int64_t idle_resource_timestamp_ms = 0;
+  // The idle duration of the node from resources reported by raylet.
+  int64_t idle_resource_duration_ms = 0;
+
+  // The timestamp of the last resource update if there was a resource report.
+  absl::optional<absl::Time> last_resource_update_time = absl::nullopt;
 
   /// Normal task resources could be uploaded by 1) Raylets' periodical reporters; 2)
   /// Rejected RequestWorkerLeaseReply. So we need the timestamps to decide whether an

--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -436,8 +436,8 @@ class NodeResources {
   // The key-value labels of this node.
   absl::flat_hash_map<std::string, std::string> labels;
 
-  // The idle duration of the node from resources.
-  int64_t idle_resource_duration_ms = 0;
+  // The idle timestamp of the node from resources.
+  int64_t idle_resource_timestamp_ms = 0;
 
   /// Normal task resources could be uploaded by 1) Raylets' periodical reporters; 2)
   /// Rejected RequestWorkerLeaseReply. So we need the timestamps to decide whether an

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -239,8 +239,6 @@ bool ClusterResourceManager::UpdateNodeAvailableResourcesIfExist(
     return false;
   }
 
-  node_resources->last_resource_update_time = absl::Now();
-
   if (!resource_data.resources_available_changed()) {
     return true;
   }
@@ -257,7 +255,10 @@ bool ClusterResourceManager::UpdateNodeAvailableResourcesIfExist(
   }
 
   // Update the idle timestamp for the node in terms of resources usage.
-  node_resources->idle_resource_duration_ms = resource_data.last_idle_duration_ms();
+  node_resources->idle_resource_duration_ms = resource_data.idle_duration_ms();
+
+  // Last update time to the local node resources view.
+  node_resources->last_resource_update_time = absl::Now();
   return true;
 }
 

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -167,8 +167,8 @@ std::string ClusterResourceManager::GetNodeResourceViewString(
   return node.GetLocalView().DictString();
 }
 
-const absl::flat_hash_map<scheduling::NodeID, Node>
-    &ClusterResourceManager::GetResourceView() const {
+const absl::flat_hash_map<scheduling::NodeID, Node> &
+ClusterResourceManager::GetResourceView() const {
   return nodes_;
 }
 
@@ -239,6 +239,8 @@ bool ClusterResourceManager::UpdateNodeAvailableResourcesIfExist(
     return false;
   }
 
+  node_resources->last_resource_update_time = absl::Now();
+
   if (!resource_data.resources_available_changed()) {
     return true;
   }
@@ -255,7 +257,7 @@ bool ClusterResourceManager::UpdateNodeAvailableResourcesIfExist(
   }
 
   // Update the idle timestamp for the node in terms of resources usage.
-  node_resources->idle_resource_timestamp_ms = resource_data.last_idle_timestamp_ms();
+  node_resources->idle_resource_duration_ms = resource_data.last_idle_duration_ms();
   return true;
 }
 

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -167,8 +167,8 @@ std::string ClusterResourceManager::GetNodeResourceViewString(
   return node.GetLocalView().DictString();
 }
 
-const absl::flat_hash_map<scheduling::NodeID, Node>
-    &ClusterResourceManager::GetResourceView() const {
+const absl::flat_hash_map<scheduling::NodeID, Node> &
+ClusterResourceManager::GetResourceView() const {
   return nodes_;
 }
 
@@ -254,7 +254,7 @@ bool ClusterResourceManager::UpdateNodeAvailableResourcesIfExist(
     node_resources->available.Set(resource_id, resources.Get(resource_id));
   }
 
-  // Update the idle timestamp for the node in terms of resources usage.
+  // Update the idle duration for the node in terms of resources usage.
   node_resources->idle_resource_duration_ms = resource_data.idle_duration_ms();
 
   // Last update time to the local node resources view.

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -254,8 +254,8 @@ bool ClusterResourceManager::UpdateNodeAvailableResourcesIfExist(
     node_resources->available.Set(resource_id, resources.Get(resource_id));
   }
 
-  // Update the idle duration for the node in terms of resources usage.
-  node_resources->idle_resource_duration_ms = resource_data.idle_duration_ms();
+  // Update the idle timestamp for the node in terms of resources usage.
+  node_resources->idle_resource_timestamp_ms = resource_data.last_idle_timestamp_ms();
   return true;
 }
 

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -167,8 +167,8 @@ std::string ClusterResourceManager::GetNodeResourceViewString(
   return node.GetLocalView().DictString();
 }
 
-const absl::flat_hash_map<scheduling::NodeID, Node> &
-ClusterResourceManager::GetResourceView() const {
+const absl::flat_hash_map<scheduling::NodeID, Node>
+    &ClusterResourceManager::GetResourceView() const {
   return nodes_;
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It was assumed resource update is broadcasted periodically (which isn't the case), so the idle time wasn't updated when the node keeps in the idle state. 

This PR makes the raylet sent the last idle time (if idle) to the GCS, and allows GCS to calculate the duration. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
