### PR TITLE
[RLLib] Add proper evaluation error message if batch is not episodic

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -1085,12 +1085,7 @@ class Algorithm(Trainable, AlgorithmBase):
                             for batch in ma_batch.policy_batches.values():
                                 if not batch.is_terminated_or_truncated():
                                     raise ValueError(
-                                        "RLlib attempts to evaluate your policy per "
-                                        "episode, which is determined by the "
-                                        "evaluation config's "
-                                        "`evaluation_duration_unit`. However, "
-                                        "the evaluation batch is neither terminated "
-                                        "nor truncated."
+                                        "In your evaluation config you have specified evaluation_duration_unit="episodes". However, the evaluation batch is neither terminated nor truncated."
                                     )
                     # n timesteps per returned batch.
                     else:

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -1083,7 +1083,15 @@ class Algorithm(Trainable, AlgorithmBase):
                         for ma_batch in batches:
                             ma_batch = ma_batch.as_multi_agent()
                             for batch in ma_batch.policy_batches.values():
-                                assert batch.is_terminated_or_truncated()
+                                if not batch.is_terminated_or_truncated():
+                                    raise ValueError(
+                                        "RLlib attempts to evaluate your policy per "
+                                        "episode, which is determined by the "
+                                        "evaluation config's "
+                                        "`evaluation_duration_unit`. However, "
+                                        "the evaluation batch is neither terminated "
+                                        "nor truncated."
+                                    )
                     # n timesteps per returned batch.
                     else:
                         num_units_done += (

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -1085,7 +1085,13 @@ class Algorithm(Trainable, AlgorithmBase):
                             for batch in ma_batch.policy_batches.values():
                                 if not batch.is_terminated_or_truncated():
                                     raise ValueError(
-                                        "In your evaluation config you have specified evaluation_duration_unit="episodes". However, the evaluation batch is neither terminated nor truncated."
+                                        "In your evaluation config you have specified "
+                                        "evaluation_duration_unit='episodes'. "
+                                        "However, the evaluation batch is neither "
+                                        "terminated nor truncated. Please make sure "
+                                        "that your environment terminates the "
+                                        "episode after each episode end or use "
+                                        "another evaluation_duration_unit."
                                     )
                     # n timesteps per returned batch.
                     else:


### PR DESCRIPTION
## Why are these changes needed?

The error message if batches are not episodic, while episodic evaluation is chosen is not helpful.
This PR makes it helpful.

Solves https://github.com/ray-project/ray/issues/37447