### PR TITLE
[Serve] Fix `serve run` help message

### DIFF
--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -124,7 +124,7 @@ def convert_args_to_dict(args: Tuple[str]) -> Dict[str, str]:
 
 @click.group(
     help="CLI for managing Serve applications on a Ray cluster.",
-    context_settings=dict(help_option_names=["-h", "--help"]),
+    context_settings=dict(help_option_names=["--help", "-h"]),
 )
 def cli():
     pass


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Re: https://github.com/ray-project/ray/pull/35754 We previously added `-h` help command to the serve cli's click group. This caused the autogenerated help message to take `-h` as the default help command. For `serve run` we have a collusion on `-h` as it's used for host option as well. This PR changed the order of the click help option so the `--help` will be used in autogenerated help messages.

## Related issue number

Closes https://anyscaleteam.slack.com/archives/C043A9QJLNR/p1690471497886949

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

