### PR TITLE
[Core][Label scheduling 3/n] Implement node label scheduling strategy

### DIFF
--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -30,6 +30,7 @@ from ray.includes.common cimport (
     CAddress,
     CConcurrencyGroup,
     CSchedulingStrategy,
+    CLabelMatchExpressions,
 )
 from ray.includes.libcoreworker cimport (
     ActorHandleSharedPtr,
@@ -155,6 +156,9 @@ cdef class CoreWorker:
     cdef python_scheduling_strategy_to_c(
         self, python_scheduling_strategy,
         CSchedulingStrategy *c_scheduling_strategy)
+    cdef python_label_match_expressions_to_c(
+        self, python_expressions,
+        CLabelMatchExpressions *c_expressions)
     cdef CObjectID allocate_dynamic_return_id_for_generator(
             self,
             const CAddress &owner_address,

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -186,6 +186,7 @@ cdef extern from "src/ray/protobuf/common.pb.h" nogil:
         CDefaultSchedulingStrategy* mutable_default_scheduling_strategy()
         CPlacementGroupSchedulingStrategy* mutable_placement_group_scheduling_strategy()  # noqa: E501
         CNodeAffinitySchedulingStrategy* mutable_node_affinity_scheduling_strategy()
+        CNodeLabelSchedulingStrategy* mutable_node_label_scheduling_strategy()
     cdef cppclass CAddress "ray::rpc::Address":
         CAddress()
         const c_string &SerializeAsString() const
@@ -197,6 +198,37 @@ cdef extern from "src/ray/protobuf/common.pb.h" nogil:
         CAddress owner_address() const
         const c_string &object_id() const
         const c_string &call_site() const
+    cdef cppclass CNodeLabelSchedulingStrategy "ray::rpc::NodeLabelSchedulingStrategy":  # noqa: E501
+        CNodeLabelSchedulingStrategy()
+        CLabelMatchExpressions* mutable_hard()
+        CLabelMatchExpressions* mutable_soft()
+    cdef cppclass CLabelMatchExpressions "ray::rpc::LabelMatchExpressions":  # noqa: E501
+        CLabelMatchExpressions()
+        CLabelMatchExpression* add_expressions()
+    cdef cppclass CLabelMatchExpression "ray::rpc::LabelMatchExpression":  # noqa: E501
+        CLabelMatchExpression()
+        void set_key(const c_string &key)
+        CLabelOperator* mutable_operator_()
+    cdef cppclass CLabelIn "ray::rpc::LabelIn":  # noqa: E501
+        CLabelIn()
+        void add_values(const c_string &value)
+    cdef cppclass CLabelNotIn "ray::rpc::LabelNotIn":  # noqa: E501
+        CLabelNotIn()
+        void add_values(const c_string &value)
+    cdef cppclass CLabelExists "ray::rpc::LabelExists":  # noqa: E501
+        CLabelExists()
+    cdef cppclass CLabelDoesNotExist "ray::rpc::LabelDoesNotExist":  # noqa: E501
+        CLabelDoesNotExist()
+    cdef cppclass CLabelNotIn "ray::rpc::LabelNotIn":  # noqa: E501
+        CLabelNotIn()
+        void add_values(const c_string &value)
+    cdef cppclass CLabelOperator "ray::rpc::LabelOperator":  # noqa: E501
+        CLabelOperator()
+        CLabelIn* mutable_label_in()
+        CLabelNotIn* mutable_label_not_in()
+        CLabelExists* mutable_label_exists()
+        CLabelDoesNotExist* mutable_label_does_not_exist()
+
 
 # This is a workaround for C++ enum class since Cython has no corresponding
 # representation.

--- a/python/ray/tests/test_node_label_scheduling_strategy.py
+++ b/python/ray/tests/test_node_label_scheduling_strategy.py
@@ -3,6 +3,7 @@ import sys
 import pytest
 
 import ray
+from ray._private.test_utils import wait_for_condition
 from ray.util.scheduling_strategies import (
     In,
     NotIn,
@@ -15,10 +16,13 @@ from ray.util.scheduling_strategies import (
 @ray.remote
 class MyActor:
     def __init__(self):
-        pass
+        self.value = 0
 
-    def double(self, x):
-        return 2 * x
+    def value(self):
+        return self.value
+
+    def get_node_id(self):
+        return ray.get_runtime_context().get_node_id()
 
 
 @pytest.mark.parametrize(
@@ -28,24 +32,124 @@ class MyActor:
 )
 def test_node_label_scheduling_basic(call_ray_start):
     ray.init(address=call_ray_start)
-    MyActor.options(
+    actor = MyActor.options(
         scheduling_strategy=NodeLabelSchedulingStrategy(
             {"gpu_type": In("A100", "T100"), "region": Exists()}
         )
-    )
+    ).remote()
+    assert ray.get(actor.value.remote(), timeout=3) == 0
 
-    MyActor.options(
-        scheduling_strategy=NodeLabelSchedulingStrategy(
-            {"gpu_type": NotIn("A100", "T100"), "other_key": DoesNotExist()}
-        )
-    )
+    actor = MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy({"gpu_type": NotIn("A100")})
+    ).remote()
+    with pytest.raises(TimeoutError):
+        assert ray.get(actor.value.remote(), timeout=3) == 0
 
-    MyActor.options(
+    actor = MyActor.options(
         scheduling_strategy=NodeLabelSchedulingStrategy(
-            hard={"gpu_type": Exists()},
+            hard={"gpu_type": DoesNotExist()},
             soft={"gpu_type": In("A100")},
         )
-    )
+    ).remote()
+    with pytest.raises(TimeoutError):
+        assert ray.get(actor.value.remote(), timeout=3) == 0
+
+    actor = MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy(
+            hard={"gpu_type": In("T100")},
+        )
+    ).remote()
+    with pytest.raises(TimeoutError):
+        assert ray.get(actor.value.remote(), timeout=3) == 0
+
+    actor = MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy(
+            hard={},
+            soft={"gpu_type": In("T100ssss")},
+        )
+    ).remote()
+    assert ray.get(actor.value.remote(), timeout=3) == 0
+
+
+def test_node_label_scheduling_in_cluster(ray_start_cluster):
+    cluster = ray_start_cluster
+    created_nodes = []
+    cluster.add_node(num_cpus=3, labels={"gpu_type": "A100", "azone": "azone-1"})
+    cluster.wait_for_nodes()
+    ray.init(address=cluster.address)
+    node_1 = get_new_node_id(created_nodes)
+    cluster.add_node(num_cpus=3, labels={"gpu_type": "T100", "azone": "azone-1"})
+    node_2 = get_new_node_id(created_nodes)
+    cluster.add_node(num_cpus=3, labels={"gpu_type": "T100", "azone": "azone-2"})
+    node_3 = get_new_node_id(created_nodes)
+    cluster.add_node(num_cpus=3)
+    node_4 = get_new_node_id(created_nodes)
+    cluster.wait_for_nodes()
+
+    actor = MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy({"gpu_type": In("A100")})
+    ).remote()
+    assert ray.get(actor.get_node_id.remote(), timeout=3) == node_1
+
+    actor = MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy({"ray.io/node_id": In(node_4)})
+    ).remote()
+    assert ray.get(actor.get_node_id.remote(), timeout=3) == node_4
+
+    actor = MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy({"gpu_type": In("T100")})
+    ).remote()
+    assert ray.get(actor.get_node_id.remote(), timeout=3) in (node_2, node_3)
+
+    actor = MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy(
+            {"azone": In("azone-1", "azone-2")}
+        )
+    ).remote()
+    assert ray.get(actor.get_node_id.remote(), timeout=3) in (node_1, node_2, node_3)
+
+    actor = MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy(
+            {"gpu_type": In("T100"), "azone": In("azone-1")}
+        )
+    ).remote()
+    assert ray.get(actor.get_node_id.remote(), timeout=3) in (node_2)
+
+    actor = MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy(
+            {
+                "gpu_type": NotIn("A100"),
+            }
+        )
+    ).remote()
+    assert ray.get(actor.get_node_id.remote(), timeout=3) in (node_2, node_3, node_4)
+
+    actor = MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy(
+            {
+                "gpu_type": DoesNotExist(),
+            }
+        )
+    ).remote()
+    assert ray.get(actor.get_node_id.remote(), timeout=3) in (node_4)
+
+    actor = MyActor.options(
+        scheduling_strategy=NodeLabelSchedulingStrategy(
+            {
+                "gpu_type": Exists(),
+            }
+        )
+    ).remote()
+    assert ray.get(actor.get_node_id.remote(), timeout=3) in (node_1, node_2, node_3)
+
+
+def get_new_node_id(created_nodes):
+    wait_for_condition(lambda: len(ray.nodes()) > len(created_nodes), timeout=30)
+    nodes = ray.nodes()
+    for node in nodes:
+        if node["NodeID"] not in created_nodes:
+            created_nodes.append(node["NodeID"])
+            return node["NodeID"]
 
 
 def test_node_label_scheduling_invalid_paramter(call_ray_start):

