### PR TITLE
[data] streaming generator integration

### DIFF
--- a/python/ray/data/_internal/execution/bulk_executor.py
+++ b/python/ray/data/_internal/execution/bulk_executor.py
@@ -98,16 +98,20 @@ def _naive_run_until_complete(op: PhysicalOperator) -> List[RefBundle]:
         The list of output ref bundles for the operator.
     """
     output = []
-    tasks = op.get_work_refs()
+    tasks = op.get_active_tasks()
     if tasks:
         bar = ProgressBar(op.name, total=op.num_outputs_total())
         while tasks:
+            waitable_to_tasks = {task.get_waitable(): task for task in tasks}
             done, _ = ray.wait(
-                tasks, num_returns=len(tasks), fetch_local=True, timeout=0.1
+                list(waitable_to_tasks.keys()),
+                num_returns=len(tasks),
+                fetch_local=True,
+                timeout=0.1,
             )
             for ready in done:
-                op.notify_work_completed(ready)
-            tasks = op.get_work_refs()
+                waitable_to_tasks[ready].on_waitable_ready()
+            tasks = op.get_active_tasks()
             while op.has_next():
                 bar.update(1)
                 output.append(op.get_next())

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -1,13 +1,117 @@
-from typing import Callable, Dict, List, Optional
+from abc import ABC, abstractmethod
+from typing import Callable, Dict, List, Optional, Union
 
 import ray
 from .ref_bundle import RefBundle
+from ray._raylet import StreamingObjectRefGenerator
 from ray.data._internal.execution.interfaces.execution_options import (
     ExecutionOptions,
     ExecutionResources,
 )
 from ray.data._internal.logical.interfaces import Operator
 from ray.data._internal.stats import StatsDict
+
+# TODO(hchen): Ray Core should have a common interface for these two types.
+Waitable = Union[ray.ObjectRef, StreamingObjectRefGenerator]
+
+
+class OpTask(ABC):
+    """Abstract class that represents a task that is created by an PhysicalOperator.
+
+    The task can be either a regular task or an actor task.
+    """
+
+    @abstractmethod
+    def get_waitable(self) -> Waitable:
+        """Return the ObjectRef or StreamingObjectRefGenerator to wait on."""
+        pass
+
+    @abstractmethod
+    def on_waitable_ready(self):
+        """Called when the waitable is ready.
+
+        This method may get called multiple times if the waitable is a
+        streaming generator.
+        """
+        pass
+
+
+class DataOpTask(OpTask):
+    """Represents an OpTask that handles Block data."""
+
+    def __init__(
+        self,
+        streaming_gen: StreamingObjectRefGenerator,
+        output_ready_callback: Callable[[RefBundle], None],
+        task_done_callback: Callable[[], None],
+    ):
+        """
+        Args:
+            streaming_gen: The streaming generator of this task. It should yield blocks.
+            output_ready_callback: The callback to call when a new RefBundle is output
+                from the generator.
+            task_done_callback: The callback to call when the task is done.
+        """
+        # TODO(hchen): Right now, the streaming generator is required to yield a Block
+        # and a BlockMetadata each time. We should unify task submission with an unified
+        # interface. So each individual operator don't need to take care of the
+        # BlockMetadata.
+        self._streaming_gen = streaming_gen
+        self._output_ready_callback = output_ready_callback
+        self._task_done_callback = task_done_callback
+
+    def get_waitable(self) -> StreamingObjectRefGenerator:
+        return self._streaming_gen
+
+    def on_waitable_ready(self):
+        # Handle all the available outputs of the streaming generator.
+        while True:
+            try:
+                block_ref = self._streaming_gen._next_sync(0)
+                if block_ref.is_nil():
+                    # The generator currently doesn't have new output.
+                    # And it's not stopped yet.
+                    return
+            except StopIteration:
+                self._task_done_callback()
+                return
+
+            try:
+                meta = ray.get(next(self._streaming_gen))
+            except StopIteration:
+                # The generator should always yield 2 values (block and metadata)
+                # each time. If we get a StopIteration here, it means an error
+                # happened in the task.
+                # And in this case, the block_ref is the exception object.
+                # TODO(hchen): Ray Core should have a better interface for
+                # detecting and obtaining the exception.
+                ex = ray.get(block_ref)
+                self._task_done_callback()
+                raise ex
+            self._output_ready_callback(
+                RefBundle([(block_ref, meta)], owns_blocks=True)
+            )
+
+
+class MetadataOpTask(OpTask):
+    """Represents an OpTask that only handles metadata, instead of Block data."""
+
+    def __init__(
+        self, object_ref: ray.ObjectRef, task_done_callback: Callable[[], None]
+    ):
+        """
+        Args:
+            object_ref: The ObjectRef of the task.
+            task_done_callback: The callback to call when the task is done.
+        """
+        self._object_ref = object_ref
+        self._task_done_callback = task_done_callback
+
+    def get_waitable(self) -> ray.ObjectRef:
+        return self._object_ref
+
+    def on_waitable_ready(self):
+        self._task_done_callback()
 
 
 class PhysicalOperator(Operator):
@@ -63,7 +167,7 @@ class PhysicalOperator(Operator):
         """
         return (
             self._inputs_complete
-            and len(self.get_work_refs()) == 0
+            and self.num_active_tasks() == 0
             and not self.has_next()
         ) or self._dependents_complete
 
