### PR TITLE
[Serve] Fix queued metrics not set when no traffic

### DIFF
--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1001,7 +1001,7 @@ class Router:
         await query.buffer_starlette_requests_and_warn()
         result = await self._replica_scheduler.assign_replica(query)
 
-        self.num_queued_queries -= 1
+        self.num_queued_queries[request_meta.app_name] -= 1
 
         return result
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -976,7 +976,7 @@ class Router:
                     "application": app_name,
                 },
             )
-        # The dictionary should only has one entry in the self.num_queued_queries 
+        # The dictionary should only has one entry in the self.num_queued_queries
         # for the deployment queued metrics.
         return {self.deployment_name: sum(self.num_queued_queries.values())}
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -923,8 +923,8 @@ class Router:
             tag_keys=("deployment", "route", "application"),
         )
         self.num_router_requests.set_default_tags({"deployment": deployment_name})
-
-        self.num_queued_queries = defaultdict(int)
+        # Key is application name, value is the number of queued queries.
+        self.num_queued_queries: DefaultDict[str, int] = defaultdict(int)
         self.num_queued_queries_gauge = metrics.Gauge(
             "serve_deployment_queued_queries",
             description=(
@@ -971,7 +971,7 @@ class Router:
     def _collect_handle_queue_metrics(self) -> Dict[str, int]:
         for app_name, num_queued_queries in self.num_queued_queries.items():
             self.num_queued_queries_gauge.set(
-                self.num_queued_queries,
+                num_queued_queries,
                 tags={
                     "application": app_name,
                 },

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -976,7 +976,9 @@ class Router:
                     "application": app_name,
                 },
             )
-        return {self.deployment_name: self.num_queued_queries}
+        # The dictionary should only has one entry in the self.num_queued_queries 
+        # for the deployment queued metrics.
+        return {self.deployment_name: sum(self.num_queued_queries.values())}
 
     async def assign_request(
         self,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Make sure gauge metric can be set without traffic.

- Periodically set gauge metrics by using separate thread.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
