### PR TITLE
[Serve] Use `wait_for_condition` in `test_request_context_pass_for_http_proxy`

### DIFF
--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -464,15 +464,15 @@ class TestRequestContextMetrics:
     def test_request_context_pass_for_http_proxy(self, serve_start_shutdown):
         """Test HTTP proxy passing request context"""
 
-        @serve.deployment
+        @serve.deployment(graceful_shutdown_timeout_s=0.001)
         def f():
             return "hello"
 
-        @serve.deployment
+        @serve.deployment(graceful_shutdown_timeout_s=0.001)
         def g():
             return "world"
 
-        @serve.deployment
+        @serve.deployment(graceful_shutdown_timeout_s=0.001)
         def h():
             return 1 / 0
 
@@ -497,20 +497,37 @@ class TestRequestContextMetrics:
             timeout=20,
         )
 
+        def wait_for_route_and_name(
+            metric_name: str,
+            deployment_name: str,
+            app_name: str,
+            route: str,
+            timeout: float = 5,
+        ):
+            """Waits for app name and route to appear in deployment's metric."""
+
+            def check():
+                # Check replica qps & latency
+                (
+                    qps_metrics_route,
+                    qps_metrics_app_name,
+                ) = self._generate_metrics_summary(get_metric_dictionaries(metric_name))
+                assert qps_metrics_app_name[deployment_name] == app_name
+                assert qps_metrics_route[deployment_name] == {route}
+                return True
+
+            wait_for_condition(check, timeout=timeout)
+
         # Check replica qps & latency
-        qps_metrics_route, qps_metrics_app_name = self._generate_metrics_summary(
-            get_metric_dictionaries("serve_deployment_request_counter")
+        wait_for_route_and_name(
+            "serve_deployment_request_counter", "app1_f", "app1", "/app1"
         )
-        print(qps_metrics_route)
-        assert qps_metrics_route["app1_f"] == {"/app1"}
-        assert qps_metrics_route["app2_g"] == {"/app2"}
-        assert qps_metrics_app_name["app1_f"] == "app1"
-        assert qps_metrics_app_name["app2_g"] == "app2"
-        qps_metrics_route, qps_metrics_app_name = self._generate_metrics_summary(
-            get_metric_dictionaries("serve_deployment_error_counter")
+        wait_for_route_and_name(
+            "serve_deployment_request_counter", "app2_g", "app2", "/app2"
         )
-        assert qps_metrics_route["app3_h"] == {"/app3"}
-        assert qps_metrics_app_name["app3_h"] == "app3"
+        wait_for_route_and_name(
+            "serve_deployment_error_counter", "app3_h", "app3", "/app3"
+        )
 
         # Check http proxy qps & latency
         for metric_name in [

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -448,11 +448,11 @@ class TestRequestContextMetrics:
         metrics_summary_route = DefaultDict(set)
         metrics_summary_app = DefaultDict(str)
 
-        for request_metrcis in metrics:
-            metrics_summary_route[request_metrcis["deployment"]].add(
-                request_metrcis["route"]
+        for request_metrics in metrics:
+            metrics_summary_route[request_metrics["deployment"]].add(
+                request_metrics["route"]
             )
-            metrics_summary_app[request_metrcis["deployment"]] = request_metrcis[
+            metrics_summary_app[request_metrics["deployment"]] = request_metrics[
                 "application"
             ]
         return metrics_summary_route, metrics_summary_app


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_metrics` has been flaky on Windows recently:

<img width="1331" alt="Screen Shot 2023-07-12 at 2 45 00 PM" src="https://github.com/ray-project/ray/assets/92341594/50198893-631c-450f-aea9-276d7c9b2c20">

The issue seems to be that `test_request_context_pass_for_http_proxy` fails periodically. [Example traceback](https://buildkite.com/ray-project/oss-ci-build-branch/builds/4930#0189472e-553b-489b-b124-aec4bb21f131/2763-2901):

```console
================================== FAILURES ===================================
--
  | _____ TestRequestContextMetrics.test_request_context_pass_for_http_proxy ______
  |  
  | self = <com_github_ray_project_ray.python.ray.serve.tests.test_metrics.TestRequestContextMetrics object at 0x0000015C4AEAEBE0>
  | serve_start_shutdown = <ray.serve._private.client.ServeControllerClient object at 0x0000015C4B2F0910>
  |  
  | def test_request_context_pass_for_http_proxy(self, serve_start_shutdown):
  | """Test HTTP proxy passing request context"""
  |  
  | @serve.deployment
  | def f():
  | return "hello"
  |  
  | @serve.deployment
  | def g():
  | return "world"
  |  
  | @serve.deployment
  | def h():
  | return 1 / 0
  |  
  | serve.run(f.bind(), name="app1", route_prefix="/app1")
  | serve.run(g.bind(), name="app2", route_prefix="/app2")
  | serve.run(h.bind(), name="app3", route_prefix="/app3")
  |  
  | resp = requests.get("http://127.0.0.1:8000/app1")
  | assert resp.status_code == 200
  | assert resp.text == "hello"
  | resp = requests.get("http://127.0.0.1:8000/app2")
  | assert resp.status_code == 200
  | assert resp.text == "world"
  | resp = requests.get("http://127.0.0.1:8000/app3")
  | assert resp.status_code == 500
  |  
  | wait_for_condition(
  | lambda: len(
  | get_metric_dictionaries("serve_deployment_processing_latency_ms_sum")
  | )
  | == 3,
  | timeout=20,
  | )
  |  
  | # Check replica qps & latency
  | qps_metrics_route, qps_metrics_app_name = self._generate_metrics_summary(
  | get_metric_dictionaries("serve_deployment_request_counter")
  | )
  | print(qps_metrics_route)
  | >       assert qps_metrics_route["app1_f"] == {"/app1"}
  | E       AssertionError: assert set() == {'/app1'}
  | E         Extra items in the right set:
  | E         '/app1'
  | E         Full diff:
  | E         - {'/app1'}
  | E         + set()
  |  
  | \\?\C:\Users\ContainerAdministrator\AppData\Local\Temp\Bazel.runfiles_1b0b8x37\runfiles\com_github_ray_project_ray\python\ray\serve\tests\test_metrics.py:505: AssertionError
```

This change uses a `wait_for_condition` instead of `assert` to give the metrics a chance to update.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change deflakes `test_metrics.py`.
