### PR TITLE
[civ2][flakiness/1] Use a central file to track flaky tests for core

### DIFF
--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -185,7 +185,10 @@
     - pip install ray[client]
     - bazel test --config=ci $(./ci/run/bazel_export_options) 
       --test_tag_filters=client_tests,small_size_python_tests 
-      $(bazel query "attr(tags, civ1, tests(python/ray/tests/...))")
+      -- $(yq -r .flaky_tests[] ci/v2/test/core.tests.yml)
+    - bazel test --config=ci $(./ci/run/bazel_export_options) 
+      --test_tag_filters=client_tests,small_size_python_tests,-team:core 
+      -- python/ray/tests/...
     - bazel test --config=ci $(./ci/run/bazel_export_options)
       --test_tag_filters=ray_ha
       --test_env=DOCKER_HOST=tcp://docker:2376

--- a/.buildkite/pipeline.build_core.yml
+++ b/.buildkite/pipeline.build_core.yml
@@ -10,5 +10,5 @@
     - ./ci/env/env_info.sh
     - pip install ray[client]
     - bazel test --config=ci $(./ci/run/bazel_export_options) 
-      --test_tag_filters=client_tests,small_size_python_tests,-civ1
-      -- python/ray/tests/...
+      --test_tag_filters=client_tests,small_size_python_tests
+      -- $(bazel query "attr(tags, team:core, tests(python/ray/tests/...))") $(yq -r ".flaky_tests | map(\"-\"+.) | join(\" \")" ci/v2/test/core.tests.yml)

--- a/ci/v2/test/core.tests.yml
+++ b/ci/v2/test/core.tests.yml
@@ -1,0 +1,12 @@
+flaky_tests:
+  - //python/ray/tests:test_runtime_env_working_dir_3
+  - //python/ray/tests:test_placement_group_3
+  - //python/ray/tests:test_memory_pressure
+  - //python/ray/tests:test_placement_group_5
+  - //python/ray/tests:test_runtime_env_2
+  - //python/ray/tests:test_gcs_fault_tolerance
+  - //python/ray/tests:test_plasma_unlimited
+  - //python/ray/tests:test_scheduling_performance
+  - //python/ray/tests:test_object_manager
+  - //python/ray/tests:test_threaded_actor
+  - //python/ray/tests:test_unhandled_error

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -93,14 +93,6 @@ py_test_module_list(
     "test_client_builder.py",
     "test_client_init.py",
     "test_client_proxy.py",
-  ],
-  size = "medium",
-  tags = ["exclusive", "client_tests", "team:serverless", "civ1"],
-  deps = ["//:ray_lib", ":conftest"],
-)
-
-py_test_module_list(
-  files = [
     "test_client_compat.py",
     "test_client_multi.py",
     "test_client_references.py",
@@ -247,14 +239,6 @@ py_test_module_list(
 py_test_module_list(
   files = [
     "test_autoscaler.py",
-  ],
-  size = "small",
-  tags = ["exclusive", "small_size_python_tests", "team:serverless", "civ1"],
-  deps = ["//:ray_lib", ":conftest"],
-)
-
-py_test_module_list(
-  files = [
     "test_batch_node_provider_unit.py",
     "test_batch_node_provider_integration.py",
     "test_autoscaler_drain_node_api.py",
@@ -510,23 +494,12 @@ py_test(
 # no way to filter by both flaky and client mode tests in bazel.
 py_test_module_list(
   files = [
-    "test_basic_3.py",
-    "test_asyncio.py",
-    "test_object_assign_owner.py",
-  ],
-  size = "large",
-  name_suffix = "_client_mode",
-  env = {"RAY_CLIENT_MODE": "1", "RAY_PROFILING": "1"},
-  tags = ["exclusive", "client_tests", "team:serverless", "civ1"],
-  deps = ["//:ray_lib", ":conftest"],
-)
-
-py_test_module_list(
-  files = [
     "test_actor.py",
     "test_advanced.py",
+    "test_asyncio.py",
     "test_basic.py",
     "test_basic_2.py",
+    "test_basic_3.py",
     "test_basic_4.py",
     "test_basic_5.py",
     "test_multiprocessing.py",
@@ -534,6 +507,7 @@ py_test_module_list(
     "test_list_actors_2.py",
     "test_list_actors_3.py",
     "test_list_actors_4.py",
+    "test_object_assign_owner.py",
   ],
   size = "large",
   name_suffix = "_client_mode",

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -77,6 +77,8 @@ werkzeug==2.1.2
 xlrd==2.0.1
 memray; platform_system != "Windows" and sys_platform != "darwin" and platform_machine != 'aarch64'
 memray @ git+https://github.com/bloomberg/memray.git; platform_system != "Windows" and sys_platform != "darwin" and platform_machine == 'aarch64'
+yq==3.2.2
+
 # For doc tests
 myst-parser==0.15.2
 myst-nb==0.13.1

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -547,6 +547,7 @@ xxhash==3.2.0
 y-py==0.5.9
 yarl==1.9.2
 ypy-websocket==0.8.2
+yq==3.2.2
 zict==3.0.0
 zipp==3.15.0
 zoopt==0.4.1


### PR DESCRIPTION
Previously we introduced a bazel tag called civ1 to track flaky tests. This PR changes to using a central file to track flaky tests. This gives us more dynamic to manage flaky tests, either through source control or real time via a database. Also this makes it easier to migrate tests between civ1 and civ2.

Test:
- CI