### PR TITLE
Optmize the failed msg when ssh failed during file mounts

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -288,9 +288,7 @@ class SSHCommandRunner(CommandRunnerInterface):
                 )
             fail_msg = "Command failed: \n\n  {}\n".format(joined_cmd)
             if exit_on_fail:
-                raise click.ClickException(
-                    fail_msg
-                ) from None
+                raise click.ClickException(fail_msg) from None
             else:
                 if is_output_redirected():
                     fail_msg += " See above for the output from the failure."

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -286,13 +286,12 @@ class SSHCommandRunner(CommandRunnerInterface):
                     code=e.returncode,
                     command=joined_cmd,
                 )
-
+            fail_msg = "Command failed: \n\n  {}\n".format(joined_cmd)
             if exit_on_fail:
                 raise click.ClickException(
-                    "Command failed:\n\n  {}\n".format(joined_cmd)
+                    fail_msg
                 ) from None
             else:
-                fail_msg = "SSH command failed."
                 if is_output_redirected():
                     fail_msg += " See above for the output from the failure."
                 raise click.ClickException(fail_msg) from None


### PR DESCRIPTION
## Why are these changes needed?

I have a failure at step 2 when launching my Ray cluster on Debian VMs.
```
  [2/7] Processing file mounts
  Setting tags for vm vm-1074
  Removing tag ray-node-status from the VM vm-1074
  Attaching tag ray-node-status:update-failed to vm-1074
  Tag attached
  New status: update-failed
  !!!
  SSH command failed.
  !!!
```
This msg told me nothing, I spend some time to do the troubleshooting and finally find that the root cause is I don't have "rsync" package on the Debian VM.

I did the troubleshooting by add the log in my Python lib, and find that the failed command is:
```
  SSH command failed.  rsync --rsh ssh -i /root/ray-bootstrap-key.pem -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=5 -o ServerAliveCountMax=3 -o ControlMaster=auto -o ControlPath=/tmp/ray_ssh_63a9f0ea7b/c21f969b5f/%C -o ControlPersist=10s -o ConnectTimeout=120s -avz --exclude **/.git --exclude **/.git/** --filter dir-merge,- .gitignore /root/ray_bootstrap_public_key.key ray@XXXXXX:/tmp/ray_tmp_mount/default/~/ray_bootstrap_public_key.key
```

So I think print the failed command here is really important for the developers.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
