### PR TITLE
[Serve] router cast replicas set to list for random sample in python 3.11

### DIFF
--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -443,7 +443,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
                 replica_ids_attempted, request_metadata
             )
             chosen_ids = random.sample(
-                candidate_replica_ids, k=min(2, len(candidate_replica_ids))
+                list(candidate_replica_ids), k=min(2, len(candidate_replica_ids))
             )
             yield [self._replicas[chosen_id] for chosen_id in chosen_ids]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Python 3.11 has a breaking change enforcing the type of `random.sample()` to be a list. Cast the `candidate_replica_ids` to list before feeding into the function. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/37765

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
