### PR TITLE
[Core]Change output of get_assigned_resources in pg to origin resources

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -73,6 +73,12 @@ _CALLED_FREQ = defaultdict(lambda: 0)
 _CALLED_FREQ_LOCK = threading.Lock()
 
 
+PLACEMENT_GROUP_INDEXED_BUNDLED_RESOURCE_PATTERN = re.compile(
+    r"(.+)_group_(\d+)_([0-9a-zA-Z]+)"
+)
+PLACEMENT_GROUP_WILDCARD_RESOURCE_PATTERN = re.compile(r"(.+)_group_([0-9a-zA-Z]+)")
+
+
 def get_user_temp_dir():
     if "RAY_TMPDIR" in os.environ:
         return os.environ["RAY_TMPDIR"]
@@ -1964,3 +1970,22 @@ def validate_node_labels(labels: Dict[str, str]):
                 f"{ray_constants.RAY_DEFAULT_LABEL_KEYS_PREFIX}. "
                 f"This is reserved for Ray defined labels."
             )
+
+
+def pasre_pg_formatted_resources_to_original(
+    pg_formatted_resources: Dict[str, float]
+) -> Dict[str, float]:
+    original_resources = {}
+
+    for key, value in pg_formatted_resources.items():
+        result = PLACEMENT_GROUP_WILDCARD_RESOURCE_PATTERN.match(key)
+        if result and len(result.groups()) == 2:
+            original_resources[result.group(1)] = value
+            continue
+        result = PLACEMENT_GROUP_INDEXED_BUNDLED_RESOURCE_PATTERN.match(key)
+        if result and len(result.groups()) == 3:
+            original_resources[result.group(1)] = value
+            continue
+        original_resources[key] = value
+
+    return original_resources

--- a/python/ray/air/tests/execution/test_resource_manager_placement_group.py
+++ b/python/ray/air/tests/execution/test_resource_manager_placement_group.py
@@ -200,15 +200,15 @@ def test_bind_two_bundles(ray_start_4_cpus):
 
     res1 = ray.get(av1.remote())
 
-    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0_")) == 1, res1
+    assert res1 == {"CPU": 1}
 
     [av1, av2] = acq.annotate_remote_entities(
         [get_assigned_resources, get_assigned_resources]
     )
 
     res1, res2 = ray.get([av1.remote(), av2.remote()])
-    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0_")) == 1, res1
-    assert sum(v for k, v in res2.items() if k.startswith("CPU_group_1_")) == 2, res2
+    assert res1 == {"CPU": 1}
+    assert res2 == {"CPU": 2}
 
 
 def test_bind_empty_head_bundle(ray_start_4_cpus):
@@ -234,15 +234,15 @@ def test_bind_empty_head_bundle(ray_start_4_cpus):
 
     res1 = ray.get(av1.remote())
 
-    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0_")) == 0, res1
+    assert res1 == {}
 
     [av1, av2] = acq.annotate_remote_entities(
         [get_assigned_resources, get_assigned_resources]
     )
 
     res1, res2 = ray.get([av1.remote(), av2.remote()])
-    assert sum(v for k, v in res1.items() if k.startswith("CPU_group_0_")) == 0, res1
-    assert sum(v for k, v in res2.items() if k.startswith("CPU_group_0_")) == 2, res2
+    assert res1 == {}
+    assert res2 == {"CPU": 2}
 
 
 def test_capture_child_tasks(ray_start_4_cpus):

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 
 import ray._private.worker
 from ray._private.client_mode_hook import client_mode_hook
+from ray._private.utils import pasre_pg_formatted_resources_to_original
 from ray.runtime_env import RuntimeEnv
 from ray.util.annotations import Deprecated, PublicAPI
 
@@ -323,7 +324,7 @@ class RuntimeContext(object):
             res: sum(amt for _, amt in mapping)
             for res, mapping in resource_id_map.items()
         }
