### PR TITLE
Fix worker setup hook docs

### DIFF
--- a/doc/source/ray-observability/user-guides/configure-logging.md
+++ b/doc/source/ray-observability/user-guides/configure-logging.md
@@ -216,7 +216,7 @@ This is an experimental feature. It doesn't support [Ray Client](ray-client-ref)
 
 Set up the Python logger for driver and worker processes separately:
 1. Set up the logger for the driver process after importing `ray`.
-2. Use `worker_process_setup_hook` to configure the Python logger for all worker processes.
+2. Use `worker_setup_hook` to configure the Python logger for all worker processes.
 
 ![Set up python loggers](../images/setup-logger-application.png)
 
@@ -387,7 +387,7 @@ ray.get(f.remote("A log message for a task."))
 This is an experimental feature. It doesn't support [Ray Client](ray-client-ref) yet.
 ```
 
-Use `worker_process_setup_hook` to apply the new logging configuration to all worker processes within a job.
+Use `worker_setup_hook` to apply the new logging configuration to all worker processes within a job.
 ```python
 # driver.py
 def logging_setup_func():
@@ -395,7 +395,7 @@ def logging_setup_func():
     logger.setLevel(logging.DEBUG)
     warnings.simplefilter("always")
 
-ray.init(runtime_env={"worker_process_setup_hook": logging_setup_func})
+ray.init(runtime_env={"worker_setup_hook": logging_setup_func})
 
 logging_setup_func()
 ```


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The documentation for the `worker_setup_hook` runtime env option is incorrect and following the code in the docs results in an error.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

no issue
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X] This PR is not tested :(
