### PR TITLE
[docs] side nav TOC name for Monitoring and Debugging>Getting Started

### DIFF
--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -394,6 +394,7 @@ parts:
         title: "Monitoring and Debugging"
         sections:
           - file: ray-observability/getting-started
+            title: Dashboard
           - file: ray-observability/key-concepts
           - file: ray-observability/user-guides/index
             title: User Guides


### PR DESCRIPTION

## Why are these changes needed?
Changing it to Dashboard because the page is all about the Dashboard. This change should make it more discoverable for users when they use docs search with the "dashboard" keyword. @scottsun94 reported this.

## Related issue number


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