@@ -176,13 +280,16 @@ class PhysicalOperator(Operator):
         """
         raise NotImplementedError
 
-    def get_work_refs(self) -> List[ray.ObjectRef]:
-        """Get a list of object references the executor should wait on.
-
-        When a reference becomes ready, the executor must call
-        `notify_work_completed(ref)` to tell this operator of the state change.
-        """
+    def get_active_tasks(self) -> List[OpTask]:
+        """Get a list of the active tasks of this operator."""
         return []
+
+    def num_active_tasks(self) -> int:
+        """Return the number of active tasks.
+
+        Subclasses can override this as a performance optimization.
+        """
+        return len(self.get_active_tasks())
 
     def throttling_disabled(self) -> bool:
         """Whether to disable resource throttling for this operator.
@@ -193,27 +300,12 @@ class PhysicalOperator(Operator):
         """
         return False
 
-    def num_active_work_refs(self) -> int:
-        """Return the number of active work refs.
-
-        Subclasses can override this as a performance optimization.
-        """
-        return len(self.get_work_refs())
-
     def internal_queue_size(self) -> int:
         """If the operator has an internal input queue, return its size.
 
         This is used to report tasks pending submission to actor pools.
         """
         return 0
-
-    def notify_work_completed(self, work_ref: ray.ObjectRef) -> None:
-        """Executor calls this when the given work is completed and local.
-
-        This must be called as soon as the operator is aware that `work_ref` is
-        ready.
-        """
-        raise NotImplementedError
 
     def shutdown(self) -> None:
         """Abort execution and release all resources used by this operator.

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -1,9 +1,8 @@
 import collections
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 
 import ray
-from ray._raylet import ObjectRefGenerator
 from ray.data._internal.compute import ActorPoolStrategy
 from ray.data._internal.dataset_logger import DatasetLogger
 from ray.data._internal.execution.interfaces import (
@@ -14,11 +13,7 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
     TaskContext,
 )
-from ray.data._internal.execution.operators.map_operator import (
-    MapOperator,
-    _map_task,
-    _TaskState,
-)
+from ray.data._internal.execution.operators.map_operator import MapOperator, _map_task
 from ray.data._internal.execution.util import locality_string
 from ray.data.block import Block, BlockMetadata, _CallableClassProtocol
 from ray.data.context import DataContext
@@ -83,11 +78,6 @@ class ActorPoolMapOperator(MapOperator):
 
         # Create autoscaling policy from compute strategy.
         self._autoscaling_policy = autoscaling_policy
-        # A map from task output futures to task state and the actor on which its
-        # running.
-        self._tasks: Dict[
-            ObjectRef[ObjectRefGenerator], Tuple[_TaskState, ray.actor.ActorHandle]
-        ] = {}
         # A pool of running actors on which we can execute mapper tasks.
         self._actor_pool = _ActorPool(autoscaling_policy._config.max_tasks_in_flight)
         # A queue of bundles awaiting dispatch to actors.
@@ -96,7 +86,6 @@ class ActorPoolMapOperator(MapOperator):
         self._cls = None
         # Whether no more submittable bundles will be added.
         self._inputs_done = False
-        self._next_task_idx = 0
 
     def get_init_fn(self) -> Callable[[], None]:
         return self._init_fn
@@ -143,7 +132,23 @@ class ActorPoolMapOperator(MapOperator):
         assert self._cls is not None
         ctx = DataContext.get_current()
         actor = self._cls.remote(ctx, src_fn_name=self.name, init_fn=self._init_fn)
-        self._actor_pool.add_pending_actor(actor, actor.get_location.remote())
+        res_ref = actor.get_location.remote()
+
+        def _task_done_callback(res_ref):
+            # res_ref is a future for a now-ready actor; move actor from pending to the
+            # active actor pool.
+            has_actor = self._actor_pool.pending_to_running(res_ref)
+            if not has_actor:
+                # Actor has already been killed.
+                return
+            # A new actor has started, we try to dispatch queued tasks.
+            self._dispatch_tasks()
+
+        self._submit_metadata_task(
+            res_ref,
+            lambda: _task_done_callback(res_ref),
+        )
+        self._actor_pool.add_pending_actor(actor, res_ref)
 
     def _add_bundled_input(self, bundle: RefBundle):
         self._bundle_queue.append(bundle)
@@ -170,14 +175,25 @@ class ActorPoolMapOperator(MapOperator):
             # Submit the map task.
             bundle = self._bundle_queue.popleft()
             input_blocks = [block for block, _ in bundle.blocks]
