### PR TITLE
[CI] Enable doctest ratchet for Core and Train

### DIFF
--- a/semgrep.yml
+++ b/semgrep.yml
@@ -2,8 +2,25 @@ rules:
   - id: code-block-python
     paths:
       include:
+        # Ray Data
         - "python/ray/data/**/*.py"
         - "doc/source/data/**/*.rst"
+        # Ray Core
+        - "python/ray/util/**/*.py"
+        - "python/ray/_private/**/*.py"
+        - "python/ray/core/**/*.py"
+        - "doc/source/ray-core/**/*.rst"
+        - "doc/source/ray-overview/**/*.rst"
+        - "doc/source/ray-observability/**/*.rst"
+        # Ray Train
+        - "python/ray/train/**/*.py"
+        - "doc/source/train/**/*.rst"
+      exclude:
+        # FIXME(@matthewdeng): We're ignoring the examples for now since they'll likely
+        # get re-written.
+        - "doc/source/train/examples/pytorch/torch_data_prefetch_benchmark/benchmark_example.rst"
+        - "doc/source/train/dl_guide.rst"
+
     languages:
       - generic
     message: > 

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -2,9 +2,6 @@ rules:
   - id: code-block-python
     paths:
       include:
-        # Ray Data
-        - "python/ray/data/**/*.py"
-        - "doc/source/data/**/*.rst"
         # Ray Core
         - "python/ray/util/**/*.py"
         - "python/ray/_private/**/*.py"
@@ -12,6 +9,9 @@ rules:
         - "doc/source/ray-core/**/*.rst"
         - "doc/source/ray-overview/**/*.rst"
         - "doc/source/ray-observability/**/*.rst"
+        # Ray Data
+        - "python/ray/data/**/*.py"
+        - "doc/source/data/**/*.rst"
         # Ray Train
         - "python/ray/train/**/*.py"
         - "doc/source/train/**/*.rst"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR enables a ratchet on Core and Train so that developers don't add examples with `code-block: python` (which isn't tested).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
