### PR TITLE
[Data] Skip `test_parquet_read_partitioned_explicit` for Arrow nightly

### DIFF
--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from packaging import version
 from pytest_lazyfixture import lazy_fixture
 
 import ray
@@ -516,6 +517,9 @@ def test_parquet_read_partitioned_with_filter(ray_start_regular_shared, tmp_path
     assert ds.count() == 2
 
 
+# FIXME: This test is failing with Arrow nightly (13.0.0.dev497). See 
+# https://github.com/ray-project/ray/issues/37429.
+@pytest.skipif(version.parse(pa.__version__).major >= 13)
 def test_parquet_read_partitioned_explicit(ray_start_regular_shared, tmp_path):
     df = pd.DataFrame(
         {"one": [1, 1, 1, 3, 3, 3], "two": ["a", "b", "c", "e", "f", "g"]}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The nightly Arrow version changed from 12.0.1 to 13.0.0.dev497. Now, `test_parquet_read_partitioned_explicit` is failing with a segmentation fault. This PR temporarily skips the test if the Arrow version is nightly.

## Related issue number

<!-- For example: "Closes #1234" -->

See https://github.com/ray-project/ray/issues/37429

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
