### PR TITLE
[ci/release] Remove `default` images in app config templates

### DIFF
--- a/release/air_examples/gptj_deepspeed_finetuning/gptj_deepspeed_env.yaml
+++ b/release/air_examples/gptj_deepspeed_finetuning/gptj_deepspeed_env.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/air_examples/gptj_deepspeed_finetuning/gptj_deepspeed_env.yaml
+++ b/release/air_examples/gptj_deepspeed_finetuning/gptj_deepspeed_env.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/air_examples/opt_deepspeed_batch_inference/30b_deepspeed_env.yaml
+++ b/release/air_examples/opt_deepspeed_batch_inference/30b_deepspeed_env.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/air_examples/opt_deepspeed_batch_inference/30b_deepspeed_env.yaml
+++ b/release/air_examples/opt_deepspeed_batch_inference/30b_deepspeed_env.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/air_tests/air_benchmarks/app_config.yaml
+++ b/release/air_tests/air_benchmarks/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/air_tests/air_benchmarks/app_config.yaml
+++ b/release/air_tests/air_benchmarks/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 
 env_vars: {"RAY_task_oom_retries": "50", "RAY_min_memory_free_bytes": "1000000000"}
 

--- a/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 
 env_vars: {"RAY_task_oom_retries": "50", "RAY_min_memory_free_bytes": "1000000000"}
 

--- a/release/air_tests/air_benchmarks/xgboost_app_config.yaml
+++ b/release/air_tests/air_benchmarks/xgboost_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 debian_packages:
   - curl
 

--- a/release/air_tests/air_benchmarks/xgboost_app_config.yaml
+++ b/release/air_tests/air_benchmarks/xgboost_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 debian_packages:
   - curl
 

--- a/release/air_tests/frequent_pausing/app_config.yaml
+++ b/release/air_tests/frequent_pausing/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 debian_packages: []
 # Lower the threshold to trigger memory pressure.
 env_vars: {"RAY_memory_usage_threshold": "0.5", "automatic_object_spilling_enabled": "0"}

--- a/release/air_tests/frequent_pausing/app_config.yaml
+++ b/release/air_tests/frequent_pausing/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 debian_packages: []
 # Lower the threshold to trigger memory pressure.
 env_vars: {"RAY_memory_usage_threshold": "0.5", "automatic_object_spilling_enabled": "0"}

--- a/release/air_tests/horovod/app_config_master.yaml
+++ b/release/air_tests/horovod/app_config_master.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/air_tests/horovod/app_config_master.yaml
+++ b/release/air_tests/horovod/app_config_master.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/air_tests/oom/stress_tests_tune_air_oom_app_config.yaml
+++ b/release/air_tests/oom/stress_tests_tune_air_oom_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 debian_packages: []
 # Lower the threshold to trigger memory pressure.
 # TODO: turn on infinite retry by default when we switch to new policy.

--- a/release/air_tests/oom/stress_tests_tune_air_oom_app_config.yaml
+++ b/release/air_tests/oom/stress_tests_tune_air_oom_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 debian_packages: []
 # Lower the threshold to trigger memory pressure.
 # TODO: turn on infinite retry by default when we switch to new policy.

--- a/release/alpa_tests/app_config.yaml
+++ b/release/alpa_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/alpa_tests/app_config.yaml
+++ b/release/alpa_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/benchmarks/app_config.yaml
+++ b/release/benchmarks/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {"LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so"}
 
 debian_packages:

--- a/release/benchmarks/app_config.yaml
+++ b/release/benchmarks/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {"LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so"}
 
 debian_packages:

--- a/release/benchmarks/distributed/many_nodes_tests/app_config.yaml
+++ b/release/benchmarks/distributed/many_nodes_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 debian_packages: []
 
 python:

--- a/release/benchmarks/distributed/many_nodes_tests/app_config.yaml
+++ b/release/benchmarks/distributed/many_nodes_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 debian_packages: []
 
 python:

--- a/release/cluster_tests/app_config.yaml
+++ b/release/cluster_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/cluster_tests/app_config.yaml
+++ b/release/cluster_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/dashboard/agent_stress_app_config.yaml
+++ b/release/dashboard/agent_stress_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_GPU"] | default("anyscale/ray-ml:2.0.0-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:2.0.0-py38-gpu") }}
 debian_packages: []
 env_vars: {"RAY_INTERNAL_MEM_PROFILE_COMPONENTS": "dashboard_agent"}
 debian_packages:

