### PR TITLE
[Data] Refactor sort key

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -415,7 +415,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
         self, boundaries: List[T], sort_key: "SortKey"
     ) -> List["Block"]:
         columns = sort_key.get_columns()
-        if len(columns) > 0:
+        if len(columns) > 1:
             raise NotImplementedError(
                 "Sorting by multiple columns is not supported yet"
             )

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -414,6 +414,11 @@ class ArrowBlockAccessor(TableBlockAccessor):
     def sort_and_partition(
         self, boundaries: List[T], sort_key: "SortKey"
     ) -> List["Block"]:
+        columns = sort_key.get_columns()
+        if len(columns) > 0:
+            raise NotImplementedError(
+                "Sorting by multiple columns is not supported yet"
+            )
         if self._table.num_rows == 0:
             # If the pyarrow table is empty we may not have schema
             # so calling sort_indices() will raise an error.
@@ -421,7 +426,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
 
         context = DataContext.get_current()
         sort = get_sort_transform(context)
-        col = sort_key.get_columns()[0]
+        col = columns[0]
         table = sort(self._table, sort_key)
         if len(boundaries) == 0:
             return [table]

--- a/python/ray/data/_internal/arrow_ops/transform_polars.py
+++ b/python/ray/data/_internal/arrow_ops/transform_polars.py
@@ -7,7 +7,7 @@ except ImportError:
 
 
 if TYPE_CHECKING:
-    from ray.data._internal.sort import SortKeyT
+    from ray.data._internal.sort import SortKey
 
 pl = None
 
@@ -23,18 +23,18 @@ def check_polars_installed():
         )
 
 
-def sort(table: "pyarrow.Table", key: "SortKeyT", descending: bool) -> "pyarrow.Table":
+def sort(table: "pyarrow.Table", sort_key: "SortKey") -> "pyarrow.Table":
     check_polars_installed()
-    col, _ = key[0]
+    columns, ascending = sort_key.to_pandas_sort_args()
     df = pl.from_arrow(table)
-    return df.sort(col, reverse=descending).to_arrow()
+    return df.sort(columns, reverse=not ascending).to_arrow()
 
 
 def concat_and_sort(
-    blocks: List["pyarrow.Table"], key: "SortKeyT", descending: bool
+    blocks: List["pyarrow.Table"], sort_key: "SortKey"
 ) -> "pyarrow.Table":
     check_polars_installed()
-    col, _ = key[0]
+    columns, ascending = sort_key.to_pandas_sort_args()
     blocks = [pl.from_arrow(block) for block in blocks]
-    df = pl.concat(blocks).sort(col, reverse=descending)
+    df = pl.concat(blocks).sort(columns, reverse=not ascending)
     return df.to_arrow()

--- a/python/ray/data/_internal/arrow_ops/transform_polars.py
+++ b/python/ray/data/_internal/arrow_ops/transform_polars.py
@@ -25,16 +25,16 @@ def check_polars_installed():
 
 def sort(table: "pyarrow.Table", sort_key: "SortKey") -> "pyarrow.Table":
     check_polars_installed()
-    columns, ascending = sort_key.to_pandas_sort_args()
     df = pl.from_arrow(table)
-    return df.sort(columns, reverse=not ascending).to_arrow()
+    return df.sort(sort_key.get_columns(), reverse=sort_key.get_descending()).to_arrow()
 
 
 def concat_and_sort(
     blocks: List["pyarrow.Table"], sort_key: "SortKey"
 ) -> "pyarrow.Table":
     check_polars_installed()
-    columns, ascending = sort_key.to_pandas_sort_args()
     blocks = [pl.from_arrow(block) for block in blocks]
-    df = pl.concat(blocks).sort(columns, reverse=not ascending)
+    df = pl.concat(blocks).sort(
+        sort_key.get_columns(), reverse=sort_key.get_descending()
+    )
     return df.to_arrow()

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -258,8 +258,10 @@ def concat(blocks: List["pyarrow.Table"]) -> "pyarrow.Table":
 def concat_and_sort(
     blocks: List["pyarrow.Table"], sort_key: "SortKey"
 ) -> "pyarrow.Table":
+    import pyarrow.compute as pac
+
     ret = concat(blocks)
-    indices = pyarrow.compute.sort_indices(ret, sort_keys=sort_key.to_arrow_sort_args())
+    indices = pac.sort_indices(ret, sort_keys=sort_key.to_arrow_sort_args())
     return take_table(ret, indices)
 
 

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -6,13 +6,13 @@ except ImportError:
     pyarrow = None
 
 if TYPE_CHECKING:
-    from ray.data._internal.sort import SortKeyT
+    from ray.data._internal.sort import SortKey
 
 
-def sort(table: "pyarrow.Table", key: "SortKeyT", descending: bool) -> "pyarrow.Table":
+def sort(table: "pyarrow.Table", sort_key: "SortKey") -> "pyarrow.Table":
     import pyarrow.compute as pac
 
-    indices = pac.sort_indices(table, sort_keys=key)
+    indices = pac.sort_indices(table, sort_keys=sort_key.to_arrow_sort_args())
     return take_table(table, indices)
 
 
@@ -256,10 +256,10 @@ def concat(blocks: List["pyarrow.Table"]) -> "pyarrow.Table":
 
 
 def concat_and_sort(
-    blocks: List["pyarrow.Table"], key: "SortKeyT", descending: bool
+    blocks: List["pyarrow.Table"], sort_key: "SortKey"
 ) -> "pyarrow.Table":
     ret = concat(blocks)
-    indices = pyarrow.compute.sort_indices(ret, sort_keys=key)
+    indices = pyarrow.compute.sort_indices(ret, sort_keys=sort_key.to_arrow_sort_args())
     return take_table(ret, indices)
 
 

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -4,6 +4,7 @@ from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data._internal.planner.exchange.interfaces import ExchangeTaskSpec
 from ray.data._internal.planner.exchange.shuffle_task_spec import ShuffleTaskSpec
 from ray.data._internal.planner.exchange.sort_task_spec import SortTaskSpec
+from ray.data._internal.sort import SortKey
 from ray.data.aggregate import AggregateFn
 
 
@@ -108,8 +109,7 @@ class Sort(AbstractAllToAll):
     def __init__(
         self,
         input_op: LogicalOperator,
-        key: Optional[str],
-        descending: bool,
+        sort_key: SortKey,
     ):
         super().__init__(
             "Sort",
@@ -120,8 +120,7 @@ class Sort(AbstractAllToAll):
                 ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
             ],
         )
-        self._key = key
-        self._descending = descending
+        self._sort_key = sort_key
 
 
 class Aggregate(AbstractAllToAll):

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -347,7 +347,10 @@ class PandasBlockAccessor(TableBlockAccessor):
         self, boundaries: List[T], sort_key: "SortKey"
     ) -> List[Block]:
         columns, ascending = sort_key.to_pandas_sort_args()
-
+        if len(columns) > 0:
+            raise NotImplementedError(
+                "Sorting by multiple columns is not supported yet"
+            )
         if self._table.shape[0] == 0:
             # If the pyarrow table is empty we may not have schema
             # so calling sort_indices() will raise an error.

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -347,7 +347,7 @@ class PandasBlockAccessor(TableBlockAccessor):
         self, boundaries: List[T], sort_key: "SortKey"
     ) -> List[Block]:
         columns, ascending = sort_key.to_pandas_sort_args()
-        if len(columns) > 0:
+        if len(columns) > 1:
             raise NotImplementedError(
                 "Sorting by multiple columns is not supported yet"
             )

--- a/python/ray/data/_internal/planner/aggregate.py
+++ b/python/ray/data/_internal/planner/aggregate.py
@@ -15,6 +15,7 @@ from ray.data._internal.planner.exchange.push_based_shuffle_task_scheduler impor
     PushBasedShuffleTaskScheduler,
 )
 from ray.data._internal.planner.exchange.sort_task_spec import SortTaskSpec
+from ray.data._internal.sort import SortKey
 from ray.data._internal.stats import StatsDict
 from ray.data._internal.util import unify_block_metadata_schema
 from ray.data.aggregate import AggregateFn
