### PR TITLE
[Data] Remove usage of the phrase "local iterator" from `iter_batches` docs

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3155,7 +3155,7 @@ class Dataset:
         # Deprecated.
         prefetch_blocks: int = 0,
     ) -> Iterator[DataBatch]:
-        """Return a local batched iterator over the dataset.
+        """Return a batched iterator over the dataset.
 
         Examples:
             >>> import ray
@@ -3220,7 +3220,7 @@ class Dataset:
         # Deprecated
         prefetch_blocks: int = 0,
     ) -> Iterator["TorchTensorBatchType"]:
-        """Return a local batched iterator of Torch Tensors over the dataset.
+        """Return a batched iterator of Torch Tensors over the dataset.
 
         This iterator will yield single-tensor batches if the underlying dataset
         consists of a single column; otherwise, it will yield a dictionary of
@@ -3301,7 +3301,7 @@ class Dataset:
         # Deprecated
         prefetch_blocks: int = 0,
     ) -> Iterator[TensorFlowTensorBatchType]:
-        """Return a local batched iterator of TensorFlow Tensors over the dataset.
+        """Return a batched iterator of TensorFlow Tensors over the dataset.
 
         This iterator will yield single-tensor batches of the underlying dataset
         consists of a single column; otherwise, it will yield a dictionary of

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -176,7 +176,7 @@ class DatasetPipeline:
         local_shuffle_seed: Optional[int] = None,
         _collate_fn: Optional[Callable[[DataBatch], Any]] = None,
     ) -> Iterator[DataBatch]:
-        """Return a local batched iterator over the data in the pipeline.
+        """Return a batched iterator over the data in the pipeline.
 
         Examples:
             >>> import ray

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -98,7 +98,7 @@ class DataIterator(abc.ABC):
         # Deprecated.
         prefetch_blocks: int = 0,
     ) -> Iterator[DataBatch]:
-        """Return a local batched iterator over the dataset.
+        """Return a batched iterator over the dataset.
 
         Examples:
             >>> import ray
@@ -265,7 +265,7 @@ class DataIterator(abc.ABC):
         # Deprecated.
         prefetch_blocks: int = 0,
     ) -> Iterator["TorchTensorBatchType"]:
-        """Return a local batched iterator of Torch Tensors over the dataset.
+        """Return a batched iterator of Torch Tensors over the dataset.
 
         This iterator will yield single-tensor batches if the underlying dataset
         consists of a single column; otherwise, it will yield a dictionary of
@@ -386,7 +386,7 @@ class DataIterator(abc.ABC):
         # Deprecated.
         prefetch_blocks: int = 0,
     ) -> Iterator["TensorFlowTensorBatchType"]:
-        """Return a local batched iterator of TensorFlow Tensors over the dataset.
+        """Return a batched iterator of TensorFlow Tensors over the dataset.
 
         This iterator will yield single-tensor batches of the underlying dataset
         consists of a single column; otherwise, it will yield a dictionary of


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Previously, the docs text for `iter_batches` and other related methods was:
```
Return a local batched iterator over the dataset.
```

Here, "local" refers to the caller of `iter_batches` itself. For example, in the training use case, the training worker calls this, so it returns an iterator per each training worker node. In the single-node case (e.g. laptop debugging use case), the driver or head node calls this, so it returns an iterator to driver or head node.

However, some OSS users and internal developers found the phrase confusing and unnecessary. Therefore, we remove it from the docs to reduce confusion.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
