### PR TITLE
[Serve] Convert `DeploymentFunctionNodes` to `ServeHandles`

### DIFF
--- a/python/ray/serve/_private/deployment_graph_build.py
+++ b/python/ray/serve/_private/deployment_graph_build.py
@@ -172,7 +172,9 @@ def transform_ray_dag_to_serve_dag(
         # deployment handles (executable and picklable) in ray serve DAG to make
         # serve DAG end to end executable.
         def replace_with_handle(node):
-            if isinstance(node, DeploymentNode):
+            if isinstance(node, DeploymentNode) or isinstance(
+                node, DeploymentFunctionNode
+            ):
                 return RayServeHandle(node._deployment.name)
             elif isinstance(node, DeploymentExecutorNode):
                 return node._deployment_handle


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`DeploymentFunctionNodes` are converted to `None` objects instead of `ServeHandles` inside deployment graphs. This prevents function nodes from serving requests inside a deployment graph.

This change converts `DeploymentFunctionNodes` to `ServeHandles` in deployment graphs.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #37669.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - This change adds `test_deployment_function_node_build`.