### PR TITLE
When clamping surrogate loss, do this based on absolute value

### DIFF
--- a/rllib/algorithms/ppo/ppo_torch_policy.py
+++ b/rllib/algorithms/ppo/ppo_torch_policy.py
@@ -126,12 +126,12 @@ class PPOTorchPolicy(
         curr_entropy = curr_action_dist.entropy()
         mean_entropy = reduce_mean_valid(curr_entropy)
 
-        surrogate_loss = torch.min(
-            train_batch[Postprocessing.ADVANTAGES] * logp_ratio,
-            train_batch[Postprocessing.ADVANTAGES]
-            * torch.clamp(
-                logp_ratio, 1 - self.config["clip_param"], 1 + self.config["clip_param"]
-            ),
+        absolute_advantages = torch.abs(train_batch[Postprocessing.ADVANTAGES])
+        clamped_logp_ratio = torch.clamp(
+            logp_ratio, 1 - self.config["clip_param"], 1 + self.config["clip_param"]
+        )
+        surrogate_loss = torch.sign(train_batch[Postprocessing.ADVANTAGES]) * torch.min(
+            absolute_advantages * logp_ratio, absolute_advantages * clamped_logp_ratio
         )
 
         # Compute a value function loss.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fixes #37334. Surrogate loss is now clamped based on the absolute value, i.s.o. on the value, which could result in huge negative surrogate loss values to be preferred, neglecting clamping.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #37334 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
