### PR TITLE
Support same subnet for multiple network interfaces

### DIFF
--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import time
+from collections import Counter
 from functools import lru_cache, partial
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -766,6 +767,8 @@ def _get_vpc_id_or_die(ec2, subnet_id: str):
 
 @lru_cache()
 def _get_subnets_or_die(ec2, subnet_ids: Tuple[str]):
+    # Remove any duplicates as multiple interfaces are allowed to use same subnet
+    subnet_ids = tuple(Counter(subnet_ids).keys())
     subnets = list(
         ec2.subnets.filter(Filters=[{"Name": "subnet-id", "Values": list(subnet_ids)}])
     )

--- a/python/ray/autoscaler/aws/example-network-interfaces.yaml
+++ b/python/ray/autoscaler/aws/example-network-interfaces.yaml
@@ -54,7 +54,7 @@ available_node_types:
             - sg-00000000 # Replace with your Security Group ID.
 
         # Multiple network interfaces can optionally be attached to a single
-        # node. Each interface should be assigned a different subnet, but each
+        # node. Each interface can be assigned a different subnet, but each
         # subnet should be in the same availability zone.
         # For more information, see:
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html
@@ -65,6 +65,11 @@ available_node_types:
           PrivateIpAddress: 172.31.16.10 # Replace with an IP in your subnet.
           Groups:
             - sg-11111111 # Replace with your Security Group ID.
+        - DeviceIndex: 2 # Tertiary network interface.
+          SubnetId: subnet-11111111 # (Same as deviceIndex-1)
+          PrivateIpAddress: 172.31.16.11 # Replace with an IP in your subnet.
+          Groups:
+            - sg-11111111 # (Same as deviceIndex-1)
 
       # Use any node and instance type with default network interface types.
       ImageId: latest_dlami
@@ -80,10 +85,18 @@ available_node_types:
       # multiple workers trying to use the same private IP.
       NetworkInterfaces:
         - DeviceIndex: 0 # Primary network interface.
+          NetworkCardIndex: 0 # NetworkCard index else defaults to ZERO by ec2 API
           AssociatePublicIpAddress: False # Omit to let your Subnet auto-assign a public IP (if enabled).
           SubnetId: subnet-22222222 # Replace with your actual Subnet ID
           Groups:
             - sg-22222222 # Replace with your actual Security Group ID.
+          InterfaceType: efa # Use EFA for higher throughput and lower latency.
+        - DeviceIndex: 1 # Secondary interface.
+          NetworkCardIndex: 1 # NetworkCard index else defaults to ZERO by ec2 API
+          AssociatePublicIpAddress: False # Omit to let your Subnet auto-assign a public IP (if enabled).
+          SubnetId: subnet-22222222 # (Must be same AZ, subnetId can be same)
+          Groups:
+            - sg-22222222 # (Must be self-referenced with ALL traffic)
           InterfaceType: efa # Use EFA for higher throughput and lower latency.
 
       # Use an AMI and instance type that supports Elastic Fabric Adapters (EFA).


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, we cannot pass same subnet to multiple network-interfaces on instance-launch. Taking an example, a trainium instance supports multiple network-interfaces (0-7) and all the interfaces can reside in same subnet/AZ. This change is to unblock the assertion of subnetIds passed to `NetworkInterfaces` as AWS by default allows creating multiple network-interfaces in same subnet.


## Related issue number

