### PR TITLE
[core][autoscaler] Fix env variable overwrite not able to be used if command itself uses the env

### DIFF
--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -395,12 +395,14 @@ def with_envs(cmds: List[str], kv: Dict[str, str]) -> str:
 
     Example:
         with_envs(["echo $FOO"], {"FOO": "BAR"})
-            -> ["FOO=BAR echo $FOO"]
+            -> ["export FOO=BAR; echo $FOO"]
     """
     out_cmds = []
     for cmd in cmds:
         kv_str = ""
         for k, v in kv.items():
+            # We will need to do export here so that it works correctly with 
+            # shell if the cmd args uses the argument. 
             kv_str += f"export {k}={v}; "
 
         out_cmds.append(f"{kv_str}{cmd}")

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -401,8 +401,8 @@ def with_envs(cmds: List[str], kv: Dict[str, str]) -> str:
     for cmd in cmds:
         kv_str = ""
         for k, v in kv.items():
-            # We will need to do export here so that it works correctly with 
-            # shell if the cmd args uses the argument. 
+            # We will need to do export here so that it works correctly with
+            # shell if the cmd args uses the argument.
             kv_str += f"export {k}={v}; "
 
         out_cmds.append(f"{kv_str}{cmd}")

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -401,7 +401,7 @@ def with_envs(cmds: List[str], kv: Dict[str, str]) -> str:
     for cmd in cmds:
         kv_str = ""
         for k, v in kv.items():
-            kv_str += f"{k}={v} "
+            kv_str += f"export {k}={v}; "
 
         out_cmds.append(f"{kv_str}{cmd}")
     return out_cmds

--- a/python/ray/tests/test_autoscaler_util.py
+++ b/python/ray/tests/test_autoscaler_util.py
@@ -10,22 +10,22 @@ def test_with_envs():
     assert with_envs(
         ["echo $RAY_HEAD_IP", "ray start"], {"RAY_HEAD_IP": "127.0.0.0"}
     ) == [
-        "RAY_HEAD_IP=127.0.0.0 echo $RAY_HEAD_IP",
-        "RAY_HEAD_IP=127.0.0.0 ray start",
+        "export RAY_HEAD_IP=127.0.0.0; echo $RAY_HEAD_IP",
+        "export RAY_HEAD_IP=127.0.0.0; ray start",
     ]
 
     assert with_head_node_ip(["echo $RAY_HEAD_IP"], "127.0.0.0") == [
-        "RAY_HEAD_IP=127.0.0.0 echo $RAY_HEAD_IP"
+        "export RAY_HEAD_IP=127.0.0.0; echo $RAY_HEAD_IP"
     ]
 
     assert (
-        "RAY_HEAD_IP=456"
+        "export RAY_HEAD_IP=456"
         in with_envs(
             ["echo $RAY_CLOUD_ID"], {"RAY_CLOUD_ID": "123", "RAY_HEAD_IP": "456"}
         )[0]
     )
     assert (
-        "RAY_CLOUD_ID=123"
+        "export RAY_CLOUD_ID=123"
         in with_envs(
             ["echo $RAY_CLOUD_ID"], {"RAY_CLOUD_ID": "123", "RAY_HEAD_IP": "456"}
         )[0]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Things will break If the command itself uses the env variable as part of command,e.g 
```
cmd = "RAY_KEY=$RAY_VAL <command>"
```

And we preappend env overwrites with
```
RAY_VAL=1 RAY_KEY=$RAY_VAL <command> 

#RAY_KEY is not 1 in <command> 
```





<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
