### PR TITLE
[air] Add fault tolerance for wandb logging actors

### DIFF
--- a/python/ray/air/integrations/wandb.py
+++ b/python/ray/air/integrations/wandb.py
@@ -636,10 +636,17 @@ class WandbLoggerCallback(LoggerCallback):
                 num_cpus=0,
                 **_force_on_current_node(),
                 runtime_env={"env_vars": env_vars},
+                max_restarts=-1,
+                max_task_retries=-1,
             )(self._logger_actor_cls)
 
         self._trial_queues[trial] = Queue(
-            actor_options={"num_cpus": 0, **_force_on_current_node()}
+            actor_options={
+                "num_cpus": 0,
+                **_force_on_current_node(),
+                "max_restarts": -1,
+                "max_task_retries": -1,
+            }
         )
         self._trial_logging_actors[trial] = self._remote_logger_class.remote(
             logdir=trial.local_path,

--- a/python/ray/air/tests/test_integration_wandb.py
+++ b/python/ray/air/tests/test_integration_wandb.py
@@ -34,6 +34,8 @@ Template for testing with these mocks:
 """
 
 import gc
+from pathlib import Path
+
 import numpy as np
 import os
 import pytest
@@ -448,6 +450,41 @@ class TestWandbLogger:
         gc.collect()
         with pytest.raises(RayActorError):
             ray.get(actor.get_state.remote())
+
+    def test_wandb_logging_actor_fault_tolerance(self, trial):
+        """Tests that failing wandb logging actors are restarted"""
+
+        fail_marker = Path(tempfile.mktemp())
+
+        class _FailingWandbLoggingActor(_MockWandbLoggingActor):
+            def _handle_result(self, result):
+                if result.get("training_iteration") == 3 and not fail_marker.exists():
+                    fail_marker.write_text("Ok")
+                    raise SystemExit
+
+                return super()._handle_result(result)
+
+        logger = WandbLoggerCallback(
+            project="test_project", api_key="1234", excludes=["metric2"]
+        )
+        logger._logger_actor_cls = _FailingWandbLoggingActor
+        logger.setup()
+        logger.log_trial_start(trial)
+
+        actor = logger._trial_logging_actors[trial]
+        queue = logger._trial_queues[trial]
+
+        logger.log_trial_result(1, trial, result={"training_iteration": 1})
+        logger.log_trial_result(2, trial, result={"training_iteration": 2})
+        logger.log_trial_result(3, trial, result={"training_iteration": 3})
+
+        logger.log_trial_result(4, trial, result={"training_iteration": 4})
+        logger.log_trial_result(5, trial, result={"training_iteration": 5})
+
+        queue.put(_QueueItem.END)
+
+        state = ray.get(actor.get_state.remote())
+        assert [metrics["training_iteration"] for metrics in state.logs] == [4, 5]
 
 
 def test_wandb_logging_process_run_info_hook(monkeypatch):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When W&B logging actors fail, they aren't restarted. Subsequent logs are silently discarded instead. This PR adds fault tolerance to these actors with Ray core's built-in fault tolerance mechanisms. This will ensure that while some logs may be lost, logging is at least continued.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
