### PR TITLE
[ci][release-tests] fix RAY_COMMIT_OF_WHEEL check

### DIFF
--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -38,8 +38,9 @@ export RAY_TEST_REPO RAY_TEST_BRANCH RELEASE_RESULTS_DIR BUILDKITE_MAX_RETRIES B
 if [ -n "${RAY_COMMIT_OF_WHEEL-}" ]; then 
   git config --global --add safe.directory /workdir
   HEAD_COMMIT=$(git rev-parse HEAD)
+  HEAD_BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo "The test repo has head commit of ${HEAD_COMMIT}"
-  if [ "${HEAD_COMMIT}" != "${RAY_COMMIT_OF_WHEEL}" ]; then
+  if [[ "${HEAD_COMMIT}" != "${RAY_COMMIT_OF_WHEEL}" && ("${HEAD_BRANCH}" == "master" || "${HEAD_BRANCH}" = "releases/*") ]]; then
     echo "The checked out test code doesn't match with the installed wheel. \
           This is likely due to a racing condition when a PR is landed between \
           a wheel is installed and test code is checked out."

--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -40,7 +40,7 @@ if [ -n "${RAY_COMMIT_OF_WHEEL-}" ]; then
   HEAD_COMMIT=$(git rev-parse HEAD)
   HEAD_BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo "The test repo has head commit of ${HEAD_COMMIT}"
-  if [[ "${HEAD_COMMIT}" != "${RAY_COMMIT_OF_WHEEL}" && ("${HEAD_BRANCH}" == "master" || "${HEAD_BRANCH}" = "releases/*") ]]; then
+  if [[ "${HEAD_COMMIT}" != "${RAY_COMMIT_OF_WHEEL}" && ("${HEAD_BRANCH}" == "master" || "${HEAD_BRANCH}" = releases/*) ]]; then
     echo "The checked out test code doesn't match with the installed wheel. \
           This is likely due to a racing condition when a PR is landed between \
           a wheel is installed and test code is checked out."


### PR DESCRIPTION
A recent change causes the release test infra to always synchronize the wheel commit and release test infra commit before running test. This breaks the workflow for PR testing where people intentionally want the wheel and release test infra commit to be different.

Explicitly check that the branch has to be master or a release branch before synchronize the commit of the wheel and release test infra.

Testing strategies:
- Release test