--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -158,6 +158,10 @@ std::string NodeResourceInstances::DebugString() const {
            << FixedPointVectorToString(available.Get(resource_id)) << "/"
            << FixedPointVectorToString(total.Get(resource_id));
   }
+  buffer << "}, \"labels\":{";
+  for (const auto &[key, value] : labels) {
+    buffer << "\"" << key << "\":\"" << value << "\",";
+  }
   buffer << "}";
   return buffer.str();
 };

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -473,6 +473,9 @@ class NodeResourceInstances {
  public:
   TaskResourceInstances available;
   TaskResourceInstances total;
+  // The key-value labels of this node.
+  absl::flat_hash_map<std::string, std::string> labels;
+
   /// Extract available resource instances.
   const TaskResourceInstances &GetAvailableResourceInstances() const;
   const TaskResourceInstances &GetTotalResourceInstances() const;

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -61,6 +61,10 @@ inline bool operator==(const ray::rpc::SchedulingStrategy &lhs,
             rhs.placement_group_scheduling_strategy()
                 .placement_group_capture_child_tasks());
   }
+  case ray::rpc::SchedulingStrategy::kNodeLabelSchedulingStrategy: {
+    return google::protobuf::util::MessageDifferencer::Equivalent(
+        lhs.node_label_scheduling_strategy(), rhs.node_label_scheduling_strategy());
+  }
   default:
     return true;
   }