-        return resource_map
+        return pasre_pg_formatted_resources_to_original(resource_map)
 
     def get_runtime_env_string(self):
         """Get the runtime env string used for the current driver or worker.

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -432,8 +432,7 @@ def test_placement_group_actor_resource_ids(ray_start_cluster, connect_to_client
             scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=g1)
         ).remote()
         resources = ray.get(a1.f.remote())
-        assert len(resources) == 1, resources
-        assert "CPU_group_" in list(resources.keys())[0], resources
+        assert resources == {"CPU": 1}
         placement_group_assert_no_leak([g1])
 
 
@@ -455,9 +454,7 @@ def test_placement_group_task_resource_ids(ray_start_cluster, connect_to_client)
             scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=g1)
         ).remote()
         resources = ray.get(o1)
-        assert len(resources) == 1, resources
-        assert "CPU_group_" in list(resources.keys())[0], resources
-        assert "CPU_group_0_" not in list(resources.keys())[0], resources
+        assert resources == {"CPU": 1}
 
         # Now retry with a bundle index constraint.
         o1 = f.options(
@@ -466,11 +463,7 @@ def test_placement_group_task_resource_ids(ray_start_cluster, connect_to_client)
             )
         ).remote()
         resources = ray.get(o1)
-        assert len(resources) == 2, resources
-        keys = list(resources.keys())
-        assert "CPU_group_" in keys[0], resources
-        assert "CPU_group_" in keys[1], resources
-        assert "CPU_group_0_" in keys[0] or "CPU_group_0_" in keys[1], resources
+        assert resources == {"CPU": 1}
 
         placement_group_assert_no_leak([g1])
 
@@ -499,8 +492,7 @@ def test_placement_group_hang(ray_start_cluster, connect_to_client):
         ).remote()
 
         resources = ray.get(o1)
-        assert len(resources) == 1, resources
-        assert "CPU_group_" in list(resources.keys())[0], resources
+        assert resources == {"CPU": 1}
 
         placement_group_assert_no_leak([g1])
 
@@ -609,6 +601,72 @@ def test_object_store_memory_deprecation_warning(ray_start_regular_shared):
         in str(warning.message)
         for warning in w
     )
+    ray.shutdown()
+
+
+def test_get_assigned_resources_in_pg(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=3)
+    ray.init(address=cluster.address)
+
+    @ray.remote
+    def get_assigned_resources():
+        return ray.get_runtime_context().get_assigned_resources()
+
+    resources = ray.get(get_assigned_resources.options(num_cpus=1).remote())
+    assert resources == {"CPU": 1}
+
+    pg = ray.util.placement_group(bundles=[{"CPU": 3, "memory": 500}])
+    ray.get(pg.ready())
+
+    resources = ray.get(
+        get_assigned_resources.options(
+            num_cpus=1,
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
+        ).remote()
+    )
+    assert resources == {"CPU": 1}
+
+    resources = ray.get(
+        get_assigned_resources.options(
+            num_cpus=1,
+            memory=100,
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg, placement_group_bundle_index=0
+            ),
+        ).remote()
+    )
+    assert resources == {"CPU": 1, "memory": 100}
+
+
+def test_omp_num_threads_in_pg(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=3)
+    ray.init(address=cluster.address)
+
+    @ray.remote(num_cpus=3)
+    def test_omp_num_threads():
+        import os
+
+        omp_threads = os.environ["OMP_NUM_THREADS"]
+        return int(omp_threads)
+
+    assert ray.get(test_omp_num_threads.remote()) == 3
+
+    pg = ray.util.placement_group(bundles=[{"CPU": 3}])
+    ray.get(pg.ready())
+
+    ref = test_omp_num_threads.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+    ).remote()
+    assert ray.get(ref) == 3
+
+    ref = test_omp_num_threads.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=pg, placement_group_bundle_index=0
+        )
+    ).remote()
+    assert ray.get(ref) == 3
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_utils.py
+++ b/python/ray/tests/test_utils.py
@@ -7,7 +7,11 @@ This currently expects to work for minimal installs.
 
 import pytest
 import logging
-from ray._private.utils import get_or_create_event_loop, try_import_each_module
+from ray._private.utils import (
+    get_or_create_event_loop,
+    pasre_pg_formatted_resources_to_original,
+    try_import_each_module,
+)
 from unittest.mock import patch
 import sys
 
@@ -74,6 +78,23 @@ def test_try_import_each_module():
                 "Did not find print call with import "
                 f"error {mocked_log_exception.call_args_list}"
             )
+
+
+def test_pasre_pg_formatted_resources():
+    out = pasre_pg_formatted_resources_to_original(
+        {"CPU_group_e765be422c439de2cd263c5d9d1701000000": 1, "memory": 100}
+    )
+    assert out == {"CPU": 1, "memory": 100}
+
+    out = pasre_pg_formatted_resources_to_original(
+        {
+            "memory_group_4da1c24ac25bec85bc817b258b5201000000": 100.0,
+            "memory_group_0_4da1c24ac25bec85bc817b258b5201000000": 100.0,
+            "CPU_group_0_4da1c24ac25bec85bc817b258b5201000000": 1.0,
+            "CPU_group_4da1c24ac25bec85bc817b258b5201000000": 1.0,
+        }
+    )
+    assert out == {"CPU": 1, "memory": 100}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?
1. Fixed the issue of ray.get_runtime_context.get_assigned_resources() does not return raw resources in PG
    For any user faceing APIs, we shouldn't expose resources like CPU_group_e765be422c439de2cd263c5d9d1701000000, which is an implementation detail
2. Fixed the issue of use placement group doesn't set OMP_NUM_THREADS properly

## Related issue number
[core] ray.get_runtime_context.get_assigned_resources() does not return raw resources in PG #28814
[Core] Using placement group doesn't set OMP_NUM_THREADS properly #37384

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
