### PR TITLE
[dag] Fix the `workflow` doc code build

### DIFF
--- a/doc/source/workflows/basics.rst
+++ b/doc/source/workflows/basics.rst
@@ -336,8 +336,8 @@ node, not the output of `bar`:
     )
 
 
-Workflow introduces a utility function called ``workflow.continuation`` which
-enables Ray DAG nodes to return a DAG at runtime:
+To enable dynamically executing DAG nodes at runtime, workflows introduces a utility
+function called ``workflow.continuation``:
 
 .. testcode::
 

--- a/doc/source/workflows/basics.rst
+++ b/doc/source/workflows/basics.rst
@@ -308,8 +308,8 @@ Idempotent workflow:
 Dynamic workflows
 -----------------
 
-Ray DAGs are static -- returning a node from another node is not a valid way to
-construct a graph. For example, the following code will print an instance of a DAG
+Ray DAGs are static -- returning a node from another node isn't a valid way to
+construct a graph. For example, the following code prints a DAG
 node, not the output of `bar`:
 
 .. testcode::
@@ -320,7 +320,7 @@ node, not the output of `bar`:
 
     @ray.remote
     def foo():
-        # This will be evaluated at runtime, not in DAG construction.
+        # This is evaluated at runtime, not in DAG construction.
         return bar.bind()
 
     # Executing `foo` returns the `bar` DAG node, *not* its result.

--- a/doc/source/workflows/basics.rst
+++ b/doc/source/workflows/basics.rst
@@ -323,17 +323,12 @@ node, not the output of `bar`:
         # This will be evaluated at runtime, not in DAG construction.
         return bar.bind()
 
-    # This will print the `bar` DAG node, *not* its result.
+    # Executing `foo` returns the `bar` DAG node, *not* its result.
     print("Output of foo DAG:", type(ray.get(foo.bind().execute())))
 
 .. testoutput::
 
-    Output of foo DAG: (FunctionNode, 04ea82a452e945b0829de5fd86d4c5e8)(
-        body=<function bar at 0x108f291f0>
-        args=[]
-        kwargs={}options={}
-        other_args_to_resolve={}
-    )
+    Output of foo DAG: <class 'ray.dag.function_node.FunctionNode'>
 
 
 To enable dynamically executing DAG nodes at runtime, workflows introduces a utility


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously this code was relying on an implementation detail (DAG nodes not being serializable) to illustrate the point about static DAGs. Serializability was enabled in https://github.com/ray-project/ray/pull/37198.

I've updated the code sample to show that the DAG must be constructed statically and returning nodes from other nodes will be evaluated at runtime.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
