### PR TITLE
[serve] Install `fastapi[all]` in test requirements

### DIFF
--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -20,7 +20,7 @@ cloudpickle==2.2.0
 cryptography==38.0.1
 cython==0.29.32
 dataclasses; python_version < '3.7'
-fastapi==0.99.1
+fastapi[all]==0.99.1
 feather-format==0.4.1
 # Keep compatible with Werkzeug
 flask==2.1.3


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For some reason `httpx` isn't being installed properly on Windows. Maybe this fixes it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
