### PR TITLE
[serve] Document that generators raise `asyncio.CancelledError` when the client disconnects

### DIFF
--- a/doc/source/serve/advanced-guides/dyn-req-batch.md
+++ b/doc/source/serve/advanced-guides/dyn-req-batch.md
@@ -51,10 +51,6 @@ Use these methods in the `reconfigure` [method](serve-user-config) to control th
 
 ## Streaming batched requests
 
-```{warning}
-Support for HTTP streaming responses is experimental. To enable this feature, set `RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING=1` on the cluster before starting Ray. If you encounter any issues, [file an issue on GitHub](https://github.com/ray-project/ray/issues/new/choose).
-```
-
 Use an async generator to stream the outputs from your batched requests. Let's convert the `StreamingResponder` class to accept a batch.
 
 ```{literalinclude} ../doc_code/batching_guide.py

--- a/doc/source/serve/doc_code/http_guide/streaming_example.py
+++ b/doc/source/serve/doc_code/http_guide/streaming_example.py
@@ -38,3 +38,45 @@ r = requests.get("http://localhost:8000?max=10", stream=True)
 r.raise_for_status()
 for i, chunk in enumerate(r.iter_content(chunk_size=None, decode_unicode=True)):
     assert chunk == str(i)
+
+
+# __begin_cancellation__
+import asyncio
+import time
+from typing import AsyncGenerator
+
+import requests
+from starlette.responses import StreamingResponse
+from starlette.requests import Request
+
+from ray import serve
+
+
+@serve.deployment
+class StreamingResponder:
+    async def generate_forever(self) -> AsyncGenerator[str, None]:
+        try:
+            i = 0
+            while True:
+                yield str(i)
+                i += 1
+                await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            print("Cancelled! Exiting.")
+
+    def __call__(self, request: Request) -> StreamingResponse:
+        gen = self.generate_forever()
+        return StreamingResponse(gen, status_code=200, media_type="text/plain")
+
+
+serve.run(StreamingResponder.bind())
+
+r = requests.get("http://localhost:8000?max=10", stream=True)
+start = time.time()
+r.raise_for_status()
+for i, chunk in enumerate(r.iter_content(chunk_size=None, decode_unicode=True)):
+    print(f"Got result {round(time.time()-start, 1)}s after start: '{chunk}'")
+    if i == 10:
+        print("Client disconnecting")
+        break
+# __end_cancellation__

--- a/doc/source/serve/http-guide.md
+++ b/doc/source/serve/http-guide.md
@@ -73,10 +73,6 @@ Existing middlewares, **automatic OpenAPI documentation generation**, and other 
 
 ### WebSockets
 
-```{warning}
-Support for WebSockets is experimental. To enable this feature, set `RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING=1` on the cluster before starting Ray. If you encounter any issues, [file an issue on GitHub](https://github.com/ray-project/ray/issues/new/choose).
-```
-
 Serve supports WebSockets via FastAPI:
 
 ```{literalinclude} doc_code/http_guide/websockets_example.py
@@ -98,10 +94,6 @@ Query the deployment using the `websockets` package (`pip install websockets`):
 (serve-http-streaming-response)=
 ## Streaming Responses
 
-```{warning}
-Support for HTTP streaming responses is experimental. To enable this feature, set `RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING=1` on the cluster before starting Ray. If you encounter any issues, [file an issue on GitHub](https://github.com/ray-project/ray/issues/new/choose).
-```
-
 Some applications must stream incremental results back to the caller.
 This is common for text generation using large language models (LLMs) or video processing applications.
 The full forward pass may take multiple seconds, so providing incremental results as they're available provides a much better user experience.
@@ -122,7 +114,7 @@ This code uses the `stream=True` option to the [requests](https://requests.readt
 Save this code in `stream.py` and run it:
 
 ```bash
-$ RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING=1 python stream.py
+$ python stream.py
 [2023-05-25 10:44:23]  INFO ray._private.worker::Started a local Ray instance. View the dashboard at http://127.0.0.1:8265
 (ServeController pid=40401) INFO 2023-05-25 10:44:25,296 controller 40401 deployment_state.py:1259 - Deploying new version of deployment default_StreamingResponder.
 (HTTPProxyActor pid=40403) INFO:     Started server process [40403]
@@ -138,6 +130,43 @@ Got result 0.7s after start: '7'
 Got result 0.8s after start: '8'
 Got result 0.9s after start: '9'
 (ServeReplica:default_StreamingResponder pid=41052) INFO 2023-05-25 10:49:52,230 default_StreamingResponder default_StreamingResponder#qlZFCa yomKnJifNJ / default replica.py:634 - __CALL__ OK 1017.6ms
+```
+
+### Handling client disconnects
+
+In some cases, you may want to cease processing a request when the client disconnects before the full stream has been returned.
+If you pass an async generator to `StreamingResponse`, it will be cancelled and raise an `asyncio.CancelledError` when the client disconnects.
+Note that you must `await` at some point in the generator for this to work, otherwise the full generator will run before the cancellation can occur.
+
+In the example below, the generator streams responses forever until the client disconnects, then it prints that it was cancelled and exits. Save this code in `stream.py` and run it:
+
+
+```{literalinclude} doc_code/http_guide/streaming_example.py
+:start-after: __begin_cancellation__
+:end-before: __end_cancellation__
+:language: python
+```
+
+```bash
+$ python stream.py
+[2023-07-10 16:08:41]  INFO ray._private.worker::Started a local Ray instance. View the dashboard at http://127.0.0.1:8265
+(ServeController pid=50801) INFO 2023-07-10 16:08:42,296 controller 40401 deployment_state.py:1259 - Deploying new version of deployment default_StreamingResponder.
+(HTTPProxyActor pid=50803) INFO:     Started server process [50803]
+(ServeController pid=50805) INFO 2023-07-10 16:08:42,963 controller 50805 deployment_state.py:1586 - Adding 1 replica to deployment default_StreamingResponder.
+Got result 0.0s after start: '0'
+Got result 0.1s after start: '1'
+Got result 0.2s after start: '2'
+Got result 0.3s after start: '3'
+Got result 0.4s after start: '4'
+Got result 0.5s after start: '5'
+Got result 0.6s after start: '6'
+Got result 0.7s after start: '7'
+Got result 0.8s after start: '8'
+Got result 0.9s after start: '9'
+Got result 1.0s after start: '10'
+Client disconnecting
+(ServeReplica:default_StreamingResponder pid=50842) Cancelled! Exiting.
+(ServeReplica:default_StreamingResponder pid=50842) INFO 2023-07-10 16:08:45,756 default_StreamingResponder default_StreamingResponder#cmpnmF ahteNDQSWx / default replica.py:691 - __CALL__ OK 1019.1ms
 ```
 
 (serve-http-adapters)=

--- a/doc/source/serve/http-guide.md
+++ b/doc/source/serve/http-guide.md
@@ -136,7 +136,7 @@ Got result 0.9s after start: '9'
 
 In some cases, you may want to cease processing a request when the client disconnects before the full stream has been returned.
 If you pass an async generator to `StreamingResponse`, it will be cancelled and raise an `asyncio.CancelledError` when the client disconnects.
-Note that you must `await` at some point in the generator for this to work, otherwise the full generator will run before the cancellation can occur.
+Note that you must `await` at some point in the generator for the cancellation to occur.
 
 In the example below, the generator streams responses forever until the client disconnects, then it prints that it was cancelled and exits. Save this code in `stream.py` and run it:
 

--- a/doc/source/serve/tutorials/streaming.md
+++ b/doc/source/serve/tutorials/streaming.md
@@ -2,10 +2,6 @@
 
 # Streaming Tutorial
 
-:::{warning}
-Support for streaming is experimental. To enable this feature, set `RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING=1` on the cluster before starting Ray. If you encounter any issues, [file an issue on GitHub](https://github.com/ray-project/ray/issues/new/choose).
-:::
-
 This guide walks you through deploying a chatbot that streams output back to the
 user. It shows:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Documents cancellation behavior for streaming responses.

As a fly-by I also removed the info about setting the streaming feature flag (it's on by default now).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
