### PR TITLE
[core][logging][ipython] Fix log buffering when consecutive runs with in ray log dedup window (#37134)

### DIFF
--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -91,6 +91,28 @@ def setup_component_logger(
     return logger
 
 
+def run_callback_on_events_in_ipython(event: str, cb: Callable):
+    """
+    Register a callback to be run after each cell completes in IPython.
+    E.g.:
+        This is used to flush the logs after each cell completes.
+
+    If IPython is not installed, this function does nothing.
+
+    Args:
+        cb: The callback to run.
+    """
+    try:
+        from IPython import get_ipython
+
+        ipython = get_ipython()
+        # Register a callback on cell completion.
+        if ipython is not None:
+            ipython.events.register(event, cb)
+    except ImportError:
+        pass
+
+
 """
 All components underneath here is used specifically for the default_worker.py.
 """
@@ -225,6 +247,8 @@ class LogDeduplicator:
         # This buffer is cleared if the pattern isn't seen within the window.
         self.recent: Dict[str, DedupState] = {}
         self.timesource = _timesource or (lambda: time.time())
+
+        run_callback_on_events_in_ipython("post_execute", self.flush)
 
     def deduplicate(self, batch: LogBatch) -> List[LogBatch]:
         """Rewrite a batch of lines to reduce duplicate log messages.


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes https://github.com/ray-project/ray/issues/34831

The issue is when tasks runs within the same job are executed and producing logs, log lines will be dedup for better observability. 

So ray might be buffering some lines, in case there are logs that could be dedup within the same `RAY_DEDUP_LOGS_AGG_WINDOW_S`. This will show up as logs line not available until future ray tasks runs since buffer is not flushed when there's no activity (no job done, no new task) 

This PR adds callbacks to the `post_execute` to flush the log lines in log monitor when execution in shell took place. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
