### PR TITLE
[ci] remove cluster_env from release tests

### DIFF
--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -50,18 +50,7 @@ class ClusterManager(abc.ABC):
         self.autosuspend_minutes = DEFAULT_AUTOSUSPEND_MINS
         self.maximum_uptime_minutes = DEFAULT_MAXIMUM_UPTIME_MINS
 
-    def set_cluster_env(self, cluster_env: Dict[str, Any]):
-        self.cluster_env = cluster_env
-
-        # Add flags for redisless Ray
-        self.cluster_env.setdefault("env_vars", {})
-        self.cluster_env["env_vars"]["MATCH_AUTOSCALER_AND_RAY_IMAGES"] = "1"
-        self.cluster_env["env_vars"]["RAY_USAGE_STATS_ENABLED"] = "1"
-        self.cluster_env["env_vars"]["RAY_USAGE_STATS_SOURCE"] = "nightly-tests"
-        self.cluster_env["env_vars"][
-            "RAY_USAGE_STATS_EXTRA_TAGS"
-        ] = f"test_name={self.test.get_name()};smoke_test={self.smoke_test}"
-
+    def set_cluster_env(self, cluster_env: Optional[Dict[str, Any]]):
         if self.test.is_byod_cluster():
             byod_image_name_normalized = (
                 self.test.get_anyscale_byod_image()
@@ -74,6 +63,16 @@ class ClusterManager(abc.ABC):
                 f"__env__{dict_hash(self.test.get_byod_runtime_env())}"
             )
         else:
+            self.cluster_env = cluster_env
+
+            # Add flags for redisless Ray
+            self.cluster_env.setdefault("env_vars", {})
+            self.cluster_env["env_vars"]["MATCH_AUTOSCALER_AND_RAY_IMAGES"] = "1"
+            self.cluster_env["env_vars"]["RAY_USAGE_STATS_ENABLED"] = "1"
+            self.cluster_env["env_vars"]["RAY_USAGE_STATS_SOURCE"] = "nightly-tests"
+            self.cluster_env["env_vars"][
+                "RAY_USAGE_STATS_EXTRA_TAGS"
+            ] = f"test_name={self.test.get_name()};smoke_test={self.smoke_test}"
             self.cluster_env_name = (
                 f"{self.project_name}_{self.project_id[4:8]}"
                 f"__env__{self.test.get_name().replace('.', '_')}__"

--- a/release/ray_release/cluster_manager/minimal.py
+++ b/release/ray_release/cluster_manager/minimal.py
@@ -24,8 +24,6 @@ class MinimalClusterManager(ClusterManager):
     def create_cluster_env(self):
         assert self.cluster_env_id is None
 
-        if not self.cluster_env:
-            return
         assert self.cluster_env_name
 
         logger.info(

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -172,6 +172,12 @@ def validate_cluster_compute(cluster_compute: Dict[str, Any]) -> Optional[str]:
 
 
 def validate_test_cluster_env(test: Test) -> Optional[str]:
+    if test.is_byod_cluster():
+        """
+        BYOD clusters are not validated because they do not need cluster environment
+        """
+        return None
+
     from ray_release.template import get_cluster_env_path
 
     cluster_env_path = get_cluster_env_path(test)

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -152,7 +152,6 @@ def _setup_cluster_environment(
 ) -> Tuple[str, int, int, int, int]:
     setup_signal_handling()
     # Load configs
-    cluster_env = load_test_cluster_env(test, ray_wheels_url=ray_wheels_url)
     cluster_compute = load_test_cluster_compute(test)
 
     if cluster_env_id:
@@ -171,6 +170,11 @@ def _setup_cluster_environment(
                 f"{cluster_env_id}: {e}"
             ) from e
     else:
+        cluster_env = (
+            None
+            if test.is_byod_cluster()
+            else load_test_cluster_env(test, ray_wheels_url=ray_wheels_url)
+        )
         cluster_manager.set_cluster_env(cluster_env)
 
     # Load some timeouts

--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -90,8 +90,7 @@
 				}
 			},
 			"required": [
-				"cluster_compute",
-				"cluster_env"
+				"cluster_compute"
 			],
 			"title": "Cluster"
 		},

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -90,7 +90,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: cpt_autoscaling_1-3_aws.yaml
 
   run:
@@ -125,7 +124,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_gpu_1_cpu_16_aws.yaml
   
   run:
@@ -154,7 +152,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_gpu_1_cpu_16_aws.yaml
   
   run:
@@ -185,7 +182,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_gpu_4x4_aws.yaml
 
   run:
@@ -219,7 +215,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_gpu_4x4_aws.yaml
 
   run:
@@ -252,7 +247,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_hetero_10x10_aws.yaml
 
   run:
@@ -280,7 +274,6 @@
       runtime_env:
         - RAY_memory_usage_threshold=0.5
         - automatic_object_spilling_enabled=0
-    cluster_env: frequent_pausing/app_config.yaml
     cluster_compute: frequent_pausing/compute_config_aws.yaml
 
   run:
@@ -311,7 +304,6 @@
     byod:
       type: gpu
       post_build_script: byod_horovod_master_test.sh
-    cluster_env: horovod/app_config_master.yaml
     cluster_compute: horovod/compute_tpl_aws.yaml
 
   variations:
@@ -349,7 +341,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_data_20_nodes_aws.yaml
 
   run:
@@ -381,7 +372,6 @@
     byod:
       type: gpu
       post_build_script: byod_xgboost_cuj_test.sh
-    cluster_env: xgboost_app_config.yaml
     cluster_compute: compute_xgboost_aws.yaml
 
   run:
@@ -419,7 +409,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_cpu_4_aws.yaml
 
   run:
@@ -450,7 +439,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_gpu_4x4_aws.yaml
 
   run:
@@ -497,7 +485,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_cpu_1_aws.yaml
 
   run:
@@ -526,7 +513,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_cpu_4_aws.yaml
 
   run:
@@ -557,7 +543,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_cpu_8_aws.yaml
 
   run:
@@ -588,7 +573,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_gpu_4x4_aws.yaml
 
   run:
@@ -620,7 +604,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_cpu_4_aws.yaml
 
   run:
@@ -652,7 +635,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_cpu_1_aws.yaml
 
   run:
@@ -683,7 +665,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_cpu_4_aws.yaml
 
   run:
@@ -717,7 +698,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_gpu_4x4_aws.yaml
 
   run:
@@ -762,7 +742,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_gpu_1_aws.yaml
 
   run:
@@ -793,7 +772,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_gpu_4x4_aws.yaml
 
   run:
@@ -831,7 +809,6 @@
       runtime_env:
         - RAY_task_oom_retries=50
         - RAY_min_memory_free_bytes=1000000000
-    cluster_env: app_config_oom.yaml
     cluster_compute: compute_cpu_16.yaml
 
   run:
@@ -863,7 +840,6 @@
       runtime_env:
         - RAY_task_oom_retries=50
         - RAY_min_memory_free_bytes=1000000000
-    cluster_env: app_config_oom.yaml
     cluster_compute: compute_cpu_16.yaml
 
   run:
@@ -897,7 +873,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: dreambooth_env.yaml
     cluster_compute: dreambooth_compute_aws.yaml
 
   run:
@@ -923,7 +898,6 @@
         - myst-parser==0.15.2
         - myst-nb==0.13.1
         - jupytext==1.13.6
-    cluster_env: gptj_deepspeed_env.yaml
     cluster_compute: gptj_deepspeed_compute_aws.yaml
 
   run:
@@ -958,7 +932,6 @@
         - myst-nb==0.13.1
         - jupytext==1.13.6
       post_build_script: byod_dolly_test.sh
-    cluster_env: dolly_v2_fsdp_env.yaml
     cluster_compute: dolly_v2_fsdp_compute_aws.yaml
 
   run:
@@ -982,7 +955,6 @@
         - myst-parser==0.15.2
         - myst-nb==0.13.1
         - jupytext==1.13.6
-    cluster_env: vicuna_13b_deepspeed_env.yaml
     cluster_compute: vicuna_13b_deepspeed_compute_aws.yaml
 
   run:
@@ -1002,7 +974,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: ../testing/cluster_envs/default_cluster_env_nightly_ml_py39.yaml
     cluster_compute: ../testing/compute_configs/gpu/aws.yaml
 
   run:
@@ -1028,7 +999,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: ../testing/cluster_envs/02_many_model_training.yaml
     cluster_compute: ../testing/compute_configs/cpu/aws.yaml
 
   run:
@@ -1054,7 +1024,6 @@
   cluster:
     byod:
       type: cu118
-    cluster_env: ../testing/cluster_envs/03_serving_stable_diffusion.yaml
     cluster_compute: ../testing/compute_configs/gpu/aws.yaml
 
   run:
@@ -1079,7 +1048,6 @@
   cluster:
     byod:
       type: cu118
-    cluster_env: ../testing/cluster_envs/04_finetuning_llms_with_deepspeed.yaml
     cluster_compute: ../testing/compute_configs/04_finetuning_llms_with_deepspeed/aws_7b_or_13b.yaml
 
   run:
@@ -1107,7 +1075,6 @@
   cluster:
     byod:
       type: cu118
-    cluster_env: ../testing/cluster_envs/04_finetuning_llms_with_deepspeed.yaml
     cluster_compute: ../testing/compute_configs/04_finetuning_llms_with_deepspeed/aws_7b_or_13b.yaml
 
   run:
@@ -1161,7 +1128,6 @@
   cluster:
     byod:
       post_build_script: byod_xgboost_test.sh
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_moderate_aws.yaml
 
   run:
@@ -1195,7 +1161,6 @@
       runtime_env:
         - NCCL_SOCKET_IFNAME=ens
       post_build_script: byod_xgboost_test.sh
-    cluster_env: app_config_gpu.yaml
     cluster_compute: tpl_gpu_small_aws.yaml
 
   run:
@@ -1226,7 +1191,6 @@
   cluster:
     byod:
       post_build_script: byod_xgboost_test.sh
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_small_aws.yaml
 
   run:
@@ -1257,7 +1221,6 @@
   cluster:
     byod:
       post_build_script: byod_xgboost_test.sh
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_small_aws.yaml
 
   run:
@@ -1288,7 +1251,6 @@
   cluster:
     byod:
       post_build_script: byod_xgboost_test.sh
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_small_aws.yaml
 
   run:
@@ -1319,7 +1281,6 @@
   cluster:
     byod:
       post_build_script: byod_xgboost_test.sh
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_small_aws.yaml
 
   run:
@@ -1351,7 +1312,6 @@
   cluster:
     byod:
       post_build_script: byod_xgboost_test.sh
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_moderate_aws.yaml
 
   run:
@@ -1383,7 +1343,6 @@
   cluster:
     byod:
       post_build_script: byod_xgboost_test.sh
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_moderate_aws.yaml
 
   run:
@@ -1442,7 +1401,6 @@
       post_build_script: byod_xgboost_test.sh
       pip:
         - lightgbm_ray
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_moderate_aws.yaml
 
   run:
@@ -1475,7 +1433,6 @@
       post_build_script: byod_xgboost_test.sh
       pip:
         - lightgbm_ray
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_small_aws.yaml
 
   run:
@@ -1508,7 +1465,6 @@
       post_build_script: byod_xgboost_test.sh
       pip:
         - lightgbm_ray
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_small_aws.yaml
 
   run:
@@ -1539,7 +1495,6 @@
   cluster:
     byod:
       post_build_script: byod_xgboost_test.sh
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_small_aws.yaml
 
   run:
@@ -1569,7 +1524,6 @@
   cluster:
     byod:
       post_build_script: byod_xgboost_test.sh
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_moderate_aws.yaml
 
   run:
@@ -1599,7 +1553,6 @@
   cluster:
     byod:
       post_build_script: byod_xgboost_test.sh
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_moderate_aws.yaml
 
   run:
@@ -1635,7 +1588,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_aws.yaml
 
   run:
@@ -1665,7 +1617,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_aws.yaml
 
   run:
@@ -1699,7 +1650,6 @@
     byod:
       type: gpu
       post_build_script: byod_horovod_test.sh
-    cluster_env: horovod/app_config.yaml
     cluster_compute: horovod/compute_tpl_aws.yaml
 
   run:
@@ -1730,7 +1680,6 @@
     byod:
       type: gpu
       post_build_script: byod_horovod_master_test.sh
-    cluster_env: horovod/app_config_master.yaml
     cluster_compute: horovod/compute_tpl_aws.yaml
 
   run:
@@ -1762,7 +1711,6 @@
       runtime_env:
         - TRAIN_PLACEMENT_GROUP_TIMEOUT_S=2000
       type: gpu
-    cluster_env: train/app_config.yaml
     cluster_compute: train/compute_tpl_aws.yaml
 
   run:
@@ -1794,7 +1742,6 @@
       runtime_env:
         - TRAIN_PLACEMENT_GROUP_TIMEOUT_S=2000
       type: gpu
-    cluster_env: train/app_config.yaml
     cluster_compute: train/compute_tpl_aws.yaml
 
   run:
