### PR TITLE
Disable click CLI standalone mode.

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2474,7 +2474,7 @@ except Exception as e:
 
 
 def main():
-    return cli()
+    return cli(standalone_mode=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`click` has a behavior that it `exit`s, not returns, when it finishes the cli call, with a exit code it chooses. I found it sometimes return a non-0 return code even if the process finishes fine. Specifically in unit tests this command `ray stop --force` returns `-6` which causes some unit test failure.

https://click.palletsprojects.com/en/8.1.x/api/#click.BaseCommand.main

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