-            ctx = TaskContext(task_idx=self._next_task_idx)
-            ref = actor.submit.options(num_returns="dynamic", name=self.name).remote(
+            ctx = TaskContext(task_idx=self._next_data_task_idx)
+            gen = actor.submit.options(num_returns="streaming", name=self.name).remote(
                 self._transform_fn_ref, ctx, *input_blocks
             )
-            self._next_task_idx += 1
-            task = _TaskState(bundle)
-            self._tasks[ref] = (task, actor)
-            self._handle_task_submitted(task)
+
+            def _task_done_callback(actor_to_return):
+                # Return the actor that was running the task to the pool.
+                self._actor_pool.return_actor(actor_to_return)
+                # Dipsatch more tasks.
+                self._dispatch_tasks()
+
+            # For some reason, if we don't define a new variable `actor_to_return`,
+            # the following lambda won't capture the correct `actor` variable.
+            actor_to_return = actor
+            self._submit_data_task(
+                gen,
+                bundle,
+                lambda: _task_done_callback(actor_to_return),
+            )
 
         # Needed in the bulk execution path for triggering autoscaling. This is a
         # no-op in the streaming execution case.
@@ -211,28 +227,6 @@ class ActorPoolMapOperator(MapOperator):
                 # inactive worker exists. If there are no inactive workers to kill, we
                 # break out of the scale-down loop.
                 break
-
-    def notify_work_completed(
-        self, ref: Union[ObjectRef[ObjectRefGenerator], ray.ObjectRef]
-    ):
-        # This actor pool MapOperator implementation has both task output futures AND
-        # worker started futures to handle here.
-        if ref in self._tasks:
-            # Get task state and set output.
-            task, actor = self._tasks.pop(ref)
-            task.output = self._map_ref_to_ref_bundle(ref)
-            self._handle_task_done(task)
-            # Return the actor that was running the task to the pool.
-            self._actor_pool.return_actor(actor)
-        else:
-            # ref is a future for a now-ready actor; move actor from pending to the
-            # active actor pool.
-            has_actor = self._actor_pool.pending_to_running(ref)
-            if not has_actor:
-                # Actor has already been killed.
-                return
-        # For either a completed task or ready worker, we try to dispatch queued tasks.
-        self._dispatch_tasks()
 
     def all_inputs_done(self):
         # Call base implementation to handle any leftover bundles. This may or may not
@@ -284,15 +278,6 @@ class ActorPoolMapOperator(MapOperator):
                 f"{min_workers} distinct blocks. Consider increasing "
                 "the parallelism when creating the Dataset."
             )
-
-    def get_work_refs(self) -> List[ray.ObjectRef]:
-        # Work references that we wish the executor to wait on includes both task
-        # futures AND worker ready futures.
-        return list(self._tasks.keys()) + self._actor_pool.get_pending_actor_refs()
-
-    def num_active_work_refs(self) -> int:
-        # Active work references only includes running tasks, not pending actor starts.
-        return len(self._tasks)
 
     def progress_str(self) -> str:
         base = f"{self._actor_pool.num_running_actors()} actors"

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -1,11 +1,13 @@
 import copy
 import itertools
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, replace
-from typing import Any, Callable, Dict, Iterator, List, Optional, Union
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import Any, Callable, Deque, Dict, Iterator, List, Optional, Set, Union
 
 import ray
-from ray._raylet import ObjectRefGenerator
+from ray import ObjectRef
+from ray._raylet import StreamingObjectRefGenerator
 from ray.data._internal.compute import (
     ActorPoolStrategy,
     ComputeStrategy,
@@ -19,6 +21,11 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
     TaskContext,
 )
+from ray.data._internal.execution.interfaces.physical_operator import (
+    DataOpTask,
+    MetadataOpTask,
+    OpTask,
+)
 from ray.data._internal.execution.operators.base_physical_operator import (
     OneToOneOperator,
 )
@@ -26,7 +33,6 @@ from ray.data._internal.memory_tracing import trace_allocation
 from ray.data._internal.stats import StatsDict
 from ray.data.block import Block, BlockAccessor, BlockExecStats, BlockMetadata
 from ray.data.context import DataContext
-from ray.types import ObjectRef
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 
@@ -63,7 +69,12 @@ class MapOperator(OneToOneOperator, ABC):
         self._output_queue: _OutputQueue = None
         # Output metadata, added to on get_next().
         self._output_metadata: List[BlockMetadata] = []
-
+        # All active `DataOpTask`s.
+        self._data_tasks: Dict[int, DataOpTask] = {}
+        self._next_data_task_idx = 0
+        # All active `MetadataOpTask`s.
+        self._metadata_tasks: Dict[int, MetadataOpTask] = {}
+        self._next_metadata_task_idx = 0
         super().__init__(name, input_op)
 
     @classmethod
