### PR TITLE
[RLlib] Put notices and error out on invalid ModelV2/Policy related configs for RL Modules

### DIFF
--- a/doc/source/_includes/rllib/rlm_learner_migration_banner.rst
+++ b/doc/source/_includes/rllib/rlm_learner_migration_banner.rst
@@ -1,4 +1,5 @@
 .. note::
 
-    From Ray 2.6.0 onwards, RLlib is adopting a new stack for training and model customization, moving away from ModelV2 API and some convoluted parts of Policy API.
-    Starting from PPO algorithm, we will be gradually replace components with `RLModule API <rllib-rlmodule.html>`__.
+    From Ray 2.6.0 onwards, RLlib is adopting a new stack for training and model customization,
+    gradually replacing the ModelV2 API and some convoluted parts of Policy API with the RLModule API.
+    Click `here <rllib-rlmodule.html>`__ for more details.

--- a/doc/source/_includes/rllib/rlm_learner_migration_banner.rst
+++ b/doc/source/_includes/rllib/rlm_learner_migration_banner.rst
@@ -1,4 +1,4 @@
 .. note::
 
     From Ray 2.6.0 onwards, RLlib is adopting a new stack for training and model customization, moving away from ModelV2 API and some convoluted parts of Policy API.
-    Starting with PPO, these components are gradually being replaced by `RLModule API <rllib-rlmodule.html>`__.
+    Starting from PPO algorithm, we will be gradually replace components with `RLModule API <rllib-rlmodule.html>`__.

--- a/doc/source/_includes/rllib/rlm_learner_migration_banner.rst
+++ b/doc/source/_includes/rllib/rlm_learner_migration_banner.rst
@@ -1,4 +1,4 @@
 .. note::
 
-    From Ray 2.6.0 on, RLLib is undergoing a major migration away from the Policy API and the MovelV2 API.
+    From Ray 2.6.0 on, RLlib is undergoing a major migration away from the Policy API and the MovelV2 API.
     Starting with PPO, these components are gradually being replaced by `RLModule API <rllib-rlmodule.html>`__.

--- a/doc/source/_includes/rllib/rlm_learner_migration_banner.rst
+++ b/doc/source/_includes/rllib/rlm_learner_migration_banner.rst
@@ -1,4 +1,4 @@
 .. note::
 
-    From Ray 2.6.0 on, RLlib is undergoing a major migration away from the Policy API and the MovelV2 API.
+    From Ray 2.6.0 onwards, RLlib is adopting a new stack for training and model customization, moving away from ModelV2 API and some convoluted parts of Policy API.
     Starting with PPO, these components are gradually being replaced by `RLModule API <rllib-rlmodule.html>`__.

--- a/doc/source/_includes/rllib/rlm_learner_migration_banner.rst
+++ b/doc/source/_includes/rllib/rlm_learner_migration_banner.rst
@@ -2,4 +2,4 @@
 
     From Ray 2.6.0 onwards, RLlib is adopting a new stack for training and model customization,
     gradually replacing the ModelV2 API and some convoluted parts of Policy API with the RLModule API.
-    Click `here <rllib-rlmodule.html>`__ for more details.
+    Click `here <rllib-rlmodule.html>`__ for details.

--- a/doc/source/_includes/rllib/rlm_learner_migration_banner.rst
+++ b/doc/source/_includes/rllib/rlm_learner_migration_banner.rst
@@ -1,0 +1,4 @@
+.. note::
+
+    From Ray 2.6.0 on, RLLib is undergoing a major migration away from the Policy API and the MovelV2 API.
+    Starting with PPO, these components are gradually being replaced by `RLModule API <rllib-rlmodule.html>`__.

--- a/doc/source/rllib/key-concepts.rst
+++ b/doc/source/rllib/key-concepts.rst
@@ -2,6 +2,8 @@
 
 .. include:: /_includes/rllib/we_are_hiring.rst
 
+.. include:: /_includes/rllib/rlm_learner_migration_banner.rst
+
 .. TODO: We need algorithms, environments, policies, models here. Likely in that order.
     Execution plans are not a "core" concept for users. Sample batches should probably also be left out.
 

--- a/doc/source/rllib/package_ref/algorithm.rst
+++ b/doc/source/rllib/package_ref/algorithm.rst
@@ -1,5 +1,7 @@
 .. algorithm-reference-docs:
 
