### PR TITLE
[serve] Reduce `num_replicas` in `test_standalone_2.py::test_controller_recover_and_delete`

### DIFF
--- a/python/ray/serve/tests/test_standalone_2.py
+++ b/python/ray/serve/tests/test_standalone_2.py
@@ -334,8 +334,10 @@ def test_controller_recover_and_delete(shutdown_ray):
     ray_context = ray.init()
     client = serve.start()
 
+    num_replicas = 10
+
     @serve.deployment(
-        num_replicas=50,
+        num_replicas=num_replicas,
         ray_actor_options={"num_cpus": 0.001},
     )
     def f():
@@ -369,7 +371,7 @@ def test_controller_recover_and_delete(shutdown_ray):
                 filters=[("state", "=", "ALIVE")],
             )
         )
-        == len(actors) - 50
+        == len(actors) - num_replicas
     )
 
     # The deployment should be deleted, meaning its state should not be stored


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Attempting to deflake `test_standalone_2.py` by starting fewer actors in CI.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