--- a/release/dashboard/agent_stress_app_config.yaml
+++ b/release/dashboard/agent_stress_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:2.0.0-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 debian_packages: []
 env_vars: {"RAY_INTERNAL_MEM_PROFILE_COMPONENTS": "dashboard_agent"}
 debian_packages:

--- a/release/golden_notebook_tests/dask_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/dask_xgboost_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: { }
 debian_packages:
   - curl

--- a/release/golden_notebook_tests/dask_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/dask_xgboost_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: { }
 debian_packages:
   - curl

--- a/release/golden_notebook_tests/modin_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/modin_xgboost_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: { }
 debian_packages:
   - curl

--- a/release/golden_notebook_tests/modin_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/modin_xgboost_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: { }
 debian_packages:
   - curl

--- a/release/golden_notebook_tests/torch_tune_serve_app_config.yaml
+++ b/release/golden_notebook_tests/torch_tune_serve_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: { }
 debian_packages:
   - curl

--- a/release/golden_notebook_tests/torch_tune_serve_app_config.yaml
+++ b/release/golden_notebook_tests/torch_tune_serve_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: { }
 debian_packages:
   - curl

--- a/release/jobs_tests/app_config.yaml
+++ b/release/jobs_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/jobs_tests/app_config.yaml
+++ b/release/jobs_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/k8s_tests/app_config.yaml
+++ b/release/k8s_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/k8s_tests/app_config.yaml
+++ b/release/k8s_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/lightgbm_tests/app_config.yaml
+++ b/release/lightgbm_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/lightgbm_tests/app_config.yaml
+++ b/release/lightgbm_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/lightgbm_tests/app_config_gpu.yaml
+++ b/release/lightgbm_tests/app_config_gpu.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/lightgbm_tests/app_config_gpu.yaml
+++ b/release/lightgbm_tests/app_config_gpu.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/lightning_tests/app_config.yaml
+++ b/release/lightning_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 
 debian_packages:
   - curl

--- a/release/lightning_tests/app_config.yaml
+++ b/release/lightning_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 
 debian_packages:
   - curl

--- a/release/long_running_distributed_tests/app_config.yaml
+++ b/release/long_running_distributed_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/long_running_distributed_tests/app_config.yaml
+++ b/release/long_running_distributed_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {"RLLIB_TEST_NO_JAX_IMPORT": "1"}
 
 debian_packages:

--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {"RLLIB_TEST_NO_JAX_IMPORT": "1"}
 
 debian_packages:

--- a/release/long_running_tests/app_config_np.yaml
+++ b/release/long_running_tests/app_config_np.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 
 debian_packages:

--- a/release/long_running_tests/app_config_np.yaml
+++ b/release/long_running_tests/app_config_np.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 
 debian_packages:

--- a/release/microbenchmark/app_config.yaml
+++ b/release/microbenchmark/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 debian_packages: []
 

--- a/release/microbenchmark/app_config.yaml
+++ b/release/microbenchmark/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 debian_packages: []
 

--- a/release/ml_user_tests/horovod/app_config.yaml
+++ b/release/ml_user_tests/horovod/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {"HOROVOD_GLOO_TIMEOUT_SECONDS": "120"}
 debian_packages:
   - curl

--- a/release/ml_user_tests/horovod/app_config.yaml
+++ b/release/ml_user_tests/horovod/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {"HOROVOD_GLOO_TIMEOUT_SECONDS": "120"}
 debian_packages:
   - curl

--- a/release/ml_user_tests/horovod/app_config_master.yaml
+++ b/release/ml_user_tests/horovod/app_config_master.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {"HOROVOD_GLOO_TIMEOUT_SECONDS": "120"}
 debian_packages:
   - curl

--- a/release/ml_user_tests/horovod/app_config_master.yaml
+++ b/release/ml_user_tests/horovod/app_config_master.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {"HOROVOD_GLOO_TIMEOUT_SECONDS": "120"}
 debian_packages:
   - curl

--- a/release/ml_user_tests/train/app_config.yaml
+++ b/release/ml_user_tests/train/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars:
     TRAIN_PLACEMENT_GROUP_TIMEOUT_S: "2000"
 

