### PR TITLE
[RFC] add a 10s wait after each cluster down.

### DIFF
--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -484,6 +484,7 @@ def _ray_start_cluster(**kwargs):
     # The code after the yield will run as teardown code.
     ray.shutdown()
     cluster.shutdown()
+    time.sleep(10)  # give some time for the raylet-created agents to die
 
 
 # This fixture will start a cluster with empty nodes.


### PR DESCRIPTION
This is based on the observation that many test failures can only happen when it's a cluster test after another cluster test, and the tests involve http client (e.g. for job submission), and that the log says port #52365 is occupied so the cluster dashboard agent http server can't start. The theory is that the previous clust er's down, but node.py only waits for raylet and node.py-managed processes but not dashboard agent, and while the agent has not yet died, the second cluster's raylet has started, brought up the second dashboard agent, who found the http port 52365 is already binded.

Test provenance: on master, run `python ray/tests/test_runtime_env_2.py`.

Without this patch: TestNoUserInfoInLogs::test_basic[no_ray_client] failed.
With this patch: it passes.

### Alternative?

If we can directly wait all raylet children in node.py that'd be better. But I tried and for some reason I did not explore, many test failed.

