### PR TITLE
[deflakey] Fix the Redis failure detection and deflakey the test

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -822,7 +822,7 @@ print("DONE")
     gcs_server_pid = gcs_server_process.pid
     # GCS should exit in this case
     print(">>> Waiting gcs server to exit", gcs_server_pid)
-    wait_for_pid_to_exit(gcs_server_pid, 2000)
+    wait_for_pid_to_exit(gcs_server_pid, 10000)
 
 
 @pytest.mark.parametrize(

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -720,8 +720,18 @@ def test_redis_failureover(redis_replicas, ray_start_cluster_head_with_external_
 
     redis_addr = os.environ.get("RAY_REDIS_ADDRESS")
     ip, port = redis_addr.split(":")
-    cli = redis.Redis(ip, port)
-    nodes = cli.cluster("nodes")
+    redis_cli = redis.Redis(ip, port)
+
+    def get_connected_nodes():
+        return [
+            (k, v) for (k, v) in redis_cli.cluster("nodes").items() if v["connected"]
+        ]
+
+    wait_for_condition(
+        lambda: len(get_connected_nodes())
+        == int(os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS"))
+    )
+    nodes = redis_cli.cluster("nodes")
     leader_cli = None
     follower_cli = []
     for addr in nodes:
@@ -731,6 +741,7 @@ def test_redis_failureover(redis_replicas, ray_start_cluster_head_with_external_
         flags = meta["flags"].split(",")
         if "master" in flags:
             leader_cli = cli
+            print("LEADER", addr, redis_addr)
         else:
             follower_cli.append(cli)
 
@@ -769,6 +780,10 @@ def test_redis_failureover(redis_replicas, ray_start_cluster_head_with_external_
     print("GCS killed")
 
     follower_cli[0].cluster("failover", "takeover")
+    wait_for_condition(
+        lambda: len(get_connected_nodes())
+        == int(os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS")) - 1
+    )
 
     # Kill Counter actor. It should restart after GCS is back
     c_process.kill()
@@ -776,6 +791,7 @@ def test_redis_failureover(redis_replicas, ray_start_cluster_head_with_external_
     cluster.head_node.kill_gcs_server(False)
 
     print("Start gcs")
+    sleep(2)
     cluster.head_node.start_gcs_server()
 
     assert len(ray.nodes()) == 1
@@ -788,11 +804,15 @@ ray.init('{cluster.address}')
 def f():
     return 10
 assert ray.get(f.remote()) == 10
+
 c = ray.get_actor("c", namespace="test")
-assert ray.get(c.r.remote(10)) == 10
+v = ray.get(c.r.remote(10))
+assert v == 10
+print("DONE")
 """
+
     # Make sure the cluster is usable
-    run_string_as_driver(driver_script)
+    wait_for_condition(lambda: "DONE" in run_string_as_driver(driver_script))
 
     # Now make follower_cli[0] become replica
     # and promote follower_cli[1] as leader
@@ -802,7 +822,7 @@ assert ray.get(c.r.remote(10)) == 10
     gcs_server_pid = gcs_server_process.pid
     # GCS should exit in this case
     print(">>> Waiting gcs server to exit", gcs_server_pid)
-    wait_for_pid_to_exit(gcs_server_pid, 1000)
+    wait_for_pid_to_exit(gcs_server_pid, 2000)
 
 
 @pytest.mark.parametrize(

--- a/src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc
+++ b/src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc
@@ -43,13 +43,13 @@ void GcsRedisFailureDetector::Stop() {
 
 void GcsRedisFailureDetector::DetectRedis() {
   auto redis_callback = [this](const std::shared_ptr<CallbackReply> &reply) {
-    if (reply->IsError()) {
+    if (reply->IsNil()) {
       RAY_LOG(ERROR) << "Redis is inactive.";
       callback_();
     }
   };
   auto cxt = redis_client_->GetShardContext("");
-  cxt->RunArgvAsync({"GET", "HOLD"}, redis_callback);
+  cxt->RunArgvAsync({"PING"}, redis_callback);
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_redis_failure_detector.h
+++ b/src/ray/gcs/gcs_server/gcs_redis_failure_detector.h
@@ -18,7 +18,7 @@
 
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/asio/periodical_runner.h"
-#include "ray/gcs/redis_context.h"
+#include "ray/gcs/redis_client.h"
 
 namespace ray {
 
@@ -39,7 +39,7 @@ class GcsRedisFailureDetector {
   /// \param redis_context The redis context is used to ping redis.
   /// \param callback Callback that will be called when redis is detected as not alive.
   explicit GcsRedisFailureDetector(instrumented_io_context &io_service,
-                                   std::shared_ptr<RedisContext> redis_context,
+                                   std::shared_ptr<RedisClient> redis_client,
                                    std::function<void()> callback);
 
   /// Start detecting redis.
@@ -55,9 +55,7 @@ class GcsRedisFailureDetector {
  private:
   instrumented_io_context &io_service_;
 
-  /// A redis context is used to ping redis.
-  /// TODO(ffbin): We will use redis client later.
-  std::shared_ptr<RedisContext> redis_context_;
+  std::shared_ptr<RedisClient> redis_client_;
 
   /// The runner to run function periodically.
   std::unique_ptr<PeriodicalRunner> periodical_runner_;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -827,8 +827,8 @@ std::shared_ptr<RedisClient> GcsServer::GetOrConnectRedis() {
     RAY_CHECK(status.ok()) << "Failed to init redis gcs client as " << status;
 
     // Init redis failure detector.
-    gcs_redis_failure_detector_ = std::make_shared<GcsRedisFailureDetector>(
-        main_service_, redis_client_->GetPrimaryContext(), []() {
+    gcs_redis_failure_detector_ =
+        std::make_shared<GcsRedisFailureDetector>(main_service_, redis_client_, []() {
           RAY_LOG(FATAL) << "Redis connection failed. Shutdown GCS.";
         });
     gcs_redis_failure_detector_->Start();

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -210,6 +210,7 @@ void RedisRequestContext::Run() {
           auto end_time = absl::Now();
           ray::stats::GcsLatency().Record((end_time - request_cxt->start_time_) /
                                           absl::Milliseconds(1));
+          delete request_cxt;
         }
       };
 

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -202,13 +202,14 @@ void RedisRequestContext::Run() {
           auto reply = std::make_shared<CallbackReply>(redis_reply);
           request_cxt->io_service_.post(
               [reply, callback = std::move(request_cxt->callback_)]() {
-                callback(std::move(reply));
+                if (callback) {
+                  callback(std::move(reply));
+                }
               },
               "RedisRequestContext.Callback");
           auto end_time = absl::Now();
           ray::stats::GcsLatency().Record((end_time - request_cxt->start_time_) /
                                           absl::Milliseconds(1));
-          delete request_cxt;
         }
       };
 


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->

The test is flakey due to several reasons:

- The redis cluster is not ready
- The redis recover is not done
- GCS exit used more time

This PR fixed these issues. In the same time also fix a corner cases where the callback is none.

## Related issue number
Closes #36678 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