+.. include:: /_includes/rllib/rlm_learner_migration_banner.rst
+
 Algorithms
 ==========
 

--- a/doc/source/rllib/package_ref/catalogs.rst
+++ b/doc/source/rllib/package_ref/catalogs.rst
@@ -1,6 +1,6 @@
-
-
 .. _catalog-reference-docs:
+
+.. include:: /_includes/rllib/rlm_learner_migration_banner.rst
 
 .. include:: /_includes/rllib/rlmodules_rollout.rst
 

--- a/doc/source/rllib/package_ref/index.rst
+++ b/doc/source/rllib/package_ref/index.rst
@@ -2,6 +2,8 @@
 
 .. include:: /_includes/rllib/we_are_hiring.rst
 
+.. include:: /_includes/rllib/rlm_learner_migration_banner.rst
+
 .. _rllib-reference-docs:
 
 Ray RLlib API

--- a/doc/source/rllib/package_ref/models.rst
+++ b/doc/source/rllib/package_ref/models.rst
@@ -1,5 +1,7 @@
 .. _model-reference-docs:
 
+.. include:: /_includes/rllib/rlm_learner_migration_banner.rst
+
 Model APIs
 ==========
 

--- a/doc/source/rllib/package_ref/policy.rst
+++ b/doc/source/rllib/package_ref/policy.rst
@@ -1,5 +1,7 @@
 .. _policy-reference-docs:
 
+.. include:: /_includes/rllib/rlm_learner_migration_banner.rst
+
 Policy API
 ==========
 

--- a/doc/source/rllib/rllib-algorithms.rst
+++ b/doc/source/rllib/rllib-algorithms.rst
@@ -2,6 +2,8 @@
 
 .. include:: /_includes/rllib/we_are_hiring.rst
 
+.. include:: /_includes/rllib/rlm_learner_migration_banner.rst
+
 .. _rllib-algorithms-doc:
 
 Algorithms

--- a/doc/source/rllib/rllib-concepts.rst
+++ b/doc/source/rllib/rllib-concepts.rst
@@ -2,6 +2,8 @@
 
 .. include:: /_includes/rllib/we_are_hiring.rst
 
+.. include:: /_includes/rllib/rlm_learner_migration_banner.rst
+
 .. _rllib-policy-walkthrough:
 
 How To Customize Policies

--- a/doc/source/rllib/rllib-examples.rst
+++ b/doc/source/rllib/rllib-examples.rst
@@ -2,6 +2,8 @@
 
 .. include:: /_includes/rllib/we_are_hiring.rst
 
+.. include:: /_includes/rllib/rlm_learner_migration_banner.rst
+
 Examples
 ========
 

--- a/doc/source/rllib/rllib-models.rst
+++ b/doc/source/rllib/rllib-models.rst
@@ -2,6 +2,8 @@
 
 .. include:: /_includes/rllib/we_are_hiring.rst
 
+.. include:: /_includes/rllib/rlm_learner_migration_banner.rst
+
 .. _rllib-models-walkthrough:
 
 Models, Preprocessors, and Action Distributions

--- a/doc/source/rllib/rllib-rlmodule.rst
+++ b/doc/source/rllib/rllib-rlmodule.rst
@@ -2,6 +2,8 @@
 
 .. include:: /_includes/rllib/we_are_hiring.rst
 
+.. include:: /_includes/rllib/rlm_learner_migration_banner.rst
+
 .. |tensorflow| image:: images/tensorflow.png
     :class: inline-figure
     :width: 16

--- a/doc/source/rllib/rllib-training.rst
+++ b/doc/source/rllib/rllib-training.rst
@@ -2,6 +2,8 @@
 
 .. include:: /_includes/rllib/we_are_hiring.rst
 
+.. include:: /_includes/rllib/rlm_learner_migration_banner.rst
+
 .. _rllib-getting-started:
 
 Getting Started with RLlib

--- a/doc/source/rllib/user-guides.rst
+++ b/doc/source/rllib/user-guides.rst
@@ -2,6 +2,8 @@
 
 .. include:: /_includes/rllib/we_are_hiring.rst
 
