### PR TITLE
[Data] Cherry-pick #37359

### DIFF
--- a/doc/source/data/doc_code/batch_formats.py
+++ b/doc/source/data/doc_code/batch_formats.py
@@ -5,10 +5,10 @@
 # __simple_map_function_start__
 import ray
 
-ds = ray.data.read_csv("example://iris.csv")
+ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
 
 def map_function(data):
-    return data[data["sepal.length"] < 5]
+    return data[data["sepal length (cm)"] < 5]
 
 batch = ds.take_batch(10, batch_format="pandas")
 mapped_batch = map_function(batch)
@@ -20,18 +20,18 @@ transformed = ds.map_batches(map_function, batch_format="pandas", batch_size=10)
 import ray
 import pandas as pd
 
-ds = ray.data.read_csv("example://iris.csv")
+ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
 ds.show(1)
-# -> {'sepal.length': 5.1, ..., 'petal.width': 0.2, 'variety': 'Setosa'}
+# -> {'sepal length (cm)': 5.1, ..., 'petal width (cm)': 0.2, 'target': 0}
 
 def transform_pandas(df_batch: pd.DataFrame) -> pd.DataFrame:
-    df_batch = df_batch[df_batch["variety"] == "Versicolor"]
-    df_batch.loc[:, "normalized.sepal.length"] = df_batch["sepal.length"] / df_batch["sepal.length"].max()
-    df_batch = df_batch.drop(columns=["sepal.length"])
+    df_batch = df_batch[df_batch["target"] == 2]
+    df_batch.loc[:, "normalized.sepal length (cm)"] = df_batch["sepal length (cm)"] / df_batch["sepal length (cm)"].max()
+    df_batch = df_batch.drop(columns=["sepal length (cm)"])
     return df_batch
 
 ds.map_batches(transform_pandas, batch_format="pandas").show(1)
-# -> {..., 'variety': 'Versicolor', 'normalized.sepal.length': 1.0}
+# -> {..., 'target': 2, 'normalized.sepal length (cm)': 1.0}
 # __simple_pandas_end__
 
 # __simple_numpy_start__
@@ -62,12 +62,12 @@ import ray
 import pyarrow as pa
 import pyarrow.compute as pac
 
-ds = ray.data.read_csv("example://iris.csv")
+ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
 
 
 def transform_pyarrow(batch: pa.Table) -> pa.Table:
-    batch = batch.filter(pac.equal(batch["variety"], "Versicolor"))
-    return batch.drop(["sepal.length"])
+    batch = batch.filter(pac.equal(batch["target"], 1))
+    return batch.drop(["sepal length (cm)"])
 
 
 # test map function on a batch
@@ -75,6 +75,6 @@ batch = ds.take_batch(1, batch_format="pyarrow")
 mapped_batch = transform_pyarrow(batch)
 
 ds.map_batches(transform_pyarrow, batch_format="pyarrow").show(1)
-# -> {'sepal.width': 3.2, ..., 'variety': 'Versicolor'}
+# -> {'sepal width (cm)': 3.2, ..., 'target': 1}
 # __simple_pyarrow_end__
 # fmt: on

--- a/doc/source/data/doc_code/key_concepts.py
+++ b/doc/source/data/doc_code/key_concepts.py
@@ -65,7 +65,7 @@ def map_udf(df):
     df["sepal.area"] = df["sepal.length"] * df["sepal.width"]
     return df
 
-ds = ray.data.read_parquet("example://iris.parquet") \
+ds = ray.data.read_parquet("s3://anonymous@ray-example-data/iris.parquet") \
     .lazy() \
     .map_batches(map_udf) \
     .filter(lambda row: row["sepal.area"] > 15)
@@ -81,7 +81,7 @@ from io import BytesIO
 import ray
 
 # ML ingest re-reading from storage on every epoch.
-torch_ds = ray.data.read_parquet("example://iris.parquet") \
+torch_ds = ray.data.read_parquet("s3://anonymous@ray-example-data/iris.parquet") \
     .repeat() \
     .random_shuffle_each_window() \
     .iter_torch_batches()
@@ -89,7 +89,7 @@ torch_ds = ray.data.read_parquet("example://iris.parquet") \
 # Streaming batch inference pipeline that pipelines the transforming of a single
 # file with the reading of a single file (at most 2 file's worth of data in-flight
 # at a time).
