### PR TITLE
[CI] [Serve] [Docs] Update Gradio documentation links

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -241,6 +241,8 @@ linkcheck_ignore = [
     "https://dev.mysql.com/doc/connector-python/en/",
     # Returning 522s intermittently.
     "https://lczero.org/",
+    # Returns 429 errors in Linkcheck due to too many requests
+    "https://archive.is/2022.12.16-171259/https://www.businessinsider.com/openai-chatgpt-trained-on-anyscale-ray-generative-lifelike-ai-models-2022-12",
 ]
 
 # -- Options for HTML output ----------------------------------------------

--- a/doc/source/ray-overview/use-cases.rst
+++ b/doc/source/ray-overview/use-cases.rst
@@ -58,7 +58,7 @@ Learn more about how Ray scales LLMs and generative AI with the following resour
         :img-top: /images/ray_logo.png
         :class-img-top: pt-2 w-75 d-block mx-auto fixed-height-img
 
-        .. button-link:: https://archive.vn/2022.12.16-171259/https://www.businessinsider.com/openai-chatgpt-trained-on-anyscale-ray-generative-lifelike-ai-models-2022-12
+        .. button-link:: https://archive.is/2022.12.16-171259/https://www.businessinsider.com/openai-chatgpt-trained-on-anyscale-ray-generative-lifelike-ai-models-2022-12
 
             [Article] How OpenAI Uses Ray to Train Tools like ChatGPT
 

--- a/doc/source/serve/tutorials/gradio-dag-visualization.md
+++ b/doc/source/serve/tutorials/gradio-dag-visualization.md
@@ -123,7 +123,7 @@ Since the Gradio UI is set at deploy time, the type of Gradio component used to 
 
 Specify the return type annotation of each function or method in the deployment graph.
 :::{note}