--- a/release/ml_user_tests/train/app_config.yaml
+++ b/release/ml_user_tests/train/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars:
     TRAIN_PLACEMENT_GROUP_TIMEOUT_S: "2000"
 

--- a/release/ml_user_tests/xgboost/app_config_gpu.yaml
+++ b/release/ml_user_tests/xgboost/app_config_gpu.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/ml_user_tests/xgboost/app_config_gpu.yaml
+++ b/release/ml_user_tests/xgboost/app_config_gpu.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/ml_user_tests/xgboost/app_config_gpu_master.yaml
+++ b/release/ml_user_tests/xgboost/app_config_gpu_master.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/ml_user_tests/xgboost/app_config_gpu_master.yaml
+++ b/release/ml_user_tests/xgboost/app_config_gpu_master.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/nightly_tests/chaos_test/app_config.yaml
+++ b/release/nightly_tests/chaos_test/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 debian_packages: []
 

--- a/release/nightly_tests/chaos_test/app_config.yaml
+++ b/release/nightly_tests/chaos_test/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 debian_packages: []
 

--- a/release/nightly_tests/chaos_test/dask_on_ray_app_config_reconstruction.yaml
+++ b/release/nightly_tests/chaos_test/dask_on_ray_app_config_reconstruction.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {"RAY_lineage_pinning_enabled": "1"}
 debian_packages: []
 

--- a/release/nightly_tests/chaos_test/dask_on_ray_app_config_reconstruction.yaml
+++ b/release/nightly_tests/chaos_test/dask_on_ray_app_config_reconstruction.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {"RAY_lineage_pinning_enabled": "1"}
 debian_packages: []
 

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 # We use retriable_lifo as the workload can crash due to multiple tasks from different
 # callers running on the same node, we also observed raylet memory leak that would
 # trigger the group-by-policy to fail the workload.

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 # We use retriable_lifo as the workload can crash due to multiple tasks from different
 # callers running on the same node, we also observed raylet memory leak that would
 # trigger the group-by-policy to fail the workload.

--- a/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/dataset/app_config.yaml
+++ b/release/nightly_tests/dataset/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 
 python:
   pip_packages:

--- a/release/nightly_tests/dataset/app_config.yaml
+++ b/release/nightly_tests/dataset/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 
 python:
   pip_packages:

--- a/release/nightly_tests/dataset/pipelined_ingestion_app.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_app.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {"RAY_lineage_pinning_enabled": "1", "RAY_record_ref_creation_sites": "1"}
 python:
   pip_packages:

--- a/release/nightly_tests/dataset/pipelined_ingestion_app.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_app.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {"RAY_lineage_pinning_enabled": "1", "RAY_record_ref_creation_sites": "1"}
 python:
   pip_packages:

--- a/release/nightly_tests/dataset/pipelined_training_app.yaml
+++ b/release/nightly_tests/dataset/pipelined_training_app.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 
 python:
   pip_packages:

--- a/release/nightly_tests/dataset/pipelined_training_app.yaml
+++ b/release/nightly_tests/dataset/pipelined_training_app.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 
 python:
   pip_packages:

--- a/release/nightly_tests/dataset/read_tfrecords_benchmark_app.yaml
+++ b/release/nightly_tests/dataset/read_tfrecords_benchmark_app.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/nightly_tests/dataset/read_tfrecords_benchmark_app.yaml
+++ b/release/nightly_tests/dataset/read_tfrecords_benchmark_app.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/nightly_tests/dataset/shuffle_app_config.yaml
+++ b/release/nightly_tests/dataset/shuffle_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 
 python:
   pip_packages:

--- a/release/nightly_tests/dataset/shuffle_app_config.yaml
+++ b/release/nightly_tests/dataset/shuffle_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 
 python:
   pip_packages:

--- a/release/nightly_tests/decision_tree/decision_tree_app_config.yaml
+++ b/release/nightly_tests/decision_tree/decision_tree_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/decision_tree/decision_tree_app_config.yaml
+++ b/release/nightly_tests/decision_tree/decision_tree_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/placement_group_tests/app_config.yaml
+++ b/release/nightly_tests/placement_group_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/placement_group_tests/app_config.yaml
+++ b/release/nightly_tests/placement_group_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/shuffle/100tb_shuffle_app_config.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 debian_packages: []
 env_vars: {"RAY_object_spilling_config": "{\"type\":\"filesystem\",\"params\":{\"directory_path\":[\"/tmp/data0\",\"/tmp/data1\"]}}"}
 