@@ -1825,7 +1772,6 @@
     byod:
       type: gpu
       post_build_script: byod_xgboost_test.sh
-    cluster_env: xgboost/app_config_gpu.yaml
     cluster_compute: xgboost/tpl_gpu_small_scaling_aws.yaml
 
   run:
@@ -1856,7 +1802,6 @@
     byod:
       type: gpu
       post_build_script: byod_xgboost_master_test.sh
-    cluster_env: xgboost/app_config_gpu_master.yaml
     cluster_compute: xgboost/tpl_gpu_small_scaling_aws.yaml
 
   run:
@@ -1890,7 +1835,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: ../rllib_tests/app_config.yaml
     cluster_compute: tune_rllib/compute_tpl_aws.yaml
 
   run:
@@ -1921,7 +1865,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: tpl_aws_4x2.yaml
 
   run:
@@ -1949,7 +1892,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: tpl_aws_4x2.yaml
 
   run:
@@ -1977,7 +1919,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: tpl_aws_4x2.yaml
 
   run:
@@ -2015,7 +1956,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config_ml.yaml
     cluster_compute: tpl_aws_4x2.yaml
 
   run:
@@ -2057,7 +1997,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config_ml.yaml
     cluster_compute: tpl_aws_4x2.yaml
 
   run:
@@ -2094,7 +2033,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: tpl_aws_1x4.yaml
 
   run:
@@ -2133,7 +2071,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: tpl_1x16.yaml
 
   run:
@@ -2160,7 +2097,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: tpl_16x2.yaml
 
   run:
@@ -2195,7 +2131,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: tpl_16x2.yaml
 
   run:
@@ -2229,7 +2164,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: tpl_1x32_hd.yaml
 
   run:
@@ -2265,7 +2199,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: tpl_100x2.yaml
 
   run:
@@ -2306,7 +2239,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: tpl_16x64.yaml
 
   run:
@@ -2336,7 +2268,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: tpl_1x96.yaml
 
   run:
@@ -2367,7 +2298,6 @@
   cluster:
     byod:
       post_build_script: byod_xgboost_tune_test.sh
-    cluster_env: app_config_data.yaml
     cluster_compute: tpl_16x64.yaml
 
   run:
@@ -2404,7 +2334,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: tpl_aws_16x1.yaml
 
   run:
@@ -2443,7 +2372,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: torch_tune_serve_app_config.yaml
     cluster_compute: gpu_tpl_aws.yaml
 
   run:
@@ -2480,7 +2408,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
   run:
@@ -2521,7 +2448,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: ../rllib_tests/app_config.yaml
     cluster_compute: tpl_cpu_3.yaml
 
   run:
@@ -2567,7 +2493,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: ../rllib_tests/app_config.yaml
     cluster_compute: tpl_cpu_1_large.yaml
 
   run:
@@ -2607,7 +2532,6 @@
     byod:
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
   run:
@@ -2647,7 +2571,6 @@
     byod:
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
   run:
@@ -2692,7 +2615,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: ../rllib_tests/app_config.yaml
     cluster_compute: many_ppo.yaml
 
   run:
@@ -2735,7 +2657,6 @@
     byod:
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
   run:
@@ -2775,7 +2696,6 @@
     byod:
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
   run:
@@ -2815,7 +2735,6 @@
     byod:
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
   run:
@@ -2858,7 +2777,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: ../rllib_tests/app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
   run:
@@ -2898,7 +2816,6 @@
     byod:
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
   run:
@@ -2940,7 +2857,6 @@
     byod:
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1_c5.yaml
 
   run:
@@ -2982,7 +2898,6 @@
     byod:
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
-    cluster_env: app_config.yaml
     cluster_compute: tpl_cpu_1.yaml
 
   run:
@@ -3021,7 +2936,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl.yaml
 
   run:
@@ -3063,7 +2977,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_4_xlarge.yaml
 
   run:
@@ -3094,7 +3007,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_4_xlarge.yaml
 
   run:
@@ -3124,7 +3036,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_4_xlarge.yaml
   run:
     timeout: 600
@@ -3150,7 +3061,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_gpu_node.yaml
   run:
     timeout: 600
@@ -3176,7 +3086,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_gpu_worker.yaml
   run:
     timeout: 600
@@ -3205,7 +3114,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: rte_small.yaml
 
   run:
@@ -3235,7 +3143,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: rte_minimal.yaml
 
   run:
