### PR TITLE
[Serve] Deflaky metric test

### DIFF
--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -22,7 +22,7 @@ def serve_start_shutdown():
     ray.init(
         _metrics_export_port=9999,
         _system_config={
-            "metrics_report_interval_ms": 1000,
+            "metrics_report_interval_ms": 500,
             "task_retry_delay_ms": 50,
         },
     )
@@ -800,7 +800,7 @@ class TestRequestContextMetrics:
         assert resp.text == "hello"
         wait_for_condition(
             lambda: len(get_metric_dictionaries("my_gauge")) == 1,
-            timeout=20,
+            timeout=30,
         )
 
         counter_metrics = get_metric_dictionaries("my_counter")

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -307,7 +307,7 @@ def test_http_redirect_metrics(serve_start_shutdown):
     assert resp.text == '"123"'
 
     wait_for_condition(
-        lambda: len(get_metric_dictionaries("serve_num_http_requests")) == 2,
+        lambda: len(get_metric_dictionaries("serve_num_http_requests", timeout=5)) == 2,
         timeout=40,
     )
     num_http_requests = get_metric_dictionaries("serve_num_http_requests")
@@ -328,7 +328,7 @@ def test_http_redirect_metrics(serve_start_shutdown):
     verify_metrics_with_route(num_http_requests, expected_output)
 
     wait_for_condition(
-        lambda: len(get_metric_dictionaries("serve_http_request_latency_ms_sum")) == 2,
+        lambda: len(get_metric_dictionaries("serve_http_request_latency_ms_sum", timeout=5)) == 2,
         timeout=40,
     )
     http_latency = get_metric_dictionaries("serve_num_http_requests")
@@ -363,7 +363,7 @@ def test_replica_metrics_fields(serve_start_shutdown):
             assert metric[key] == expected_output[key]
 
     wait_for_condition(
-        lambda: len(get_metric_dictionaries("serve_deployment_request_counter")) == 2,
+        lambda: len(get_metric_dictionaries("serve_deployment_request_counter", timeout=5)) == 2,
         timeout=40,
     )
 
