### PR TITLE
[data] Add microbenchmark for torch vs ray.data image-loading and transform

### DIFF
--- a/release/nightly_tests/dataset/image_loader_microbenchmark.py
+++ b/release/nightly_tests/dataset/image_loader_microbenchmark.py
@@ -1,7 +1,6 @@
 import ray
 import torch
 import torchvision
-import numpy as np
 import os
 import time
 import json
@@ -11,21 +10,26 @@ DEFAULT_IMAGE_SIZE = 224
 DIR = "/home/ray/data"
 
 
-def build_torch_dataset(root_dir, batch_size, shuffle=False, num_workers=None, transform=None):
+def build_torch_dataset(
+    root_dir, batch_size, shuffle=False, num_workers=None, transform=None
+):
     if num_workers is None:
         num_workers = os.cpu_count()
 
     data = torchvision.datasets.ImageFolder(root_dir, transform=transform)
-    data_loader = torch.utils.data.DataLoader(data,
-                                            batch_size=batch_size,
-                                            shuffle=shuffle,
-                                            num_workers=num_workers,
-                                            persistent_workers=True,
-                                            )
+    data_loader = torch.utils.data.DataLoader(
+        data,
+        batch_size=batch_size,
+        shuffle=shuffle,
+        num_workers=num_workers,
+        persistent_workers=True,
+    )
     return data_loader
+
 
 if __name__ == "__main__":
     metrics = []
+
     def iterate(dataset, label):
         start = time.time()
         it = iter(dataset)
@@ -36,71 +40,94 @@ if __name__ == "__main__":
         print(label, end - start, "epoch", i)
 
         tput = num_rows / (end - start)
-        metrics.append({
-            "perf_metric_name": label,
-            "perf_metric_value": tput,
-            "perf_metric_type": "THROUGHPUT",
-        })
-
+        metrics.append(
+            {
+                "perf_metric_name": label,
+                "perf_metric_value": tput,
+                "perf_metric_type": "THROUGHPUT",
+            }
+        )
 
     def get_transform(to_torch_tensor):
         # Note(swang): This is a different order from tf.data.
         # torch: decode -> randCrop+resize -> randFlip
         # tf.data: decode -> randCrop -> randFlip -> resize
-        transform = torchvision.transforms.Compose([
-            torchvision.transforms.RandomResizedCrop(
-                size=DEFAULT_IMAGE_SIZE,
-                scale=(0.05, 1.0),
-                ratio=(0.75, 1.33),
-            ),
-            torchvision.transforms.RandomHorizontalFlip(),
-        ] + [torchvision.transforms.ToTensor()] if to_torch_tensor else [])
+        transform = torchvision.transforms.Compose(
+            [
+                torchvision.transforms.RandomResizedCrop(
+                    size=DEFAULT_IMAGE_SIZE,
+                    scale=(0.05, 1.0),
+                    ratio=(0.75, 1.33),
+                ),
+                torchvision.transforms.RandomHorizontalFlip(),
+            ]
+            + [torchvision.transforms.ToTensor()]
+            if to_torch_tensor
+            else []
+        )
         return transform
 
     def crop_and_flip_image_batch(image_batch):
         transform = get_transform(False)
         batch_size, height, width, channels = image_batch["image"].shape
         tensor_shape = (batch_size, channels, height, width)
-        image_batch["image"] = transform(torch.Tensor(image_batch["image"].reshape(tensor_shape)))
+        image_batch["image"] = transform(
+            torch.Tensor(image_batch["image"].reshape(tensor_shape))
+        )
         return image_batch
-
 
     torch_dataset = build_torch_dataset(DIR, 32, transform=get_transform(True))
     for i in range(3):
         iterate(torch_dataset, "torch+transform")
-    torch_dataset = build_torch_dataset(DIR, 32, transform=torchvision.transforms.ToTensor())
+    torch_dataset = build_torch_dataset(
+        DIR, 32, transform=torchvision.transforms.ToTensor()
+    )
     for i in range(3):
         iterate(torch_dataset, "torch")
