### PR TITLE
[Core] Fix the segfault from Opencensus upon shutdown (#36906)

### DIFF
--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -146,7 +146,6 @@ CoreWorkerProcessImpl::CoreWorkerProcessImpl(const CoreWorkerOptions &options)
 
 CoreWorkerProcessImpl::~CoreWorkerProcessImpl() {
   RAY_LOG(INFO) << "Destructing CoreWorkerProcessImpl. pid: " << getpid();
-  RAY_LOG(DEBUG) << "Stats stop in core worker.";
   // Shutdown stats module if worker process exits.
   stats::Shutdown();
   if (options_.enable_logging) {

--- a/src/ray/stats/metric_exporter.cc
+++ b/src/ray/stats/metric_exporter.cc
@@ -111,6 +111,7 @@ OpenCensusProtoExporter::OpenCensusProtoExporter(const int port,
                                                  const std::string address,
                                                  const WorkerID &worker_id)
     : client_call_manager_(io_service), worker_id_(worker_id) {
+  absl::MutexLock l(&mu_);
   client_.reset(new rpc::MetricsAgentClient(address, port, client_call_manager_));
 };
 
@@ -202,15 +203,18 @@ void OpenCensusProtoExporter::ExportViewData(
     }
   }
 
-  client_->ReportOCMetrics(
-      request_proto, [](const Status &status, const rpc::ReportOCMetricsReply &reply) {
-        RAY_UNUSED(reply);
-        if (!status.ok()) {
-          RAY_LOG_EVERY_N(WARNING, 10000)
-              << "Export metrics to agent failed: " << status
-              << ". This won't affect Ray, but you can lose metrics from the cluster.";
-        }
-      });
+  {
+    absl::MutexLock l(&mu_);
+    client_->ReportOCMetrics(
+        request_proto, [](const Status &status, const rpc::ReportOCMetricsReply &reply) {
+          RAY_UNUSED(reply);
+          if (!status.ok()) {
+            RAY_LOG_EVERY_N(WARNING, 10000)
+                << "Export metrics to agent failed: " << status
+                << ". This won't affect Ray, but you can lose metrics from the cluster.";
+          }
+        });
+  }
 }
 
 }  // namespace stats

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -117,8 +117,10 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
  private:
   /// Call Manager for gRPC client.
   rpc::ClientCallManager client_call_manager_;
+  /// Lock to protect the client
+  mutable absl::Mutex mu_;
   /// Client to call a metrics agent gRPC server.
-  std::unique_ptr<rpc::MetricsAgentClient> client_;
+  std::unique_ptr<rpc::MetricsAgentClient> client_ GUARDED_BY(&mu_);
   /// The worker ID of the current component.
   WorkerID worker_id_;
 };

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -125,6 +125,7 @@ static inline void Shutdown() {
   metrics_io_service_pool = nullptr;
   exporter = nullptr;
   StatsConfig::instance().SetIsInitialized(false);
+  RAY_LOG(INFO) << "Stats module has shutdown.";
 }
 
 }  // namespace stats


### PR DESCRIPTION
Seems like client_ in the metrics exporter is not lock-protected, but it is accessed by 2 thread (by a metrics export thread + task execution thread when ExportNow is called). I added a lock. I am not 100% sure if this will fix the issue because I was unable to reproduce the issue, but we can ask the user to try after merging this PR.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Handles https://github.com/ray-project/ray/issues/36885

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
