### PR TITLE
[no_ci] [air] `pyarrow.fs` persistence: Pass `StorageContext` to Train workers (3/n)

### DIFF
--- a/python/ray/air/_internal/uri_utils.py
+++ b/python/ray/air/_internal/uri_utils.py
@@ -20,6 +20,13 @@ class URI:
         's3://bucket/a?scheme=http&endpoint_override=localhost%3A900'
         >>> s3_uri.parent.name, s3_uri.name
         ('bucket', 'a')
+        >>> local_path = URI("/tmp/local")
+        >>> str(local_path)
+        '/tmp/local'
+        >>> str(local_path.parent)
+        '/tmp'
+        >>> str(local_path / "b" / "c")
+        '/tmp/local/b/c'
 
     Args:
         uri: The URI to represent.
@@ -30,8 +37,10 @@ class URI:
     def __init__(self, uri: str):
         self._parsed = urllib.parse.urlparse(uri)
         if not self._parsed.scheme:
-            raise ValueError(f"Invalid URI: {uri}")
-        self._path = Path(os.path.normpath(self._parsed.netloc + self._parsed.path))
+            # Just treat this as a regular path
+            self._path = Path(uri)
+        else:
+            self._path = Path(os.path.normpath(self._parsed.netloc + self._parsed.path))
 
     @property
     def name(self) -> str:
@@ -60,6 +69,8 @@ class URI:
     def _get_str_representation(
         cls, parsed_uri: urllib.parse.ParseResult, path: Union[str, Path]
     ) -> str:
+        if not parsed_uri.scheme:
+            return str(path)
         return parsed_uri._replace(netloc=str(path), path="").geturl()
 
     def __repr__(self):
@@ -67,6 +78,10 @@ class URI:
 
     def __str__(self):
         return self._get_str_representation(self._parsed, self._path)
+
+
+def is_uri(path: str) -> bool:
+    return bool(urllib.parse.urlparse(path).scheme)
 
 
 def _join_path_or_uri(base_path: str, path_to_join: str) -> str:

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -17,6 +17,8 @@ from typing import (
     Tuple,
 )
 
+import pyarrow.fs
+
 from ray._private.storage import _get_storage_uri
 from ray._private.thirdparty.tabulate.tabulate import tabulate
 from ray.air.constants import WILDCARD_KEY
@@ -750,6 +752,7 @@ class RunConfig:
 
     name: Optional[str] = None
     storage_path: Optional[str] = None
+    storage_filesystem: Optional[pyarrow.fs.FileSystem] = None
     callbacks: Optional[List["Callback"]] = None
     stop: Optional[Union[Mapping, "Stopper", Callable[[str, Mapping], bool]]] = None
     failure_config: Optional[FailureConfig] = None

--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -17,6 +17,7 @@ from ray.train._internal.session import (
     init_session,
     shutdown_session,
 )
+from ray.train._internal.storage import _use_storage_context, get_storage_context
 from ray.train._internal.utils import check_for_failure
 from ray.train._internal.worker_group import WorkerGroup
 from ray.train.backend import BackendConfig
@@ -378,6 +379,7 @@ class BackendExecutor:
             encode_data_fn,
             checkpoint_keep_all_ranks,
             checkpoint_upload_from_workers,
+            storage,
         ):
             try:
                 init_session(
@@ -395,6 +397,7 @@ class BackendExecutor:
                     enable_lazy_checkpointing=use_lazy_checkpointing,
                     checkpoint_keep_all_ranks=checkpoint_keep_all_ranks,
                     checkpoint_upload_from_workers=(checkpoint_upload_from_workers),
+                    storage=storage,
                 )
             except ValueError:
                 raise TrainBackendError(
@@ -440,6 +443,8 @@ class BackendExecutor:
                     checkpoint_upload_from_workers=(
                         self._checkpoint_upload_from_workers
                     ),
+                    # Pass the Trainable's shared storage context to the Train workers
+                    storage=get_storage_context() if _use_storage_context() else None,
                 )
             )
 

--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -346,6 +346,7 @@ class BackendExecutor:
         datasets: Dict[str, Dataset],
         data_config: DataConfig,
         checkpoint: Optional[Checkpoint] = None,
