### PR TITLE
[Serve] Push models ids info early & fix num of models issue

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -856,13 +856,8 @@ class RayServeReplica:
                     await sync_to_async(self.callable.__del__)()
                     setattr(self.callable, "__del__", lambda _: None)
 
-                # Check self.callable has __serve_multiplex prefix as attribute function
-                # If it has, call it to clean up the multiplexed model
-                for attr in dir(self.callable):
-                    if attr.startswith("__serve_multiplex"):
-                        await getattr(self.callable, attr).__del__()
-                        setattr(getattr(self.callable, attr), "__del__", lambda _: None)
-                        break
+                if hasattr(self.callable, "__serve_multiplex_wrapper"):
+                    await getattr(self.callable, "__serve_multiplex_wrapper").shutdown()
 
             except Exception as e:
                 logger.exception(f"Exception during graceful shutdown of replica: {e}")

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -855,6 +855,14 @@ class RayServeReplica:
                     # Make sure to accept `async def __del__(self)` as well.
                     await sync_to_async(self.callable.__del__)()
                     setattr(self.callable, "__del__", lambda _: None)
+
+                # Check self.callable has __serve_multiplex prefix as attribute function
+                # If it has, call it to clean up the multiplexed model
+                for attr in dir(self.callable):
+                    if attr.startswith("__serve_multiplex"):
+                        await getattr(self.callable, attr).__del__()
+                        break
+
             except Exception as e:
                 logger.exception(f"Exception during graceful shutdown of replica: {e}")
             finally:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -861,6 +861,7 @@ class RayServeReplica:
                 for attr in dir(self.callable):
                     if attr.startswith("__serve_multiplex"):
                         await getattr(self.callable, attr).__del__()
+                        setattr(getattr(self.callable, attr), "__del__", lambda _: None)
                         break
 
             except Exception as e:

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -672,7 +672,7 @@ def multiplexed(
                     )
                 multiplex_object = self
                 model_id = args[1]
-            multiplex_attr = f"__serve_multiplex_{func.__name__}"
+            multiplex_attr = "__serve_multiplex_wrapper"
             # If the multiplexed function is called for the first time,
             # create a model multiplex wrapper and cache it in the multiplex object.
             if not hasattr(multiplex_object, multiplex_attr):

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -6,7 +6,6 @@ import time
 from typing import Any, Callable, List, Set
 
 from ray._private.async_compat import sync_to_async
-from ray._private.utils import get_or_create_event_loop
 from ray.serve._private.constants import (
     SERVE_LOGGER_NAME,
     PUSH_MULTIPLEXED_MODEL_IDS_INTERVAL_S,

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -92,9 +92,9 @@ class _ModelMultiplexWrapper:
 
         # Model cache lock to ensure that only one model is loading/unloading at a time.
         self._model_cache_lock = asyncio.Lock()
-        # The set of model IDs that are being loaded. This is used to early push model ids
-        # info to the controller. The tasks will be added when there is cache miss, and
-        # removed when the model is loaded or failed to load.
+        # The set of model IDs that are being loaded. This is used to early push
+        # model ids info to the controller. The tasks will be added when there is cache
+        # miss, and will be removed when the model is loaded successfully or failed to load.
         self._model_load_tasks: Set[str] = set()
 
         self.metrics_pusher = MetricsPusher()
@@ -106,8 +106,8 @@ class _ModelMultiplexWrapper:
 
     def _get_loading_and_loaded_model_ids(self) -> List[str]:
         """Get the model IDs of the loaded models & loading models in the replica.
-        This is to push the model id information early to the controller, so that requests
-        can be routed to the replica.
+        This is to push the model id information early to the controller, so that
+        requests can be routed to the replica.
         """
         models_list = set(self.models.keys())
         models_list.update(self._model_load_tasks)

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -94,7 +94,8 @@ class _ModelMultiplexWrapper:
         self._model_cache_lock = asyncio.Lock()
         # The set of model IDs that are being loaded. This is used to early push
         # model ids info to the controller. The tasks will be added when there is cache
-        # miss, and will be removed when the model is loaded successfully or failed to load.
+        # miss, and will be removed when the model is loaded successfully or
+        # failed to load.
         self._model_load_tasks: Set[str] = set()
 
         self.metrics_pusher = MetricsPusher()

--- a/python/ray/serve/tests/test_multiplex.py
+++ b/python/ray/serve/tests/test_multiplex.py
@@ -1,16 +1,17 @@
+import asyncio
 import pytest
 from typing import List
 import os
 import requests
 
 import ray
+from ray import serve
+
 from ray._private.test_utils import (
-    async_wait_for_condition,
     wait_for_condition,
     SignalActor,
 )
-
-from ray import serve
+from ray._private.utils import get_or_create_event_loop
 from ray.serve.context import get_internal_replica_context
 from ray.serve.handle import RayServeHandle
 from ray.serve.multiplex import _ModelMultiplexWrapper
@@ -32,6 +33,13 @@ def start_serve_with_context():
     ray.shutdown()
 
 
+def stop_model_ids_pusher_thread(multiplexer):
+    multiplexer.metrics_pusher.stop_event.set()
+    wait_for_condition(
+        lambda: multiplexer.metrics_pusher.pusher_thread.is_alive() is False
+    )
+
+
 class TestMultiplexWrapper:
     def test_failed_to_get_replica_context(self):
         async def model_load_func(model_id: str):
@@ -41,6 +49,26 @@ class TestMultiplexWrapper:
             RuntimeError, match="Fail to retrieve serve replica context"
         ):
             _ModelMultiplexWrapper(model_load_func, None, max_num_models_per_replica=2)