-infer_ds = ray.data.read_binary_files("example://mnist_subset_partitioned/") \
+infer_ds = ray.data.read_binary_files("s3://anonymous@ray-example-data/mnist_subset_partitioned/") \
     .window(blocks_per_window=1) \
     .map(lambda bytes_: np.asarray(PIL.Image.open(BytesIO(bytes_)).convert("L"))) \
     .map_batches(lambda imgs: [img.mean() > 0.5 for img in imgs])

--- a/doc/source/data/doc_code/tensor.py
+++ b/doc/source/data/doc_code/tensor.py
@@ -52,14 +52,14 @@ ray.data.from_numpy(np.zeros((1000, 128, 128, 3), dtype=np.int64))
 #               schema={data: numpy.ndarray(shape=(128, 128, 3), dtype=int64)})
 
 # From saved numpy files.
-ray.data.read_numpy("example://mnist_subset.npy")
+ray.data.read_numpy("s3://anonymous@ray-example-data/mnist_subset.npy")
 # -> Dataset(num_blocks=1, num_rows=3,
 #               schema={data: numpy.ndarray(shape=(28, 28), dtype=uint8)})
 # __create_numpy_end__
 
 # __create_parquet_1_begin__
 # Reading previously saved Tensor data works out of the box.
-ds = ray.data.read_parquet("example://parquet_images_mini")
+ds = ray.data.read_parquet("s3://anonymous@ray-example-data/parquet_images_mini")
 # -> Dataset(num_blocks=3, num_rows=3,
 #               schema={image: numpy.ndarray(shape=(128, 128, 3), dtype=uint8),
 #                       label: string})
@@ -156,7 +156,7 @@ print(ds.schema())
 ds.materialize()
 
 # __create_images_begin__
-ds = ray.data.read_images("example://image-datasets/simple")
+ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
 # -> Dataset(num_blocks=3, num_rows=3, 
 #               schema={data: numpy.ndarray(shape=(32, 32, 3), dtype=uint8)})
 
@@ -171,7 +171,7 @@ ds.take(1)
 # __create_images_end__
 
 # __consume_pandas_2_begin__
-ds = ray.data.read_parquet("example://parquet_images_mini")
+ds = ray.data.read_parquet("s3://anonymous@ray-example-data/parquet_images_mini")
 # -> Dataset(num_blocks=3, num_rows=3,
 #               schema={image: numpy.ndarray(shape=(128, 128, 3), dtype=uint8),
 #                       label: string})
@@ -194,7 +194,7 @@ next(ds.iter_batches(batch_format="pandas"))
 # __consume_pyarrow_2_begin__
 from ray.data.extensions.tensor_extension import ArrowTensorArray
 
-ds = ray.data.read_parquet("example://parquet_images_mini")
+ds = ray.data.read_parquet("s3://anonymous@ray-example-data/parquet_images_mini")
 # -> Dataset(num_blocks=3, num_rows=3,
 #               schema={image: numpy.ndarray(shape=(128, 128, 3), dtype=uint8),
 #                       label: object})
@@ -233,7 +233,7 @@ next(ds.iter_batches(batch_format="pyarrow"))
 # __consume_pyarrow_2_end__
 
 # __consume_numpy_2_begin__
-ds = ray.data.read_parquet("example://parquet_images_mini")
+ds = ray.data.read_parquet("s3://anonymous@ray-example-data/parquet_images_mini")
 # -> Dataset(num_blocks=3, num_rows=3,
 #               schema={image: numpy.ndarray(shape=(128, 128, 3), dtype=uint8),
 #                       label: object})
@@ -270,7 +270,7 @@ shutil.rmtree("/tmp/some_path")
 
 # __write_1_begin__
 # Read a multi-column example dataset.
-ds = ray.data.read_parquet("example://parquet_images_mini")
+ds = ray.data.read_parquet("s3://anonymous@ray-example-data/parquet_images_mini")
 # -> Dataset(num_blocks=3, num_rows=3,
 #               schema={image: numpy.ndarray(shape=(128, 128, 3), dtype=uint8),
 #                       label: object})
@@ -290,7 +290,7 @@ shutil.rmtree("/tmp/some_path")
 
 # __write_2_begin__
 # Read a single-column example dataset.