-
 
     ray_dataset = ray.data.read_images(DIR).map_batches(crop_and_flip_image_batch)
     for i in range(3):
         iterate(ray_dataset.iter_torch_batches(batch_size=32), "ray.data+transform")
 
-    ray_dataset = ray.data.read_images(DIR).map_batches(crop_and_flip_image_batch, zero_copy_batch=True)
+    ray_dataset = ray.data.read_images(DIR).map_batches(
+        crop_and_flip_image_batch, zero_copy_batch=True
+    )
     for i in range(3):
-        iterate(ray_dataset.iter_torch_batches(batch_size=32), "ray.data+transform+zerocopy")
+        iterate(
+            ray_dataset.iter_torch_batches(batch_size=32), "ray.data+transform+zerocopy"
+        )
 
     ray_dataset = ray.data.read_images(DIR)
     for i in range(3):
         iterate(ray_dataset.iter_torch_batches(batch_size=None), "ray.data")
 
-    ray_dataset = ray.data.read_images(DIR).map_batches(lambda x: x, batch_format="pyarrow", batch_size=None)
+    ray_dataset = ray.data.read_images(DIR).map_batches(
+        lambda x: x, batch_format="pyarrow", batch_size=None
+    )
     for i in range(3):
-        iterate(ray_dataset.iter_torch_batches(batch_size=None), "ray.data+dummy_pyarrow_transform")
+        iterate(
+            ray_dataset.iter_torch_batches(batch_size=None),
+            "ray.data+dummy_pyarrow_transform",
+        )
 
-    ray_dataset = ray.data.read_images(DIR).map_batches(lambda x: x, batch_format="numpy", batch_size=None)
+    ray_dataset = ray.data.read_images(DIR).map_batches(
+        lambda x: x, batch_format="numpy", batch_size=None
+    )
     for i in range(3):
-        iterate(ray_dataset.iter_torch_batches(batch_size=None), "ray.data+dummy_np_transform")
-
+        iterate(
+            ray_dataset.iter_torch_batches(batch_size=None),
+            "ray.data+dummy_np_transform",
+        )
 
     # Test manual loading using map_batches on the pathnames.
     def load(batch):
         batch["image"] = [torchvision.io.read_image(path) for path in batch["image"]]
         return batch
-            
+
     paths = [os.path.join(DIR, path) for path in os.listdir(DIR)]
-    ray_dataset = ray.data.from_items([{"image": path} for path in paths]).map_batches(load)
+    ray_dataset = ray.data.from_items([{"image": path} for path in paths]).map_batches(
+        load
+    )
     for i in range(3):
         iterate(ray_dataset.iter_torch_batches(batch_size=32), "ray.data_manual_load")
 
@@ -109,7 +136,9 @@ if __name__ == "__main__":
         "success": 1,
     }
 
-    test_output_json = os.environ.get("TEST_OUTPUT_JSON", "/tmp/image_loader_microbenchmark.json")
+    test_output_json = os.environ.get(
+        "TEST_OUTPUT_JSON", "/tmp/image_loader_microbenchmark.json"
+    )
 
     with open(test_output_json, "wt") as f:
         json.dump(result_dict, f)

