### PR TITLE
[core][autoscaler] Add `experimental` into `ray/core/generated` for protos

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -264,9 +264,7 @@ if setup_spec.type == SetupType.RAY:
             "virtualenv >=20.0.24, < 20.21.1",  # For pip runtime env.
         ],
         "client": [
-            # The Ray client needs a specific range of gRPC to work:
-            # Tracking issue: https://github.com/grpc/grpc/issues/31885
-            "grpcio >= 1.42.0, <= 1.50.0",
+            "grpcio",
         ],
         "serve": ["uvicorn", "requests", "starlette", "fastapi", "aiorwlock"],
         "tune": ["pandas", "tensorboardX>=1.9", "requests", pyarrow_dep],

--- a/python/setup.py
+++ b/python/setup.py
@@ -184,6 +184,7 @@ if setup_spec.type == SetupType.RAY_CPP:
 # bindings are created.
 generated_python_directories = [
     "ray/core/generated",
+    "ray/core/generated/experimental",
     "ray/serve/generated",
 ]
 
@@ -263,7 +264,9 @@ if setup_spec.type == SetupType.RAY:
             "virtualenv >=20.0.24, < 20.21.1",  # For pip runtime env.
         ],
         "client": [
-            "grpcio",
+            # The Ray client needs a specific range of gRPC to work:
+            # Tracking issue: https://github.com/grpc/grpc/issues/31885
+            "grpcio >= 1.42.0, <= 1.50.0",
         ],
         "serve": ["uvicorn", "requests", "starlette", "fastapi", "aiorwlock"],
         "tune": ["pandas", "tensorboardX>=1.9", "requests", pyarrow_dep],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We are currently putting autoscaler's v2 proto under a `experimental` subdirectory and namespace to prevent interfering with existing implementation. 

Without this, the `core/generated/experimental` protos are not included in the wheel, even though it works in CI/local dev. 



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

Tested locally with wheel and make sure import works 
```
python setup.py bdist_wheel  
pip install <wheel>

# in python
>>> from ray.core.generated.experimental.autoscaler_pb2 import GetClusterStatusReply
```

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
