### PR TITLE
[Core] Add a better error message for health checking network failure…

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
@@ -105,8 +105,12 @@ void GcsHealthCheckManager::HealthCheckContext::StartHealthCheck() {
                 health_check_remaining_ = manager_->failure_threshold_;
               } else {
                 --health_check_remaining_;
-                RAY_LOG(WARNING) << "Health check failed for node " << node_id_
-                                 << ", remaining checks " << health_check_remaining_;
+                RAY_LOG(WARNING)
+                    << "Health check failed for node " << node_id_
+                    << ", remaining checks " << health_check_remaining_ << ", status "
+                    << status.error_code() << ", response status " << response_.status()
+                    << ", status message " << status.error_message()
+                    << ", status details " << status.error_details();
               }
 
               if (health_check_remaining_ == 0) {


### PR DESCRIPTION
…s (#36957)

This PR adds a better error message for health checking network failures

Currently, it doesn't log why health check RPCs fail.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR is necessary to debug random head node failures that happened to one of users. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
