### PR TITLE
[Core][Label scheduling 4/n] Refactor the hash of node label scheduling strategy

### DIFF
--- a/src/ray/common/test/task_spec_test.cc
+++ b/src/ray/common/test/task_spec_test.cc
@@ -145,6 +145,57 @@ TEST(TaskSpecTest, TestTaskSpecification) {
   ASSERT_TRUE(task_spec.GetNodeAffinitySchedulingStrategySoft());
   ASSERT_TRUE(task_spec.GetNodeAffinitySchedulingStrategyNodeId() == node_id);
 }
+
+TEST(TaskSpecTest, TestNodeLabelSchedulingStrategy) {
+  rpc::SchedulingStrategy scheduling_strategy_1;
+  auto expr_1 = scheduling_strategy_1.mutable_node_label_scheduling_strategy()
+                    ->mutable_hard()
+                    ->add_expressions();
+  expr_1->set_key("key");
+  expr_1->mutable_operator_()->mutable_label_in()->add_values("value1");
+
+  rpc::SchedulingStrategy scheduling_strategy_2;
+  auto expr_2 = scheduling_strategy_2.mutable_node_label_scheduling_strategy()
+                    ->mutable_hard()
+                    ->add_expressions();
+  expr_2->set_key("key");
+  expr_2->mutable_operator_()->mutable_label_in()->add_values("value1");
+
+  ASSERT_TRUE(std::hash<rpc::SchedulingStrategy>()(scheduling_strategy_1) ==
+              std::hash<rpc::SchedulingStrategy>()(scheduling_strategy_1));
+  ASSERT_TRUE(std::hash<rpc::SchedulingStrategy>()(scheduling_strategy_1) ==
+              std::hash<rpc::SchedulingStrategy>()(scheduling_strategy_2));
+
+  rpc::SchedulingStrategy scheduling_strategy_3;
+  auto expr_3 = scheduling_strategy_3.mutable_node_label_scheduling_strategy()
+                    ->mutable_soft()
+                    ->add_expressions();
+  expr_3->set_key("key");
+  expr_3->mutable_operator_()->mutable_label_in()->add_values("value1");
+  ASSERT_FALSE(std::hash<rpc::SchedulingStrategy>()(scheduling_strategy_1) ==
+               std::hash<rpc::SchedulingStrategy>()(scheduling_strategy_3));
+
+  rpc::SchedulingStrategy scheduling_strategy_4;
+  auto expr_4 = scheduling_strategy_4.mutable_node_label_scheduling_strategy()
+                    ->mutable_hard()
+                    ->add_expressions();
+  expr_4->set_key("key");
+  expr_4->mutable_operator_()->mutable_label_in()->add_values("value1");
+  expr_4->mutable_operator_()->mutable_label_in()->add_values("value2");
+
+  ASSERT_FALSE(std::hash<rpc::SchedulingStrategy>()(scheduling_strategy_1) ==
+               std::hash<rpc::SchedulingStrategy>()(scheduling_strategy_4));
+
+  rpc::SchedulingStrategy scheduling_strategy_5;
+  auto expr_5 = scheduling_strategy_5.mutable_node_label_scheduling_strategy()
+                    ->mutable_hard()
+                    ->add_expressions();
+  expr_5->set_key("key");
+  expr_5->mutable_operator_()->mutable_label_not_in()->add_values("value1");
+
+  ASSERT_FALSE(std::hash<rpc::SchedulingStrategy>()(scheduling_strategy_1) ==
+               std::hash<rpc::SchedulingStrategy>()(scheduling_strategy_5));
+}
 }  // namespace ray
 
 int main(int argc, char **argv) {

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -62,7 +62,7 @@ message LabelExists {}
 message LabelDoesNotExist {}
 
 message LabelOperator {
-  oneof LabelOperator {
+  oneof label_operator {
     LabelIn label_in = 1;
     LabelNotIn label_not_in = 2;
     LabelExists label_exists = 3;


### PR DESCRIPTION
## Why are these changes needed?


## Related issue number

#34894
(P2)Implement the node affinity with labels interface in Python and transparently transmit it to the CoreWorker.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