@@ -132,6 +136,9 @@ struct hash<ray::rpc::SchedulingStrategy> {
       hash ^=
           static_cast<size_t>(scheduling_strategy.placement_group_scheduling_strategy()
                                   .placement_group_capture_child_tasks());
+    } else if (scheduling_strategy.has_node_label_scheduling_strategy()) {
+      hash ^= std::hash<std::string>()(
+          scheduling_strategy.node_label_scheduling_strategy().DebugString());
     }
     return hash;
   }

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -174,6 +174,9 @@ scheduling::NodeID ClusterResourceScheduler::GetBestSchedulableNode(
                       .placement_group_bundle_index());
     best_node_id = scheduling_policy_->Schedule(
         resource_request, SchedulingOptions::AffinityWithBundle(bundle_id));
+  } else if (scheduling_strategy.has_node_label_scheduling_strategy()) {
+    best_node_id = scheduling_policy_->Schedule(
+        resource_request, SchedulingOptions::NodeLabelScheduling(scheduling_strategy));
   } else {
     // TODO (Alex): Setting require_available == force_spillback is a hack in order to
     // remain bug compatible with the legacy scheduling algorithms.

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -33,6 +33,7 @@ LocalResourceManager::LocalResourceManager(
       resource_change_subscriber_(resource_change_subscriber) {
   local_resources_.available = TaskResourceInstances(node_resources.available);
   local_resources_.total = TaskResourceInstances(node_resources.total);
+  local_resources_.labels = node_resources.labels;
   const auto now = absl::Now();
   for (const auto &resource_id : local_resources_.total.ResourceIds()) {
     resources_last_idle_time_[resource_id] = now;
@@ -342,6 +343,7 @@ NodeResources ToNodeResources(const NodeResourceInstances &instance) {
   NodeResources node_resources;
   node_resources.available = instance.available.ToResourceRequest();
   node_resources.total = instance.total.ToResourceRequest();
+  node_resources.labels = instance.labels;
   return node_resources;
 }
 

--- a/src/ray/raylet/scheduling/policy/composite_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/composite_scheduling_policy.cc
@@ -36,6 +36,8 @@ scheduling::NodeID CompositeSchedulingPolicy::Schedule(
     return node_affinity_policy_.Schedule(resource_request, options);
   case SchedulingType::AFFINITY_WITH_BUNDLE:
     return affinity_with_bundle_policy_.Schedule(resource_request, options);
+  case SchedulingType::NODE_LABEL:
+    return node_label_scheduling_policy_.Schedule(resource_request, options);
   default:
     RAY_LOG(FATAL) << "Unsupported scheduling type: "
                    << static_cast<typename std::underlying_type<SchedulingType>::type>(

--- a/src/ray/raylet/scheduling/policy/composite_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/composite_scheduling_policy.h
@@ -21,6 +21,7 @@
 #include "ray/raylet/scheduling/policy/bundle_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/hybrid_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/node_affinity_scheduling_policy.h"
+#include "ray/raylet/scheduling/policy/node_label_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/random_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/spread_scheduling_policy.h"
 
@@ -45,7 +46,10 @@ class CompositeSchedulingPolicy : public ISchedulingPolicy {
         affinity_with_bundle_policy_(local_node_id,
                                      cluster_resource_manager.GetResourceView(),
                                      is_node_available,
-                                     cluster_resource_manager.GetBundleLocationIndex()) {}
+                                     cluster_resource_manager.GetBundleLocationIndex()),
+        node_label_scheduling_policy_(local_node_id,
+                                      cluster_resource_manager.GetResourceView(),
+                                      is_node_available) {}
 
   scheduling::NodeID Schedule(const ResourceRequest &resource_request,
                               SchedulingOptions options) override;
@@ -56,6 +60,7 @@ class CompositeSchedulingPolicy : public ISchedulingPolicy {
   SpreadSchedulingPolicy spread_policy_;
   NodeAffinitySchedulingPolicy node_affinity_policy_;
   AffinityWithBundleSchedulingPolicy affinity_with_bundle_policy_;
+  NodeLabelSchedulingPolicy node_label_scheduling_policy_;
 };
 
 /// A composite scheduling policy that routes the request to the underlining

--- a/src/ray/raylet/scheduling/policy/node_label_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/node_label_scheduling_policy.cc
@@ -1,0 +1,177 @@
+// Copyright 2023 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/raylet/scheduling/policy/node_label_scheduling_policy.h"
+
+#include "ray/raylet/scheduling/policy/scheduling_context.h"
+
+namespace ray {
+namespace raylet_scheduling_policy {
+
+scheduling::NodeID NodeLabelSchedulingPolicy::Schedule(
+    const ResourceRequest &resource_request, SchedulingOptions options) {
+  RAY_CHECK(options.scheduling_type == SchedulingType::NODE_LABEL);
+  auto context =
+      dynamic_cast<const NodeLabelSchedulingContext *>(options.scheduling_context.get());
+  const auto &scheduling_strategy = context->GetSchedulingStrategy();
+  RAY_CHECK(scheduling_strategy.has_node_label_scheduling_strategy());
+  const auto &node_label_scheduling_strategy =
+      scheduling_strategy.node_label_scheduling_strategy();
+  // 1. Selet feasible nodes
+  auto candidate_nodes = SelectFeasibleNodes(resource_request);
+  if (candidate_nodes.empty()) {
+    return scheduling::NodeID::Nil();
+  }
+  // 2. Filter by hard expressions.
+  if (node_label_scheduling_strategy.hard().expressions().size() > 0) {
+    candidate_nodes = FilterNodesByLabelMatchExpressions(
+        candidate_nodes, node_label_scheduling_strategy.hard());
+    if (candidate_nodes.empty()) {
+      return scheduling::NodeID::Nil();
+    }
+  }
+
+  // 3. Filter by soft expressions.
+  const auto &soft_expressions = node_label_scheduling_strategy.soft();
+  if (soft_expressions.expressions().size() > 0) {
+    auto match_nodes =
+        FilterNodesByLabelMatchExpressions(candidate_nodes, soft_expressions);
+    if (!match_nodes.empty()) {
+      candidate_nodes = match_nodes;
+    }
+  }
+
+  return SelectBestNode(candidate_nodes, resource_request);
+}
+
+scheduling::NodeID NodeLabelSchedulingPolicy::SelectBestNode(
+    const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes,
+    const ResourceRequest &resource_request) {
+  auto available_nodes = SelectAvailableNodes(candidate_nodes, resource_request);
+  if (available_nodes.empty()) {
+    return SelectRandomNode(candidate_nodes);
+  }
+  return SelectRandomNode(available_nodes);
+}
+
+scheduling::NodeID NodeLabelSchedulingPolicy::SelectRandomNode(
+    const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes) {
+  std::uniform_int_distribution<int> distribution(0, candidate_nodes.size() - 1);
+  int node_index = distribution(gen_);
+  auto it = candidate_nodes.begin();
+  std::advance(it, node_index);
+  return it->first;
+}
+
+absl::flat_hash_map<scheduling::NodeID, const Node *>
+NodeLabelSchedulingPolicy::FilterNodesByLabelMatchExpressions(
+    const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes,
+    const rpc::LabelMatchExpressions &expressions) const {
+  auto match_nodes = candidate_nodes;
+  for (const auto &expression : expressions.expressions()) {
+    if (match_nodes.empty()) {
+      return match_nodes;
+    }
+
+    for (auto iter = match_nodes.begin(); iter != match_nodes.end(); iter++) {
+      if (!IsNodeMatchLabelExpression(*(iter->second), expression)) {
+        match_nodes.erase(iter);
+      }
+    }
+  }
+  return match_nodes;
+}
+
+bool NodeLabelSchedulingPolicy::IsNodeMatchLabelExpression(
+    const Node &node, const rpc::LabelMatchExpression &expression) const {
+  const auto &key = expression.key();
+  const auto &match_operator = expression.operator_();
+  if (match_operator.has_label_exists()) {
+    if (IsNodeLabelKeyExists(node, key)) {
+      return true;
+    }
+  } else if (match_operator.has_label_does_not_exist()) {
+    if (!IsNodeLabelKeyExists(node, key)) {
+      return true;
+    }
+  } else if (match_operator.has_label_in()) {
+    absl::flat_hash_set<std::string> values;
+    for (const auto &value : match_operator.label_in().values()) {
+      values.insert(value);
+    }
+    if (IsNodeLabelInValues(node, key, values)) {
+      return true;
+    }
+  } else if (match_operator.has_label_not_in()) {
+    absl::flat_hash_set<std::string> values;
+    for (const auto &value : match_operator.label_not_in().values()) {
+      values.insert(value);
+    }
+    if (!IsNodeLabelInValues(node, key, values)) {
+      return true;
+    }
+  } else {
+    RAY_CHECK(false) << "Node label match operator type must be one of `label_in`、"
+                        "`label_not_in`、`label_exists` or `label_does_not_exist`.";
+  }
+  return false;
+}
+
+bool NodeLabelSchedulingPolicy::IsNodeLabelKeyExists(const Node &node,
+                                                     const std::string &key) const {
+  return node.GetLocalView().labels.contains(key);
+}
+
+bool NodeLabelSchedulingPolicy::IsNodeLabelInValues(
+    const Node &node,
+    const std::string &key,
+    const absl::flat_hash_set<std::string> &values) const {
+  const auto &node_labels = node.GetLocalView().labels;
+  if (!node_labels.contains(key)) {
+    return false;
+  }
+
+  return values.contains(node_labels.at(key));
+}
+
+absl::flat_hash_map<scheduling::NodeID, const Node *>
+NodeLabelSchedulingPolicy::SelectFeasibleNodes(
+    const ResourceRequest &resource_request) const {
+  absl::flat_hash_map<scheduling::NodeID, const Node *> candidate_nodes;
+  for (const auto &pair : nodes_) {
+    const auto &node_id = pair.first;
+    const auto &node_resources = pair.second.GetLocalView();
+    if (is_node_alive_(node_id) && node_resources.IsFeasible(resource_request)) {
+      candidate_nodes.emplace(node_id, &pair.second);
+    }
+  }
+  return candidate_nodes;
+}
+
+absl::flat_hash_map<scheduling::NodeID, const Node *>
+NodeLabelSchedulingPolicy::SelectAvailableNodes(
+    const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes,
+    const ResourceRequest &resource_request) const {
+  absl::flat_hash_map<scheduling::NodeID, const Node *> available_nodes;
+  for (const auto &pair : candidate_nodes) {
+    const auto &node_id = pair.first;
+    const auto &node_resources = pair.second->GetLocalView();
+    if (node_resources.IsAvailable(resource_request)) {
+      available_nodes.emplace(node_id, pair.second);
+    }
+  }
+  return available_nodes;
+}
+}  // namespace raylet_scheduling_policy
+}  // namespace ray

--- a/src/ray/raylet/scheduling/policy/node_label_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/node_label_scheduling_policy.h
@@ -1,0 +1,74 @@
+// Copyright 2023 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "ray/raylet/scheduling/policy/scheduling_policy.h"
+
+namespace ray {
+namespace raylet_scheduling_policy {
+
+// Label based node affinity scheduling strategy
+class NodeLabelSchedulingPolicy : public ISchedulingPolicy {
+ public:
+  NodeLabelSchedulingPolicy(scheduling::NodeID local_node_id,
+                            const absl::flat_hash_map<scheduling::NodeID, Node> &nodes,
+                            std::function<bool(scheduling::NodeID)> is_node_alive)
+      : local_node_id_(local_node_id),
+        nodes_(nodes),
+        is_node_alive_(is_node_alive),
+        gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
+
+  scheduling::NodeID Schedule(const ResourceRequest &resource_request,
+                              SchedulingOptions options) override;
+
+ private:
+  bool IsNodeMatchLabelExpression(const Node &node,
+                                  const rpc::LabelMatchExpression &expression) const;
+
+  bool IsNodeLabelKeyExists(const Node &node, const std::string &key) const;
+
+  bool IsNodeLabelInValues(const Node &node,
+                           const std::string &key,
+                           const absl::flat_hash_set<std::string> &values) const;
+
+  absl::flat_hash_map<scheduling::NodeID, const Node *> SelectAvailableNodes(
+      const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes,
+      const ResourceRequest &resource_request) const;
+
+  absl::flat_hash_map<scheduling::NodeID, const Node *> SelectFeasibleNodes(
+      const ResourceRequest &resource_request) const;
+
+  absl::flat_hash_map<scheduling::NodeID, const Node *>
+  FilterNodesByLabelMatchExpressions(
+      const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes,
+      const rpc::LabelMatchExpressions &expressions) const;
+
+  scheduling::NodeID SelectBestNode(
+      const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes,
+      const ResourceRequest &resource_request);
+
+  scheduling::NodeID SelectRandomNode(
+      const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes);
+
+  const scheduling::NodeID local_node_id_;
+  const absl::flat_hash_map<scheduling::NodeID, Node> &nodes_;
+  std::function<bool(scheduling::NodeID)> is_node_alive_;
+  /// Internally maintained random number generator.
+  std::mt19937_64 gen_;
+};
+}  // namespace raylet_scheduling_policy
+}  // namespace ray

--- a/src/ray/raylet/scheduling/policy/scheduling_context.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_context.h
@@ -48,5 +48,17 @@ struct AffinityWithBundleSchedulingContext : public SchedulingContext {
   BundleID affinity_bundle_id_;
 };
 
+struct NodeLabelSchedulingContext : public SchedulingContext {
+ public:
+  explicit NodeLabelSchedulingContext(const rpc::SchedulingStrategy &scheduling_strategy)
+      : scheduling_strategy_(scheduling_strategy) {}
+  const rpc::SchedulingStrategy &GetSchedulingStrategy() const {
+    return scheduling_strategy_;
+  }
+
+ private:
+  rpc::SchedulingStrategy scheduling_strategy_;
+};
+
 }  // namespace raylet_scheduling_policy
 }  // namespace ray

--- a/src/ray/raylet/scheduling/policy/scheduling_options.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_options.h
@@ -36,7 +36,8 @@ enum class SchedulingType {
   BUNDLE_SPREAD = 5,
   BUNDLE_STRICT_PACK = 6,
   BUNDLE_STRICT_SPREAD = 7,
-  AFFINITY_WITH_BUNDLE = 8
+  AFFINITY_WITH_BUNDLE = 8,
+  NODE_LABEL = 9
 };
 
 // Options that controls the scheduling behavior.
@@ -108,6 +109,19 @@ struct SchedulingOptions {
         std::move(scheduling_context));
   }
 
+  static SchedulingOptions NodeLabelScheduling(
+      const rpc::SchedulingStrategy &scheduling_strategy) {
+    auto scheduling_context =
+        std::make_unique<NodeLabelSchedulingContext>(scheduling_strategy);
+    return SchedulingOptions(
+        SchedulingType::NODE_LABEL,
+        /*spread_threshold*/ 0,
+        /*avoid_local_node*/ false,
+        /*require_node_available*/ true,
+        /*avoid_gpu_nodes*/ RayConfig::instance().scheduler_avoid_gpu_nodes(),
+        /*max_cpu_fraction_per_node*/ 0,
+        std::move(scheduling_context));
+  }
   /*
    * Bundle scheduling options.
    */


### PR DESCRIPTION
## Why are these changes needed?
Implement node label scheduling strategy

## Related issue number
#34894
 (P2)Implement the node affinity with labels interface in Python and transparently transmit it to the CoreWorker.
 (P2)Implement the node affinity with labels scheduling policy.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
