### PR TITLE
[Train] Adding more flexibility to the default checkpointing behavior

### DIFF
--- a/doc/source/templates/04_finetuning_llms_with_deepspeed/finetune_hf_llm.py
+++ b/doc/source/templates/04_finetuning_llms_with_deepspeed/finetune_hf_llm.py
@@ -461,6 +461,15 @@ def parse_args():
     parser.add_argument(
         "--num-epochs", type=int, default=1, help="Number of epochs to train for."
     )
+    parser.add_argument(
+        "--num-checkpoints-to-keep",
+        type=int,
+        help=(
+            "Number of checkpoints to keep, if None, all checkpoints will be kept, "
+            "if set to n>=1, the top n checkpoint with min. evaluation perplexity "
+            "will be kept."
+        ),
+    )
     parser.add_argument("--lr", type=float, default=5e-6, help="Learning rate to use.")
 
     parser.add_argument(
@@ -550,7 +559,9 @@ def main():
             # sync_config=tune.SyncConfig(sync_artifacts=False),
             storage_path=storage_path,
             checkpoint_config=air.CheckpointConfig(
-                num_to_keep=1,
+                num_to_keep=args.num_checkpoints_to_keep,
+                checkpoint_score_attribute="preplexity",
+                checkpoint_score_order="min",
                 # Enable distributed checkpointing
                 _checkpoint_keep_all_ranks=True,
                 _checkpoint_upload_from_workers=True,

--- a/doc/source/templates/04_finetuning_llms_with_deepspeed/finetune_hf_llm.py
+++ b/doc/source/templates/04_finetuning_llms_with_deepspeed/finetune_hf_llm.py
@@ -560,7 +560,7 @@ def main():
             storage_path=storage_path,
             checkpoint_config=air.CheckpointConfig(
                 num_to_keep=args.num_checkpoints_to_keep,
-                checkpoint_score_attribute="preplexity",
+                checkpoint_score_attribute="perplexity",
                 checkpoint_score_order="min",
                 # Enable distributed checkpointing
                 _checkpoint_keep_all_ranks=True,

--- a/doc/source/templates/04_finetuning_llms_with_deepspeed/run_llama_ft.sh
+++ b/doc/source/templates/04_finetuning_llms_with_deepspeed/run_llama_ft.sh
@@ -53,6 +53,8 @@ fine_tune() {
         --train_path "${train_path}" \
         --test_path "${test_path}"  \
         --special_token_path "${token_path}" \
+        --num-checkpoints-to-keep 1 \
+        --num-epochs 1 \
         "${params[@]}"; then
         echo "Failed to fine-tune the model. Exiting..."
         exit 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds evaluation perplexity as a metric to decide when do store the checkpoints. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