+.. include:: /_includes/rllib/rlm_learner_migration_banner.rst
+
 .. _rllib-guides:
 
 ===========

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -803,6 +803,8 @@ class Algorithm(Trainable, AlgorithmBase):
     ) -> Optional[Type[Policy]]:
         """Returns a default Policy class to use, given a config.
 
+        Note that this method is ignored when the RLModule API is enabled.
+
         This class will be used by an Algorithm in case
         the policy class is not provided by the user in any single- or
         multi-agent PolicySpec.

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -803,11 +803,11 @@ class Algorithm(Trainable, AlgorithmBase):
     ) -> Optional[Type[Policy]]:
         """Returns a default Policy class to use, given a config.
 
-        Note that this method is ignored when the RLModule API is enabled.
-
         This class will be used by an Algorithm in case
         the policy class is not provided by the user in any single- or
         multi-agent PolicySpec.
+
+        Note: This method is ignored when the RLModule API is enabled.
         """
         return None
 

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -1011,18 +1011,28 @@ class AlgorithmConfig(_Config):
             else:
                 self.rl_module_spec = default_rl_module_spec
 
+            not_compatible_w_rlm_msg = (
+                "Cannot use `{}` option with RLModule API. `{"
+                "}` is part of the ModelV2 API and Policy API,"
+                " which are not compatible with the RLModule "
+                "API. You can either deactivate the RLModule "
+                "API by setting `config.rl_module( "
+                "_enable_rl_module_api=False)` and "
+                "`config.training(_enable_learner_api=False)` "
+                "or use the RLModule API and implement your "
+                "custom model as an RLModule."
+            )
+
             if self.model["custom_model"] is not None:
                 raise ValueError(
-                    "Cannot use `custom_model` option with RLModule API."
-                    "`custom_model` is part of the ModelV2 API and Policy API, "
-                    "which are not compatible with the RLModule API."
+                    not_compatible_w_rlm_msg.format("custom_model", "custom_model")
                 )
 
             if self.model["custom_model_config"] != {}:
                 raise ValueError(
-                    "Cannot use `custom_model_config` option with RLModule API."
-                    "`custom_model_config` is part of the ModelV2 API and Policy API, "
-                    "which are not compatible with the RLModule API."
+                    not_compatible_w_rlm_msg.format(
+                        "custom_model_config", "custom_model_config"
+                    )
                 )
 
             if self.exploration_config:

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -1018,7 +1018,7 @@ class AlgorithmConfig(_Config):
                 "API. You can either deactivate the RLModule "
                 "API by setting `config.rl_module( "
                 "_enable_rl_module_api=False)` and "
-                "`config.training(_enable_learner_api=False)` "
+                "`config.training(_enable_learner_api=False)` ,"
                 "or use the RLModule API and implement your "
                 "custom model as an RLModule."
             )

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -2192,13 +2192,6 @@ class AlgorithmConfig(_Config):
             for pid in policies:
                 validate_policy_id(pid, error=True)
 
-            if self._enable_rl_module_api:
-                raise ValueError(
-                    "`policies` uses the Policy and ModelV2 API. This is incompatible "
-                    "with the RLModule API. Please set `_enable_rl_module_api=False` "
-                    "to use the legacy Policy and ModelV2 API."
-                )
-
             # Validate each policy spec in a given dict.
             if isinstance(policies, dict):
                 for pid, spec in policies.items():

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -1011,13 +1011,19 @@ class AlgorithmConfig(_Config):
             else:
                 self.rl_module_spec = default_rl_module_spec
 
-            for option in ["custom_model", "custom_model_config"]:
-                if self.model[option] is not None:
-                    raise ValueError(
-                        f"Cannot use `{option}` option with RLModule API."
-                        f"`{option}` is part of the ModelV2 API and Policy API, "
-                        f"which are not compatible with the RLModule API."
-                    )
+            if self.model["custom_model"] is not None:
+                raise ValueError(
+                    "Cannot use `custom_model` option with RLModule API."
+                    "`custom_model` is part of the ModelV2 API and Policy API, "
+                    "which are not compatible with the RLModule API."
+                )
+
+            if self.model["custom_model_config"] != {}:
+                raise ValueError(
+                    "Cannot use `custom_model_config` option with RLModule API."
+                    "`custom_model_config` is part of the ModelV2 API and Policy API, "
+                    "which are not compatible with the RLModule API."
+                )
 
             if self.exploration_config:
                 # This is not compatible with RLModules, which have a method

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -1011,6 +1011,14 @@ class AlgorithmConfig(_Config):
             else:
                 self.rl_module_spec = default_rl_module_spec
 
+            if self.model["custom_model"] is not None:
+                raise ValueError(
+                    "Cannot use `custom_model` option with RLModule API."
+                    "`custom_model` is part of the ModelV2 API, which is not"
+                    "compatible with the RLModule API. The ModelV2 API is "
+                    "being deprecated."
+                )
+
             if self.exploration_config:
                 # This is not compatible with RLModules, which have a method
                 # `forward_exploration` to specify custom exploration behavior.

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -1011,13 +1011,13 @@ class AlgorithmConfig(_Config):
             else:
                 self.rl_module_spec = default_rl_module_spec
 
-            if self.model["custom_model"] is not None:
-                raise ValueError(
-                    "Cannot use `custom_model` option with RLModule API."
-                    "`custom_model` is part of the ModelV2 API, which is not"
-                    "compatible with the RLModule API. The ModelV2 API is "
-                    "being deprecated."
-                )
+            for option in ["custom_model", "custom_model_config"]:
+                if self.model[option] is not None:
+                    raise ValueError(
+                        f"Cannot use `{option}` option with RLModule API."
+                        f"`{option}` is part of the ModelV2 API and Policy API, "
+                        f"which are not compatible with the RLModule API."
+                    )
 
             if self.exploration_config:
                 # This is not compatible with RLModules, which have a method
@@ -2191,6 +2191,13 @@ class AlgorithmConfig(_Config):
             # is a dict or just any Sequence).
             for pid in policies:
                 validate_policy_id(pid, error=True)
+
+            if self._enable_rl_module_api:
+                raise ValueError(
+                    "`policies` uses the Policy and ModelV2 API. This is incompatible "
+                    "with the RLModule API. Please set `_enable_rl_module_api=False` "
+                    "to use the legacy Policy and ModelV2 API."
+                )
 
             # Validate each policy spec in a given dict.
             if isinstance(policies, dict):

--- a/rllib/evaluation/tests/test_trajectory_view_api.py
+++ b/rllib/evaluation/tests/test_trajectory_view_api.py
@@ -210,6 +210,9 @@ class TestTrajectoryViewAPI(unittest.TestCase):
                 sgd_minibatch_size=201,
                 num_sgd_iter=5,
             )
+            # Batch-norm models have not been migrated to the RL Module API yet.
+            .training(_enable_learner_api=False)
+            .rl_module(_enable_rl_module_api=False)
         )
 
         for _ in framework_iterator(config, frameworks="tf2"):

--- a/rllib/examples/autoregressive_action_dist.py
+++ b/rllib/examples/autoregressive_action_dist.py
@@ -144,6 +144,9 @@ if __name__ == "__main__":
         .training(gamma=0.5)
         # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
         .resources(num_gpus=int(os.environ.get("RLLIB_NUM_GPUS", "0")))
+        # Batch-norm models have not been migrated to the RL Module API yet.
+        .training(_enable_learner_api=False)
+        .rl_module(_enable_rl_module_api=False)
     )
 
     # Use registered model and dist in config.

--- a/rllib/examples/batch_norm_model.py
+++ b/rllib/examples/batch_norm_model.py
@@ -68,9 +68,15 @@ if __name__ == "__main__":
         .environment("Pendulum-v1" if args.run in ["DDPG", "SAC"] else "CartPole-v1")
         .framework(args.framework)
         .rollouts(num_rollout_workers=3)
-        .training(model={"custom_model": "bn_model"}, lr=0.0003)
+        .training(
+            model={"custom_model": "bn_model"},
+            lr=0.0003,
+        )
         # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
         .resources(num_gpus=int(os.environ.get("RLLIB_NUM_GPUS", "0")))
+        # Batch-norm models have not been migrated to the RL Module API yet.
+        .training(_enable_learner_api=False)
+        .rl_module(_enable_rl_module_api=False)
     )
 
     stop = {

--- a/rllib/examples/custom_env.py
+++ b/rllib/examples/custom_env.py
@@ -1,9 +1,8 @@
 """