@@ -58,7 +59,7 @@ def generate_aggregate_fn(
             # Sample boundaries for aggregate key.
             boundaries = SortTaskSpec.sample_boundaries(
                 blocks,
-                [(key, "ascending")] if isinstance(key, str) else key,
+                SortKey(key),
                 num_outputs,
             )
 

--- a/python/ray/data/_internal/planner/exchange/sort_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/sort_task_spec.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List, Tuple, TypeVar, Union
+from typing import List, Tuple, TypeVar, Union
 
 import numpy as np
 
@@ -6,15 +6,11 @@ from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.planner.exchange.interfaces import ExchangeTaskSpec
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.remote_fn import cached_remote_fn
+from ray.data._internal.sort import SortKey
 from ray.data.block import Block, BlockAccessor, BlockExecStats, BlockMetadata
 from ray.types import ObjectRef
 
 T = TypeVar("T")
-
-# Data can be sorted by value (None), a list of columns and
-# ascending/descending orders (List), or a custom transform function
-# (Callable).
-SortKeyT = Union[None, List[Tuple[str, str]], Callable[[T], Any]]
 
 
 class SortTaskSpec(ExchangeTaskSpec):
@@ -44,12 +40,11 @@ class SortTaskSpec(ExchangeTaskSpec):
     def __init__(
         self,
         boundaries: List[T],
-        key: SortKeyT,
-        descending: bool,
+        sort_key: SortKey,
     ):
         super().__init__(
-            map_args=[boundaries, key, descending],
-            reduce_args=[key, descending],
+            map_args=[boundaries, sort_key],
+            reduce_args=[sort_key],
         )
 
     @staticmethod
@@ -58,13 +53,10 @@ class SortTaskSpec(ExchangeTaskSpec):
         block: Block,
         output_num_blocks: int,
         boundaries: List[T],
-        key: SortKeyT,
-        descending: bool,
+        sort_key: SortKey,
     ) -> List[Union[BlockMetadata, Block]]:
         stats = BlockExecStats.builder()
-        out = BlockAccessor.for_block(block).sort_and_partition(
-            boundaries, key, descending
-        )
+        out = BlockAccessor.for_block(block).sort_and_partition(boundaries, sort_key)
         meta = BlockAccessor.for_block(block).get_metadata(
             input_files=None, exec_stats=stats.build()
         )
@@ -72,25 +64,25 @@ class SortTaskSpec(ExchangeTaskSpec):
 
     @staticmethod
     def reduce(
-        key: SortKeyT,
-        descending: bool,
+        sort_key: SortKey,
         *mapper_outputs: List[Block],
         partial_reduce: bool = False,
     ) -> Tuple[Block, BlockMetadata]:
         return BlockAccessor.for_block(mapper_outputs[0]).merge_sorted_blocks(
-            mapper_outputs, key, descending
+            mapper_outputs, sort_key
         )
 
     @staticmethod
     def sample_boundaries(
-        blocks: List[ObjectRef[Block]], key: SortKeyT, num_reducers: int
+        blocks: List[ObjectRef[Block]], sort_key: SortKey, num_reducers: int
     ) -> List[T]:
         """
         Return (num_reducers - 1) items in ascending order from the blocks that
         partition the domain into ranges with approximately equally many elements.
         """
+        columns = sort_key.get_columns()
         # TODO(Clark): Support multiple boundary sampling keys.
-        if isinstance(key, list) and len(key) > 1:
+        if len(columns) > 1:
             raise ValueError("Multiple boundary sampling keys not supported.")
 
         n_samples = int(num_reducers * 10 / len(blocks))
