### PR TITLE
Support both pydantic 1.x and 2.x

### DIFF
--- a/dashboard/modules/job/utils.py
+++ b/dashboard/modules/job/utils.py
@@ -168,7 +168,7 @@ async def get_driver_jobs(
             driver = DriverInfo(
                 id=job_id,
                 node_ip_address=job_table_entry.driver_address.ip_address,
-                pid=job_table_entry.driver_pid,
+                pid=str(job_table_entry.driver_pid),
             )
             job = JobDetails(
                 job_id=job_id,
@@ -190,7 +190,7 @@ async def get_driver_jobs(
             driver = DriverInfo(
                 id=job_id,
                 node_ip_address=job_table_entry.driver_address.ip_address,
-                pid=job_table_entry.driver_pid,
+                pid=str(job_table_entry.driver_pid),
             )
             submission_job_drivers[job_submission_id] = driver
 

--- a/python/ray/serve/_private/version.py
+++ b/python/ray/serve/_private/version.py
@@ -124,7 +124,14 @@ class DeploymentVersion:
         should prompt a deployment version update.
         """
         reconfigure_dict = {}
-        for option_name, field in self.deployment_config.__fields__.items():
+        # TODO(aguo): Once we only support pydantic 2, we can remove this if check.
+        # In pydantic 2.0, `__fields__` has been renamed to `model_fields`.
+        fields = (
+            self.deployment_config.model_fields
+            if hasattr(self.deployment_config, "model_fields")
+            else self.deployment_config.__fields__
+        )
+        for option_name, field in fields.items():
             option_weight = field.field_info.extra.get("update_type")
             if option_weight in update_types:
                 reconfigure_dict[option_name] = getattr(

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -678,6 +678,33 @@ def test_serialization_before_init(shutdown_only):
     ray.get(ray.put(A(1)))  # success!
 
 
+def test_serialization_pydantic(ray_start_regular):
+    @ray.remote
+    def test(pydantic_model):
+        return pydantic_model.x
+
+    @ray.remote(runtime_env={"pip": ["pydantic<2"]})
+    def py1():
+        from pydantic import BaseModel
+
+        class Foo(BaseModel):
+            x: int
+
+        return ray.get(test.remote(Foo(x=1)))
+
+    @ray.remote(runtime_env={"pip": ["pydantic>=2"]})
+    def py2():
+        from pydantic.v1 import BaseModel
+
+        class Foo(BaseModel):
+            x: int
+
+        return ray.get(test.remote(Foo(x=2)))
+
+    assert ray.get(py1.remote()) == 1
+    assert ray.get(py2.remote()) == 2
+
+
 if __name__ == "__main__":
     import os
     import pytest

--- a/python/ray/util/serialization_addons.py
+++ b/python/ray/util/serialization_addons.py
@@ -11,30 +11,50 @@ from ray.util.annotations import DeveloperAPI
 @DeveloperAPI
 def register_pydantic_serializer(serialization_context):
     try:
-        import pydantic.fields
+        from pydantic import fields
     except ImportError:
-        return
+        fields = None
 
-    # Pydantic's Cython validators are not serializable.
-    # https://github.com/cloudpipe/cloudpickle/issues/408
-    serialization_context._register_cloudpickle_serializer(
-        pydantic.fields.ModelField,
-        custom_serializer=lambda o: {
-            "name": o.name,
-            # outer_type_ is the original type for ModelFields,
-            # while type_ can be updated later with the nested type
-            # like int for List[int].
-            "type_": o.outer_type_,
-            "class_validators": o.class_validators,
-            "model_config": o.model_config,
-            "default": o.default,
-            "default_factory": o.default_factory,
-            "required": o.required,
-            "alias": o.alias,
-            "field_info": o.field_info,
-        },
-        custom_deserializer=lambda kwargs: pydantic.fields.ModelField(**kwargs),
-    )
+    try:
+        from pydantic.v1 import fields as pydantic_v1_fields
+    except ImportError:
+        pydantic_v1_fields = None
+
+    if hasattr(fields, "ModelField"):
+        ModelField = fields.ModelField
+    elif pydantic_v1_fields:
+        ModelField = pydantic_v1_fields.ModelField
+    else:
+        ModelField = None
+
+    if ModelField is not None:
+        # In Pydantic 2.x, ModelField has been removed so this serialization
+        # strategy no longer works. We keep this code around to allow support
+        # for users with pydantic 1.x installed or users using pydantic.v1
+        # import within the pydantic 2.x package.
+        # TODO(aguo): Figure out how to enable cloudpickle serialization for
+        # pydantic 2.x
+
+        # Pydantic's Cython validators are not serializable.
+        # https://github.com/cloudpipe/cloudpickle/issues/408
+        serialization_context._register_cloudpickle_serializer(
+            ModelField,
+            custom_serializer=lambda o: {
+                "name": o.name,
+                # outer_type_ is the original type for ModelFields,
+                # while type_ can be updated later with the nested type
+                # like int for List[int].
+                "type_": o.outer_type_,
+                "class_validators": o.class_validators,
+                "model_config": o.model_config,
+                "default": o.default,
+                "default_factory": o.default_factory,
+                "required": o.required,
+                "alias": o.alias,
+                "field_info": o.field_info,
+            },
+            custom_deserializer=lambda kwargs: ModelField(**kwargs),
+        )
 
 
 @DeveloperAPI

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -24,9 +24,17 @@ from ray.util.state.custom_types import (
 from ray.util.state.exception import RayStateApiException
 
 try:
+    import pydantic
     from pydantic.dataclasses import dataclass
 
     from ray.dashboard.modules.job.pydantic_models import JobDetails
+
+    # TODO(aguo): Instead of a version check, modify these classes to use
+    # pydantic BaseModel instead of dataclass.
+    # In pydantic 2, dataclass no longer needs the `init=True` kwarg to
+    # generate an __init__ method. Additionally, it will raise an error if
+    # it detects `init=True` to be set.
+    is_pydantic_2 = pydantic.__version__.startswith("2")
 
 except ImportError:
     # pydantic is not available in the dashboard.
@@ -34,6 +42,7 @@ except ImportError:
     from dataclasses import dataclass
 
     JobDetails = object
+    is_pydantic_2 = False
 
 
 logger = logging.getLogger(__name__)
@@ -117,7 +126,7 @@ class Humanify:
         return resources
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class ListApiOptions:
     # Maximum number of entries to return
     limit: int = DEFAULT_LIMIT
@@ -159,13 +168,13 @@ class ListApiOptions:
                 )
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class GetApiOptions:
     # Timeout for the HTTP request
     timeout: int = DEFAULT_RPC_TIMEOUT
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class SummaryApiOptions:
     # Timeout for the HTTP request
     timeout: int = DEFAULT_RPC_TIMEOUT
@@ -336,7 +345,7 @@ def filter_fields(data: dict, state_dataclass: StateSchema, detail: bool) -> dic
     return filtered_data
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class GetLogOptions:
     timeout: int
     node_id: Optional[str] = None
@@ -407,7 +416,7 @@ class GetLogOptions:
 
 # See the ActorTableData message in gcs.proto for all potential options that
 # can be included in this class.
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class ActorState(StateSchema):
     """Actor State"""
 
@@ -458,7 +467,7 @@ class ActorState(StateSchema):
     repr_name: Optional[str] = state_column(detail=True, filterable=True)
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class PlacementGroupState(StateSchema):
     """PlacementGroup State"""
 
@@ -487,7 +496,7 @@ class PlacementGroupState(StateSchema):
     stats: Optional[dict] = state_column(filterable=False, detail=True)
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class NodeState(StateSchema):
     """Node State"""
 
@@ -557,7 +566,13 @@ class JobState(StateSchema, JobDetails):
             # check if the class is a pydantic model.
             return []
 
-        return JobDetails.__fields__
+        # TODO(aguo): Once we only support pydantic 2, we can remove this if check.
+        # In pydantic 2.0, `__fields__` has been renamed to `model_fields`.
+        return (
+            JobDetails.model_fields
+            if hasattr(JobDetails, "model_fields")
+            else JobDetails.__fields__
+        )
 
     def asdict(self):
         return JobDetails.dict(self)
@@ -571,7 +586,7 @@ class JobState(StateSchema, JobDetails):
         }
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class WorkerState(StateSchema):
     """Worker State"""
 
@@ -633,7 +648,7 @@ class WorkerState(StateSchema):
     )
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class ClusterEventState(StateSchema):
     severity: str = state_column(filterable=True)
     time: str = state_column(filterable=False)
@@ -643,7 +658,7 @@ class ClusterEventState(StateSchema):
     custom_fields: Optional[dict] = state_column(filterable=False, detail=True)
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class TaskState(StateSchema):
     """Task State"""
 
@@ -727,7 +742,7 @@ class TaskState(StateSchema):
     error_message: Optional[str] = state_column(detail=True, filterable=False)
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class ObjectState(StateSchema):
     """Object State"""
 
@@ -783,7 +798,7 @@ class ObjectState(StateSchema):
     ip: str = state_column(filterable=True)
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class RuntimeEnvState(StateSchema):
     """Runtime Environment State"""
 
@@ -839,7 +854,7 @@ for state in AVAILABLE_STATES:
 """
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class ListApiResponse:
     # NOTE(rickyyx): We currently perform hard truncation when querying
     # resources which could have a large number (e.g. asking raylets for
@@ -885,7 +900,7 @@ Summary API schema
 DRIVER_TASK_ID_PREFIX = "ffffffffffffffffffffffffffffffffffffffff"
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class TaskSummaryPerFuncOrClassName:
     #: The function or class name of this task.
     func_or_class_name: str
@@ -904,7 +919,7 @@ class Link:
     id: str
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class NestedTaskSummary:
     #: The name of this task group
     name: str
@@ -1259,7 +1274,7 @@ class TaskSummaries:
         )
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class ActorSummaryPerClass:
     #: The class name of the actor.
     class_name: str
@@ -1304,7 +1319,7 @@ class ActorSummaries:
         )
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class ObjectSummaryPerKey:
     #: Total number of objects of the type.
     total_objects: int
@@ -1397,7 +1412,7 @@ class ObjectSummaries:
         )
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class StateSummary:
     #: Node ID -> summary per node
     #: If the data is not required to be orgnized per node, it will contain
@@ -1405,7 +1420,7 @@ class StateSummary:
     node_id_to_summary: Dict[str, Union[TaskSummaries, ActorSummaries, ObjectSummaries]]
 
 
-@dataclass(init=True)
+@dataclass(init=not is_pydantic_2)
 class SummaryApiResponse:
     # Carried over from ListApiResponse
     # We currently use list API for listing the resources


### PR DESCRIPTION
Cherry-pick of #37055
These changes fixes a couple of things when ray and pydantic 2.0 is installed:

ray can start up now
ray jobs works now
gets rid of some deprecation warnings when using old pydantic field names. Some things are still broken:

ray serve doesn't work because it depends on fastapi and fastapi does not support pydantic 2.0 yet: Prepare for Pydantic V2 release tiangolo/fastapi#6051 Pickling pydantic 2 models is not possible, although users can still pickle pydantic 1.0 models via the compatibility pydantic.v1 import.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