@@ -234,53 +245,72 @@ class MapOperator(OneToOneOperator, ABC):
         """
         raise NotImplementedError
 
-    def _handle_task_submitted(self, task: "_TaskState"):
-        """Handle a newly submitted task, notifying the output queue and updating
-        object store metrics.
-
-        This should be called by subclasses right after a task is submitted.
-
-        Args:
-            task: The task state for the newly submitted task.
-        """
-        # Notify output queue that this task is pending.
-        self._output_queue.notify_pending_task(task)
-
-    @abstractmethod
-    def notify_work_completed(
-        self, ref: Union[ObjectRef[ObjectRefGenerator], ray.ObjectRef]
+    def _submit_data_task(
+        self,
+        gen: StreamingObjectRefGenerator,
+        inputs: RefBundle,
+        task_done_callback: Optional[Callable[[], None]] = None,
     ):
-        """Indicates that a task is done executing OR that a worker is done starting.
+        """Submit a new data-handling task."""
+        # TODO(hchen):
+        # 1. Move this to the base PhyscialOperator class.
+        # 2. This method should only take a block-processing function as input,
+        #    instead of a streaming generator. The logic of submitting ray tasks
+        #    can also be capsulated in the base class.
+        task_index = self._next_data_task_idx
+        self._next_data_task_idx += 1
 
-        This must be implemented by subclasses.
+        def _output_ready_callback(task_index, output: RefBundle):
+            # Since output is streamed, it should only contain one block.
+            assert len(output.blocks) == 1
+            for block_ref, _ in output.blocks:
+                trace_allocation(block_ref, "map_operator_output")
+            # Notify output queue that the task has produced an new output.
+            self._output_queue.notify_task_output_ready(task_index, output)
+            # Update object store metrics.
+            allocated = output.size_bytes()
+            self._metrics.alloc += allocated
+            self._metrics.cur += allocated
+            if self._metrics.cur > self._metrics.peak:
+                self._metrics.peak = self._metrics.cur
 
-        Args:
-            ref: The output ref for the task that's done or the worker that has
-                been started.
-        """
-        raise NotImplementedError
+        def _task_done_callback(task_index, inputs):
+            # We should only destroy the input bundle when the whole task is done.
+            # Otherwise, if the task crashes in the middle, we can't rerun it.
+            inputs.destroy_if_owned()
+            freed = inputs.size_bytes()
+            self._metrics.freed += freed
+            self._metrics.cur -= freed
+            self._data_tasks.pop(task_index)
+            # Notify output queue that this task is complete.
+            self._output_queue.notify_task_completed(task_index)
+            if task_done_callback:
+                task_done_callback()
 
-    def _handle_task_done(self, task: "_TaskState"):
-        """Handle a newly completed task, notifying the output queue, freeing task
-        inputs, and updating object store metrics.
+        self._data_tasks[task_index] = DataOpTask(
+            gen,
+            lambda output: _output_ready_callback(task_index, output),
+            lambda: _task_done_callback(task_index, inputs),
+        )
 
-        This should be called by subclasses right after a task completes.
+    def _submit_metadata_task(
+        self, result_ref: ObjectRef, task_done_callback: Callable[[], None]
+    ):
+        """Submit a new metadata-handling task."""
+        # TODO(hchen): Move this to the base PhyscialOperator class.
+        task_index = self._next_metadata_task_idx
+        self._next_metadata_task_idx += 1
 