+        on_session_init: Callable[[], None] = None,
     ) -> None:
         """Executes a training function on all workers in a separate thread.
 
@@ -451,6 +452,9 @@ class BackendExecutor:
         self._backend.on_training_start(self.worker_group, self._backend_config)
 
         self.get_with_failure_handling(futures)
+
+        if on_session_init:
+            on_session_init()
 
         # Run the training function asynchronously in its own thread.
         def train_async():

--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -123,7 +123,7 @@ class StorageContext:
         return os.path.join(self.storage_fs_path, self.experiment_dir_name)
 
     @property
-    def experiment_cache_dir(self) -> str:
+    def experiment_cache_path(self) -> str:
         return os.path.join(self.storage_cache_path, self.experiment_dir_name)
 
     @property

--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -83,10 +83,6 @@ class StorageContext:
             )
         )
 
-        # TODO(justinvyu): This is needed for the legacy Trainable syncing code.
-        # Remove this after syncer argument is removed from SyncConfig.
-        self.sync_config.syncer = self.syncer
-
         self._create_validation_file()
         self._check_validation_file()
 

--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -1,0 +1,154 @@
+import dataclasses
+import os
+from typing import Optional
+
+import pyarrow.fs
+
+from ray.air._internal.uri_utils import is_uri
+from ray.air._internal.remote_storage import get_fs_and_path
+from ray.tune.syncer import Syncer, SyncConfig, _DefaultSyncer
+from ray.tune.result import _get_defaults_results_dir
+
+
+def _use_storage_context() -> bool:
+    # Whether to enable the new simple persistence mode.
+    return bool(int(os.environ.get("TUNE_USE_STORAGE_CONTEXT", "1")))
+
+
+class StorageContext:
+    """Shared context that holds all paths and storage utilities, passed along from
+    the driver to workers.
+
+    Example:
+        storage_path = "s3://bucket/results"
+        storage_filesystem = S3FileSystem (auto-resolved)
+        storage_cache_path = "~/ray_results"
+        storage_fs_path = "bucket/results"
+
+        experiment_dir_name = "exp_name"
+        # experiment_path = "s3://bucket/results/exp_name"
+        experiment_fs_path = "bucket/results/exp_name"  # Use this path with pyarrow
+        experiment_cache_path = "~/ray_results/exp_name"
+
+        # Only set on workers.
+        trial_dir_name = "trial_dir"
+        # trial_path = "s3://bucket/results/exp_name/trial_dir"
+        trial_fs_path = "bucket/results/exp_name/trial_dir"
+        # trial_cache_path = "~/ray_results/exp_name/trial_dir"
+
+    Internal Usage Examples:
+        construct_checkpoint_fs_path("checkpoint_000001")
+        -> "bucket/results/exp_name/trial_dir/checkpoint_000001"
+
+        pyarrow.fs.copy_files(
+            local_dir,
+            os.path.join(storage.trial_fs_path, "subdir"),
+            destination_filesystem=storage.filesystem
+        )
+    """
+
+    def __init__(
+        self,
+        storage_path: str,
+        sync_config: SyncConfig,
+        experiment_dir_name: str,
+        storage_filesystem: Optional[pyarrow.fs.FileSystem] = None,
+        trial_dir_name: Optional[str] = None,
+    ):
+        self.storage_path: str = storage_path
+        self.storage_cache_path: str = _get_defaults_results_dir()
+        self.experiment_dir_name: str = experiment_dir_name
+        self.trial_dir_name: Optional[str] = trial_dir_name
+        self.sync_config: SyncConfig = dataclasses.replace(sync_config)
+
+        if storage_filesystem:
+            # Custom pyarrow filesystem
+            self.storage_filesystem = storage_filesystem
+            if is_uri(self.storage_path):
+                raise ValueError("TODO")
+            self.storage_fs_path = self.storage_path
+        else:
+            (
+                self.storage_filesystem,
+                self.storage_fs_path,
+            ) = get_fs_and_path(self.storage_path)
+
+        self.syncer: Optional[Syncer] = (
+            None
+            if self.storage_path == self.storage_cache_path
+            else _DefaultSyncer(
+                sync_period=self.sync_config.sync_period,
+                sync_timeout=self.sync_config.sync_timeout,
+                storage_filesystem=self.storage_filesystem,
+            )
+        )
+
+        # TODO(justinvyu): This is needed for the legacy Trainable syncing code.
+        # Remove this after syncer argument is removed from SyncConfig.
+        self.sync_config.syncer = self.syncer
+
+        self._create_validation_file()
+        self._check_validation_file()
+
+    def __str__(self):
+        attrs = [
+            "storage_path",
+            "storage_cache_path",
+            "storage_filesystem",
+            "storage_fs_path",
+            "experiment_dir_name",
+            "trial_dir_name",
+        ]
+        attr_str = "\n".join([f"  {attr}={getattr(self, attr)}" for attr in attrs])
+        return f"StorageContext<\n{attr_str}\n>"
+
+    def _create_validation_file(self):
+        valid_file = os.path.join(self.experiment_fs_path, ".validate_storage_marker")
+        self.storage_filesystem.create_dir(self.experiment_fs_path)
+        with self.storage_filesystem.open_output_stream(valid_file):
+            pass
+
+    def _check_validation_file(self):
+        valid_file = os.path.join(self.experiment_fs_path, ".validate_storage_marker")
+        valid = self.storage_filesystem.get_file_info([valid_file])[0]
+        if valid.type == pyarrow.fs.FileType.NotFound:
+            raise RuntimeError(
+                f"Unable to set up cluster storage at storage_path={self.storage_path}"
+                "\nCheck that all nodes in the cluster have read/write access "
+                "to the configured storage path."
+            )
+
+    @property
+    def experiment_fs_path(self) -> str:
+        return os.path.join(self.storage_fs_path, self.experiment_dir_name)
+
+    @property
+    def experiment_cache_dir(self) -> str:
+        return os.path.join(self.storage_cache_path, self.experiment_dir_name)
+
+    @property
+    def trial_fs_path(self) -> str:
+        if self.trial_dir_name is None:
+            raise RuntimeError(
+                "Should not access `trial_fs_path` without setting `trial_dir_name`"
+            )
+        return os.path.join(self.experiment_fs_path, self.trial_dir_name)
+
+    def construct_checkpoint_fs_path(self, checkpoint_dir_name: str) -> str:
+        return os.path.join(self.trial_fs_path, checkpoint_dir_name)
+
+
+_storage_context: Optional[StorageContext] = None
+
+
+def init_shared_storage_context(storage_context: StorageContext):
+    global _storage_context
+    _storage_context = storage_context
+
+
+def get_storage_context() -> StorageContext:
+    assert _storage_context, (
+        "You must first call `init_shared_storage_context` in order to access a "
+        "global shared copy of StorageContext."
+    )
+    return _storage_context

--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -12,7 +12,7 @@ from ray.tune.result import _get_defaults_results_dir
 
 def _use_storage_context() -> bool:
     # Whether to enable the new simple persistence mode.
-    return bool(int(os.environ.get("RAY_AIR_NEW_PERSISTENCE_MODE", "1")))
+    return bool(int(os.environ.get("RAY_AIR_NEW_PERSISTENCE_MODE", "0")))
 
 
 class StorageContext:

--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -12,7 +12,7 @@ from ray.tune.result import _get_defaults_results_dir
 
 def _use_storage_context() -> bool:
     # Whether to enable the new simple persistence mode.
-    return bool(int(os.environ.get("TUNE_USE_STORAGE_CONTEXT", "1")))
+    return bool(int(os.environ.get("RAY_AIR_NEW_PERSISTENCE_MODE", "1")))
 
 
 class StorageContext:

--- a/python/ray/train/tests/test_new_persistence.py
+++ b/python/ray/train/tests/test_new_persistence.py
@@ -15,6 +15,13 @@ def dummy_context_manager():
     yield "dummy value"
 
 
+@pytest.fixture(autouse=True)
+def enable_new_persistence_mode(monkeypatch):
+    monkeypatch.setenv("RAY_AIR_NEW_PERSISTENCE_MODE", "1")
+    yield
+    monkeypatch.setenv("RAY_AIR_NEW_PERSISTENCE_MODE", "0")
+
+
 def train_fn(config):
     start = 0
 

--- a/python/ray/train/tests/test_new_persistence.py
+++ b/python/ray/train/tests/test_new_persistence.py
@@ -1,0 +1,112 @@
+from contextlib import contextmanager
+import os
+import pickle
+import pytest
+import tempfile
+import time
+
+from ray import air, train, tune
+from ray.air.tests.test_checkpoints import mock_s3_bucket_uri
+from ray.air._internal.remote_storage import download_from_uri
+
+
+@contextmanager
+def dummy_context_manager():
+    yield "dummy value"
+
+
+def train_fn(config):
+    start = 0
+
+    checkpoint = train.get_context().get_checkpoint()
+    if checkpoint:
+        with checkpoint.as_directory() as checkpoint_dir:
+            with open(os.path.join(checkpoint_dir, "dummy.pkl"), "rb") as f:
+                state = pickle.load(f)
+        print("Loaded back state from checkpoint:", state)
+        start = state["iter"] + 1
+
+    for i in range(start, config.get("num_iterations", 5)):
+        time.sleep(0.5)
+
+        with open(f"artifact-{i}.txt", "w") as f:
+            f.write(f"{i}")
+
+        temp_dir = tempfile.mkdtemp()
+        with open(os.path.join(temp_dir, "dummy.pkl"), "wb") as f:
+            pickle.dump({"iter": i}, f)
+
+        train.report({"iter": i}, checkpoint=air.Checkpoint.from_directory(temp_dir))
+
+
+@pytest.mark.parametrize("storage_path_type", [None, "nfs", "cloud", "custom_fs"])
+def test_tuner(monkeypatch, storage_path_type, tmp_path):
+    # Set the cache dir to some temp directory
+    LOCAL_CACHE_DIR = tmp_path / "ray_results"
+    monkeypatch.setenv("RAY_AIR_LOCAL_CACHE_DIR", str(LOCAL_CACHE_DIR))
+
+    context_manager = (
+        mock_s3_bucket_uri if storage_path_type == "cloud" else dummy_context_manager
+    )
+
+    exp_name = "simple_persistence_test"
+
+    with context_manager() as cloud_storage_path:
+        storage_filesystem = None
+        if storage_path_type is None:
+            storage_path = None
+        elif storage_path_type == "nfs":
+            storage_path = str(tmp_path / "fake_nfs")
+        elif storage_path_type == "cloud":
+            storage_path = str(cloud_storage_path)
+        elif storage_path_type == "custom_fs":
+            from fsspec.implementations.dirfs import DirFileSystem
+            from fsspec.implementations.local import LocalFileSystem
+
+            import pyarrow.fs
+
+            storage_path = "mock_bucket"
+            storage_filesystem = pyarrow.fs.PyFileSystem(
+                pyarrow.fs.FSSpecHandler(
+                    DirFileSystem(
+                        path=str(tmp_path / "custom_fs"), fs=LocalFileSystem()
+                    )
+                )
+            )
+
+        NUM_ITERATIONS = 6  # == num_checkpoints == num_artifacts
+        NUM_TRIALS = 2
+        tuner = tune.Tuner(
+            train_fn,
+            param_space={"num_iterations": NUM_ITERATIONS},
+            run_config=train.RunConfig(
+                storage_path=storage_path,
+                storage_filesystem=storage_filesystem,
+                name="simple_persistence_test",
+                verbose=0,
+                failure_config=train.FailureConfig(max_failures=1),
+            ),
+            # 2 samples, running 1 at at time to test with actor reuse
+            tune_config=tune.TuneConfig(
+                num_samples=NUM_TRIALS, max_concurrent_trials=1
+            ),
+        )
+        tuner.fit()
+
+        local_inspect_dir = tmp_path / "inspect"
+        if storage_path:
+            download_from_uri(
+                storage_path,
+                str(local_inspect_dir),
+                source_filesystem=storage_filesystem,
+            )
+        else:
+            local_inspect_dir = LOCAL_CACHE_DIR
+
+    assert len(list(local_inspect_dir.glob("*"))) == 1  # Only expect 1 experiment dir
+    exp_dir = local_inspect_dir / exp_name
+
+    # Files synced by the driver
+    assert len(list(exp_dir.glob("basic-variant-state-*"))) == 1
+    assert len(list(exp_dir.glob("experiment_state-*"))) == 1
+    assert len(list(exp_dir.glob("tuner.pkl"))) == 1

--- a/python/ray/train/trainer.py
+++ b/python/ray/train/trainer.py
@@ -100,11 +100,10 @@ class TrainingIterator:
                 datasets=datasets,
                 data_config=data_config,
                 checkpoint=checkpoint,
+                # Workers need to start out with a path to write the first checkpoint to
+                on_session_init=self._send_next_checkpoint_path_to_workers,
             )
         )
-
-        # Workers need to start out with a path to write the first checkpoint to.
-        self._send_next_checkpoint_path_to_workers()
 
     def _send_next_checkpoint_path_to_workers(self):
         # NOTE: Always upload to storage from workers in the new persistence path

--- a/python/ray/train/trainer.py
+++ b/python/ray/train/trainer.py
@@ -30,6 +30,8 @@ from ray.train.base_trainer import (  # noqa: F401
 )
 from ray.tune.trainable.util import TrainableUtil
 from ray.util.annotations import DeveloperAPI
+from ray.train._internal.storage import _use_storage_context, get_storage_context
+
 
 T = TypeVar("T")
 S = TypeVar("S")
@@ -101,8 +103,28 @@ class TrainingIterator:
             )
         )
 
-        # Session has started. Set current cloud checkpoint dir if necessary.
-        if self._checkpoint_strategy._checkpoint_upload_from_workers:
+        # Workers need to start out with a path to write the first checkpoint to.
+        self._send_next_checkpoint_path_to_workers()
+
+    def _send_next_checkpoint_path_to_workers(self):
+        # NOTE: Always upload to storage from workers in the new persistence path
+        # (no need to check for the `checkpoint_upload_from_workers` flag)
+        if _use_storage_context():
+            storage = get_storage_context()
+
+            # NOTE: Idea: this checkpoint dir name should be customizable
+            # and created on the fly when the checkpoint is reported with metrics.
+            # Ex: lambda metrics: f"checkpoint_iter={metrics['training_iteration']}"
+            checkpoint_dir_name = TrainableUtil._make_checkpoint_dir_name(
+                self._checkpoint_manager._latest_checkpoint_id
+            )
+            checkpoint_path = storage.construct_checkpoint_fs_path(checkpoint_dir_name)
+
+            # TODO(justinvyu): This checkpoint_path is NOT a URI anymore.
+            # It's just a path relative to the storage filesystem.
+            # `session.report` needs to be updated to upload using pyarrow.fs.copy_files
+            self._backend_executor._set_checkpoint_uri(checkpoint_path)
+        elif self._checkpoint_strategy._checkpoint_upload_from_workers:
             self._backend_executor._set_checkpoint_uri(
                 self.__get_cloud_checkpoint_dir()
             )
@@ -201,10 +223,7 @@ class TrainingIterator:
                 # TODO(jungong) : It would be nicer if we find a cleaner way
                 # to sync the current cloud checkpointing directory between
                 # Tuner, Trainable, and Trainers.
-                if self._checkpoint_strategy._checkpoint_upload_from_workers:
-                    self._backend_executor._set_checkpoint_uri(
-                        self.__get_cloud_checkpoint_dir()
-                    )
+                self._send_next_checkpoint_path_to_workers()
                 # Iterate until next REPORT call or training has finished.
             else:
                 raise TrainBackendError(
@@ -214,6 +233,7 @@ class TrainingIterator:
                     f"{[type in TrainingResultType]}"
                 )
 
+    # TODO(justinvyu): Remove unused code
     def _finish_checkpointing(self):
         while True:
             results = self._backend_executor.get_next_results()
@@ -225,11 +245,10 @@ class TrainingIterator:
                 self._checkpoint_manager._process_checkpoints(
                     results, decode_checkpoint_fn=self._backend._decode_data
                 )
-                if self._checkpoint_strategy._checkpoint_upload_from_workers:
-                    self._backend_executor._set_checkpoint_uri(
-                        self.__get_cloud_checkpoint_dir()
-                    )
+                # TODO: Is this needed? I don't think this is ever called...
+                self._send_next_checkpoint_path_to_workers()
 
+    # TODO(justinvyu): Remove unused code
     def _finish_training(self):
         """Finish training and return final results. Propagate any exceptions.
 
