### PR TITLE
[data] Fix off-by-one bug in push-based shuffle when computing reduce task args

### DIFF
--- a/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
@@ -30,6 +30,11 @@ class _MergeTaskSchedule:
         self.merge_partition_size = output_num_blocks // num_merge_tasks_per_round
         self._partitions_with_extra_task = output_num_blocks % num_merge_tasks_per_round
 
+        if self.merge_partition_size == 0:
+            self.num_merge_tasks_per_round = self._partitions_with_extra_task
+            self.merge_partition_size = 1
+            self._partitions_with_extra_task = 0
+
     def get_num_reducers_per_merge_idx(self, merge_idx: int) -> int:
         """
         Each intermediate merge task will produce outputs for a partition of P
@@ -102,7 +107,6 @@ class _PushBasedShuffleStage:
     ):
         self.num_rounds = num_rounds
         self.num_map_tasks_per_round = num_map_tasks_per_round
-        self.num_merge_tasks_per_round = len(merge_task_placement)
 
         node_strategies = {
             node_id: {
@@ -117,7 +121,7 @@ class _PushBasedShuffleStage:
         ]
 
         self.merge_schedule = _MergeTaskSchedule(
-            output_num_blocks, self.num_merge_tasks_per_round
+            output_num_blocks, len(merge_task_placement)
         )
 
     def get_merge_task_options(self, merge_idx):
@@ -237,7 +241,7 @@ class _MergeStageIterator:
         # (ObjectRefs). Each merge task index corresponds to a partition of P
         # final reduce tasks.
         self._all_merge_results = [
-            [] for _ in range(self._stage.num_merge_tasks_per_round)
+            [] for _ in range(self._stage.merge_schedule.num_merge_tasks_per_round)
         ]
 
     def __next__(self):
@@ -265,7 +269,7 @@ class _MergeStageIterator:
         del merge_result
 
         self._merge_idx += 1
-        self._merge_idx %= self._stage.num_merge_tasks_per_round
+        self._merge_idx %= self._stage.merge_schedule.num_merge_tasks_per_round
         return metadata_ref
 
     def pop_merge_results(self) -> List[List[ObjectRef]]:
@@ -426,7 +430,7 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
         shuffle_map = cached_remote_fn(map_partition)
         shuffle_map = shuffle_map.options(
             **map_ray_remote_args,
-            num_returns=1 + stage.num_merge_tasks_per_round,
+            num_returns=1 + stage.merge_schedule.num_merge_tasks_per_round,
         )
 
         map_stage_iter = _MapStageIterator(
@@ -448,9 +452,10 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
             map_stage_iter, shuffle_merge, stage, self._exchange_spec._reduce_args
         )
         merge_stage_executor = _PipelinedStageExecutor(
-            merge_stage_iter, stage.num_merge_tasks_per_round, max_concurrent_rounds=2
+            merge_stage_iter,
+            stage.merge_schedule.num_merge_tasks_per_round,
+            max_concurrent_rounds=2,
         )
-
         # Execute the map-merge stage. This submits tasks in rounds of M map
         # tasks and N merge tasks each. Task execution between map and merge is
         # pipelined, so that while executing merge for one round of inputs, we

--- a/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
@@ -43,7 +43,10 @@ class _MergeTaskSchedule:
         return partition_size
 
     def get_merge_idx_for_reducer_idx(self, reducer_idx: int) -> int:
-        if reducer_idx < self.merge_partition_size * self._partitions_with_extra_task:
+        if (
+            reducer_idx
+            < (self.merge_partition_size + 1) * self._partitions_with_extra_task
+        ):
             merge_idx = reducer_idx // (self.merge_partition_size + 1)
         else:
             reducer_idx -= (

--- a/python/ray/data/_internal/push_based_shuffle.py
+++ b/python/ray/data/_internal/push_based_shuffle.py
@@ -27,6 +27,11 @@ class _MergeTaskSchedule:
         self.merge_partition_size = output_num_blocks // num_merge_tasks_per_round
         self._partitions_with_extra_task = output_num_blocks % num_merge_tasks_per_round
 
+        if self.merge_partition_size == 0:
+            self.num_merge_tasks_per_round = self._partitions_with_extra_task
+            self.merge_partition_size = 1
+            self._partitions_with_extra_task = 0
+
     def get_num_reducers_per_merge_idx(self, merge_idx: int) -> int:
         """
         Each intermediate merge task will produce outputs for a partition of P
@@ -99,7 +104,6 @@ class _PushBasedShuffleStage:
     ):
         self.num_rounds = num_rounds
         self.num_map_tasks_per_round = num_map_tasks_per_round