-If no return type annotation is specified for a node, then the Gradio component for that node will default to a [Gradio Textbox](https://gradio.app/docs/#textbox).
+If no return type annotation is specified for a node, then the Gradio component for that node will default to a [Gradio Textbox](https://www.gradio.app/docs/textbox).
 :::
 
 The following table lists the supported data types and which Gradio component they're displayed on.
@@ -134,20 +134,20 @@ The following table lists the supported data types and which Gradio component th
 * - Data Type
   - Gradio component
 * - `int`, `float`
-  - [Numeric field](https://gradio.app/docs/#number)
+  - [Numeric field](https://www.gradio.app/docs/number)
 * - `str`
-  - [Textbox](https://gradio.app/docs/#textbox)
+  - [Textbox](https://www.gradio.app/docs/textbox)
 * - `bool`
-  - [Checkbox](https://gradio.app/docs/#checkbox)
+  - [Checkbox](https://www.gradio.app/docs/checkbox)
 * - `pd.Dataframe`
-  - [DataFrame](https://gradio.app/docs/#dataframe)
+  - [DataFrame](https://www.gradio.app/docs/dataframe)
 * - `list`, `dict`, `np.ndarray`
-  - [JSON field](https://gradio.app/docs/#json)
+  - [JSON field](https://www.gradio.app/docs/json)
 * - `PIL.Image`, `torch.Tensor`
-  - [Image](https://gradio.app/docs/#image)
+  - [Image](https://www.gradio.app/docs/image)
 :::
 
-For instance, the output of the following function node will be displayed through a [Gradio Checkbox](https://gradio.app/docs/#textbox).
+For instance, the output of the following function node will be displayed through a [Gradio Checkbox](https://www.gradio.app/docs/textbox).
 ```python
 @serve.deployment
 def is_valid(begin, end) -> bool:
@@ -171,15 +171,15 @@ The following table describes the supported input data types and which Gradio co
 * - Data Type
   - Gradio component
 * - `int`, `float`
-  - [Numeric field](https://gradio.app/docs/#number)
+  - [Numeric field](https://www.gradio.app/docs/number)
 * - `str`
-  - [Textbox](https://gradio.app/docs/#textbox)
+  - [Textbox](https://www.gradio.app/docs/textbox)
 * - `bool`
-  - [Checkbox](https://gradio.app/docs/#checkbox)
+  - [Checkbox](https://www.gradio.app/docs/checkbox)
 * - `pd.Dataframe`
-  - [DataFrame](https://gradio.app/docs/#dataframe)
+  - [DataFrame](https://www.gradio.app/docs/dataframe)
 * - `PIL.Image`, `torch.Tensor`
-  - [Image](https://gradio.app/docs/#image)
+  - [Image](https://www.gradio.app/docs/image)
 :::
 
 #### Single Input
@@ -194,7 +194,7 @@ with InputNode(input_type=ImageFile) as user_input:
 :::{note}
 Notice there is a single input, which is stored in `user_input` (an instance of `InputNode`). The data type of this single input must be one of the supported input data types.
 :::
-When initializating `InputNode()`, the data type can be specified by passing in a `type` variable to the parameter `input_type`. Here, the type is specified to be `ImageFile`, so the Gradio visualization will take in user input through an [Image component](https://gradio.app/docs/#image).
+When initializating `InputNode()`, the data type can be specified by passing in a `type` variable to the parameter `input_type`. Here, the type is specified to be `ImageFile`, so the Gradio visualization will take in user input through an [Image component](https://www.gradio.app/docs/image).
 ![single input example](https://raw.githubusercontent.com/ray-project/images/master/docs/serve/gradio_visualization/single_input.png)
 
 #### Multiple Inputs
@@ -211,6 +211,6 @@ with InputNode(input_type={0: int, 1: str, "id": str}) as user_input:
 Notice there are multiple inputs: `user_input[0]`, `user_input[1]`, and `user_input["id"]`. They are accessed by indexing into `user_input`. The data types for each of these inputs must be one of the supported input data types.
 :::
 
-When initializing `InputNode()`, these data types can be specified by passing in a dictionary that maps key to `type` (where key is integer or string) to the parameter `input_type`. Here, the input types are specified to be `int`, `str`, and `str`, so the Gradio visualization will take in the three inputs through one [Numeric Field](https://gradio.app/docs/#number) and two [Textboxes](https://gradio.app/docs/#textbox).
+When initializing `InputNode()`, these data types can be specified by passing in a dictionary that maps key to `type` (where key is integer or string) to the parameter `input_type`. Here, the input types are specified to be `int`, `str`, and `str`, so the Gradio visualization will take in the three inputs through one [Numeric Field](https://www.gradio.app/docs/number) and two [Textboxes](https://www.gradio.app/docs/textbox).
 
 ![multiple input example](https://raw.githubusercontent.com/ray-project/images/master/docs/serve/gradio_visualization/multiple_inputs.png)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The Serve docs on Gradio visualization link to the Gradio docs. The Gradio docs were updated recently, causing failures in Linkcheck:

<img width="1346" alt="Screen Shot 2023-07-05 at 6 26 57 PM" src="https://github.com/ray-project/ray/assets/92341594/620afad1-aa91-42a1-984e-cbcf3cdeba9e">

See [example traceback](https://buildkite.com/ray-project/oss-ci-build-pr/builds/27718#018928ab-a3b3-4b5d-a547-e9a4333049d2/1182-5708):

```console
BROKEN LINKS SUMMARY:
--
  |  
  | (serve/tutorials/gradio-dag-visualization: line    8) broken    https://gradio.app/docs/#checkbox - 404 Client Error: Not Found for url: https://www.gradio.app/docs/
  | (serve/tutorials/gradio-dag-visualization: line   10) broken    https://gradio.app/docs/#dataframe - 404 Client Error: Not Found for url: https://www.gradio.app/docs/
  | (serve/tutorials/gradio-dag-visualization: line   14) broken    https://gradio.app/docs/#image - 404 Client Error: Not Found for url: https://www.gradio.app/docs/
  | (serve/tutorials/gradio-dag-visualization: line   12) broken    https://gradio.app/docs/#json - 404 Client Error: Not Found for url: https://www.gradio.app/docs/
  | (serve/tutorials/gradio-dag-visualization: line    4) broken    https://gradio.app/docs/#number - 404 Client Error: Not Found for url: https://www.gradio.app/docs/
  | (serve/tutorials/gradio-dag-visualization: line    1) broken    https://gradio.app/docs/#textbox - 404 Client Error: Not Found for url: https://www.gradio.app/docs/
  | (ray-overview/use-cases: line   61) broken    https://archive.vn/2022.12.16-171259/https://www.businessinsider.com/openai-chatgpt-trained-on-anyscale-ray-generative-lifelike-ai-models-2022-12 - 429 Client Error: Too Many Requests for url: https://archive.vn/2022.12.16-171259/https://www.businessinsider.com/openai-chatgpt-trained-on-anyscale-ray-generative-lifelike-ai-models-2022-12
```

This change updates the Gradio links. It also makes the Linkcheck ignore the `archive.is` link since that link raises 429 errors in the Linkcheck.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change fixes the `Linkcheck` test.