@@ -251,6 +270,7 @@ class TrainingIterator:
     def is_finished(self) -> bool:
         return self._finished_training
 
+    # TODO(justinvyu): Remove unused code
     def get_final_results(self, force: bool = False) -> List[T]:
         """Gets the training func return values from each worker.
 
@@ -281,12 +301,6 @@ class TrainingIterator:
 
         return self._final_results
 
-    # This is extremely hacky and fragile.
-    # TODO(jungong) : We should refactor things so Tuner, Trinable, and
-    # Trainers have a consistent view of the current cloud checkpointing
-    # directory.
-    # We should probably also refactor things so Syncer and SyncConfig
-    # are available everywhere session is available.
     def __get_cloud_checkpoint_dir(self):
         if not self._storage_path:
             # Can't run cloud upload if storage path is not set.

--- a/python/ray/tune/execution/experiment_state.py
+++ b/python/ray/tune/execution/experiment_state.py
@@ -131,7 +131,7 @@ class _ExperimentCheckpointManager:
     ):
         if _use_storage_context():
             assert storage
-            self._local_checkpoint_dir = storage.experiment_cache_dir
+            self._local_checkpoint_dir = storage.experiment_cache_path
             self._remote_checkpoint_dir = storage.experiment_fs_path
             self._sync_config = storage.sync_config
             self._syncer = storage.syncer

--- a/python/ray/tune/execution/trial_runner.py
+++ b/python/ray/tune/execution/trial_runner.py
@@ -1,3 +1,4 @@
+import copy
 import uuid
 from typing import Any, Dict, List, Optional, Union, Tuple, Set
 
@@ -458,6 +459,8 @@ class _TuneControllerBase:
 
             # The following properties may be updated on restoration
             # Ex: moved local/cloud experiment directory
+            if _use_storage_context():
+                trial.storage = copy.copy(self._storage)
             # ATTN: Set `local_experiment_path` to update trial checkpoints!
             trial.local_experiment_path = self._local_experiment_path
             trial.remote_experiment_path = self._remote_experiment_path

--- a/python/ray/tune/execution/trial_runner.py
+++ b/python/ray/tune/execution/trial_runner.py
@@ -155,7 +155,7 @@ class _TuneControllerBase:
         if _use_storage_context():
             assert storage
             self._experiment_dir_name = storage.experiment_dir_name
-            self._local_experiment_path = storage.experiment_cache_dir
+            self._local_experiment_path = storage.experiment_cache_path
             self._remote_experiment_path = storage.experiment_fs_path
             self._sync_config = storage.sync_config
         else:

--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -1066,11 +1066,15 @@ class TuneController(_TuneControllerBase):
 
         kwargs = {}
 
+        # TODO(justinvyu): These alternate restore paths need to all be cleaned up.
         if checkpoint.storage_mode == CheckpointStorage.MEMORY:
             method_name = "restore_from_object"
             args = (checkpoint.dir_or_data,)
         elif (
-            trial.uses_cloud_checkpointing
+            # NOTE: The head node syncing case doesn't apply anymore (the next elif),
+            # so always sync down from storage in the new persistence mode.
+            _use_storage_context()
+            or trial.uses_cloud_checkpointing
             or not trial.sync_on_checkpoint
             or not os.path.exists(checkpoint.dir_or_data)
         ):

--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -14,7 +14,7 @@ from ray.air.config import CheckpointConfig
 from ray.air._internal.checkpoint_manager import CheckpointStorage, _TrackedCheckpoint
 from ray.air.execution import ResourceManager, PlacementGroupResourceManager
 from ray.air.execution._internal import RayActorManager, TrackedActor
-from ray.train._internal.storage import _use_storage_context, StorageContext
+from ray.train._internal.storage import StorageContext
 from ray.exceptions import RayActorError
 from ray.tune.error import _AbortTrialExecution
 from ray.tune.execution.ray_trial_executor import _class_cache

--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -14,6 +14,7 @@ from ray.air.config import CheckpointConfig
 from ray.air._internal.checkpoint_manager import CheckpointStorage, _TrackedCheckpoint
 from ray.air.execution import ResourceManager, PlacementGroupResourceManager
 from ray.air.execution._internal import RayActorManager, TrackedActor
+from ray.train._internal.storage import _use_storage_context, StorageContext
 from ray.exceptions import RayActorError
 from ray.tune.error import _AbortTrialExecution
 from ray.tune.execution.ray_trial_executor import _class_cache
@@ -64,6 +65,7 @@ class TuneController(_TuneControllerBase):
         callbacks: Optional[List[Callback]] = None,
         metric: Optional[str] = None,
         trial_checkpoint_config: Optional[CheckpointConfig] = None,
+        storage: Optional[StorageContext] = None,
         chdir_to_trial_dir: bool = False,
         reuse_actors: bool = False,
         resource_manager_factory: Optional[Callable[[], ResourceManager]] = None,
@@ -161,6 +163,7 @@ class TuneController(_TuneControllerBase):
             callbacks=callbacks,
             metric=metric,
             trial_checkpoint_config=trial_checkpoint_config,
+            storage=storage,
             _trainer_api=_trainer_api,
         )
 

--- a/python/ray/tune/experiment/config_parser.py
+++ b/python/ray/tune/experiment/config_parser.py
@@ -236,5 +236,6 @@ def _create_trial_from_spec(
         log_to_file=spec.get("log_to_file"),
         # str(None) doesn't create None
         max_failures=args.max_failures,
+        storage=spec.get("storage"),
         **trial_kwargs,
     )

--- a/python/ray/tune/experiment/experiment.py
+++ b/python/ray/tune/experiment/experiment.py
@@ -328,7 +328,7 @@ class Experiment:
                 experiment_dir_name=self.dir_name,
             )
             self.storage = spec["storage"] = storage
-            logging.debug(f"StorageContext on the DRIVER:\n{storage}")
+            logger.debug(f"StorageContext on the DRIVER:\n{storage}")
 
         self.spec = spec
 

--- a/python/ray/tune/experiment/experiment.py
+++ b/python/ray/tune/experiment/experiment.py
@@ -187,15 +187,25 @@ class Experiment:
         # If set, it should be a subpath under `local_dir`. Also deduce `dir_name`.
         if _experiment_checkpoint_dir:
             experiment_checkpoint_dir_path = Path(_experiment_checkpoint_dir)
-            local_dir_path = Path(full_local_storage_path)
-            assert local_dir_path in experiment_checkpoint_dir_path.parents, (
-                local_dir_path,
-                str(list(experiment_checkpoint_dir_path.parents)),
-            )
-            # `dir_name` is set by `_experiment_checkpoint_dir` indirectly.
-            self.dir_name = os.path.relpath(
-                _experiment_checkpoint_dir, full_local_storage_path
-            )
+            if _use_storage_context():
+                # TODO(justinvyu): This is a temporary hack for the
+                # custom storage_filesystem case.
+                # With a custom storage_filesystem, the storage path is possibly
+                # a "local path" (ex: [fs, path] = CustomS3FileSystem, "bucket/subdir")
+                # Our current path resolution treats a local storage_path as
+                # the cache dir, so the assertion in the else case would fail.
+                # This will be re-worked in a follow-up.
+                self.dir_name = experiment_checkpoint_dir_path.name
+            else:
+                local_dir_path = Path(full_local_storage_path)
+                assert local_dir_path in experiment_checkpoint_dir_path.parents, (
+                    local_dir_path,
+                    str(list(experiment_checkpoint_dir_path.parents)),
+                )
+                # `dir_name` is set by `_experiment_checkpoint_dir` indirectly.
+                self.dir_name = os.path.relpath(
+                    _experiment_checkpoint_dir, full_local_storage_path
+                )
 
         self._local_storage_path = full_local_storage_path
         self._remote_storage_path = remote_storage_path

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -662,6 +662,7 @@ class TunerInternal:
 
         return dict(
             storage_path=self._run_config.storage_path,
+            storage_filesystem=self._run_config.storage_filesystem,
             mode=self._tune_config.mode,
             metric=self._tune_config.metric,
             callbacks=self._run_config.callbacks,

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -26,10 +26,12 @@ from ray.air._internal.remote_storage import download_from_uri, is_non_local_pat
 from ray.air._internal.uri_utils import URI
 from ray.air._internal.usage import AirEntrypoint
 from ray.air.config import RunConfig, ScalingConfig
+from ray.train._internal.storage import _use_storage_context
 from ray.tune import Experiment, TuneError, ExperimentAnalysis
 from ray.tune.execution.experiment_state import _ResumeConfig
 from ray.tune.tune import _Config
 from ray.tune.registry import is_function_trainable
+from ray.tune.result import _get_defaults_results_dir
 from ray.tune.result_grid import ResultGrid
 from ray.tune.trainable import Trainable
 from ray.tune.tune import run
@@ -523,7 +525,11 @@ class TunerInternal:
         """Sets up experiment checkpoint dir before actually running the experiment."""
         path = Experiment.get_experiment_checkpoint_dir(
             trainable,
-            run_config.storage_path,
+            # TODO(justinvyu): This is a result of the old behavior of parsing
+            # local vs. remote storage paths and should be reworked in a follow-up.
+            _get_defaults_results_dir()
+            if _use_storage_context()
+            else run_config.storage_path,
             run_config.name,
         )
         if not os.path.exists(path):

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -55,6 +55,8 @@ from ray.util.annotations import PublicAPI, DeveloperAPI
 from ray.widgets import Template
 
 if TYPE_CHECKING:
+    import pyarrow.fs
+
     from ray.tune.experiment import Trial
 
 logger = logging.getLogger(__name__)

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -1182,7 +1182,9 @@ def run(
         trials=all_trials,
         default_metric=metric,
         default_mode=mode,
-        remote_storage_path=remote_path,
+        # NOTE: In the new persistence mode, we don't distinguish
+        # between remote/local storage_path.
+        remote_storage_path=storage_path if _use_storage_context() else remote_path,
     )
 
     return ea

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -93,6 +93,8 @@ from ray.util.annotations import PublicAPI
 from ray.util.queue import Queue
 
 if TYPE_CHECKING:
+    import pyarrow.fs
+
     from ray.tune.experimental.output import ProgressReporter as AirProgressReporter
 
 logger = logging.getLogger(__name__)

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -28,6 +28,7 @@ from ray.air import CheckpointConfig
 from ray.air._internal import usage as air_usage
 from ray.air._internal.usage import AirEntrypoint
 from ray.air.util.node import _force_on_current_node
+from ray.train._internal.storage import _use_storage_context
 from ray.tune.analysis import ExperimentAnalysis
 from ray.tune.callback import Callback
 from ray.tune.error import TuneError
@@ -303,6 +304,7 @@ def run(
     ] = None,
     num_samples: int = 1,
     storage_path: Optional[str] = None,
+    storage_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     search_alg: Optional[Union[Searcher, SearchAlgorithm, str]] = None,
     scheduler: Optional[Union[TrialScheduler, str]] = None,
     checkpoint_config: Optional[CheckpointConfig] = None,
@@ -862,6 +864,7 @@ def run(
                 resources_per_trial=resources_per_trial,
                 num_samples=num_samples,
                 storage_path=storage_path,
+                storage_filesystem=storage_filesystem,
                 _experiment_checkpoint_dir=_experiment_checkpoint_dir,
                 sync_config=sync_config,
                 checkpoint_config=checkpoint_config,
@@ -1024,6 +1027,7 @@ def run(
         callbacks=callbacks,
         metric=metric,
         trial_checkpoint_config=experiments[0].checkpoint_config,
+        storage=experiments[0].storage,
         _trainer_api=_entrypoint == AirEntrypoint.TRAINER,
     )
 

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -1027,7 +1027,6 @@ def run(
         callbacks=callbacks,
         metric=metric,
         trial_checkpoint_config=experiments[0].checkpoint_config,
-        storage=experiments[0].storage,
         _trainer_api=_entrypoint == AirEntrypoint.TRAINER,
     )
 
@@ -1036,8 +1035,13 @@ def run(
         runner_kwargs.pop("trial_executor")
         runner_kwargs["reuse_actors"] = reuse_actors
         runner_kwargs["chdir_to_trial_dir"] = chdir_to_trial_dir
+        runner_kwargs["storage"] = experiments[0].storage
     else:
         trial_runner_cls = TrialRunner
+        if _use_storage_context():
+            raise ValueError(
+                "The old execution path does not support the new persistence mode."
+            )
 
     runner = trial_runner_cls(**runner_kwargs)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR passes a storage context to Train workers of a `DataParallelTrainer`, in preparation for using its `storage_filesystem` for uploading checkpoints/artifacts directly upon a `train.report` call.

This PR is stacked on:
1. https://github.com/ray-project/ray/pull/37690
2. https://github.com/ray-project/ray/pull/37694

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
