### PR TITLE
[Serve] Raise exception if ASGI app replica lifespan startup fails

### DIFF
--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -400,6 +400,10 @@ class ASGIAppReplicaWrapper:
 
         with LoggingContext(self._serve_asgi_lifespan.logger, level=logging.WARNING):
             await self._serve_asgi_lifespan.startup()
+            if self._serve_asgi_lifespan.should_exit:
+                raise RuntimeError(
+                    "ASGI lifespan startup failed. Check replica logs for details."
+                )
 
     async def __call__(
         self,

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -365,6 +365,23 @@ def test_fastapi_init_lifespan_should_not_shutdown(serve_instance):
     assert ray.get(A.get_handle().f.remote()) == 1
 
 
+def test_fastapi_lifespan_startup_failure_crashes_actor(serve_instance):
+    async def lifespan(app):
+        raise Exception("crash")
+
+        yield
+
+    app = FastAPI(lifespan=lifespan)
+
+    @serve.deployment
+    @serve.ingress(app)
+    class A:
+        pass
+
+    with pytest.raises(RuntimeError):
+        A.deploy()
+
+
 def test_fastapi_duplicate_routes(serve_instance):
     app = FastAPI()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR makes Ray Serve respect the failure of an ASGI application's lifecycle startup: if startup fails, the ASGI replica wrapper will raise an exception, which will prevent the replica from coming up successfully.

See #37575 for more details.

## Related issue number

Closes #37575 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