+
+    def test_push_model_ids_info(self, start_serve_with_context):
+        async def model_load_func(model_id: str):
+            return model_id
+
+        multiplexer = _ModelMultiplexWrapper(
+            model_load_func, None, max_num_models_per_replica=1
+        )
+        stop_model_ids_pusher_thread(multiplexer)
+        assert multiplexer._push_multiplexed_replica_info is False
+        multiplexer._push_multiplexed_replica_info = True
+        multiplexer._push_model_ids_info()
+        assert multiplexer._push_multiplexed_replica_info is False
+
+    def test_collect_model_ids(self):
+        multiplexer = _ModelMultiplexWrapper(None, None, max_num_models_per_replica=1)
+        multiplexer.models = {"1": "1", "2": "2"}
+        assert sorted(multiplexer._get_model_ids()) == ["1", "2"]
+        multiplexer._model_load_tasks = {"3"}
+        assert sorted(multiplexer._get_model_ids()) == ["1", "2", "3"]
 
     @pytest.mark.asyncio
     async def test_multiplex_wrapper(self, start_serve_with_context):
@@ -52,28 +80,25 @@ class TestMultiplexWrapper:
         multiplexer = _ModelMultiplexWrapper(
             model_load_func, None, max_num_models_per_replica=2
         )
-
-        # Check the replica info pushed
-        def check_info_pushed():
-            return multiplexer._push_multiplexed_replica_info is False
+        stop_model_ids_pusher_thread(multiplexer)
 
         # Load model1
         await multiplexer.load_model("1")
         assert multiplexer.models == {"1": "1"}
         assert multiplexer._push_multiplexed_replica_info
-        await async_wait_for_condition(check_info_pushed)
+        multiplexer._push_multiplexed_replica_info = False
 
         # Load model2
         await multiplexer.load_model("2")
         assert multiplexer.models == {"1": "1", "2": "2"}
         assert multiplexer._push_multiplexed_replica_info
-        await async_wait_for_condition(check_info_pushed)
+        multiplexer._push_multiplexed_replica_info = False
 
         # Load model3, model1 should be unloaded
         await multiplexer.load_model("3")
         assert multiplexer.models == {"2": "2", "3": "3"}
         assert multiplexer._push_multiplexed_replica_info
-        await async_wait_for_condition(check_info_pushed)
+        multiplexer._push_multiplexed_replica_info = False
 
         # reload model2, model2 should be moved to the end of the LRU cache
         # _push_multiplexed_replica_info should be False.
@@ -110,8 +135,8 @@ class TestMultiplexWrapper:
             def __del__(self):
                 raise Exception(f"{self.model_id} is dead")
 
-            def __eq__(self, model):
-                return model.model_id == self.model_id
+            def __eq__(self, other):
+                return self.model_id == other.model_id
 
         async def model_load_func(model_id: str) -> MyModel:
             return MyModel(model_id)
@@ -119,10 +144,79 @@ class TestMultiplexWrapper:
         multiplexer = _ModelMultiplexWrapper(
             model_load_func, None, max_num_models_per_replica=1
         )
