### PR TITLE
[Data] remove usage of `.` in benchmark metric names

### DIFF
--- a/release/nightly_tests/dataset/image_loader_microbenchmark.py
+++ b/release/nightly_tests/dataset/image_loader_microbenchmark.py
@@ -162,10 +162,10 @@ if __name__ == "__main__":
         args.data_root, batch_size=args.batch_size, image_size=FULL_IMAGE_SIZE
     )
     for i in range(args.num_epochs):
-        iterate(tf_dataset, "tf.data", metrics)
+        iterate(tf_dataset, "tf_data", metrics)
     tf_dataset = tf_dataset.map(lambda img, label: (tf_crop_and_flip(img), label))
     for i in range(args.num_epochs):
-        iterate(tf_dataset, "tf.data+transform", metrics)
+        iterate(tf_dataset, "tf_data+transform", metrics)
 
     torch_dataset = build_torch_dataset(
         args.data_root, args.batch_size, transform=torchvision.transforms.ToTensor()
@@ -184,7 +184,7 @@ if __name__ == "__main__":
     for i in range(args.num_epochs):
         iterate(
             ray_dataset.iter_torch_batches(batch_size=args.batch_size),
-            "ray.data+transform",
+            "ray_data+transform",
             metrics,
         )
 
@@ -194,7 +194,7 @@ if __name__ == "__main__":
     for i in range(args.num_epochs):
         iterate(
             ray_dataset.iter_torch_batches(batch_size=args.batch_size),
-            "ray.data+transform+zerocopy",
+            "ray_data+transform+zerocopy",
             metrics,
         )
 
@@ -202,7 +202,7 @@ if __name__ == "__main__":
     for i in range(args.num_epochs):
         iterate(
             ray_dataset.iter_torch_batches(batch_size=args.batch_size),
-            "ray.data",
+            "ray_data",
             metrics,
         )
 
@@ -212,7 +212,7 @@ if __name__ == "__main__":
     for i in range(args.num_epochs):
         iterate(
             ray_dataset.iter_torch_batches(batch_size=args.batch_size),
-            "ray.data+dummy_pyarrow_transform",
+            "ray_data+dummy_pyarrow_transform",
             metrics,
         )
 
@@ -222,7 +222,7 @@ if __name__ == "__main__":
     for i in range(args.num_epochs):
         iterate(
             ray_dataset.iter_torch_batches(batch_size=args.batch_size),
-            "ray.data+dummy_np_transform",
+            "ray_data+dummy_np_transform",
             metrics,
         )
 
@@ -243,7 +243,7 @@ if __name__ == "__main__":
     for i in range(args.num_epochs):
         iterate(
             ray_dataset.iter_torch_batches(batch_size=args.batch_size),
-            "ray.data_manual_load",
+            "ray_data_manual_load",
             metrics,
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
When parsing release test results via Hive's `get_json_object` [function](https://cwiki.apache.org/confluence/display/hive/languagemanual+udf#LanguageManualUDF-get_json_object), the `.` indicates a child operator. Therefore, metric names which include `.` cause incorrect parsing of the test results JSON. This PR replaces usage of `.` with `_` to resolve this issue.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
