### PR TITLE
[Serve] Multiplex enforce the num of models per replica

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -146,7 +146,7 @@ RAY_GCS_RPC_TIMEOUT_S = 3.0
 RECOVERING_LONG_POLL_BROADCAST_TIMEOUT_S = 10.0
 
 # Minimum duration to wait until broadcasting model IDs.
-PUSH_MULTIPLEXED_MODEL_IDS_INTERVAL_S = 1.0
+PUSH_MULTIPLEXED_MODEL_IDS_INTERVAL_S = 0.1
 
 
 # Deprecation message for V1 migrations.

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -219,3 +219,8 @@ RAY_SERVE_CONTROLLER_CALLBACK_IMPORT_PATH = os.environ.get(
 )
 # Serve gauge metric set period.
 RAY_SERVE_GAUGE_METRIC_SET_PERIOD_S = 1
+
+# The time for router waiting for maching multiplexed model id with replica.
+RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S = int(
+    os.environ.get("RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S", "0")
+)

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -460,12 +460,12 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
                     "Got replicas for deployment {self._deployment_name}, waking up.",
                     extra={"log_to_stderr": False},
                 )
-#            candidate_replica_ids = set()
+            candidate_replica_ids = set()
             if request_metadata is not None and request_metadata.multiplexed_model_id:
                 trace(tag, "Start wait for ", request_metadata.multiplexed_model_id)
                 start = time.time()