-        Args:
-            task: The task state for the newly completed task.
-        """
-        # Notify output queue that this task is complete.
-        self._output_queue.notify_task_completed(task)
-        task.inputs.destroy_if_owned()
-        # Update object store metrics.
-        allocated = task.output.size_bytes()
-        self._metrics.alloc += allocated
-        self._metrics.cur += allocated
-        freed = task.inputs.size_bytes()
-        self._metrics.freed += freed
-        self._metrics.cur -= freed
-        if self._metrics.cur > self._metrics.peak:
-            self._metrics.peak = self._metrics.cur
+        def _task_done_callback():
+            self._metadata_tasks.pop(task_index)
+            task_done_callback()
+
+        self._metadata_tasks[task_index] = MetadataOpTask(
+            result_ref, _task_done_callback
+        )
+
+    def get_active_tasks(self) -> List[OpTask]:
+        return list(self._metadata_tasks.values()) + list(self._data_tasks.values())
 
     def all_inputs_done(self):
         self._block_ref_bundler.done_adding_bundles()
@@ -303,16 +333,6 @@ class MapOperator(OneToOneOperator, ABC):
         return bundle
 
     @abstractmethod
-    def get_work_refs(
-        self,
-    ) -> List[Union[ObjectRef[ObjectRefGenerator], ray.ObjectRef]]:
-        raise NotImplementedError
-
-    @abstractmethod
-    def num_active_work_refs(self) -> int:
-        raise NotImplementedError
-
-    @abstractmethod
     def progress_str(self) -> str:
         raise NotImplementedError
 
@@ -331,9 +351,7 @@ class MapOperator(OneToOneOperator, ABC):
 
     @abstractmethod
     def shutdown(self):
-        # NOTE: This must be implemented by subclasses, and those overriding methods
-        # must call this method.
-        super().shutdown()
+        pass
 
     @abstractmethod
     def current_resource_usage(self) -> ExecutionResources:
@@ -346,35 +364,6 @@ class MapOperator(OneToOneOperator, ABC):
     @abstractmethod
     def incremental_resource_usage(self) -> ExecutionResources:
         raise NotImplementedError
-
-    @staticmethod
-    def _map_ref_to_ref_bundle(ref: ObjectRef[ObjectRefGenerator]) -> RefBundle:
-        """Utility for converting a generator ref to a RefBundle.
-
-        This function blocks on the completion of the underlying generator task via
-        ray.get().
-        """
-        all_refs = list(ray.get(ref))
-        del ref
-        block_refs = all_refs[:-1]
-        block_metas = ray.get(all_refs[-1])
-        assert len(block_metas) == len(block_refs), (block_refs, block_metas)
-        for ref in block_refs:
-            trace_allocation(ref, "map_operator_work_completed")
-        return RefBundle(list(zip(block_refs, block_metas)), owns_blocks=True)
-
-
-@dataclass
-class _TaskState:
-    """Tracks the driver-side state for an MapOperator task.
-
-    Attributes:
-        inputs: The input ref bundle.
-        output: The output ref bundle that is set when the task completes.
-    """
-
-    inputs: RefBundle
-    output: Optional[RefBundle] = None
 
 
 @dataclass
@@ -410,16 +399,14 @@ def _map_task(
         A generator of blocks, followed by the list of BlockMetadata for the blocks
         as the last generator return.
     """
-    output_metadata = []
     stats = BlockExecStats.builder()
     for b_out in fn(iter(blocks), ctx):
         # TODO(Clark): Add input file propagation from input blocks.
         m_out = BlockAccessor.for_block(b_out).get_metadata([], None)
         m_out.exec_stats = stats.build()
-        output_metadata.append(m_out)
         yield b_out
+        yield m_out
         stats = BlockExecStats.builder()
-    yield output_metadata
 
 
 class _BlockRefBundler:
@@ -512,57 +499,65 @@ def _merge_ref_bundles(*bundles: RefBundle) -> RefBundle:
     return RefBundle(blocks, owns_blocks)
 
 
-class _OutputQueue:
+class _OutputQueue(ABC):
     """Interface for swapping between different output order modes."""
 
-    def notify_pending_task(self, task: _TaskState):
-        """Called when a new task becomes pending."""
+    @abstractmethod
+    def notify_task_output_ready(self, task_index: int, output: RefBundle):
+        """Called when a task's output is ready."""
         pass
 
-    def notify_task_completed(self, task: _TaskState):
+    def notify_task_completed(self, task_index: int):
         """Called when a previously pending task completes."""
         pass
 
+    @abstractmethod
     def has_next(self) -> bool:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def get_next(self) -> RefBundle:
-        raise NotImplementedError
+        pass
 
 
 class _OrderedOutputQueue(_OutputQueue):
     """An queue that returns finished tasks in submission order."""
 
     def __init__(self):
-        self._tasks_by_output_order: Dict[int, _TaskState] = {}
-        self._next_task_index: int = 0
-        self._next_output_index: int = 0
+        self._task_outputs: Dict[int, Deque[RefBundle]] = defaultdict(lambda: deque())
+        self._current_output_index: int = 0
+        self._completed_tasks: Set[int] = set()
 
-    def notify_pending_task(self, task: _TaskState):
-        self._tasks_by_output_order[self._next_task_index] = task
-        self._next_task_index += 1
+    def notify_task_output_ready(self, task_index: int, output: RefBundle):
+        self._task_outputs[task_index].append(output)
+
+    def _move_to_next_task(self):
+        """Move the outut index to the next task.
+
+        This method should only be called when the current task is complete and all
+        outputs have been taken.
+        """
+        assert len(self._task_outputs[self._current_output_index]) == 0
+        assert self._current_output_index in self._completed_tasks
+        del self._task_outputs[self._current_output_index]
+        self._completed_tasks.remove(self._current_output_index)
+        self._current_output_index += 1
+
+    def notify_task_completed(self, task_index: int):
+        assert task_index >= self._current_output_index
+        self._completed_tasks.add(task_index)
+        if task_index == self._current_output_index:
+            if len(self._task_outputs[task_index]) == 0:
+                self._move_to_next_task()
 
     def has_next(self) -> bool:
-        i = self._next_output_index
-        return (
-            i in self._tasks_by_output_order
-            and self._tasks_by_output_order[i].output is not None
-        )
+        return len(self._task_outputs[self._current_output_index]) > 0
 
     def get_next(self) -> RefBundle:
