### PR TITLE
[RLlib] Add agent index on first step in env runner v2

### DIFF
--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -781,6 +781,7 @@ class EnvRunnerV2:
                         SampleBatch.NEXT_OBS: obs,
                         SampleBatch.INFOS: infos,
                         SampleBatch.T: episode.length,
+                        SampleBatch.AGENT_INDEX: episode.agent_index(agent_id),
                     },
                 )
                 for agent_id, obs in agents_obs


### PR DESCRIPTION
## Why are these changes needed?

When starting a new sequence in EnvRunnerV2, we call __process_resetted_obs_for_eval to initialize it.
Unlike when we add steps after that, we don't give it an agent index.
This RP changes that.

Solves https://github.com/ray-project/ray/issues/37521 