### PR TITLE
[Core][Node Labels 5/n]Add test case for invalid parameters when setting node labels

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1942,13 +1942,11 @@ def parse_node_labels_json(
             if not isinstance(value, str):
                 raise ValueError(f'The value of the "{key}" is not string type')
     except Exception as e:
-        cli_logger.error(
-            "`{}` is not a valid JSON string, detail error:{}",
+        cli_logger.abort(
+            "`{}` is not a valid JSON string, detail error:{}"
+            "Valid values look like this: `{}`",
             cf.bold(f"{command_arg}={labels_json}"),
             str(e),
-        )
-        cli_logger.abort(
-            "Valid values look like this: `{}`",
             cf.bold(f'{command_arg}=\'{{"gpu_type": "A100", "region": "us"}}\''),
         )
     return labels
@@ -1960,7 +1958,7 @@ def validate_node_labels(labels: Dict[str, str]):
     for key in labels.keys():
         if key.startswith(ray_constants.RAY_DEFAULT_LABEL_KEYS_PREFIX):
             raise ValueError(
-                f"Custom label keys cannot start with the prefix "
-                f"{ray_constants.RAY_DEFAULT_LABEL_KEYS_PREFIX}. "
+                f"Custom label keys `{key}` cannot start with the prefix "
+                f"`{ray_constants.RAY_DEFAULT_LABEL_KEYS_PREFIX}`. "
                 f"This is reserved for Ray defined labels."
             )

--- a/python/ray/tests/test_node_labels.py
+++ b/python/ray/tests/test_node_labels.py
@@ -1,8 +1,13 @@
 import os
 import sys
 import pytest
+import subprocess
 
 import ray
+
+
+def check_cmd_stderr(cmd):
+    return subprocess.run(cmd, stderr=subprocess.PIPE).stderr.decode("utf-8")
 
 
 def add_default_labels(node_info, labels):
@@ -49,9 +54,45 @@ def test_ray_init_set_node_labels(shutdown_only):
 
 def test_ray_init_set_node_labels_value_error(ray_start_cluster):
     cluster = ray_start_cluster
+
+    key = "ray.io/node_id"
+    with pytest.raises(
+        ValueError,
+        match=f"Custom label keys `{key}` cannot start with the prefix `ray.io/`",
+    ):
+        cluster.add_node(num_cpus=1, labels={key: "111111"})
+
+    key = "ray.io/other_key"
+    with pytest.raises(
+        ValueError,
+        match=f"Custom label keys `{key}` cannot start with the prefix `ray.io/`",
+    ):
+        ray.init(labels={key: "value"})
+
     cluster.add_node(num_cpus=1)
     with pytest.raises(ValueError, match="labels must not be provided"):
         ray.init(address=cluster.address, labels={"gpu_type": "A100"})
+
+    with pytest.raises(ValueError, match="labels must not be provided"):
+        ray.init(labels={"gpu_type": "A100"})
+
+
+def test_ray_start_set_node_labels_value_error():
+    out = check_cmd_stderr(["ray", "start", "--head", "--labels=xxx"])
+    assert "is not a valid JSON string, detail error" in out
+
+    out = check_cmd_stderr(["ray", "start", "--head", '--labels={"gpu_type":1}'])
+    assert 'The value of the "gpu_type" is not string type' in out
+
+    out = check_cmd_stderr(
+        ["ray", "start", "--head", '--labels={"ray.io/node_id":"111"}']
+    )
+    assert "cannot start with the prefix `ray.io/`" in out
+
+    out = check_cmd_stderr(
+        ["ray", "start", "--head", '--labels={"ray.io/other_key":"111"}']
+    )
+    assert "cannot start with the prefix `ray.io/`" in out
 
 
 def test_cluster_add_node_with_labels(ray_start_cluster):


### PR DESCRIPTION
## Why are these changes needed?
Add test case for invalid parameters when setting node labels.

## Related issue number
https://github.com/ray-project/ray/issues/34894

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