-Example of a custom gym environment and model. Run this for a demo.
+Example of a custom gym environment. Run this for a demo.
 
 This example shows:
   - using a custom environment
-  - using a custom model
   - using Tune for grid search to try different learning rates
 
 You can visualize experiment results in ~/ray_results using TensorBoard.
@@ -23,11 +22,6 @@ import random
 import ray
 from ray import air, tune
 from ray.rllib.env.env_context import EnvContext
-from ray.rllib.models import ModelCatalog
-from ray.rllib.models.tf.tf_modelv2 import TFModelV2
-from ray.rllib.models.tf.fcnet import FullyConnectedNetwork
-from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
-from ray.rllib.models.torch.fcnet import FullyConnectedNetwork as TorchFC
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.tune.logger import pretty_print
@@ -109,46 +103,6 @@ class SimpleCorridor(gym.Env):
         )
 
 
-class CustomModel(TFModelV2):
-    """Example of a keras custom model that just delegates to an fc-net."""
-
-    def __init__(self, obs_space, action_space, num_outputs, model_config, name):
-        super(CustomModel, self).__init__(
-            obs_space, action_space, num_outputs, model_config, name
-        )
-        self.model = FullyConnectedNetwork(
-            obs_space, action_space, num_outputs, model_config, name
-        )
-
-    def forward(self, input_dict, state, seq_lens):
-        return self.model.forward(input_dict, state, seq_lens)
-
-    def value_function(self):
-        return self.model.value_function()
-
-
-class TorchCustomModel(TorchModelV2, nn.Module):
-    """Example of a PyTorch custom model that just delegates to a fc-net."""
-
-    def __init__(self, obs_space, action_space, num_outputs, model_config, name):
-        TorchModelV2.__init__(
-            self, obs_space, action_space, num_outputs, model_config, name
-        )
-        nn.Module.__init__(self)
-
-        self.torch_sub_model = TorchFC(
-            obs_space, action_space, num_outputs, model_config, name
-        )
-
-    def forward(self, input_dict, state, seq_lens):
-        input_dict["obs"] = input_dict["obs"].float()
-        fc_out, _ = self.torch_sub_model(input_dict, state, seq_lens)
-        return fc_out, []
-
-    def value_function(self):
-        return torch.reshape(self.torch_sub_model.value_function(), [-1])
-
-
 if __name__ == "__main__":
     args = parser.parse_args()
     print(f"Running with following CLI options: {args}")
