### PR TITLE
[ci] support BYOD release test run on PR

### DIFF
--- a/release/BUILD
+++ b/release/BUILD
@@ -578,6 +578,21 @@ py_test(
 )
 
 py_test(
+    name = "test_byod_build_ray",
+    size = "small",
+    srcs = ["ray_release/tests/test_byod_build_ray.py"],
+    exec_compatible_with = [":hermetic_python"],
+    tags = [
+        "release_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":ray_release",
+        bk_require("pytest"),
+    ],
+)
+
+py_test(
     name = "test_cluster_manager",
     size = "small",
     srcs = ["ray_release/tests/test_cluster_manager.py"],

--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import time
 
+from ray_release.byod.build_ray import build_ray
 from ray_release.config import RELEASE_PACKAGE_DIR
 from ray_release.configs.global_config import get_global_config
 from ray_release.logger import logger
@@ -105,6 +106,7 @@ def build_anyscale_base_byod_images(tests: List[Test]) -> None:
     """
     Builds the Anyscale BYOD images for the given tests.
     """
+    build_ray()
     _download_dataplane_build_file()
     to_be_built = {}
     built = set()

--- a/release/ray_release/byod/build_ray.py
+++ b/release/ray_release/byod/build_ray.py
@@ -1,0 +1,122 @@
+import time
+import os
+import subprocess
+import json
+from typing import Any, Dict
+
+import boto3
+
+from ray_release.logger import logger
+
+BASE_IMAGE_WAIT_TIMEOUT = 7200
+BASE_IMAGE_WAIT_DURATION = 30
+DOCKER_ECR = "029272617770.dkr.ecr.us-west-2.amazonaws.com"
+DOCKER_PROJECT = "ci_base_images"
+PY_VERSIONS = ["py38", "py39"]
+
+
+def build_ray() -> None:
+    """
+    Builds ray and ray-ml images for PR builds
+    """
+    if not _is_pr():
+        logger.info("Not a PR, skipping build_ray")
+        return
+    start = int(time.time())
+    base_image = _get_docker_name()
+    while (
+        not _base_image_exist() and int(time.time()) - start < BASE_IMAGE_WAIT_TIMEOUT
+    ):
+        timeout = BASE_IMAGE_WAIT_TIMEOUT - (int(time.time()) - start)
+        logger.info(
+            f"Image {base_image} does not exist yet. " f"Wait for another {timeout}s..."
+        )
+        time.sleep(BASE_IMAGE_WAIT_DURATION)
+    _upload_builds()
+
+
+def _is_pr() -> bool:
+    return os.getenv("BUILDKITE_PULL_REQUEST", "false") != "false"
+
+
+def _upload_builds() -> None:
+    builds = {"steps": [_get_build(py_version) for py_version in PY_VERSIONS]}
+    subprocess.run(
+        ["buildkite-agent", "pipeline", "upload"],
+        input=json.dumps(builds).encode(),
+    )
+
+
+def _get_docker_name() -> str:
+    return f"{DOCKER_ECR}/{DOCKER_PROJECT}:{_get_docker_image_tag()}"
+
+
+def _get_docker_image_tag() -> str:
+    return f"oss-ci-build_{os.environ.get('BUILDKITE_COMMIT', '')}"
+
+
+def _get_build(py_version: str) -> Dict[str, Any]:
+    cmd = [
+        f"LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY={py_version} ./ci/ci.sh build",
+        "pip install -q docker aws_requests_auth boto3",
+        "./ci/env/env_info.sh",
+        "python .buildkite/copy_files.py --destination docker_login",
+        "python ./ci/build/build-docker-images.py "
+        f"--py-versions {py_version} -T cpu -T cu118 "
+        "--build-type BUILDKITE --build-base --push-pr-build",
+    ]
+    return {
+        "label": py_version,
+        "agents": {"queue": "release_queue_small"},
+        "commands": cmd,
+        "plugins": [
+            {
+                "ray-project/dind#v1.0.10": {
+                    "network-name": "dind-network",
+                    "certs-volume-name": "ray-docker-certs-client",
+                    "additional-volume-mount": "ray-volume:/ray",
+                },
+            },
+            {
+                "docker#v5.3.0": {
+                    "image": _get_docker_name(),
+                    "shell": ["/bin/bash", "-ecil"],
+                    "network": "dind-network",
+                    "volumes": [
+                        "ray-docker-certs-client:/certs/client:ro",
+                        "ray-volume:/ray-mount",
+                        "/tmp/artifacts:/artifact-mount",
+                    ],
+                    "workdir": "/ray",
+                    "add-caps:": ["SYS_ADMIN", "SYS_PTRACE", "NET_ADMIN"],
+                    "shm-size": "2.5gb",
+                    "environment": [
+                        "BUILDKITE_JOB_ID",
+                        "BUILDKITE_COMMIT",
+                        "BUILDKITE_LABEL",
+                        "BUILDKITE_BRANCH",
+                        "BUILDKITE_BUILD_URL",
+                        "BUILDKITE_BUILD_ID",
+                        "BUILDKITE_MESSAGE",
+                        "BUILDKITE_BUILD_NUMBER",
+                    ],
+                    "mount-checkout": "false",
+                },
+            },
+        ],
+    }
+
+
+def _base_image_exist() -> bool:
+    """
+    Checks if the given base docer image exists.
+    """
+    client = boto3.client("ecr", region_name="us-west-2")
+    try:
+        client.describe_images(
+            repositoryName=DOCKER_PROJECT,
+            imageIds=[{"imageTag": _get_docker_image_tag()}],
+        )
+        return True
+    except client.exceptions.ImageNotFoundException:
+        return False

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -118,9 +118,6 @@ class Test(dict):
         """
         Returns whether this test is running on a BYOD cluster.
         """
-        if os.environ.get("BUILDKITE_PULL_REQUEST", "false") != "false":
-            # Do not run BYOD tests on PRs
-            return False
         return self["cluster"].get("byod") is not None
 
     def get_byod_type(self) -> Optional[str]:
@@ -218,11 +215,14 @@ class Test(dict):
             "BRANCH_TO_TEST",
             os.environ["BUILDKITE_BRANCH"],
         )