-        # Get the output RefBundle for the current task.
-        out_bundle = self._tasks_by_output_order[self._next_output_index].output
-        # Pop out the next single-block bundle.
-        next_bundle = RefBundle(
-            [out_bundle.blocks[0]], owns_blocks=out_bundle.owns_blocks
-        )
-        out_bundle = replace(out_bundle, blocks=out_bundle.blocks[1:])
-        if not out_bundle.blocks:
-            # If this task's RefBundle is exhausted, move to the next one.
-            del self._tasks_by_output_order[self._next_output_index]
-            self._next_output_index += 1
-        else:
-            self._tasks_by_output_order[self._next_output_index].output = out_bundle
+        next_bundle = self._task_outputs[self._current_output_index].popleft()
+        if len(self._task_outputs[self._current_output_index]) == 0:
+            if self._current_output_index in self._completed_tasks:
+                self._move_to_next_task()
         return next_bundle
 
 
@@ -570,28 +565,16 @@ class _UnorderedOutputQueue(_OutputQueue):
     """An queue that does not guarantee output order of finished tasks."""
 
     def __init__(self):
-        self._completed_tasks: List[_TaskState] = []
+        self._queue: Deque[RefBundle] = deque()
 
-    def notify_task_completed(self, task: _TaskState):
-        self._completed_tasks.append(task)
+    def notify_task_output_ready(self, _: int, output: RefBundle):
+        self._queue.append(output)
 
     def has_next(self) -> bool:
-        return len(self._completed_tasks) > 0
+        return len(self._queue) > 0
 
     def get_next(self) -> RefBundle:
-        # Get the output RefBundle for the oldest completed task.
-        out_bundle = self._completed_tasks[0].output
-        # Pop out the next single-block bundle.
-        next_bundle = RefBundle(
-            [out_bundle.blocks[0]], owns_blocks=out_bundle.owns_blocks
-        )
-        out_bundle = replace(out_bundle, blocks=out_bundle.blocks[1:])
-        if not out_bundle.blocks:
-            # If this task's RefBundle is exhausted, move to the next one.
-            del self._completed_tasks[0]
-        else:
-            self._completed_tasks[0].output = out_bundle
-        return next_bundle
+        return self._queue.popleft()
 
 
 def _canonicalize_ray_remote_args(ray_remote_args: Dict[str, Any]) -> Dict[str, Any]:

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -1,21 +1,15 @@
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, Optional
 
 import ray
-from ray._raylet import ObjectRefGenerator
 from ray.data._internal.execution.interfaces import (
     ExecutionResources,
     PhysicalOperator,
     RefBundle,
     TaskContext,
 )
-from ray.data._internal.execution.operators.map_operator import (
-    MapOperator,
-    _map_task,
-    _TaskState,
-)
+from ray.data._internal.execution.operators.map_operator import MapOperator, _map_task
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data.block import Block
-from ray.types import ObjectRef
 
 
 class TaskPoolMapOperator(MapOperator):
@@ -44,36 +38,25 @@ class TaskPoolMapOperator(MapOperator):
         super().__init__(
             transform_fn, input_op, name, min_rows_per_bundle, ray_remote_args
         )
-        self._tasks: Dict[ObjectRef[ObjectRefGenerator], _TaskState] = {}
-        self._next_task_idx = 0
 
     def _add_bundled_input(self, bundle: RefBundle):
         # Submit the task as a normal Ray task.
-        map_task = cached_remote_fn(_map_task, num_returns="dynamic")
+        map_task = cached_remote_fn(_map_task, num_returns="streaming")
         input_blocks = [block for block, _ in bundle.blocks]
