### PR TITLE
[Serve] Make `test_lightweight_config_options` check for different statuses

### DIFF
--- a/python/ray/serve/tests/test_telemetry.py
+++ b/python/ray/serve/tests/test_telemetry.py
@@ -462,7 +462,7 @@ def test_lightweight_config_options(manage_ray, lightweight_option, value):
     client.deploy_apps(ServeDeploySchema(**config))
     wait_for_condition(
         lambda: client.get_serve_status("receiver_app").app_status.status
-        == ApplicationStatus.DEPLOYING,
+        == ApplicationStatus.RUNNING,
         timeout=15,
     )
     wait_for_condition(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_telemetry.py` has been flaky on `master`:

<img width="1314" alt="Screen Shot 2023-07-21 at 4 23 05 PM" src="https://github.com/ray-project/ray/assets/92341594/88e3658a-f7fc-4add-bffc-8b6c27c30ad4">

Generally the test fails on `test_lightweight_config_options`. [Example](https://buildkite.com/ray-project/oss-ci-build-branch/builds/5073#0189769e-eb1c-4d3e-a00b-1bcab5b99112/2917-3229):

```console
=================================== FAILURES ===================================
--
  | _______________ test_lightweight_config_options[num_replicas-2] ________________
  |  
  ...
  | wait_for_condition(
  | lambda: ray.get(storage.get_reports_received.remote()) > 0, timeout=5
  | )
  | report = ray.get(storage.get_report.remote())
  |  
  | # Check
  | assert int(report["extra_usage_tags"]["serve_num_apps"]) == 2
  | assert report["extra_usage_tags"]["serve_api_version"] == "v2"
  | for tagkey in lightweight_tagkeys:
  | assert tagkey not in report["extra_usage_tags"]
  |  
  | # Change config and deploy again
  | config["applications"][1]["deployments"][0][lightweight_option] = value
  | client.deploy_apps(ServeDeploySchema(**config))
  | wait_for_condition(
  | lambda: client.get_serve_status("receiver_app").app_status.status
  | == ApplicationStatus.DEPLOYING,
  | >           timeout=15,
  | )
  |  
  | python/ray/serve/tests/test_telemetry.py:466
```

The root cause is that the `ApplicationStatus.DEPLOYING` check fails periodically, likely because the app finishes deploying to quickly. This change switches this to check `ApplicationStatus.RUNNING` since that's the expected steady-state status.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change fixes `test_telemetry.py`.