@@ -3291,7 +3198,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_32_cpu.yaml
 
   run:
@@ -3319,7 +3225,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_32_cpu.yaml
 
   run:
@@ -3347,7 +3252,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_8_cpu_autoscaling.yaml
 
   run:
@@ -3375,7 +3279,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_32_cpu_autoscaling.yaml
 
   run:
@@ -3403,7 +3306,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_single_node.yaml
 
   run:
@@ -3451,7 +3353,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_single_node_32_cpu.yaml
 
   run:
@@ -3480,7 +3381,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_single_node_32_cpu.yaml
 
   run:
@@ -3509,7 +3409,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_single_node_32_cpu.yaml
 
   run:
@@ -3538,7 +3437,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_single_node_32_cpu.yaml
 
   run:
@@ -3568,7 +3466,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_single_node.yaml
 
   run:
@@ -3596,7 +3493,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_single_node.yaml
 
   run:
@@ -3626,7 +3522,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: gpu_app_config.yaml
     cluster_compute: compute_tpl_gpu_node.yaml
 
   run:
@@ -3660,7 +3555,6 @@
     byod:
       type: gpu
       post_build_script: byod_horovod_test.sh
-    cluster_env: app_config.yaml
     cluster_compute: compute_tpl_aws.yaml
 
   run:
@@ -3696,7 +3590,6 @@
     byod:
       type: gpu
       post_build_script: byod_alpa_test.sh
-    cluster_env: app_config.yaml
     cluster_compute: gpu_2x4_t4_aws.yaml
 
   run:
@@ -3734,7 +3627,6 @@
     byod:
       type: gpu
       post_build_script: byod_alpa_test.sh
-    cluster_env: app_config.yaml
     cluster_compute: gpu_1x8_v100_aws.yaml
 
   run:
@@ -3779,7 +3671,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: multi_node_checkpointing_compute_config.yaml
 
   run:
@@ -3814,7 +3705,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: multi_node_checkpointing_compute_config.yaml
 
   run:
@@ -3849,7 +3739,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -3881,7 +3770,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -3913,7 +3801,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 32cpus.yaml
 
   run:
@@ -3948,7 +3835,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_24cpus.yaml
 
   run:
@@ -3980,7 +3866,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_24cpus.yaml
 
   run:
@@ -4012,7 +3897,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 4gpus_64cpus.yaml
 
   run:
@@ -4047,7 +3931,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 4gpus_64cpus.yaml
 
   run:
@@ -4080,7 +3963,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 2gpus_32cpus.yaml
 
   run:
@@ -4116,7 +3998,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 2gpus_32cpus.yaml
 
   run:
@@ -4148,7 +4029,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4180,7 +4060,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4215,7 +4094,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4250,7 +4128,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4282,7 +4159,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4314,7 +4190,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4346,7 +4221,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_32cpus.yaml
 
   run:
@@ -4381,7 +4255,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4413,7 +4286,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 2gpus_64cpus.yaml
 
   run:
@@ -4445,7 +4317,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 2gpus_64cpus.yaml
 
   run:
@@ -4477,7 +4348,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4509,7 +4379,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4544,7 +4413,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4579,7 +4447,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4611,7 +4478,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 4gpus_64cpus.yaml
 
   run:
@@ -4646,7 +4512,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 4gpus_64cpus.yaml
 
   run:
@@ -4679,7 +4544,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 2gpus_32cpus.yaml
 
   run:
@@ -4715,7 +4579,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 2gpus_32cpus.yaml
 
   run:
@@ -4747,7 +4610,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4779,7 +4641,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4811,7 +4672,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4846,7 +4706,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4878,7 +4737,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4910,7 +4768,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 1gpu_16cpus.yaml
 
   run:
@@ -4942,7 +4799,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 8gpus_96cpus.yaml
 
   run:
@@ -4974,7 +4830,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 8gpus_96cpus.yaml
 
   run:
@@ -5006,7 +4861,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 8gpus_96cpus.yaml
 
   run:
@@ -5041,7 +4895,6 @@
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin
-    cluster_env: app_config.yaml
     cluster_compute: 4gpus_544_cpus.yaml
 
   run:
@@ -5088,7 +4941,6 @@
     byod:
       runtime_env:
         - RAY_worker_killing_policy=retriable_lifo
-    cluster_env: shuffle/shuffle_app_config.yaml
     cluster_compute: shuffle/shuffle_compute_multi.yaml
 
   run:
@@ -5116,7 +4968,6 @@
   team: core
   cluster:
     byod: {}
-    cluster_env: stress_tests/stress_tests_app_config.yaml
     cluster_compute: stress_tests/placement_group_tests_compute.yaml
 
   run:
@@ -5141,7 +4992,6 @@
   team: core
   cluster:
     byod: {}
-    cluster_env: decision_tree/decision_tree_app_config.yaml
     cluster_compute: decision_tree/autoscaling_compute.yaml
 
   run:
@@ -5168,7 +5018,6 @@
     byod:
       runtime_env:
         - RAY_worker_killing_policy=retriable_lifo
-    cluster_env: shuffle/shuffle_app_config.yaml
     cluster_compute: shuffle/shuffle_compute_autoscaling.yaml
 
   run:
@@ -5193,7 +5042,6 @@
 
   cluster:
     byod: {}
-    cluster_env: app_config.yaml
     cluster_compute: tpl_64.yaml
 
   run:
@@ -5222,7 +5070,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config_gpu.yaml
     cluster_compute: only_head_node_1gpu_64cpu.yaml
 
   run:
@@ -5254,7 +5101,6 @@
       runtime_env:
         - RAY_worker_killing_policy=retriable_lifo
       post_build_script: byod_dask_test.sh
-    cluster_env: dask_on_ray/dask_on_ray_app_config.yaml
     cluster_compute: dask_on_ray/dask_on_ray_sort_compute_template.yaml
 
   run:
@@ -5284,7 +5130,6 @@
       runtime_env:
         - RAY_worker_killing_policy=retriable_lifo
       post_build_script: byod_dask_test.sh
-    cluster_env: dask_on_ray/large_scale_dask_on_ray_app_config.yaml
     cluster_compute: dask_on_ray/dask_on_ray_stress_compute.yaml
 
   run:
@@ -5323,7 +5168,6 @@
       runtime_env:
         - RAY_MAX_LIMIT_FROM_API_SERVER=1000000000
         - RAY_MAX_LIMIT_FROM_DATA_SOURCE=1000000000
-    cluster_env: stress_tests/state_api_app_config.yaml
     cluster_compute: stress_tests/stress_tests_compute_large.yaml
 
   run:
@@ -5367,7 +5211,6 @@
       runtime_env:
         - RAY_MAX_LIMIT_FROM_API_SERVER=1000000000
         - RAY_MAX_LIMIT_FROM_DATA_SOURCE=1000000000
-    cluster_env: shuffle/shuffle_with_state_api_app_config.yaml
     cluster_compute: shuffle/shuffle_compute_single.yaml
 
   run:
@@ -5392,7 +5235,6 @@
   team: core
   cluster:
     byod: {}
-    cluster_env: stress_tests/stress_tests_app_config.yaml
     cluster_compute: stress_tests/stress_tests_compute.yaml
 
   run:
@@ -5433,7 +5275,6 @@
   team: core
   cluster:
     byod: {}
-    cluster_env: stress_tests/stress_tests_app_config.yaml
     cluster_compute: stress_tests/stress_tests_compute.yaml
 
   run:
@@ -5477,7 +5318,6 @@
   team: core
   cluster:
     byod: {}
-    cluster_env: stress_tests/stress_tests_app_config.yaml
     cluster_compute: stress_tests/smoke_test_compute.yaml
 
   run:
@@ -5539,7 +5379,6 @@
   team: core
   cluster:
     byod: {}
-    cluster_env: stress_tests/stress_tests_single_node_oom_app_config.yaml
     cluster_compute: stress_tests/stress_tests_single_node_oom_compute.yaml
 
   run:
@@ -5570,7 +5409,6 @@
       runtime_env:
         - RAY_memory_usage_threshold=0.7
         - RAY_task_oom_retries=-1
-    cluster_env: oom/stress_tests_tune_air_oom_app_config.yaml
     cluster_compute: oom/stress_tests_tune_air_oom_compute.yaml
 
   run:
@@ -5590,7 +5428,6 @@
       runtime_env:
         - RAY_worker_killing_policy=retriable_lifo
       post_build_script: byod_dask_test.sh
-    cluster_env: dask_on_ray/dask_on_ray_app_config.yaml
     cluster_compute: dask_on_ray/1tb_sort_compute.yaml
 
   run:
@@ -5610,7 +5447,6 @@
   team: core
   cluster:
     byod: {}