@@ -98,7 +90,7 @@ class SortTaskSpec(ExchangeTaskSpec):
         sample_block = cached_remote_fn(_sample_block)
 
         sample_results = [
-            sample_block.remote(block, n_samples, key) for block in blocks
+            sample_block.remote(block, n_samples, sort_key) for block in blocks
         ]
         sample_bar = ProgressBar(
             SortTaskSpec.SORT_SAMPLE_SUB_PROGRESS_BAR_NAME, len(sample_results)
@@ -114,7 +106,7 @@ class SortTaskSpec(ExchangeTaskSpec):
         for sample in samples:
             builder.add_block(sample)
         samples = builder.build()
-        column = key[0][0] if isinstance(key, list) else None
+        column = columns[0]
         sample_items = BlockAccessor.for_block(samples).to_numpy(column)
         sample_items = np.sort(sample_items)
         ret = [
@@ -124,5 +116,5 @@ class SortTaskSpec(ExchangeTaskSpec):
         return ret[1:]
 
 
-def _sample_block(block: Block, n_samples: int, key: SortKeyT) -> Block:
-    return BlockAccessor.for_block(block).sample(n_samples, key)
+def _sample_block(block: Block, n_samples: int, sort_key: SortKey) -> Block:
+    return BlockAccessor.for_block(block).sample(n_samples, sort_key)

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -33,7 +33,7 @@ def _plan_all_to_all_op(
     elif isinstance(op, Repartition):
         fn = generate_repartition_fn(op._num_outputs, op._shuffle)
     elif isinstance(op, Sort):
-        fn = generate_sort_fn(op._key, op._descending)
+        fn = generate_sort_fn(op._sort_key)
     elif isinstance(op, Aggregate):
         fn = generate_aggregate_fn(op._key, op._aggs)
     else:

--- a/python/ray/data/_internal/planner/sort.py
+++ b/python/ray/data/_internal/planner/sort.py
@@ -12,7 +12,8 @@ from ray.data._internal.planner.exchange.pull_based_shuffle_task_scheduler impor
 from ray.data._internal.planner.exchange.push_based_shuffle_task_scheduler import (
     PushBasedShuffleTaskScheduler,
 )
-from ray.data._internal.planner.exchange.sort_task_spec import SortKeyT, SortTaskSpec
+from ray.data._internal.planner.exchange.sort_task_spec import SortTaskSpec
+from ray.data._internal.sort import SortKey
 from ray.data._internal.stats import StatsDict
 from ray.data._internal.util import unify_block_metadata_schema
 from ray.data.block import _validate_key_fn
@@ -20,14 +21,12 @@ from ray.data.context import DataContext
 
 
 def generate_sort_fn(
-    key: SortKeyT,
-    descending: bool,
+    sort_key: SortKey,
 ) -> AllToAllTransformFn:
     """Generate function to sort blocks by the specified key column or key function."""
 
     def fn(
-        key: SortKeyT,
-        descending: bool,
+        sort_key: SortKey,
         refs: List[RefBundle],
         ctx: TaskContext,
     ) -> Tuple[List[RefBundle], StatsDict]:
@@ -40,22 +39,18 @@ def generate_sort_fn(
         if len(blocks) == 0:
             return (blocks, {})
         unified_schema = unify_block_metadata_schema(metadata)
-        _validate_key_fn(unified_schema, key)
-
-        if isinstance(key, str):
-            key = [(key, "descending" if descending else "ascending")]
-        if isinstance(key, list):
-            descending = key[0][1] == "descending"
+        _validate_key_fn(unified_schema, sort_key.get_columns())
 
         num_mappers = len(blocks)
         # Use same number of output partitions.
         num_outputs = num_mappers
 
         # Sample boundaries for sort key.
-        boundaries = SortTaskSpec.sample_boundaries(blocks, key, num_outputs)
-        if descending:
+        boundaries = SortTaskSpec.sample_boundaries(blocks, sort_key, num_outputs)
+        _, ascending = sort_key.to_pandas_sort_args()
+        if not ascending:
             boundaries.reverse()
-        sort_spec = SortTaskSpec(boundaries=boundaries, key=key, descending=descending)
+        sort_spec = SortTaskSpec(boundaries=boundaries, sort_key=sort_key)
 
         if DataContext.get_current().use_push_based_shuffle:
             scheduler = PushBasedShuffleTaskScheduler(sort_spec)
@@ -67,4 +62,4 @@ def generate_sort_fn(
     # NOTE: use partial function to pass parameters to avoid error like
     # "UnboundLocalError: local variable ... referenced before assignment",
     # because `key` and `descending` variables are reassigned in `fn()`.
-    return partial(fn, key, descending)
+    return partial(fn, sort_key)

--- a/python/ray/data/_internal/planner/sort.py
+++ b/python/ray/data/_internal/planner/sort.py
@@ -16,7 +16,6 @@ from ray.data._internal.planner.exchange.sort_task_spec import SortTaskSpec
 from ray.data._internal.sort import SortKey
 from ray.data._internal.stats import StatsDict
 from ray.data._internal.util import unify_block_metadata_schema
-from ray.data.block import _validate_key_fn
 from ray.data.context import DataContext
 
 
@@ -38,8 +37,7 @@ def generate_sort_fn(
                 metadata.append(block_metadata)
         if len(blocks) == 0:
             return (blocks, {})
-        unified_schema = unify_block_metadata_schema(metadata)
-        _validate_key_fn(unified_schema, sort_key.get_columns())
+        sort_key.validate_schema(unify_block_metadata_schema(metadata))
 
         num_mappers = len(blocks)
         # Use same number of output partitions.

--- a/python/ray/data/_internal/sort.py
+++ b/python/ray/data/_internal/sort.py
@@ -16,7 +16,7 @@ Merging: a merge task would receive a block from every worker that consists
 of items in a certain range. It then merges the sorted blocks into one sorted
 block and becomes part of the new, sorted dataset.
 """
-from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union
+from typing import List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 
@@ -33,10 +33,32 @@ from ray.types import ObjectRef
 
 T = TypeVar("T")
 
-# Data can be sorted by value (None), a list of columns and
-# ascending/descending orders (List), or a custom transform function
-# (Callable).
-SortKeyT = Union[None, List[Tuple[str, str]], Callable[[T], Any]]
+
+class SortKey:
+    """SortKey class to convert between different sort args formats."""
+
+    def __init__(
+        self,
+        key: Optional[Union[str, List[str]]] = None,
+        descending: bool = False,
+    ):
+        if isinstance(key, list) and not key:
+            raise ValueError("`key` must be a list of non-zero length")
+
+        self._columns = [key] if isinstance(key, str) else key
+        self._descending = descending
+
+    def get_columns(self) -> List[str]:
+        return self._columns
+
+    def to_arrow_sort_args(self) -> List[Tuple[str, str]]:
+        return [
+            (key, "descending" if self._descending else "ascending")
+            for key in self._columns
+        ]
+
+    def to_pandas_sort_args(self) -> Tuple[List[str], bool]:
+        return self._columns, not self._descending
 
 
 class _SortOp(ShuffleOp):
@@ -46,13 +68,10 @@ class _SortOp(ShuffleOp):
         block: Block,
         output_num_blocks: int,
         boundaries: List[T],
-        key: SortKeyT,
-        descending: bool,
+        sort_key: SortKey,
     ) -> List[Union[BlockMetadata, Block]]:
         stats = BlockExecStats.builder()
-        out = BlockAccessor.for_block(block).sort_and_partition(
-            boundaries, key, descending
-        )
+        out = BlockAccessor.for_block(block).sort_and_partition(boundaries, sort_key)
         meta = BlockAccessor.for_block(block).get_metadata(
             input_files=None, exec_stats=stats.build()
         )
@@ -60,13 +79,12 @@ class _SortOp(ShuffleOp):
 
     @staticmethod
     def reduce(
-        key: SortKeyT,
-        descending: bool,
+        sort_key: SortKey,
         *mapper_outputs: List[Block],
         partial_reduce: bool = False,
     ) -> (Block, BlockMetadata):
         return BlockAccessor.for_block(mapper_outputs[0]).merge_sorted_blocks(
-            mapper_outputs, key, descending
+            mapper_outputs, sort_key
         )
 
 
@@ -80,7 +98,7 @@ class PushBasedSortOp(_SortOp, PushBasedShufflePlan):
 
 def sample_boundaries(
     blocks: List[ObjectRef[Block]],
-    key: SortKeyT,
+    sort_key: SortKey,
     num_reducers: int,
     ctx: Optional[TaskContext] = None,
 ) -> List[T]:
@@ -88,15 +106,18 @@ def sample_boundaries(
     Return (num_reducers - 1) items in ascending order from the blocks that
     partition the domain into ranges with approximately equally many elements.
     """
+    columns = sort_key.get_columns()
     # TODO(Clark): Support multiple boundary sampling keys.
-    if isinstance(key, list) and len(key) > 1:
+    if len(columns) > 1:
         raise ValueError("Multiple boundary sampling keys not supported.")
 
     n_samples = int(num_reducers * 10 / len(blocks))
 
     sample_block = cached_remote_fn(_sample_block)
 
-    sample_results = [sample_block.remote(block, n_samples, key) for block in blocks]
+    sample_results = [
+        sample_block.remote(block, n_samples, columns) for block in blocks
+    ]
 
     should_close_bar = True
     if ctx is not None and ctx.sub_progress_bar_dict is not None:
@@ -120,7 +141,7 @@ def sample_boundaries(
     for sample in samples:
         builder.add_block(sample)
     samples = builder.build()
-    column = key[0][0] if isinstance(key, list) else None
+    column = sort_key.get_columns()[0]
     sample_items = BlockAccessor.for_block(samples).to_numpy(column)
     sample_items = np.sort(sample_items)
     ret = [
@@ -135,8 +156,7 @@ def sample_boundaries(
 def sort_impl(
     blocks: BlockList,
     clear_input_blocks: bool,
-    key: SortKeyT,
-    descending: bool = False,
+    sort_key: SortKey,
     ctx: Optional[TaskContext] = None,
 ) -> Tuple[BlockList, dict]:
     stage_info = {}
@@ -144,18 +164,13 @@ def sort_impl(
     if len(blocks_list) == 0:
         return BlockList([], []), stage_info
 
-    if isinstance(key, str):
-        key = [(key, "descending" if descending else "ascending")]
-
-    if isinstance(key, list):
-        descending = key[0][1] == "descending"
-
     num_mappers = len(blocks_list)
     # Use same number of output partitions.
     num_reducers = num_mappers
     # TODO(swang): sample_boundaries could be fused with a previous stage.
-    boundaries = sample_boundaries(blocks_list, key, num_reducers, ctx)
-    if descending:
+    boundaries = sample_boundaries(blocks_list, sort_key, num_reducers, ctx)
+    _, ascending = sort_key.to_pandas_sort_args()
+    if not ascending:
         boundaries.reverse()
 
     context = DataContext.get_current()
@@ -163,9 +178,7 @@ def sort_impl(
         sort_op_cls = PushBasedSortOp
     else:
         sort_op_cls = SimpleSortOp
-    sort_op = sort_op_cls(
-        map_args=[boundaries, key, descending], reduce_args=[key, descending]
-    )
+    sort_op = sort_op_cls(map_args=[boundaries, sort_key], reduce_args=[sort_key])
     return sort_op.execute(
         blocks,
         num_reducers,
@@ -173,5 +186,5 @@ def sort_impl(
     )
 
 
-def _sample_block(block: Block, n_samples: int, key: SortKeyT) -> Block:
-    return BlockAccessor.for_block(block).sample(n_samples, key)
+def _sample_block(block: Block, n_samples: int, sort_key: SortKey) -> Block:
+    return BlockAccessor.for_block(block).sample(n_samples, sort_key)

--- a/python/ray/data/_internal/sort.py
+++ b/python/ray/data/_internal/sort.py
@@ -45,15 +45,13 @@ class SortKey:
         key: Optional[Union[str, List[str]]] = None,
         descending: bool = False,
     ):
+        if key is None:
+            key = []
         if isinstance(key, str):
             key = [key]
         if not (isinstance(key, list) and all(isinstance(k, str) for k in key)):
             raise ValueError(
                 f"Key must be a string or a list of strings, but got {key}."
-            )
-        if len(key) > 0:
-            raise NotImplementedError(
-                "Sorting by multiple columns is not supported yet"
             )
         self._columns = key
         self._descending = descending

--- a/python/ray/data/_internal/sort.py
+++ b/python/ray/data/_internal/sort.py
@@ -45,7 +45,7 @@ class SortKey:
         key: Optional[Union[str, List[str]]] = None,
         descending: bool = False,
     ):
-        if isinstance(key， str):
+        if isinstance(key, str):
             key = [key]
         if not (isinstance(key, list) and all(isinstance(k, str) for k in key)):
             raise ValueError(

--- a/python/ray/data/_internal/sort.py
+++ b/python/ray/data/_internal/sort.py
@@ -116,7 +116,7 @@ def sample_boundaries(
     sample_block = cached_remote_fn(_sample_block)
 
     sample_results = [
-        sample_block.remote(block, n_samples, columns) for block in blocks
+        sample_block.remote(block, n_samples, sort_key) for block in blocks
     ]
 
     should_close_bar = True

--- a/python/ray/data/_internal/sort.py
+++ b/python/ray/data/_internal/sort.py
@@ -45,16 +45,17 @@ class SortKey:
         key: Optional[Union[str, List[str]]] = None,
         descending: bool = False,
     ):
-        if callable(key):
-            raise ValueError("`key` must be a column name")
-        elif isinstance(key, list) and not key:
-            raise ValueError("`key` must be a list of non-zero length")
-        elif isinstance(key, list) and len(key) > 1:
+        if isinstance(key， str):
+            key = [key]
+        if not (isinstance(key, list) and all(isinstance(k, str) for k in key)):
+            raise ValueError(
+                f"Key must be a string or a list of strings, but got {key}."
+            )
+        if len(key) > 0:
             raise NotImplementedError(
                 "Sorting by multiple columns is not supported yet"
             )
-
-        self._columns = [key] if isinstance(key, str) else key
+        self._columns = key
         self._descending = descending
 
     def get_columns(self) -> List[str]:

--- a/python/ray/data/_internal/stage_impl.py
+++ b/python/ray/data/_internal/stage_impl.py
@@ -20,7 +20,6 @@ from ray.data.block import (
     BlockExecStats,
     BlockMetadata,
     BlockPartition,
-    _validate_key_fn,
 )
 from ray.data.context import DataContext
 
@@ -327,8 +326,7 @@ class SortStage(AllToAllStage):
                 block_list.clear()
             else:
                 blocks = block_list
-            schema = ds.schema(fetch_if_missing=True)
-            _validate_key_fn(schema, sort_key.get_columns())
+            sort_key.validate_schema(ds.schema(fetch_if_missing=True))
             return sort_impl(blocks, clear_input_blocks, sort_key, ctx)
 
         super().__init__(

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -11,7 +11,7 @@ from ray.data.block import Block, BlockAccessor
 from ray.data.row import TableRow
 
 if TYPE_CHECKING:
-    from ray.data._internal.sort import SortKeyT
+    from ray.data._internal.sort import SortKey
 
 
 T = TypeVar("T")
@@ -221,17 +221,17 @@ class TableBlockAccessor(BlockAccessor):
     def _empty_table() -> Any:
         raise NotImplementedError
 
-    def _sample(self, n_samples: int, key: "SortKeyT") -> Any:
+    def _sample(self, n_samples: int, sort_key: "SortKey") -> Any:
         raise NotImplementedError
 
-    def sample(self, n_samples: int, key: "SortKeyT") -> Any:
-        if key is None or callable(key):
+    def sample(self, n_samples: int, sort_key: "SortKey") -> Any:
+        if sort_key is None or callable(sort_key):
             raise NotImplementedError(
-                f"Table sort key must be a column name, was: {key}"
+                f"Table sort key must be a column name, was: {sort_key}"
             )
         if self.num_rows() == 0:
             # If the pyarrow table is empty we may not have schema
             # so calling table.select() will raise an error.
             return self._empty_table()
         k = min(n_samples, self.num_rows())
-        return self._sample(k, key)
+        return self._sample(k, sort_key)

--- a/python/ray/data/aggregate/_aggregate.py
+++ b/python/ray/data/aggregate/_aggregate.py
@@ -8,15 +8,8 @@ from ray.data._internal.null_aggregate import (
     _null_wrap_init,
     _null_wrap_merge,
 )
-from ray.data.block import (
-    AggType,
-    Block,
-    BlockAccessor,
-    KeyType,
-    T,
-    U,
-    _validate_key_fn,
-)
+from ray.data._internal.sort import SortKey
+from ray.data.block import AggType, Block, BlockAccessor, KeyType, T, U
 from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
@@ -90,7 +83,7 @@ class _AggregateOnKeyBase(AggregateFn):
         self._key_fn = on
 
     def _validate(self, schema: Optional[Union[type, "pa.lib.Schema"]]) -> None:
-        _validate_key_fn(schema, self._key_fn)
+        SortKey(self._key_fn).validate_schema(schema)
 
 
 @PublicAPI

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -51,41 +51,6 @@ KeyType = TypeVar("KeyType")
 AggType = TypeVar("AggType")
 
 
-def _validate_key_fn(
-    schema: Optional[Union[type, "pyarrow.lib.Schema"]],
-    key: Optional[Union[str, List[str]]],
-) -> None:
-    """Check the key function is valid on the given schema."""
-    if schema is None:
-        # Dataset is empty/cleared, validation not possible.
-        return
-    is_simple_format = isinstance(schema, type)
-    if isinstance(key, str):
-        if is_simple_format:
-            raise ValueError(
-                "String key '{}' requires dataset format to be "
-                "'arrow' or 'pandas', was 'simple'.".format(key)
-            )
-        if len(schema.names) > 0 and key not in schema.names:
-            raise ValueError(
-                "The column '{}' does not exist in the "
-                "schema '{}'.".format(key, schema)
-            )
-    elif isinstance(key, list):
-        if isinstance(key, list):
-            if not key:
-                raise ValueError("`key` must be a list of non-zero length")
-        if len(schema.names) > 0:
-            for _key in key:
-                if _key not in schema.names:
-                    raise ValueError(
-                        "The column '{}' does not exist in the "
-                        "schema '{}'.".format(_key, schema)
-                    )
-    else:
-        raise ValueError(f"In Ray 2.5, the key must be a string, was: {key}")
-
-
 # Represents a batch of records to be stored in the Ray object store.
 #
 # Block data can be accessed in a uniform way via ``BlockAccessors`` like`

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -103,7 +103,6 @@ from ray.data.block import (
     UserDefinedFunction,
     _apply_strict_mode_batch_format,
     _apply_strict_mode_batch_size,
-    _validate_key_fn,
 )
 from ray.data.context import (
     ESTIMATED_SAFE_MEMORY_FRACTION,
@@ -1731,8 +1730,7 @@ class Dataset:
 
         # Always allow None since groupby interprets that as grouping all
         # records into a single global group.
-        if key is not None:
-            _validate_key_fn(self.schema(fetch_if_missing=True), key)
+        SortKey(key).validate_schema(self.schema(fetch_if_missing=True))
 
         return GroupedData(self, key)
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1730,7 +1730,8 @@ class Dataset:
 
         # Always allow None since groupby interprets that as grouping all
         # records into a single global group.
-        SortKey(key).validate_schema(self.schema(fetch_if_missing=True))
+        if key is not None:
+            SortKey(key).validate_schema(self.schema(fetch_if_missing=True))
 
         return GroupedData(self, key)
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -73,6 +73,7 @@ from ray.data._internal.planner.map_rows import generate_map_rows_fn
 from ray.data._internal.planner.write import generate_write_fn
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.remote_fn import cached_remote_fn
+from ray.data._internal.sort import SortKey
 from ray.data._internal.split import _get_num_rows, _split_at_indices
 from ray.data._internal.stage_impl import (
     LimitStage,
@@ -2043,14 +2044,14 @@ class Dataset:
             A new, sorted dataset.
         """
 
-        plan = self._plan.with_stage(SortStage(self, key, descending))
+        sort_key = SortKey(key, descending)
+        plan = self._plan.with_stage(SortStage(self, sort_key))
 
         logical_plan = self._logical_plan
         if logical_plan is not None:
             op = Sort(
                 logical_plan.dag,
-                key=key,
-                descending=descending,
+                sort_key=sort_key,
             )
             logical_plan = LogicalPlan(op)
         return Dataset(plan, self._epoch, self._lazy, logical_plan)

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -10,6 +10,7 @@ from ray.data._internal.logical.operators.all_to_all_operator import Aggregate
 from ray.data._internal.plan import AllToAllStage
 from ray.data._internal.push_based_shuffle import PushBasedShufflePlan
 from ray.data._internal.shuffle import ShuffleOp, SimpleShufflePlan
+from ray.data._internal.sort import SortKey
 from ray.data.aggregate import AggregateFn, Count, Max, Mean, Min, Std, Sum
 from ray.data.aggregate._aggregate import _AggregateOnKeyBase
 from ray.data.block import (
@@ -45,8 +46,7 @@ class _GroupbyOp(ShuffleOp):
         else:
             partitions = BlockAccessor.for_block(block).sort_and_partition(
                 boundaries,
-                [(key, "ascending")] if isinstance(key, str) else key,
-                descending=False,
+                SortKey(key),
             )
         parts = [BlockAccessor.for_block(p).combine(key, aggs) for p in partitions]
         meta = BlockAccessor.for_block(block).get_metadata(
@@ -160,9 +160,7 @@ class GroupedData:
             else:
                 boundaries = sort.sample_boundaries(
                     blocks.get_blocks(),
-                    [(self._key, "ascending")]
-                    if isinstance(self._key, str)
-                    else self._key,
+                    SortKey(self._key),
                     num_reducers,
                     task_ctx,
                 )

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -46,6 +46,7 @@ from ray.data._internal.logical.util import (
     _recorded_operators_lock,
 )
 from ray.data._internal.planner.planner import Planner
+from ray.data._internal.sort import SortKey
 from ray.data._internal.stats import DatasetStats
 from ray.data.aggregate import Count
 from ray.data.datasource.datasource import RangeDatasource
@@ -904,8 +905,7 @@ def test_sort_operator(ray_start_regular_shared, enable_optimizer):
     read_op = Read(ParquetDatasource(), [], 0)
     op = Sort(
         read_op,
-        key="col1",
-        descending=False,
+        sort_key=SortKey("col1"),
     )
     plan = LogicalPlan(op)
     physical_op = planner.plan(plan).dag


### PR DESCRIPTION
## Why are these changes needed?

As discussed in #37124 with @raulchen,  sort key definition has been inconsistent across the codebase. This change introduces `SortKey` class to wrap sort key and ordering and encapsulates logic to convert between different sort key arguments e.g. pyarrow-style `[(column, "descending")]` or pandas-style `column, True`.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
