### PR TITLE
[Data] Remove default limit on `to_pandas()` (#37418)

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3809,7 +3809,7 @@ class Dataset:
     def to_pandas(self, limit: int = None) -> "pandas.DataFrame":
         """Convert this :class:`~ray.data.Dataset` to a single pandas DataFrame.
 
-        This method errors if the number of rows exceeds the provided ``limit``. 
+        This method errors if the number of rows exceeds the provided ``limit``.
         To truncate the dataset beforehand, call :meth:`.limit`.
 
         Examples:
@@ -3825,7 +3825,7 @@ class Dataset:
 
         Args:
             limit: The maximum number of rows to return. An error is
-                raised if the dataset has more rows than this limit. Defaults to 
+                raised if the dataset has more rows than this limit. Defaults to
                 ``None``, which means no limit.
 
         Returns:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3806,7 +3806,7 @@ class Dataset:
         )
 
     @ConsumptionAPI(pattern="Time complexity:")
-    def to_pandas(self, limit: int = 100000) -> "pandas.DataFrame":
+    def to_pandas(self, limit: int = -1) -> "pandas.DataFrame":
         """Convert this :class:`~ray.data.Dataset` into a single pandas DataFrame.
 
         This method errors if the number of rows exceeds the
@@ -3826,7 +3826,8 @@ class Dataset:
 
         Args:
             limit: The maximum number of records to return. An error is
-                raised if the dataset has more rows than this limit.
+                raised if the dataset has more rows than this limit. Defaults to -1,
+                which means no limit.
 
         Returns:
             A pandas DataFrame created from this dataset, containing a limited
@@ -3837,12 +3838,12 @@ class Dataset:
             ``limit``.
         """
         count = self.count()
-        if count > limit:
+        if limit != -1 and count > limit:
             raise ValueError(
                 f"the dataset has more than the given limit of {limit} "
                 f"records: {count}. If you are sure that a DataFrame with "
                 f"{count} rows will fit in local memory, use "
-                f"ds.to_pandas(limit={count})."
+                f"ds.to_pandas(limit={count}) or ds.to_pandas(limit=-1) to disable limits."
             )
         blocks = self.get_internal_block_refs()
         output = DelegatingBlockBuilder()

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3806,12 +3806,11 @@ class Dataset:
         )
 
     @ConsumptionAPI(pattern="Time complexity:")
-    def to_pandas(self, limit: int = -1) -> "pandas.DataFrame":
-        """Convert this :class:`~ray.data.Dataset` into a single pandas DataFrame.
+    def to_pandas(self, limit: int = None) -> "pandas.DataFrame":
+        """Convert this :class:`~ray.data.Dataset` to a single pandas DataFrame.
 
-        This method errors if the number of rows exceeds the
-        provided ``limit``. You can use :meth:`.limit` on the dataset
-        beforehand to truncate the dataset manually.
+        This method errors if the number of rows exceeds the provided ``limit``. 
+        To truncate the dataset beforehand, call :meth:`.limit`.
 
         Examples:
             >>> import ray
@@ -3825,25 +3824,25 @@ class Dataset:
         Time complexity: O(dataset size)
 
         Args:
-            limit: The maximum number of records to return. An error is
-                raised if the dataset has more rows than this limit. Defaults to -1,
-                which means no limit.
+            limit: The maximum number of rows to return. An error is
+                raised if the dataset has more rows than this limit. Defaults to 
+                ``None``, which means no limit.
 
         Returns:
             A pandas DataFrame created from this dataset, containing a limited
-            number of records.
+            number of rows.
 
         Raises:
             ValueError: if the number of rows in the :class:`~ray.data.Dataset` exceeds
             ``limit``.
         """
         count = self.count()
-        if limit != -1 and count > limit:
+        if limit is not None and count > limit:
             raise ValueError(
                 f"the dataset has more than the given limit of {limit} "
-                f"records: {count}. If you are sure that a DataFrame with "
-                f"{count} rows will fit in local memory, use "
-                f"ds.to_pandas(limit={count}) or ds.to_pandas(limit=-1) to disable limits."
+                f"rows: {count}. If you are sure that a DataFrame with "
+                f"{count} rows will fit in local memory, set ds.to_pandas(limit=None) "
+                "to disable limits."
             )
         blocks = self.get_internal_block_refs()
         output = DelegatingBlockBuilder()


### PR DESCRIPTION
## Why are these changes needed?

Removes default hard-limit of 100k rows for dataframes, which is an unexpected and unreasonably low limit. 

## Related issue number

Closes #37418 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x ] This PR is not tested :(
