### PR TITLE
[ci][cluster-launcher] Fix GCP multi-cluster terminate nodes race

### DIFF
--- a/python/ray/autoscaler/_private/gcp/node_provider.py
+++ b/python/ray/autoscaler/_private/gcp/node_provider.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 import logging
 import time
 from functools import wraps
@@ -203,16 +202,20 @@ class GCPNodeProvider(NodeProvider):
     @_retry
     def terminate_node(self, node_id: str):
         with self.lock:
-            self._thread_unsafe_terminate_node(node_id)
-
-    def terminate_nodes(self, node_ids: List[str]):
-        if not node_ids:
-            return None
-
-        with self.lock, concurrent.futures.ThreadPoolExecutor() as executor:
-            result = executor.map(self._thread_unsafe_terminate_node, node_ids)
-
-        return list(result)
+            resource = self._get_resource_depending_on_node_name(node_id)
+            try:
+                result = resource.delete_instance(
+                    node_id=node_id,
+                )
+            except googleapiclient.errors.HttpError as http_error:
+                if http_error.resp.status == 404:
+                    logger.warning(
+                        f"Tried to delete the node with id {node_id} "
+                        "but it was already gone."
+                    )
+                else:
+                    raise http_error from None
+            return result
 
     @_retry
     def _get_node(self, node_id: str) -> GCPNode:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -7005,6 +7005,7 @@
   stable: true
 
   env: gce
+  python: "3.8"
   frequency: nightly
   team: core
   cluster:
@@ -7022,6 +7023,7 @@
   stable: true
 
   env: gce
+  python: "3.8"
   frequency: nightly
   team: core
   cluster:
@@ -7039,6 +7041,7 @@
   stable: true
 
   env: gce
+  python: "3.8"
   frequency: nightly
   team: core
   cluster:
@@ -7056,6 +7059,7 @@
   stable: true
 
   env: gce
+  python: "3.8"
   frequency: nightly
   team: core
   cluster:
@@ -7074,6 +7078,7 @@
   stable: true
 
   env: gce
+  python: "3.8"
   frequency: manual
   team: core
   cluster:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
1. We are using 38 docker images specifically for cluster launcher tests. This updates the test runnner to use 3.8 as well (w/o this, test would error at tearing down due to SSH version mismatched) 

2. There was a race condition when terminating multiple nodes in GCP, which is introduced by this PR's optimization https://github.com/ray-project/ray/pull/34455/files , this PR essentially reverts it.
```
Traceback (most recent call last):
  File "/home/ray/anaconda3/bin/ray", line 8, in <module>
    sys.exit(main())
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/scripts/scripts.py", line 2477, in main
    return cli()
  File "/home/ray/anaconda3/lib/python3.8/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ray/anaconda3/lib/python3.8/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/autoscaler/_private/cli_logger.py", line 856, in wrapper
    return f(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/scripts/scripts.py", line 1316, in down
    teardown_cluster(
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/autoscaler/_private/commands.py", line 547, in teardown_cluster
    provider.terminate_nodes(A)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/autoscaler/_private/gcp/node_provider.py", line 215, in terminate_nodes
    return list(result)
  File "/home/ray/anaconda3/lib/python3.8/concurrent/futures/_base.py", line 619, in result_iterator
    yield fs.pop().result()
  File "/home/ray/anaconda3/lib/python3.8/concurrent/futures/_base.py", line 437, in result
    return self.__get_result()
  File "/home/ray/anaconda3/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/home/ray/anaconda3/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/autoscaler/_private/gcp/node_provider.py", line 189, in _thread_unsafe_terminate_node
    result = resource.delete_instance(
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/autoscaler/_private/gcp/node.py", line 540, in delete_instance
    result = self.wait_for_operation(operation)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/autoscaler/_private/gcp/node.py", line 327, in wait_for_operation
    raise Exception(result["error"])
Exception: {'errors': [{'code': 'RESOURCE_NOT_FOUND', 'message': "The resource 'projects/anyscale-bridge-cd812d38/zones/us-west1-a/instances/ray-default-1690304733-head-7c1acb6c-compute' was not found"}]}
```

Apparently, the `resource.delete_instance` would need to be made with independent http objects to ensure thread safety. More info here: https://github.com/googleapis/google-api-python-client/blob/main/docs/thread_safety.md



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/37795

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
