### PR TITLE
Replace job_hook with env_hook

### DIFF
--- a/dashboard/modules/job/cli.py
+++ b/dashboard/modules/job/cli.py
@@ -204,21 +204,9 @@ def submit(
 
     submission_id = submission_id or job_id
 
-    if ray_constants.RAY_JOB_SUBMIT_HOOK in os.environ:
-        # Submit all args as **kwargs per the JOB_SUBMIT_HOOK contract.
-        _load_class(os.environ[ray_constants.RAY_JOB_SUBMIT_HOOK])(
-            address=address,
-            job_id=submission_id,
-            submission_id=submission_id,
-            runtime_env=runtime_env,
-            runtime_env_json=runtime_env_json,
-            metadata_json=metadata_json,
-            working_dir=working_dir,
-            entrypoint=entrypoint,
-            entrypoint_num_cpus=entrypoint_num_cpus,
-            entrypoint_num_gpus=entrypoint_num_gpus,
-            entrypoint_resources=entrypoint_resources,
-            no_wait=no_wait,
+    if ray_constants.RAY_RUNTIME_ENV_HOOK in os.environ:
+        runtime_env = _load_class(os.environ[ray_constants.RAY_RUNTIME_ENV_HOOK])(
+            runtime_env
         )
 
     client = _get_sdk_client(address, create_cluster_if_needed=True, verify=verify)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When submitting jobs, invoke env_hook instead of job_hook, because job_hook is actually a no-op, and we need to use env_hook to pack working_dir for job submit.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
