### PR TITLE
[data] Make file datasource outputs streaming to avoid OOM

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -452,6 +452,9 @@ class DatasetStatsSummary:
     def get_max_heap_memory(self) -> float:
         parent_memory = [p.get_max_heap_memory() for p in self.parents]
         parent_max = max(parent_memory) if parent_memory else 0
+        if not self.stages_stats:
+            return parent_max
+
         return max(
             parent_max,
             *[ss.memory.get("max", 0) for ss in self.stages_stats],

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2609,6 +2609,7 @@ class Dataset:
         block_path_provider: BlockWritePathProvider = DefaultBlockWritePathProvider(),
         arrow_parquet_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
         ray_remote_args: Dict[str, Any] = None,
+        arrow_parquet_row_group_size: int = None,
         **arrow_parquet_args,
     ) -> None:
         """Writes the :class:`~ray.data.Dataset` to parquet files under the provided ``path``.
@@ -2667,11 +2668,16 @@ class Dataset:
                 can't pickled, or if you'd like to lazily resolve the write
                 arguments for each dataset block.
             ray_remote_args: Kwargs passed to :meth:`~ray.remote` in the write tasks.
+            arrow_parquet_row_group_size: Option to pass to
+                `pyarrow.parquet.ParquetWriter.write_table <https://arrow.apache.org\
+                        /docs/python/generated/pyarrow.parquet.ParquetWriter.html\
+                        #pyarrow.parquet.ParquetWriter.write_table>`_, which is
+                used to write out each block to a file.
             arrow_parquet_args: Options to pass to
-                `pyarrow.parquet.write_table() <https://arrow.apache.org/docs/python\
-                    /generated/pyarrow.parquet.write_table.html\
-                        #pyarrow.parquet.write_table>`_, which is used to write out each
-                block to a file.
+                `pyarrow.parquet.ParquetWriter() <https://arrow.apache.org/docs/python\
+                        /generated/pyarrow.parquet.ParquetWriter.html\
+                        #pyarrow-parquet-parquetwriter>`_, which is created to
+                write out each block to a file.
         """
         self.write_datasource(
             ParquetDatasource(),
@@ -2683,6 +2689,7 @@ class Dataset:
             open_stream_args=arrow_open_stream_args,
             block_path_provider=block_path_provider,
             write_args_fn=arrow_parquet_args_fn,
+            row_group_size=arrow_parquet_row_group_size,
             **arrow_parquet_args,
         )
 
@@ -2795,6 +2802,7 @@ class Dataset:
         block_path_provider: BlockWritePathProvider = DefaultBlockWritePathProvider(),
         arrow_csv_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
         ray_remote_args: Dict[str, Any] = None,
+        arrow_csv_maxchunk_size: int = None,
         **arrow_csv_args,
     ) -> None:
         """Writes the :class:`~ray.data.Dataset` to CSV files.
@@ -2861,10 +2869,15 @@ class Dataset:
                 arguments cannot be pickled, or if you'd like to lazily resolve the
                 write arguments for each dataset block.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
-            arrow_csv_args: Options to pass to `pyarrow.write.write_csv <https://\
-                arrow.apache.org/docs/python/generated/pyarrow.csv.write_csv.html\
-                    #pyarrow.csv.write_csv>`_
-                when writing each block to a file.
+            arrow_csv_maxchunk_size: Option to pass to
+                `pyarrow.csv.CSVWriter.write_table <https://arrow.apache.org\
+                        /docs/python/generated/pyarrow.csv.CSVWriter.html
+                        #pyarrow.csv.CSVWriter.write_table>`_, which is used to
+                write each block to a file.
+            arrow_csv_args: Options to pass to `pyarrow.csv.CSVWriter() <https://\
+                    arrow.apache.org/docs/python/generated/pyarrow.csv.CSVWriter.html\
+                    #pyarrow.csv.CSVWriter>`_, which is created to write blocks
+                to a file.
         """
         self.write_datasource(
             CSVDatasource(),
@@ -2876,6 +2889,7 @@ class Dataset:
             open_stream_args=arrow_open_stream_args,
             block_path_provider=block_path_provider,
             write_args_fn=arrow_csv_args_fn,
+            maxchunk_size=arrow_csv_maxchunk_size,
             **arrow_csv_args,
         )
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2802,7 +2802,7 @@ class Dataset:
         block_path_provider: BlockWritePathProvider = DefaultBlockWritePathProvider(),
         arrow_csv_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
         ray_remote_args: Dict[str, Any] = None,
