### PR TITLE
Fix _ReduceStageIterator IndexError.

### DIFF
--- a/python/ray/data/_internal/push_based_shuffle.py
+++ b/python/ray/data/_internal/push_based_shuffle.py
@@ -40,7 +40,7 @@ class _MergeTaskSchedule:
         return partition_size
 
     def get_merge_idx_for_reducer_idx(self, reducer_idx: int) -> int:
-        if reducer_idx < self.merge_partition_size * self._partitions_with_extra_task:
+        if reducer_idx < (self.merge_partition_size + 1) * self._partitions_with_extra_task:
             merge_idx = reducer_idx // (self.merge_partition_size + 1)
         else:
             reducer_idx -= (


### PR DESCRIPTION
## Why are these changes needed?

_ReduceStageIterator throws IndexError in our production env, there is a code logic error here  _MergeTaskSchedule#get_merge_idx_for_reducer_idx.


## Related issue number

#37222

## Checks

Existing UTs.
