### PR TITLE
[Test] Change instance type to r5.8xlarge for dask_on_ray_1tb_sort (#37321)

### DIFF
--- a/release/nightly_tests/dask_on_ray/1tb_sort_compute.yaml
+++ b/release/nightly_tests/dask_on_ray/1tb_sort_compute.yaml
@@ -10,13 +10,13 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m6i.8xlarge
+    instance_type: r5.8xlarge
     resources:
       cpu: 8
 
 worker_node_types:
     - name: worker_node
-      instance_type: m6i.8xlarge
+      instance_type: r5.8xlarge
       min_workers: 32
       max_workers: 32
       use_spot: false


### PR DESCRIPTION
#34932 changed the instance type from i3.8xlarge (244GB memory) to m6i.8xlarge (128G) and the head node is more likely to hit OOM causing the job supervisor actor to be killed. This PR changes the instance type to r5.8xlarge which has 256G memory.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