-                max_dt = RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S
-#                max_dt = 2 * RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S * random.random()
+                #max_dt = RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S
+                max_dt = 2 * RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S * random.random()
                 while (
                     time.time() - start
                     < max_dt

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -388,7 +388,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
         return self.update_replicas([ActorReplicaWrapper(r) for r in running_replicas])
 
     def _get_candidate_replica_ids_for_matched_model_ids(
-        self, model_id: str, blacklist_replica_ids: Set[str], fallback = False
+        self, model_id: str, blacklist_replica_ids: Set[str], fallback=False
     ) -> Set[str]:
         candidates = set()
 
@@ -467,8 +467,12 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
                         break
                     await asyncio.sleep(0.01)
                 if not candidate_replica_ids:
-                    candidate_replica_ids = self._get_candidate_replica_ids_for_matched_model_ids(
-                        request_metadata.multiplexed_model_id, replica_ids_attempted, fallback=True
+                    candidate_replica_ids = (
+                        self._get_candidate_replica_ids_for_matched_model_ids(
+                            request_metadata.multiplexed_model_id,
+                            replica_ids_attempted,
+                            fallback=True,
+                        )
                     )
 
             if not candidate_replica_ids:

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -396,6 +396,8 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
             candidates = self._multiplexed_model_id_to_replica_ids[model_id].difference(
                 blacklist_replica_ids
             )
+            if len(candidates) > 0:
+                return candidates
         if fallback:
             # Sort the replicas based on the number of models they are serving.
             # Choose the replica with the least number of models.

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -17,7 +17,6 @@ from ray.serve.context import (
 )
 from ray.serve._private.common import MultiplexedReplicaInfo
 from ray.serve import metrics
-from ray._private.utils import get_or_create_event_loop
 
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -147,13 +147,9 @@ class _ModelMultiplexWrapper:
                 self.models_load_counter.inc()
                 load_start_time = time.time()
                 if self.self_arg is None:
-                    self.models[
-                        model_id
-                    ] = await self._func(model_id)
+                    self.models[model_id] = await self._func(model_id)
                 else:
-                    self.models[
-                        model_id
-                    ] = await self._func(self.self_arg, model_id)
+                    self.models[model_id] = await self._func(self.self_arg, model_id)
                 self._push_multiplexed_replica_info = True
                 self._model_load_tasks.discard(model_id)
                 self.model_load_latency_s.set(time.time() - load_start_time)

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -95,7 +95,6 @@ class _ModelMultiplexWrapper:
         self._model_cache_lock = asyncio.Lock()
         self._model_load_tasks: Set[str] = set()
 
-
         self.metrics_pusher = MetricsPusher()
         self.metrics_pusher.register_task(
             self._push_model_ids,
@@ -168,7 +167,9 @@ class _ModelMultiplexWrapper:
                     if self.self_arg is None:
                         self.models[model_id] = await self._func(model_id)
                     else:
-                        self.models[model_id] = await self._func(self.self_arg, model_id)
+                        self.models[model_id] = await self._func(
+                            self.self_arg, model_id
+                        )
                     self._model_load_tasks.discard(model_id)
                     self.model_load_latency_s.set(time.time() - load_start_time)
                     return self.models[model_id]
@@ -178,7 +179,7 @@ class _ModelMultiplexWrapper:
                     )
                     self._model_load_tasks.discard(model_id)
                     raise e
-        
+
     async def unload_model(self) -> None:
         """Unload the least recently used model."""
         self.models_unload_counter.inc()

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -16,6 +16,7 @@ from ray.serve.context import (
     get_internal_replica_context,
 )
 from ray.serve._private.common import MultiplexedReplicaInfo
+from ray.serve._private.utils import MetricsPusher
 from ray.serve import metrics
 
 
@@ -93,11 +94,32 @@ class _ModelMultiplexWrapper:
         # Model cache lock
         self._model_cache_lock = asyncio.Lock()
         self._model_load_tasks: Set[str] = set()
-        self._model_ids_pusher_thread_stop: bool = False
-        # Push the model IDs to the controller periodically.
-        self._model_ids_pusher_thread = threading.Thread(target=self._push_model_ids)
-        self._model_ids_pusher_thread.setDaemon(True)
-        self._model_ids_pusher_thread.start()
+
+
+        self.metrics_pusher = MetricsPusher()
+        self.metrics_pusher.register_task(
+            self._push_model_ids,
+            PUSH_MULTIPLEXED_MODEL_IDS_INTERVAL_S,
+        )
+        self.metrics_pusher.start()
+
+    def _push_model_ids(self):
+        """Push the multiplexed replica info to the controller."""
+        try:
+            if self._push_multiplexed_replica_info:
+                get_global_client().record_multiplexed_replica_info(
+                    MultiplexedReplicaInfo(
+                        self._deployment_name,
+                        self._replica_tag,
+                        self._get_model_ids(),
+                    )
+                )
+                self._push_multiplexed_replica_info = False
+        except Exception as e:
+            logger.warning(
+                "Failed to push the multiplexed replica info "
+                f"to the controller. Error: {e}"
+            )
 
     async def load_model(self, model_id: str) -> Any:
         """Load the model if it is not loaded yet, and return the user-constructed model object.
@@ -128,34 +150,39 @@ class _ModelMultiplexWrapper:
                 # Check if the model has been loaded by another request.
                 if model_id in self.models:
                     return self.models[model_id]
+                try:
+                    # If the number of models per replica is specified, check if
+                    # the number of models on the current replica has reached the limit.
+                    if (
+                        self.max_num_models_per_replica > 0
+                        and len(self.models) >= self.max_num_models_per_replica
+                    ):
+                        # Unload the least recently used model.
+                        await self.unload_model()
+                        self._push_multiplexed_replica_info = True
 
-                # If the number of models per replica is specified, check if
-                # the number of models on the current replica has reached the limit.
-                if (
-                    self.max_num_models_per_replica > 0
-                    and len(self.models) >= self.max_num_models_per_replica
-                ):
-                    # Unload the least recently used model.
-                    self.models_unload_counter.inc()
-                    unload_start_time = time.time()
-                    await self.unload_model()
-                    self.model_unload_latency_s.set(time.time() - unload_start_time)
-
-                # Load the model.
-                logger.info(f"Loading model '{model_id}'.")
-                self.models_load_counter.inc()
-                load_start_time = time.time()
-                if self.self_arg is None:
-                    self.models[model_id] = await self._func(model_id)
-                else:
-                    self.models[model_id] = await self._func(self.self_arg, model_id)
-                self._push_multiplexed_replica_info = True
-                self._model_load_tasks.discard(model_id)
-                self.model_load_latency_s.set(time.time() - load_start_time)
-                return self.models[model_id]
-
+                    # Load the model.
+                    logger.info(f"Loading model '{model_id}'.")
+                    self.models_load_counter.inc()
+                    load_start_time = time.time()
+                    if self.self_arg is None:
+                        self.models[model_id] = await self._func(model_id)
+                    else:
+                        self.models[model_id] = await self._func(self.self_arg, model_id)
+                    self._model_load_tasks.discard(model_id)
+                    self.model_load_latency_s.set(time.time() - load_start_time)
+                    return self.models[model_id]
+                except Exception as e:
+                    logger.error(
+                        f"Failed to load model '{model_id}'. Error: {e}",
+                    )
+                    self._model_load_tasks.discard(model_id)
+                    raise e
+        
     async def unload_model(self) -> None:
         """Unload the least recently used model."""
+        self.models_unload_counter.inc()
+        unload_start_time = time.time()
         model_id, model = self.models.popitem(last=False)
         logger.info(f"Unloading model '{model_id}'.")
 
@@ -167,6 +194,7 @@ class _ModelMultiplexWrapper:
             else:
                 await sync_to_async(model.__del__)()
             setattr(model, "__del__", lambda _: None)
+        self.model_unload_latency_s.set(time.time() - unload_start_time)
 
     def _get_model_ids(self) -> List[str]:
         """Get the model IDs of the models loaded & loading on the current replica."""
@@ -174,31 +202,6 @@ class _ModelMultiplexWrapper:
         models_list.update(self._model_load_tasks)
         return list(models_list)
 
-    def _push_model_ids(self):
-        """Push the multiplexed replica info to the controller."""
-
-        while True:
-            try:
-                if self._model_ids_pusher_thread_stop:
-                    break
-                if self._push_multiplexed_replica_info:
-                    get_global_client().record_multiplexed_replica_info(
-                        MultiplexedReplicaInfo(
-                            self._deployment_name,
-                            self._replica_tag,
-                            self._get_model_ids(),
-                        )
-                    )
-                    self._push_multiplexed_replica_info = False
-            except Exception as e:
-                logger.warning(
-                    "Failed to push the multiplexed replica info "
-                    f"to the controller. Error: {e}"
-                )
-            time.sleep(PUSH_MULTIPLEXED_MODEL_IDS_INTERVAL_S)
-
     def __del__(self):
         while len(self.models) > 0:
             asyncio.run(self.unload_model())
-        self._model_ids_pusher_thread_stop = True
-        self._model_ids_pusher_thread.join()

--- a/python/ray/serve/tests/test_multiplex.py
+++ b/python/ray/serve/tests/test_multiplex.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 from typing import List
 import os
@@ -5,13 +6,14 @@ import requests
 import time
 
 import ray
+from ray import serve
+
 from ray._private.test_utils import (
     async_wait_for_condition,
     wait_for_condition,
     SignalActor,
 )
-
-from ray import serve
+from ray._private.utils import get_or_create_event_loop
 from ray.serve.context import get_internal_replica_context
 from ray.serve.handle import RayServeHandle
 from ray.serve.multiplex import _ModelMultiplexWrapper
@@ -33,7 +35,13 @@ def start_serve_with_context():
     ray.shutdown()
 
 
+def stop_model_ids_pusher_thread(multiplexer):
+    multiplexer.metrics_pusher.stop_event.set()
+    wait_for_condition(lambda: multiplexer.metrics_pusher.pusher_thread.is_alive() is False)
+
+
 class TestMultiplexWrapper:
+
     def test_failed_to_get_replica_context(self):
         async def model_load_func(model_id: str):
             return model_id
@@ -53,28 +61,25 @@ class TestMultiplexWrapper:
         multiplexer = _ModelMultiplexWrapper(
             model_load_func, None, max_num_models_per_replica=2
         )
-
-        # Check the replica info pushed
-        def check_info_pushed():
-            return multiplexer._push_multiplexed_replica_info is False
+        stop_model_ids_pusher_thread(multiplexer)
 
         # Load model1
         await multiplexer.load_model("1")
         assert multiplexer.models == {"1": "1"}
         assert multiplexer._push_multiplexed_replica_info
-        await async_wait_for_condition(check_info_pushed)
+        multiplexer._push_multiplexed_replica_info = False
 
         # Load model2
         await multiplexer.load_model("2")
         assert multiplexer.models == {"1": "1", "2": "2"}
         assert multiplexer._push_multiplexed_replica_info
-        await async_wait_for_condition(check_info_pushed)
+        multiplexer._push_multiplexed_replica_info = False
 
         # Load model3, model1 should be unloaded
         await multiplexer.load_model("3")
         assert multiplexer.models == {"2": "2", "3": "3"}
         assert multiplexer._push_multiplexed_replica_info
-        await async_wait_for_condition(check_info_pushed)
+        multiplexer._push_multiplexed_replica_info = False
 
         # reload model2, model2 should be moved to the end of the LRU cache
         # _push_multiplexed_replica_info should be False.
@@ -124,6 +129,95 @@ class TestMultiplexWrapper:
         assert multiplexer.models == {"1": MyModel("1")}
         with pytest.raises(Exception, match="1 is dead"):
             await multiplexer.load_model("2")
+    
+    def test_push_model_ids_info(self, start_serve_with_context):
+        async def model_load_func(model_id: str):
+            return model_id
+
+        multiplexer = _ModelMultiplexWrapper(
+            model_load_func, None, max_num_models_per_replica=1
+        )
+        stop_model_ids_pusher_thread(multiplexer)
+        assert multiplexer._push_multiplexed_replica_info is False
+        multiplexer._push_multiplexed_replica_info = True
+        multiplexer._push_model_ids()
+        assert multiplexer._push_multiplexed_replica_info is False
+    
+    def test_collect_model_ids(self):
+        multiplexer = _ModelMultiplexWrapper(
+            None, None, max_num_models_per_replica=1
+        )
+        multiplexer.models = {"1": "1", "2": "2"}
+        assert sorted(multiplexer._get_model_ids()) == ["1", "2"]
+        multiplexer._model_load_tasks = {"3"}
+        assert sorted(multiplexer._get_model_ids()) == ["1", "2", "3"]
+
+    @pytest.mark.asyncio
+    async def test_push_model_ids_info_after_unload_model(self):
+        """
+        Push the model ids info right after the model is unloaded, even though
+        new model is not loaded yet.
+        """
+        signal = SignalActor.remote()
+        async def model_load_func(model_id: str):
+            if model_id == "1":
+                return model_id
+            await signal.wait.remote()
+            return 
+        
+        multiplexer = _ModelMultiplexWrapper(
+            model_load_func, None, max_num_models_per_replica=1
+        )
+        stop_model_ids_pusher_thread(multiplexer)
+        await multiplexer.load_model("1")
+        assert multiplexer._push_multiplexed_replica_info
+        multiplexer._push_multiplexed_replica_info = False
+
+        loop = get_or_create_event_loop()
+        loop.create_task(multiplexer.load_model("2"))
+        # _push_multiplexed_replica_info is True right after model1 is unloaded.
+        # and model2 is not finished loading.
+        await asyncio.sleep(1)
+        assert len(multiplexer.models) == 0
+        assert "2" in multiplexer._model_load_tasks
+        assert multiplexer._push_multiplexed_replica_info
+        signal.send.remote()
+
+    @pytest.mark.asyncio
+    async def test_load_models_concurrently(self, start_serve_with_context):
+        """
+        Test load models concurrently. models info should include loading models and
+        loaded models.
+        And the models cache should not execeed the limit.
+        """
+
+        signal = SignalActor.remote()
+
+        async def model_load_func(model_id: str):
+            await signal.wait.remote()
+            return 
+        
+        multiplexer = _ModelMultiplexWrapper(
+            model_load_func, None, max_num_models_per_replica=1
+        )
+        stop_model_ids_pusher_thread(multiplexer)
+
+        loop = get_or_create_event_loop()
+        tasks = [
+            loop.create_task(multiplexer.load_model("1")),
+            loop.create_task(multiplexer.load_model("2")),
+            loop.create_task(multiplexer.load_model("3")),
+        ]
+        await asyncio.sleep(1)
+        assert len(multiplexer.models) == 0
+        assert len(multiplexer._model_load_tasks) == len(tasks)
+        assert multiplexer._push_multiplexed_replica_info
+        signal.send.remote()
+        done, _ = await asyncio.wait(tasks, timeout=1)
+        assert len(done) == len(tasks)
+        assert len(multiplexer.models) == 1
+        assert "3" in multiplexer.models
+        assert len(multiplexer._model_load_tasks) == 0
 
 
 class TestBasicAPI:
@@ -416,54 +510,6 @@ def test_setting_model_id_on_handle_does_not_set_it_locally(serve_instance):
 
     handle = serve.run(Upstream.bind(Downstream.bind()))
     assert ray.get(handle.options(multiplexed_model_id="foo").remote()) == "foo"
-
-
-async def test_concurrent_load_models(serve_instance):
-    """Test concurrent load models"""
-
-    signal = SignalActor.remote()
-
-    @serve.deployment
-    class Model:
-        @serve.multiplexed(max_num_models_per_replica=2)
-        async def get_model(self, tag):
-            await signal.wait.remote()
-            return tag
-
-        async def __call__(self, request):
-            tag = serve.get_multiplexed_model_id()
-            await self.get_model(tag)
-            return (tag, os.getpid())
-
-    handle = serve.run(Model.bind())
-
-    @ray.remote
-    def send_request(model_id):
-        headers = {SERVE_MULTIPLEXED_MODEL_ID: model_id}
-        resp = requests.get("http://localhost:8000", headers=headers)
-        return resp.status_code
-
-    send_request.remote("1")
-    # second request for model1 will hit the cache
-    send_request.remote("1")
-    send_request.remote("2")
-    send_request.remote("3")
-    for i in range(10):
-        if ray.get(signal.cur_num_waiters.remote()) > 0:
-            break
-        time.sleep(0.1)
-    assert ray.get(signal.cur_num_waiters.remote()) == 1
-    signal.send.remote()
-    for i in range(10):
-        if ray.get(signal.cur_num_waiters.remote()) > 1:
-            break
-        time.sleep(0.1)
-    # model2 is loaded & model3 is loaded
-    assert ray.get(signal.cur_num_waiters.remote()) == 3
-
-    # model1 is evicted
-    wait_for_condition(check_model_id_in_replicas, handle=handle, model_id="2")
-    wait_for_condition(check_model_id_in_replicas, handle=handle, model_id="3")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Move populating the model ids task into different thread.
- Early populating the model ids information.
- Add lock to the model loading. (Currently there is only one model loading at one time).
- Nob to control at least how long to wait for the matching model ids.
- When there is no model id matched, prefer the replica which has least model ids serving. 

Testing with @ericl bench script. With this change, it is 99seconds in my mac local.

`RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S=2 RAY_DEDUP_LOGS=0 python infer.py`



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
