### PR TITLE
[air] fix pyarrow lazy import (#37670)

### DIFF
--- a/python/ray/air/_internal/remote_storage.py
+++ b/python/ray/air/_internal/remote_storage.py
@@ -139,10 +139,10 @@ def is_non_local_path_uri(uri: str) -> bool:
 
 
 # Cache fs objects. Map from cache_key --> timestamp, fs
-_cached_fs: Dict[tuple, Tuple[float, pyarrow.fs.FileSystem]] = {}
+_cached_fs: Dict[tuple, Tuple[float, "pyarrow.fs.FileSystem"]] = {}
 
 
-def _get_cache(cache_key: tuple) -> Optional[pyarrow.fs.FileSystem]:
+def _get_cache(cache_key: tuple) -> Optional["pyarrow.fs.FileSystem"]:
     ts, fs = _cached_fs.get(cache_key, (0, None))
     if not fs:
         return None
@@ -155,7 +155,7 @@ def _get_cache(cache_key: tuple) -> Optional[pyarrow.fs.FileSystem]:
     return fs
 
 
-def _put_cache(cache_key: tuple, fs: pyarrow.fs.FileSystem):
+def _put_cache(cache_key: tuple, fs: "pyarrow.fs.FileSystem"):
     now = time.monotonic()
     _cached_fs[cache_key] = (now, fs)
 


### PR DESCRIPTION
#35938 introduced a pyarrow typehint, though pyarrow is being lazily imported.

Cherry-pick of #37670.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
