### PR TITLE
[serve] Deflake and clean up `test_serve_ha`

### DIFF
--- a/python/ray/serve/tests/test_serve_ha.py
+++ b/python/ray/serve/tests/test_serve_ha.py
@@ -29,11 +29,11 @@ check_script = """
 import ray
 import requests
 
-pids = set(ray.get([
-    requests.get("http://127.0.0.1:8000/").json()["pid"]
-    for _ in range(10)
-]))
+@ray.remote
+def get_pid():
+    return requests.get("http://127.0.0.1:8000/").json()["pid"]
 
+pids = set(ray.get([get_pid.remote() for _ in range(10)]))
 print(pids)
 assert len(pids) == {num_replicas}
 """

--- a/python/ray/serve/tests/test_serve_ha.py
+++ b/python/ray/serve/tests/test_serve_ha.py
@@ -62,19 +62,18 @@ def test_ray_serve_basic(docker_cluster):
 
     head, worker = docker_cluster
     output = worker.exec_run(cmd=f"python -c '{scripts.format(num_replicas=1)}'")
-    assert output.exit_code == 0
+    assert output.exit_code == 0, output.output
     assert b"Adding 1 replica to deployment " in output.output
 
     output = worker.exec_run(cmd=f"python -c '{check_script.format(num_replicas=1)}'")
-
-    assert output.exit_code == 0
+    assert output.exit_code == 0, output.output
 
     # Kill the head node
     head.kill()
 
     # Make sure serve is still working
     output = worker.exec_run(cmd=f"python -c '{check_script.format(num_replicas=1)}'")
-    assert output.exit_code == 0
+    assert output.exit_code == 0, output.output
 
     # Script is running on another thread so that it won't block the main thread.
     def reconfig():
@@ -102,7 +101,7 @@ def test_ray_serve_basic(docker_cluster):
     wait_for_condition(check_for_head_node_come_back_up)
 
     output = worker.exec_run(cmd=f"python -c '{check_script.format(num_replicas=2)}'")
-    assert output.exit_code == 0
+    assert output.exit_code == 0, output.output
 
     # Make sure the serve controller still runs on the head node after restart
     check_controller_head_node_script = """
@@ -117,7 +116,7 @@ serve_details = ServeInstanceDetails(
 assert serve_details.controller_info.node_id == head_node_id
 """
     output = head.exec_run(cmd=f"python -c '{check_controller_head_node_script}'")
-    assert output.exit_code == 0
+    assert output.exit_code == 0, output.output
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_serve_ha.py
+++ b/python/ray/serve/tests/test_serve_ha.py
@@ -17,7 +17,6 @@ import ray
 from ray import serve
 
 @serve.deployment
-@serve.ingress(app)
 class GetPID:
     def __call__(self, *args):
         return {{"pid": os.getpid()}}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test_serve_ha` is flaky in CI, looks like it's due to a small sample size of requests which may all get placed on the same replica given that they are made sequentially. I increased the sample size from 5 to 25.

I also cleaned up the script in a number of ways, removing unnecessary parameters and endpoints on the app and fixing import ordering.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
