### PR TITLE
[Doc] Refactor example gallery to remove temporary flash

### DIFF
--- a/doc/source/_static/css/examples.css
+++ b/doc/source/_static/css/examples.css
@@ -22,6 +22,14 @@
   text-transform: uppercase;
 }
 
+/* Hide the default sidebar content */
+#site-navigation > div.bd-sidebar__content {
+  display: none;
+}
+#site-navigation > div.rtd-footer-container {
+  display: none;
+}
+
 .searchDiv {
   margin-bottom: 2em;
 }
@@ -160,7 +168,7 @@ div.sd-card-body > p.sd-card-text > a > span {
   justify-content: center;
 }
 
-#noMatches.hidden,.gallery-item.hidden,.footer-article.hidden,div.header-article.row.sticky-top.noprint {
+#noMatches.hidden,.gallery-item.hidden {
   display: none !important;
 }
 
@@ -196,4 +204,14 @@ button.try-anyscale > span {
 
 .top-nav-content {
   justify-content: initial;
+}
+
+/* Hide nav bar that has github, fullscreen, and print icons */
+div.header-article.row.sticky-top.noprint {
+  display: none !important;
+}
+
+/* Hide the footer with 'prev article' and 'next article' buttons */
+.footer-article.hidden {
+  display: none !important;
 }

--- a/doc/source/_static/js/tags.js
+++ b/doc/source/_static/js/tags.js
@@ -245,16 +245,6 @@ window.addEventListener('load', () => {
 
     const isGallery = window.location.href.endsWith("ray-overview/examples.html")
     if (isGallery) {
-        // Hide the nav bar that has sandwich, fullscreen, github, and download buttons.
-        document.querySelector("div.header-article.row.sticky-top.noprint").classList.add("hidden");
-
-        let navBar = document.getElementById("site-navigation");
-
-        // Recursively remove all children of the navbar.
-        while (navBar.firstChild) {
-          navBar.firstChild.remove();
-        }
-
         const tags = {
           useCaseTags: [
             {
@@ -366,16 +356,9 @@ window.addEventListener('load', () => {
         const tempDiv = document.createElement('div');
         tempDiv.innerHTML = tagString;
         const newNav = tempDiv.firstChild;
-        navBar.appendChild(newNav);
 
-        // Hide "previous" and "next" footer on the gallery page
-        document.querySelector("footer.footer-article.noprint").classList.add("hidden");
-
-        // Apply custom css rules for
-        document.getElementsByTagName('head')[0].insertAdjacentHTML(
-          'beforeend',
-          '<link rel="stylesheet" href="../_static/css/examples.css" />'
-        );
+        // Populate the sidebar with buttons that filter for different example tags
+        document.getElementById("site-navigation").appendChild(newNav);
 
         document.querySelectorAll('.tag').forEach(tag => {
             tag.addEventListener('click', generateTagClickHandler(tag, tags));

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import json
+from datetime import datetime
 from pathlib import Path
 from importlib import import_module
 import os
@@ -7,8 +7,13 @@ import sys
 from jinja2.filters import FILTERS
 
 sys.path.insert(0, os.path.abspath("."))
-from custom_directives import *
-from datetime import datetime
+from custom_directives import (
+    DownloadAndPreprocessEcosystemDocs,
+    mock_modules,
+    update_context,
+    LinkcheckSummarizer,
+    build_gallery,
+)
 
 
 # Mocking modules allows Sphinx to work without installing Ray.

--- a/doc/source/ray-overview/examples.rst
+++ b/doc/source/ray-overview/examples.rst
@@ -5,6 +5,8 @@ Ray Examples
 
 .. raw:: html
 
+    <link rel="stylesheet" type="text/css" href="../_static/css/examples.css">
+
     <div>
        <div class="searchDiv">
           <input type="text" id="searchInput" class="searchTerm"


### PR DESCRIPTION
## Why are these changes needed?

This PR reworks the docs example gallery to fix an annoying transient state that pops up when the example gallery first loads, before the js that overrides a bunch of default sphinx styles is executed and replaces the content.

This is achieved by directly inserting a link to a stylesheet into the example gallery file instead of loading it via js. This applies styles on first page load rather than whenever js gets around to executing. Other minor changes:

* Removed a bit of the script that runs on the example gallery that removes content from the site navigation bar on the left of the page. It's unnecessary to modify the DOM; we can just hide these nodes with css, and should speed up rendering.
* Removed a wildcard import in `conf.py`; linters don't like these and it's less clear than explicit imports.

## Related issue number

Closes https://github.com/ray-project/ray/issues/37216.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