@@ -382,7 +382,7 @@ def test_replica_metrics_fields(serve_start_shutdown):
     # Latency metrics
     wait_for_condition(
         lambda: len(
-            get_metric_dictionaries("serve_deployment_processing_latency_ms_count")
+            get_metric_dictionaries("serve_deployment_processing_latency_ms_count", timeout=5)
         )
         == 2,
         timeout=40,
@@ -415,7 +415,7 @@ def test_replica_metrics_fields(serve_start_shutdown):
     serve.run(h.bind(), name="app3", route_prefix="/h")
     assert 500 == requests.get("http://127.0.0.1:8000/h").status_code
     wait_for_condition(
-        lambda: len(get_metric_dictionaries("serve_deployment_error_counter")) == 1,
+        lambda: len(get_metric_dictionaries("serve_deployment_error_counter", timeout=5)) == 1,
         timeout=40,
     )
     err_requests = get_metric_dictionaries("serve_deployment_error_counter")
@@ -491,7 +491,7 @@ class TestRequestContextMetrics:
 
         wait_for_condition(
             lambda: len(
-                get_metric_dictionaries("serve_deployment_processing_latency_ms_sum")
+                get_metric_dictionaries("serve_deployment_processing_latency_ms_sum", timeout=5)
             )
             == 3,
             timeout=40,
@@ -597,7 +597,7 @@ class TestRequestContextMetrics:
         # g2 deployment metrics:
         #   {xxx, route:/api2}
         wait_for_condition(
-            lambda: len(get_metric_dictionaries("serve_deployment_request_counter"))
+            lambda: len(get_metric_dictionaries("serve_deployment_request_counter", timeout=5))
             == 4,
             timeout=40,
         )
@@ -663,7 +663,7 @@ class TestRequestContextMetrics:
         resp = requests.get("http://127.0.0.1:8000/app")
         deployment_name, replica_tag = resp.json()
         wait_for_condition(
-            lambda: len(get_metric_dictionaries("my_gauge")) == 1,
+            lambda: len(get_metric_dictionaries("my_gauge", timeout=5)) == 1,
             timeout=40,
         )
 
@@ -799,7 +799,7 @@ class TestRequestContextMetrics:
         resp = requests.get("http://127.0.0.1:8000/app")
         assert resp.text == "hello"
         wait_for_condition(
-            lambda: len(get_metric_dictionaries("my_gauge")) == 1,
+            lambda: len(get_metric_dictionaries("my_gauge", timeout=5)) == 1,
             timeout=40,
         )
 

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -328,7 +328,10 @@ def test_http_redirect_metrics(serve_start_shutdown):
     verify_metrics_with_route(num_http_requests, expected_output)
 
     wait_for_condition(
-        lambda: len(get_metric_dictionaries("serve_http_request_latency_ms_sum", timeout=5)) == 2,
+        lambda: len(
+            get_metric_dictionaries("serve_http_request_latency_ms_sum", timeout=5)
+        )
+        == 2,
         timeout=40,
     )
     http_latency = get_metric_dictionaries("serve_num_http_requests")
@@ -363,7 +366,10 @@ def test_replica_metrics_fields(serve_start_shutdown):
             assert metric[key] == expected_output[key]
 
     wait_for_condition(
-        lambda: len(get_metric_dictionaries("serve_deployment_request_counter", timeout=5)) == 2,
+        lambda: len(
+            get_metric_dictionaries("serve_deployment_request_counter", timeout=5)
+        )
+        == 2,
         timeout=40,
     )
 
@@ -382,7 +388,9 @@ def test_replica_metrics_fields(serve_start_shutdown):
     # Latency metrics
     wait_for_condition(
         lambda: len(
-            get_metric_dictionaries("serve_deployment_processing_latency_ms_count", timeout=5)
+            get_metric_dictionaries(
+                "serve_deployment_processing_latency_ms_count", timeout=5
+            )
         )
         == 2,
         timeout=40,
@@ -415,7 +423,10 @@ def test_replica_metrics_fields(serve_start_shutdown):
     serve.run(h.bind(), name="app3", route_prefix="/h")
     assert 500 == requests.get("http://127.0.0.1:8000/h").status_code
     wait_for_condition(
-        lambda: len(get_metric_dictionaries("serve_deployment_error_counter", timeout=5)) == 1,
+        lambda: len(
+            get_metric_dictionaries("serve_deployment_error_counter", timeout=5)
+        )
+        == 1,
         timeout=40,
     )
     err_requests = get_metric_dictionaries("serve_deployment_error_counter")
@@ -491,7 +502,9 @@ class TestRequestContextMetrics:
 
         wait_for_condition(
             lambda: len(
-                get_metric_dictionaries("serve_deployment_processing_latency_ms_sum", timeout=5)
+                get_metric_dictionaries(
+                    "serve_deployment_processing_latency_ms_sum", timeout=5
+                )
             )
             == 3,
             timeout=40,
@@ -597,7 +610,9 @@ class TestRequestContextMetrics:
         # g2 deployment metrics:
         #   {xxx, route:/api2}
         wait_for_condition(
-            lambda: len(get_metric_dictionaries("serve_deployment_request_counter", timeout=5))
+            lambda: len(
+                get_metric_dictionaries("serve_deployment_request_counter", timeout=5)
+            )
             == 4,
             timeout=40,
         )

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -22,7 +22,7 @@ def serve_start_shutdown():
     ray.init(
         _metrics_export_port=9999,
         _system_config={
-            "metrics_report_interval_ms": 500,
+            "metrics_report_interval_ms": 1000,
             "task_retry_delay_ms": 50,
         },
     )
@@ -308,7 +308,7 @@ def test_http_redirect_metrics(serve_start_shutdown):
 
     wait_for_condition(
         lambda: len(get_metric_dictionaries("serve_num_http_requests")) == 2,
-        timeout=20,
+        timeout=40,
     )
     num_http_requests = get_metric_dictionaries("serve_num_http_requests")
     expected_output = [
@@ -329,7 +329,7 @@ def test_http_redirect_metrics(serve_start_shutdown):
 
     wait_for_condition(
         lambda: len(get_metric_dictionaries("serve_http_request_latency_ms_sum")) == 2,
-        timeout=20,
+        timeout=40,
     )
     http_latency = get_metric_dictionaries("serve_num_http_requests")
     expected_output = [
@@ -364,7 +364,7 @@ def test_replica_metrics_fields(serve_start_shutdown):
 
     wait_for_condition(
         lambda: len(get_metric_dictionaries("serve_deployment_request_counter")) == 2,
-        timeout=20,
+        timeout=40,
     )
 
     num_requests = get_metric_dictionaries("serve_deployment_request_counter")
@@ -385,7 +385,7 @@ def test_replica_metrics_fields(serve_start_shutdown):
             get_metric_dictionaries("serve_deployment_processing_latency_ms_count")
         )
         == 2,
-        timeout=20,
+        timeout=40,
     )
     for metric_name in [
         "serve_deployment_processing_latency_ms_count",
@@ -416,7 +416,7 @@ def test_replica_metrics_fields(serve_start_shutdown):
     assert 500 == requests.get("http://127.0.0.1:8000/h").status_code
     wait_for_condition(
         lambda: len(get_metric_dictionaries("serve_deployment_error_counter")) == 1,
-        timeout=20,
+        timeout=40,
     )
     err_requests = get_metric_dictionaries("serve_deployment_error_counter")
     assert len(err_requests) == 1
@@ -494,7 +494,7 @@ class TestRequestContextMetrics:
                 get_metric_dictionaries("serve_deployment_processing_latency_ms_sum")
             )
             == 3,
-            timeout=20,
+            timeout=40,
         )
 
         def wait_for_route_and_name(
@@ -599,7 +599,7 @@ class TestRequestContextMetrics:
         wait_for_condition(
             lambda: len(get_metric_dictionaries("serve_deployment_request_counter"))
             == 4,
-            timeout=20,
+            timeout=40,
         )
         (
             requests_metrics_route,
@@ -664,7 +664,7 @@ class TestRequestContextMetrics:
         deployment_name, replica_tag = resp.json()
         wait_for_condition(
             lambda: len(get_metric_dictionaries("my_gauge")) == 1,
-            timeout=20,
+            timeout=40,
         )
 
         counter_metrics = get_metric_dictionaries("my_counter")
@@ -800,7 +800,7 @@ class TestRequestContextMetrics:
         assert resp.text == "hello"
         wait_for_condition(
             lambda: len(get_metric_dictionaries("my_gauge")) == 1,
-            timeout=20,
+            timeout=40,
         )
 
         counter_metrics = get_metric_dictionaries("my_counter")
@@ -866,7 +866,7 @@ def test_multiplexed_metrics(serve_start_shutdown):
 
     wait_for_condition(
         verify_metrics,
-        timeout=20,
+        timeout=40,
         retry_interval_ms=1000,
     )
 

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -443,10 +443,7 @@ def test_replica_metrics_fields(serve_start_shutdown):
     serve.run(h.bind(), name="app3", route_prefix="/h")
     assert 500 == requests.get("http://127.0.0.1:8000/h").status_code
     wait_for_condition(
-        lambda: len(
-            get_metric_dictionaries("serve_deployment_error_counter", timeout=5)
-        )
-        == 1,
+        lambda: len(get_metric_dictionaries("serve_deployment_error_counter")) == 1,
         timeout=40,
     )
     err_requests = get_metric_dictionaries("serve_deployment_error_counter")

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -800,7 +800,7 @@ class TestRequestContextMetrics:
         assert resp.text == "hello"
         wait_for_condition(
             lambda: len(get_metric_dictionaries("my_gauge")) == 1,
-            timeout=30,
+            timeout=20,
         )
 
         counter_metrics = get_metric_dictionaries("my_counter")

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -322,12 +322,12 @@ def test_http_redirect_metrics(serve_start_shutdown):
     assert resp.text == '"123"'
 
     # wait_for_condition(
-    #    lambda: len(get_metric_dictionaries("serve_num_http_requests", timeout=5)) == 2,
+    #    lambda: len(get_metric_dictionaries("serve_num_http_requests")) == 2,
     #    timeout=40,
     # )
     print_metrics_wait_time(
         "test_http_redirect_metrics",
-        lambda: len(get_metric_dictionaries("serve_num_http_requests", timeout=5)) == 2,
+        lambda: len(get_metric_dictionaries("serve_num_http_requests")) == 2,
         timeout=40,
     )
     num_http_requests = get_metric_dictionaries("serve_num_http_requests")
@@ -348,10 +348,7 @@ def test_http_redirect_metrics(serve_start_shutdown):
     verify_metrics_with_route(num_http_requests, expected_output)
 
     wait_for_condition(
-        lambda: len(
-            get_metric_dictionaries("serve_http_request_latency_ms_sum", timeout=5)
-        )
-        == 2,
+        lambda: len(get_metric_dictionaries("serve_http_request_latency_ms_sum")) == 2,
         timeout=40,
     )
     http_latency = get_metric_dictionaries("serve_num_http_requests")
@@ -387,17 +384,14 @@ def test_replica_metrics_fields(serve_start_shutdown):
 
     # wait_for_condition(
     #    lambda: len(
-    #        get_metric_dictionaries("serve_deployment_request_counter", timeout=5)
+    #        get_metric_dictionaries("serve_deployment_request_counter")
     #    )
     #    == 2,
     #    timeout=40,
     # )
     print_metrics_wait_time(
         "test_replica_metrics_fields",
-        lambda: len(
-            get_metric_dictionaries("serve_deployment_request_counter", timeout=5)
-        )
-        == 2,
+        lambda: len(get_metric_dictionaries("serve_deployment_request_counter")) == 2,
         timeout=40,
     )
 
@@ -416,9 +410,7 @@ def test_replica_metrics_fields(serve_start_shutdown):
     # Latency metrics
     wait_for_condition(
         lambda: len(
-            get_metric_dictionaries(
-                "serve_deployment_processing_latency_ms_count", timeout=5
-            )
+            get_metric_dictionaries("serve_deployment_processing_latency_ms_count")
         )
         == 2,
         timeout=40,
@@ -531,7 +523,7 @@ class TestRequestContextMetrics:
         # wait_for_condition(
         #    lambda: len(
         #        get_metric_dictionaries(
-        #            "serve_deployment_processing_latency_ms_sum", timeout=5
+        #            "serve_deployment_processing_latency_ms_sum"
         #        )
         #    )
         #    == 3,
@@ -540,9 +532,7 @@ class TestRequestContextMetrics:
         print_metrics_wait_time(
             "test_request_context_pass_for_http_proxy",
             lambda: len(
-                get_metric_dictionaries(
-                    "serve_deployment_processing_latency_ms_sum", timeout=5
-                )
+                get_metric_dictionaries("serve_deployment_processing_latency_ms_sum")
             )
             == 3,
             timeout=40,
@@ -649,16 +639,14 @@ class TestRequestContextMetrics:
         #   {xxx, route:/api2}
         # wait_for_condition(
         #    lambda: len(
-        #        get_metric_dictionaries("serve_deployment_request_counter", timeout=5)
+        #        get_metric_dictionaries("serve_deployment_request_counter")
         #    )
         #    == 4,
         #    timeout=40,
         # )
         print_metrics_wait_time(
             "test_request_context_pass_for_handle_passing",
-            lambda: len(
-                get_metric_dictionaries("serve_deployment_request_counter", timeout=5)
-            )
+            lambda: len(get_metric_dictionaries("serve_deployment_request_counter"))
             == 4,
             timeout=40,
         )
@@ -724,12 +712,12 @@ class TestRequestContextMetrics:
         resp = requests.get("http://127.0.0.1:8000/app")
         deployment_name, replica_tag = resp.json()
         # wait_for_condition(
-        #    lambda: len(get_metric_dictionaries("my_gauge", timeout=5)) == 1,
+        #    lambda: len(get_metric_dictionaries("my_gauge")) == 1,
         #    timeout=40,
         # )
         print_metrics_wait_time(
             "test_customer_metrics_with_context",
-            lambda: len(get_metric_dictionaries("my_gauge", timeout=5)) == 1,
+            lambda: len(get_metric_dictionaries("my_gauge")) == 1,
             timeout=40,
         )
 
@@ -865,13 +853,13 @@ class TestRequestContextMetrics:
         resp = requests.get("http://127.0.0.1:8000/app")
         assert resp.text == "hello"
         # wait_for_condition(
-        #    lambda: len(get_metric_dictionaries("my_gauge", timeout=5)) == 1,
+        #    lambda: len(get_metric_dictionaries("my_gauge")) == 1,
         #    timeout=40,
         # )
 
         print_metrics_wait_time(
             "test_serve_metrics_outside_serve",
-            lambda: len(get_metric_dictionaries("my_gauge", timeout=5)) == 1,
+            lambda: len(get_metric_dictionaries("my_gauge")) == 1,
             timeout=40,
         )
 

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -22,7 +22,7 @@ def serve_start_shutdown():
     ray.init(
         _metrics_export_port=9999,
         _system_config={
-            "metrics_report_interval_ms": 1000,
+            "metrics_report_interval_ms": 100,
             "task_retry_delay_ms": 50,
         },
     )

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -31,16 +31,6 @@ def serve_start_shutdown():
     ray.shutdown()
 
 
-def print_metrics_wait_time(test_name: str, *args, **kwargs):
-    import time
-
-    print(f"[DEBUG_METRIC]Starting {test_name}")
-    start = time.time()
-    wait_for_condition(*args, **kwargs)
-    end = time.time()
-    print(f"[DEBUG_METRIC]Finished {test_name} in {end - start} seconds")
-
-
 def test_serve_metrics_for_successful_connection(serve_start_shutdown):
     @serve.deployment(name="metrics")
     async def f(request):
@@ -93,12 +83,7 @@ def test_serve_metrics_for_successful_connection(serve_start_shutdown):
         return True
 
     try:
-        # wait_for_condition(verify_metrics, retry_interval_ms=500)
-        print_metrics_wait_time(
-            "test_serve_metrics_for_successful_connection",
-            verify_metrics,
-            retry_interval_ms=500,
-        )
+        wait_for_condition(verify_metrics, retry_interval_ms=500)
     except RuntimeError:
         verify_metrics(do_assert=True)
 
@@ -321,12 +306,7 @@ def test_http_redirect_metrics(serve_start_shutdown):
     assert resp.status_code == 200
     assert resp.text == '"123"'
 
-    # wait_for_condition(
-    #    lambda: len(get_metric_dictionaries("serve_num_http_requests")) == 2,
-    #    timeout=40,
-    # )
-    print_metrics_wait_time(
-        "test_http_redirect_metrics",
+    wait_for_condition(
         lambda: len(get_metric_dictionaries("serve_num_http_requests")) == 2,
         timeout=40,
     )
@@ -382,15 +362,7 @@ def test_replica_metrics_fields(serve_start_shutdown):
         for key in expected_output:
             assert metric[key] == expected_output[key]
 
-    # wait_for_condition(
-    #    lambda: len(
-    #        get_metric_dictionaries("serve_deployment_request_counter")
-    #    )
-    #    == 2,
-    #    timeout=40,
-    # )
-    print_metrics_wait_time(
-        "test_replica_metrics_fields",
+    wait_for_condition(
         lambda: len(get_metric_dictionaries("serve_deployment_request_counter")) == 2,
         timeout=40,
     )
@@ -517,17 +489,7 @@ class TestRequestContextMetrics:
         resp = requests.get("http://127.0.0.1:8000/app3")
         assert resp.status_code == 500
 
-        # wait_for_condition(
-        #    lambda: len(
-        #        get_metric_dictionaries(
-        #            "serve_deployment_processing_latency_ms_sum"
-        #        )
-        #    )
-        #    == 3,
-        #    timeout=40,
-        # )
-        print_metrics_wait_time(
-            "test_request_context_pass_for_http_proxy",
+        wait_for_condition(
             lambda: len(
                 get_metric_dictionaries("serve_deployment_processing_latency_ms_sum")
             )
@@ -634,15 +596,7 @@ class TestRequestContextMetrics:
         #   {xxx, route:/api}
         # g2 deployment metrics:
         #   {xxx, route:/api2}
-        # wait_for_condition(
-        #    lambda: len(
-        #        get_metric_dictionaries("serve_deployment_request_counter")
-        #    )
-        #    == 4,
-        #    timeout=40,
-        # )
-        print_metrics_wait_time(
-            "test_request_context_pass_for_handle_passing",
+        wait_for_condition(
             lambda: len(get_metric_dictionaries("serve_deployment_request_counter"))
             == 4,
             timeout=40,
@@ -708,12 +662,7 @@ class TestRequestContextMetrics:
         serve.run(Model.bind(), name="app", route_prefix="/app")
         resp = requests.get("http://127.0.0.1:8000/app")
         deployment_name, replica_tag = resp.json()
-        # wait_for_condition(
-        #    lambda: len(get_metric_dictionaries("my_gauge")) == 1,
-        #    timeout=40,
-        # )
-        print_metrics_wait_time(
-            "test_customer_metrics_with_context",
+        wait_for_condition(
             lambda: len(get_metric_dictionaries("my_gauge")) == 1,
             timeout=40,
         )
@@ -849,13 +798,7 @@ class TestRequestContextMetrics:
         serve.run(Model.bind(), name="app", route_prefix="/app")
         resp = requests.get("http://127.0.0.1:8000/app")
         assert resp.text == "hello"
-        # wait_for_condition(
-        #    lambda: len(get_metric_dictionaries("my_gauge")) == 1,
-        #    timeout=40,
-        # )
-
-        print_metrics_wait_time(
-            "test_serve_metrics_outside_serve",
+        wait_for_condition(
             lambda: len(get_metric_dictionaries("my_gauge")) == 1,
             timeout=40,
         )
@@ -921,15 +864,10 @@ def test_multiplexed_metrics(serve_start_shutdown):
             assert metric in resp
         return True
 
-    """
     wait_for_condition(
         verify_metrics,
         timeout=40,
         retry_interval_ms=1000,
-    )
-    """
-    print_metrics_wait_time(
-        "test_multiplexed_metrics", verify_metrics, timeout=40, retry_interval_ms=1000
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Extend the timeout & increase the push timeout interval.

(Try 7 times, it all passes)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
