### PR TITLE
Upgrade grpcio to a secure version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -20,8 +20,8 @@ requests
 
 # Python version-specific requirements
 dataclasses; python_version < '3.7'
-grpcio >= 1.32.0; python_version < '3.10'
-grpcio >= 1.42.0; python_version >= '3.10'
+grpcio >= 1.54.2; python_version < '3.10'
+grpcio >= 1.54.2; python_version >= '3.10'
 numpy>=1.16; python_version < '3.9'
 numpy>=1.19.3; python_version >= '3.9'
 typing_extensions; python_version < '3.8'
@@ -54,7 +54,7 @@ requests
 pandas
 tensorboardX<=2.6.0,>=1.9  # >=2.6.1 uses protobuf>=4, and conflicts with other packages.
 gymnasium==0.26.3
-grpcio<=1.50.0,>=1.42.0  # ray client
+grpcio>=1.54.2  # ray client
 aiohttp>=3.7
 starlette
 typer


### PR DESCRIPTION
Please upgrade grpcio to at least 1.52.2. Versions below 1.52.2 are vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2023-32731 which was fixed in release 1.54.2 in https://github.com/grpc/grpc/releases/tag/v1.54.2

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Versions lower than 1.54.2 are vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2023-32731
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
N/A
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