+        stop_model_ids_pusher_thread(multiplexer)
         await multiplexer.load_model("1")
         assert multiplexer.models == {"1": MyModel("1")}
         with pytest.raises(Exception, match="1 is dead"):
             await multiplexer.load_model("2")
+
+    @pytest.mark.asyncio
+    async def test_push_model_ids_info_after_unload_model(self):
+        """
+        Push the model ids info right after the model is unloaded, even though
+        new model is not loaded yet.
+        """
+        signal = SignalActor.remote()
+
+        async def model_load_func(model_id: str):
+            if model_id == "1":
+                return model_id
+            await signal.wait.remote()
+            return
+
+        multiplexer = _ModelMultiplexWrapper(
+            model_load_func, None, max_num_models_per_replica=1
+        )
+        stop_model_ids_pusher_thread(multiplexer)
+        await multiplexer.load_model("1")
+        assert multiplexer._push_multiplexed_replica_info
+        multiplexer._push_multiplexed_replica_info = False
+
+        loop = get_or_create_event_loop()
+        loop.create_task(multiplexer.load_model("2"))
+        # _push_multiplexed_replica_info is True right after model1 is unloaded.
+        # and model2 is not finished loading.
+        await asyncio.sleep(1)
+        assert len(multiplexer.models) == 0
+        assert "2" in multiplexer._model_load_tasks
+        assert multiplexer._push_multiplexed_replica_info
+        signal.send.remote()
+
+    @pytest.mark.asyncio
+    async def test_load_models_concurrently(self, start_serve_with_context):
+        """
+        Test load models concurrently. models info should include loading models and
+        loaded models.
+        And the models cache should not execeed the limit.
+        """
+
+        signal = SignalActor.remote()
+
+        async def model_load_func(model_id: str):
+            await signal.wait.remote()
+            return
+
+        multiplexer = _ModelMultiplexWrapper(
+            model_load_func, None, max_num_models_per_replica=1
+        )
+        stop_model_ids_pusher_thread(multiplexer)
+
+        loop = get_or_create_event_loop()
+        tasks = [
+            loop.create_task(multiplexer.load_model("1")),
+            loop.create_task(multiplexer.load_model("2")),
+            loop.create_task(multiplexer.load_model("3")),
+        ]
+        await asyncio.sleep(1)
+        assert len(multiplexer.models) == 0
+        assert len(multiplexer._model_load_tasks) == len(tasks)
+        assert multiplexer._push_multiplexed_replica_info
+        signal.send.remote()
+        done, _ = await asyncio.wait(tasks, timeout=1)
+        assert len(done) == len(tasks)
+        assert len(multiplexer.models) == 1
+        assert "3" in multiplexer.models
+        assert len(multiplexer._model_load_tasks) == 0
 
 
 class TestBasicAPI:

--- a/python/ray/serve/tests/test_multiplex.py
+++ b/python/ray/serve/tests/test_multiplex.py
@@ -66,9 +66,13 @@ class TestMultiplexWrapper:
     def test_collect_model_ids(self):
         multiplexer = _ModelMultiplexWrapper(None, None, max_num_models_per_replica=1)
         multiplexer.models = {"1": "1", "2": "2"}
-        assert sorted(multiplexer._get_model_ids()) == ["1", "2"]
+        assert sorted(multiplexer._get_loading_and_loaded_model_ids()) == ["1", "2"]
         multiplexer._model_load_tasks = {"3"}
-        assert sorted(multiplexer._get_model_ids()) == ["1", "2", "3"]
+        assert sorted(multiplexer._get_loading_and_loaded_model_ids()) == [
+            "1",
+            "2",
+            "3",
+        ]
 
     @pytest.mark.asyncio
     async def test_multiplex_wrapper(self, start_serve_with_context):

--- a/python/ray/serve/tests/test_multiplex.py
+++ b/python/ray/serve/tests/test_multiplex.py
@@ -135,8 +135,8 @@ class TestMultiplexWrapper:
             def __del__(self):
                 raise Exception(f"{self.model_id} is dead")
 
-            def __eq__(self, other):
-                return self.model_id == other.model_id
+            def __eq__(self, model):
+                return model.model_id == self.model_id
 
         async def model_load_func(model_id: str) -> MyModel:
             return MyModel(model_id)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Move push model ids into different thread.
- Early push model ids info during model loading.
- Add a lock for model cache. (One model load at a time)

## Related issue number

Closes: #37516

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
