### PR TITLE
[serve] Loosen `wait_for_condition` timeouts in an attempt to fix `test_controller_recovery` on windows

### DIFF
--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -291,12 +291,12 @@ def test_replica_deletion_after_controller_recover(serve_instance):
     wait_for_condition(lambda: len(check_replica(ReplicaState.STOPPING)) > 0)
 
     # The graceful shutdown timeout of 3 seconds should be used
-    wait_for_condition(lambda: len(check_replica()) == 0, timeout=5)
+    wait_for_condition(lambda: len(check_replica()) == 0, timeout=20)
     # Application should be removed soon after
     wait_for_condition(
         lambda: serve_instance.get_serve_status("app").app_status.status
         == ApplicationStatus.NOT_STARTED,
-        timeout=1,
+        timeout=20,
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Test is failing on the first `wait_for_condition`, and 5s is very tight when the expected time is 3s.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
