### PR TITLE
[core][autoscaler] Fix pg id serialization with hex rather than binary for cluster state reporting #37132

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
@@ -126,7 +126,8 @@ void GcsAutoscalerStateManager::GetPendingGangResourceRequests(
         << "Placement group load should only include pending/rescheduling PGs. ";
 
     const auto pg_constraint = GenPlacementConstraintForPlacementGroup(
-        pg_data.placement_group_id(), pg_data.strategy());
+        PlacementGroupID::FromBinary(pg_data.placement_group_id()).Hex(),
+        pg_data.strategy());
 
     // Copy the PG's bundles to the request.
     for (const auto &bundle : pg_data.bundles()) {
@@ -222,7 +223,7 @@ void GcsAutoscalerStateManager::GetNodeStates(
         NodeID::FromBinary(gcs_node_info.node_id()));
     for (const auto &[pg_id, _bundle_indices] : pgs_on_node) {
       node_state_proto->mutable_dynamic_labels()->insert(
-          {FormatPlacementGroupLabelName(pg_id.Binary()), ""});
+          {FormatPlacementGroupLabelName(pg_id.Hex()), ""});
     }
   };
 

--- a/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
@@ -281,31 +281,31 @@ TEST_F(GcsAutoscalerStateManagerTest, TestGenPlacementConstraintForPlacementGrou
   auto pg = PlacementGroupID::Of(JobID::FromInt(0));
   {
     auto strict_spread_constraint = GenPlacementConstraintForPlacementGroup(
-        pg.Binary(), rpc::PlacementStrategy::STRICT_SPREAD);
+        pg.Hex(), rpc::PlacementStrategy::STRICT_SPREAD);
     ASSERT_TRUE(strict_spread_constraint.has_value());
     ASSERT_TRUE(strict_spread_constraint->has_anti_affinity());
     ASSERT_EQ(strict_spread_constraint->anti_affinity().label_name(),
-              FormatPlacementGroupLabelName(pg.Binary()));
+              FormatPlacementGroupLabelName(pg.Hex()));
   }
 
   {
     auto strict_pack_constraint = GenPlacementConstraintForPlacementGroup(
-        pg.Binary(), rpc::PlacementStrategy::STRICT_PACK);
+        pg.Hex(), rpc::PlacementStrategy::STRICT_PACK);
     ASSERT_TRUE(strict_pack_constraint.has_value());
     ASSERT_TRUE(strict_pack_constraint->has_affinity());
     ASSERT_EQ(strict_pack_constraint->affinity().label_name(),
-              FormatPlacementGroupLabelName(pg.Binary()));
+              FormatPlacementGroupLabelName(pg.Hex()));
   }
 
   {
-    auto no_pg_constraint_for_pack = GenPlacementConstraintForPlacementGroup(
-        pg.Binary(), rpc::PlacementStrategy::PACK);
+    auto no_pg_constraint_for_pack =
+        GenPlacementConstraintForPlacementGroup(pg.Hex(), rpc::PlacementStrategy::PACK);
     ASSERT_FALSE(no_pg_constraint_for_pack.has_value());
   }
 
   {
-    auto no_pg_constraint_for_spread = GenPlacementConstraintForPlacementGroup(
-        pg.Binary(), rpc::PlacementStrategy::SPREAD);
+    auto no_pg_constraint_for_spread =
+        GenPlacementConstraintForPlacementGroup(pg.Hex(), rpc::PlacementStrategy::SPREAD);
     ASSERT_FALSE(no_pg_constraint_for_spread.has_value());
   }
 }
@@ -378,8 +378,8 @@ TEST_F(GcsAutoscalerStateManagerTest, TestNodeDynamicLabelsWithPG) {
     const auto &state = GetClusterResourceStateSync();
     ASSERT_EQ(state.node_states_size(), 1);
     CheckNodeLabels(state.node_states(0),
-                    {{FormatPlacementGroupLabelName(pg1.Binary()), ""},
-                     {FormatPlacementGroupLabelName(pg2.Binary()), ""}});
+                    {{FormatPlacementGroupLabelName(pg1.Hex()), ""},
+                     {FormatPlacementGroupLabelName(pg2.Hex()), ""}});
   }
 }
 
@@ -450,7 +450,7 @@ TEST_F(GcsAutoscalerStateManagerTest, TestGangResourceRequestsBasic) {
     auto state = GetClusterResourceStateSync();
     CheckGangResourceRequests(state,
                               {{GenPlacementConstraintForPlacementGroup(
-                                    pg.Binary(), rpc::PlacementStrategy::STRICT_SPREAD)
+                                    pg.Hex(), rpc::PlacementStrategy::STRICT_SPREAD)
                                     ->DebugString(),
                                 {{{"CPU", 1}}, {{"GPU", 1}}}}});
   }
@@ -469,7 +469,7 @@ TEST_F(GcsAutoscalerStateManagerTest, TestGangResourceRequestsBasic) {
     auto state = GetClusterResourceStateSync();
     CheckGangResourceRequests(state,
                               {{GenPlacementConstraintForPlacementGroup(
-                                    pg.Binary(), rpc::PlacementStrategy::STRICT_PACK)
+                                    pg.Hex(), rpc::PlacementStrategy::STRICT_PACK)
                                     ->DebugString(),
                                 {{{"CPU", 1}}, {{"GPU", 1}}}}});
   }
@@ -534,7 +534,7 @@ TEST_F(GcsAutoscalerStateManagerTest, TestGangResourceRequestsPartialReschedulin
     // CPU_success_2 should not be reported as needed.
     CheckGangResourceRequests(state,
                               {{GenPlacementConstraintForPlacementGroup(
-                                    pg1.Binary(), rpc::PlacementStrategy::STRICT_SPREAD)
+                                    pg1.Hex(), rpc::PlacementStrategy::STRICT_SPREAD)
                                     ->DebugString(),
                                 {{{"CPU_failed_1", 1}}}}});
   }

--- a/src/ray/protobuf/experimental/autoscaler.proto
+++ b/src/ray/protobuf/experimental/autoscaler.proto
@@ -27,7 +27,7 @@ package ray.rpc.autoscaler;
 // value.
 //
 // This is now used to implement placement group anti-affinity, i.e.
-// strict-spread. The label_name is "_PG_<pg_id>",
+// strict-spread. The label_name is "_PG_<pg_id_in_hex>",
 // and the label_value is empty string.
 message AntiAffinityConstraint {
   string label_name = 1;
@@ -38,7 +38,7 @@ message AntiAffinityConstraint {
 // should be allocated to node with the same label name and value.
 //
 // This is now used to implement placement group affinity, i.e.
-// strict-pack. The label_name is "_PG_<pg_id>",
+// strict-pack. The label_name is "_PG_<pg_id_in_hex>",
 // and the label_value is empty string.
 message AffinityConstraint {
   string label_name = 1;


### PR DESCRIPTION


### Why are these changes needed?
The labels are declared as strings, and PG will generate (anti)affinity labels. The current implementation geneates _PG_<binary_pg_id> as the label key. However, binary chars are not encodable in string.

This PR changes the pg generated dynamic labels to _PG_<hex_pg_id> which is more readable as well.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