-        ctx = TaskContext(task_idx=self._next_task_idx)
-        ref = map_task.options(
+        ctx = TaskContext(task_idx=self._next_data_task_idx)
+        gen = map_task.options(
             **self._get_runtime_ray_remote_args(input_bundle=bundle), name=self.name
         ).remote(self._transform_fn_ref, ctx, *input_blocks)
-        self._next_task_idx += 1
-        task = _TaskState(bundle)
-        self._tasks[ref] = task
-        self._handle_task_submitted(task)
-
-    def notify_work_completed(self, ref: ObjectRef[ObjectRefGenerator]):
-        task: _TaskState = self._tasks.pop(ref)
-        task.output = self._map_ref_to_ref_bundle(ref)
-        self._handle_task_done(task)
+        self._submit_data_task(gen, bundle)
 
     def shutdown(self):
-        task_refs = self.get_work_refs()
         # Cancel all active tasks.
-        for task in task_refs:
-            ray.cancel(task)
+        for _, task in self._data_tasks.items():
+            ray.cancel(task.get_waitable())
         # Wait until all tasks have failed or been cancelled.
-        for task in task_refs:
+        for _, task in self._data_tasks.items():
             try:
-                ray.get(task)
+                ray.get(task.get_waitable())
             except ray.exceptions.RayError:
                 # Cancellation either succeeded, or the task had already failed with
                 # a different error, or cancellation failed. In all cases, we
@@ -84,17 +67,11 @@ class TaskPoolMapOperator(MapOperator):
     def progress_str(self) -> str:
         return ""
 
-    def get_work_refs(self) -> List[ray.ObjectRef]:
-        return list(self._tasks.keys())
-
-    def num_active_work_refs(self) -> int:
-        return len(self.get_work_refs())
-
     def base_resource_usage(self) -> ExecutionResources:
         return ExecutionResources()
 
     def current_resource_usage(self) -> ExecutionResources:
-        num_active_workers = self.num_active_work_refs()
+        num_active_workers = self.num_active_tasks()
         return ExecutionResources(
             cpu=self._ray_remote_args.get("num_cpus", 0) * num_active_workers,
             gpu=self._ray_remote_args.get("num_gpus", 0) * num_active_workers,

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -35,6 +35,7 @@ from ray.data._internal.execution.operators.task_pool_map_operator import (
 from ray.data._internal.execution.operators.union_operator import UnionOperator
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data.block import Block
+from ray.data.tests.util import run_one_op_task, run_op_tasks_sync
 from ray.tests.conftest import *  # noqa
 
 
@@ -147,16 +148,16 @@ def test_map_operator_bulk(ray_start_regular_shared, use_actors):
         else:
             assert op.internal_queue_size() == 0
     op.all_inputs_done()
-    work_refs = op.get_work_refs()
-    while work_refs:
-        for work_ref in work_refs:
-            ray.get(work_ref)
-            op.notify_work_completed(work_ref)
-        work_refs = op.get_work_refs()
-        if use_actors and work_refs:
+
+    tasks = op.get_active_tasks()
+    while tasks:
+        run_op_tasks_sync(op, only_existing=True)
+        tasks = op.get_active_tasks()
+        if use_actors and tasks:
             # After actor is ready (first work ref resolved), actor will remain ready
             # while there is work to do.
             assert op.progress_str() == "1 actors [locality off]"
+
     assert op.internal_queue_size() == 0
     if use_actors:
         # After all work is done, actor will have been killed to free up resources..
@@ -179,7 +180,7 @@ def test_map_operator_bulk(ray_start_regular_shared, use_actors):
     # Check memory stats.
     metrics = op.get_metrics()
     assert metrics["obj_store_mem_alloc"] == pytest.approx(832200, 0.5), metrics
-    assert metrics["obj_store_mem_peak"] == pytest.approx(832200, 0.5), metrics
+    assert metrics["obj_store_mem_peak"] == pytest.approx(1688000, 0.5), metrics
     assert metrics["obj_store_mem_freed"] == pytest.approx(832200, 0.5), metrics
 
 
@@ -203,9 +204,7 @@ def test_map_operator_streamed(ray_start_regular_shared, use_actors):
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
         while not op.has_next():
-            work_refs = op.get_work_refs()
-            ready, _ = ray.wait(work_refs, num_returns=1, fetch_local=False)
-            op.notify_work_completed(ready[0])
+            run_one_op_task(op)
         while op.has_next():
             ref = op.get_next()
             assert ref.owns_blocks, ref
@@ -215,7 +214,7 @@ def test_map_operator_streamed(ray_start_regular_shared, use_actors):
     assert np.array_equal(output, [[np.ones(1024) * i * 2] for i in range(100)])
     metrics = op.get_metrics()
     assert metrics["obj_store_mem_alloc"] == pytest.approx(832200, 0.5), metrics
-    assert metrics["obj_store_mem_peak"] == pytest.approx(8320, 0.5), metrics
+    assert metrics["obj_store_mem_peak"] == pytest.approx(16880, 0.5), metrics
     assert metrics["obj_store_mem_freed"] == pytest.approx(832200, 0.5), metrics
     if use_actors:
         assert "locality_hits" in metrics, metrics
@@ -366,9 +365,7 @@ def test_map_operator_actor_locality_stats(ray_start_regular_shared):
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
         while not op.has_next():
-            work_refs = op.get_work_refs()
-            ready, _ = ray.wait(work_refs, num_returns=1, fetch_local=False)
-            op.notify_work_completed(ready[0])
+            run_one_op_task(op)
         while op.has_next():
             ref = op.get_next()
             assert ref.owns_blocks, ref
@@ -378,7 +375,7 @@ def test_map_operator_actor_locality_stats(ray_start_regular_shared):
     assert np.array_equal(output, [[np.ones(100) * i * 2] for i in range(100)])
     metrics = op.get_metrics()
     assert metrics["obj_store_mem_alloc"] == pytest.approx(92900, 0.5), metrics
-    assert metrics["obj_store_mem_peak"] == pytest.approx(929, 0.5), metrics
+    assert metrics["obj_store_mem_peak"] == pytest.approx(2096, 0.5), metrics
     assert metrics["obj_store_mem_freed"] == pytest.approx(92900, 0.5), metrics
     # Check e2e locality manager working.
     assert metrics["locality_hits"] == 100, metrics
@@ -392,6 +389,8 @@ def test_map_operator_min_rows_per_bundle(ray_start_regular_shared, use_actors):
     def _check_batch(block_iter: Iterable[Block], ctx) -> Iterable[Block]:
         block_iter = list(block_iter)
         assert len(block_iter) == 5, block_iter
+        data = [block["id"][0] for block in block_iter]
+        assert data == list(range(5)) or data == list(range(5, 10)), data
         for block in block_iter:
             yield block
 
@@ -411,15 +410,9 @@ def test_map_operator_min_rows_per_bundle(ray_start_regular_shared, use_actors):
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
     op.all_inputs_done()
-    work_refs = op.get_work_refs()
-    while work_refs:
-        for work_ref in work_refs:
-            ray.get(work_ref)
-            op.notify_work_completed(work_ref)
-        work_refs = op.get_work_refs()
+    run_op_tasks_sync(op)
 
-    # Check we return transformed bundles in order.
-    assert _take_outputs(op) == [[i] for i in range(10)]
+    _take_outputs(op)
     assert op.completed()
 
 
@@ -456,12 +449,7 @@ def test_map_operator_output_unbundling(
     for input_ in inputs:
         op.add_input(input_, 0)
     op.all_inputs_done()
-    work_refs = op.get_work_refs()
-    while work_refs:
-        for work_ref in work_refs:
-            ray.get(work_ref)
-            op.notify_work_completed(work_ref)
-        work_refs = op.get_work_refs()
+    run_op_tasks_sync(op)
 
     # Check that bundles are unbundled in the output queue.
     outputs = []
@@ -491,12 +479,7 @@ def test_map_operator_ray_args(shutdown_only, use_actors):
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
     op.all_inputs_done()
-    work_refs = op.get_work_refs()
-    while work_refs:
-        for work_ref in work_refs:
-            ray.get(work_ref)
-            op.notify_work_completed(work_ref)
-        work_refs = op.get_work_refs()
+    run_op_tasks_sync(op)
 
     # Check we don't hang and complete with num_gpus=1.
     assert _take_outputs(op) == [[i * 2] for i in range(10)]
@@ -525,7 +508,7 @@ def test_map_operator_shutdown(shutdown_only, use_actors):
     # Start one task and then cancel.
     op.start(ExecutionOptions())
     op.add_input(input_op.get_next(), 0)
-    assert len(op.get_work_refs()) == 1
+    assert op.num_active_tasks() == 1
     op.shutdown()
 
     # Tasks/actors should be cancelled/killed.
@@ -579,8 +562,7 @@ def test_actor_pool_map_operator_should_add_input(ray_start_regular_shared):
 
     # Cannot add input until actor has started.
     assert not op.should_add_input()
-    for ref in op.get_work_refs():
-        op.notify_work_completed(ref)
+    run_op_tasks_sync(op)
     assert op.should_add_input()
 
     # Can accept up to four inputs per actor by default.

--- a/python/ray/data/tests/util.py
+++ b/python/ray/data/tests/util.py
@@ -4,6 +4,7 @@ import tempfile
 from contextlib import contextmanager
 
 import ray
+from ray.data._internal.execution.interfaces.physical_operator import PhysicalOperator
 
 
 @ray.remote
@@ -57,3 +58,33 @@ def named_values(col_names, tuples):
 
 def extract_values(col_name, tuples):
     return [t[col_name] for t in tuples]
+
+
+def run_op_tasks_sync(op: PhysicalOperator, only_existing=False):
+    """Run tasks of a PhysicalOperator synchronously.
+
+    By default, this function will run until the op no longer has any active tasks.
+    If only_existing is True, this function will only run the currently existing tasks.
+    """
+    tasks = op.get_active_tasks()
+    while tasks:
+        ray.wait(
+            [task.get_waitable() for task in tasks],
+            num_returns=len(tasks),
+            fetch_local=False,
+        )
+        for task in tasks:
+            task.on_waitable_ready()
+        if only_existing:
+            return
+        tasks = op.get_active_tasks()
+
+
+def run_one_op_task(op):
+    """Run one task of a PhysicalOperator."""
+    tasks = op.get_active_tasks()
+    waitable_to_tasks = {task.get_waitable(): task for task in tasks}
+    ready, _ = ray.wait(
+        list(waitable_to_tasks.keys()), num_returns=1, fetch_local=False
+    )
+    waitable_to_tasks[ready[0]].on_waitable_ready()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR changes the MapOperator to use streaming generators, and move common code about task management from `TaskPoolMapOperator` and `ActorPoolMapOperator` to the base `MapOperator` class. 

Note, ideally all operators should use streaming generators. But that requires a larger refactor, which will be done in follow-up PRs (see #37630).

## Related issue number

<!-- For example: "Closes #1234" -->
#36444 
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
