### PR TITLE
[ci] Support BYOD release tests on PR

### DIFF
--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -118,9 +118,6 @@ class Test(dict):
         """
         Returns whether this test is running on a BYOD cluster.
         """
-        if os.environ.get("BUILDKITE_PULL_REQUEST", "false") != "false":
-            # Do not run BYOD tests on PRs
-            return False
         return self["cluster"].get("byod") is not None
 
     def get_byod_type(self) -> Optional[str]:
@@ -218,11 +215,14 @@ class Test(dict):
             "BRANCH_TO_TEST",
             os.environ["BUILDKITE_BRANCH"],
         )
-        ray_version = commit[:6]
-        assert branch == "master" or branch.startswith(
-            "releases/"
+        pr = os.environ.get("BUILDKITE_PULL_REQUEST")
+        assert (
+            pr != "false" or branch == "master" or branch.startswith("releases/")
         ), f"Invalid branch name {branch}"
-        if branch.startswith("releases/"):
+        ray_version = commit[:6]
+        if pr != "false":
+            ray_version = f"pr-{pr}.{ray_version}"
+        elif branch.startswith("releases/"):
             release_name = branch[len("releases/") :]
             ray_version = f"{release_name}.{ray_version}"
         python_version = f"py{self.get_python_version().replace('.',   '')}"


### PR DESCRIPTION
People starts to add more release tests and are unable to test using BYOD on PR, then the test fails when merged into master (https://buildkite.com/ray-project/release-tests-branch/builds/1998). This temporarily supports this feature until we figure out a better way to do this.

Test:
- CI