### PR TITLE
[serve] fix flaky http state test with fewer http proxies and longer timeout

### DIFF
--- a/python/ray/serve/tests/test_http_state.py
+++ b/python/ray/serve/tests/test_http_state.py
@@ -630,8 +630,10 @@ def test_unhealthy_retry_correct_number_of_times():
 
 
 @patch("ray.serve._private.http_state.PROXY_HEALTH_CHECK_PERIOD_S", 0.1)
-@pytest.mark.parametrize("number_of_worker_nodes", [1])
-def test_update_draining(mock_get_all_node_ids, all_nodes, setup_controller):
+@pytest.mark.parametrize("number_of_worker_nodes", [1, 2, 3])
+def test_update_draining(
+    mock_get_all_node_ids, all_nodes, setup_controller, number_of_worker_nodes
+):
     """Test update draining logics.
 
     When update nodes to inactive, head node http proxy should never be draining while
@@ -664,7 +666,8 @@ def test_update_draining(mock_get_all_node_ids, all_nodes, setup_controller):
         timeout=20,
         http_state=state,
         node_ids=node_ids,
-        statuses=[HTTPProxyStatus.HEALTHY, HTTPProxyStatus.DRAINING],
+        statuses=[HTTPProxyStatus.HEALTHY]
+        + [HTTPProxyStatus.DRAINING] * number_of_worker_nodes,
         active_nodes=active_nodes,
     )
 
@@ -678,7 +681,7 @@ def test_update_draining(mock_get_all_node_ids, all_nodes, setup_controller):
         timeout=20,
         http_state=state,
         node_ids=node_ids,
-        statuses=[HTTPProxyStatus.HEALTHY, HTTPProxyStatus.HEALTHY],
+        statuses=[HTTPProxyStatus.HEALTHY] * (number_of_worker_nodes + 1),
         active_nodes=active_nodes,
     )
 

--- a/python/ray/serve/tests/test_http_state.py
+++ b/python/ray/serve/tests/test_http_state.py
@@ -630,7 +630,7 @@ def test_unhealthy_retry_correct_number_of_times():
 
 
 @patch("ray.serve._private.http_state.PROXY_HEALTH_CHECK_PERIOD_S", 0.1)
-@pytest.mark.parametrize("number_of_worker_nodes", [1, 2, 3])
+@pytest.mark.parametrize("number_of_worker_nodes", [0, 1, 2, 3])
 def test_update_draining(
     mock_get_all_node_ids, all_nodes, setup_controller, number_of_worker_nodes
 ):

--- a/python/ray/serve/tests/test_http_state.py
+++ b/python/ray/serve/tests/test_http_state.py
@@ -34,9 +34,15 @@ def _make_http_state(
 
 
 @pytest.fixture
-def all_nodes() -> List[Tuple[str, str]]:
+def number_of_worker_nodes() -> int:
+    return 100
+
+
+@pytest.fixture
+def all_nodes(number_of_worker_nodes) -> List[Tuple[str, str]]:
     return [(HEAD_NODE_ID, "fake-head-ip")] + [
-        (f"worker-node-id-{i}", f"fake-worker-ip-{i}") for i in range(100)
+        (f"worker-node-id-{i}", f"fake-worker-ip-{i}")
+        for i in range(number_of_worker_nodes)
     ]
 
 
@@ -624,7 +630,8 @@ def test_unhealthy_retry_correct_number_of_times():
 
 
 @patch("ray.serve._private.http_state.PROXY_HEALTH_CHECK_PERIOD_S", 0.1)
-def test_update_draining(mock_get_all_node_ids, setup_controller, all_nodes):
+@pytest.mark.parametrize("number_of_worker_nodes", [1])
+def test_update_draining(mock_get_all_node_ids, all_nodes, setup_controller):
     """Test update draining logics.
 
     When update nodes to inactive, head node http proxy should never be draining while
@@ -632,7 +639,6 @@ def test_update_draining(mock_get_all_node_ids, setup_controller, all_nodes):
     node http proxy should continue to be healthy while worker node http proxy should
     be healthy.
     """
-    worker_node_id = all_nodes[1][0]
     state = _make_http_state(HTTPOptions(location=DeploymentMode.EveryNode))
 
     for node_id, node_ip_address in all_nodes:
@@ -646,6 +652,7 @@ def test_update_draining(mock_get_all_node_ids, setup_controller, all_nodes):
             controller_name=SERVE_CONTROLLER_NAME,
             node_ip_address=node_ip_address,
         )
+    node_ids = [node_id for node_id, _ in all_nodes]
 
     # No active nodes
     active_nodes = set()
@@ -654,23 +661,23 @@ def test_update_draining(mock_get_all_node_ids, setup_controller, all_nodes):
     # Worker node proxy should turn DRAINING.
     wait_for_condition(
         condition_predictor=_update_and_check_http_state,
-        timeout=15,
+        timeout=20,
         http_state=state,
-        node_ids=[HEAD_NODE_ID, worker_node_id],
+        node_ids=node_ids,
         statuses=[HTTPProxyStatus.HEALTHY, HTTPProxyStatus.DRAINING],
         active_nodes=active_nodes,
     )
 
     # All nodes are active
-    active_nodes = {node_id for node_id, _ in all_nodes}
+    active_nodes = set(node_ids)
 
     # Head node proxy should continue to be HEALTHY.
     # Worker node proxy should turn HEALTHY.
     wait_for_condition(
         condition_predictor=_update_and_check_http_state,
-        timeout=15,
+        timeout=20,
         http_state=state,
-        node_ids=[HEAD_NODE_ID, worker_node_id],
+        node_ids=node_ids,
         statuses=[HTTPProxyStatus.HEALTHY, HTTPProxyStatus.HEALTHY],
         active_nodes=active_nodes,
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Reduce the amount of http proxies that needs to update and increase the amount of timeout to help the test passing

## Related issue number

[<!-- For example: "Closes #1234" -->](https://buildkite.com/ray-project/oss-ci-build-branch/builds/4887#01893846-b13d-4386-b6a6-c51876c36659)

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