-    cluster_env: distributed/many_nodes_tests/app_config.yaml
     cluster_compute: distributed/many_nodes_tests/compute_config.yaml
 
   run:
@@ -5655,7 +5491,6 @@
   team: core
   cluster:
     byod: {}
-    cluster_env: placement_group_tests/app_config.yaml
     cluster_compute: placement_group_tests/compute.yaml
 
   run:
@@ -5679,7 +5514,6 @@
   team: core
   cluster:
     byod: {}
-    cluster_env: placement_group_tests/app_config.yaml
     cluster_compute: placement_group_tests/pg_perf_test_compute.yaml
 
   run:
@@ -5713,7 +5547,6 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-    cluster_env: app_config.yaml
     cluster_compute: single_node.yaml
 
   run:
@@ -5741,7 +5574,6 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-    cluster_env: app_config.yaml
     cluster_compute: object_store.yaml
 
   run:
@@ -5770,7 +5602,6 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-    cluster_env: app_config.yaml
     cluster_compute: distributed.yaml
 
   run:
@@ -5799,7 +5630,6 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-    cluster_env: app_config.yaml
     cluster_compute: distributed_smoke_test.yaml
 
   run:
@@ -5849,7 +5679,6 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-    cluster_env: app_config.yaml
     cluster_compute: distributed.yaml
 
   run:
@@ -5879,7 +5708,6 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-    cluster_env: app_config.yaml
     cluster_compute: distributed_smoke_test.yaml
 
   run:
@@ -5932,7 +5760,6 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-    cluster_env: app_config.yaml
     cluster_compute: scheduling.yaml
 
   run:
@@ -6009,7 +5836,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: inference.yaml
 
   run:
@@ -6037,7 +5863,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: shuffle_app_config.yaml
     cluster_compute: shuffle_compute.yaml
 
   run:
@@ -6095,7 +5920,6 @@
       type: gpu
       pip:
         - git+https://github.com/ray-project/ray_shuffling_data_loader.git@add-embedding-model
-    cluster_env: pipelined_training_app.yaml
     cluster_compute: pipelined_training_compute.yaml
 
   run:
@@ -6123,7 +5947,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: data_ingest_benchmark_compute.yaml
 
   run:
@@ -6151,7 +5974,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: data_ingest_benchmark_compute.yaml
 
   run:
@@ -6179,7 +6001,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: data_ingest_benchmark_compute_gpu.yaml
 
   run:
@@ -6212,7 +6033,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: data_ingest_benchmark_compute_gpu.yaml
 
   run:
@@ -6240,7 +6060,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
@@ -6266,7 +6085,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
@@ -6293,7 +6111,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
@@ -6319,7 +6136,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
@@ -6345,7 +6161,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
@@ -6371,7 +6186,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_2x2_aws.yaml
 
   run:
@@ -6397,7 +6211,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_4x4_aws.yaml
 
   run:
@@ -6423,7 +6236,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_4x4_aws.yaml
 
   run:
@@ -6449,7 +6261,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_2x2_aws.yaml
 
   run:
@@ -6475,7 +6286,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_4x4_aws.yaml
 
   run:
@@ -6501,7 +6311,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: read_tfrecords_benchmark_app.yaml
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
@@ -6528,7 +6337,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
@@ -6555,7 +6363,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
@@ -6582,7 +6389,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: multi_node_benchmark_compute.yaml
 
   run:
@@ -6609,7 +6415,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
@@ -6637,7 +6442,6 @@
     byod:
       type: gpu
       post_build_script: byod_data_pipelined_test.sh
-    cluster_env: pipelined_training_app.yaml
     cluster_compute: pipelined_training_compute.yaml
 
   run:
@@ -6669,7 +6473,6 @@
         - RAY_lineage_pinning_enabled=1
         - RAY_record_ref_creation_sites=1
       post_build_script: byod_data_pipelined_test.sh
-    cluster_env: pipelined_ingestion_app.yaml
     cluster_compute: pipelined_ingestion_compute.yaml
 
   run:
@@ -6702,7 +6505,6 @@
         - RAY_worker_killing_policy=retriable_lifo
       pip:
         - ray[default]
-    cluster_env: shuffle/shuffle_app_config.yaml
     cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
 
   run:
@@ -6733,7 +6535,6 @@
         - RAY_worker_killing_policy=retriable_lifo
       pip:
         - ray[default]
-    cluster_env: shuffle/shuffle_app_config.yaml
     cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
 
   run:
@@ -6766,7 +6567,6 @@
         - RAY_worker_killing_policy=retriable_lifo
       pip:
         - ray[default]
-    cluster_env: shuffle/shuffle_app_config.yaml
     cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
 
   run:
@@ -6797,7 +6597,6 @@
         - RAY_worker_killing_policy=retriable_lifo
       pip:
         - ray[default]
-    cluster_env: shuffle/shuffle_app_config.yaml
     cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
 
   run:
@@ -6829,7 +6628,6 @@
       runtime_env:
         - RAY_object_spilling_config={"type":"filesystem","params":{"directory_path":["/tmp/data0","/tmp/data1"]}}
       post_build_script: byod_dataset_shuffle.sh
-    cluster_env: shuffle/100tb_shuffle_app_config.yaml
     cluster_compute: shuffle/100tb_shuffle_compute.yaml
 
   run:
@@ -6864,7 +6662,6 @@
   team: core
   cluster:
     byod: {}
-    cluster_env: chaos_test/app_config.yaml
     cluster_compute: chaos_test/compute_template.yaml
 
   run:
@@ -6891,7 +6688,6 @@
   team: core
   cluster:
     byod: {}
-    cluster_env: chaos_test/app_config.yaml
     cluster_compute: chaos_test/compute_template.yaml
 
   run:
@@ -6923,7 +6719,6 @@
       runtime_env:
         - RAY_lineage_pinning_enabled=1
       post_build_script: byod_dask_test.sh
-    cluster_env: chaos_test/dask_on_ray_app_config_reconstruction.yaml
     cluster_compute: dask_on_ray/chaos_dask_on_ray_stress_compute.yaml
 
   run:
@@ -6955,7 +6750,6 @@
       runtime_env:
         - RAY_lineage_pinning_enabled=1
       post_build_script: byod_dask_test.sh
-    cluster_env: chaos_test/dask_on_ray_app_config_reconstruction.yaml
     cluster_compute: dask_on_ray/dask_on_ray_stress_compute.yaml
 
   run:
@@ -6991,7 +6785,6 @@
         - RAY_lineage_pinning_enabled=1
         - RAY_record_ref_creation_sites=1
       post_build_script: byod_data_pipelined_test.sh
-    cluster_env: dataset/pipelined_ingestion_app.yaml
     cluster_compute: dataset/pipelined_ingestion_compute.yaml
 
   run:
@@ -7026,7 +6819,6 @@
         - RAY_worker_killing_policy=retriable_lifo
       pip:
         - ray[default]
-    cluster_env: shuffle/shuffle_app_config.yaml
     cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
 
   run:
@@ -7058,7 +6850,6 @@
     byod:
       runtime_env:
         - RAY_memory_monitor_refresh_ms=0
-    cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml
     cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
 
   run:
@@ -7093,7 +6884,6 @@
         - RAY_memory_monitor_refresh_ms=0
       pip:
         - ray[default]
-    cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml
     cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
 
   run:
@@ -7126,7 +6916,6 @@
     byod:
       runtime_env:
         - RAY_memory_monitor_refresh_ms=0
-    cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml
     cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
 
   run:
@@ -7160,7 +6949,6 @@
       runtime_env:
         - RAY_INTERNAL_MEM_PROFILE_COMPONENTS=dashboard_agent
       post_build_script: byod_agent_stress_test.sh
-    cluster_env: agent_stress_app_config.yaml
     cluster_compute: agent_stress_compute.yaml
 
   run:
@@ -7204,7 +6992,6 @@
 
   cluster:
     byod: {}
-    cluster_env: aws/tests/aws_config.yaml
     cluster_compute: aws/tests/aws_compute.yaml
 
   run:
@@ -7238,7 +7025,6 @@
   python: "3.8"
   cluster:
     byod: {}
-    cluster_env: aws/tests/aws_config.yaml
     cluster_compute: aws/tests/aws_compute.yaml
 
   run:
@@ -7272,7 +7058,6 @@
   team: core
   cluster:
     byod: {}
-    cluster_env: aws/tests/aws_config.yaml
     cluster_compute: aws/tests/aws_compute.yaml
 
   run:


### PR DESCRIPTION
All aws release tests are now BYOD, so they don't need the cluster_env entry anymore. Remove all of them so people do not keep using them when copy-pasting the test definitions.

Test:
- CI
- Release tests: https://buildkite.com/ray-project/release-tests-pr/builds/47078