--- a/release/nightly_tests/shuffle/100tb_shuffle_app_config.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 debian_packages: []
 env_vars: {"RAY_object_spilling_config": "{\"type\":\"filesystem\",\"params\":{\"directory_path\":[\"/tmp/data0\",\"/tmp/data1\"]}}"}
 

--- a/release/nightly_tests/shuffle/100tb_shuffle_app_config_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_app_config_gce.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 debian_packages: []
 env_vars: {"RAY_object_spilling_config": "{\"type\":\"filesystem\",\"params\":{\"directory_path\":[\"/tmp/data0\",\"/tmp/data1\"],\"buffer_size\":1000000}}"}
 

--- a/release/nightly_tests/shuffle/100tb_shuffle_app_config_gce.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_app_config_gce.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 debian_packages: []
 env_vars: {"RAY_object_spilling_config": "{\"type\":\"filesystem\",\"params\":{\"directory_path\":[\"/tmp/data0\",\"/tmp/data1\"],\"buffer_size\":1000000}}"}
 

--- a/release/nightly_tests/shuffle/shuffle_app_config.yaml
+++ b/release/nightly_tests/shuffle/shuffle_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 debian_packages: []
 
 # We use retriable_lifo as the workload can crash due to multiple tasks from different

--- a/release/nightly_tests/shuffle/shuffle_app_config.yaml
+++ b/release/nightly_tests/shuffle/shuffle_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 debian_packages: []
 
 # We use retriable_lifo as the workload can crash due to multiple tasks from different

--- a/release/nightly_tests/shuffle/shuffle_app_config_oom_disabled.yaml
+++ b/release/nightly_tests/shuffle/shuffle_app_config_oom_disabled.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {"RAY_memory_monitor_refresh_ms": "0"}
 debian_packages: []
 

--- a/release/nightly_tests/shuffle/shuffle_app_config_oom_disabled.yaml
+++ b/release/nightly_tests/shuffle/shuffle_app_config_oom_disabled.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {"RAY_memory_monitor_refresh_ms": "0"}
 debian_packages: []
 

--- a/release/nightly_tests/shuffle/shuffle_with_state_api_app_config.yaml
+++ b/release/nightly_tests/shuffle/shuffle_with_state_api_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 debian_packages: []
 env_vars: {"RAY_MAX_LIMIT_FROM_API_SERVER": "1000000000", "RAY_MAX_LIMIT_FROM_DATA_SOURCE":"1000000000"}
 

--- a/release/nightly_tests/shuffle/shuffle_with_state_api_app_config.yaml
+++ b/release/nightly_tests/shuffle/shuffle_with_state_api_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 debian_packages: []
 env_vars: {"RAY_MAX_LIMIT_FROM_API_SERVER": "1000000000", "RAY_MAX_LIMIT_FROM_DATA_SOURCE":"1000000000"}
 

--- a/release/nightly_tests/stress_tests/state_api_app_config.yaml
+++ b/release/nightly_tests/stress_tests/state_api_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 debian_packages: []
 env_vars: {"RAY_MAX_LIMIT_FROM_API_SERVER": "1000000000", "RAY_MAX_LIMIT_FROM_DATA_SOURCE":"1000000000"}
 

--- a/release/nightly_tests/stress_tests/state_api_app_config.yaml
+++ b/release/nightly_tests/stress_tests/state_api_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 debian_packages: []
 env_vars: {"RAY_MAX_LIMIT_FROM_API_SERVER": "1000000000", "RAY_MAX_LIMIT_FROM_DATA_SOURCE":"1000000000"}
 

