### PR TITLE
[ci][release-test] always use machine type as docker image suffix

### DIFF
--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -41,12 +41,10 @@ def build_champagne_image(
     if image_type == "cpu":
         ray_project = "ray"
         anyscale_repo = DATAPLANE_ECR_REPO
-        image_suffix = ""
     else:
         ray_project = "ray-ml"
         anyscale_repo = DATAPLANE_ECR_ML_REPO
-        image_suffix = f"-{image_type}"
-    ray_image = f"rayproject/{ray_project}:{ray_version}-{python_version}{image_suffix}"
+    ray_image = f"rayproject/{ray_project}:{ray_version}-{python_version}-{image_type}"
     anyscale_image = (
         f"{get_global_config()['byod_ecr']}/{anyscale_repo}:champagne-{ray_version}"
     )

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -225,10 +225,8 @@ class Test(dict):
         if branch.startswith("releases/"):
             release_name = branch[len("releases/") :]
             ray_version = f"{release_name}.{ray_version}"
-        byod_type = self.get_byod_type()
-        image_suffix = f"-{byod_type}" if byod_type != "cpu" else ""
         python_version = f"py{self.get_python_version().replace('.',   '')}"
-        return f"{ray_version}-{python_version}{image_suffix}"
+        return f"{ray_version}-{python_version}-{self.get_byod_type()}"
 
     def get_byod_image_tag(self) -> str:
         """

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -66,7 +66,7 @@ def test_get_ray_image():
                 "cluster": {"byod": {}},
             }
         ).get_ray_image()
-        == "rayproject/ray:123456-py38"
+        == "rayproject/ray:123456-py38-cpu"
     )
     assert (
         _stub_test(
@@ -84,7 +84,7 @@ def test_get_ray_image():
     os.environ["BUILDKITE_BRANCH"] = "releases/1.0.0"
     assert (
         _stub_test({"cluster": {"byod": {}}}).get_ray_image()
-        == "rayproject/ray:1.0.0.123456-py37"
+        == "rayproject/ray:1.0.0.123456-py37-cpu"
     )
 
 
@@ -93,7 +93,7 @@ def test_get_anyscale_byod_image():
     os.environ["BUILDKITE_COMMIT"] = "1234567890"
     assert (
         _stub_test({"python": "3.7", "cluster": {"byod": {}}}).get_anyscale_byod_image()
-        == f"{get_global_config()['byod_ecr']}/{DATAPLANE_ECR_REPO}:123456-py37"
+        == f"{get_global_config()['byod_ecr']}/{DATAPLANE_ECR_REPO}:123456-py37-cpu"
     )
     assert _stub_test(
         {


### PR DESCRIPTION
For consistency, always append the machine type to the BYOD docker image used for release testing

Test strategies:
- Unit tests