### PR TITLE
[serve] Enable returning a generator from top-level callable for `stream=True` calls

### DIFF
--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -11,7 +11,6 @@ from enum import Enum
 from functools import wraps
 from typing import (
     Any,
-    AsyncGenerator,
     Callable,
     Dict,
     Iterable,
@@ -724,24 +723,3 @@ def calculate_remaining_timeout(
 
     time_since_start_s = curr_time_s - start_time_s
     return max(0, timeout_s - time_since_start_s)
-
-
-def wrap_generator_function_in_async_if_needed(
-    f: Callable,
-) -> Callable[[Any], AsyncGenerator]:
-    """Given a callable, make sure it returns an async generator.
-
-    If the callable is not a generator at all, raise a `TypeError`.
-    """
-    if inspect.isasyncgenfunction(f):
-        return f
-    elif inspect.isgeneratorfunction(f):
-
-        @wraps(f)
-        async def async_gen_wrapper(*args, **kwargs):
-            for result in f(*args, **kwargs):
-                yield result
-
-        return async_gen_wrapper
-    else:
-        raise TypeError(f"Method '{f.__name__}' is not a generator.")

--- a/python/ray/serve/tests/test_handle_streaming.py
+++ b/python/ray/serve/tests/test_handle_streaming.py
@@ -1,4 +1,6 @@
+import re
 import sys
+from typing import AsyncGenerator, Generator
 
 import pytest
 
@@ -14,35 +16,45 @@ from ray.serve._private.constants import (
 
 @serve.deployment
 class AsyncStreamer:
-    async def __call__(self, n: int, should_error: bool = False):
+    async def __call__(
+        self, n: int, should_error: bool = False
+    ) -> AsyncGenerator[int, None]:
         if should_error:
             raise RuntimeError("oopsies")
 
         for i in range(n):
             yield i
 
-    async def other_method(self, n: int):
+    async def other_method(self, n: int) -> AsyncGenerator[int, None]:
         for i in range(n):
             yield i
 
-    async def unary(self, n: int):
+    async def call_inner_generator(self, n: int) -> AsyncGenerator[int, None]:
+        return self.other_method(n)
+
+    async def unary(self, n: int) -> int:
         return n
 
 
 @serve.deployment
 class SyncStreamer:
-    def __call__(self, n: int, should_error: bool = False):
+    def __call__(
+        self, n: int, should_error: bool = False
+    ) -> Generator[int, None, None]:
         if should_error:
             raise RuntimeError("oopsies")
 
         for i in range(n):
             yield i
 
-    def other_method(self, n: int):
+    def other_method(self, n: int) -> Generator[int, None, None]:
         for i in range(n):
             yield i
 
-    def unary(self, n: int):
+    def call_inner_generator(self, n: int) -> Generator[int, None, None]:
+        return self.other_method(n)
+
+    def unary(self, n: int) -> int:
         return n
 
 
@@ -66,6 +78,10 @@ class TestAppHandleStreaming:
         obj_ref_gen = ray.get(h.options(method_name="other_method").remote(5))
         assert ray.get(list(obj_ref_gen)) == list(range(5))
 
+        # Test calling a method that returns another generator.
+        obj_ref_gen = ray.get(h.call_inner_generator.remote(5))
+        assert ray.get(list(obj_ref_gen)) == list(range(5))
+
         # Test calling a unary method on the same deployment.
         assert ray.get(h.options(stream=False).unary.remote(5)) == 5
 
@@ -75,18 +91,29 @@ class TestAppHandleStreaming:
         with pytest.raises(
             TypeError,
             match=(
-                "Method '__call__' is a generator. You must use "
-                "`handle.options\(stream=True\)` to call generator "
-                "methods on a deployment."
+                "Method '__call__' is a generator function. You must use "
+                "`handle.options\(stream=True\)` to call generators on a deployment."
             ),
         ):
-            ray.get(h.remote())
+            ray.get(h.remote(5))
+
+        with pytest.raises(
+            TypeError,
+            match=(
+                "Method 'call_inner_generator' returned a generator. You must use "
+                "`handle.options\(stream=True\)` to call generators on a deployment."
+            ),
+        ):
+            ray.get(h.call_inner_generator.remote(5))
 
     def test_call_no_gen_with_stream_flag(self, serve_instance, deployment: Deployment):
         h = serve.run(deployment.bind()).options(stream=True)
 
         obj_ref_gen = ray.get(h.unary.remote(0))
-        with pytest.raises(TypeError, match="Method 'unary' is not a generator."):
+        with pytest.raises(
+            TypeError,
+            match=re.escape("must be a generator function, but 'unary' is not"),
+        ):
             ray.get(next(obj_ref_gen))
 
     def test_generator_yields_no_results(self, serve_instance, deployment: Deployment):
@@ -148,12 +175,22 @@ class TestDeploymentHandleStreaming:
                 with pytest.raises(
                     TypeError,
                     match=(
-                        "Method '__call__' is a generator. You must use "
-                        "`handle.options\(stream=True\)` to call generator "
-                        "methods on a deployment."
+                        "Method '__call__' is a generator function. You must use "
+                        "`handle.options\(stream=True\)` to call generators on a "
+                        "deployment."
                     ),
                 ):
-                    await (await self._h.remote())
+                    await (await self._h.remote(5))
+
+                with pytest.raises(
+                    TypeError,
+                    match=(
+                        "Method 'call_inner_generator' returned a generator. You must "
+                        "use `handle.options\(stream=True\)` to call generators on a "
+                        "deployment."
+                    ),
+                ):
+                    await (await h.call_inner_generator.remote(5))
 
         h = serve.run(Delegate.bind(deployment.bind()))
         ray.get(h.remote())

--- a/python/ray/serve/tests/test_handle_streaming.py
+++ b/python/ray/serve/tests/test_handle_streaming.py
@@ -1,4 +1,3 @@
-import re
 import sys
 from typing import AsyncGenerator, Generator
 
@@ -112,7 +111,7 @@ class TestAppHandleStreaming:
         obj_ref_gen = ray.get(h.unary.remote(0))
         with pytest.raises(
             TypeError,
-            match=re.escape("must be a generator function, but 'unary' is not"),
+            match="must be a generator function, but 'unary' is not",
         ):
             ray.get(next(obj_ref_gen))
 
@@ -190,7 +189,7 @@ class TestDeploymentHandleStreaming:
                         "deployment."
                     ),
                 ):
-                    await (await h.call_inner_generator.remote(5))
+                    await (await self._h.call_inner_generator.remote(5))
 
         h = serve.run(Delegate.bind(deployment.bind()))
         ray.get(h.remote())
@@ -206,7 +205,7 @@ class TestDeploymentHandleStreaming:
 
                 obj_ref_gen = await h.unary.remote(0)
                 with pytest.raises(
-                    TypeError, match="Method 'unary' is not a generator."
+                    TypeError, match="must be a generator function, but 'unary' is not"
                 ):
                     await (await obj_ref_gen.__anext__())
 

--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -23,7 +23,6 @@ from ray.serve._private.utils import (
     snake_to_camel_case,
     dict_keys_snake_to_camel_case,
     get_head_node_id,
-    wrap_generator_function_in_async_if_needed,
 )
 from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
 
@@ -617,41 +616,6 @@ def test_calculate_remaining_timeout():
         )
         == 0
     )
-
-
-@pytest.mark.asyncio
-async def test_wrap_generator_function_in_async_if_needed():
-    def regular_function():
-        return "hi"
-
-    with pytest.raises(TypeError):
-        wrap_generator_function_in_async_if_needed(regular_function)
-
-    def sync_gen():
-        for i in range(5):
-            yield i
-
-    wrapped = wrap_generator_function_in_async_if_needed(sync_gen)
-    assert wrapped.__name__ == sync_gen.__name__
-
-    nums = []
-    async for i in wrapped():
-        nums.append(i)
-
-    assert nums == list(range(5))
-
-    async def async_gen():
-        for i in range(5):
-            yield i
-
-    not_wrapped = wrap_generator_function_in_async_if_needed(async_gen)
-    assert not_wrapped == async_gen
-
-    nums = []
-    async for i in not_wrapped():
-        nums.append(i)
-
-    assert nums == list(range(5))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Modifies the check for generator vs. non-generator codepaths to support the pattern of returning a generator in the top-level callable (see issue linked below for example).

## Related issue number

Closes https://github.com/ray-project/ray/issues/37233

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