Closes [#33586](https://github.com/ray-project/ray/issues/33586)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] ~~I've included any doc changes needed for https://docs.ray.io/en/master/.~~
    - [ ] ~~I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.~~
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Manual testing
   - [ ] Release tests
   - [ ] This PR is not tested :(

### Testing

#### UT
1. Add multiple subnets to existing examples-network-interfaces.yaml
2. Before fix
```
Results (0.59s):
       1 failed
         - python/ray/tests/aws/test_autoscaler_aws.py:525 test_network_interfaces
       1 error
```
3. After fix
```
 python/ray/tests/aws/test_autoscaler_aws.py::test_cloudwatch_alarm_update_worker_node ✓                                                                               100% ██████████

Results (15.00s):
      57 passed
```

#### Manual testing
Where the resource contains multiple network-interfaces of same subnet
```
(venv) [mde-user@ip-10-2-1-69 ray]$ ray up /tmp/simple-trn32.yaml --no-config-cache -y
OpenBLAS WARNING - could not determine the L2 cache size on this system, assuming 256k
Cluster: chappidim-trn1-32

2023-07-14 23:19:23,738 INFO util.py:375 -- setting max workers for head node type to 0
2023-07-14 23:19:23,738 INFO util.py:379 -- setting max workers for ray.worker.default to 1
Checking AWS environment settings
AWS config
  IAM Profile: DydEc2S3
  EC2 Key pair (all available node types): ray-autoscaler_1_us-west-2 [default]
  VPC Subnets (all available node types): subnet-f8f15ed3, subnet-f8f15ed3, subnet-f8f15ed3, subnet-f8f15ed3, subnet-f8f15ed3, subnet-f8f15ed3, subnet-f8f15ed3, subnet-f8f15ed3
  EC2 Security groups (all available node types): sg-f5942291, sg-f5942291, sg-f5942291, sg-f5942291, sg-f5942291, sg-f5942291, sg-f5942291, sg-f5942291
  EC2 AMI (all available node types): ami-0434fdb9032d4c364

No head node found. Launching a new cluster. Confirm [y/N]: y [automatic, due to --yes]

Usage stats collection is disabled.

Acquiring an up-to-date head node
  Launched 1 nodes [network_interfaces=[{'DeviceIndex': 0, 'NetworkCardIndex': 0, 'SubnetId': 'subnet-f8f15ed3', 'Groups': ['sg-f5942291'], 'InterfaceType': 'efa', 'AssociatePublicIpAddress': False}, {'DeviceIndex': 1, 'NetworkCardIndex': 1, 'SubnetId': 'subnet-f8f15ed3', 'Groups': ['sg-f5942291'], 'InterfaceType': 'efa', 'AssociatePublicIpAddress': False}, {'DeviceIndex': 2, 'NetworkCardIndex': 2, 'SubnetId': 'subnet-f8f15ed3', 'Groups': ['sg-f5942291'], 'InterfaceType': 'efa', 'AssociatePublicIpAddress': False}, {'DeviceIndex': 3, 'NetworkCardIndex': 3, 'SubnetId': 'subnet-f8f15ed3', 'Groups': ['sg-f5942291'], 'InterfaceType': 'efa', 'AssociatePublicIpAddress': False}, {'DeviceIndex': 4, 'NetworkCardIndex': 4, 'SubnetId': 'subnet-f8f15ed3', 'Groups': ['sg-f5942291'], 'InterfaceType': 'efa', 'AssociatePublicIpAddress': False}, {'DeviceIndex': 5, 'NetworkCardIndex': 5, 'SubnetId': 'subnet-f8f15ed3', 'Groups': ['sg-f5942291'], 'InterfaceType': 'efa', 'AssociatePublicIpAddress': False}, {'DeviceIndex': 6, 'NetworkCardIndex': 6, 'SubnetId': 'subnet-f8f15ed3', 'Groups': ['sg-f5942291'], 'InterfaceType': 'efa', 'AssociatePublicIpAddress': False}, {'DeviceIndex': 7, 'NetworkCardIndex': 7, 'SubnetId': 'subnet-f8f15ed3', 'Groups': ['sg-f5942291'], 'InterfaceType': 'efa', 'AssociatePublicIpAddress': False}]]
    Launched instance i-0b1e5a8f52b8b24fe [state=pending, info=pending]
  Launched a new head node
  Fetching the new head node
```

