### PR TITLE
[RLlib] Bug fix: `TorchBinaryAutoregressiveDistribution.sampled_action_logp()` returns probs not log-probs.

### DIFF
--- a/rllib/examples/models/autoregressive_action_dist.py
+++ b/rllib/examples/models/autoregressive_action_dist.py
@@ -115,7 +115,7 @@ class TorchBinaryAutoregressiveDistribution(TorchDistributionWrapper):
         )
 
     def sampled_action_logp(self):
-        return torch.exp(self._action_logp)
+        return self._action_logp
 
     def entropy(self):
         a1_dist = self._a1_distribution()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Bug fix: `TorchBinaryAutoregressiveDistribution.sampled_action_logp()` returns probs not log-probs.

See tf-version for comparison (here it was correct):
https://github.com/ray-project/ray/blob/master/rllib/examples/models/autoregressive_action_dist.py#L48

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
