### PR TITLE
[core][autoscaler] Add cluster session name to report to autoscaler

### DIFF
--- a/python/ray/autoscaler/v2/tests/test_sdk.py
+++ b/python/ray/autoscaler/v2/tests/test_sdk.py
@@ -170,6 +170,10 @@ def test_node_info_basic(shutdown_only, monkeypatch):
             assert node.node_ip_address == ip
             assert node.instance_type_name == "instance-type-name"
 
+            assert (
+                state.cluster_session_name
+                == ray._private.worker.global_worker.node.session_name
+            )
             return True
 
         wait_for_condition(verify)

--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
@@ -24,11 +24,13 @@ namespace ray {
 namespace gcs {
 
 GcsAutoscalerStateManager::GcsAutoscalerStateManager(
+    const std::string &session_name,
     const ClusterResourceManager &cluster_resource_manager,
     const GcsResourceManager &gcs_resource_manager,
     const GcsNodeManager &gcs_node_manager,
     const GcsPlacementGroupManager &gcs_placement_group_manager)
-    : cluster_resource_manager_(cluster_resource_manager),
+    : session_name_(session_name),
+      cluster_resource_manager_(cluster_resource_manager),
       gcs_node_manager_(gcs_node_manager),
       gcs_resource_manager_(gcs_resource_manager),
       gcs_placement_group_manager_(gcs_placement_group_manager),
@@ -112,6 +114,7 @@ void GcsAutoscalerStateManager::MakeClusterResourceStateInternal(
   state->set_last_seen_autoscaler_state_version(last_seen_autoscaler_state_version_);
   state->set_cluster_resource_state_version(
       IncrementAndGetNextClusterResourceStateVersion());
+  state->set_cluster_session_name(session_name_);
 
   GetNodeStates(state);
   GetPendingResourceRequests(state);

--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.h
@@ -27,7 +27,8 @@ class GcsPlacementGroupManager;
 
 class GcsAutoscalerStateManager : public rpc::AutoscalerStateHandler {
  public:
-  GcsAutoscalerStateManager(const ClusterResourceManager &cluster_resource_manager,
+  GcsAutoscalerStateManager(const std::string &session_name,
+                            const ClusterResourceManager &cluster_resource_manager,
                             const GcsResourceManager &gcs_resource_manager,
                             const GcsNodeManager &gcs_node_manager,
                             const GcsPlacementGroupManager &gcs_placement_group_manager);
@@ -108,6 +109,9 @@ class GcsAutoscalerStateManager : public rpc::AutoscalerStateHandler {
   /// See rpc::autoscaler::ClusterResourceState::cluster_resource_constraints for
   /// more details. This is requested through autoscaler SDK for request_resources().
   void GetClusterResourceConstraints(rpc::autoscaler::ClusterResourceState *state);
+
+  // Ray cluster session name.
+  const std::string session_name_ = "";
 
   /// Cluster resources manager that provides cluster resources information.
   const ClusterResourceManager &cluster_resource_manager_;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -656,6 +656,7 @@ void GcsServer::InitGcsWorkerManager() {
 
 void GcsServer::InitGcsAutoscalerStateManager() {
   gcs_autoscaler_state_manager_ = std::make_unique<GcsAutoscalerStateManager>(
+      config_.session_name,
       cluster_resource_scheduler_->GetClusterResourceManager(),
       *gcs_resource_manager_,
       *gcs_node_manager_,

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -58,6 +58,7 @@ struct GcsServerConfig {
   std::string log_dir;
   // This includes the config list of raylet.
   std::string raylet_config_list;
+  std::string session_name;
 };
 
 class GcsNodeManager;

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -98,6 +98,7 @@ int main(int argc, char *argv[]) {
   gcs_server_config.node_ip_address = node_ip_address;
   gcs_server_config.log_dir = log_dir;
   gcs_server_config.raylet_config_list = config_list;
+  gcs_server_config.session_name = session_name;
   ray::gcs::GcsServer gcs_server(gcs_server_config, main_service);
 
   // Destroy the GCS server on a SIGTERM. The pointer to main_service is

--- a/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
@@ -56,9 +56,9 @@ class GcsAutoscalerStateManagerTest : public ::testing::Test {
 
     gcs_placement_group_manager_ =
         std::make_shared<MockGcsPlacementGroupManager>(*gcs_resource_manager_);
-
     gcs_autoscaler_state_manager_.reset(
-        new GcsAutoscalerStateManager(*cluster_resource_manager_,
+        new GcsAutoscalerStateManager("fake_cluster",
+                                      *cluster_resource_manager_,
                                       *gcs_resource_manager_,
                                       *gcs_node_manager_,
                                       *gcs_placement_group_manager_));

--- a/src/ray/protobuf/experimental/autoscaler.proto
+++ b/src/ray/protobuf/experimental/autoscaler.proto
@@ -175,6 +175,8 @@ message ClusterResourceState {
   // There could be multiple constraints issued by different
   // jobs. Autoscaler to make sure all constraints are satisfied.
   repeated ClusterResourceConstraint cluster_resource_constraints = 6;
+  // The cluster session name.
+  string cluster_session_name = 7;
 }
 
 message GetClusterResourceStateReply {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add the cluster session name to metadata reported to autoscaler. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
