### PR TITLE
[RLlib] DreamerV3 hotfix (for 2.6 release).

### DIFF
--- a/rllib/core/learner/learner.py
+++ b/rllib/core/learner/learner.py
@@ -35,7 +35,6 @@ from ray.rllib.core.rl_module.rl_module import (
     SingleAgentRLModuleSpec,
 )
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, MultiAgentBatch
-from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import (
     OverrideToImplementCustomLogic,
     OverrideToImplementCustomLogic_CallToSuperRecommended,

--- a/rllib/core/learner/learner.py
+++ b/rllib/core/learner/learner.py
@@ -1351,9 +1351,6 @@ class Learner:
 
         for pid, policy_batch in batch.policy_batches.items():
             if self.module[pid].is_stateful():
-                assert (
-                    policy_batch.get(SampleBatch.SEQ_LENS, None) is not None
-                ), "Recurrent modules require a `seq_lens` tensor in the policy batch."
                 # We assume that arriving batches for recurrent modules are already
                 # padded to the max sequence length and have tensors of shape
                 # [B, T, ...]. Therefore, we slice sequence lengths in B. See


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

DreamerV3 hotfix (for 2.6 release).
- Removed assertion error. DreamerV3 does NOT need SEQ_LENS in train batch in order to work (even though it has a RNN-model).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
