### PR TITLE
Fix a wrong metrics setup link from the doc. (#37312)

### DIFF
--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -331,7 +331,7 @@ export const GrafanaNotRunningAlert = ({
       Time-series charts are hidden because either Prometheus or Grafana server
       is not detected. Follow{" "}
       <a
-        href="https://docs.ray.io/en/latest/ray-observability/ray-metrics.html"
+        href="https://docs.ray.io/en/latest/cluster/metrics.html"
         target="_blank"
         rel="noreferrer"
       >


### PR DESCRIPTION
The current link is not working from 2.6.

Note; We should cherry pick this PR

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is a very simple PR to change the wrong URL link from the dashboard

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
