### PR TITLE
[Core] toggle worker graceful shutdown when actor goes out of scope.

### DIFF
--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -936,6 +936,8 @@ def test_exit_actor_queued(shutdown_only):
 
 
 def test_actor_graceful_shutdown(shutdown_only):
+    """with `graceful_actor_worker_shutdown=True`, actor worker will
+    wait for all references to be drained before shutting down."""
     ray.init(
         _system_config={
             "graceful_actor_worker_shutdown": True,

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -942,7 +942,7 @@ def test_actor_graceful_shutdown(shutdown_only):
         },
     )
 
-    @ray.remote()
+    @ray.remote
     class Consumer:
         def consume(self, refs):
             self.refs = refs
@@ -950,7 +950,7 @@ def test_actor_graceful_shutdown(shutdown_only):
         def read(self):
             return ray.get(self.refs[0])
 
-    @ray.remote(max_restarts=1)
+    @ray.remote
     class Producer:
         def __init__(self, consumer):
             self.consumer = consumer
@@ -963,6 +963,8 @@ def test_actor_graceful_shutdown(shutdown_only):
     producer = Producer.remote(consumer)
     ray.get(producer.produce.remote())
     del producer
+
+    time.sleep(5)
 
     assert ray.get(consumer.read.remote()) == 1
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -833,3 +833,7 @@ RAY_CONFIG(bool, kill_child_processes_on_worker_exit, true)
 
 // If autoscaler v2 is enabled.
 RAY_CONFIG(bool, enable_autoscaler_v2, false)
+
+// Kill actor worker gracefully, waiting for owned object references
+// to be released before killing the worker.
+RAY_CONFIG(bool, graceful_kill_actor_worker, false)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -834,6 +834,6 @@ RAY_CONFIG(bool, kill_child_processes_on_worker_exit, true)
 // If autoscaler v2 is enabled.
 RAY_CONFIG(bool, enable_autoscaler_v2, false)
 
-// Kill actor worker gracefully, waiting for owned object references
+// Shutdown actor worker gracefully, waiting for owned object references
 // to be released before killing the worker.
-RAY_CONFIG(bool, graceful_kill_actor_worker, false)
+RAY_CONFIG(bool, graceful_actor_worker_shutdown, false)

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -796,7 +796,9 @@ void GcsActorManager::PollOwnerForActorOutOfScope(
           // Only destroy the actor if its owner is still alive. The actor may
           // have already been destroyed if the owner died.
           DestroyActor(
-              actor_id, GenActorOutOfScopeCause(GetActor(actor_id)), /*force_kill=*/true);
+              actor_id,
+              GenActorOutOfScopeCause(GetActor(actor_id)),
+              /*force_kill=*/!RayConfig::instance().graceful_kill_actor_worker());
         }
       });
 }

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -798,7 +798,7 @@ void GcsActorManager::PollOwnerForActorOutOfScope(
           DestroyActor(
               actor_id,
               GenActorOutOfScopeCause(GetActor(actor_id)),
-              /*force_kill=*/!RayConfig::instance().graceful_kill_actor_worker());
+              /*force_kill=*/!RayConfig::instance().graceful_actor_worker_shutdown());
         }
       });
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

By default, we will force kill the actor worker process if the actor has go of of scope, regardless the owned objects by the worker process. the intention is to release resources owned by the process (such as GPU memory) which can only be cleaned up by killing the process.

However this has caused undesired side-effect, such as object lost. To add the problem, we add a flag to allow graceful worker shutdown in short term.

in long term, we'd need object downscaling or moving ownership back to raylet. (cc @iycheng)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
