### PR TITLE
[tune] Fix typo in tune-output.rst

### DIFF
--- a/doc/source/tune/tutorials/tune-output.rst
+++ b/doc/source/tune/tutorials/tune-output.rst
@@ -324,7 +324,7 @@ You can create a custom logger by inheriting the LoggerCallback interface (:ref:
     class CustomLoggerCallback(LoggerCallback):
         """Custom logger interface"""
 
-        def __init__(self, filename: str = "log.txt):
+        def __init__(self, filename: str = "log.txt"):
             self._trial_files = {}
             self._filename = filename
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