--- a/release/nightly_tests/dataset/image_loader_microbenchmark.py
+++ b/release/nightly_tests/dataset/image_loader_microbenchmark.py
@@ -1,0 +1,115 @@
+import ray
+import torch
+import torchvision
+import numpy as np
+import os
+import time
+import json
+
+
+DEFAULT_IMAGE_SIZE = 224
+DIR = "/home/ray/data"
+
+
+def build_torch_dataset(root_dir, batch_size, shuffle=False, num_workers=None, transform=None):
+    if num_workers is None:
+        num_workers = os.cpu_count()
+
+    data = torchvision.datasets.ImageFolder(root_dir, transform=transform)
+    data_loader = torch.utils.data.DataLoader(data,
+                                            batch_size=batch_size,
+                                            shuffle=shuffle,
+                                            num_workers=num_workers,
+                                            persistent_workers=True,
+                                            )
+    return data_loader
+
+if __name__ == "__main__":
+    metrics = []
+    def iterate(dataset, label):
+        start = time.time()
+        it = iter(dataset)
+        num_rows = 0
+        for batch in it:
+            num_rows += len(batch)
+        end = time.time()
+        print(label, end - start, "epoch", i)
+
+        tput = num_rows / (end - start)
+        metrics.append({
+            "perf_metric_name": label,
+            "perf_metric_value": tput,
+            "perf_metric_type": "THROUGHPUT",
+        })
+
+
+    def get_transform(to_torch_tensor):
+        # Note(swang): This is a different order from tf.data.
+        # torch: decode -> randCrop+resize -> randFlip
+        # tf.data: decode -> randCrop -> randFlip -> resize
+        transform = torchvision.transforms.Compose([
+            torchvision.transforms.RandomResizedCrop(
+                size=DEFAULT_IMAGE_SIZE,
+                scale=(0.05, 1.0),
+                ratio=(0.75, 1.33),
+            ),
+            torchvision.transforms.RandomHorizontalFlip(),
+        ] + [torchvision.transforms.ToTensor()] if to_torch_tensor else [])
+        return transform
+
+    def crop_and_flip_image_batch(image_batch):
+        transform = get_transform(False)
+        batch_size, height, width, channels = image_batch["image"].shape
+        tensor_shape = (batch_size, channels, height, width)
+        image_batch["image"] = transform(torch.Tensor(image_batch["image"].reshape(tensor_shape)))
+        return image_batch
+
+
+    torch_dataset = build_torch_dataset(DIR, 32, transform=get_transform(True))
+    for i in range(3):
+        iterate(torch_dataset, "torch+transform")
+    torch_dataset = build_torch_dataset(DIR, 32, transform=torchvision.transforms.ToTensor())
+    for i in range(3):
+        iterate(torch_dataset, "torch")
+
+
+    ray_dataset = ray.data.read_images(DIR).map_batches(crop_and_flip_image_batch)
+    for i in range(3):
+        iterate(ray_dataset.iter_torch_batches(batch_size=32), "ray.data+transform")
+
+    ray_dataset = ray.data.read_images(DIR).map_batches(crop_and_flip_image_batch, zero_copy_batch=True)
+    for i in range(3):
+        iterate(ray_dataset.iter_torch_batches(batch_size=32), "ray.data+transform+zerocopy")
+
+    ray_dataset = ray.data.read_images(DIR)
+    for i in range(3):
+        iterate(ray_dataset.iter_torch_batches(batch_size=None), "ray.data")
+
+    ray_dataset = ray.data.read_images(DIR).map_batches(lambda x: x, batch_format="pyarrow", batch_size=None)
+    for i in range(3):
+        iterate(ray_dataset.iter_torch_batches(batch_size=None), "ray.data+dummy_pyarrow_transform")
+
+    ray_dataset = ray.data.read_images(DIR).map_batches(lambda x: x, batch_format="numpy", batch_size=None)
+    for i in range(3):
+        iterate(ray_dataset.iter_torch_batches(batch_size=None), "ray.data+dummy_np_transform")
+
+
+    # Test manual loading using map_batches on the pathnames.
+    def load(batch):
+        batch["image"] = [torchvision.io.read_image(path) for path in batch["image"]]
+        return batch
+            
+    paths = [os.path.join(DIR, path) for path in os.listdir(DIR)]
+    ray_dataset = ray.data.from_items([{"image": path} for path in paths]).map_batches(load)
+    for i in range(3):
+        iterate(ray_dataset.iter_torch_batches(batch_size=32), "ray.data_manual_load")
+
+    result_dict = {
+        "perf_metrics": metrics,
+        "success": 1,
+    }
+
+    test_output_json = os.environ.get("TEST_OUTPUT_JSON", "/tmp/image_loader_microbenchmark.json")
+
+    with open(test_output_json, "wt") as f:
+        json.dump(result_dict, f)