-ds = ray.data.read_numpy("example://mnist_subset.npy")
+ds = ray.data.read_numpy("s3://anonymous@ray-example-data/mnist_subset.npy")
 # -> Dataset(num_blocks=1, num_rows=3,
 #               schema={data: numpy.ndarray(shape=(28, 28), dtype=uint8)})
 

--- a/doc/source/data/inspecting-data.rst
+++ b/doc/source/data/inspecting-data.rst
@@ -109,7 +109,7 @@ of the returned batch, set ``batch_format``.
 
             import ray
 
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
 
             batch = ds.take_batch(batch_size=2, batch_format="numpy")
             print("Batch:", batch)

--- a/doc/source/data/iterating-over-data.rst
+++ b/doc/source/data/iterating-over-data.rst
@@ -64,7 +64,7 @@ formats by calling one of the following methods:
 
             import ray
 
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
 
             for batch in ds.iter_batches(batch_size=2, batch_format="numpy"):
                 print(batch)
@@ -106,7 +106,7 @@ formats by calling one of the following methods:
 
             import ray
 
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
 
             for batch in ds.iter_torch_batches(batch_size=2):
                 print(batch)
@@ -172,7 +172,7 @@ movement.
 
             import ray
 
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
 
             for batch in ds.iter_batches(
                 batch_size=2,
@@ -223,7 +223,7 @@ movement.
 
             import ray
 
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
             for batch in ds.iter_torch_batches(
                 batch_size=2,
                 local_shuffle_buffer_size=250,

--- a/doc/source/data/key-concepts.rst
+++ b/doc/source/data/key-concepts.rst
@@ -161,7 +161,7 @@ or remote filesystems.
 
     transformed_ds.write_parquet("/tmp/iris")
 
-    print(os.listdir("/tmp/iris"))
+    print(sorted(os.listdir("/tmp/iris")))
 
 .. testoutput::
 

--- a/doc/source/data/performance-tips.rst
+++ b/doc/source/data/performance-tips.rst
@@ -44,7 +44,7 @@ Current Dataset will read all Parquet columns into memory.
 If you only need a subset of the columns, make sure to specify the list of columns
 explicitly when calling :meth:`ray.data.read_parquet() <ray.data.read_parquet>` to
 avoid loading unnecessary data (projection pushdown).
-For example, use ``ray.data.read_parquet("example://iris.parquet", columns=["sepal.length", "variety"])`` to read
+For example, use ``ray.data.read_parquet("s3://anonymous@ray-example-data/iris.parquet", columns=["sepal.length", "variety"])`` to read
 just two of the five columns of Iris dataset.
 
 .. _parquet_row_pruning:
@@ -55,7 +55,7 @@ Parquet row pruning
 Similarly, you can pass in a filter to :meth:`ray.data.read_parquet() <ray.data.Dataset.read_parquet>` (filter pushdown)
 which will be applied at the file scan so only rows that match the filter predicate
 will be returned.
-For example, use ``ray.data.read_parquet("example://iris.parquet", filter=pyarrow.dataset.field("sepal.length") > 5.0)``
+For example, use ``ray.data.read_parquet("s3://anonymous@ray-example-data/iris.parquet", filter=pyarrow.dataset.field("sepal.length") > 5.0)``
 (where ``pyarrow`` has to be imported)
 to read rows with sepal.length greater than 5.0.
 This can be used in conjunction with column pruning when appropriate to get the benefits of both.

--- a/doc/source/data/saving-data.rst
+++ b/doc/source/data/saving-data.rst
@@ -32,7 +32,7 @@ directory with the `local://` scheme.
 
     import ray
 
-    ds = ray.data.read_csv("example://iris.csv")
+    ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
 
     ds.write_parquet("local:///tmp/iris/")
 
@@ -119,7 +119,7 @@ mounted directory.
 
     import ray
 
-    ds = ray.data.read_csv("example://iris.csv")
+    ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
 
     ds.write_parquet("/mnt/cluster_storage/iris")
 
@@ -137,7 +137,7 @@ To change the number of blocks, call :meth:`~ray.data.Dataset.repartition`.
     import os
     import ray
 
-    ds = ray.data.read_csv("example://iris.csv")
+    ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
     ds.repartition(2).write_csv("/tmp/two_files/")
 
     print(os.listdir("/tmp/two_files/"))
@@ -162,7 +162,7 @@ on the head node.
 
     import ray
 
-    ds = ray.data.read_csv("example://iris.csv")
+    ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
 
     df = ds.to_pandas()
     print(df)
@@ -170,11 +170,18 @@ on the head node.
 .. testoutput::
     :options: +NORMALIZE_WHITESPACE
 
-         sepal.length  sepal.width  petal.length  petal.width    variety
-    0             5.1          3.5           1.4          0.2     Setosa
-    1             4.9          3.0           1.4          0.2     Setosa
-    ...
-    149           5.9          3.0           5.1          1.8  Virginica
+         sepal length (cm)  sepal width (cm)  ...  petal width (cm)  target
+    0                  5.1               3.5  ...               0.2       0
+    1                  4.9               3.0  ...               0.2       0
+    2                  4.7               3.2  ...               0.2       0
+    3                  4.6               3.1  ...               0.2       0
+    4                  5.0               3.6  ...               0.2       0
+    ..                 ...               ...  ...               ...     ...
+    145                6.7               3.0  ...               2.3       2
+    146                6.3               2.5  ...               1.9       2
+    147                6.5               3.0  ...               2.0       2
+    148                6.2               3.4  ...               2.3       2
+    149                5.9               3.0  ...               1.8       2
     <BLANKLINE>
     [150 rows x 5 columns]
 
@@ -198,7 +205,7 @@ Ray Data interoperates with distributed data processing frameworks like
 
             import ray
 
-            ds = ray.data.read_csv("example://iris.csv")
+            ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
 
             df = ds.to_dask()
 
@@ -213,7 +220,7 @@ Ray Data interoperates with distributed data processing frameworks like
 
             import ray
 
-            ds = ray.data.read_csv("example://iris.csv")
+            ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
 
             df = ds.to_spark()
 
@@ -227,7 +234,7 @@ Ray Data interoperates with distributed data processing frameworks like
 
             import ray
 
-            ds = ray.data.read_csv("example://iris.csv")
+            ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
 
             mdf = ds.to_modin()
 
@@ -241,6 +248,6 @@ Ray Data interoperates with distributed data processing frameworks like
 
             import ray
 
-            ds = ray.data.read_csv("example://iris.csv")
+            ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
 
             mdf = ds.to_mars()

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -43,7 +43,7 @@ If your transformation returns exactly one row for each input row, call
         return row
 
     ds = (
-        ray.data.read_images("example://image-datasets/simple", include_paths=True)
+        ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple", include_paths=True)
         .map(parse_filename)
     )
 
@@ -111,7 +111,7 @@ uses tasks by default.
         return batch
 
     ds = (
-        ray.data.read_images("example://image-datasets/simple")
+        ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
         .map_batches(increase_brightness)
     )
 
@@ -226,7 +226,7 @@ To configure the batch type, specify ``batch_format`` in
                 return batch
 
             ds = (
-                ray.data.read_images("example://image-datasets/simple")
+                ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
                 .map_batches(increase_brightness, batch_format="numpy")
             )
 
@@ -321,7 +321,7 @@ To randomly shuffle all rows, call :meth:`~ray.data.Dataset.random_shuffle`.
     import ray
 
     ds = (
-        ray.data.read_images("example://image-datasets/simple")
+        ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
         .random_shuffle()
     )
 

--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -263,7 +263,7 @@ see the :ref:`Input/Output reference <input-output>`.
 
             import ray
 
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
             ds.write_parquet("/tmp/simple")
 
 
@@ -275,7 +275,7 @@ see the :ref:`Input/Output reference <input-output>`.
 
             import ray
 
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
             ds.write_numpy("/tmp/simple", column="image")
 
     .. tab-item:: JSON
@@ -286,7 +286,7 @@ see the :ref:`Input/Output reference <input-output>`.
 
             import ray
 
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
             ds.write_json("/tmp/simple")
 
 For more information on saving data, see :ref:`Saving data <loading_data>`.

--- a/doc/source/data/working-with-pytorch.rst
+++ b/doc/source/data/working-with-pytorch.rst
@@ -26,7 +26,7 @@ This is useful for training torch models with batches from your dataset. For con
     import ray
     import torch
 
-    ds = ray.data.read_images("example://image-datasets/simple")
+    ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
 
     for batch in ds.iter_torch_batches(batch_size=2):
         print(batch)
@@ -104,7 +104,7 @@ Transformations applied with `map` or `map_batches` can return torch tensors.
             import torch
             import ray
 
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
 
             def convert_to_torch(row: Dict[str, np.ndarray]) -> Dict[str, torch.Tensor]:
                 return {"tensor": torch.as_tensor(row["image"])}
@@ -135,7 +135,7 @@ Transformations applied with `map` or `map_batches` can return torch tensors.
             import torch
             import ray
 
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
 
             def convert_to_torch(batch: Dict[str, np.ndarray]) -> Dict[str, torch.Tensor]:
                 return {"tensor": torch.as_tensor(batch["image"])}
@@ -177,7 +177,7 @@ You can use built-in torch transforms from `torchvision`, `torchtext`, and `torc
             import ray
 
             # Create the Dataset.
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
 
             # Define the torchvision transform.
             transform = transforms.Compose(
@@ -213,7 +213,7 @@ You can use built-in torch transforms from `torchvision`, `torchtext`, and `torc
             import ray
 
             # Create the Dataset.
-            ds = ray.data.read_text("example://simple.txt")
+            ds = ray.data.read_text("s3://anonymous@ray-example-data/simple.txt")
 
             # Define the torchtext transform.
             VOCAB_FILE = "https://huggingface.co/bert-base-uncased/resolve/main/vocab.txt"

--- a/doc/source/data/working-with-tensors.rst
+++ b/doc/source/data/working-with-tensors.rst
@@ -122,7 +122,7 @@ formats, see the :ref:`Input/Output reference <input-output>`.
 
             import ray
 
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
             ds.write_parquet("/tmp/simple")
 
 
@@ -135,7 +135,7 @@ formats, see the :ref:`Input/Output reference <input-output>`.
 
             import ray
 
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
             ds.write_numpy("/tmp/simple", column="image")
 
     .. tab-item:: JSON
@@ -146,7 +146,7 @@ formats, see the :ref:`Input/Output reference <input-output>`.
 
             import ray
 
-            ds = ray.data.read_images("example://image-datasets/simple")
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
             ds.write_json("/tmp/simple")
 
 For more information on saving data, read :ref:`Saving data <loading_data>`.

--- a/doc/source/ray-air/doc_code/air_ingest_new.py
+++ b/doc/source/ray-air/doc_code/air_ingest_new.py
@@ -11,7 +11,7 @@ import numpy as np
 from typing import Dict
 
 # Load the data.
-train_ds = ray.data.read_parquet("example://iris.parquet")
+train_ds = ray.data.read_parquet("s3://anonymous@ray-example-data/iris.parquet")
 ## Uncomment to randomize the block order each epoch.
 # train_ds = train_ds.randomize_block_order()
 
@@ -52,8 +52,10 @@ my_trainer.fit()
 # __basic_end__
 
 # __custom_split__
-dataset_a = ray.data.read_text("example://sms_spam_collection_subset.txt")
-dataset_b = ray.data.read_csv("example://dow_jones.csv")
+dataset_a = ray.data.read_text(
+    "s3://anonymous@ray-example-data/sms_spam_collection_subset.txt"
+)
+dataset_b = ray.data.read_csv("s3://anonymous@ray-example-data/dow_jones.csv")
 
 my_trainer = TorchTrainer(
     train_loop_per_worker,
@@ -72,7 +74,7 @@ def augment_data(batch):
 
 # __materialized__
 # Load the data.
-train_ds = ray.data.read_parquet("example://iris.parquet")
+train_ds = ray.data.read_parquet("s3://anonymous@ray-example-data/iris.parquet")
 
 # Preprocess the data. Transformations that are made to the materialize call below
 # will only be run once.

--- a/doc/source/ray-contribute/writing-code-snippets.rst
+++ b/doc/source/ray-contribute/writing-code-snippets.rst
@@ -223,7 +223,7 @@ Ignoring *doctest-style* outputs
 To ignore parts of a *doctest-style* output, replace problematic sections with ellipses. ::
 
     >>> import ray
-    >>> ray.data.read_images("example://image-datasets/simple")
+    >>> ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
     Dataset(
        num_blocks=...,
        num_rows=...,
@@ -241,7 +241,7 @@ with ellipses. ::
     .. testcode::
 
         import ray
-        ds = ray.data.read_images("example://image-datasets/simple")
+        ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
         print(ds)
 
     .. testoutput::

--- a/doc/source/ray-observability/getting-started.rst
+++ b/doc/source/ray-observability/getting-started.rst
@@ -38,7 +38,12 @@ When you start a single-node Ray Cluster on your laptop, access the dashboard wi
     context = ray.init()
     print(context.dashboard_url)
 
+..
+    This test output is flaky. If Ray isn't completely shutdown, the port can be
+    "8266" instead of "8265".
+
 .. testoutput::
+    :options: +MOCK
 
    127.0.0.1:8265
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1743,21 +1743,21 @@ class Dataset:
             in a machine learning dataset:
 
             >>> import ray
-            >>> ds = ray.data.read_csv("example://iris.csv")
-            >>> ds.unique("variety")
-            ['Setosa', 'Versicolor', 'Virginica']
+            >>> ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
+            >>> ds.unique("target")
+            [0, 1, 2]
 
             One common use case is to convert the class labels
             into integers for training and inference:
 
-            >>> classes = {label: i for i, label in enumerate(ds.unique("variety"))}
+            >>> classes = {0: 'Setosa', 1: 'Versicolor', 2: 'Virginica'}
             >>> def preprocessor(df, classes):
-            ...     df["variety"] = df["variety"].map(classes)
+            ...     df["variety"] = df["target"].map(classes)
             ...     return df
             >>> train_ds = ds.map_batches(
             ...     preprocessor, fn_kwargs={"classes": classes}, batch_format="pandas")
-            >>> train_ds.sort("sepal.length").take(1)  # Sort to make it deterministic
-            [{'sepal.length': 4.3, ..., 'variety': 0}]
+            >>> train_ds.sort("sepal length (cm)").take(1)  # Sort to make it deterministic
+            [{'sepal length (cm)': 4.3, ..., 'variety': 'Setosa'}]
 
         Time complexity: O(dataset size * log(dataset size / parallelism))
 
@@ -1766,7 +1766,7 @@ class Dataset:
 
         Returns:
             A list with unique elements in the given column.
-        """
+        """  # noqa: E501
         ds = self.groupby(column).count().select_columns([column])
         return [item[column] for item in ds.take_all()]
 
@@ -4272,9 +4272,9 @@ class Dataset:
             >>> import ray
             >>> ray.data.from_items(list(range(10))).has_serializable_lineage()
             False
-            >>> ray.data.read_csv("example://iris.csv").has_serializable_lineage()
+            >>> ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv").has_serializable_lineage()
             True
-        """
+        """  # noqa: E501
         return self._plan.has_lazy_input()
 
     @DeveloperAPI
@@ -4300,7 +4300,7 @@ class Dataset:
 
                 import ray
 
-                ds = ray.data.read_csv("example://iris.csv")
+                ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
                 serialized_ds = ds.serialize_lineage()
                 ds = ray.data.Dataset.deserialize_lineage(serialized_ds)
                 print(ds)
@@ -4308,14 +4308,14 @@ class Dataset:
             .. testoutput::
 
                 Dataset(
-                   num_blocks=...,
+                   num_blocks=1,
                    num_rows=150,
                    schema={
-                      sepal.length: double,
-                      sepal.width: double,
-                      petal.length: double,
-                      petal.width: double,
-                      variety: string
+                      sepal length (cm): double,
+                      sepal width (cm): double,
+                      petal length (cm): double,
+                      petal width (cm): double,
+                      target: int64
                    }
                 )
 
@@ -4383,7 +4383,7 @@ class Dataset:
 
                 import ray
 
-                ds = ray.data.read_csv("example://iris.csv")
+                ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
                 serialized_ds = ds.serialize_lineage()
                 ds = ray.data.Dataset.deserialize_lineage(serialized_ds)
                 print(ds)
@@ -4391,14 +4391,14 @@ class Dataset:
             .. testoutput::
 
                 Dataset(
-                   num_blocks=...,
+                   num_blocks=1,
                    num_rows=150,
                    schema={
-                      sepal.length: double,
-                      sepal.width: double,
-                      petal.length: double,
-                      petal.width: double,
-                      variety: string
+                      sepal length (cm): double,
+                      sepal width (cm): double,
+                      petal length (cm): double,
+                      petal width (cm): double,
+                      target: int64
                    }
                 )
 

--- a/python/ray/data/datasource/partitioning.py
+++ b/python/ray/data/datasource/partitioning.py
@@ -36,6 +36,36 @@ class Partitioning:
 
     Path-based partition formats embed all partition keys and values directly in
     their dataset file paths.
+
+    For example, to read a dataset with
+    `Hive-style partitions <https://athena.guide/articles/hive-style-partitioning/>`_:
+
+        >>> import ray
+        >>> from ray.data.datasource.partitioning import Partitioning
+        >>> ds = ray.data.read_csv(
+        ...     "s3://anonymous@ray-example-data/iris.csv",
+        ...     partitioning=Partitioning("hive"),
+        ... )
+
+    Instead, if your files are arranged in a directory structure such as:
+
+    .. code::
+
+        root/dog/dog_0.jpeg
+        root/dog/dog_1.jpeg
+        ...
+
+        root/cat/cat_0.jpeg
+        root/cat/cat_1.jpeg
+        ...
+
+    Then you can use directory-based partitioning:
+
+        >>> import ray
+        >>> from ray.data.datasource.partitioning import Partitioning
+        >>> root = "s3://anonymous@air-example-data/cifar-10/images"
+        >>> partitioning = Partitioning("dir", field_names=["class"], base_dir=root)
+        >>> ds = ray.data.read_images(root, partitioning=partitioning)
     """
 
     #: The partition style - may be either HIVE or DIRECTORY.

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -532,17 +532,6 @@ def read_parquet(
         ...           ("variety", pa.string())]
         >>> ds = ray.data.read_parquet("s3://anonymous@ray-example-data/iris.parquet",
         ...     schema=pa.schema(fields))
-        Dataset(
-           num_blocks=...,
-           num_rows=150,
-           schema={
-              sepal.length: double,
-              sepal.width: double,
-              petal.length: double,
-              petal.width: double,
-              variety: string
-           }
-        )
 
         The Parquet reader also supports projection and filter pushdown, allowing column
         selection and row filtering to be pushed down to the file scan.
@@ -1184,7 +1173,7 @@ def read_tfrecords(
         We can also read compressed TFRecord files which uses one of the
         `compression type supported by Arrow <https://arrow.apache.org/docs/python/generated/pyarrow.CompressedInputStream.html>`_:
 
-        >>> ray.data.read_tfrecords(
+        >>> ds = ray.data.read_tfrecords(
         ...     "s3://anonymous@ray-example-data/iris.tfrecords.gz",
         ...     arrow_open_stream_args={"compression": "gzip"},
         ... )

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -925,8 +925,8 @@ def read_csv(
         >>> # Read files that use a different delimiter. For more uses of ParseOptions see
         >>> # https://arrow.apache.org/docs/python/generated/pyarrow.csv.ParseOptions.html  # noqa: #501
         >>> from pyarrow import csv
-        >>> parse_options = csv.ParseOptions(delimiter="\\t")
-        >>> ds = ray.data.read_csv(
+        >>> parse_options = csv.ParseOptions(delimiter="\\t")  # doctest: +SKIP
+        >>> ds = ray.data.read_csv(  # doctest: +SKIP
         ...     "s3://anonymous@ray-example-data/iris.tsv",
         ...     parse_options=parse_options)
 
@@ -954,7 +954,7 @@ def read_csv(
 
         >>> # Read only *.csv files from multiple directories.
         >>> from ray.data.datasource import FileExtensionFilter
-        >>> ray.data.read_csv("s3://anonymous@ray-example-data/different-extensions/",
+        >>> ray.data.read_csv("s3://anonymous@ray-example-data/different-extensions/",  # doctest: +SKIP
         ...     partition_filter=FileExtensionFilter("csv"))
 
     Args:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR cherry picks https://github.com/ray-project/ray/pull/37359 into Ray 2.6.0, which replaces usages of file paths prefixed by `example://` with corresponding paths in the Ray S3 example data directory.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
