### PR TITLE
[Data] Support JSONL file format

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2529,10 +2529,11 @@ class Dataset:
         and pass it in as the ``block_path_provider`` argument.
 
         Examples:
-            Write the dataset as JSON files to a local directory.
+            Write the dataset as JSON file to a local directory.
 
             >>> import ray
-            >>> ds = ray.data.range(100)
+            >>> import pandas as pd
+            >>> ds = ray.data.from_pandas([pd.DataFrame({"one": [1], "two": ["a"]})])
             >>> ds.write_json("local:///tmp/data")
 
             Write the dataset as JSONL files to a local directory.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2513,7 +2513,7 @@ class Dataset:
         ray_remote_args: Dict[str, Any] = None,
         **pandas_json_args,
     ) -> None:
-        """Writes the :class:`~ray.data.Dataset` to JSON files.
+        """Writes the :class:`~ray.data.Dataset` to JSON and JSONL files.
 
         The number of files is determined by the number of blocks in the dataset.
         To control the number of number of blocks, call
@@ -2533,6 +2533,11 @@ class Dataset:
 
             >>> import ray
             >>> ds = ray.data.range(100)
+            >>> ds.write_json("local:///tmp/data")
+
+            Write the dataset as JSONL files to a local directory.
+
+            >>> ds = ray.data.read_json("s3://anonymous@ray-example-data/train.jsonl")
             >>> ds.write_json("local:///tmp/data")
 
         Time complexity: O(dataset size / parallelism)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2515,9 +2515,6 @@ class Dataset:
     ) -> None:
         """Writes the :class:`~ray.data.Dataset` to JSON and JSONL files.
 
-        When the dataset has multiple rows, the output file is in JSONL format.
-        Otherwise, the output file is in JSON format.
-
         The number of files is determined by the number of blocks in the dataset.
         To control the number of number of blocks, call
         :meth:`~ray.data.Dataset.repartition`.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2515,6 +2515,9 @@ class Dataset:
     ) -> None:
         """Writes the :class:`~ray.data.Dataset` to JSON and JSONL files.
 
+        When the dataset has multiple rows, the output file is in JSONL format.
+        Otherwise, the output file is in JSON format.
+
         The number of files is determined by the number of blocks in the dataset.
         To control the number of number of blocks, call
         :meth:`~ray.data.Dataset.repartition`.

--- a/python/ray/data/datasource/json_datasource.py
+++ b/python/ray/data/datasource/json_datasource.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 @PublicAPI
 class JSONDatasource(FileBasedDatasource):
-    """JSON datasource, for reading and writing JSON files.
+    """JSON datasource, for reading and writing JSON and JSONL files.
 
     Examples:
         >>> import ray
@@ -24,7 +24,7 @@ class JSONDatasource(FileBasedDatasource):
         [{"a": 1, "b": "foo"}, ...]
     """
 
-    _FILE_EXTENSION = "json"
+    _FILE_EXTENSION = ["json", "jsonl"]
 
     # TODO(ekl) The PyArrow JSON reader doesn't support streaming reads.
     def _read_file(self, f: "pyarrow.NativeFile", path: str, **reader_args):

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -939,7 +939,7 @@ def read_json(
         Read a JSON file in remote storage.
 
         >>> import ray
-        >>> ds = ray.data.read_json("s3://anonymous@ray-example-data/logs.json")
+        >>> ds = ray.data.read_json("s3://anonymous@ray-example-data/log.json")
         >>> ds.schema()
         Column     Type
         ------     ----

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -933,10 +933,10 @@ def read_json(
     ignore_missing_paths: bool = False,
     **arrow_json_args,
 ) -> Dataset:
-    """Creates a :class:`~ray.data.Dataset` from JSON files.
+    """Creates a :class:`~ray.data.Dataset` from JSON and JSONL files.
 
     Examples:
-        Read a file in remote storage.
+        Read a JSON file in remote storage.
 
         >>> import ray
         >>> ds = ray.data.read_json("s3://anonymous@ray-example-data/logs.json")
@@ -945,6 +945,14 @@ def read_json(
         ------     ----
         timestamp  timestamp[s]
         size       int64
+
+        Read a JSONL file in remote storage.
+
+        >>> ds = ray.data.read_json("s3://anonymous@ray-example-data/train.jsonl")
+        >>> ds.schema()
+        Column  Type
+        ------  ----
+        input   string
 
         Read multiple local files.
 
@@ -997,7 +1005,7 @@ def read_json(
             Use with a custom callback to read only selected partitions of a
             dataset.
             By default, this filters out any file paths whose file extension does not
-            match "*.json*".
+            match "*.json" or "*.jsonl".
         partitioning: A :class:`~ray.data.datasource.partitioning.Partitioning` object
             that describes how paths are organized. By default, this function parses
             `Hive-style partitions <https://athena.guide/articles/\

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -935,6 +935,9 @@ def read_json(
 ) -> Dataset:
     """Creates a :class:`~ray.data.Dataset` from JSON and JSONL files.
 
+    For JSON file, the whole file is read as one row.
+    For JSONL file, each line of file is read as separate row.
+
     Examples:
         Read a JSON file in remote storage.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is to add supporting for JSONL file format. Our `read_json` and `write_json` already supports JSONL file format. The actual code change is to support ".jsonl" file extension in `read_json`, and update documentation and example.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/37611

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
