### PR TITLE
[serve] Skip tests requiring starlette `TestClient` on Windows

### DIFF
--- a/python/ray/serve/tests/test_deployment_graph_driver.py
+++ b/python/ray/serve/tests/test_deployment_graph_driver.py
@@ -4,7 +4,6 @@ from pydantic import BaseModel
 import pytest
 import requests
 import starlette.requests
-from starlette.testclient import TestClient
 
 from ray.serve.drivers import DAGDriver
 from ray.serve.air_integrations import SimpleSchemaIngress
@@ -41,7 +40,13 @@ class EchoIngress(SimpleSchemaIngress):
         return inp
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="TestClient not working on Windows."
+)
 def test_unit_schema_injection():
+    # Delayed import because TestClient is missing a dependency on Windows.
+    from starlette.testclient import TestClient
+
     async def resolver(my_custom_param: int):
         return my_custom_param
 
@@ -70,7 +75,12 @@ class MyType(BaseModel):
     b: str
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="TestClient not working on Windows."
+)
 def test_unit_pydantic_class_adapter():
+    # Delayed import because TestClient is missing a dependency on Windows.
+    from starlette.testclient import TestClient
 
     server = EchoIngress(http_adapter=MyType)
     client = TestClient(server.app)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For some reason `httpx` isn't being installed properly on Windows.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
