### PR TITLE
[air][cherry-pick] Fix behavior of multi-node checkpointing without an external `storage_path` to hard-fail

### DIFF
--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -78,6 +78,14 @@ _EXCLUDE_FROM_SYNC = [
     f"./{LAZY_CHECKPOINT_MARKER_FILE}",
 ]
 
+
+class _HeadNodeSyncDeprecationWarning(DeprecationWarning):
+    """Error raised when trying to rely on deprecated head node syncing when
+    checkpointing across multiple nodes."""
+
+    pass
+
+
 _SYNC_TO_HEAD_DEPRECATION_MESSAGE = (
     "Ray AIR no longer supports the synchronization of checkpoints and other "
     "artifacts from worker nodes to the head node. This means that the "
@@ -92,7 +100,8 @@ _SYNC_TO_HEAD_DEPRECATION_MESSAGE = (
     "`RunConfig(storage_path='/mnt/path/to/nfs_storage')`\n"
     "See this Github issue for more details on transitioning to cloud storage/NFS "
     "as well as an explanation on why this functionality is "
-    "being removed: https://github.com/ray-project/ray/issues/37177\n\n"
+    "being removed: https://github.com/ray-project/ray/issues/37177\n"
+    "If you are already using NFS, you can ignore this warning message.\n\n"
     "Other temporary workarounds:\n"
     "- If you want to avoid errors/warnings and continue running with "
     "syncing explicitly turned off, set `RunConfig(SyncConfig(syncer=None))`\n"
@@ -926,7 +935,7 @@ class SyncerCallback(Callback):
             # that means that it lives on some other node and would be synced to head
             # prior to Ray 2.6.
             if not os.path.exists(checkpoint.dir_or_data):
-                raise DeprecationWarning(_SYNC_TO_HEAD_DEPRECATION_MESSAGE)
+                raise _HeadNodeSyncDeprecationWarning(_SYNC_TO_HEAD_DEPRECATION_MESSAGE)
             # else:
             #   No need to raise an error about syncing, since the driver can find
             #   the checkpoint, because either:


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is a cherry-pick of https://github.com/ray-project/ray/pull/37543

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
