### PR TITLE
[ci][configs] pass --global-config down to run_release_test.py

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -71,12 +71,16 @@ def get_step(
     ray_wheels: Optional[str] = None,
     env: Optional[Dict] = None,
     priority_val: int = 0,
+    global_config: Optional[str] = None,
 ):
     env = env or {}
 
     step = copy.deepcopy(DEFAULT_STEP_TEMPLATE)
 
     cmd = ["./release/run_release_test.sh", test["name"]]
+
+    if global_config:
+        cmd += ["--global-config", global_config]
 
     if report and not bool(int(os.environ.get("NO_REPORT_OVERRIDE", "0"))):
         cmd += ["--report"]

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -247,6 +247,7 @@ def main(
                 ray_wheels=this_ray_wheels_url,
                 env=env,
                 priority_val=priority.value,
+                global_config=global_config,
             )
 
             if no_concurrency_limit:


### PR DESCRIPTION
Pass --global-config downs from build_pipeline.by to run_release_test.py. This is required for the same config is used across release test jobs.

Test strategies:
- Release tests