### PR TITLE
[air] fix pyarrow lazy import

### DIFF
--- a/python/ray/air/_internal/remote_storage.py
+++ b/python/ray/air/_internal/remote_storage.py
@@ -139,10 +139,10 @@ def is_non_local_path_uri(uri: str) -> bool:
 
 
 # Cache fs objects. Map from cache_key --> timestamp, fs
-_cached_fs: Dict[tuple, Tuple[float, pyarrow.fs.FileSystem]] = {}
+_cached_fs: Dict[tuple, Tuple[float, "pyarrow.fs.FileSystem"]] = {}
 
 
-def _get_cache(cache_key: tuple) -> Optional[pyarrow.fs.FileSystem]:
+def _get_cache(cache_key: tuple) -> Optional["pyarrow.fs.FileSystem"]:
     ts, fs = _cached_fs.get(cache_key, (0, None))
     if not fs:
         return None
@@ -155,7 +155,7 @@ def _get_cache(cache_key: tuple) -> Optional[pyarrow.fs.FileSystem]:
     return fs
 
 
-def _put_cache(cache_key: tuple, fs: pyarrow.fs.FileSystem):
+def _put_cache(cache_key: tuple, fs: "pyarrow.fs.FileSystem"):
     now = time.monotonic()
     _cached_fs[cache_key] = (now, fs)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->


https://github.com/ray-project/ray/pull/35938 introduced a `pyarrow` typehint, though `pyarrow` is being lazily imported. This leads to the following error:

```python
>>> from ray import tune
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/matt/miniconda3/envs/test-tune/lib/python3.9/site-packages/ray/tune/__init__.py", line 2, in <module>
    from ray.tune.tune import run_experiments, run
  File "/Users/matt/miniconda3/envs/test-tune/lib/python3.9/site-packages/ray/tune/tune.py", line 27, in <module>
    from ray.air import CheckpointConfig
  File "/Users/matt/miniconda3/envs/test-tune/lib/python3.9/site-packages/ray/air/__init__.py", line 1, in <module>
    from ray.air.checkpoint import Checkpoint
  File "/Users/matt/miniconda3/envs/test-tune/lib/python3.9/site-packages/ray/air/checkpoint.py", line 22, in <module>
    from ray.air._internal.remote_storage import (
  File "/Users/matt/miniconda3/envs/test-tune/lib/python3.9/site-packages/ray/air/_internal/remote_storage.py", line 142, in <module>
    _cached_fs: Dict[tuple, Tuple[float, pyarrow.fs.FileSystem]] = {}
AttributeError: 'NoneType' object has no attribute 'fs'
```

Note that functionality that does rely on `pyarrow` will call the following utility function and raise a descriptive error if it is not installed:

https://github.com/ray-project/ray/blob/b385a0b151ac768d9b36ddf20a86904b0951283c/python/ray/air/_internal/remote_storage.py#L102-L109


## Related issue number

<!-- For example: "Closes #1234" -->
Closes #37656

## Checks

Verified locally that running `from ray import tune` succeeds.

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
