### PR TITLE
Respects resource limits by default when reusing workers.

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -702,7 +702,7 @@ RAY_CONFIG(uint64_t, max_sync_message_batch_bytes, 1 * 1024 * 1024)
 
 // If enabled and worker stated in container, the container will add
 // resource limit.
-RAY_CONFIG(bool, worker_resource_limits_enabled, false)
+RAY_CONFIG(bool, worker_resource_limits_enabled, true)
 
 // When enabled, workers will not be re-used across tasks requesting different
 // resources (e.g., CPU vs GPU).


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When a new ray task has some resource requirements (e.g. `num_cpus=2`), one would expect the assigned worker holds that resource. However currently by default we ignore the requirements. So if there's an idle worker with 1 CPU, and we have a task with 2 CPU requirements, it's still reusing that smaller worker instead of creating a new one.

This may be useful in some case, but in general we want to satisfy the resource requirements. Hence we flip the default value.


## Related issue number

Closes #35937

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