-        self.num_merge_tasks_per_round = len(merge_task_placement)
 
         node_strategies = {
             node_id: {
@@ -114,7 +118,7 @@ class _PushBasedShuffleStage:
         ]
 
         self.merge_schedule = _MergeTaskSchedule(
-            output_num_blocks, self.num_merge_tasks_per_round
+            output_num_blocks, len(merge_task_placement)
         )
 
     def get_merge_task_options(self, merge_idx):
@@ -234,7 +238,7 @@ class _MergeStageIterator:
         # (ObjectRefs). Each merge task index corresponds to a partition of P
         # final reduce tasks.
         self._all_merge_results = [
-            [] for _ in range(self._stage.num_merge_tasks_per_round)
+            [] for _ in range(self._stage.merge_schedule.num_merge_tasks_per_round)
         ]
 
     def __next__(self):
@@ -262,7 +266,7 @@ class _MergeStageIterator:
         del merge_result
 
         self._merge_idx += 1
-        self._merge_idx %= self._stage.num_merge_tasks_per_round
+        self._merge_idx %= self._stage.merge_schedule.num_merge_tasks_per_round
         return metadata_ref
 
     def pop_merge_results(self) -> List[List[ObjectRef]]:
@@ -423,7 +427,7 @@ class PushBasedShufflePlan(ShuffleOp):
         shuffle_map = cached_remote_fn(map_partition)
         shuffle_map = shuffle_map.options(
             **map_ray_remote_args,
-            num_returns=1 + stage.num_merge_tasks_per_round,
+            num_returns=1 + stage.merge_schedule.num_merge_tasks_per_round,
         )
 
         map_stage_iter = _MapStageIterator(
@@ -444,7 +448,9 @@ class PushBasedShufflePlan(ShuffleOp):
             )
 
         map_stage_executor = _PipelinedStageExecutor(
-            map_stage_iter, stage.num_map_tasks_per_round, progress_bar=map_bar
+            map_stage_iter,
+            stage.merge_schedule.num_map_tasks_per_round,
+            progress_bar=map_bar,
         )
 
         shuffle_merge = cached_remote_fn(merge)
@@ -452,7 +458,9 @@ class PushBasedShufflePlan(ShuffleOp):
             map_stage_iter, shuffle_merge, stage, self._reduce_args
         )
         merge_stage_executor = _PipelinedStageExecutor(
-            merge_stage_iter, stage.num_merge_tasks_per_round, max_concurrent_rounds=2
+            merge_stage_iter,
+            stage.merge_schedule.num_merge_tasks_per_round,
+            max_concurrent_rounds=2,
         )
 
         # Execute the map-merge stage. This submits tasks in rounds of M map

--- a/python/ray/data/_internal/push_based_shuffle.py
+++ b/python/ray/data/_internal/push_based_shuffle.py
@@ -40,7 +40,10 @@ class _MergeTaskSchedule:
         return partition_size
 
     def get_merge_idx_for_reducer_idx(self, reducer_idx: int) -> int:
-        if reducer_idx < self.merge_partition_size * self._partitions_with_extra_task:
+        if (
+            reducer_idx
+            < (self.merge_partition_size + 1) * self._partitions_with_extra_task
+        ):
             merge_idx = reducer_idx // (self.merge_partition_size + 1)
         else:
             reducer_idx -= (

--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -220,6 +220,18 @@ def test_sort_pandas_with_empty_blocks(ray_start_regular, use_push_based_shuffle
     assert ds.sort("id").count() == 0
 
 
+def test_sort_with_one_block(shutdown_only, use_push_based_shuffle):
+    ray.init(num_cpus=128)
+    ctx = ray.data.DataContext.get_current()
+    ctx.execution_options.verbose_progress = True
+    ctx.use_push_based_shuffle = True
+
+    # Use a dataset that will produce only one block to sort.
+    ray.data.range(1024).map_batches(
+        lambda _: pa.table([pa.array([1])], ["token_counts"])
+    ).sum("token_counts")
+
+
 @pytest.mark.parametrize("streaming", [False, True])
 def test_push_based_shuffle_schedule(streaming):
     def _test(num_input_blocks, merge_factor, num_cpus_per_node_map):

--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -221,7 +221,7 @@ def test_sort_pandas_with_empty_blocks(ray_start_regular, use_push_based_shuffle
 
 
 def test_sort_with_one_block(shutdown_only, use_push_based_shuffle):
-    ray.init(num_cpus=128)
+    ray.init(num_cpus=8)
     ctx = ray.data.DataContext.get_current()
     ctx.execution_options.verbose_progress = True
     ctx.use_push_based_shuffle = True


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes two bugs in push-based shuffle:
1. The push-based shuffle scheduler tries to assign merge task outputs to reduce tasks as evenly as possible. This PR fixes an off-by-one bug that could appear if the number of merge tasks does not divide evenly into the number of reduce tasks.
2. If there are fewer blocks in the dataset than the number of CPUs available, make sure that all scheduled tasks produce at least one output.

## Related issue number

Closes #37754.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/