--- a/release/nightly_tests/dataset/image_loader_microbenchmark.py
+++ b/release/nightly_tests/dataset/image_loader_microbenchmark.py
@@ -7,7 +7,7 @@ import json
 
 
 DEFAULT_IMAGE_SIZE = 224
-DIR = "/home/ray/data"
+DIR = "/home/ray/imagenet-1gb-data"
 
 
 def build_torch_dataset(
@@ -28,6 +28,8 @@ def build_torch_dataset(
 
 
 if __name__ == "__main__":
+    # TODO(swang): Should also add tf.data with and without transform.
+
     metrics = []
 
     def iterate(dataset, label):

--- a/release/nightly_tests/dataset/image_loader_microbenchmark.py
+++ b/release/nightly_tests/dataset/image_loader_microbenchmark.py
@@ -4,11 +4,33 @@ import torchvision
 import os
 import time
 import json
+import tensorflow as tf
 
 
 DEFAULT_IMAGE_SIZE = 224
-DIR = "/home/ray/imagenet-1gb-data"
 
+# tf.data needs to resize all images to the same size when loading.
+# This is the size of dog.jpg in s3://air-cuj-imagenet-1gb.
+FULL_IMAGE_SIZE = (1213, 1546)
+
+
+def iterate(dataset, label, metrics):
+    start = time.time()
+    it = iter(dataset)
+    num_rows = 0
+    for batch in it:
+        num_rows += len(batch)
+    end = time.time()
+    print(label, end - start, "epoch", i)
+
+    tput = num_rows / (end - start)
+    metrics.append(
+        {
+            "perf_metric_name": label,
+            "perf_metric_value": tput,
+            "perf_metric_type": "THROUGHPUT",
+        }
+    )
 
 def build_torch_dataset(
     root_dir, batch_size, shuffle=False, num_workers=None, transform=None
@@ -27,111 +49,182 @@ def build_torch_dataset(
     return data_loader
 
 
+def tf_crop_and_flip(image_buffer, num_channels=3):
+    """Crops the given image to a random part of the image, and randomly flips.
+
+    We use the fused decode_and_crop op, which performs better than the two ops
+    used separately in series, but note that this requires that the image be
+    passed in as an un-decoded string Tensor.
+
+    Args:
+        image_buffer: scalar string Tensor representing the raw JPEG image buffer.
+        bbox: 3-D float Tensor of bounding boxes arranged [1, num_boxes, coords]
+            where each coordinate is [0, 1) and the coordinates are arranged as
+            [ymin, xmin, ymax, xmax].
+        num_channels: Integer depth of the image buffer for decoding.
+
+    Returns:
+        3-D tensor with cropped image.
+
+    """
+    # A large fraction of image datasets contain a human-annotated bounding box
+    # delineating the region of the image containing the object of interest.    We
+    # choose to create a new bounding box for the object which is a randomly
+    # distorted version of the human-annotated bounding box that obeys an
+    # allowed range of aspect ratios, sizes and overlap with the human-annotated
+    # bounding box. If no box is supplied, then we assume the bounding box is
+    # the entire image.
+    shape = tf.shape(image_buffer)[1:]
+    bbox = tf.constant(
+        [0.0, 0.0, 1.0, 1.0], dtype=tf.float32, shape=[1, 1, 4]
+    )  # From the entire image
+    sample_distorted_bounding_box = tf.image.sample_distorted_bounding_box(
+        shape,
+        bounding_boxes=bbox,
+        min_object_covered=0.1,
+        aspect_ratio_range=[0.75, 1.33],
+        area_range=[0.05, 1.0],
+        max_attempts=100,
+        use_image_if_no_bounding_boxes=True,
+    )
+    bbox_begin, bbox_size, _ = sample_distorted_bounding_box
+
+    # Reassemble the bounding box in the format the crop op requires.
+    offset_y, offset_x, _ = tf.unstack(bbox_begin)
+    target_height, target_width, _ = tf.unstack(bbox_size)
+    crop_window = tf.stack([offset_y, offset_x, target_height, target_width])
+
+    image_buffer = tf.image.crop_to_bounding_box(
+        image_buffer,
+        offset_height=offset_y,
+        offset_width=offset_x,
+        target_height=target_height,
+        target_width=target_width,
+    )
+    # Flip to add a little more random distortion in.
+    image_buffer = tf.image.random_flip_left_right(image_buffer)
+    return image_buffer
+
+
+def get_transform(to_torch_tensor):
+    # Note(swang): This is a different order from tf.data.
+    # torch: decode -> randCrop+resize -> randFlip
+    # tf.data: decode -> randCrop -> randFlip -> resize
+    transform = torchvision.transforms.Compose(
+        [
+            torchvision.transforms.RandomResizedCrop(
+                size=DEFAULT_IMAGE_SIZE,
+                scale=(0.05, 1.0),
+                ratio=(0.75, 1.33),
+            ),
+            torchvision.transforms.RandomHorizontalFlip(),
+        ]
+        + [torchvision.transforms.ToTensor()]
+        if to_torch_tensor
+        else []
+    )
+    return transform
+
+def crop_and_flip_image_batch(image_batch):
+    transform = get_transform(False)
+    batch_size, height, width, channels = image_batch["image"].shape
+    tensor_shape = (batch_size, channels, height, width)
+    image_batch["image"] = transform(
+        torch.Tensor(image_batch["image"].reshape(tensor_shape))
+    )
+    return image_batch
+
+
 if __name__ == "__main__":
-    # TODO(swang): Should also add tf.data with and without transform.
+    import argparse
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--data-root",
+        default="/home/ray/imagenet-1gb-data",
+        type=str,
+        help='Directory path with TFRecords. Filenames should start with "train".',
+    )
+    parser.add_argument(
+        "--batch-size",
+        default=32,
+        type=int,
+        help='Batch size to use.',
+    )
+    parser.add_argument(
+        "--num-epochs",
+        default=3,
+        type=int,
+        help='Number of epochs to run. The throughput for the last epoch will be kept.',
+    )
+    args = parser.parse_args()
 
     metrics = []
 
-    def iterate(dataset, label):
-        start = time.time()
-        it = iter(dataset)
-        num_rows = 0
-        for batch in it:
-            num_rows += len(batch)
-        end = time.time()
-        print(label, end - start, "epoch", i)
+    tf_dataset = tf.keras.preprocessing.image_dataset_from_directory(
+            args.data_root, batch_size=args.batch_size, image_size=FULL_IMAGE_SIZE)
+    #for i in range(args.num_epochs):
+    #    iterate(tf_dataset, "tf.data", metrics)
+    tf_dataset = tf_dataset.map(lambda img, label: (tf_crop_and_flip(img), label))
+    for i in range(args.num_epochs):
+        iterate(tf_dataset, "tf.data+transform", metrics)
 
-        tput = num_rows / (end - start)
-        metrics.append(
-            {
-                "perf_metric_name": label,
-                "perf_metric_value": tput,
-                "perf_metric_type": "THROUGHPUT",
-            }
-        )
-
-    def get_transform(to_torch_tensor):
-        # Note(swang): This is a different order from tf.data.
-        # torch: decode -> randCrop+resize -> randFlip
-        # tf.data: decode -> randCrop -> randFlip -> resize
-        transform = torchvision.transforms.Compose(
-            [
-                torchvision.transforms.RandomResizedCrop(
-                    size=DEFAULT_IMAGE_SIZE,
-                    scale=(0.05, 1.0),
-                    ratio=(0.75, 1.33),
-                ),
-                torchvision.transforms.RandomHorizontalFlip(),
-            ]
-            + [torchvision.transforms.ToTensor()]
-            if to_torch_tensor
-            else []
-        )
-        return transform
-
-    def crop_and_flip_image_batch(image_batch):
-        transform = get_transform(False)
-        batch_size, height, width, channels = image_batch["image"].shape
-        tensor_shape = (batch_size, channels, height, width)
-        image_batch["image"] = transform(
-            torch.Tensor(image_batch["image"].reshape(tensor_shape))
-        )
-        return image_batch
-
-    torch_dataset = build_torch_dataset(DIR, 32, transform=get_transform(True))
-    for i in range(3):
-        iterate(torch_dataset, "torch+transform")
     torch_dataset = build_torch_dataset(
-        DIR, 32, transform=torchvision.transforms.ToTensor()
+        args.data_root, args.batch_size, transform=torchvision.transforms.ToTensor()
     )
-    for i in range(3):
-        iterate(torch_dataset, "torch")
+    for i in range(args.num_epochs):
+        iterate(torch_dataset, "torch", metrics)
+    torch_dataset = build_torch_dataset(args.data_root, args.batch_size, transform=get_transform(True))
+    for i in range(args.num_epochs):
+        iterate(torch_dataset, "torch+transform", metrics)
 
-    ray_dataset = ray.data.read_images(DIR).map_batches(crop_and_flip_image_batch)
-    for i in range(3):
-        iterate(ray_dataset.iter_torch_batches(batch_size=32), "ray.data+transform")
+    ray_dataset = ray.data.read_images(args.data_root).map_batches(crop_and_flip_image_batch)
+    for i in range(args.num_epochs):
+        iterate(ray_dataset.iter_torch_batches(batch_size=args.batch_size), "ray.data+transform", metrics)
 
-    ray_dataset = ray.data.read_images(DIR).map_batches(
+    ray_dataset = ray.data.read_images(args.data_root).map_batches(
         crop_and_flip_image_batch, zero_copy_batch=True
     )
-    for i in range(3):
+    for i in range(args.num_epochs):
         iterate(
-            ray_dataset.iter_torch_batches(batch_size=32), "ray.data+transform+zerocopy"
-        )
+            ray_dataset.iter_torch_batches(batch_size=args.batch_size), "ray.data+transform+zerocopy", metrics)
 
-    ray_dataset = ray.data.read_images(DIR)
-    for i in range(3):
-        iterate(ray_dataset.iter_torch_batches(batch_size=None), "ray.data")
+    ray_dataset = ray.data.read_images(args.data_root)
+    for i in range(args.num_epochs):
+        iterate(ray_dataset.iter_torch_batches(batch_size=args.batch_size), "ray.data", metrics)
 
-    ray_dataset = ray.data.read_images(DIR).map_batches(
-        lambda x: x, batch_format="pyarrow", batch_size=None
+    ray_dataset = ray.data.read_images(args.data_root).map_batches(
+        lambda x: x, batch_format="pyarrow", batch_size=args.batch_size
     )
-    for i in range(3):
+    for i in range(args.num_epochs):
         iterate(
-            ray_dataset.iter_torch_batches(batch_size=None),
+            ray_dataset.iter_torch_batches(batch_size=args.batch_size),
             "ray.data+dummy_pyarrow_transform",
-        )
+        metrics)
 
-    ray_dataset = ray.data.read_images(DIR).map_batches(
-        lambda x: x, batch_format="numpy", batch_size=None
+    ray_dataset = ray.data.read_images(args.data_root).map_batches(
+        lambda x: x, batch_format="numpy", batch_size=args.batch_size
     )
-    for i in range(3):
+    for i in range(args.num_epochs):
         iterate(
-            ray_dataset.iter_torch_batches(batch_size=None),
+            ray_dataset.iter_torch_batches(batch_size=args.batch_size),
             "ray.data+dummy_np_transform",
-        )
+            metrics)
 
     # Test manual loading using map_batches on the pathnames.
     def load(batch):
         batch["image"] = [torchvision.io.read_image(path) for path in batch["image"]]
         return batch
 
-    paths = [os.path.join(DIR, path) for path in os.listdir(DIR)]
+    paths = []
+    for subdir in os.listdir(args.data_root):
+        paths += [os.path.join(args.data_root, subdir, basename) for basename in os.listdir(os.path.join(args.data_root, subdir))]
     ray_dataset = ray.data.from_items([{"image": path} for path in paths]).map_batches(
         load
     )
-    for i in range(3):
-        iterate(ray_dataset.iter_torch_batches(batch_size=32), "ray.data_manual_load")
+    for i in range(args.num_epochs):
+        iterate(ray_dataset.iter_torch_batches(batch_size=args.batch_size), "ray.data_manual_load", metrics)
 
     result_dict = {
         "perf_metrics": metrics,

--- a/release/nightly_tests/dataset/image_loader_microbenchmark.py
+++ b/release/nightly_tests/dataset/image_loader_microbenchmark.py
@@ -24,13 +24,7 @@ def iterate(dataset, label, metrics):
     print(label, end - start, "epoch", i)
 
     tput = num_rows / (end - start)
-    metrics.append(
-        {
-            "perf_metric_name": label,
-            "perf_metric_value": tput,
-            "perf_metric_type": "THROUGHPUT",
-        }
-    )
+    metrics[label] = tput
 
 
 def build_torch_dataset(
@@ -161,13 +155,13 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    metrics = []
+    metrics = {}
 
     tf_dataset = tf.keras.preprocessing.image_dataset_from_directory(
         args.data_root, batch_size=args.batch_size, image_size=FULL_IMAGE_SIZE
     )
     for i in range(args.num_epochs):
-       iterate(tf_dataset, "tf.data", metrics)
+        iterate(tf_dataset, "tf.data", metrics)
     tf_dataset = tf_dataset.map(lambda img, label: (tf_crop_and_flip(img), label))
     for i in range(args.num_epochs):
         iterate(tf_dataset, "tf.data+transform", metrics)
@@ -252,8 +246,17 @@ if __name__ == "__main__":
             metrics,
         )
 
+    metrics_list = []
+    for label, tput in metrics.items():
+        metrics_list.append(
+            {
+                "perf_metric_name": label,
+                "perf_metric_value": tput,
+                "perf_metric_type": "THROUGHPUT",
+            }
+        )
     result_dict = {
-        "perf_metrics": metrics,
+        "perf_metrics": metrics_list,
         "success": 1,
     }
 

--- a/release/nightly_tests/dataset/run_image_loader_microbenchmark.sh
+++ b/release/nightly_tests/dataset/run_image_loader_microbenchmark.sh
@@ -8,13 +8,14 @@ aws s3 sync s3://air-cuj-imagenet-1gb $INPUT_DIR
 
 # Preprocess files to get to the directory structure that torch dataloader
 # expects.
-for filename in `ls $INPUT_DIR`; do
-    class_dir=$(echo $filename | awk '{split($0, array, "_"); print array[1]}')
-    img_path=$(echo $filename | awk '{split($0, array, "_"); print array[2]}')
-    mkdir -p $OUTPUT_DIR/$class_dir
+for filename in "$INPUT_DIR"/*; do
+    filename=$(basename "$filename")
+    class_dir=$(echo "$filename" | awk '{split($0, array, "_"); print array[1]}')
+    img_path=$(echo "$filename" | awk '{split($0, array, "_"); print array[2]}')
+    mkdir -p "$OUTPUT_DIR"/"$class_dir"
     out_path="$OUTPUT_DIR/$class_dir/$img_path"
-    echo $out_path
-    cp $INPUT_DIR/$filename $out_path
+    echo "$out_path"
+    cp "$INPUT_DIR"/"$filename" "$out_path"
 done
 
 python image_loader_microbenchmark.py

--- a/release/nightly_tests/dataset/run_image_loader_microbenchmark.sh
+++ b/release/nightly_tests/dataset/run_image_loader_microbenchmark.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+INPUT_DIR=~/imagenet-1gb
+OUTPUT_DIR=~/imagenet-1gb-data
+
+# Download 1GB dataset from S3 to local disk.
+aws s3 sync s3://air-cuj-imagenet-1gb $INPUT_DIR
+
+# Preprocess files to get to the directory structure that torch dataloader
+# expects.
+for filename in `ls $INPUT_DIR`; do
+    class_dir=$(echo $filename | awk '{split($0, array, "_"); print array[1]}')
+    img_path=$(echo $filename | awk '{split($0, array, "_"); print array[2]}')
+    mkdir -p $OUTPUT_DIR/$class_dir
+    out_path="$OUTPUT_DIR/$class_dir/$img_path"
+    echo $out_path
+    cp $INPUT_DIR/$filename $out_path
+done
+
+python image_loader_microbenchmark.py

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -6201,6 +6201,32 @@
         cluster_env: app_config.yaml
         cluster_compute: single_node_benchmark_compute_gce.yaml
 
+- name: read_images_vs_torch_benchmark_single_node
+  group: data-tests
+  working_dir: nightly_tests/dataset
+
+  frequency: nightly
+  team: data
+  python: "3.8"
+  cluster:
+    byod:
+      type: gpu
+    cluster_env: app_config.yaml
+    cluster_compute: single_node_benchmark_compute.yaml
+
+  run:
+    timeout: 1800
+    script: bash run_image_loader_microbenchmark.sh
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_env: app_config.yaml
+        cluster_compute: single_node_benchmark_compute_gce.yaml
+
 - name: read_tfrecords_benchmark_single_node
   group: data-tests
   working_dir: nightly_tests/dataset

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -6201,7 +6201,7 @@
         cluster_env: app_config.yaml
         cluster_compute: single_node_benchmark_compute_gce.yaml
 
-- name: read_images_vs_torch_benchmark_single_node
+- name: read_images_comparison_microbenchmark_single_node
   group: data-tests
   working_dir: nightly_tests/dataset
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a microbenchmark that tests ray.data.read_images and .map_batches performance compared to torch dataloader.

Here is some example print output from the test:
```
torch +transform 5.619816780090332 epoch 0
torch +transform 5.355570316314697 epoch 1
torch +transform 5.356362819671631 epoch 2
torch 14.441798686981201 epoch 0
torch 14.508012294769287 epoch 1
torch 13.936351537704468 epoch 2
ray.data +transform 20.033137321472168 epoch 0
ray.data +transform 14.71841311454773 epoch 1
ray.data +transform 14.504080772399902 epoch 2
ray.data +transform +zero copy 14.002910137176514 epoch 0
ray.data +transform +zero copy 14.16610336303711 epoch 1
ray.data +transform +zero copy 13.919943571090698 epoch 2
ray.data 6.622779607772827 epoch 0
ray.data 6.558531045913696 epoch 1
ray.data 6.409739017486572 epoch 2
ray.data +dummy pyarrow transform 6.5802366733551025 epoch 0
ray.data +dummy pyarrow transform 6.598402738571167 epoch 1
ray.data +dummy pyarrow transform 6.554988861083984 epoch 2
ray.data +dummy np transform 7.211748361587524 epoch 0
ray.data +dummy np transform 7.307156324386597 epoch 1
ray.data +dummy np transform 7.262319803237915 epoch 2
ray.data manual load 4.941357135772705 epoch 0
ray.data manual load 4.840577840805054 epoch 1
ray.data manual load 4.956918001174927 epoch 2
```

The test records the warmed-up throughput for each version.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
