### PR TITLE
[WIP][serve] Prevent intra-version communication between deployments

### DIFF
--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -368,12 +368,12 @@ class ReplicaName:
 
 @dataclass(frozen=True)
 class RunningReplicaInfo:
-    app_name: Optional[str]
     deployment_name: str
     replica_tag: ReplicaTag
     actor_handle: ActorHandle
     max_concurrent_queries: int
     is_cross_language: bool = False
+    app_name: Optional[str] = None
     multiplexed_model_ids: List[str] = field(default_factory=list)
 
     def __post_init__(self):

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1588,13 +1588,15 @@ class DeploymentState:
                     f"to deployment {self._name}."
                 )
                 for _ in range(to_add):
-                    replica_name = ReplicaName(self._name, get_random_letters())
+                    version = self._target_state.version
+                    suffix = version.code_version[:6] + "-" + get_random_letters()
+                    replica_name = ReplicaName(self._name, suffix)
                     new_deployment_replica = DeploymentReplica(
                         self._controller_name,
                         self._detached,
                         replica_name.replica_tag,
                         replica_name.deployment_tag,
-                        self._target_state.version,
+                        version,
                     )
                     upscale.append(
                         new_deployment_replica.start(self._target_state.info)
@@ -2040,13 +2042,15 @@ class DriverDeploymentState(DeploymentState):
         upscale = []
         num_existing_replicas = self._replicas.count()
         for _ in range(self._target_state.num_replicas - num_existing_replicas):
-            replica_name = ReplicaName(self._name, get_random_letters())
+            version = self._target_state.version
+            suffix = version.code_version[:6] + "-" + get_random_letters()
+            replica_name = ReplicaName(self._name, suffix)
             new_deployment_replica = DeploymentReplica(
                 self._controller_name,
                 self._detached,
                 replica_name.replica_tag,
                 replica_name.deployment_tag,
-                self._target_state.version,
+                version,
             )
             upscale.append(new_deployment_replica.start(self._target_state.info))
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -395,6 +395,9 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
             return True
 
         current_app = internal_replica_context.app_name
+        if not current_app:
+            return True
+
         # NOTE(zcin): This is a slightly hacky way of getting the application
         # of the deployment to which this router sends requests. We include
         # application info in RunningReplicaInfo, and fetch it from there.
@@ -810,6 +813,9 @@ class RoundRobinReplicaScheduler(ReplicaScheduler):
             return True
 
         current_app = internal_replica_context.app_name
+        if not current_app:
+            return True
+
         # NOTE(zcin): This is a slightly hacky way of getting the application
         # of the deployment to which this router sends requests. We include
         # application info in RunningReplicaInfo, and fetch it from there.

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -470,6 +470,7 @@ def run(
 
     parameter_group = []
 
+    app_code_version = get_random_letters()
     for deployment in deployments:
         # Overwrite route prefix
         if route_prefix is not DEFAULT.VALUE and deployment._route_prefix is not None:
@@ -486,7 +487,7 @@ def run(
             "init_kwargs": deployment.init_kwargs,
             "ray_actor_options": deployment._ray_actor_options,
             "config": deployment._config,
-            "version": deployment._version or get_random_letters(),
+            "version": app_code_version,
             "route_prefix": deployment.route_prefix,
             "url": deployment.url,
             "is_driver_deployment": deployment._is_driver_deployment,

--- a/python/ray/serve/tests/test_common.py
+++ b/python/ray/serve/tests/test_common.py
@@ -31,10 +31,11 @@ def test_replica_tag_formatting():
 
 
 def test_replica_name_from_str():
+    code_version = get_random_letters()
     replica_suffix = get_random_letters()
-    actor_name = f"{ReplicaName.prefix}DeploymentA#{replica_suffix}"
+    actor_name = f"{ReplicaName.prefix}DeploymentA#{code_version}-{replica_suffix}"
 
-    replica_name = ReplicaName.from_str(actor_name)
+    replica_name = ReplicaName.from_actor_name(actor_name)
     assert (
         str(replica_name)
         == replica_name.replica_tag
@@ -47,12 +48,12 @@ def test_invalid_name_from_str():
 
     replica_tag = f"DeploymentA##{replica_suffix}"
     with pytest.raises(AssertionError):
-        ReplicaName.from_str(replica_tag)
+        ReplicaName.from_actor_name(replica_tag)
 
     # No prefix
     replica_tag = f"DeploymentA#{replica_suffix}"
     with pytest.raises(AssertionError):
-        ReplicaName.from_str(replica_tag)
+        ReplicaName.from_actor_name(replica_tag)
 
 
 def test_is_replica_name():

--- a/python/ray/serve/tests/test_common.py
+++ b/python/ray/serve/tests/test_common.py
@@ -20,11 +20,14 @@ from ray.serve.generated.serve_pb2 import (
 
 def test_replica_tag_formatting():
     deployment_tag = "DeploymentA"
+    code_version = get_random_letters()
     replica_suffix = get_random_letters()
 
-    replica_name = ReplicaName(deployment_tag, replica_suffix)
-    assert replica_name.replica_tag == f"{deployment_tag}#{replica_suffix}"
-    assert str(replica_name) == f"{deployment_tag}#{replica_suffix}"
+    replica_name = ReplicaName(deployment_tag, code_version, replica_suffix)
+    assert (
+        replica_name.replica_tag == f"{deployment_tag}#{code_version}-{replica_suffix}"
+    )
+    assert str(replica_name) == f"{deployment_tag}#{code_version}-{replica_suffix}"
 
 
 def test_replica_name_from_str():

--- a/python/ray/serve/tests/test_deployment_state.py
+++ b/python/ray/serve/tests/test_deployment_state.py
@@ -2557,7 +2557,7 @@ def test_resource_requirements_none():
         available_resources = {}
 
     # Make a DeploymentReplica just to accesss its resource_requirement function
-    replica = DeploymentReplica(None, None, "random_tag", None, None)
+    replica = DeploymentReplica(None, None, "random_tag", None, None, None)
     replica._actor = FakeActor()
 
     # resource_requirements() should not error


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently deployment handles route traffic to *all* replicas within a deployment regardless of version. This PR enforces that traffic within an application can only be routed between replicas of the same version.

Traffic between applications is not restricted.

Details:
- In router: if inside a deployment replica, and sending requests to a deployment replica in the same application, ignore replicas that don't have the same code version.
- Add app name to `RunningReplicaInfo` as a workaround to routers not know which application it is sending requests to.


## Related issue number

Closes https://github.com/ray-project/ray/issues/36216

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
