### PR TITLE
[core] Add template parameter for RPC auth in GCS

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -101,6 +101,7 @@ cc_library(
         "//src/ray/common:asio",
         "//src/ray/common:grpc_util",
         "//src/ray/common:id",
+        "//src/ray/common:ray_config",
         "//src/ray/common:status",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -537,16 +537,6 @@ def ray_start_cluster_head_with_env_vars(request, maybe_external_redis, monkeypa
 
 
 @pytest.fixture
-def ray_start_with_env_vars(request, maybe_external_redis, monkeypatch):
-    param = getattr(request, "param", {})
-    env_vars = param.pop("env_vars", {})
-    for k, v in env_vars.items():
-        monkeypatch.setenv(k, v)
-    with _ray_start(**param) as res:
-        yield res
-
-
-@pytest.fixture
 def ray_start_cluster_2_nodes(request, maybe_external_redis):
     param = getattr(request, "param", {})
     with _ray_start_cluster(do_init=True, num_nodes=2, **param) as res:

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -537,6 +537,16 @@ def ray_start_cluster_head_with_env_vars(request, maybe_external_redis, monkeypa
 
 
 @pytest.fixture
+def ray_start_with_env_vars(request, maybe_external_redis, monkeypatch):
+    param = getattr(request, "param", {})
+    env_vars = param.pop("env_vars", {})
+    for k, v in env_vars.items():
+        monkeypatch.setenv(k, v)
+    with _ray_start(**param) as res:
+        yield res
+
+
+@pytest.fixture
 def ray_start_cluster_2_nodes(request, maybe_external_redis):
     param = getattr(request, "param", {})
     with _ray_start_cluster(do_init=True, num_nodes=2, **param) as res:

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -828,6 +828,23 @@ print("DONE")
     wait_for_pid_to_exit(gcs_server_pid, 10000)
 
 
+def test_cluster_id(ray_start_regular):
+    raylet_proc = ray._private.worker._global_node.all_processes[
+        ray_constants.PROCESS_TYPE_RAYLET
+    ][0].process
+
+    def check_raylet_healthy():
+        return raylet_proc.poll() is None
+
+    wait_for_condition(lambda: check_raylet_healthy())
+
+    ray._private.worker._global_node.kill_gcs_server()
+    ray._private.worker._global_node.start_gcs_server()
+
+    # Waiting for raylet to become unhealthy
+    wait_for_condition(lambda: not check_raylet_healthy())
+
+
 @pytest.mark.parametrize(
     "ray_start_regular_with_external_redis",
     [

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -832,7 +832,18 @@ print("DONE")
 @pytest.mark.skipif(
     enable_external_redis(), reason="Only valid when started without external redis"
 )
-def test_cluster_id(ray_start_regular):
+@pytest.mark.parametrize(
+    "ray_start_with_env_vars",
+    [
+        {
+            "env_vars": {
+                "RAY_enable_cluster_auth": "1",
+            },
+        },
+    ],
+    indirect=True,
+)
+def test_cluster_id(ray_start_with_env_vars):
     raylet_proc = ray._private.worker._global_node.all_processes[
         ray_constants.PROCESS_TYPE_RAYLET
     ][0].process

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -12,6 +12,7 @@ import ray._private.gcs_utils as gcs_utils
 from ray._private import ray_constants
 from ray._private.test_utils import (
     convert_actor_state,
+    enable_external_redis,
     generate_system_config_map,
     wait_for_condition,
     wait_for_pid_to_exit,
@@ -828,6 +829,9 @@ print("DONE")
     wait_for_pid_to_exit(gcs_server_pid, 10000)
 
 
+@pytest.mark.skipif(
+    enable_external_redis(), reason="Only valid when started without external redis"
+)
 def test_cluster_id(ray_start_regular):
     raylet_proc = ray._private.worker._global_node.all_processes[
         ray_constants.PROCESS_TYPE_RAYLET

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -839,6 +839,10 @@ print("DONE")
     indirect=True,
 )
 def test_cluster_id(ray_start_regular):
+    # Kill GCS and check that raylets kill themselves when not backed by Redis,
+    # and stay alive when backed by Redis.
+    # Raylets should kill themselves due to cluster ID mismatch in the
+    # non-persisted case.
     raylet_proc = ray._private.worker._global_node.all_processes[
         ray_constants.PROCESS_TYPE_RAYLET
     ][0].process
@@ -858,7 +862,7 @@ def test_cluster_id(ray_start_regular):
         # Waiting for raylet to become unhealthy
         wait_for_condition(lambda: not check_raylet_healthy())
     else:
-        # Waiting for raylet to become unhealthy
+        # Waiting for raylet to stay healthy
         for i in range(10):
             assert check_raylet_healthy()
             sleep(1)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -34,6 +34,9 @@ RAY_CONFIG(bool, event_stats_metrics, false)
 /// TODO(ekl) remove this after Ray 1.8
 RAY_CONFIG(bool, legacy_scheduler_warnings, false)
 
+/// Whether to enable cluster authentication.
+RAY_CONFIG(bool, enable_cluster_auth, false)
+
 /// The interval of periodic event loop stats print.
 /// -1 means the feature is disabled. In this case, stats are available to
 /// debug_state_*.txt

--- a/src/ray/common/status.cc
+++ b/src/ray/common/status.cc
@@ -54,6 +54,7 @@ namespace ray {
 #define STATUS_CODE_NOT_FOUND "NotFound"
 #define STATUS_CODE_DISCONNECTED "Disconnected"
 #define STATUS_CODE_SCHEDULING_CANCELLED "SchedulingCancelled"
+#define STATUS_CODE_AUTH_ERROR "AuthError"
 // object store status
 #define STATUS_CODE_OBJECT_EXISTS "ObjectExists"
 #define STATUS_CODE_OBJECT_NOT_FOUND "ObjectNotFound"
@@ -114,6 +115,7 @@ std::string Status::CodeAsString() const {
       {StatusCode::TransientObjectStoreFull, STATUS_CODE_TRANSIENT_OBJECT_STORE_FULL},
       {StatusCode::GrpcUnavailable, STATUS_CODE_GRPC_UNAVAILABLE},
       {StatusCode::GrpcUnknown, STATUS_CODE_GRPC_UNKNOWN},
+      {StatusCode::AuthError, STATUS_CODE_AUTH_ERROR},
   };
 
   auto it = code_to_str.find(code());
@@ -149,6 +151,7 @@ StatusCode Status::StringToCode(const std::string &str) {
       {STATUS_CODE_OBJECT_UNKNOWN_OWNER, StatusCode::ObjectUnknownOwner},
       {STATUS_CODE_OBJECT_STORE_FULL, StatusCode::ObjectStoreFull},
       {STATUS_CODE_TRANSIENT_OBJECT_STORE_FULL, StatusCode::TransientObjectStoreFull},
+      {STATUS_CODE_AUTH_ERROR, StatusCode::AuthError},
   };
 
   auto it = str_to_code.find(str);

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -115,8 +115,8 @@ enum class StatusCode : char {
   ObjectUnknownOwner = 29,
   RpcError = 30,
   OutOfResource = 31,
-  // Meaning the ObjectRefStream reaches to the end of stream.
-  ObjectRefEndOfStream = 32
+  ObjectRefEndOfStream = 32,
+  AuthError = 33,
 };
 
 #if defined(__clang__)
@@ -252,6 +252,10 @@ class RAY_EXPORT Status {
     return Status(StatusCode::OutOfResource, msg);
   }
 
+  static Status AuthError(const std::string &msg) {
+    return Status(StatusCode::AuthError, msg);
+  }
+
   static StatusCode StringToCode(const std::string &str);
 
   // Returns true iff the status indicates success.
@@ -302,6 +306,8 @@ class RAY_EXPORT Status {
   bool IsRpcError() const { return code() == StatusCode::RpcError; }
 
   bool IsOutOfResource() const { return code() == StatusCode::OutOfResource; }
+
+  bool IsAuthError() const { return code() == StatusCode::AuthError; }
 
   // Return a string representation of this status suitable for printing.
   // Returns the string "OK" for success.

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -34,6 +34,8 @@
 #include "src/ray/protobuf/autoscaler.grpc.pb.h"
 
 namespace ray {
+class GcsClientTest;
+class GcsClientTest_TestCheckAlive_Test;
 
 namespace gcs {
 
@@ -82,6 +84,7 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
   /// Connect to GCS Service. Non-thread safe.
   /// This function must be called before calling other functions.
   /// \param instrumented_io_context IO execution service.
+  /// \param cluster_id Optional cluster ID to provide to the client.
   ///
   /// \return Status
   virtual Status Connect(instrumented_io_context &io_service,
@@ -175,6 +178,9 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
   std::unique_ptr<WorkerInfoAccessor> worker_accessor_;
   std::unique_ptr<PlacementGroupInfoAccessor> placement_group_accessor_;
   std::unique_ptr<InternalKVAccessor> internal_kv_accessor_;
+
+  friend class ray::GcsClientTest;
+  FRIEND_TEST(ray::GcsClientTest, TestCheckAlive);
   std::unique_ptr<TaskInfoAccessor> task_accessor_;
 
  private:

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -34,8 +34,6 @@
 #include "src/ray/protobuf/autoscaler.grpc.pb.h"
 
 namespace ray {
-class GcsClientTest;
-class GcsClientTest_TestCheckAlive_Test;
 
 namespace gcs {
 
@@ -159,7 +157,10 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
     return *placement_group_accessor_;
   }
 
-  const ClusterID &GetClusterId() { return client_call_manager_->GetClusterId(); }
+  const ClusterID &GetClusterId() {
+    RAY_CHECK(client_call_manager_) << "Cannot retrieve cluster ID before it is set.";
+    return client_call_manager_->GetClusterId();
+  }
 
   /// Get the sub-interface for accessing worker information in GCS.
   /// This function is thread safe.
@@ -181,8 +182,6 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
   std::unique_ptr<PlacementGroupInfoAccessor> placement_group_accessor_;
   std::unique_ptr<InternalKVAccessor> internal_kv_accessor_;
 
-  friend class ray::GcsClientTest;
-  FRIEND_TEST(ray::GcsClientTest, TestCheckAlive);
   std::unique_ptr<TaskInfoAccessor> task_accessor_;
 
  private:

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -159,6 +159,8 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
     return *placement_group_accessor_;
   }
 
+  const ClusterID &GetClusterId() { return client_call_manager_->GetClusterId(); }
+
   /// Get the sub-interface for accessing worker information in GCS.
   /// This function is thread safe.
   virtual InternalKVAccessor &InternalKV() { return *internal_kv_accessor_; }

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -121,8 +121,6 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
   }
 
   void StampContext(grpc::ClientContext &context) {
-    RAY_CHECK(gcs_client_->client_call_manager_)
-        << "Cannot stamp context before initializing client call manager.";
     context.AddMetadata(kClusterIdKey, gcs_client_->GetClusterId().Hex());
   }
 

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -95,7 +95,7 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
     // Create GCS client.
     gcs::GcsClientOptions options("127.0.0.1:5397");
     gcs_client_ = std::make_unique<gcs::GcsClient>(options);
-    RAY_CHECK_OK(gcs_client_->Connect(*client_io_service_));
+    ReconnectClient();
   }
 
   void TearDown() override {
@@ -113,6 +113,18 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
       TestSetupUtil::FlushAllRedisServers();
     }
     rpc::ResetServerCallExecutor();
+  }
+
+  void ReconnectClient() {
+    ClusterID cluster_id = gcs_server_->rpc_server_.GetClusterId();
+    RAY_CHECK_OK(gcs_client_->Connect(*client_io_service_, cluster_id));
+  }
+
+  void StampContext(grpc::ClientContext &context) {
+    RAY_CHECK(gcs_client_->client_call_manager_)
+        << "Cannot stamp context before initializing client call manager.";
+    context.AddMetadata(kClusterIdKey,
+                        gcs_client_->client_call_manager_->cluster_id_.Hex());
   }
 
   void RestartGcsServer() {
@@ -141,12 +153,17 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
           grpc::CreateChannel(absl::StrCat("127.0.0.1:", gcs_server_->GetPort()),
                               grpc::InsecureChannelCredentials());
       auto stub = rpc::NodeInfoGcsService::NewStub(std::move(channel));
+      bool in_memory =
+          RayConfig::instance().gcs_storage() == gcs::GcsServer::kInMemoryStorage;
       grpc::ClientContext context;
+      StampContext(context);
       context.set_deadline(std::chrono::system_clock::now() + 1s);
       const rpc::CheckAliveRequest request;
       rpc::CheckAliveReply reply;
       auto status = stub->CheckAlive(&context, request, &reply);
-      if (!status.ok()) {
+      // If it is in memory, we don't have the new token until we connect again.
+      if (!((!in_memory && status.ok()) ||
+            (in_memory && GrpcStatusToRayStatus(status).IsAuthError()))) {
         RAY_LOG(WARNING) << "Unable to reach GCS: " << status.error_code() << " "
                          << status.error_message();
         continue;
@@ -923,6 +940,7 @@ TEST_P(GcsClientTest, TestEvictExpiredDestroyedActors) {
 
   // Restart GCS.
   RestartGcsServer();
+  ReconnectClient();
 
   for (int index = 0; index < actor_count; ++index) {
     auto actor_table_data = Mocker::GenActorTableData(job_id);
@@ -945,9 +963,26 @@ TEST_P(GcsClientTest, TestEvictExpiredDestroyedActors) {
   }
 }
 
+TEST_P(GcsClientTest, TestGcsAuth) {
+  // Restart GCS.
+  RestartGcsServer();
+  auto node_info = Mocker::GenNodeInfo();
+  if (RayConfig::instance().gcs_storage() != gcs::GcsServer::kInMemoryStorage) {
+    EXPECT_TRUE(RegisterNode(*node_info));
+    return;
+  }
+
+  EXPECT_FALSE(RegisterNode(*node_info));
+  ReconnectClient();
+  EXPECT_TRUE(RegisterNode(*node_info));
+}
+
 TEST_P(GcsClientTest, TestEvictExpiredDeadNodes) {
   // Restart GCS.
   RestartGcsServer();
+  if (RayConfig::instance().gcs_storage() == gcs::GcsServer::kInMemoryStorage) {
+    ReconnectClient();
+  }
 
   // Simulate the scenario of node dead.
   int node_count = RayConfig::instance().maximum_gcs_dead_node_cached_count();

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -123,8 +123,7 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
   void StampContext(grpc::ClientContext &context) {
     RAY_CHECK(gcs_client_->client_call_manager_)
         << "Cannot stamp context before initializing client call manager.";
-    context.AddMetadata(kClusterIdKey,
-                        gcs_client_->client_call_manager_->cluster_id_.Hex());
+    context.AddMetadata(kClusterIdKey, gcs_client_->GetClusterId().Hex());
   }
 
   void RestartGcsServer() {

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -984,10 +984,13 @@ TEST_P(GcsClientTest, TestGcsAuth) {
   RestartGcsServer();
   auto node_info = Mocker::GenNodeInfo();
   if (!no_redis_) {
+    // If we are backed by Redis, we can reuse cluster ID, so the RPC passes.
     EXPECT_TRUE(RegisterNode(*node_info));
     return;
   }
 
+  // If we are not backed by Redis, we need to first fetch
+  // the new cluster ID, so we expect failure before success.
   EXPECT_FALSE(RegisterNode(*node_info));
   ReconnectClient();
   EXPECT_TRUE(RegisterNode(*node_info));

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -15,7 +15,6 @@
 #include "ray/gcs/gcs_server/gcs_server.h"
 
 #include <fstream>
-#include <future>
 
 #include "ray/common/asio/asio_util.h"
 #include "ray/common/asio/instrumented_io_context.h"

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -15,6 +15,7 @@
 #include "ray/gcs/gcs_server/gcs_server.h"
 
 #include <fstream>
+#include <future>
 
 #include "ray/common/asio/asio_util.h"
 #include "ray/common/asio/instrumented_io_context.h"
@@ -58,6 +59,7 @@ GcsServer::GcsServer(const ray::gcs::GcsServerConfig &config,
       rpc_server_(config.grpc_server_name,
                   config.grpc_server_port,
                   config.node_ip_address == "127.0.0.1",
+                  ClusterID::Nil(),
                   config.grpc_server_thread_num,
                   /*keepalive_time_ms=*/RayConfig::instance().grpc_keepalive_time_ms()),
       client_call_manager_(main_service,
@@ -167,7 +169,7 @@ void GcsServer::GetOrGenerateClusterId(
               kClusterIdKey,
               cluster_id.Binary(),
               false,
-              [&cluster_id,
+              [cluster_id,
                continuation = std::move(continuation)](bool added_entry) mutable {
                 RAY_CHECK(added_entry) << "Failed to persist new cluster ID!";
                 continuation(cluster_id);

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -41,6 +41,8 @@
 namespace ray {
 using raylet::ClusterTaskManager;
 using raylet::NoopLocalTaskManager;
+
+class GcsClientTest;
 namespace gcs {
 
 struct GcsServerConfig {
@@ -171,6 +173,8 @@ class GcsServer {
 
   /// Initialize monitor service.
   void InitMonitorServer();
+
+  friend class ray::GcsClientTest;
 
  private:
   /// Gets the type of KV storage to use from config.

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -100,6 +100,7 @@ ObjectManager::ObjectManager(
       object_manager_server_("ObjectManager",
                              config_.object_manager_port,
                              config_.object_manager_address == "127.0.0.1",
+                             ClusterID::Nil(),
                              config_.rpc_service_threads_number),
       object_manager_service_(rpc_service_, *this),
       client_call_manager_(

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -561,7 +561,7 @@ ray::Status NodeManager::RegisterGcs() {
                 RAY_LOG(FATAL)
                     << "GCS returned an authentication error. This may happen when "
                     << "GCS is not backed by a DB and restarted or there is data loss "
-                    << "in the DB.";
+                    << "in the DB. Local cluster ID: " << gcs_client_->GetClusterId();
               }
               *checking_ptr = false;
             },

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -551,14 +551,12 @@ ray::Status NodeManager::RegisterGcs() {
         RAY_CHECK_OK(gcs_client_->Nodes().AsyncCheckSelfAlive(
             // capture checking ptr here because vs17 fail to compile
             [checking_ptr = &checking](auto status, auto alive) mutable {
-              if (status.ok()) {
-                if (!alive) {
+              if ((status.ok() && !alive) || status.IsAuthError()) {
                   // GCS think this raylet is dead. Fail the node
                   RAY_LOG(FATAL)
                       << "GCS consider this node to be dead. This may happen when "
                       << "GCS is not backed by a DB and restarted or there is data loss "
                       << "in the DB.";
-                }
               }
               *checking_ptr = false;
             },

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -550,7 +550,7 @@ ray::Status NodeManager::RegisterGcs() {
         checking = true;
         RAY_CHECK_OK(gcs_client_->Nodes().AsyncCheckSelfAlive(
             // capture checking ptr here because vs17 fail to compile
-            [checking_ptr = &checking](auto status, auto alive) mutable {
+            [this, checking_ptr = &checking](auto status, auto alive) mutable {
               if ((status.ok() && !alive)) {
                 // GCS think this raylet is dead. Fail the node
                 RAY_LOG(FATAL)

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -552,11 +552,11 @@ ray::Status NodeManager::RegisterGcs() {
             // capture checking ptr here because vs17 fail to compile
             [checking_ptr = &checking](auto status, auto alive) mutable {
               if ((status.ok() && !alive) || status.IsAuthError()) {
-                  // GCS think this raylet is dead. Fail the node
-                  RAY_LOG(FATAL)
-                      << "GCS consider this node to be dead. This may happen when "
-                      << "GCS is not backed by a DB and restarted or there is data loss "
-                      << "in the DB.";
+                // GCS think this raylet is dead. Fail the node
+                RAY_LOG(FATAL)
+                    << "GCS consider this node to be dead. This may happen when "
+                    << "GCS is not backed by a DB and restarted or there is data loss "
+                    << "in the DB.";
               }
               *checking_ptr = false;
             },

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -551,10 +551,15 @@ ray::Status NodeManager::RegisterGcs() {
         RAY_CHECK_OK(gcs_client_->Nodes().AsyncCheckSelfAlive(
             // capture checking ptr here because vs17 fail to compile
             [checking_ptr = &checking](auto status, auto alive) mutable {
-              if ((status.ok() && !alive) || status.IsAuthError()) {
+              if ((status.ok() && !alive)) {
                 // GCS think this raylet is dead. Fail the node
                 RAY_LOG(FATAL)
                     << "GCS consider this node to be dead. This may happen when "
+                    << "GCS is not backed by a DB and restarted or there is data loss "
+                    << "in the DB.";
+              } else if (status.IsAuthError()) {
+                RAY_LOG(FATAL)
+                    << "GCS returned an authentication error. This may happen when "
                     << "GCS is not backed by a DB and restarted or there is data loss "
                     << "in the DB.";
               }

--- a/src/ray/rpc/agent_manager/agent_manager_server.h
+++ b/src/ray/rpc/agent_manager/agent_manager_server.h
@@ -24,7 +24,8 @@ namespace ray {
 namespace rpc {
 
 #define RAY_AGENT_MANAGER_RPC_HANDLERS \
-  RPC_SERVICE_HANDLER(AgentManagerService, RegisterAgent, -1)
+  RPC_SERVICE_HANDLER_CUSTOM_AUTH(     \
+      AgentManagerService, RegisterAgent, -1, AuthType::NO_AUTH)
 
 /// Implementations of the `AgentManagerGrpcService`, check interface in
 /// `src/ray/protobuf/agent_manager.proto`.

--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -19,7 +19,6 @@
 #include <atomic>
 #include <boost/asio.hpp>
 #include <chrono>
-#include <future>
 
 #include "absl/synchronization/mutex.h"
 #include "ray/common/asio/instrumented_io_context.h"
@@ -29,8 +28,6 @@
 #include "ray/util/util.h"
 
 namespace ray {
-class GcsClientTest;
-class GcsClientTest_TestCheckAlive_Test;
 namespace rpc {
 
 /// Represents an outgoing gRPC request.
@@ -271,11 +268,11 @@ class ClientCallManager {
     return call;
   }
 
+  /// Get the cluster ID.
+  const ClusterID &GetClusterId() const { return cluster_id_; }
+
   /// Get the main service of this rpc.
   instrumented_io_context &GetMainService() { return main_service_; }
-
-  friend class ray::GcsClientTest;
-  FRIEND_TEST(ray::GcsClientTest, TestCheckAlive);
 
  private:
   /// This function runs in a background thread. It keeps polling events from the

--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -239,7 +239,7 @@ class ClientCallManager {
   /// -1 means it will use the default timeout configured for the handler.
   ///
   /// \return A `ClientCall` representing the request that was just sent.
-  template <class GrpcService, class Request, class Reply, bool Insecure>
+  template <class GrpcService, class Request, class Reply>
   std::shared_ptr<ClientCall> CreateCall(
       typename GrpcService::Stub &stub,
       const PrepareAsyncFunction<GrpcService, Request, Reply> prepare_async_function,
@@ -252,15 +252,8 @@ class ClientCallManager {
       method_timeout_ms = call_timeout_ms_;
     }
 
-    ClusterID cluster_id;
-    if constexpr (Insecure) {
-      cluster_id = ClusterID::Nil();
-    } else {
-      cluster_id = cluster_id_;
-    }
-
     auto call = std::make_shared<ClientCallImpl<Reply>>(
-        callback, cluster_id, std::move(stats_handle), method_timeout_ms);
+        callback, cluster_id_, std::move(stats_handle), method_timeout_ms);
     // Send request.
     // Find the next completion queue to wait for response.
     call->response_reader_ = (stub.*prepare_async_function)(

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -87,12 +87,11 @@ class Executor {
 /// The priority of timeout is each call > handler > whole service
 /// (the lower priority timeout is overwritten by the higher priority timeout).
 /// \param SPECS The cpp method spec. For example, override.
-/// \param IS_INSECURE Whether to attach a cluster_id token to the metadata of the call.
 ///
 /// Currently, SyncMETHOD will copy the reply additionally.
 /// TODO(sang): Fix it.
-#define _VOID_GCS_RPC_CLIENT_METHOD(                                                     \
-    SERVICE, METHOD, grpc_client, method_timeout_ms, SPECS, IS_INSECURE)                 \
+#define VOID_GCS_RPC_CLIENT_METHOD(                                                      \
+    SERVICE, METHOD, grpc_client, method_timeout_ms, SPECS)                              \
   void METHOD(const METHOD##Request &request,                                            \
               const ClientCallback<METHOD##Reply> &callback,                             \
               const int64_t timeout_ms = method_timeout_ms) SPECS {                      \
@@ -149,13 +148,12 @@ class Executor {
     };                                                                                   \
     auto operation =                                                                     \
         [request, operation_callback, timeout_ms](GcsRpcClient *gcs_rpc_client) {        \
-          RAY_UNUSED(_INVOKE_RPC_CALL(SERVICE,                                           \
-                                      METHOD,                                            \
-                                      request,                                           \
-                                      operation_callback,                                \
-                                      gcs_rpc_client->grpc_client,                       \
-                                      timeout_ms,                                        \
-                                      IS_INSECURE));                                     \
+          RAY_UNUSED(INVOKE_RPC_CALL(SERVICE,                                            \
+                                     METHOD,                                             \
+                                     request,                                            \
+                                     operation_callback,                                 \
+                                     gcs_rpc_client->grpc_client,                        \
+                                     timeout_ms));                                       \
         };                                                                               \
     executor->Execute(std::move(operation));                                             \
   }                                                                                      \
@@ -172,16 +170,6 @@ class Executor {
         timeout_ms);                                                                     \
     return promise.get_future().get();                                                   \
   }
-
-#define VOID_GCS_RPC_CLIENT_METHOD(                         \
-    SERVICE, METHOD, grpc_client, method_timeout_ms, SPECS) \
-  _VOID_GCS_RPC_CLIENT_METHOD(                              \
-      SERVICE, METHOD, grpc_client, method_timeout_ms, SPECS, false)
-
-#define VOID_GCS_RPC_CLIENT_METHOD_NO_AUTH(                 \
-    SERVICE, METHOD, grpc_client, method_timeout_ms, SPECS) \
-  _VOID_GCS_RPC_CLIENT_METHOD(                              \
-      SERVICE, METHOD, grpc_client, method_timeout_ms, SPECS, true)
 
 /// Client used for communicating with gcs server.
 class GcsRpcClient {

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -381,6 +381,8 @@ class NodeInfoGrpcService : public GrpcService {
       const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
       std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
       const ClusterID &cluster_id) override {
+    // We only allow raylets to have one cluster ID in their lifetime.
+    // So, if a client connects, it should not have a pre-existing different ID.
     RPC_SERVICE_HANDLER_CUSTOM_AUTH(
         NodeInfoGcsService,
         GetClusterId,

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -139,9 +139,8 @@ namespace rpc {
                       HANDLER,                            \
                       RayConfig::instance().gcs_max_active_rpcs_per_handler())
 
-// TODO(vitsai): Set auth for everything except GCS.
 #define INTERNAL_KV_SERVICE_RPC_HANDLER(HANDLER) \
-  RPC_SERVICE_HANDLER_CUSTOM_AUTH(InternalKVGcsService, HANDLER, -1, AuthType::NO_AUTH)
+  RPC_SERVICE_HANDLER(InternalKVGcsService, HANDLER, -1)
 
 #define RUNTIME_ENV_SERVICE_RPC_HANDLER(HANDLER) \
   RPC_SERVICE_HANDLER(RuntimeEnvGcsService, HANDLER, -1)

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -381,7 +381,7 @@ class NodeInfoGrpcService : public GrpcService {
       const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
       std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
       const ClusterID &cluster_id) override {
-    // We only allow raylets to have one cluster ID in their lifetime.
+    // We only allow one cluster ID in the lifetime of a client.
     // So, if a client connects, it should not have a pre-existing different ID.
     RPC_SERVICE_HANDLER_CUSTOM_AUTH(
         NodeInfoGcsService,

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -387,7 +387,7 @@ class NodeInfoGrpcService : public GrpcService {
         NodeInfoGcsService,
         GetClusterId,
         RayConfig::instance().gcs_max_active_rpcs_per_handler(),
-        AuthType::LAZY_AUTH);
+        AuthType::EMPTY_AUTH);
     NODE_INFO_SERVICE_RPC_HANDLER(RegisterNode);
     NODE_INFO_SERVICE_RPC_HANDLER(DrainNode);
     NODE_INFO_SERVICE_RPC_HANDLER(GetAllNodeInfo);

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -141,7 +141,7 @@ namespace rpc {
 
 // TODO(vitsai): Set auth for everything except GCS.
 #define INTERNAL_KV_SERVICE_RPC_HANDLER(HANDLER) \
-  RPC_SERVICE_HANDLER(InternalKVGcsService, HANDLER, -1)
+  RPC_SERVICE_HANDLER_CUSTOM_AUTH(InternalKVGcsService, HANDLER, -1, AuthType::NO_AUTH)
 
 #define RUNTIME_ENV_SERVICE_RPC_HANDLER(HANDLER) \
   RPC_SERVICE_HANDLER(RuntimeEnvGcsService, HANDLER, -1)
@@ -382,7 +382,11 @@ class NodeInfoGrpcService : public GrpcService {
       const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
       std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
       const ClusterID &cluster_id) override {
-    NODE_INFO_SERVICE_RPC_HANDLER(GetClusterId);
+    RPC_SERVICE_HANDLER_CUSTOM_AUTH(
+        NodeInfoGcsService,
+        GetClusterId,
+        RayConfig::instance().gcs_max_active_rpcs_per_handler(),
+        AuthType::LAZY_AUTH);
     NODE_INFO_SERVICE_RPC_HANDLER(RegisterNode);
     NODE_INFO_SERVICE_RPC_HANDLER(DrainNode);
     NODE_INFO_SERVICE_RPC_HANDLER(GetAllNodeInfo);

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -29,19 +29,14 @@ namespace rpc {
 
 // This macro wraps the logic to call a specific RPC method of a service,
 // to make it easier to implement a new RPC client.
-#define _INVOKE_RPC_CALL(                                                           \
-    SERVICE, METHOD, request, callback, rpc_client, method_timeout_ms, IS_INSECURE) \
-  (rpc_client->CallMethod<METHOD##Request, METHOD##Reply, IS_INSECURE>(             \
-      &SERVICE::Stub::PrepareAsync##METHOD,                                         \
-      request,                                                                      \
-      callback,                                                                     \
-      #SERVICE ".grpc_client." #METHOD,                                             \
-      method_timeout_ms))
-
 #define INVOKE_RPC_CALL(                                               \
     SERVICE, METHOD, request, callback, rpc_client, method_timeout_ms) \
-  _INVOKE_RPC_CALL(                                                    \
-      SERVICE, METHOD, request, callback, rpc_client, method_timeout_ms, false);
+  (rpc_client->CallMethod<METHOD##Request, METHOD##Reply>(             \
+      &SERVICE::Stub::PrepareAsync##METHOD,                            \
+      request,                                                         \
+      callback,                                                        \
+      #SERVICE ".grpc_client." #METHOD,                                \
+      method_timeout_ms))
 
 // Define a void RPC client method.
 #define VOID_RPC_CLIENT_METHOD(SERVICE, METHOD, rpc_client, method_timeout_ms, SPECS)   \
@@ -141,14 +136,14 @@ class GrpcClient {
   /// -1 means it will use the default timeout configured for the handler.
   ///
   /// \return Status.
-  template <class Request, class Reply, bool Insecure = false>
+  template <class Request, class Reply>
   void CallMethod(
       const PrepareAsyncFunction<GrpcService, Request, Reply> prepare_async_function,
       const Request &request,
       const ClientCallback<Reply> &callback,
       std::string call_name = "UNKNOWN_RPC",
       int64_t method_timeout_ms = -1) {
-    auto call = client_call_manager_.CreateCall<GrpcService, Request, Reply, Insecure>(
+    auto call = client_call_manager_.CreateCall<GrpcService, Request, Reply>(
         *stub_,
         prepare_async_function,
         request,

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -29,8 +29,6 @@ namespace rpc {
 
 /// NOTE: See src/ray/core_worker/core_worker.h on how to add a new grpc handler.
 #define RAY_NODE_MANAGER_RPC_HANDLERS                          \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(UpdateResourceUsage)    \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(RequestResourceReport)  \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetResourceLoad)        \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(NotifyGCSRestart)       \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(RequestWorkerLease)     \

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -23,30 +23,36 @@
 namespace ray {
 namespace rpc {
 
+/// TODO(vitsai): Remove this when auth is implemented for node manager
+#define RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(METHOD) \
+  RPC_SERVICE_HANDLER_CUSTOM_AUTH(NodeManagerService, METHOD, -1, AuthType::NO_AUTH)
+
 /// NOTE: See src/ray/core_worker/core_worker.h on how to add a new grpc handler.
-#define RAY_NODE_MANAGER_RPC_HANDLERS                                 \
-  RPC_SERVICE_HANDLER(NodeManagerService, GetResourceLoad, -1)        \
-  RPC_SERVICE_HANDLER(NodeManagerService, NotifyGCSRestart, -1)       \
-  RPC_SERVICE_HANDLER(NodeManagerService, RequestWorkerLease, -1)     \
-  RPC_SERVICE_HANDLER(NodeManagerService, ReportWorkerBacklog, -1)    \
-  RPC_SERVICE_HANDLER(NodeManagerService, ReturnWorker, -1)           \
-  RPC_SERVICE_HANDLER(NodeManagerService, ReleaseUnusedWorkers, -1)   \
-  RPC_SERVICE_HANDLER(NodeManagerService, CancelWorkerLease, -1)      \
-  RPC_SERVICE_HANDLER(NodeManagerService, PinObjectIDs, -1)           \
-  RPC_SERVICE_HANDLER(NodeManagerService, GetNodeStats, -1)           \
-  RPC_SERVICE_HANDLER(NodeManagerService, GlobalGC, -1)               \
-  RPC_SERVICE_HANDLER(NodeManagerService, FormatGlobalMemoryInfo, -1) \
-  RPC_SERVICE_HANDLER(NodeManagerService, PrepareBundleResources, -1) \
-  RPC_SERVICE_HANDLER(NodeManagerService, CommitBundleResources, -1)  \
-  RPC_SERVICE_HANDLER(NodeManagerService, CancelResourceReserve, -1)  \
-  RPC_SERVICE_HANDLER(NodeManagerService, RequestObjectSpillage, -1)  \
-  RPC_SERVICE_HANDLER(NodeManagerService, ReleaseUnusedBundles, -1)   \
-  RPC_SERVICE_HANDLER(NodeManagerService, GetSystemConfig, -1)        \
-  RPC_SERVICE_HANDLER(NodeManagerService, ShutdownRaylet, -1)         \
-  RPC_SERVICE_HANDLER(NodeManagerService, DrainRaylet, -1)            \
-  RPC_SERVICE_HANDLER(NodeManagerService, GetTasksInfo, -1)           \
-  RPC_SERVICE_HANDLER(NodeManagerService, GetObjectsInfo, -1)         \
-  RPC_SERVICE_HANDLER(NodeManagerService, GetTaskFailureCause, -1)
+#define RAY_NODE_MANAGER_RPC_HANDLERS                          \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(UpdateResourceUsage)    \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(RequestResourceReport)  \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetResourceLoad)        \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(NotifyGCSRestart)       \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(RequestWorkerLease)     \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ReportWorkerBacklog)    \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ReturnWorker)           \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ReleaseUnusedWorkers)   \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(CancelWorkerLease)      \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(PinObjectIDs)           \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetNodeStats)           \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GlobalGC)               \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(FormatGlobalMemoryInfo) \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(PrepareBundleResources) \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(CommitBundleResources)  \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(CancelResourceReserve)  \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(RequestObjectSpillage)  \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ReleaseUnusedBundles)   \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetSystemConfig)        \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ShutdownRaylet)         \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(DrainRaylet)            \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetTasksInfo)           \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetObjectsInfo)         \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetTaskFailureCause)
 
 /// Interface of the `NodeManagerService`, see `src/ray/protobuf/node_manager.proto`.
 class NodeManagerServiceHandler {

--- a/src/ray/rpc/object_manager/object_manager_server.h
+++ b/src/ray/rpc/object_manager/object_manager_server.h
@@ -23,10 +23,13 @@
 namespace ray {
 namespace rpc {
 
-#define RAY_OBJECT_MANAGER_RPC_HANDLERS               \
-  RPC_SERVICE_HANDLER(ObjectManagerService, Push, -1) \
-  RPC_SERVICE_HANDLER(ObjectManagerService, Pull, -1) \
-  RPC_SERVICE_HANDLER(ObjectManagerService, FreeObjects, -1)
+#define RAY_OBJECT_MANAGER_RPC_SERVICE_HANDLER(METHOD) \
+  RPC_SERVICE_HANDLER_CUSTOM_AUTH(ObjectManagerService, METHOD, -1, AuthType::NO_AUTH)
+
+#define RAY_OBJECT_MANAGER_RPC_HANDLERS        \
+  RAY_OBJECT_MANAGER_RPC_SERVICE_HANDLER(Push) \
+  RAY_OBJECT_MANAGER_RPC_SERVICE_HANDLER(Pull) \
+  RAY_OBJECT_MANAGER_RPC_SERVICE_HANDLER(FreeObjects)
 
 /// Implementations of the `ObjectManagerGrpcService`, check interface in
 /// `src/ray/protobuf/object_manager.proto`.

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -237,7 +237,7 @@ class ServerCallImpl : public ServerCall {
       if (auth_success) {
         SendReply(Status::Invalid("HandleServiceClosed"));
       } else {
-        SendReply(Status::AuthError("WrongClusterToken"));
+        SendReply(Status::AuthError("WrongClusterID"));
       }
     }
   }
@@ -260,7 +260,7 @@ class ServerCallImpl : public ServerCall {
     if (!auth_success) {
       boost::asio::post(GetServerCallExecutor(), [this]() {
         SendReply(
-            Status::AuthError("WrongClusterToken: Perhaps the client is accessing GCS "
+            Status::AuthError("WrongClusterID: Perhaps the client is accessing GCS "
                               "after it has restarted."));
       });
     } else {

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -29,6 +29,13 @@
 namespace ray {
 namespace rpc {
 
+// Authentication type of ServerCall.
+enum class AuthType {
+  NO_AUTH,      // Do not authenticate (accept all).
+  LAZY_AUTH,    // Accept missing token, but reject wrong token.
+  STRICT_AUTH,  // Reject missing token and wrong token.
+};
+
 /// Get the thread pool for the gRPC server.
 /// This pool is shared across gRPC servers.
 boost::asio::thread_pool &GetServerCallExecutor();
@@ -147,7 +154,10 @@ using HandleRequestFunction = void (ServiceHandler::*)(Request,
 /// \tparam ServiceHandler Type of the handler that handles the request.
 /// \tparam Request Type of the request message.
 /// \tparam Reply Type of the reply message.
-template <class ServiceHandler, class Request, class Reply>
+template <class ServiceHandler,
+          class Request,
+          class Reply,
+          AuthType EnableAuth = AuthType::STRICT_AUTH>
 class ServerCallImpl : public ServerCall {
  public:
   /// Constructor.
@@ -194,21 +204,54 @@ class ServerCallImpl : public ServerCall {
   void SetState(const ServerCallState &new_state) override { state_ = new_state; }
 
   void HandleRequest() override {
+    bool auth_success = true;
+    if constexpr (EnableAuth == AuthType::STRICT_AUTH) {
+      RAY_CHECK(!cluster_id_.IsNil()) << "Expected cluster ID in server call!";
+      auto &metadata = context_.client_metadata();
+      if (auto it = metadata.find(kClusterIdKey);
+          it == metadata.end() || it->second != cluster_id_.Hex()) {
+        RAY_LOG(DEBUG) << "Wrong cluster ID token in request! Expected: "
+                       << cluster_id_.Hex() << ", but got: "
+                       << (it == metadata.end() ? "No token!" : it->second);
+        auth_success = false;
+      }
+    } else if constexpr (EnableAuth == AuthType::LAZY_AUTH) {
+      RAY_CHECK(!cluster_id_.IsNil()) << "Expected cluster ID in server call!";
+      auto &metadata = context_.client_metadata();
+      if (auto it = metadata.find(kClusterIdKey);
+          it != metadata.end() && it->second != cluster_id_.Hex()) {
+        RAY_LOG(DEBUG) << "Wrong cluster ID token in request! Expected: "
+                       << cluster_id_.Hex() << ", but got: "
+                       << (it == metadata.end() ? "No token!" : it->second);
+        auth_success = false;
+      }
+    } else {
+      if (!cluster_id_.IsNil()) {
+        RAY_LOG_EVERY_MS(WARNING, 5000)
+            << "Unexpected cluster ID in server call! " << cluster_id_;
+      }
+    }
+
     start_time_ = absl::GetCurrentTimeNanos();
     if (record_metrics_) {
       ray::stats::STATS_grpc_server_req_handling.Record(1.0, call_name_);
     }
     if (!io_service_.stopped()) {
-      io_service_.post([this] { HandleRequestImpl(); }, call_name_);
+      io_service_.post([this, auth_success] { HandleRequestImpl(auth_success); },
+                       call_name_);
     } else {
       // Handle service for rpc call has stopped, we must handle the call here
       // to send reply and remove it from cq
       RAY_LOG(DEBUG) << "Handle service has been closed.";
-      SendReply(Status::Invalid("HandleServiceClosed"));
+      if (auth_success) {
+        SendReply(Status::Invalid("HandleServiceClosed"));
+      } else {
+        SendReply(Status::AuthError("WrongClusterToken"));
+      }
     }
   }
 
-  void HandleRequestImpl() {
+  void HandleRequestImpl(bool auth_success) {
     if constexpr (std::is_base_of_v<DelayedServiceHandler, ServiceHandler>) {
       service_handler_.WaitUntilInitialized();
     }
@@ -223,18 +266,27 @@ class ServerCallImpl : public ServerCall {
       // a new request comes in.
       factory.CreateCall();
     }
-    (service_handler_.*handle_request_function_)(
-        std::move(request_),
-        reply_,
-        [this](
-            Status status, std::function<void()> success, std::function<void()> failure) {
-          // These two callbacks must be set before `SendReply`, because `SendReply`
-          // is async and this `ServerCall` might be deleted right after `SendReply`.
-          send_reply_success_callback_ = std::move(success);
-          send_reply_failure_callback_ = std::move(failure);
-          boost::asio::post(GetServerCallExecutor(),
-                            [this, status]() { SendReply(status); });
-        });
+    if (!auth_success) {
+      boost::asio::post(GetServerCallExecutor(), [this]() {
+        SendReply(
+            Status::AuthError("WrongClusterToken: Perhaps the client is accessing GCS "
+                              "after it has restarted."));
+      });
+    } else {
+      (service_handler_.*handle_request_function_)(
+          std::move(request_),
+          reply_,
+          [this](Status status,
+                 std::function<void()> success,
+                 std::function<void()> failure) {
+            // These two callbacks must be set before `SendReply`, because `SendReply`
+            // is async and this `ServerCall` might be deleted right after `SendReply`.
+            send_reply_success_callback_ = std::move(success);
+            send_reply_failure_callback_ = std::move(failure);
+            boost::asio::post(GetServerCallExecutor(),
+                              [this, status]() { SendReply(status); });
+          });
+    }
   }
 
   void OnReplySent() override {
@@ -334,7 +386,7 @@ class ServerCallImpl : public ServerCall {
   /// If true, the server call will generate gRPC server metrics.
   bool record_metrics_;
 
-  template <class T1, class T2, class T3, class T4>
+  template <class T1, class T2, class T3, class T4, AuthType T5>
   friend class ServerCallFactoryImpl;
 };
 
@@ -358,7 +410,11 @@ using RequestCallFunction =
 /// \tparam ServiceHandler Type of the handler that handles the request.
 /// \tparam Request Type of the request message.
 /// \tparam Reply Type of the reply message.
-template <class GrpcService, class ServiceHandler, class Request, class Reply>
+template <class GrpcService,
+          class ServiceHandler,
+          class Request,
+          class Reply,
+          AuthType EnableAuth = AuthType::STRICT_AUTH>
 class ServerCallFactoryImpl : public ServerCallFactory {
   using AsyncService = typename GrpcService::AsyncService;
 
@@ -401,14 +457,14 @@ class ServerCallFactoryImpl : public ServerCallFactory {
   void CreateCall() const override {
     // Create a new `ServerCall`. This object will eventually be deleted by
     // `GrpcServer::PollEventsFromCompletionQueue`.
-    auto call =
-        new ServerCallImpl<ServiceHandler, Request, Reply>(*this,
-                                                           service_handler_,
-                                                           handle_request_function_,
-                                                           io_service_,
-                                                           call_name_,
-                                                           cluster_id_,
-                                                           record_metrics_);
+    auto call = new ServerCallImpl<ServiceHandler, Request, Reply, EnableAuth>(
+        *this,
+        service_handler_,
+        handle_request_function_,
+        io_service_,
+        call_name_,
+        cluster_id_,
+        record_metrics_);
     /// Request gRPC runtime to starting accepting this kind of request, using the call as
     /// the tag.
     (service_.*request_call_function_)(&call->context_,

--- a/src/ray/rpc/test/grpc_bench/grpc_bench.cc
+++ b/src/ray/rpc/test/grpc_bench/grpc_bench.cc
@@ -53,7 +53,8 @@ class GreeterGrpcService : public GrpcService {
       const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
       std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
       const ClusterID &cluster_id) override{
-      RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(Greeter, SayHello, -1)}
+      RPC_SERVICE_HANDLER_CUSTOM_AUTH_SERVER_METRICS_DISABLED(
+          Greeter, SayHello, -1, AuthType::NO_AUTH)}
 
   /// The grpc async service object.
   Greeter::AsyncService service_;

--- a/src/ray/rpc/test/grpc_server_client_test.cc
+++ b/src/ray/rpc/test/grpc_server_client_test.cc
@@ -86,8 +86,10 @@ class TestGrpcService : public GrpcService {
       const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
       std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
       const ClusterID &cluster_id) override {
-    RPC_SERVICE_HANDLER(TestService, Ping, /*max_active_rpcs=*/1);
-    RPC_SERVICE_HANDLER(TestService, PingTimeout, /*max_active_rpcs=*/1);
+    RPC_SERVICE_HANDLER_CUSTOM_AUTH(
+        TestService, Ping, /*max_active_rpcs=*/1, AuthType::NO_AUTH);
+    RPC_SERVICE_HANDLER_CUSTOM_AUTH(
+        TestService, PingTimeout, /*max_active_rpcs=*/1, AuthType::NO_AUTH);
   }
 
  private:

--- a/src/ray/rpc/worker/core_worker_server.h
+++ b/src/ray/rpc/worker/core_worker_server.h
@@ -54,7 +54,7 @@ namespace rpc {
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(DeleteSpilledObjects)           \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(PlasmaObjectReady)              \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(Exit)                           \
-  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(AssignObjectOwner) \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(AssignObjectOwner)              \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(NumPendingTasks)
 
 #define RAY_CORE_WORKER_DECLARE_RPC_HANDLERS                              \

--- a/src/ray/rpc/worker/core_worker_server.h
+++ b/src/ray/rpc/worker/core_worker_server.h
@@ -25,41 +25,36 @@ namespace ray {
 class CoreWorker;
 
 namespace rpc {
+/// TODO(vitsai): Remove this when auth is implemented for node manager
+#define RAY_CORE_WORKER_RPC_SERVICE_HANDLER(METHOD)        \
+  RPC_SERVICE_HANDLER_CUSTOM_AUTH_SERVER_METRICS_DISABLED( \
+      CoreWorkerService, METHOD, -1, AuthType::NO_AUTH)
 
 /// NOTE: See src/ray/core_worker/core_worker.h on how to add a new grpc handler.
 /// Disable gRPC server metrics since it incurs too high cardinality.
-#define RAY_CORE_WORKER_RPC_HANDLERS                                                     \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, PushTask, -1)           \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
-      CoreWorkerService, DirectActorCallArgWaitComplete, -1)                             \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
-      CoreWorkerService, RayletNotifyGCSRestart, -1)                                     \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, GetObjectStatus, -1)    \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
-      CoreWorkerService, WaitForActorOutOfScope, -1)                                     \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, PubsubLongPolling, -1)  \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, PubsubCommandBatch, -1) \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
-      CoreWorkerService, UpdateObjectLocationBatch, -1)                                  \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
-      CoreWorkerService, GetObjectLocationsOwner, -1)                                    \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
-      CoreWorkerService, ReportGeneratorItemReturns, -1)                                 \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, KillActor, -1)          \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, CancelTask, -1)         \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, RemoteCancelTask, -1)   \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, GetCoreWorkerStats, -1) \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, LocalGC, -1)            \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, DeleteObjects, -1)      \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, SpillObjects, -1)       \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
-      CoreWorkerService, RestoreSpilledObjects, -1)                                      \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(                                           \
-      CoreWorkerService, DeleteSpilledObjects, -1)                                       \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, PlasmaObjectReady, -1)  \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, Exit, -1)               \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, AssignObjectOwner, -1)  \
-  RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(CoreWorkerService, NumPendingTasks, -1)
+#define RAY_CORE_WORKER_RPC_HANDLERS                                  \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(PushTask)                       \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(DirectActorCallArgWaitComplete) \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(RayletNotifyGCSRestart)         \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(GetObjectStatus)                \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(WaitForActorOutOfScope)         \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(PubsubLongPolling)              \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(PubsubCommandBatch)             \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(UpdateObjectLocationBatch)      \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(GetObjectLocationsOwner)        \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(KillActor)                      \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(CancelTask)                     \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(RemoteCancelTask)               \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(GetCoreWorkerStats)             \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(LocalGC)                        \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(DeleteObjects)                  \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(SpillObjects)                   \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(RestoreSpilledObjects)          \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(DeleteSpilledObjects)           \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(PlasmaObjectReady)              \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(Exit)                           \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(AssignObjectOwner)
+
 #define RAY_CORE_WORKER_DECLARE_RPC_HANDLERS                              \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(PushTask)                       \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(DirectActorCallArgWaitComplete) \

--- a/src/ray/rpc/worker/core_worker_server.h
+++ b/src/ray/rpc/worker/core_worker_server.h
@@ -42,6 +42,7 @@ namespace rpc {
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(PubsubCommandBatch)             \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(UpdateObjectLocationBatch)      \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(GetObjectLocationsOwner)        \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(ReportGeneratorItemReturns)     \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(KillActor)                      \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(CancelTask)                     \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(RemoteCancelTask)               \
@@ -53,7 +54,8 @@ namespace rpc {
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(DeleteSpilledObjects)           \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(PlasmaObjectReady)              \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(Exit)                           \
-  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(AssignObjectOwner)
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(AssignObjectOwner) \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(NumPendingTasks)
 
 #define RAY_CORE_WORKER_DECLARE_RPC_HANDLERS                              \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(PushTask)                       \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

This change adds a parameter to the ServerCall object to specify whether to validate the metadata on incoming RPCs. ServerCall objects will by default reject incorrect but not missing metadata. Validation occurs after a ServerCall is popped from its completion queue. By setting the parameter, a GRPC server has the options of STRICT (rejecting incorrect and missing metadata), LAZY (rejecting incorrect but not missing metadata), and NO_AUTH (no authentication).

With this change, GCS service handlers now populate their completion queues with LAZY ServiceCalls, while all others populate with NO_AUTH. 

## Why are these changes needed?
This prevents Ray components from reconnecting to GCS after a restart when GCS is not persisted.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