-        ray_version = commit[:6]
-        assert branch == "master" or branch.startswith(
-            "releases/"
+        pr = os.environ.get("BUILDKITE_PULL_REQUEST", "false")
+        assert (
+            pr != "false" or branch == "master" or branch.startswith("releases/")
         ), f"Invalid branch name {branch}"
-        if branch.startswith("releases/"):
+        ray_version = commit[:6]
+        if pr != "false":
+            ray_version = f"pr-{pr}.{ray_version}"
+        elif branch.startswith("releases/"):
             release_name = branch[len("releases/") :]
             ray_version = f"{release_name}.{ray_version}"
         python_version = f"py{self.get_python_version().replace('.',   '')}"

--- a/release/ray_release/tests/test_byod_build_ray.py
+++ b/release/ray_release/tests/test_byod_build_ray.py
@@ -1,0 +1,42 @@
+import pytest
+import sys
+from unittest.mock import patch
+from typing import List
+
+from ray_release.byod.build_ray import build_ray
+
+
+def test_build_ray() -> None:
+    cmds = []
+    inputs = []
+
+    def _mock_run(
+        cmd: List[str],
+        input: bytes,
+        *args,
+        **kwargs,
+    ) -> None:
+        cmds.append(cmd)
+        inputs.append(input.decode("utf-8"))
+
+    with patch.dict(
+        "os.environ",
+        {"BUILDKITE_PULL_REQUEST": "false"},
+    ):
+        build_ray()
+        assert cmds == []
+
+    with patch.dict(
+        "os.environ",
+        {"BUILDKITE_PULL_REQUEST": "1234", "BUILDKITE_COMMIT": "abcdef"},
+    ), patch("subprocess.run", side_effect=_mock_run,), patch(
+        "ray_release.byod.build_ray._base_image_exist",
+        return_value=True,
+    ):
+        build_ray()
+        assert cmds[0] == ["buildkite-agent", "pipeline", "upload"]
+        assert "oss-ci-build_abcdef" in inputs[0]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -37,7 +37,7 @@ def test_is_byod_cluster():
     assert _stub_test({"cluster": {"byod": {}}}).is_byod_cluster()
     assert _stub_test({"cluster": {"byod": {"type": "gpu"}}}).is_byod_cluster()
     with mock.patch.dict(os.environ, {"BUILDKITE_PULL_REQUEST": "1"}):
-        assert not _stub_test({"cluster": {"byod": {}}}).is_byod_cluster()
+        assert _stub_test({"cluster": {"byod": {}}}).is_byod_cluster()
     with mock.patch.dict(os.environ, {"BUILDKITE_PULL_REQUEST": "false"}):
         assert _stub_test({"cluster": {"byod": {}}}).is_byod_cluster()
 
@@ -86,6 +86,11 @@ def test_get_ray_image():
         _stub_test({"cluster": {"byod": {}}}).get_ray_image()
         == "rayproject/ray:1.0.0.123456-py38-cpu"
     )
+    with mock.patch.dict(os.environ, {"BUILDKITE_PULL_REQUEST": "123"}):
+        assert (
+            _stub_test({"cluster": {"byod": {}}}).get_ray_image()
+            == "rayproject/ray:pr-123.123456-py38-cpu"
+        )
 
 
 def test_get_anyscale_byod_image():


### PR DESCRIPTION
Folks have been adding release tests and break them since they cannot test on PR. This supports running release tests with BYOD on PR.
- Add the ability to build and upload rayproject/ray docker image on release test run
- Use the built docker image to run tests

Test:
- CI
- Release tests