### PR TITLE
[serve] Pin `fastapi==0.99.1` in `requirements-doc.txt` to fix API reference (#37340)

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -12,7 +12,7 @@ fairscale<=0.4.0; python_version < '3.7'
 filelock
 flask
 flatbuffers
-fastapi
+fastapi==0.99.1
 jsonschema
 mock
 numpy

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -20,7 +20,7 @@ cloudpickle==2.2.0
 cryptography==38.0.1
 cython==0.29.32
 dataclasses; python_version < '3.7'
-fastapi==0.99.1
+fastapi[all]==0.99.1
 feather-format==0.4.1
 # Keep compatible with Werkzeug
 flask==2.1.3

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -20,10 +20,7 @@ cloudpickle==2.2.0
 cryptography==38.0.1
 cython==0.29.32
 dataclasses; python_version < '3.7'
-# 0.85.0 of fastapi is breaking the ci because
-# requires newer starlette -> newer version typing-extensions
-# conflicting with tensorflow 2.6
-fastapi==0.75.0
+fastapi==0.99.1
 feather-format==0.4.1
 # Keep compatible with Werkzeug
 flask==2.1.3
@@ -100,7 +97,7 @@ importlib-metadata==4.10.0
 # Some packages have downstream dependencies that we have to specify here to resolve conflicts.
 # Feel free to add (or remove!) packages here liberally.
 tensorboardX==2.6.0
-starlette==0.17.1
+starlette==0.27.0
 h11==0.12.0
 markdown-it-py==1.1.0
 attrs==21.4.0


### PR DESCRIPTION
## Why are these changes needed?

Cherry-pick https://github.com/ray-project/ray/pull/37340

Also cherry-picks: https://github.com/ray-project/ray/pull/37375, which is a one-line change to fix the Windows build in CI.

## Related issue number

Closes https://github.com/ray-project/ray/issues/37337

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
