### PR TITLE
[serve] Cherry-pick Serve enum `to_proto` fixes for Python 3.11

### DIFF
--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -60,7 +60,7 @@ class ApplicationStatusInfo:
 
     def to_proto(self):
         return ApplicationStatusInfoProto(
-            status=f"APPLICATION_STATUS_{self.status}",
+            status=f"APPLICATION_STATUS_{self.status.name}",
             message=self.message,
             deployment_timestamp=self.deployment_timestamp,
         )

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -93,7 +93,7 @@ class DeploymentStatusInfo:
     def to_proto(self):
         return DeploymentStatusInfoProto(
             name=self.name,
-            status=f"DEPLOYMENT_STATUS_{self.status}",
+            status=f"DEPLOYMENT_STATUS_{self.status.name}",
             message=self.message,
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cherry-picks the following 1-line compatibility fixes for Python 3.11:

- https://github.com/ray-project/ray/pull/36954
- https://github.com/ray-project/ray/pull/37258

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