-        arrow_csv_maxchunk_size: int = None,
+        arrow_csv_max_chunksize: int = None,
         **arrow_csv_args,
     ) -> None:
         """Writes the :class:`~ray.data.Dataset` to CSV files.
@@ -2869,7 +2869,7 @@ class Dataset:
                 arguments cannot be pickled, or if you'd like to lazily resolve the
                 write arguments for each dataset block.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
-            arrow_csv_maxchunk_size: Option to pass to
+            arrow_csv_max_chunksize: Option to pass to
                 `pyarrow.csv.CSVWriter.write_table <https://arrow.apache.org\
                         /docs/python/generated/pyarrow.csv.CSVWriter.html
                         #pyarrow.csv.CSVWriter.write_table>`_, which is used to
@@ -2889,7 +2889,7 @@ class Dataset:
             open_stream_args=arrow_open_stream_args,
             block_path_provider=block_path_provider,
             write_args_fn=arrow_csv_args_fn,
-            maxchunk_size=arrow_csv_maxchunk_size,
+            max_chunksize=arrow_csv_max_chunksize,
             **arrow_csv_args,
         )
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2659,24 +2659,25 @@ class Dataset:
                 ``{uuid}_{block_idx}.parquet``, where ``uuid`` is a unique id for the
                 dataset.
             arrow_parquet_args_fn: Callable that returns a dictionary of write
-                arguments that are provided to `pyarrow.parquet.write_table() <https:/\
-                    /arrow.apache.org/docs/python/generated/\
-                        pyarrow.parquet.write_table.html#pyarrow.parquet.write_table>`_
-                when writing each block to a file. Overrides
+                arguments that are provided to
+                `pyarrow.parquet.ParquetWriter() <https://arrow.apache.org/docs/python\
+                /generated/pyarrow.parquet.ParquetWriter.html\
+                #pyarrow-parquet-parquetwriter>`_, which is created to
+                write out each block to a file. Overrides
                 any duplicate keys from ``arrow_parquet_args``. Use this argument
                 instead of ``arrow_parquet_args`` if any of your write arguments
-                can't pickled, or if you'd like to lazily resolve the write
+                can't be pickled, or if you'd like to lazily resolve the write
                 arguments for each dataset block.
             ray_remote_args: Kwargs passed to :meth:`~ray.remote` in the write tasks.
             arrow_parquet_row_group_size: Option to pass to
                 `pyarrow.parquet.ParquetWriter.write_table <https://arrow.apache.org\
-                        /docs/python/generated/pyarrow.parquet.ParquetWriter.html\
-                        #pyarrow.parquet.ParquetWriter.write_table>`_, which is
+                /docs/python/generated/pyarrow.parquet.ParquetWriter.html\
+                #pyarrow.parquet.ParquetWriter.write_table>`_, which is
                 used to write out each block to a file.
             arrow_parquet_args: Options to pass to
                 `pyarrow.parquet.ParquetWriter() <https://arrow.apache.org/docs/python\
-                        /generated/pyarrow.parquet.ParquetWriter.html\
-                        #pyarrow-parquet-parquetwriter>`_, which is created to
+                /generated/pyarrow.parquet.ParquetWriter.html\
+                #pyarrow-parquet-parquetwriter>`_, which is created to
                 write out each block to a file.
         """
         self.write_datasource(
@@ -2861,23 +2862,23 @@ class Dataset:
                 ``{uuid}_{block_idx}.csv``, where ``uuid`` is a unique id for the
                 dataset.
             arrow_csv_args_fn: Callable that returns a dictionary of write
-                arguments that are provided to `pyarrow.write.write_csv <https://\
-                arrow.apache.org/docs/python/generated/\
-                pyarrow.csv.write_csv.html#pyarrow.csv.write_csv>`_ when writing each
-                block to a file. Overrides any duplicate keys from ``arrow_csv_args``.
-                Use this argument instead of ``arrow_csv_args`` if any of your write
-                arguments cannot be pickled, or if you'd like to lazily resolve the
-                write arguments for each dataset block.
+                arguments that are provided to `pyarrow.csv.CSVWriter() <https://\
+                arrow.apache.org/docs/python/generated/pyarrow.csv.CSVWriter.html\
+                #pyarrow.csv.CSVWriter>`_, which is created to write blocks to
+                a file. Overrides any duplicate keys from ``arrow_csv_args``.
+                Use this argument instead of ``arrow_csv_args`` if any of your
+                write arguments cannot be pickled, or if you'd like to lazily
+                resolve the write arguments for each dataset block.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
             arrow_csv_max_chunksize: Option to pass to
                 `pyarrow.csv.CSVWriter.write_table <https://arrow.apache.org\
-                        /docs/python/generated/pyarrow.csv.CSVWriter.html
-                        #pyarrow.csv.CSVWriter.write_table>`_, which is used to
+                /docs/python/generated/pyarrow.csv.CSVWriter.html
+                #pyarrow.csv.CSVWriter.write_table>`_, which is used to
                 write each block to a file.
             arrow_csv_args: Options to pass to `pyarrow.csv.CSVWriter() <https://\
-                    arrow.apache.org/docs/python/generated/pyarrow.csv.CSVWriter.html\
-                    #pyarrow.csv.CSVWriter>`_, which is created to write blocks
-                to a file.
+                arrow.apache.org/docs/python/generated/pyarrow.csv.CSVWriter.html\
+                #pyarrow.csv.CSVWriter>`_, which is created to write blocks to
+                a file.
         """
         self.write_datasource(
             CSVDatasource(),

--- a/python/ray/data/datasource/csv_datasource.py
+++ b/python/ray/data/datasource/csv_datasource.py
@@ -80,4 +80,5 @@ class CSVDatasource(FileBasedDatasource):
             if writer is None:
                 writer = csv.CSVWriter(f, block.schema, **writer_args)
             writer.write_table(block, max_chunksize=max_chunksize)
-        writer.close()
+        if writer is not None:
+            writer.close()

--- a/python/ray/data/datasource/csv_datasource.py
+++ b/python/ray/data/datasource/csv_datasource.py
@@ -75,9 +75,9 @@ class CSVDatasource(FileBasedDatasource):
         writer_args = _resolve_kwargs(writer_args_fn, **writer_args)
         writer = None
         for block in blocks:
-            block = BlockAccessor.for_block(block)
-            assert block.num_rows() > 0, "Cannot write an empty block."
+            block = BlockAccessor.for_block(block).to_arrow()
+            assert block.num_rows > 0, "Cannot write an empty block."
             if writer is None:
-                writer = csv.CSVWriter(f, block.schema(), **writer_args)
-            writer.write_table(block.to_arrow(), max_chunksize=max_chunksize)
+                writer = csv.CSVWriter(f, block.schema, **writer_args)
+            writer.write_table(block, max_chunksize=max_chunksize)
         writer.close()

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -39,7 +39,6 @@ from ray.data.datasource.partitioning import (
     PathPartitionFilter,
     PathPartitionParser,
 )
-from ray.types import ObjectRef
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -72,7 +72,6 @@ class BlockWritePathProvider:
         *,
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         dataset_uuid: Optional[str] = None,
-        block: Optional[Block] = None,
         block_index: Optional[int] = None,
         file_format: Optional[str] = None,
     ) -> str:
@@ -89,7 +88,6 @@ class BlockWritePathProvider:
                 write a file out to the write path returned.
             dataset_uuid: Unique identifier for the dataset that this block
                 belongs to.
-            block: The block to write.
             block_index: Ordered index of the block to write within its parent
                 dataset.
             file_format: File format string for the block that can be used as
@@ -106,7 +104,6 @@ class BlockWritePathProvider:
         *,
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         dataset_uuid: Optional[str] = None,
-        block: Optional[Block] = None,
         block_index: Optional[int] = None,
         file_format: Optional[str] = None,
     ) -> str:
@@ -114,7 +111,6 @@ class BlockWritePathProvider:
             base_path,
             filesystem=filesystem,
             dataset_uuid=dataset_uuid,
-            block=block,
             block_index=block_index,
             file_format=file_format,
         )
@@ -133,7 +129,6 @@ class DefaultBlockWritePathProvider(BlockWritePathProvider):
         *,
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         dataset_uuid: Optional[str] = None,
-        block: Optional[ObjectRef[Block]] = None,
         block_index: Optional[int] = None,
         file_format: Optional[str] = None,
     ) -> str:
@@ -325,7 +320,6 @@ class FileBasedDatasource(Datasource):
             path,
             filesystem=filesystem,
             dataset_uuid=dataset_uuid,
-            block=None,
             block_index=ctx.task_idx,
             file_format=file_format,
         )

--- a/python/ray/data/datasource/json_datasource.py
+++ b/python/ray/data/datasource/json_datasource.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator
 
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
-from ray.data.block import Block
+from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.file_based_datasource import (
     FileBasedDatasource,
     _resolve_kwargs,
@@ -54,4 +54,5 @@ class JSONDatasource(FileBasedDatasource):
         # TODO(swang): We should add an out-of-memory warning if the block size
         # exceeds the max block size in the DataContext.
         block = builder.build()
+        block = BlockAccessor.for_block(block)
         block.to_pandas().to_json(f, orient=orient, lines=lines, **writer_args)

--- a/python/ray/data/datasource/numpy_datasource.py
+++ b/python/ray/data/datasource/numpy_datasource.py
@@ -53,5 +53,5 @@ class NumpyDatasource(FileBasedDatasource):
         # TODO(swang): We should add an out-of-memory warning if the block size
         # exceeds the max block size in the DataContext.
         block = builder.build()
-        value = block.to_numpy(column)
+        value = BlockAccessor.for_block(block).to_numpy(column)
         np.save(f, value)

--- a/python/ray/data/datasource/parquet_base_datasource.py
+++ b/python/ray/data/datasource/parquet_base_datasource.py
@@ -62,4 +62,5 @@ class ParquetBaseDatasource(FileBasedDatasource):
             if writer is None:
                 writer = pq.ParquetWriter(f, block.schema, **writer_args)
             writer.write_table(block, row_group_size=row_group_size)
-        writer.close()
+        if writer is not None:
+            writer.close()

--- a/python/ray/data/datasource/parquet_base_datasource.py
+++ b/python/ray/data/datasource/parquet_base_datasource.py
@@ -57,9 +57,9 @@ class ParquetBaseDatasource(FileBasedDatasource):
 
         writer = None
         for block in blocks:
-            block = BlockAccessor.for_block(block)
-            assert block.num_rows() > 0, "Cannot write an empty block."
+            block = BlockAccessor.for_block(block).to_arrow()
+            assert block.num_rows > 0, "Cannot write an empty block."
             if writer is None:
-                writer = pq.ParquetWriter(f, block.schema(), **writer_args)
-            writer.write_table(block.to_arrow(), row_group_size=row_group_size)
+                writer = pq.ParquetWriter(f, block.schema, **writer_args)
+            writer.write_table(block, row_group_size=row_group_size)
         writer.close()

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -60,7 +60,7 @@ class TFRecordDatasource(FileBasedDatasource):
     ) -> None:
         _check_import(self, module="crc32c", package="crc32c")
         for block in blocks:
-            arrow_table = block.to_arrow()
+            arrow_table = BlockAccessor.for_block(block).to_arrow()
 
             # It seems like TFRecords are typically row-based,
             # https://www.tensorflow.org/tutorials/load_data/tfrecord#writing_a_tfrecord_file_2

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -13,7 +13,7 @@ from typing import (
 import numpy as np
 
 from ray.data._internal.util import _check_import
-from ray.data.block import Block
+from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 from ray.util.annotations import PublicAPI
 

--- a/python/ray/data/datasource/webdataset_datasource.py
+++ b/python/ray/data/datasource/webdataset_datasource.py
@@ -300,6 +300,7 @@ def _make_iterable(blocks: BlockAccessor):
         Iterable[Dict[str,Any]]: Iterable of samples
     """
     for block in blocks:
+        block = BlockAccessor.for_block(block)
         yield from block.iter_rows(public_row_format=False)
 
 
@@ -351,7 +352,7 @@ class WebDatasetDatasource(FileBasedDatasource):
                 sample = _apply_list(decoder, sample, default=_default_decoder)
             yield pd.DataFrame({k: [v] for k, v in sample.items()})
 
-    def _write_block(
+    def _write_blocks(
         self,
         f: "pyarrow.NativeFile",
         blocks: Iterator[Block],

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -162,7 +162,7 @@ def test_block_write_path_provider():
             block_index=None,
             file_format=None,
         ):
-            suffix = f"{block_index:06}_{dataset_uuid}" f".test.{file_format}"
+            suffix = f"{block_index:06}_{dataset_uuid}.test.{file_format}"
             return posixpath.join(base_path, suffix)
 
     yield TestBlockWritePathProvider()

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -12,7 +12,7 @@ import ray
 from ray._private.utils import _get_pyarrow_version
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.arrow import ArrowTensorArray
-from ray.data.block import BlockAccessor, BlockExecStats, BlockMetadata
+from ray.data.block import BlockExecStats, BlockMetadata
 from ray.data.datasource.file_based_datasource import BlockWritePathProvider
 from ray.data.tests.mock_server import *  # noqa
 

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -159,14 +159,10 @@ def test_block_write_path_provider():
             *,
             filesystem=None,
             dataset_uuid=None,
-            block=None,
             block_index=None,
             file_format=None,
         ):
-            num_rows = BlockAccessor.for_block(block).num_rows()
-            suffix = (
-                f"{block_index:06}_{num_rows:02}_{dataset_uuid}" f".test.{file_format}"
-            )
+            suffix = f"{block_index:06}_{dataset_uuid}" f".test.{file_format}"
             return posixpath.join(base_path, suffix)
 
     yield TestBlockWritePathProvider()

--- a/python/ray/data/tests/test_csv.py
+++ b/python/ray/data/tests/test_csv.py
@@ -777,7 +777,7 @@ def test_csv_write_block_path_provider(
     ds.write_csv(
         data_path, filesystem=fs, block_path_provider=test_block_write_path_provider
     )
-    file_path = os.path.join(data_path, "000000_03_data.test.csv")
+    file_path = os.path.join(data_path, "000000_data.test.csv")
     assert df1.equals(pd.read_csv(file_path, storage_options=storage_options))
 
     # Two blocks.
@@ -787,7 +787,7 @@ def test_csv_write_block_path_provider(
     ds.write_csv(
         data_path, filesystem=fs, block_path_provider=test_block_write_path_provider
     )
-    file_path2 = os.path.join(data_path, "000001_03_data.test.csv")
+    file_path2 = os.path.join(data_path, "000001_data.test.csv")
     df = pd.concat([df1, df2])
     ds_df = pd.concat(
         [

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -411,7 +411,11 @@ def _test_write_large_data(tmp_path, ext, write_fn, read_fn, use_bytes):
 def test_write_large_data_parquet(shutdown_only, tmp_path):
     # TODO(swang): Parquet doesn't support streaming read yet.
     _test_write_large_data(
-        tmp_path, "parquet", Dataset.write_parquet, None, use_bytes=True
+        tmp_path,
+        "parquet",
+        Dataset.write_parquet,
+        ray.data.read_parquet,
+        use_bytes=True,
     )
 
 

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import numpy as np
@@ -6,6 +7,7 @@ import pyarrow as pa
 import pytest
 
 import ray
+from ray.data import Dataset
 from ray.data._internal.lazy_block_list import LazyBlockList
 from ray.data.block import BlockMetadata
 from ray.data.datasource import Datasource
@@ -18,14 +20,17 @@ from ray.tests.conftest import *  # noqa
 class RandomBytesDatasource(Datasource):
     def create_reader(self, **read_args):
         return RandomBytesReader(
-            read_args["num_blocks_per_task"], read_args["block_size"]
+            read_args["num_blocks_per_task"],
+            read_args["block_size"],
+            read_args.get("use_bytes", True),
         )
 
 
 class RandomBytesReader(Reader):
-    def __init__(self, num_blocks_per_task: int, block_size: int):
+    def __init__(self, num_blocks_per_task: int, block_size: int, use_bytes=True):
         self.num_blocks_per_task = num_blocks_per_task
         self.block_size = block_size
+        self.use_bytes = use_bytes
 
     def estimate_inmemory_data_size(self):
         return None
@@ -33,7 +38,12 @@ class RandomBytesReader(Reader):
     def get_read_tasks(self, parallelism: int):
         def _blocks_generator():
             for _ in range(self.num_blocks_per_task):
-                yield pd.DataFrame({"one": [np.random.bytes(self.block_size)]})
+                if self.use_bytes:
+                    yield pd.DataFrame({"one": [np.random.bytes(self.block_size)]})
+                else:
+                    yield pd.DataFrame(
+                        {"one": [np.array2string(np.ones(self.block_size, dtype=int))]}
+                    )
 
         return parallelism * [
             ReadTask(
@@ -369,27 +379,71 @@ def test_read_large_data(ray_start_cluster, enable_dynamic_block_splitting):
     assert ds.count() == num_blocks_per_task
 
 
-def test_write_large_data(shutdown_only, tmp_path):
+def _test_write_large_data(tmp_path, ext, write_fn, read_fn, use_bytes):
     # Test 2G input with single task
     num_blocks_per_task = 200
     block_size = 10 * 1024 * 1024
-
-    def foo(batch):
-        return pd.DataFrame({"one": [1]})
 
     ds = ray.data.read_datasource(
         RandomBytesDatasource(),
         parallelism=1,
         num_blocks_per_task=num_blocks_per_task,
         block_size=block_size,
+        use_bytes=use_bytes,
     )
 
     # This should succeed without OOM.
     # https://github.com/ray-project/ray/pull/37966.
-    ds.write_parquet(tmp_path)
+    out_dir = os.path.join(tmp_path, ext)
+    write_fn(ds, out_dir)
 
     max_heap_memory = ds._write_ds._get_stats_summary().get_max_heap_memory()
-    assert max_heap_memory < (num_blocks_per_task * block_size / 2), max_heap_memory
+    assert max_heap_memory < (num_blocks_per_task * block_size / 2), (
+        max_heap_memory,
+        ext,
+    )
+
+    # Make sure we can read out a record.
+    if read_fn is not None:
+        assert read_fn(out_dir).count() == num_blocks_per_task
+
+
+def test_write_large_data_parquet(shutdown_only, tmp_path):
+    # TODO(swang): Parquet doesn't support streaming read yet.
+    _test_write_large_data(
+        tmp_path, "parquet", Dataset.write_parquet, None, use_bytes=True
+    )
+
+
+def test_write_large_data_json(shutdown_only, tmp_path):
+    # TODO(swang): JSON doesn't support streaming read yet.
+    _test_write_large_data(tmp_path, "json", Dataset.write_json, None, use_bytes=False)
+
+
+def test_write_large_data_csv(shutdown_only, tmp_path):
+    _test_write_large_data(
+        tmp_path, "csv", Dataset.write_csv, ray.data.read_csv, use_bytes=False
+    )
+
+
+def test_write_large_data_tfrecords(shutdown_only, tmp_path):
+    _test_write_large_data(
+        tmp_path,
+        "tfrecords",
+        Dataset.write_tfrecords,
+        ray.data.read_tfrecords,
+        use_bytes=True,
+    )
+
+
+def test_write_large_data_webdataset(shutdown_only, tmp_path):
+    _test_write_large_data(
+        tmp_path,
+        "webdataset",
+        Dataset.write_webdataset,
+        ray.data.read_webdataset,
+        use_bytes=True,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If multiple blocks were to be written to the same file, it used to require all blocks to be in memory at once. This PR makes the FileBasedDatasource's internal interface streaming, so that each datasource can choose to write one block at a time. This limits memory usage per write task to about the size of one block (default 512MB).

Note that numpy and JSON datasources do not support writing multiple objects to one file. To support these, we would need to split to multiple output files.

## Related issue number

Closes #37948.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