@@ -157,9 +111,6 @@ if __name__ == "__main__":
 
     # Can also register the env creator function explicitly with:
     # register_env("corridor", lambda config: SimpleCorridor(config))
-    ModelCatalog.register_custom_model(
-        "my_model", TorchCustomModel if args.framework == "torch" else CustomModel
-    )
 
     config = (
         get_trainable_cls(args.run)
@@ -168,12 +119,6 @@ if __name__ == "__main__":
         .environment(SimpleCorridor, env_config={"corridor_length": 5})
         .framework(args.framework)
         .rollouts(num_rollout_workers=1)
-        .training(
-            model={
-                "custom_model": "my_model",
-                "vf_share_layers": True,
-            }
-        )
         # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
         .resources(num_gpus=int(os.environ.get("RLLIB_NUM_GPUS", "0")))
     )

--- a/rllib/examples/custom_env.py
+++ b/rllib/examples/custom_env.py
@@ -1,9 +1,9 @@
 """
-Example of a custom gym environment. Run this for a demo.
+Example of a custom gym environment. Run this example for a demo.
 
-This example shows:
-  - using a custom environment
-  - using Tune for grid search to try different learning rates
+This example shows the usage of:
+  - a custom environment
+  - Ray Tune for grid search to try different learning rates
 
 You can visualize experiment results in ~/ray_results using TensorBoard.
 

--- a/rllib/examples/custom_loss.py
+++ b/rllib/examples/custom_loss.py
@@ -1,5 +1,0 @@
-# File has been renamed.
-raise DeprecationWarning(
-    "This file has been renamed to `custom_model_loss_and_metrics.py` "
-    "in the same folder!"
-)

--- a/rllib/examples/custom_model_loss_and_metrics.py
+++ b/rllib/examples/custom_model_loss_and_metrics.py
@@ -1,4 +1,5 @@
-"""Example of using custom_loss() with an imitation learning loss.
+"""Example of using custom_loss() with an imitation learning loss under the Policy
+and ModelV2 API.
 
 The default input file is too small to learn a good policy, but you can
 generate new experiences for IL training as follows:


### PR DESCRIPTION
## Why are these changes needed?

Starting with Ray 2.6.0, we roll out RLModules and Learners.
This requires notifications in docs about this migration so that users are not caught off-guard.
Further more, this PR includes a hotfix for when users attempt to set a `custom_model` while using the RL Module API, which stems from the ModelV2 API, which is incompatible.

Solves https://github.com/ray-project/ray/issues/37085