### PR TITLE
[Train] Fix Deepspeed device ranks check in Lightning 2.0.5

### DIFF
--- a/python/ray/train/lightning/_lightning_utils.py
+++ b/python/ray/train/lightning/_lightning_utils.py
@@ -102,9 +102,7 @@ class RayDeepSpeedStrategy(DeepSpeedStrategy):
     """Subclass of DeepSpeedStrategy to ensure compatibility with Ray orchestration."""
 
     def setup_distributed(self):
-        # Device ranks have already been specified in RayEnvironment
-        # Clear parallel_devices to skip deepspeed local rank checks
-        self.parallel_devices = []
+        self.parallel_devices = list(range(torch.cuda.device_count()))
         super().setup_distributed()
 
     @property

--- a/python/ray/train/lightning/_lightning_utils.py
+++ b/python/ray/train/lightning/_lightning_utils.py
@@ -101,6 +101,12 @@ class RayFSDPStrategy(FSDPStrategy):
 class RayDeepSpeedStrategy(DeepSpeedStrategy):
     """Subclass of DeepSpeedStrategy to ensure compatibility with Ray orchestration."""
 
+    def setup_distributed(self):
+        # Device ranks have already been specified in RayEnvironment
+        # Clear parallel_devices to skip deepspeed local rank checks
+        self.parallel_devices = []
+        super().setup_distributed()
+
     @property
     def root_device(self) -> torch.device:
         return get_worker_root_device()

--- a/python/ray/train/lightning/_lightning_utils.py
+++ b/python/ray/train/lightning/_lightning_utils.py
@@ -102,7 +102,13 @@ class RayDeepSpeedStrategy(DeepSpeedStrategy):
     """Subclass of DeepSpeedStrategy to ensure compatibility with Ray orchestration."""
 
     def setup_distributed(self):
-        self.parallel_devices = list(range(torch.cuda.device_count()))
+        # We have to set the device ids for each node
+        # e.g. CUDA_VISIBLE_DEVICES = 2,3
+        # worker 0: LOCAL_RANK=0, parallel devices = [cuda:0, cuda:1]
+        # worker 1: LOCAL_RANK=1, parallel devices = [cuda:0, cuda:1]
+        self.parallel_devices = [
+            torch.device(f"cuda:{i}") for i in range(torch.cuda.device_count())
+        ]
         super().setup_distributed()
 
     @property


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

LightningTrainer deepspeed ci test failed due to lightning upgrade from 2.0.4 to 2.0.5, which introduced a check on device ranks in DeepSpeedStrategy [Link](https://lightning.ai/docs/pytorch/stable/generated/CHANGELOG.html). This PR aims to address the incompatibility and fix the test.

## Related issue number

<!-- For example: "Closes #1234" -->

Fix https://github.com/ray-project/ray/issues/37374

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
