### PR TITLE
[air] Catch generic exceptions from `Syncer.wait`

### DIFF
--- a/python/ray/tune/execution/experiment_state.py
+++ b/python/ray/tune/execution/experiment_state.py
@@ -11,7 +11,6 @@ import warnings
 from ray.air._internal.remote_storage import list_at_uri
 from ray.air._internal.uri_utils import _join_path_or_uri
 
-from ray.tune import TuneError
 from ray.tune.experiment import Trial
 from ray.tune.impl.out_of_band_serialize_dataset import out_of_band_serialize_dataset
 from ray.tune.syncer import SyncConfig, get_node_to_storage_syncer

--- a/python/ray/tune/tests/test_trial_runner_3.py
+++ b/python/ray/tune/tests/test_trial_runner_3.py
@@ -1120,10 +1120,7 @@ class TrialRunnerTest3(unittest.TestCase):
             # The second checkpoint will log a warning about the previous sync
             # timing out. Then, it will launch a new sync process in the background.
             runner.checkpoint(force=True)
-        assert any(
-            "sync of the experiment checkpoint to the cloud timed out" in x
-            for x in buffer
-        )
+        assert any("timed out" in x for x in buffer)
         assert syncer.sync_up_counter == 2
 
     def testPeriodicCloudCheckpointSyncTimeout(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
https://github.com/ray-project/ray/pull/36993 changed `Syncer.wait` to raise the syncing error rather than wrap in a `TuneError` in all cases except for a `TimeoutError`. This was changed due to the `TuneError` being unnecessary and causing the error logging to be confusing.

However, we do catch a `TuneError` specifically in many parts of the code that call `Syncer.wait`, so these cases now hard fail rather than soft failing with a warning log. This PR also fixes experiment syncing up and down to handle syncing errors in a standard way.

Here's the current handling of syncing errors to cloud:
1. Driver background syncing to and from cloud: Soft fail on `TimeoutError` --> Soft fail on general exceptions (this is the change from the PR)
2. Trainable checkpoint/artifact syncing: Soft fail on all syncing errors after retrying 2 times. (no change)

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/37170

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