--- a/release/nightly_tests/stress_tests/stress_tests_app_config.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/stress_tests/stress_tests_app_config.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/stress_tests/stress_tests_single_node_oom_app_config.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_single_node_oom_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/stress_tests/stress_tests_single_node_oom_app_config.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_single_node_oom_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 debian_packages: []
 
 python:

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -32,7 +32,7 @@ from ray_release.util import get_anyscale_sdk
 from ray_release.test import Test
 
 TEST_CLUSTER_ENV = {
-    "base_image": "anyscale/ray:nightly-py37",
+    "base_image": "anyscale/ray:nightly-py38",
     "env_vars": {},
     "python": {
         "pip_packages": [],

--- a/release/ray_release/tests/test_template.py
+++ b/release/ray_release/tests/test_template.py
@@ -6,14 +6,14 @@ from ray_release.exception import ReleaseTestConfigError
 from ray_release.template import populate_cluster_env_variables, render_yaml_template
 
 TEST_APP_CONFIG_CPU = """
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 debian_packages:
   - curl
 """
 
 TEST_APP_CONFIG_GPU = """
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/ray_release/tests/test_template.py
+++ b/release/ray_release/tests/test_template.py
@@ -6,14 +6,14 @@ from ray_release.exception import ReleaseTestConfigError
 from ray_release.template import populate_cluster_env_variables, render_yaml_template
 
 TEST_APP_CONFIG_CPU = """
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 debian_packages:
   - curl
 """
 
 TEST_APP_CONFIG_GPU = """
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/rllib_tests/app_config.yaml
+++ b/release/rllib_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {"LD_LIBRARY_PATH": "$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin", "RLLIB_TEST_NO_JAX_IMPORT": "1"}
 debian_packages:
   - unzip

--- a/release/rllib_tests/debug_app_config.yaml
+++ b/release/rllib_tests/debug_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {"LD_LIBRARY_PATH": "$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin", "RLLIB_TEST_NO_JAX_IMPORT": "1"}
 debian_packages:
   - unzip

--- a/release/runtime_env_tests/app_config.yaml
+++ b/release/runtime_env_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 debian_packages: []
 

--- a/release/runtime_env_tests/app_config.yaml
+++ b/release/runtime_env_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 debian_packages: []
 

--- a/release/serve_tests/app_config.yaml
+++ b/release/serve_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/serve_tests/app_config.yaml
+++ b/release/serve_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/serve_tests/gpu_app_config.yaml
+++ b/release/serve_tests/gpu_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/serve_tests/gpu_app_config.yaml
+++ b/release/serve_tests/gpu_app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/train_tests/horovod/app_config.yaml
+++ b/release/train_tests/horovod/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/train_tests/horovod/app_config.yaml
+++ b/release/train_tests/horovod/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/tune_tests/cloud_tests/app_config.yaml
+++ b/release/tune_tests/cloud_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/tune_tests/cloud_tests/app_config.yaml
+++ b/release/tune_tests/cloud_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/tune_tests/cloud_tests/app_config_ml.yaml
+++ b/release/tune_tests/cloud_tests/app_config_ml.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/tune_tests/cloud_tests/app_config_ml.yaml
+++ b/release/tune_tests/cloud_tests/app_config_ml.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/tune_tests/fault_tolerance_tests/app_config.yaml
+++ b/release/tune_tests/fault_tolerance_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/tune_tests/fault_tolerance_tests/app_config.yaml
+++ b/release/tune_tests/fault_tolerance_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/tune_tests/scalability_tests/app_config.yaml
+++ b/release/tune_tests/scalability_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/tune_tests/scalability_tests/app_config.yaml
+++ b/release/tune_tests/scalability_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/tune_tests/scalability_tests/app_config_data.yaml
+++ b/release/tune_tests/scalability_tests/app_config_data.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/tune_tests/scalability_tests/app_config_data.yaml
+++ b/release/tune_tests/scalability_tests/app_config_data.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/xgboost_tests/app_config.yaml
+++ b/release/xgboost_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/xgboost_tests/app_config.yaml
+++ b/release/xgboost_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] }}
 env_vars: {}
 debian_packages:
   - curl

--- a/release/xgboost_tests/app_config_gpu.yaml
+++ b/release/xgboost_tests/app_config_gpu.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] }}
 env_vars:
   # Manually set NCCL_SOCKET_IFNAME to "ens" so NCCL training works on
   # anyscale_default_cloud.

--- a/release/xgboost_tests/app_config_gpu.yaml
+++ b/release/xgboost_tests/app_config_gpu.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py38-gpu") }}
 env_vars:
   # Manually set NCCL_SOCKET_IFNAME to "ens" so NCCL training works on
   # anyscale_default_cloud.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR updates the app config templates to remove the `default` images.

Previously, two app configs used `RAY_IMAGE_NIGHTLY_GPU`, which was unset. This lead to a mismatch where a 3.7 base image was used (per `default` in the templates) and a 3.8 wheel was installed.

By removing the `default` clause we require the env variable to be set and will catch such errors in the future.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
